### PR TITLE
Add Helm chart publisher workflow

### DIFF
--- a/.github/workflows/helm-build-push.yml
+++ b/.github/workflows/helm-build-push.yml
@@ -2,8 +2,8 @@ name: Publish Danswer Helm Chart
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   release:

--- a/.github/workflows/helm-build-push.yml
+++ b/.github/workflows/helm-build-push.yml
@@ -42,3 +42,4 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "danswer-helm-{{ .Version }}"

--- a/.github/workflows/helm-build-push.yml
+++ b/.github/workflows/helm-build-push.yml
@@ -2,8 +2,8 @@ name: Publish Danswer Helm Chart
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   release:

--- a/.github/workflows/helm-build-push.yml
+++ b/.github/workflows/helm-build-push.yml
@@ -1,0 +1,44 @@
+name: Publish Danswer Helm Chart
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build Helm dependencies
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add vespa https://unoplat.github.io/vespa-helm-charts
+          helm dependency build deployment/helm
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: deployment
+          pages_branch: helm-publish
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This change adds a new GitHub workflow which uses the [Helm chart releaser](https://github.com/helm/chart-releaser-action) GitHub action to publish the Helm chart bundles via GitHub pages. 

This change will require the Danswer team to create a separate `helm-publish` branch for GitHub pages to target. GitHub pages can then be enabled in the repo settings and the pages target branch will need to be set to `helm-publish`. Happy to change the target branch name to something else if desired.

After creating the target branch, it might be useful to clear it of all other content similar to [this branch](https://github.com/sd109/danswer/tree/helm-publish) so that it is obvious to others that this branch is special and should not be manually changed.

Example of a successful workflow run in my own fork [here](https://github.com/sd109/danswer/actions/runs/9452382125/job/26035459965).

Relevant issue: https://github.com/danswer-ai/danswer/issues/971.