### PR TITLE
chore: error handling of notion blocks that do not support children is different

### DIFF
--- a/backend/danswer/connectors/notion/connector.py
+++ b/backend/danswer/connectors/notion/connector.py
@@ -120,6 +120,16 @@ class NotionConnector(LoadConnector, PollConnector):
                     f"with the Danswer integration. Exact exception:\n\n{e}"
                 )
                 return None
+            if res.status_code == 400 and res.json().get("code") == "validation_error":
+                # Happens on a deleted block with a specific block_type that does not support children
+                # The api then returns a 400 instead of 404
+                # Typical error message is 'Suggested blocks are not supported via the API.'
+                logger.error(
+                    f"Unable to access block with ID '{block_id}'. "
+                    f"This is a validation_error with message '{res.json().get("message")}'.] "
+                    f"Exact exception:\n\n{e}"
+                )
+                return None
             logger.exception(f"Error fetching blocks - {res.json()}")
             raise e
         return res.json()


### PR DESCRIPTION
## Description
This PR handle the error on a notion connector when referencing a deleted block that does not support children blocks. When this happen, the api call to v1/blocks/{id}/children returns a 400 instead of 404


## How Has This Been Tested?
None


## Accepted Risk
The fix could potentially handle more exceptions that anticipated.


## Related Issue(s)
This relates to this issue https://github.com/danswer-ai/danswer/issues/1230 , but when the block has been deleted
![Uploading chrome_CdHzzL0Mf0.png…]()

## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If thee are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
