### PR TITLE
Added a script to autogenerate cleanup functions for relationships

### DIFF
--- a/backend/danswer/db/relationship_cleanup.py
+++ b/backend/danswer/db/relationship_cleanup.py
@@ -1,0 +1,894 @@
+from sqlalchemy.orm import Session
+
+from danswer.db.models import ChatMessage__SearchDoc
+from danswer.db.models import ChatMessage__StandardAnswer
+from danswer.db.models import Credential__UserGroup
+from danswer.db.models import Document__Tag
+from danswer.db.models import DocumentSet__ConnectorCredentialPair
+from danswer.db.models import DocumentSet__User
+from danswer.db.models import DocumentSet__UserGroup
+from danswer.db.models import InputPrompt__User
+from danswer.db.models import LLMProvider__UserGroup
+from danswer.db.models import Persona__DocumentSet
+from danswer.db.models import Persona__Prompt
+from danswer.db.models import Persona__Tool
+from danswer.db.models import Persona__User
+from danswer.db.models import Persona__UserGroup
+from danswer.db.models import SlackBotConfig__StandardAnswerCategory
+from danswer.db.models import StandardAnswer__StandardAnswerCategory
+from danswer.db.models import TokenRateLimit__UserGroup
+from danswer.db.models import User__ExternalUserGroupId
+from danswer.db.models import User__UserGroup
+from danswer.db.models import UserGroup__ConnectorCredentialPair
+
+
+def cleanup_chatmessage__searchdoc_relationships(
+    db_session: Session,
+    chat_message_id: int | None = None,
+    search_doc_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup ChatMessage__SearchDoc relationships."""
+    query = db_session.query(ChatMessage__SearchDoc)
+
+    if all(param is None for param in [chat_message_id, search_doc_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if chat_message_id:
+        query = query.where(ChatMessage__SearchDoc.chat_message_id == chat_message_id)
+    if search_doc_id:
+        query = query.where(ChatMessage__SearchDoc.search_doc_id == search_doc_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_chatmessage__standardanswer_relationships(
+    db_session: Session,
+    chat_message_id: int | None = None,
+    standard_answer_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup ChatMessage__StandardAnswer relationships."""
+    query = db_session.query(ChatMessage__StandardAnswer)
+
+    if all(param is None for param in [chat_message_id, standard_answer_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if chat_message_id:
+        query = query.where(
+            ChatMessage__StandardAnswer.chat_message_id == chat_message_id
+        )
+    if standard_answer_id:
+        query = query.where(
+            ChatMessage__StandardAnswer.standard_answer_id == standard_answer_id
+        )
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_credential__usergroup_relationships(
+    db_session: Session,
+    credential_id: int | None = None,
+    user_group_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Credential__UserGroup relationships."""
+    query = db_session.query(Credential__UserGroup)
+
+    if all(param is None for param in [credential_id, user_group_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if credential_id:
+        query = query.where(Credential__UserGroup.credential_id == credential_id)
+    if user_group_id:
+        query = query.where(Credential__UserGroup.user_group_id == user_group_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_documentset__connectorcredentialpair_relationships(
+    db_session: Session,
+    document_set_id: int | None = None,
+    connector_credential_pair_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup DocumentSet__ConnectorCredentialPair relationships."""
+    query = db_session.query(DocumentSet__ConnectorCredentialPair)
+
+    if all(param is None for param in [document_set_id, connector_credential_pair_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if document_set_id:
+        query = query.where(
+            DocumentSet__ConnectorCredentialPair.document_set_id == document_set_id
+        )
+    if connector_credential_pair_id:
+        query = query.where(
+            DocumentSet__ConnectorCredentialPair.connector_credential_pair_id
+            == connector_credential_pair_id
+        )
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_documentset__user_relationships(
+    db_session: Session,
+    document_set_id: int | None = None,
+    user_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup DocumentSet__User relationships."""
+    query = db_session.query(DocumentSet__User)
+
+    if all(param is None for param in [document_set_id, user_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if document_set_id:
+        query = query.where(DocumentSet__User.document_set_id == document_set_id)
+    if user_id:
+        query = query.where(DocumentSet__User.user_id == user_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_documentset__usergroup_relationships(
+    db_session: Session,
+    document_set_id: int | None = None,
+    user_group_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup DocumentSet__UserGroup relationships."""
+    query = db_session.query(DocumentSet__UserGroup)
+
+    if all(param is None for param in [document_set_id, user_group_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if document_set_id:
+        query = query.where(DocumentSet__UserGroup.document_set_id == document_set_id)
+    if user_group_id:
+        query = query.where(DocumentSet__UserGroup.user_group_id == user_group_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_document__tag_relationships(
+    db_session: Session,
+    document_id: int | None = None,
+    tag_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Document__Tag relationships."""
+    query = db_session.query(Document__Tag)
+
+    if all(param is None for param in [document_id, tag_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if document_id:
+        query = query.where(Document__Tag.document_id == document_id)
+    if tag_id:
+        query = query.where(Document__Tag.tag_id == tag_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_inputprompt__user_relationships(
+    db_session: Session,
+    input_prompt_id: int | None = None,
+    user_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup InputPrompt__User relationships."""
+    query = db_session.query(InputPrompt__User)
+
+    if all(param is None for param in [input_prompt_id, user_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if input_prompt_id:
+        query = query.where(InputPrompt__User.input_prompt_id == input_prompt_id)
+    if user_id:
+        query = query.where(InputPrompt__User.user_id == user_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_llmprovider__usergroup_relationships(
+    db_session: Session,
+    llm_provider_id: int | None = None,
+    user_group_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup LLMProvider__UserGroup relationships."""
+    query = db_session.query(LLMProvider__UserGroup)
+
+    if all(param is None for param in [llm_provider_id, user_group_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if llm_provider_id:
+        query = query.where(LLMProvider__UserGroup.llm_provider_id == llm_provider_id)
+    if user_group_id:
+        query = query.where(LLMProvider__UserGroup.user_group_id == user_group_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_persona__documentset_relationships(
+    db_session: Session,
+    persona_id: int | None = None,
+    document_set_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Persona__DocumentSet relationships."""
+    query = db_session.query(Persona__DocumentSet)
+
+    if all(param is None for param in [persona_id, document_set_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if persona_id:
+        query = query.where(Persona__DocumentSet.persona_id == persona_id)
+    if document_set_id:
+        query = query.where(Persona__DocumentSet.document_set_id == document_set_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_persona__prompt_relationships(
+    db_session: Session,
+    persona_id: int | None = None,
+    prompt_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Persona__Prompt relationships."""
+    query = db_session.query(Persona__Prompt)
+
+    if all(param is None for param in [persona_id, prompt_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if persona_id:
+        query = query.where(Persona__Prompt.persona_id == persona_id)
+    if prompt_id:
+        query = query.where(Persona__Prompt.prompt_id == prompt_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_persona__tool_relationships(
+    db_session: Session,
+    persona_id: int | None = None,
+    tool_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Persona__Tool relationships."""
+    query = db_session.query(Persona__Tool)
+
+    if all(param is None for param in [persona_id, tool_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if persona_id:
+        query = query.where(Persona__Tool.persona_id == persona_id)
+    if tool_id:
+        query = query.where(Persona__Tool.tool_id == tool_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_persona__user_relationships(
+    db_session: Session,
+    persona_id: int | None = None,
+    user_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Persona__User relationships."""
+    query = db_session.query(Persona__User)
+
+    if all(param is None for param in [persona_id, user_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if persona_id:
+        query = query.where(Persona__User.persona_id == persona_id)
+    if user_id:
+        query = query.where(Persona__User.user_id == user_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_persona__usergroup_relationships(
+    db_session: Session,
+    persona_id: int | None = None,
+    user_group_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup Persona__UserGroup relationships."""
+    query = db_session.query(Persona__UserGroup)
+
+    if all(param is None for param in [persona_id, user_group_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if persona_id:
+        query = query.where(Persona__UserGroup.persona_id == persona_id)
+    if user_group_id:
+        query = query.where(Persona__UserGroup.user_group_id == user_group_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_slackbotconfig__standardanswercategory_relationships(
+    db_session: Session,
+    slack_bot_config_id: int | None = None,
+    standard_answer_category_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup SlackBotConfig__StandardAnswerCategory relationships."""
+    query = db_session.query(SlackBotConfig__StandardAnswerCategory)
+
+    if all(
+        param is None for param in [slack_bot_config_id, standard_answer_category_id]
+    ):
+        raise ValueError("At least one parameter must be provided.")
+
+    if slack_bot_config_id:
+        query = query.where(
+            SlackBotConfig__StandardAnswerCategory.slack_bot_config_id
+            == slack_bot_config_id
+        )
+    if standard_answer_category_id:
+        query = query.where(
+            SlackBotConfig__StandardAnswerCategory.standard_answer_category_id
+            == standard_answer_category_id
+        )
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_standardanswer__standardanswercategory_relationships(
+    db_session: Session,
+    standard_answer_id: int | None = None,
+    standard_answer_category_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup StandardAnswer__StandardAnswerCategory relationships."""
+    query = db_session.query(StandardAnswer__StandardAnswerCategory)
+
+    if all(
+        param is None for param in [standard_answer_id, standard_answer_category_id]
+    ):
+        raise ValueError("At least one parameter must be provided.")
+
+    if standard_answer_id:
+        query = query.where(
+            StandardAnswer__StandardAnswerCategory.standard_answer_id
+            == standard_answer_id
+        )
+    if standard_answer_category_id:
+        query = query.where(
+            StandardAnswer__StandardAnswerCategory.standard_answer_category_id
+            == standard_answer_category_id
+        )
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_tokenratelimit__usergroup_relationships(
+    db_session: Session,
+    rate_limit_id: int | None = None,
+    user_group_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup TokenRateLimit__UserGroup relationships."""
+    query = db_session.query(TokenRateLimit__UserGroup)
+
+    if all(param is None for param in [rate_limit_id, user_group_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if rate_limit_id:
+        query = query.where(TokenRateLimit__UserGroup.rate_limit_id == rate_limit_id)
+    if user_group_id:
+        query = query.where(TokenRateLimit__UserGroup.user_group_id == user_group_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_usergroup__connectorcredentialpair_relationships(
+    db_session: Session,
+    user_group_id: int | None = None,
+    cc_pair_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup UserGroup__ConnectorCredentialPair relationships."""
+    query = db_session.query(UserGroup__ConnectorCredentialPair)
+
+    if all(param is None for param in [user_group_id, cc_pair_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if user_group_id:
+        query = query.where(
+            UserGroup__ConnectorCredentialPair.user_group_id == user_group_id
+        )
+    if cc_pair_id:
+        query = query.where(UserGroup__ConnectorCredentialPair.cc_pair_id == cc_pair_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_user__externalusergroupid_relationships(
+    db_session: Session,
+    user_id: int | None = None,
+    external_user_group_id: int | None = None,
+    cc_pair_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup User__ExternalUserGroupId relationships."""
+    query = db_session.query(User__ExternalUserGroupId)
+
+    if all(param is None for param in [user_id, external_user_group_id, cc_pair_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if user_id:
+        query = query.where(User__ExternalUserGroupId.user_id == user_id)
+    if external_user_group_id:
+        query = query.where(
+            User__ExternalUserGroupId.external_user_group_id == external_user_group_id
+        )
+    if cc_pair_id:
+        query = query.where(User__ExternalUserGroupId.cc_pair_id == cc_pair_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_user__usergroup_relationships(
+    db_session: Session,
+    user_group_id: int | None = None,
+    user_id: int | None = None,
+    commit: bool = False,
+) -> None:
+    """Cleanup User__UserGroup relationships."""
+    query = db_session.query(User__UserGroup)
+
+    if all(param is None for param in [user_group_id, user_id]):
+        raise ValueError("At least one parameter must be provided.")
+
+    if user_group_id:
+        query = query.where(User__UserGroup.user_group_id == user_group_id)
+    if user_id:
+        query = query.where(User__UserGroup.user_id == user_id)
+
+    query.delete(synchronize_session=False)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_document_deletion(
+    db_session: Session, document_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Document deletion."""
+    cleanup_documentset__connectorcredentialpair_relationships(
+        db_session, document_id=document_id, connector_credential_pair_id=None
+    )
+    cleanup_documentset__user_relationships(
+        db_session, document_id=document_id, user_id=None
+    )
+    cleanup_documentset__usergroup_relationships(
+        db_session, document_id=document_id, user_group_id=None
+    )
+    cleanup_document__tag_relationships(
+        db_session, document_id=document_id, tag_id=None
+    )
+    cleanup_persona__documentset_relationships(
+        db_session, document_id=document_id, persona_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_user_deletion(
+    db_session: Session, user_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for User deletion."""
+    cleanup_credential__usergroup_relationships(
+        db_session, user_id=user_id, credential_id=None
+    )
+    cleanup_documentset__user_relationships(
+        db_session, user_id=user_id, document_set_id=None
+    )
+    cleanup_documentset__usergroup_relationships(
+        db_session, user_id=user_id, document_set_id=None
+    )
+    cleanup_inputprompt__user_relationships(
+        db_session, user_id=user_id, input_prompt_id=None
+    )
+    cleanup_llmprovider__usergroup_relationships(
+        db_session, user_id=user_id, llm_provider_id=None
+    )
+    cleanup_persona__user_relationships(db_session, user_id=user_id, persona_id=None)
+    cleanup_persona__usergroup_relationships(
+        db_session, user_id=user_id, persona_id=None
+    )
+    cleanup_tokenratelimit__usergroup_relationships(
+        db_session, user_id=user_id, rate_limit_id=None
+    )
+    cleanup_usergroup__connectorcredentialpair_relationships(
+        db_session, user_id=user_id, cc_pair_id=None
+    )
+    cleanup_user__externalusergroupid_relationships(
+        db_session, user_id=user_id, external_user_group_id=None, cc_pair_id=None
+    )
+    cleanup_user__usergroup_relationships(
+        db_session,
+        user_id=user_id,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_inputprompt_deletion(
+    db_session: Session, inputprompt_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for InputPrompt deletion."""
+    cleanup_inputprompt__user_relationships(
+        db_session, inputprompt_id=inputprompt_id, input_prompt_id=None, user_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_standardanswercategory_deletion(
+    db_session: Session, standardanswercategory_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for StandardAnswerCategory deletion."""
+    cleanup_slackbotconfig__standardanswercategory_relationships(
+        db_session,
+        standardanswercategory_id=standardanswercategory_id,
+        slack_bot_config_id=None,
+        standard_answer_category_id=None,
+    )
+    cleanup_standardanswer__standardanswercategory_relationships(
+        db_session,
+        standardanswercategory_id=standardanswercategory_id,
+        standard_answer_id=None,
+        standard_answer_category_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_chatmessage_deletion(
+    db_session: Session, chatmessage_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for ChatMessage deletion."""
+    cleanup_chatmessage__searchdoc_relationships(
+        db_session,
+        chatmessage_id=chatmessage_id,
+        chat_message_id=None,
+        search_doc_id=None,
+    )
+    cleanup_chatmessage__standardanswer_relationships(
+        db_session,
+        chatmessage_id=chatmessage_id,
+        chat_message_id=None,
+        standard_answer_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_standardanswer_deletion(
+    db_session: Session, standardanswer_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for StandardAnswer deletion."""
+    cleanup_chatmessage__standardanswer_relationships(
+        db_session,
+        standardanswer_id=standardanswer_id,
+        chat_message_id=None,
+        standard_answer_id=None,
+    )
+    cleanup_slackbotconfig__standardanswercategory_relationships(
+        db_session,
+        standardanswer_id=standardanswer_id,
+        slack_bot_config_id=None,
+        standard_answer_category_id=None,
+    )
+    cleanup_standardanswer__standardanswercategory_relationships(
+        db_session,
+        standardanswer_id=standardanswer_id,
+        standard_answer_id=None,
+        standard_answer_category_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_prompt_deletion(
+    db_session: Session, prompt_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Prompt deletion."""
+    cleanup_inputprompt__user_relationships(
+        db_session, prompt_id=prompt_id, input_prompt_id=None, user_id=None
+    )
+    cleanup_persona__prompt_relationships(
+        db_session, prompt_id=prompt_id, persona_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_slackbotconfig_deletion(
+    db_session: Session, slackbotconfig_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for SlackBotConfig deletion."""
+    cleanup_slackbotconfig__standardanswercategory_relationships(
+        db_session,
+        slackbotconfig_id=slackbotconfig_id,
+        slack_bot_config_id=None,
+        standard_answer_category_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_persona_deletion(
+    db_session: Session, persona_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Persona deletion."""
+    cleanup_persona__documentset_relationships(
+        db_session, persona_id=persona_id, document_set_id=None
+    )
+    cleanup_persona__prompt_relationships(
+        db_session, persona_id=persona_id, prompt_id=None
+    )
+    cleanup_persona__tool_relationships(db_session, persona_id=persona_id, tool_id=None)
+    cleanup_persona__user_relationships(db_session, persona_id=persona_id, user_id=None)
+    cleanup_persona__usergroup_relationships(
+        db_session, persona_id=persona_id, user_group_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_llmprovider_deletion(
+    db_session: Session, llmprovider_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for LLMProvider deletion."""
+    cleanup_llmprovider__usergroup_relationships(
+        db_session,
+        llmprovider_id=llmprovider_id,
+        llm_provider_id=None,
+        user_group_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_credential_deletion(
+    db_session: Session, credential_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Credential deletion."""
+    cleanup_credential__usergroup_relationships(
+        db_session, credential_id=credential_id, user_group_id=None
+    )
+    cleanup_documentset__connectorcredentialpair_relationships(
+        db_session,
+        credential_id=credential_id,
+        document_set_id=None,
+        connector_credential_pair_id=None,
+    )
+    cleanup_usergroup__connectorcredentialpair_relationships(
+        db_session, credential_id=credential_id, user_group_id=None, cc_pair_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_tag_deletion(
+    db_session: Session, tag_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Tag deletion."""
+    cleanup_document__tag_relationships(db_session, tag_id=tag_id, document_id=None)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_usergroup_deletion(
+    db_session: Session, usergroup_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for UserGroup deletion."""
+    cleanup_credential__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, credential_id=None, user_group_id=None
+    )
+    cleanup_documentset__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, document_set_id=None, user_group_id=None
+    )
+    cleanup_llmprovider__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, llm_provider_id=None, user_group_id=None
+    )
+    cleanup_persona__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, persona_id=None, user_group_id=None
+    )
+    cleanup_tokenratelimit__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, rate_limit_id=None, user_group_id=None
+    )
+    cleanup_usergroup__connectorcredentialpair_relationships(
+        db_session, usergroup_id=usergroup_id, user_group_id=None, cc_pair_id=None
+    )
+    cleanup_user__externalusergroupid_relationships(
+        db_session,
+        usergroup_id=usergroup_id,
+        user_id=None,
+        external_user_group_id=None,
+        cc_pair_id=None,
+    )
+    cleanup_user__usergroup_relationships(
+        db_session, usergroup_id=usergroup_id, user_group_id=None, user_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_searchdoc_deletion(
+    db_session: Session, searchdoc_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for SearchDoc deletion."""
+    cleanup_chatmessage__searchdoc_relationships(
+        db_session, searchdoc_id=searchdoc_id, chat_message_id=None, search_doc_id=None
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_tool_deletion(
+    db_session: Session, tool_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for Tool deletion."""
+    cleanup_persona__tool_relationships(db_session, tool_id=tool_id, persona_id=None)
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_connectorcredentialpair_deletion(
+    db_session: Session, connectorcredentialpair_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for ConnectorCredentialPair deletion."""
+    cleanup_documentset__connectorcredentialpair_relationships(
+        db_session,
+        connectorcredentialpair_id=connectorcredentialpair_id,
+        document_set_id=None,
+        connector_credential_pair_id=None,
+    )
+    cleanup_usergroup__connectorcredentialpair_relationships(
+        db_session,
+        connectorcredentialpair_id=connectorcredentialpair_id,
+        user_group_id=None,
+        cc_pair_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_externalusergroupid_deletion(
+    db_session: Session, externalusergroupid_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for ExternalUserGroupId deletion."""
+    cleanup_user__externalusergroupid_relationships(
+        db_session,
+        externalusergroupid_id=externalusergroupid_id,
+        user_id=None,
+        external_user_group_id=None,
+        cc_pair_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_tokenratelimit_deletion(
+    db_session: Session, tokenratelimit_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for TokenRateLimit deletion."""
+    cleanup_tokenratelimit__usergroup_relationships(
+        db_session,
+        tokenratelimit_id=tokenratelimit_id,
+        rate_limit_id=None,
+        user_group_id=None,
+    )
+
+    if commit:
+        db_session.commit()
+
+
+def cleanup_relationships_for_documentset_deletion(
+    db_session: Session, documentset_id: int, commit: bool = False
+) -> None:
+    """Cleanup all relationships for DocumentSet deletion."""
+    cleanup_documentset__connectorcredentialpair_relationships(
+        db_session,
+        documentset_id=documentset_id,
+        document_set_id=None,
+        connector_credential_pair_id=None,
+    )
+    cleanup_documentset__user_relationships(
+        db_session, documentset_id=documentset_id, document_set_id=None, user_id=None
+    )
+    cleanup_documentset__usergroup_relationships(
+        db_session,
+        documentset_id=documentset_id,
+        document_set_id=None,
+        user_group_id=None,
+    )
+    cleanup_persona__documentset_relationships(
+        db_session, documentset_id=documentset_id, persona_id=None, document_set_id=None
+    )
+
+    if commit:
+        db_session.commit()

--- a/backend/scripts/generate_relationship_cleanup_functions.py
+++ b/backend/scripts/generate_relationship_cleanup_functions.py
@@ -1,0 +1,153 @@
+import inspect
+import os
+import re
+import sys
+
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_TARGET_DIRECTORY = os.path.join(_SCRIPT_DIR, "..", "danswer", "db")
+_OUTPUT_FILE = os.path.join(_TARGET_DIRECTORY, "relationship_cleanup.py")
+
+_RELATIONSHIP_CLEANUP_FUNC_NAME_TEMPLATE = "cleanup_{}_relationships"
+
+
+def generate_relationship_cleanup_functions() -> None:
+    # Define the regex pattern
+    pattern = r"class\s+\w+__\w+"
+
+    # Get all classes from the models module
+    all_classes = [
+        obj
+        for name, obj in inspect.getmembers(sys.modules[__name__])
+        if inspect.isclass(obj)
+    ]
+
+    # Filter classes based on the regex pattern
+    matching_classes = [
+        cls for cls in all_classes if re.match(pattern, f"class {cls.__name__}")
+    ]
+
+    # Generate imports for matching classes
+    imports = "from sqlalchemy.orm import Session\n"
+    imports += "from danswer.db.models import "
+    imports += "\nfrom danswer.db.models import ".join(
+        f"{cls.__name__}" for cls in matching_classes
+    )
+
+    output = imports + "\n"
+
+    # Generate cleanup functions
+    for cls in matching_classes:
+        class_name = cls.__name__
+        table_name = class_name.lower()
+
+        # Inspect class variables to find id fields
+        id_fields = [var for var in vars(cls) if var.endswith("_id")]
+
+        # Pretty print class and fields
+        print(f"\nClass: {class_name}")
+        print(f"\tFields: {id_fields}")
+
+        if len(id_fields) < 2:
+            print(f"Relationship table {class_name} has less than 2 found id fields")
+            print(
+                "For this script to work, name id fields with the 'id' somewhere in the name"
+            )
+            raise
+
+        function_name = _RELATIONSHIP_CLEANUP_FUNC_NAME_TEMPLATE.format(table_name)
+
+        # Generate function signature
+        signature = f"def {function_name}(\n    db_session: Session,\n"
+        signature += ",\n".join(
+            f"    {field}: int | None = None" for field in id_fields
+        )
+        signature += ",\n    commit: bool = False\n) -> None:"
+
+        # Generate function body
+        body = f'    """Cleanup {class_name} relationships."""\n'
+        body += f"    query = db_session.query({class_name})\n\n"
+
+        # Add check for all None inputs
+        body += "\n    if all(param is None for param in ["
+        body += ", ".join(id_fields)
+        body += "]):\n"
+        body += (
+            '        raise ValueError("At least one parameter must be provided.")\n\n'
+        )
+
+        for field in id_fields:
+            body += f"    if {field}:\n"
+            body += f"        query = query.where({class_name}.{field} == {field})\n"
+
+        body += "\n    query.delete(synchronize_session=False)\n\n"
+        body += "    if commit:\n"
+        body += "        db_session.commit()\n"
+
+        # Combine signature and body
+        output += f"\n{signature}\n{body}\n"
+
+    os.makedirs(os.path.dirname(_OUTPUT_FILE), exist_ok=True)
+    with open(_OUTPUT_FILE, "w") as f:
+        f.write(output)
+
+    print(f"Generated cleanup functions in {_OUTPUT_FILE}")
+
+
+def generate_functions_for_object_deletion() -> None:
+    pattern = r"class\s+\w+__\w+"
+    all_classes = [
+        obj
+        for name, obj in inspect.getmembers(sys.modules[__name__])
+        if inspect.isclass(obj)
+    ]
+    matching_classes = [
+        cls for cls in all_classes if re.match(pattern, f"class {cls.__name__}")
+    ]
+
+    object_names = set()
+    for cls in matching_classes:
+        object_names.update(cls.__name__.split("__"))
+
+    with open(_OUTPUT_FILE, "a") as f:
+        for object_name in object_names:
+            function_name = f"cleanup_relationships_for_{object_name.lower()}_deletion"
+
+            f.write(
+                f"\n\ndef {function_name}(db_session: Session, {object_name.lower()}_id: int, commit: bool = False) -> None:\n"
+            )
+            f.write(
+                f'    """Cleanup all relationships for {object_name} deletion."""\n'
+            )
+
+            for cls in matching_classes:
+                if object_name in cls.__name__:
+                    relationship_function = (
+                        _RELATIONSHIP_CLEANUP_FUNC_NAME_TEMPLATE.format(
+                            cls.__name__.lower()
+                        )
+                    )
+                    id_param = f"{object_name.lower()}_id"
+                    other_params = ", ".join(
+                        [
+                            f"{field}=None"
+                            for field in vars(cls)
+                            if field.endswith("_id")
+                            and not field.startswith(f"{object_name.lower()}_")
+                        ]
+                    )
+                    f.write(
+                        f"    {relationship_function}(db_session, {id_param}={id_param}, {other_params})\n"
+                    )
+
+            f.write("\n    if commit:\n")
+            f.write("        db_session.commit()\n")
+
+        f.write("\n")  # Add an empty line at the end of the file
+
+    print(f"Generated object deletion cleanup functions in {_OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    generate_relationship_cleanup_functions()
+    generate_functions_for_object_deletion()


### PR DESCRIPTION
## Description
There is discussion to be had if this is useful. I feel like efforts to ensure that all foreignkey relationships are deleted before deleting objects is very error prone as well as duplicated for each object. this provides a centralized code location to perform these actions

There is an argument to be made that we should just switch to cascade. Thats fine, this pr took like 15 minutes
