### PR TITLE
get document title from custom header

### DIFF
--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -299,11 +299,13 @@ class WebConnector(LoadConnector):
                     page_text, metadata = read_pdf_file(
                         file=io.BytesIO(response.content)
                     )
+                    document_title = response.headers.get("X-Danswer-Document-Title")
                     last_modified = response.headers.get("Last-Modified")
 
                     doc_batch.append(
                         Document(
                             id=current_url,
+                            title=document_title,
                             sections=[Section(link=current_url, text=page_text)],
                             source=DocumentSource.WEB,
                             semantic_identifier=current_url.split("/")[-1],
@@ -319,6 +321,7 @@ class WebConnector(LoadConnector):
 
                 page = context.new_page()
                 page_response = page.goto(current_url)
+                document_title = page_response.header_value("X-Danswer-Document-Title")
                 last_modified = (
                     page_response.header_value("Last-Modified")
                     if page_response
@@ -353,6 +356,7 @@ class WebConnector(LoadConnector):
                 doc_batch.append(
                     Document(
                         id=current_url,
+                        title=document_title,
                         sections=[
                             Section(link=current_url, text=parsed_html.cleaned_text)
                         ],

--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -307,7 +307,6 @@ class WebConnector(LoadConnector):
                     doc_batch.append(
                         Document(
                             id=current_url,
-                            title=document_title or current_url.split("/")[-1],
                             sections=[Section(link=current_url, text=page_text)],
                             source=DocumentSource.WEB,
                             semantic_identifier=current_url.split("/")[-1],
@@ -362,7 +361,6 @@ class WebConnector(LoadConnector):
                 doc_batch.append(
                     Document(
                         id=current_url,
-                        title=document_title or parsed_html.title or current_url,
                         sections=[
                             Section(link=current_url, text=parsed_html.cleaned_text)
                         ],

--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -307,7 +307,7 @@ class WebConnector(LoadConnector):
                     doc_batch.append(
                         Document(
                             id=current_url,
-                            title=document_title,
+                            title=document_title or current_url.split("/")[-1],
                             sections=[Section(link=current_url, text=page_text)],
                             source=DocumentSource.WEB,
                             semantic_identifier=current_url.split("/")[-1],
@@ -362,7 +362,7 @@ class WebConnector(LoadConnector):
                 doc_batch.append(
                     Document(
                         id=current_url,
-                        title=document_title,
+                        title=document_title or parsed_html.title or current_url,
                         sections=[
                             Section(link=current_url, text=parsed_html.cleaned_text)
                         ],

--- a/backend/danswer/connectors/web/connector.py
+++ b/backend/danswer/connectors/web/connector.py
@@ -301,6 +301,8 @@ class WebConnector(LoadConnector):
                     )
                     document_title = response.headers.get("X-Danswer-Document-Title")
                     last_modified = response.headers.get("Last-Modified")
+                    if document_title:
+                        metadata["title"] = document_title
 
                     doc_batch.append(
                         Document(
@@ -353,6 +355,10 @@ class WebConnector(LoadConnector):
 
                 parsed_html = web_html_cleanup(soup, self.mintlify_cleanup)
 
+                metadata = {}
+                if document_title:
+                    metadata["title"] = document_title
+
                 doc_batch.append(
                     Document(
                         id=current_url,
@@ -362,7 +368,7 @@ class WebConnector(LoadConnector):
                         ],
                         source=DocumentSource.WEB,
                         semantic_identifier=parsed_html.title or current_url,
-                        metadata={},
+                        metadata=metadata,
                         doc_updated_at=_get_datetime_from_last_modified_header(
                             last_modified
                         )


### PR DESCRIPTION
## Description
This allows to create a custom HTTP header to control the document title explicitly.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk
[Any know risks or failure modes to point out to reviewers]


## Related Issue(s)
[If applicable, link to the issue(s) this PR addresses]


## Checklist:
- [ ] All of the automated tests pass
- [ ] All PR comments are addressed and marked resolved
- [ ] If there are migrations, they have been rebased to latest main
- [ ] If there are new dependencies, they are added to the requirements
- [ ] If there are new environment variables, they are added to all of the deployment methods
- [ ] If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- [ ] Docker images build and basic functionalities work
- [ ] Author has done a final read through of the PR right before merge
