### PR TITLE
Slack Reenable /danswer command for DM

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_message.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_message.py
@@ -205,6 +205,14 @@ def handle_message(
                 text="The DanswerBot slash command is not enabled for this channel",
                 thread_ts=None,
             )
+            return False
+
+    if is_bot_msg:
+        if not sender_id:
+            logger.error("No sender id found for Slack slash command, nobody to DM to.")
+            return False
+
+        send_to = [sender_id]
 
     try:
         send_msg_ack_to_user(message_info, client)

--- a/backend/danswer/danswerbot/slack/listener.py
+++ b/backend/danswer/danswerbot/slack/listener.py
@@ -710,6 +710,9 @@ def process_slack_event(client: TenantSocketModeClient, req: SocketModeRequest) 
             elif req.payload.get("type") == "view_submission":
                 return view_routing(req, client)
         elif req.type == "events_api" or req.type == "slash_commands":
+            # Note to developers:
+            # If you see dispatch_failed, it could be because of a conflict in the slash command
+            # as in more than 1 app is trying to use that one.
             return process_message(req, client)
     except Exception as e:
         logger.exception(f"Failed to process slack event. Error: {e}")


### PR DESCRIPTION
## Description
User noticed that the /danswer command was replying to everyone in the channel but the promised functionality is that slash commands are to be responded to only to the user who sent it.


## How Has This Been Tested?
Tested it in DanswerInternal and testing the usual Slack flows


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
