### PR TITLE
Fix the URL to add new slackbot configuration

### DIFF
--- a/web/src/app/admin/bots/[bot-id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/page.tsx
@@ -95,7 +95,7 @@ function SlackBotEditPage({
           text-sm
           w-80
         "
-        href={`/admin/bots/new?slack_bot_id=${unwrappedParams["bot-id"]}`}
+        href={`/admin/bots/${unwrappedParams["bot-id"]}/channels/new`}
       >
         <div className="mx-auto flex">
           <FiPlusSquare className="my-auto mr-2" />


### PR DESCRIPTION
## Description
Fix the URL that points to the "New Slack Channel Configuration" in the Slackbot page


## How Has This Been Tested?
Locally



## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [x] This PR should be backported (make sure to check that the backport attempt succeeds)
