### PR TITLE
Speed up integration tests

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -18,8 +18,7 @@ env:
   CONFLUENCE_ACCESS_TOKEN: ${{ secrets.CONFLUENCE_ACCESS_TOKEN }}
   
 jobs:
-  integration-tests:
-    # See https://runs-on.com/runners/linux/
+  build-docker-images:
     runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
     steps:
       - name: Checkout code
@@ -88,6 +87,16 @@ jobs:
           cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
+    outputs:
+      images_built: true
+
+  multi-tenant-tests:
+    needs: build-docker-images
+    runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       # Start containers for multi-tenant tests
       - name: Start Docker containers for multi-tenant tests
         run: |
@@ -99,12 +108,10 @@ jobs:
           DISABLE_TELEMETRY=true \
           IMAGE_TAG=test \
           docker compose -f docker-compose.dev.yml -p danswer-stack up -d
-        id: start_docker_multi_tenant
 
-      # In practice, `cloud` Auth type would require OAUTH credentials to be set.
       - name: Run Multi-Tenant Integration Tests
         run: |
-          echo "Running integration tests..."
+          echo "Running multi-tenant integration tests..."
           docker run --rm --network danswer-stack_default \
             --name test-runner \
             -e POSTGRES_HOST=relational_db \
@@ -121,23 +128,19 @@ jobs:
             -e MULTI_TENANT=true \
             danswer/danswer-integration:test \
             /app/tests/integration/multitenant_tests
-        continue-on-error: true
-        id: run_multitenant_tests
-
-      - name: Check multi-tenant test results
-        run: |
-          if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
-            echo "Integration tests failed. Exiting with error."
-            exit 1
-          else
-            echo "All integration tests passed successfully."
-          fi 
 
       - name: Stop multi-tenant Docker containers
+        if: always()
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.dev.yml -p danswer-stack down -v
 
+  standard-tests:
+    needs: build-docker-images
+    runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Start Docker containers 
         run: |
@@ -148,7 +151,6 @@ jobs:
           DISABLE_TELEMETRY=true \
           IMAGE_TAG=test \
           docker compose -f docker-compose.dev.yml -p danswer-stack up -d
-        id: start_docker
 
       - name: Wait for service to be ready
         run: |
@@ -186,7 +188,7 @@ jobs:
 
       - name: Run Standard Integration Tests
         run: |
-          echo "Running integration tests..."
+          echo "Running standard integration tests..."
           docker run --rm --network danswer-stack_default \
             --name test-runner \
             -e POSTGRES_HOST=relational_db \
@@ -205,39 +207,23 @@ jobs:
             danswer/danswer-integration:test \
             /app/tests/integration/tests \
             /app/tests/integration/connector_job_tests
-        continue-on-error: true
-        id: run_tests
 
-      - name: Check test results
+      - name: Stop Docker containers
+        if: always()
         run: |
-          if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
-            echo "Integration tests failed. Exiting with error."
-            exit 1
-          else
-            echo "All integration tests passed successfully."
-          fi
+          cd deployment/docker_compose
+          docker compose -f docker-compose.dev.yml -p danswer-stack down -v
 
-      # save before stopping the containers so the logs can be captured
       - name: Save Docker logs
-        if: success() || failure()
+        if: always()
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.dev.yml -p danswer-stack logs > docker-compose.log
           mv docker-compose.log ${{ github.workspace }}/docker-compose.log
 
-      - name: Stop Docker containers
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.dev.yml -p danswer-stack down -v
-      
       - name: Upload logs
-        if: success() || failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: docker-logs
           path: ${{ github.workspace }}/docker-compose.log
-
-      - name: Stop Docker containers
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.dev.yml -p danswer-stack down -v

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -189,7 +189,7 @@ jobs:
         run: |
           # Run docker command to list all test modules and format as JSON array
           modules=$(docker run --rm danswer/danswer-integration:test \
-            /bin/bash -c "find /app/tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print" | \
+            find /app/tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print | \
             jq -R -s 'split("\n")[:-1] | map(select(length > 0))')
           
           # Check if modules array is empty
@@ -199,7 +199,7 @@ jobs:
           fi
           
           # Correctly format the modules as a JSON string for GitHub Actions
-          echo "modules=${modules}" >> $GITHUB_ENV
+          echo "modules=$modules" >> $GITHUB_OUTPUT
           
           # Print the modules for verification
           echo "Found the following test modules:"
@@ -207,9 +207,11 @@ jobs:
 
       - name: Run Integration Tests in Parallel
         uses: actions/github-script@v7
+        env:
+          MODULES: ${{ steps.get-modules.outputs.modules }}
         with:
           script: |
-            const modules = ${{ steps.get-modules.outputs.modules }};
+            const modules = JSON.parse(process.env.MODULES);
             const batchSize = 4; // Run 4 tests in parallel
             
             for (let i = 0; i < modules.length; i += batchSize) {

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -188,7 +188,10 @@ jobs:
         id: get-modules
         run: |
           # Run docker command to list all test modules and format as JSON array
-          modules=$(docker run --rm danswer/danswer-integration:test find /app/tests/integration -type f -name "test_*.py" -o -name "*_test.py" | jq -R -s -c 'split("\n")[:-1]')
+          modules=$(docker run --rm danswer/danswer-integration:test \
+            find /app/tests/integration -type f \( -name "test_*.py" -o -name "*_test.py" \) -print0 | \
+            xargs -0 basename -a | \
+            jq -R -s 'split("\n")[:-1] | map("/app/tests/integration/" + .)')
           echo "modules=$modules" >> $GITHUB_OUTPUT
 
       - name: Run Integration Tests in Parallel

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKER_USERNAME }}
-      #     password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       # # tag every docker image with "test" so that we can spin up the correct set
       # # of images during testing
@@ -76,17 +76,17 @@ jobs:
       #     cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
       #     cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
       
-      # - name: Build integration test Docker image
-      #   uses: ./.github/actions/custom-build-and-push
-      #   with:
-      #     context: ./backend
-      #     file: ./backend/tests/integration/Dockerfile
-      #     platforms: linux/amd64
-      #     tags: danswer/danswer-integration:test
-      #     push: false
-      #     load: true
-      #     cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-      #     cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+      - name: Build integration test Docker image
+        uses: ./.github/actions/custom-build-and-push
+        with:
+          context: ./backend
+          file: ./backend/tests/integration/Dockerfile
+          platforms: linux/amd64
+          tags: danswer/danswer-integration:test
+          push: false
+          load: true
+          cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
+          cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
       # # Start containers for multi-tenant tests
       # - name: Start Docker containers for multi-tenant tests

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -25,164 +25,164 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_TOKEN }}
 
-      # tag every docker image with "test" so that we can spin up the correct set
-      # of images during testing
+      # # tag every docker image with "test" so that we can spin up the correct set
+      # # of images during testing
       
-      # We don't need to build the Web Docker image since it's not yet used
-      # in the integration tests. We have a separate action to verify that it builds 
-      # successfully.
-      - name: Pull Web Docker image
-        run: |
-          docker pull danswer/danswer-web-server:latest
-          docker tag danswer/danswer-web-server:latest danswer/danswer-web-server:test
+      # # We don't need to build the Web Docker image since it's not yet used
+      # # in the integration tests. We have a separate action to verify that it builds 
+      # # successfully.
+      # - name: Pull Web Docker image
+      #   run: |
+      #     docker pull danswer/danswer-web-server:latest
+      #     docker tag danswer/danswer-web-server:latest danswer/danswer-web-server:test
 
-      # we use the runs-on cache for docker builds
-      # in conjunction with runs-on runners, it has better speed and unlimited caching
-      # https://runs-on.com/caching/s3-cache-for-github-actions/
-      # https://runs-on.com/caching/docker/
-      # https://github.com/moby/buildkit#s3-cache-experimental
+      # # we use the runs-on cache for docker builds
+      # # in conjunction with runs-on runners, it has better speed and unlimited caching
+      # # https://runs-on.com/caching/s3-cache-for-github-actions/
+      # # https://runs-on.com/caching/docker/
+      # # https://github.com/moby/buildkit#s3-cache-experimental
       
-      # images are built and run locally for testing purposes. Not pushed.
-      - name: Build Backend Docker image
-        uses: ./.github/actions/custom-build-and-push
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          platforms: linux/amd64
-          tags: danswer/danswer-backend:test
-          push: false
-          load: true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/backend/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/backend/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+      # # images are built and run locally for testing purposes. Not pushed.
+      # - name: Build Backend Docker image
+      #   uses: ./.github/actions/custom-build-and-push
+      #   with:
+      #     context: ./backend
+      #     file: ./backend/Dockerfile
+      #     platforms: linux/amd64
+      #     tags: danswer/danswer-backend:test
+      #     push: false
+      #     load: true
+      #     cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/backend/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
+      #     cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/backend/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
-      - name: Build Model Server Docker image
-        uses: ./.github/actions/custom-build-and-push
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile.model_server
-          platforms: linux/amd64
-          tags: danswer/danswer-model-server:test
-          push: false
-          load: true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+      # - name: Build Model Server Docker image
+      #   uses: ./.github/actions/custom-build-and-push
+      #   with:
+      #     context: ./backend
+      #     file: ./backend/Dockerfile.model_server
+      #     platforms: linux/amd64
+      #     tags: danswer/danswer-model-server:test
+      #     push: false
+      #     load: true
+      #     cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
+      #     cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/model-server/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
       
-      - name: Build integration test Docker image
-        uses: ./.github/actions/custom-build-and-push
-        with:
-          context: ./backend
-          file: ./backend/tests/integration/Dockerfile
-          platforms: linux/amd64
-          tags: danswer/danswer-integration:test
-          push: false
-          load: true
-          cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
-          cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
+      # - name: Build integration test Docker image
+      #   uses: ./.github/actions/custom-build-and-push
+      #   with:
+      #     context: ./backend
+      #     file: ./backend/tests/integration/Dockerfile
+      #     platforms: linux/amd64
+      #     tags: danswer/danswer-integration:test
+      #     push: false
+      #     load: true
+      #     cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
+      #     cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
-      # Start containers for multi-tenant tests
-      - name: Start Docker containers for multi-tenant tests
-        run: |
-          cd deployment/docker_compose
-          ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
-          MULTI_TENANT=true \
-          AUTH_TYPE=basic \
-          REQUIRE_EMAIL_VERIFICATION=false \
-          DISABLE_TELEMETRY=true \
-          IMAGE_TAG=test \
-          docker compose -f docker-compose.dev.yml -p danswer-stack up -d
-        id: start_docker_multi_tenant
+      # # Start containers for multi-tenant tests
+      # - name: Start Docker containers for multi-tenant tests
+      #   run: |
+      #     cd deployment/docker_compose
+      #     ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
+      #     MULTI_TENANT=true \
+      #     AUTH_TYPE=basic \
+      #     REQUIRE_EMAIL_VERIFICATION=false \
+      #     DISABLE_TELEMETRY=true \
+      #     IMAGE_TAG=test \
+      #     docker compose -f docker-compose.dev.yml -p danswer-stack up -d
+      #   id: start_docker_multi_tenant
 
-      # In practice, `cloud` Auth type would require OAUTH credentials to be set.
-      - name: Run Multi-Tenant Integration Tests
-        run: |
-          echo "Running integration tests..."
-          docker run --rm --network danswer-stack_default \
-            --name test-runner \
-            -e POSTGRES_HOST=relational_db \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -e POSTGRES_DB=postgres \
-            -e VESPA_HOST=index \
-            -e REDIS_HOST=cache \
-            -e API_SERVER_HOST=api_server \
-            -e OPENAI_API_KEY=${OPENAI_API_KEY} \
-            -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
-            -e TEST_WEB_HOSTNAME=test-runner \
-            -e AUTH_TYPE=cloud \
-            -e MULTI_TENANT=true \
-            danswer/danswer-integration:test \
-            /app/tests/integration/multitenant_tests
-        continue-on-error: true
-        id: run_multitenant_tests
+      # # In practice, `cloud` Auth type would require OAUTH credentials to be set.
+      # - name: Run Multi-Tenant Integration Tests
+      #   run: |
+      #     echo "Running integration tests..."
+      #     docker run --rm --network danswer-stack_default \
+      #       --name test-runner \
+      #       -e POSTGRES_HOST=relational_db \
+      #       -e POSTGRES_USER=postgres \
+      #       -e POSTGRES_PASSWORD=password \
+      #       -e POSTGRES_DB=postgres \
+      #       -e VESPA_HOST=index \
+      #       -e REDIS_HOST=cache \
+      #       -e API_SERVER_HOST=api_server \
+      #       -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+      #       -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
+      #       -e TEST_WEB_HOSTNAME=test-runner \
+      #       -e AUTH_TYPE=cloud \
+      #       -e MULTI_TENANT=true \
+      #       danswer/danswer-integration:test \
+      #       /app/tests/integration/multitenant_tests
+      #   continue-on-error: true
+      #   id: run_multitenant_tests
 
-      - name: Check multi-tenant test results
-        run: |
-          if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
-            echo "Integration tests failed. Exiting with error."
-            exit 1
-          else
-            echo "All integration tests passed successfully."
-          fi 
+      # - name: Check multi-tenant test results
+      #   run: |
+      #     if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
+      #       echo "Integration tests failed. Exiting with error."
+      #       exit 1
+      #     else
+      #       echo "All integration tests passed successfully."
+      #     fi 
 
-      - name: Stop multi-tenant Docker containers
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.dev.yml -p danswer-stack down -v
+      # - name: Stop multi-tenant Docker containers
+      #   run: |
+      #     cd deployment/docker_compose
+      #     docker compose -f docker-compose.dev.yml -p danswer-stack down -v
 
 
-      - name: Start Docker containers 
-        run: |
-          cd deployment/docker_compose
-          ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
-          AUTH_TYPE=basic \
-          REQUIRE_EMAIL_VERIFICATION=false \
-          DISABLE_TELEMETRY=true \
-          IMAGE_TAG=test \
-          docker compose -f docker-compose.dev.yml -p danswer-stack up -d
-        id: start_docker
+      # - name: Start Docker containers 
+      #   run: |
+      #     cd deployment/docker_compose
+      #     ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
+      #     AUTH_TYPE=basic \
+      #     REQUIRE_EMAIL_VERIFICATION=false \
+      #     DISABLE_TELEMETRY=true \
+      #     IMAGE_TAG=test \
+      #     docker compose -f docker-compose.dev.yml -p danswer-stack up -d
+      #   id: start_docker
 
-      - name: Wait for service to be ready
-        run: |
-          echo "Starting wait-for-service script..."
+      # - name: Wait for service to be ready
+      #   run: |
+      #     echo "Starting wait-for-service script..."
           
-          docker logs -f danswer-stack-api_server-1 &
+      #     docker logs -f danswer-stack-api_server-1 &
 
-          start_time=$(date +%s)
-          timeout=300  # 5 minutes in seconds
+      #     start_time=$(date +%s)
+      #     timeout=300  # 5 minutes in seconds
           
-          while true; do
-            current_time=$(date +%s)
-            elapsed_time=$((current_time - start_time))
+      #     while true; do
+      #       current_time=$(date +%s)
+      #       elapsed_time=$((current_time - start_time))
             
-            if [ $elapsed_time -ge $timeout ]; then
-              echo "Timeout reached. Service did not become ready in 5 minutes."
-              exit 1
-            fi
+      #       if [ $elapsed_time -ge $timeout ]; then
+      #         echo "Timeout reached. Service did not become ready in 5 minutes."
+      #         exit 1
+      #       fi
             
-            # Use curl with error handling to ignore specific exit code 56
-            response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "curl_error")
+      #       # Use curl with error handling to ignore specific exit code 56
+      #       response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "curl_error")
             
-            if [ "$response" = "200" ]; then
-              echo "Service is ready!"
-              break
-            elif [ "$response" = "curl_error" ]; then
-              echo "Curl encountered an error, possibly exit code 56. Continuing to retry..."
-            else
-              echo "Service not ready yet (HTTP status $response). Retrying in 5 seconds..."
-            fi
+      #       if [ "$response" = "200" ]; then
+      #         echo "Service is ready!"
+      #         break
+      #       elif [ "$response" = "curl_error" ]; then
+      #         echo "Curl encountered an error, possibly exit code 56. Continuing to retry..."
+      #       else
+      #         echo "Service not ready yet (HTTP status $response). Retrying in 5 seconds..."
+      #       fi
             
-            sleep 5
-          done
-          echo "Finished waiting for service."
+      #       sleep 5
+      #     done
+      #     echo "Finished waiting for service."
 
       - name: Get test modules
         id: get-modules
@@ -190,9 +190,20 @@ jobs:
           # Run docker command to list all test modules and format as JSON array
           modules=$(docker run --rm danswer/danswer-integration:test \
             find /app/tests/integration -type f \( -name "test_*.py" -o -name "*_test.py" \) -print0 | \
-            xargs -0 basename -a | \
+            xargs -0 -n1 basename | \
             jq -R -s 'split("\n")[:-1] | map("/app/tests/integration/" + .)')
+          
+          # Check if modules array is empty
+          if [ "$(echo $modules | jq 'length')" -eq 0 ]; then
+            echo "Error: No test modules found!"
+            exit 1
+          fi
+          
           echo "modules=$modules" >> $GITHUB_OUTPUT
+          
+          # Print the modules for verification
+          echo "Found the following test modules:"
+          echo "$modules" | jq .
 
       - name: Run Integration Tests in Parallel
         uses: actions/github-script@v7

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -18,7 +18,8 @@ env:
   CONFLUENCE_ACCESS_TOKEN: ${{ secrets.CONFLUENCE_ACCESS_TOKEN }}
   
 jobs:
-  build-docker-images:
+  integration-tests:
+    # See https://runs-on.com/runners/linux/
     runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
     steps:
       - name: Checkout code
@@ -87,16 +88,6 @@ jobs:
           cache-from: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }}
           cache-to: type=s3,prefix=cache/${{ github.repository }}/integration-tests/integration/,region=${{ env.RUNS_ON_AWS_REGION }},bucket=${{ env.RUNS_ON_S3_BUCKET_CACHE }},mode=max
 
-    outputs:
-      images_built: true
-
-  multi-tenant-tests:
-    needs: build-docker-images
-    runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       # Start containers for multi-tenant tests
       - name: Start Docker containers for multi-tenant tests
         run: |
@@ -108,10 +99,12 @@ jobs:
           DISABLE_TELEMETRY=true \
           IMAGE_TAG=test \
           docker compose -f docker-compose.dev.yml -p danswer-stack up -d
+        id: start_docker_multi_tenant
 
+      # In practice, `cloud` Auth type would require OAUTH credentials to be set.
       - name: Run Multi-Tenant Integration Tests
         run: |
-          echo "Running multi-tenant integration tests..."
+          echo "Running integration tests..."
           docker run --rm --network danswer-stack_default \
             --name test-runner \
             -e POSTGRES_HOST=relational_db \
@@ -128,19 +121,23 @@ jobs:
             -e MULTI_TENANT=true \
             danswer/danswer-integration:test \
             /app/tests/integration/multitenant_tests
+        continue-on-error: true
+        id: run_multitenant_tests
+
+      - name: Check multi-tenant test results
+        run: |
+          if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
+            echo "Integration tests failed. Exiting with error."
+            exit 1
+          else
+            echo "All integration tests passed successfully."
+          fi 
 
       - name: Stop multi-tenant Docker containers
-        if: always()
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.dev.yml -p danswer-stack down -v
 
-  standard-tests:
-    needs: build-docker-images
-    runs-on: [runs-on,runner=8cpu-linux-x64,ram=16,"run-id=${{ github.run_id }}"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
       - name: Start Docker containers 
         run: |
@@ -151,6 +148,7 @@ jobs:
           DISABLE_TELEMETRY=true \
           IMAGE_TAG=test \
           docker compose -f docker-compose.dev.yml -p danswer-stack up -d
+        id: start_docker
 
       - name: Wait for service to be ready
         run: |
@@ -186,44 +184,102 @@ jobs:
           done
           echo "Finished waiting for service."
 
-      - name: Run Standard Integration Tests
+      - name: Get test modules
+        id: get-modules
         run: |
-          echo "Running standard integration tests..."
-          docker run --rm --network danswer-stack_default \
-            --name test-runner \
-            -e POSTGRES_HOST=relational_db \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -e POSTGRES_DB=postgres \
-            -e VESPA_HOST=index \
-            -e REDIS_HOST=cache \
-            -e API_SERVER_HOST=api_server \
-            -e OPENAI_API_KEY=${OPENAI_API_KEY} \
-            -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
-            -e CONFLUENCE_TEST_SPACE_URL=${CONFLUENCE_TEST_SPACE_URL} \
-            -e CONFLUENCE_USER_NAME=${CONFLUENCE_USER_NAME} \
-            -e CONFLUENCE_ACCESS_TOKEN=${CONFLUENCE_ACCESS_TOKEN} \
-            -e TEST_WEB_HOSTNAME=test-runner \
-            danswer/danswer-integration:test \
-            /app/tests/integration/tests \
-            /app/tests/integration/connector_job_tests
+          # Run docker command to list all test modules and format as JSON array
+          modules=$(docker run --rm danswer/danswer-integration:test find /app/tests/integration -type f -name "test_*.py" -o -name "*_test.py" | jq -R -s -c 'split("\n")[:-1]')
+          echo "modules=$modules" >> $GITHUB_OUTPUT
 
-      - name: Stop Docker containers
-        if: always()
+      - name: Run Integration Tests in Parallel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const modules = ${{ steps.get-modules.outputs.modules }};
+            const batchSize = 4; // Run 4 tests in parallel
+            
+            for (let i = 0; i < modules.length; i += batchSize) {
+              const batch = modules.slice(i, i + batchSize);
+              const promises = batch.map(module => {
+                const command = `
+                  docker run --rm --network danswer-stack_default \\
+                    --name test-runner-${i} \\
+                    -e POSTGRES_HOST=relational_db \\
+                    -e POSTGRES_USER=postgres \\
+                    -e POSTGRES_PASSWORD=password \\
+                    -e POSTGRES_DB=postgres \\
+                    -e VESPA_HOST=index \\
+                    -e REDIS_HOST=cache \\
+                    -e API_SERVER_HOST=api_server \\
+                    -e OPENAI_API_KEY=${process.env.OPENAI_API_KEY} \\
+                    -e SLACK_BOT_TOKEN=${process.env.SLACK_BOT_TOKEN} \\
+                    -e CONFLUENCE_TEST_SPACE_URL=${process.env.CONFLUENCE_TEST_SPACE_URL} \\
+                    -e CONFLUENCE_USER_NAME=${process.env.CONFLUENCE_USER_NAME} \\
+                    -e CONFLUENCE_ACCESS_TOKEN=${process.env.CONFLUENCE_ACCESS_TOKEN} \\
+                    -e TEST_WEB_HOSTNAME=test-runner-${i} \\
+                    danswer/danswer-integration:test \\
+                    "${module}"
+                `;
+                
+                return new Promise((resolve, reject) => {
+                  const exec = require('child_process').exec;
+                  console.log(`Running tests for module: ${module}`);
+                  
+                  exec(command, (error, stdout, stderr) => {
+                    console.log(`Output for ${module}:`);
+                    console.log(stdout);
+                    if (stderr) console.error(stderr);
+                    
+                    if (error) {
+                      console.error(`Tests failed for module: ${module}`);
+                      reject(error);
+                    } else {
+                      console.log(`Tests passed for module: ${module}`);
+                      resolve();
+                    }
+                  });
+                });
+              });
+              
+              try {
+                await Promise.all(promises);
+              } catch (error) {
+                core.setFailed('One or more test modules failed');
+                throw error;
+              }
+            }
+        id: run_tests
+
+      - name: Check test results
         run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.dev.yml -p danswer-stack down -v
+          if [ ${{ steps.run_tests.outcome }} == 'failure' ]; then
+            echo "Integration tests failed. Exiting with error."
+            exit 1
+          else
+            echo "All integration tests passed successfully."
+          fi
 
+      # save before stopping the containers so the logs can be captured
       - name: Save Docker logs
-        if: always()
+        if: success() || failure()
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.dev.yml -p danswer-stack logs > docker-compose.log
           mv docker-compose.log ${{ github.workspace }}/docker-compose.log
 
+      - name: Stop Docker containers
+        run: |
+          cd deployment/docker_compose
+          docker compose -f docker-compose.dev.yml -p danswer-stack down -v
+      
       - name: Upload logs
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: docker-logs
           path: ${{ github.workspace }}/docker-compose.log
+
+      - name: Stop Docker containers
+        run: |
+          cd deployment/docker_compose
+          docker compose -f docker-compose.dev.yml -p danswer-stack down -v

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Run Integration Tests v2
+name: Run Integration Tests
 concurrency:
   group: Run-Integration-Tests-${{ github.workflow }}-${{ github.head_ref || github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: true
@@ -189,9 +189,8 @@ jobs:
         run: |
           # Run docker command to list all test modules and format as JSON array
           modules=$(docker run --rm danswer/danswer-integration:test \
-            find /app/tests/integration -type f \( -name "test_*.py" -o -name "*_test.py" \) -print0 | \
-            xargs -0 -n1 basename | \
-            jq -R -s 'split("\n")[:-1] | map("/app/tests/integration/" + .)')
+            /bin/bash -c "find /app/tests/integration -type f \( -name 'test_*.py' -o -name '*_test.py' \) -print" | \
+            jq -R -s 'split("\n")[:-1] | map(select(length > 0))')
           
           # Check if modules array is empty
           if [ "$(echo $modules | jq 'length')" -eq 0 ]; then

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -198,7 +198,8 @@ jobs:
             exit 1
           fi
           
-          echo "modules=$modules" >> $GITHUB_OUTPUT
+          # Correctly format the modules as a JSON string for GitHub Actions
+          echo "modules=${modules}" >> $GITHUB_ENV
           
           # Print the modules for verification
           echo "Found the following test modules:"


### PR DESCRIPTION
## Description
- parallelize integration tests to speed them up

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
