### PR TITLE
fix: remove linear API deprecated field

### DIFF
--- a/backend/danswer/connectors/linear/connector.py
+++ b/backend/danswer/connectors/linear/connector.py
@@ -132,7 +132,6 @@ class LinearConnector(LoadConnector, PollConnector):
                             branchName
                             customerTicketCount
                             description
-                            descriptionData
                             comments {
                                 nodes {
                                     url


### PR DESCRIPTION
## Description

Removing the `descriptionData` deprecated field from the linear API query, causing this [issue](https://github.com/danswer-ai/danswer/issues/3370). The field wasn't used so no other changes required.

## How Has This Been Tested?

By running a full successful indexing with the tweaked connector.
<img width="1243" alt="Screenshot 2024-12-08 at 13 33 09" src="https://github.com/user-attachments/assets/34e33e8a-a011-4e9d-9254-60a6ae438a6c">


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
