### PR TITLE
Fix intermittent Internet Search Tool key errors

### DIFF
--- a/backend/danswer/tools/tool_implementations/internet_search/internet_search_tool.py
+++ b/backend/danswer/tools/tool_implementations/internet_search/internet_search_tool.py
@@ -233,7 +233,7 @@ class InternetSearchTool(Tool):
         )
 
     def run(self, **kwargs: str) -> Generator[ToolResponse, None, None]:
-        query = cast(str, kwargs["internet_search_query"])
+        query = cast(str, kwargs["internet_search_query"]).strip('"')
 
         results = self._perform_search(query)
         yield ToolResponse(


### PR DESCRIPTION
## Description
When the internet search tool query generated by the LLM contains quotations, the Bing Search API does not return any search results, leading to the following error in Danswer:

```bash
  File "/app/danswer/tools/tool_implementations/internet_search/internet_search_tool.py", line 237, in run
    results = self._perform_search(query)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/danswer/tools/tool_implementations/internet_search/internet_search_tool.py", line 230, in _perform_search
    for result in results["webPages"]["value"][: self.num_results]
                  ~~~~~~~^^^^^^^^^^^^
KeyError: 'webPages'
```

This seems the most prevalent with our Llama model deployments, however it should still be reproducible by prompting any model to wrap its generated query in quotes.

## How Has This Been Tested?
Docker compose dev
Extensive prompting w/Llama 3.1 70b + Internet Search tool in UCSD dev/stage envs (Onyx 0.15.4)

## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
