### PR TITLE
Add better vertex support + LLM form cleanup

### DIFF
--- a/backend/danswer/llm/chat_llm.py
+++ b/backend/danswer/llm/chat_llm.py
@@ -268,12 +268,16 @@ class DefaultMultiLLM(LLM):
 
         # NOTE: have to set these as environment variables for Litellm since
         # not all are able to passed in but they always support them set as env
-        # variables
+        # variables. We'll also try passing them in, since litellm just ignores
+        # addtional kwargs (and some kwargs MUST be passed in rather than set as
+        # env variables)
         if custom_config:
             for k, v in custom_config.items():
                 os.environ[k] = v
 
         model_kwargs = model_kwargs or {}
+        if custom_config:
+            model_kwargs.update(custom_config)
         if extra_headers:
             model_kwargs.update({"extra_headers": extra_headers})
         if extra_body:

--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -275,8 +275,9 @@ export function CustomLLMProviderUpdateForm({
             <SubLabel>
               <>
                 <div>
-                  Additional configurations needed by the model provider. Are
-                  passed to litellm via environment variables.
+                  Additional configurations needed by the model provider. These
+                  are passed to litellm via environment + as arguments into the
+                  `completion` call.
                 </div>
 
                 <div className="mt-2">
@@ -290,14 +291,14 @@ export function CustomLLMProviderUpdateForm({
             <FieldArray
               name="custom_config_list"
               render={(arrayHelpers: ArrayHelpers<any[]>) => (
-                <div>
+                <div className="w-full">
                   {formikProps.values.custom_config_list.map((_, index) => {
                     return (
                       <div
                         key={index}
-                        className={index === 0 ? "mt-2" : "mt-6"}
+                        className={(index === 0 ? "mt-2" : "mt-6") + " w-full"}
                       >
-                        <div className="flex">
+                        <div className="flex w-full">
                           <div className="w-full mr-6 border border-border p-3 rounded">
                             <div>
                               <Label>Key</Label>
@@ -457,6 +458,7 @@ export function CustomLLMProviderUpdateForm({
                   <Button
                     type="button"
                     variant="destructive"
+                    className="ml-3"
                     icon={FiTrash}
                     onClick={async () => {
                       const response = await fetch(


### PR DESCRIPTION
Adds support for specifying the service account JSON directly via the UI.

Also cleans up the form a bit (previously the custom configs only took up ~1/4 of the width and the buttons had no spacing):

<img width="882" alt="Screenshot 2024-12-09 at 1 14 00 PM" src="https://github.com/user-attachments/assets/52eec663-0a7d-4732-9003-f97941cfe2f9">
<img width="882" alt="Screenshot 2024-12-09 at 1 13 52 PM" src="https://github.com/user-attachments/assets/37a2a844-a504-421d-ab08-1cf5528f061e">
