### PR TITLE
Bump litellm to support Nova models from AWS

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -29,7 +29,7 @@ trafilatura==1.12.2
 langchain==0.1.17
 langchain-core==0.1.50
 langchain-text-splitters==0.0.1
-litellm==1.53.1
+litellm==1.54.1
 lxml==5.3.0
 lxml_html_clean==0.2.2
 llama-index==0.9.45

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -12,5 +12,5 @@ torch==2.2.0
 transformers==4.39.2
 uvicorn==0.21.1
 voyageai==0.2.3
-litellm==1.50.2
+litellm==1.54.1
 sentry-sdk[fastapi,celery,starlette]==2.14.0


### PR DESCRIPTION
^

![image](https://github.com/user-attachments/assets/fd28d519-501c-4ed6-bd4c-b1fa26bcdea8)
