### PR TITLE
Allow user to close out of User Setting modal with escape

### DIFF
--- a/web/src/app/chat/modal/SetDefaultModelModal.tsx
+++ b/web/src/app/chat/modal/SetDefaultModelModal.tsx
@@ -35,6 +35,13 @@ export function SetDefaultModelModal({
     const container = containerRef.current;
     const message = messageRef.current;
 
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleEscape);
+
     if (container && message) {
       const checkScrollable = () => {
         if (container.scrollHeight > container.clientHeight) {
@@ -45,9 +52,14 @@ export function SetDefaultModelModal({
       };
       checkScrollable();
       window.addEventListener("resize", checkScrollable);
-      return () => window.removeEventListener("resize", checkScrollable);
+      return () => {
+        window.removeEventListener("resize", checkScrollable);
+        window.removeEventListener("keydown", handleEscape);
+      };
     }
-  }, []);
+
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [onClose]);
 
   const defaultModelDestructured = defaultModel
     ? destructureValue(defaultModel)


### PR DESCRIPTION
## Description
The escape key was closing the user dropdown rather than the modal on top


## How Has This Been Tested?
Verified locally


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
