### PR TITLE
made description optional for document sets

### DIFF
--- a/backend/alembic/versions/94dc3d0236f8_make_document_set_description_optional.py
+++ b/backend/alembic/versions/94dc3d0236f8_make_document_set_description_optional.py
@@ -1,7 +1,7 @@
 """make document set description optional
 
 Revision ID: 94dc3d0236f8
-Revises: f7a894b06d02
+Revises: bf7a81109301
 Create Date: 2024-12-11 11:26:10.616722
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "94dc3d0236f8"
-down_revision = "f7a894b06d02"
+down_revision = "bf7a81109301"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/94dc3d0236f8_make_document_set_description_optional.py
+++ b/backend/alembic/versions/94dc3d0236f8_make_document_set_description_optional.py
@@ -1,0 +1,30 @@
+"""make document set description optional
+
+Revision ID: 94dc3d0236f8
+Revises: f7a894b06d02
+Create Date: 2024-12-11 11:26:10.616722
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "94dc3d0236f8"
+down_revision = "f7a894b06d02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Make document_set.description column nullable
+    op.alter_column(
+        "document_set", "description", existing_type=sa.String(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    # Revert document_set.description column to non-nullable
+    op.alter_column(
+        "document_set", "description", existing_type=sa.String(), nullable=False
+    )

--- a/backend/danswer/db/models.py
+++ b/backend/danswer/db/models.py
@@ -1207,7 +1207,7 @@ class DocumentSet(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, unique=True)
-    description: Mapped[str] = mapped_column(String)
+    description: Mapped[str | None] = mapped_column(String)
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), nullable=True
     )

--- a/backend/danswer/server/features/document_set/models.py
+++ b/backend/danswer/server/features/document_set/models.py
@@ -44,7 +44,7 @@ class CheckDocSetPublicResponse(BaseModel):
 class DocumentSet(BaseModel):
     id: int
     name: str
-    description: str
+    description: str | None
     cc_pair_descriptors: list[ConnectorCredentialPairDescriptor]
     is_up_to_date: bool
     is_public: bool

--- a/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
+++ b/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
@@ -65,9 +65,7 @@ export const DocumentSetCreationForm = ({
         }}
         validationSchema={Yup.object().shape({
           name: Yup.string().required("Please enter a name for the set"),
-          description: Yup.string().required(
-            "Please enter a description for the set"
-          ),
+          description: Yup.string().default(""),
           cc_pair_ids: Yup.array()
             .of(Yup.number().required())
             .required("Please select at least one connector"),

--- a/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
+++ b/web/src/app/admin/documents/sets/DocumentSetCreationForm.tsx
@@ -65,7 +65,7 @@ export const DocumentSetCreationForm = ({
         }}
         validationSchema={Yup.object().shape({
           name: Yup.string().required("Please enter a name for the set"),
-          description: Yup.string().default(""),
+          description: Yup.string().optional(),
           cc_pair_ids: Yup.array()
             .of(Yup.number().required())
             .required("Please select at least one connector"),
@@ -123,6 +123,7 @@ export const DocumentSetCreationForm = ({
                 label="Description:"
                 placeholder="Describe what the document set represents"
                 autoCompleteDisabled={true}
+                optional={true}
               />
 
               {isPaidEnterpriseFeaturesEnabled && (


### PR DESCRIPTION
## Description
Fixes https://linear.app/danswer/issue/DAN-1128/adding-doc-set-or-persona-with-doc-set-breaks-slackbot

Tested by creating a doc set with no description

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
