### PR TITLE
fixed ephemeral slackbot messages

### DIFF
--- a/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
+++ b/backend/danswer/danswerbot/slack/handlers/handle_regular_answer.py
@@ -373,7 +373,9 @@ def handle_regular_answer(
         respond_in_thread(
             client=client,
             channel=channel,
-            receiver_ids=receiver_ids,
+            receiver_ids=[message_info.sender]
+            if message_info.is_bot_msg and message_info.sender
+            else receiver_ids,
             text="Hello! Danswer has some results for you!",
             blocks=all_blocks,
             thread_ts=message_ts_to_respond_to,


### PR DESCRIPTION
## Description
/danswerbot command now responds privately to the user

tested by asking a /danswerbot question and ensuring only the asker could see the response by looking at the chat with another account

also tested the normal qa flow to make sure that was unaffected

also checkted @danswerbot flow to make sure that was unaffected

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
