### PR TITLE
made external group emails lowercase

### DIFF
--- a/backend/ee/danswer/db/external_perm.py
+++ b/backend/ee/danswer/db/external_perm.py
@@ -76,7 +76,7 @@ def replace_user__ext_group_for_cc_pair(
     new_external_permissions = []
     for external_group in group_defs:
         for user_email in external_group.user_emails:
-            user_id = email_id_map.get(user_email)
+            user_id = email_id_map.get(user_email.lower())
             if user_id is None:
                 logger.warning(
                     f"User in group {external_group.id}"


### PR DESCRIPTION
## Description
- This fixes an issue where when we create a user in the db, the email is converted to lowercase but we still use the upercase one to match

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
