### PR TITLE
feat: add new github pages connector

### DIFF
--- a/backend/danswer/configs/constants.py
+++ b/backend/danswer/configs/constants.py
@@ -97,6 +97,7 @@ class DocumentSource(str, Enum):
     GMAIL = "gmail"
     REQUESTTRACKER = "requesttracker"
     GITHUB = "github"
+    GITHUB_PAGES = "github_pages"
     GITLAB = "gitlab"
     GURU = "guru"
     BOOKSTACK = "bookstack"

--- a/backend/danswer/connectors/factory.py
+++ b/backend/danswer/connectors/factory.py
@@ -19,6 +19,7 @@ from danswer.connectors.file.connector import LocalFileConnector
 from danswer.connectors.fireflies.connector import FirefliesConnector
 from danswer.connectors.freshdesk.connector import FreshdeskConnector
 from danswer.connectors.github.connector import GithubConnector
+from danswer.connectors.github_pages.connector import GithubPagesConnector
 from danswer.connectors.gitlab.connector import GitlabConnector
 from danswer.connectors.gmail.connector import GmailConnector
 from danswer.connectors.gong.connector import GongConnector
@@ -68,6 +69,7 @@ def identify_connector_class(
             InputType.SLIM_RETRIEVAL: SlackPollConnector,
         },
         DocumentSource.GITHUB: GithubConnector,
+        DocumentSource.GITHUB_PAGES: GithubPagesConnector,
         DocumentSource.GMAIL: GmailConnector,
         DocumentSource.GITLAB: GitlabConnector,
         DocumentSource.GOOGLE_DRIVE: GoogleDriveConnector,

--- a/backend/danswer/connectors/github_pages/connector.py
+++ b/backend/danswer/connectors/github_pages/connector.py
@@ -1,0 +1,140 @@
+import os
+import time
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin, urlparse, urlunparse
+from typing import Any, List, Optional
+from requests.auth import HTTPBasicAuth
+from danswer.configs.app_configs import INDEX_BATCH_SIZE
+from danswer.configs.constants import DocumentSource
+from danswer.connectors.interfaces import GenerateDocumentsOutput
+from danswer.connectors.interfaces import LoadConnector
+from danswer.connectors.interfaces import PollConnector
+from danswer.connectors.interfaces import SecondsSinceUnixEpoch
+from danswer.connectors.models import Document
+from danswer.connectors.models import Section
+from danswer.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_TIMEOUT = 60
+_MAX_DEPTH = 5  
+
+class GithubPagesConnector(LoadConnector, PollConnector):
+    def __init__(
+        self,
+        base_url: str,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.base_url = base_url
+        self.batch_size = batch_size
+        self.visited_urls = set()  
+        self.auth: Optional[HTTPBasicAuth] = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> None:
+        github_username = credentials.get("github_username")
+        github_token = credentials.get("github_personal_access_token")
+        if not github_username or not github_token:
+            logger.warning("GitHub credentials are missing. Requests may fail for private pages.")
+        self.auth = HTTPBasicAuth(github_username, github_token) if github_username and github_token else None
+
+    def load_from_state(self, state: dict) -> None:
+        """Restores the state of the connector from a given state dictionary."""
+        self.visited_urls = set(state.get("visited_urls", []))
+
+    def _normalize_url(self, url: str) -> str:
+        parsed = urlparse(url)
+        return urlunparse(parsed._replace(fragment='', query=''))  
+
+    def _fetch_with_retry(self, url: str, retries: int = 3, delay: int = 2) -> Optional[str]:
+        for attempt in range(retries):
+            try:
+                response = requests.get(url, timeout=_TIMEOUT, auth=self.auth)
+                response.raise_for_status()
+                return response.text
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"Attempt {attempt + 1} failed for {url}: {e}")
+                time.sleep(delay)
+        logger.error(f"All attempts failed for {url}")
+        return None
+
+    def _crawl_github_pages(self, url: str, batch_size: int, depth: int = 0) -> List[str]:
+        if depth > _MAX_DEPTH:
+            return []
+
+        to_visit = [url]
+        crawled_urls = []
+
+        while to_visit and len(crawled_urls) < batch_size:
+            current_url = to_visit.pop()
+            if current_url not in self.visited_urls:
+                content = self._fetch_with_retry(current_url)
+                if content:
+                    soup = BeautifulSoup(content, 'html.parser')
+                    self.visited_urls.add(current_url)
+                    crawled_urls.append(current_url)
+
+                    for link in soup.find_all('a'):
+                        href = link.get('href')
+                        if href:
+                            full_url = self._normalize_url(urljoin(self.base_url, href))
+                            if full_url.startswith(self.base_url) and full_url not in self.visited_urls:
+                                to_visit.append(full_url)
+
+        return crawled_urls
+
+    def _index_pages(self, urls: List[str]) -> List[Document]:
+        documents = []
+        for url in urls:
+            content = self._fetch_with_retry(url)
+            if content:
+                soup = BeautifulSoup(content, 'html.parser')
+                text_content = soup.get_text()
+                metadata = {
+                    "url": url,
+                    "crawl_time": time.time(),
+                    "content_length": len(text_content),
+                }
+
+                documents.append(
+                    Document(
+                        id=url,
+                        sections=[Section(link=url, text=text_content)],
+                        source=DocumentSource.GITHUB_PAGES,
+                        semantic_identifier=url,
+                        metadata=metadata,
+                    )
+                )
+        return documents
+
+    def _get_all_crawled_urls(self) -> List[str]:
+        all_crawled_urls = []
+        while True:
+            crawled_urls = self._crawl_github_pages(self.base_url, self.batch_size)
+            if not crawled_urls:
+                break
+            all_crawled_urls.extend(crawled_urls)
+        return all_crawled_urls
+
+    def _pull_all_pages(self) -> GenerateDocumentsOutput:
+        for crawled_urls in self._get_all_crawled_urls():
+            yield self._index_pages(crawled_urls)
+
+    def poll_source(self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch) -> GenerateDocumentsOutput:
+        yield from self._pull_all_pages()
+
+
+if __name__ == "__main__":
+    connector = GithubPagesConnector(
+        base_url=os.environ["GITHUB_PAGES_BASE_URL"]
+    )
+
+    credentials = {
+        "github_username": os.getenv("GITHUB_USERNAME", ""),
+        "github_personal_access_token": os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN", ""),
+    }
+
+    connector.load_credentials(credentials)
+
+    document_batches = connector.poll_source(0, 0)
+    print(next(document_batches))

--- a/backend/tests/daily/connectors/github_pages/test_github_pages_connector.py
+++ b/backend/tests/daily/connectors/github_pages/test_github_pages_connector.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from danswer.connectors.github_pages.connector import GithubPagesConnector
+
+
+@pytest.fixture
+def github_pages_connector() -> GithubPagesConnector:
+    connector = GithubPagesConnector(base_url="https://test.github.io")
+    connector.load_credentials(
+        {"github_username": "test_user", "github_personal_access_token": "test_token"}
+    )
+    return connector
+
+
+@patch("requests.get")
+def test_github_pages_connector_basic(mock_get: MagicMock, github_pages_connector: GithubPagesConnector):
+    mock_get.side_effect = [
+        MagicMock(status_code=200, text="<html><a href='/page2'>Link to Page 2</a></html>"),
+        MagicMock(status_code=200, text="<html>Content of Page 2</html>"),
+    ]
+
+    doc_batch_generator = github_pages_connector.poll_source(0, time.time())
+    doc_batch = next(doc_batch_generator)
+
+    assert len(doc_batch) == 2  
+    assert doc_batch[0].semantic_identifier.startswith("https://test.github.io")  

--- a/web/src/components/admin/connectors/ConnectorTitle.tsx
+++ b/web/src/components/admin/connectors/ConnectorTitle.tsx
@@ -2,6 +2,7 @@ import {
   ConfluenceConfig,
   Connector,
   GithubConfig,
+  GithubPagesConfig,
   GitlabConfig,
   GoogleDriveConfig,
   JiraConfig,
@@ -40,6 +41,9 @@ export const ConnectorTitle = ({
       "Repo",
       `${typedConnector.connector_specific_config.repo_owner}/${typedConnector.connector_specific_config.repo_name}`
     );
+  }else if (connector.source === "github_pages") {
+    const typedConnector = connector as Connector<GithubPagesConfig>;
+    additionalMetadata.set("Site URL", typedConnector.connector_specific_config.base_url);
   } else if (connector.source === "gitlab") {
     const typedConnector = connector as Connector<GitlabConfig>;
     additionalMetadata.set(

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -192,6 +192,27 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  github_pages: {
+    description: "Configure GitHub Pages connector",
+    values: [
+      {
+        type: "text",
+        query: "Enter the base URL of the GitHub Pages site:",
+        label: "Base URL",
+        name: "base_url",
+        optional: false,
+      },
+      {
+        type: "number",
+        query: "Set the batch size for indexing (default is 10):",
+        label: "Batch Size",
+        name: "batch_size",
+        optional: true,
+        default: 10,
+      },
+    ],
+    advanced_values: [],
+  },
   gitlab: {
     description: "Configure GitLab connector",
     values: [
@@ -1148,6 +1169,13 @@ export interface GithubConfig {
   repo_name: string;
   include_prs: boolean;
   include_issues: boolean;
+}
+
+export interface GithubPagesConfig {
+  base_url: string;
+  github_username?: string;
+  github_personal_access_token?: string;
+  batch_size?: number;
 }
 
 export interface GitlabConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -19,6 +19,11 @@ export interface GithubCredentialJson {
   github_access_token: string;
 }
 
+export interface GithubPagesCredentialJson {
+  github_username: string; 
+  github_personal_access_token: string; 
+}
+
 export interface GitlabCredentialJson {
   gitlab_url: string;
   gitlab_access_token: string;
@@ -197,6 +202,10 @@ export interface WikipediaCredentialJson extends MediaWikiCredentialJson {}
 
 export const credentialTemplates: Record<ValidSources, any> = {
   github: { github_access_token: "" } as GithubCredentialJson,
+  github_pages: {
+    github_username: "",
+    github_personal_access_token: "",
+  } as GithubPagesCredentialJson,
   gitlab: {
     gitlab_url: "",
     gitlab_access_token: "",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -96,6 +96,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.CodeRepository,
     docs: "https://docs.danswer.dev/connectors/github",
   },
+  github_pages: {
+    icon: GithubIcon,
+    displayName: "Github Pages",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.danswer.dev/connectors/github_pages",
+  },
   gitlab: {
     icon: GitlabIcon,
     displayName: "Gitlab",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -270,6 +270,7 @@ export interface UserGroup {
 export enum ValidSources {
   Web = "web",
   GitHub = "github",
+  GithubPages = "github_pages",
   GitLab = "gitlab",
   Slack = "slack",
   GoogleDrive = "google_drive",


### PR DESCRIPTION
## Description

This PR introduces support for a new GitHub Pages connector.

## How Has This Been Tested?

https://github.com/user-attachments/assets/5bf0763b-fe28-4dd6-ae03-c162ccbc8cc4




## Related Issue(s) (provide if relevant)
fixes #2282 
/claim #2282 


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
