### PR TITLE
strip text for slackbot

### DIFF
--- a/backend/danswer/connectors/slack/connector.py
+++ b/backend/danswer/connectors/slack/connector.py
@@ -171,7 +171,9 @@ def thread_to_doc(
         else first_message
     )
 
-    doc_sem_id = f"{initial_sender_name} in #{channel['name']}: {snippet}"
+    doc_sem_id = f"{initial_sender_name} in #{channel['name']}: {snippet}".replace(
+        "\n", " "
+    )
 
     return Document(
         id=f"{channel_id}__{thread[0]['ts']}",

--- a/backend/danswer/danswerbot/slack/blocks.py
+++ b/backend/danswer/danswerbot/slack/blocks.py
@@ -204,7 +204,8 @@ def _build_documents_blocks(
             continue
         seen_docs_identifiers.add(d.document_id)
 
-        doc_sem_id = d.semantic_identifier
+        # Strip newlines from the semantic identifier for Slackbot formatting
+        doc_sem_id = d.semantic_identifier.replace("\n", " ")
         if d.source_type == DocumentSource.SLACK.value:
             doc_sem_id = "#" + doc_sem_id
 

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -360,7 +360,7 @@ def translate_vespa_highlight_to_slack(match_strs: list[str], used_chars: int) -
         for match_str in match_strs
         if match_str
     ]
-    combined = "... ".join(final_matches)
+    combined = " ".join(final_matches)
 
     # Slack introduces "Show More" after 300 on desktop which is ugly
     # But don't trim the message if there is still a highlight after 300 chars

--- a/backend/danswer/danswerbot/slack/utils.py
+++ b/backend/danswer/danswerbot/slack/utils.py
@@ -360,7 +360,7 @@ def translate_vespa_highlight_to_slack(match_strs: list[str], used_chars: int) -
         for match_str in match_strs
         if match_str
     ]
-    combined = " ".join(final_matches)
+    combined = "... ".join(final_matches)
 
     # Slack introduces "Show More" after 300 on desktop which is ugly
     # But don't trim the message if there is still a highlight after 300 chars


### PR DESCRIPTION
## Description
Fixes https://linear.app/danswer/issue/DAN-1119/citations-are-not-clickable-on-slack-a-large-chunk-of-the-time
Semantic ID for slack connector could contain newlines which caused issues for Slackbot formatting

Before and After
<img width="273" alt="Screenshot 2024-12-10 at 1 12 29 PM" src="https://github.com/user-attachments/assets/624c6004-9c84-4462-abd5-fe8d722abc45">

<img width="252" alt="Screenshot 2024-12-10 at 1 12 21 PM" src="https://github.com/user-attachments/assets/6c618f44-5839-4261-9415-7daf7448b9d5">

## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
