### PR TITLE
do not include slackbot sessions when fetching `chat sessions`

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -141,13 +141,19 @@ def get_valid_messages_from_query_sessions(
     return {row.chat_session_id: row.message for row in first_messages}
 
 
+# Retrieves chat sessions by user
+# Chat sessions do not include onyxbot flows
 def get_chat_sessions_by_user(
     user_id: UUID | None,
     deleted: bool | None,
     db_session: Session,
+    include_onyxbot_flows: bool = False,
     limit: int = 50,
 ) -> list[ChatSession]:
     stmt = select(ChatSession).where(ChatSession.user_id == user_id)
+
+    if not include_onyxbot_flows:
+        stmt = stmt.where(ChatSession.onyxbot_flow.is_(False))
 
     stmt = stmt.order_by(desc(ChatSession.time_created))
 


### PR DESCRIPTION
## Description
Fixes https://linear.app/danswer/issue/DAN-1167/slackbot-threads-showing-in-chat-display


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
