### PR TITLE
Added ability to set timezone offset for Confluence connector in UI

### DIFF
--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/NumberInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/NumberInput.tsx
@@ -7,12 +7,14 @@ export default function NumberInput({
   description,
   name,
   showNeverIfZero,
+  min = -1,
 }: {
   label: string;
   name: string;
   optional?: boolean;
   description?: string;
   showNeverIfZero?: boolean;
+  min?: number;
 }) {
   return (
     <div className="w-full flex flex-col">
@@ -25,7 +27,7 @@ export default function NumberInput({
       <Field
         type="number"
         name={name}
-        min="-1"
+        min={min}
         className={`mt-2 block w-full px-3 py-2 
                 bg-white border border-gray-300 rounded-md 
                 text-sm shadow-sm placeholder-gray-400

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -123,6 +123,14 @@ export const RenderField: FC<RenderFieldProps> = ({
   connector,
   currentCredential,
 }) => {
+  // Check visibility condition first
+  if (
+    field.visibleCondition &&
+    !field.visibleCondition(values, currentCredential)
+  ) {
+    return null;
+  }
+
   const label =
     typeof field.label === "function"
       ? field.label(currentCredential)
@@ -169,6 +177,7 @@ export const RenderField: FC<RenderFieldProps> = ({
           optional={field.optional}
           description={description}
           name={field.name}
+          min={field.min}
         />
       ) : field.type === "checkbox" ? (
         <AdminBooleanFormField

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -66,6 +66,7 @@ export interface TextOption extends Option {
 export interface NumberOption extends Option {
   type: "number";
   default?: number;
+  min?: number;
 }
 
 export interface BooleanOption extends Option {
@@ -345,6 +346,18 @@ export const connectorConfigs: Record<
         default: true,
         description:
           "Check if this is a Confluence Cloud instance, uncheck for Confluence Server/Data Center",
+      },
+      {
+        type: "number",
+        query: "Enter the Server Timezone Offset:",
+        label: "Server Timezone Offset",
+        name: "timezone_offset",
+        optional: false,
+        default: 0,
+        min: -24,
+        description:
+          "Enter the timezone offset for your Confluence instance (in hours). This is used to convert the server's timezone to UTC. E.g. EST is -5, CET is +1",
+        visibleCondition: (values, currentCredential) => !values.is_cloud,
       },
       {
         type: "text",


### PR DESCRIPTION
## Description
- we now allow the user to manually input their timezone through the UI if they are trying to use confluence server

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
