### PR TITLE
Security

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -14,7 +14,7 @@ const cspHeader = `
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    upgrade-insecure-requests;
+    ${process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" ? "upgrade-insecure-requests;" : ""}
 `;
 
 /** @type {import('next').NextConfig} */

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -7,11 +7,59 @@ const version = env_version || package_version;
 // Always require withSentryConfig
 const { withSentryConfig } = require("@sentry/nextjs");
 
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'unsafe-eval' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' blob: data:;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+`;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   publicRuntimeConfig: {
     version,
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: cspHeader.replace(/\n/g, ""),
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Permissions-Policy",
+            // Deny all permissions by default
+            value:
+              "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()",
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -8,10 +8,7 @@ const version = env_version || package_version;
 const { withSentryConfig } = require("@sentry/nextjs");
 
 const cspHeader = `
-    default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline';
     style-src 'self' 'unsafe-inline';
-    img-src 'self' blob: data:;
     font-src 'self';
     object-src 'none';
     base-uri 'self';


### PR DESCRIPTION
## Description
Reference: https://nextjs.org/docs/app/api-reference/config/next-config-js/headers

Fix https://linear.app/danswer/issue/DAN-1187/missing-http-security-headers
Fix https://linear.app/danswer/issue/DAN-1186/clickjacking


- CSP Header
  - Restrict resource loading 
  - Allow inline styles
  - Prevent framing to protect against clickjacking
  - upgrade-insecure-requests for cloud environments
  

- Strict Transport Security (HSTS) header
  - Max age of 2 years (63072000 seconds)
  - Include subdomains
  - Enable preloading

## Before
<img width="1378" alt="Screenshot 2024-12-12 at 1 26 41 PM" src="https://github.com/user-attachments/assets/2a345bdf-51ef-4c12-ba9c-d76f09b6c21d" />

## After
<img width="1418" alt="Screenshot 2024-12-12 at 1 26 47 PM" src="https://github.com/user-attachments/assets/24fc3256-a4f0-4651-a662-4a3dd342898a" />


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
