### PR TITLE
Remove hardcoded root path for HF models

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -27,8 +27,8 @@ from shared_configs.configs import SENTRY_DSN
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
 
-HF_CACHE_PATH = Path("/root/.cache/huggingface/")
-TEMP_HF_CACHE_PATH = Path("/root/.cache/temp_huggingface/")
+HF_CACHE_PATH = Path(os.path.expanduser("~")) / ".cache/huggingface"
+TEMP_HF_CACHE_PATH = Path(os.path.expanduser("~")) / ".cache/temp_huggingface"
 
 transformer_logging.set_verbosity_error()
 


### PR DESCRIPTION
## Description
Remove hardcoded root path for HF models, using user home dir instead


## How Has This Been Tested?
Model server started and correctly loaded models
```
NOTICE:   12/13/2024 08:27:53 PM               custom_models.py   99: Loaded model from local cache: /home/egomes/.cache/huggingface/hub/models--danswer--hybrid-intent-token-classifier/snapshots/54ed7e946f84a252c5d4e5d7a0bc839f466e9c64
```


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A