### PR TITLE
Proper display priority seeding

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -521,6 +521,7 @@ def upsert_persona(
         existing_persona.llm_model_provider_override = llm_model_provider_override
         existing_persona.llm_model_version_override = llm_model_version_override
         existing_persona.starter_messages = starter_messages
+        existing_persona.display_priority = display_priority
         existing_persona.deleted = False  # Un-delete if previously deleted
         existing_persona.is_public = is_public
         existing_persona.icon_color = icon_color

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -521,7 +521,6 @@ def upsert_persona(
         existing_persona.llm_model_provider_override = llm_model_provider_override
         existing_persona.llm_model_version_override = llm_model_version_override
         existing_persona.starter_messages = starter_messages
-        existing_persona.display_priority = display_priority
         existing_persona.deleted = False  # Un-delete if previously deleted
         existing_persona.is_public = is_public
         existing_persona.icon_color = icon_color
@@ -543,6 +542,10 @@ def upsert_persona(
 
         if tools is not None:
             existing_persona.tools = tools or []
+
+        # We should only update display priority if it is not already set
+        if existing_persona.display_priority is None:
+            existing_persona.display_priority = display_priority
 
         persona = existing_persona
 

--- a/backend/onyx/seeding/load_yamls.py
+++ b/backend/onyx/seeding/load_yamls.py
@@ -48,6 +48,7 @@ def load_personas_from_yaml(
         data = yaml.safe_load(file)
 
     all_personas = data.get("personas", [])
+
     for persona in all_personas:
         doc_set_names = persona["document_sets"]
         doc_sets: list[DocumentSetDBModel] = [
@@ -127,6 +128,7 @@ def load_personas_from_yaml(
             display_priority=(
                 existing_persona.display_priority
                 if existing_persona is not None
+                and persona.get("display_priority") is None
                 else persona.get("display_priority")
             ),
             is_visible=(

--- a/web/src/lib/assistants/utils.ts
+++ b/web/src/lib/assistants/utils.ts
@@ -114,9 +114,11 @@ export function getUserCreatedAssistants(
   user: User | null,
   assistants: Persona[]
 ) {
-  return assistants.filter((assistant) =>
+  const result = assistants.filter((assistant) =>
     checkUserOwnsAssistant(user, assistant)
   );
+  console.log("Output - user created assistants:", result);
+  return result;
 }
 
 // Filter assistants based on connector status, image compatibility and visibility

--- a/web/src/lib/assistants/utils.ts
+++ b/web/src/lib/assistants/utils.ts
@@ -114,11 +114,9 @@ export function getUserCreatedAssistants(
   user: User | null,
   assistants: Persona[]
 ) {
-  const result = assistants.filter((assistant) =>
+  return assistants.filter((assistant) =>
     checkUserOwnsAssistant(user, assistant)
   );
-  console.log("Output - user created assistants:", result);
-  return result;
 }
 
 // Filter assistants based on connector status, image compatibility and visibility


### PR DESCRIPTION
## Description
- Default assistant created in alembic migrations has `null` display priority and would not be overridden by yaml loading
- Display priority needs to update for existing assistants (if we decide to migrate


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
