### PR TITLE
Object refactoring in citation processing

### DIFF
--- a/backend/danswer/chat/answer.py
+++ b/backend/danswer/chat/answer.py
@@ -22,7 +22,9 @@ from danswer.chat.stream_processing.answer_response_handler import (
 from danswer.chat.stream_processing.answer_response_handler import (
     DummyAnswerResponseHandler,
 )
-from danswer.chat.stream_processing.utils import map_document_id_order
+from danswer.chat.stream_processing.utils import (
+    map_document_id_order,
+)
 from danswer.chat.tool_handling.tool_response_handler import ToolResponseHandler
 from danswer.file_store.utils import InMemoryChatFile
 from danswer.llm.interfaces import LLM
@@ -206,9 +208,9 @@ class Answer:
         # + figure out what the next LLM call should be
         tool_call_handler = ToolResponseHandler(current_llm_call.tools)
 
-        search_result, displayed_search_results_map = SearchTool.get_search_result(
+        final_search_results, displayed_search_results = SearchTool.get_search_result(
             current_llm_call
-        ) or ([], {})
+        ) or ([], [])
 
         # Quotes are no longer supported
         # answer_handler: AnswerResponseHandler
@@ -224,9 +226,9 @@ class Answer:
         # else:
         #     raise ValueError("No answer style config provided")
         answer_handler = CitationResponseHandler(
-            context_docs=search_result,
-            doc_id_to_rank_map=map_document_id_order(search_result),
-            display_doc_order_dict=displayed_search_results_map,
+            context_docs=final_search_results,
+            final_doc_id_to_rank_map=map_document_id_order(final_search_results),
+            display_doc_id_to_rank_map=map_document_id_order(displayed_search_results),
         )
 
         response_handler_manager = LLMResponseHandlerManager(

--- a/backend/danswer/chat/stream_processing/answer_response_handler.py
+++ b/backend/danswer/chat/stream_processing/answer_response_handler.py
@@ -37,22 +37,22 @@ class CitationResponseHandler(AnswerResponseHandler):
     def __init__(
         self,
         context_docs: list[LlmDoc],
-        doc_id_to_rank_map: DocumentIdOrderMapping,
-        display_doc_order_dict: dict[str, int],
+        final_doc_id_to_rank_map: DocumentIdOrderMapping,
+        display_doc_id_to_rank_map: DocumentIdOrderMapping,
     ):
         self.context_docs = context_docs
-        self.doc_id_to_rank_map = doc_id_to_rank_map
-        self.display_doc_order_dict = display_doc_order_dict
+        self.final_doc_id_to_rank_map = final_doc_id_to_rank_map
+        self.display_doc_id_to_rank_map = display_doc_id_to_rank_map
         self.citation_processor = CitationProcessor(
             context_docs=self.context_docs,
-            doc_id_to_rank_map=self.doc_id_to_rank_map,
-            display_doc_order_dict=self.display_doc_order_dict,
+            final_doc_id_to_rank_map=self.final_doc_id_to_rank_map,
+            display_doc_id_to_rank_map=self.display_doc_id_to_rank_map,
         )
         self.processed_text = ""
         self.citations: list[CitationInfo] = []
 
         # TODO remove this after citation issue is resolved
-        logger.debug(f"Document to ranking map {self.doc_id_to_rank_map}")
+        logger.debug(f"Document to ranking map {self.final_doc_id_to_rank_map}")
 
     def handle_response_part(
         self,

--- a/backend/danswer/chat/stream_processing/citation_processing.py
+++ b/backend/danswer/chat/stream_processing/citation_processing.py
@@ -135,8 +135,8 @@ class CitationProcessor:
                                 doc_id = int(match.group(1))
                                 context_llm_doc = self.context_docs[doc_id - 1]
                                 yield CitationInfo(
-                                    # stay with the original for now (order of LLM cites)
-                                    citation_num=citation_order_idx,
+                                    # citation_num is updated from the original target_citation_num (now: citation_order_idx)
+                                    citation_num=displayed_citation_num,
                                     document_id=context_llm_doc.document_id,
                                 )
                             except Exception as e:

--- a/backend/danswer/chat/stream_processing/citation_processing.py
+++ b/backend/danswer/chat/stream_processing/citation_processing.py
@@ -33,7 +33,7 @@ class CitationProcessor:
         self.display_order_mapping = display_doc_id_to_rank_map.order_mapping
         self.llm_out = ""
         self.max_citation_num = len(context_docs)
-        self.citation_order: list[int] = []
+        self.citation_order: list[int] = []  # order of citations in the LLM output
         self.curr_segment = ""
         self.cited_inds: set[int] = set()
         self.hold = ""
@@ -92,15 +92,15 @@ class CitationProcessor:
 
                 if 1 <= numerical_value <= self.max_citation_num:
                     context_llm_doc = self.context_docs[numerical_value - 1]
-                    real_citation_num = self.final_order_mapping[
+                    final_citation_num = self.final_order_mapping[
                         context_llm_doc.document_id
                     ]
 
-                    if real_citation_num not in self.citation_order:
-                        self.citation_order.append(real_citation_num)
+                    if final_citation_num not in self.citation_order:
+                        self.citation_order.append(final_citation_num)
 
-                    target_citation_num = (
-                        self.citation_order.index(real_citation_num) + 1
+                    citation_order_idx = (
+                        self.citation_order.index(final_citation_num) + 1
                     )
 
                     # get the value that was displayed to user, should always
@@ -110,13 +110,13 @@ class CitationProcessor:
                             context_llm_doc.document_id
                         ]
                     else:
-                        displayed_citation_num = real_citation_num
+                        displayed_citation_num = final_citation_num
                         logger.warning(
                             f"Doc {context_llm_doc.document_id} not in display_doc_order_dict. Used LLM citation number instead."
                         )
 
                     # Skip consecutive citations of the same work
-                    if real_citation_num in self.current_citations:
+                    if final_citation_num in self.current_citations:
                         start, end = citation.span()
                         real_start = length_to_add + start
                         diff = end - start
@@ -136,7 +136,7 @@ class CitationProcessor:
                                 context_llm_doc = self.context_docs[doc_id - 1]
                                 yield CitationInfo(
                                     # stay with the original for now (order of LLM cites)
-                                    citation_num=target_citation_num,
+                                    citation_num=citation_order_idx,
                                     document_id=context_llm_doc.document_id,
                                 )
                             except Exception as e:
@@ -152,13 +152,13 @@ class CitationProcessor:
                     link = context_llm_doc.link
 
                     self.past_cite_count = len(self.llm_out)
-                    self.current_citations.append(real_citation_num)
+                    self.current_citations.append(final_citation_num)
 
-                    if target_citation_num not in self.cited_inds:
-                        self.cited_inds.add(target_citation_num)
+                    if citation_order_idx not in self.cited_inds:
+                        self.cited_inds.add(citation_order_idx)
                         yield CitationInfo(
                             # stay with the original for now (order of LLM cites)
-                            citation_num=target_citation_num,
+                            citation_num=citation_order_idx,
                             document_id=context_llm_doc.document_id,
                         )
 

--- a/backend/danswer/chat/stream_processing/citation_processing.py
+++ b/backend/danswer/chat/stream_processing/citation_processing.py
@@ -21,17 +21,16 @@ class CitationProcessor:
     def __init__(
         self,
         context_docs: list[LlmDoc],
-        doc_id_to_rank_map: DocumentIdOrderMapping,
-        display_doc_order_dict: dict[str, int],
+        final_doc_id_to_rank_map: DocumentIdOrderMapping,
+        display_doc_id_to_rank_map: DocumentIdOrderMapping,
         stop_stream: str | None = STOP_STREAM_PAT,
     ):
         self.context_docs = context_docs
-        self.doc_id_to_rank_map = doc_id_to_rank_map
+        self.final_doc_id_to_rank_map = final_doc_id_to_rank_map
+        self.display_doc_id_to_rank_map = display_doc_id_to_rank_map
         self.stop_stream = stop_stream
-        self.order_mapping = doc_id_to_rank_map.order_mapping
-        self.display_doc_order_dict = (
-            display_doc_order_dict  # original order of docs to displayed to user
-        )
+        self.final_order_mapping = final_doc_id_to_rank_map.order_mapping
+        self.display_order_mapping = display_doc_id_to_rank_map.order_mapping
         self.llm_out = ""
         self.max_citation_num = len(context_docs)
         self.citation_order: list[int] = []
@@ -93,7 +92,9 @@ class CitationProcessor:
 
                 if 1 <= numerical_value <= self.max_citation_num:
                     context_llm_doc = self.context_docs[numerical_value - 1]
-                    real_citation_num = self.order_mapping[context_llm_doc.document_id]
+                    real_citation_num = self.final_order_mapping[
+                        context_llm_doc.document_id
+                    ]
 
                     if real_citation_num not in self.citation_order:
                         self.citation_order.append(real_citation_num)
@@ -104,8 +105,8 @@ class CitationProcessor:
 
                     # get the value that was displayed to user, should always
                     # be in the display_doc_order_dict. But check anyways
-                    if context_llm_doc.document_id in self.display_doc_order_dict:
-                        displayed_citation_num = self.display_doc_order_dict[
+                    if context_llm_doc.document_id in self.display_order_mapping:
+                        displayed_citation_num = self.display_order_mapping[
                             context_llm_doc.document_id
                         ]
                     else:
@@ -115,7 +116,7 @@ class CitationProcessor:
                         )
 
                     # Skip consecutive citations of the same work
-                    if target_citation_num in self.current_citations:
+                    if real_citation_num in self.current_citations:
                         start, end = citation.span()
                         real_start = length_to_add + start
                         diff = end - start
@@ -151,7 +152,7 @@ class CitationProcessor:
                     link = context_llm_doc.link
 
                     self.past_cite_count = len(self.llm_out)
-                    self.current_citations.append(target_citation_num)
+                    self.current_citations.append(real_citation_num)
 
                     if target_citation_num not in self.cited_inds:
                         self.cited_inds.add(target_citation_num)
@@ -167,7 +168,6 @@ class CitationProcessor:
                         self.curr_segment = (
                             self.curr_segment[: start + length_to_add]
                             + f"[[{displayed_citation_num}]]({link})"  # use the value that was displayed to user
-                            # + f"[[{target_citation_num}]]({link})"
                             + self.curr_segment[end + length_to_add :]
                         )
                         length_to_add += len(self.curr_segment) - prev_length
@@ -176,7 +176,6 @@ class CitationProcessor:
                         self.curr_segment = (
                             self.curr_segment[: start + length_to_add]
                             + f"[[{displayed_citation_num}]]()"  # use the value that was displayed to user
-                            # + f"[[{target_citation_num}]]()"
                             + self.curr_segment[end + length_to_add :]
                         )
                         length_to_add += len(self.curr_segment) - prev_length

--- a/backend/danswer/tools/tool_implementations/search/search_tool.py
+++ b/backend/danswer/tools/tool_implementations/search/search_tool.py
@@ -396,7 +396,7 @@ class SearchTool(Tool):
     @classmethod
     def get_search_result(
         cls, llm_call: LLMCall
-    ) -> tuple[list[LlmDoc], dict[str, int]] | None:
+    ) -> tuple[list[LlmDoc], list[LlmDoc]] | None:
         """
         Returns the final search results and a map of docs to their original search rank (which is what is displayed to user)
         """
@@ -404,7 +404,7 @@ class SearchTool(Tool):
             return None
 
         final_search_results = []
-        doc_id_to_original_search_rank_map = {}
+        initial_search_results = []
 
         for yield_item in llm_call.tool_call_info:
             if (
@@ -417,12 +417,11 @@ class SearchTool(Tool):
                 and yield_item.id == ORIGINAL_CONTEXT_DOCUMENTS_ID
             ):
                 search_contexts = yield_item.response.contexts
-                original_doc_search_rank = 1
-                for idx, doc in enumerate(search_contexts):
-                    if doc.document_id not in doc_id_to_original_search_rank_map:
-                        doc_id_to_original_search_rank_map[
-                            doc.document_id
-                        ] = original_doc_search_rank
-                        original_doc_search_rank += 1
+                # original_doc_search_rank = 1
+                for doc in search_contexts:
+                    if doc.document_id not in initial_search_results:
+                        initial_search_results.append(doc)
 
-        return final_search_results, doc_id_to_original_search_rank_map
+                initial_search_results = cast(list[LlmDoc], initial_search_results)
+
+        return final_search_results, initial_search_results

--- a/backend/tests/unit/danswer/chat/stream_processing/test_citation_processing.py
+++ b/backend/tests/unit/danswer/chat/stream_processing/test_citation_processing.py
@@ -68,11 +68,12 @@ def process_text(
     tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int]]
 ) -> tuple[str, list[CitationInfo]]:
     mock_docs, mock_doc_id_to_rank_map = mock_data
-    mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    final_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    display_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
     processor = CitationProcessor(
         context_docs=mock_docs,
-        doc_id_to_rank_map=mapping,
-        display_doc_order_dict=mock_doc_id_to_rank_map,
+        final_doc_id_to_rank_map=final_mapping,
+        display_doc_id_to_rank_map=display_mapping,
         stop_stream=None,
     )
 

--- a/backend/tests/unit/danswer/chat/stream_processing/test_citation_substitution.py
+++ b/backend/tests/unit/danswer/chat/stream_processing/test_citation_substitution.py
@@ -71,19 +71,22 @@ mock_doc_mapping_rerank = {
 
 
 @pytest.fixture
-def mock_data() -> tuple[list[LlmDoc], dict[str, int]]:
-    return mock_docs, mock_doc_mapping
+def mock_data() -> tuple[list[LlmDoc], dict[str, int], dict[str, int]]:
+    return mock_docs, mock_doc_mapping, mock_doc_mapping_rerank
 
 
 def process_text(
-    tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int]]
+    tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int], dict[str, int]]
 ) -> tuple[str, list[CitationInfo]]:
-    mock_docs, mock_doc_id_to_rank_map = mock_data
-    mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    mock_docs, mock_doc_id_to_rank_map, mock_doc_id_to_rank_map_rerank = mock_data
+    final_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    display_mapping = DocumentIdOrderMapping(
+        order_mapping=mock_doc_id_to_rank_map_rerank
+    )
     processor = CitationProcessor(
         context_docs=mock_docs,
-        doc_id_to_rank_map=mapping,
-        display_doc_order_dict=mock_doc_mapping_rerank,
+        final_doc_id_to_rank_map=final_mapping,
+        display_doc_id_to_rank_map=display_mapping,
         stop_stream=None,
     )
 
@@ -115,7 +118,7 @@ def process_text(
     ],
 )
 def test_citation_substitution(
-    mock_data: tuple[list[LlmDoc], dict[str, int]],
+    mock_data: tuple[list[LlmDoc], dict[str, int], dict[str, int]],
     test_name: str,
     input_tokens: list[str],
     expected_text: str,


### PR DESCRIPTION
## Description
Homogenization of 'final_search...' and 'display_search...' objects (i.e., chunk order post re-ranking/verification vs chunk order post vector search).


## How Has This Been Tested?
Tested by using local dummy search. The search order is now correct (as implemented earlier). Impact on CitationInfo still needs to be verified.


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
 - Related to PR https://github.com/onyx-dot-app/onyx/pull/3421


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
