### PR TITLE
Update Docker base image and system libraries

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7-slim-bookworm
+FROM python:3.11.11-slim-bookworm
 
 LABEL com.danswer.maintainer="founders@onyx.app"
 LABEL com.danswer.description="This image is the web/frontend container of Onyx which \
@@ -27,10 +27,10 @@ RUN apt-get update && \
         zip \
         ca-certificates \
         libgnutls30=3.7.9-2+deb12u3 \
-        libblkid1=2.38.1-5+deb12u1 \
-        libmount1=2.38.1-5+deb12u1 \
-        libsmartcols1=2.38.1-5+deb12u1 \
-        libuuid1=2.38.1-5+deb12u1 \
+        libblkid1=2.38.1-5+deb12u2 \
+        libmount1=2.38.1-5+deb12u2 \
+        libsmartcols1=2.38.1-5+deb12u2 \
+        libuuid1=2.38.1-5+deb12u2 \
         libxmlsec1-dev \
         pkg-config \
         gcc && \

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -1,4 +1,4 @@
-FROM python:3.11.7-slim-bookworm
+FROM python:3.11.11-slim-bookworm
 
 LABEL com.danswer.maintainer="founders@onyx.app"
 LABEL com.danswer.description="This image is for the Onyx model server which runs all of the \
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir --upgrade \
         --timeout 30 \
         -r /tmp/requirements.txt
 
-RUN apt-get remove -y --allow-remove-essential perl-base && \ 
+RUN apt-get remove -y --allow-remove-essential perl-base && \
     apt-get autoremove -y
 
 # Pre-downloading models for setups with limited egress

--- a/backend/tests/integration/Dockerfile
+++ b/backend/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7-slim-bookworm
+FROM python:3.11.11-slim-bookworm
 # Dockerfile for integration tests
 # Currently needs all dependencies, since the ITs use some of the Onyx
 # backend code.
@@ -16,10 +16,10 @@ RUN apt-get update && \
         zip \
         ca-certificates \
         libgnutls30=3.7.9-2+deb12u3 \
-        libblkid1=2.38.1-5+deb12u1 \
-        libmount1=2.38.1-5+deb12u1 \
-        libsmartcols1=2.38.1-5+deb12u1 \
-        libuuid1=2.38.1-5+deb12u1 \
+        libblkid1=2.38.1-5+deb12u2 \
+        libmount1=2.38.1-5+deb12u2 \
+        libsmartcols1=2.38.1-5+deb12u2 \
+        libuuid1=2.38.1-5+deb12u2 \
         libxmlsec1-dev \
         pkg-config \
         gcc && \


### PR DESCRIPTION
## Description
`python:3.11.7-slim-bookworm` has [a few critical vulnerabilities](https://hub.docker.com/layers/library/python/3.11.7-slim-bookworm/images/sha256-1321a0be9c13828a9b489310f1b1c265f07c5be0e67302e1759ad78da19103a7) by now. This PR updates the Docker base image to `python:3.11.11-slim-bookworm`, as well as bumps the versions of the explicitly installed system libraries accordingly.


## How Has This Been Tested?
Build the Docker images and run a local fork of the app.


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
