### PR TITLE
errors in the summary row should be counting last_finished_status as …

### DIFF
--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -326,8 +326,9 @@ export function CCPairIndexingStatusTable({
           (sum, status) => sum + status.docs_indexed,
           0
         ),
-        errors: statuses.filter((status) => status.last_status === "failed")
-          .length,
+        errors: statuses.filter(
+          (status) => status.last_finished_status === "failed"
+        ).length,
       };
     });
 


### PR DESCRIPTION
…reflected in the per connector rows

## Description
Fixes DAN-1198.


## How Has This Been Tested?
Observed error count in summary row now does not decrease if indexing for a previously connector is in progress.


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
