### PR TITLE
feat(helm): add externalHost support for postgres, redis and vespa

### DIFF
--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -84,11 +84,11 @@ Create env vars from secrets
 {{/*
 Switch between internally created postgres host or external host if given
 */}}
-{{- define "onyx-stack.postgresHost" -}}
-{{- if .Values.postgres.enabled }}
+{{- define "onyx-stack.postgresqlHost" -}}
+{{- if .Values.postgresql.enabled }}
 {{ .Release.Name }}-postgresql
 {{- else }}
-{{- .Values.postgres.externalHost }}
+{{- .Values.postgresql.externalHost }}
 {{- end }}
 {{- end }}
 

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -81,3 +81,35 @@ Create env vars from secrets
     {{- end }}
 {{- end }}
 
+{{/*
+Switch between internally created postgres host or external host if given
+*/}}
+{{- define "onyx-stack.postgresHost" -}}
+{{- if .Values.postgres.enabled }}
+{{ .Release.Name }}-postgresql
+{{- else }}
+{{- .Values.postgres.externalHost }}
+{{- end }}
+{{- end }}
+
+{{/*
+Switch between internally created redis host or external host if given
+*/}}
+{{- define "onyx-stack.redisHost" -}}
+{{- if .Values.redis.enabled }}
+{{ .Release.Name }}-redis-master
+{{- else }}
+{{- .Values.redis.externalHost }}
+{{- end }}
+{{- end }}
+
+{{/*
+Switch between internally created vespa host or external host if given
+*/}}
+{{- define "onyx-stack.vespaHost" -}}
+{{- if .Values.vespa.enabled }}
+"da-vespa-0.vespa-service"
+{{- else }}
+{{- .Values.vespa.externalHost }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "onyx-stack.labels" . | nindent 4 }}
 data:
   INTERNAL_URL: "http://{{ include "onyx-stack.fullname" . }}-api-service:{{ .Values.api.service.port | default 8080 }}"
-  POSTGRES_HOST: {{ include "onyx-stack.postgresHost" . }}
+  POSTGRES_HOST: {{ include "onyx-stack.postgresqlHost" . }}
   VESPA_HOST: {{ include "onyx-stack.vespaHost" . }}
   REDIS_HOST: {{ include "onyx-stack.redisHost" . }}
   MODEL_SERVER_HOST: "{{ include "onyx-stack.fullname" . }}-inference-model-service"

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,9 +6,9 @@ metadata:
     {{- include "onyx-stack.labels" . | nindent 4 }}
 data:
   INTERNAL_URL: "http://{{ include "onyx-stack.fullname" . }}-api-service:{{ .Values.api.service.port | default 8080 }}"
-  POSTGRES_HOST: {{ .Release.Name }}-postgresql
-  VESPA_HOST: da-vespa-0.vespa-service
-  REDIS_HOST: {{ .Release.Name }}-redis-master
+  POSTGRES_HOST: {{ include "onyx-stack.postgresHost" . }}
+  VESPA_HOST: {{ include "onyx-stack.vespaHost" . }}
+  REDIS_HOST: {{ include "onyx-stack.redisHost" . }}
   MODEL_SERVER_HOST: "{{ include "onyx-stack.fullname" . }}-inference-model-service"
   INDEXING_MODEL_SERVER_HOST: "{{ include "onyx-stack.fullname" . }}-indexing-model-service"
 {{- range $key, $value := .Values.configMap }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -89,6 +89,7 @@ postgresql:
     persistence:
       size: 5Gi
   enabled: true
+  externalHost: ""
   auth:
     existingSecret: onyx-secrets
     secretKeys:
@@ -304,6 +305,7 @@ background:
 
 vespa:
   enabled: true
+  externalHost: ""
   replicaCount: 1
   image:
     repository: vespa
@@ -339,6 +341,7 @@ vespa:
 
 redis:
   enabled: true
+  externalHost: ""
   architecture: standalone
   commonConfiguration: |-
     # Enable AOF https://redis.io/topics/persistence#append-only-file


### PR DESCRIPTION
## Description

The Helm chart design actually partially support usage of external component, especially for storage. Indeed, support for Postgres, Redis, and Vespa dependencies allow `enabled` flag to prevent from deploying such solutions, but external host configuration is not permitted as it is injected into the chart configmap without any possibilities of tuning.

This PR proposes to add the following custom values:

```yaml
postgres:
    externalHost: ""

redis:
    externalHost: ""

vespa:
    externalHost: ""
```

And associated template helpers that would decide which host to use in the ConfigMap (created resources if `enabled`, `externalHost` otherwise).

## How Has This Been Tested?

I will test it by deploying the Helm chart locally in both variations: with and without storage components `enabled` to ensure it works as expected.

## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
