### PR TITLE
Citation consistency in Citation Processing (initial ranking vs post validation/re-ranking)

### DIFF
--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -22,7 +22,9 @@ from onyx.chat.stream_processing.answer_response_handler import (
 from onyx.chat.stream_processing.answer_response_handler import (
     DummyAnswerResponseHandler,
 )
-from onyx.chat.stream_processing.utils import map_document_id_order
+from onyx.chat.stream_processing.utils import (
+    map_document_id_order,
+)
 from onyx.chat.tool_handling.tool_response_handler import ToolResponseHandler
 from onyx.file_store.utils import InMemoryChatFile
 from onyx.llm.interfaces import LLM
@@ -206,9 +208,9 @@ class Answer:
         # + figure out what the next LLM call should be
         tool_call_handler = ToolResponseHandler(current_llm_call.tools)
 
-        search_result, displayed_search_results_map = SearchTool.get_search_result(
+        final_search_results, displayed_search_results = SearchTool.get_search_result(
             current_llm_call
-        ) or ([], {})
+        ) or ([], [])
 
         # Quotes are no longer supported
         # answer_handler: AnswerResponseHandler
@@ -224,9 +226,9 @@ class Answer:
         # else:
         #     raise ValueError("No answer style config provided")
         answer_handler = CitationResponseHandler(
-            context_docs=search_result,
-            doc_id_to_rank_map=map_document_id_order(search_result),
-            display_doc_order_dict=displayed_search_results_map,
+            context_docs=final_search_results,
+            final_doc_id_to_rank_map=map_document_id_order(final_search_results),
+            display_doc_id_to_rank_map=map_document_id_order(displayed_search_results),
         )
 
         response_handler_manager = LLMResponseHandlerManager(

--- a/backend/onyx/chat/stream_processing/answer_response_handler.py
+++ b/backend/onyx/chat/stream_processing/answer_response_handler.py
@@ -37,22 +37,22 @@ class CitationResponseHandler(AnswerResponseHandler):
     def __init__(
         self,
         context_docs: list[LlmDoc],
-        doc_id_to_rank_map: DocumentIdOrderMapping,
-        display_doc_order_dict: dict[str, int],
+        final_doc_id_to_rank_map: DocumentIdOrderMapping,
+        display_doc_id_to_rank_map: DocumentIdOrderMapping,
     ):
         self.context_docs = context_docs
-        self.doc_id_to_rank_map = doc_id_to_rank_map
-        self.display_doc_order_dict = display_doc_order_dict
+        self.final_doc_id_to_rank_map = final_doc_id_to_rank_map
+        self.display_doc_id_to_rank_map = display_doc_id_to_rank_map
         self.citation_processor = CitationProcessor(
             context_docs=self.context_docs,
-            doc_id_to_rank_map=self.doc_id_to_rank_map,
-            display_doc_order_dict=self.display_doc_order_dict,
+            final_doc_id_to_rank_map=self.final_doc_id_to_rank_map,
+            display_doc_id_to_rank_map=self.display_doc_id_to_rank_map,
         )
         self.processed_text = ""
         self.citations: list[CitationInfo] = []
 
         # TODO remove this after citation issue is resolved
-        logger.debug(f"Document to ranking map {self.doc_id_to_rank_map}")
+        logger.debug(f"Document to ranking map {self.final_doc_id_to_rank_map}")
 
     def handle_response_part(
         self,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -396,7 +396,7 @@ class SearchTool(Tool):
     @classmethod
     def get_search_result(
         cls, llm_call: LLMCall
-    ) -> tuple[list[LlmDoc], dict[str, int]] | None:
+    ) -> tuple[list[LlmDoc], list[LlmDoc]] | None:
         """
         Returns the final search results and a map of docs to their original search rank (which is what is displayed to user)
         """
@@ -404,7 +404,7 @@ class SearchTool(Tool):
             return None
 
         final_search_results = []
-        doc_id_to_original_search_rank_map = {}
+        initial_search_results = []
 
         for yield_item in llm_call.tool_call_info:
             if (
@@ -417,12 +417,11 @@ class SearchTool(Tool):
                 and yield_item.id == ORIGINAL_CONTEXT_DOCUMENTS_ID
             ):
                 search_contexts = yield_item.response.contexts
-                original_doc_search_rank = 1
-                for idx, doc in enumerate(search_contexts):
-                    if doc.document_id not in doc_id_to_original_search_rank_map:
-                        doc_id_to_original_search_rank_map[
-                            doc.document_id
-                        ] = original_doc_search_rank
-                        original_doc_search_rank += 1
+                # original_doc_search_rank = 1
+                for doc in search_contexts:
+                    if doc.document_id not in initial_search_results:
+                        initial_search_results.append(doc)
 
-        return final_search_results, doc_id_to_original_search_rank_map
+                initial_search_results = cast(list[LlmDoc], initial_search_results)
+
+        return final_search_results, initial_search_results

--- a/backend/tests/unit/onyx/chat/stream_processing/test_citation_processing.py
+++ b/backend/tests/unit/onyx/chat/stream_processing/test_citation_processing.py
@@ -68,11 +68,12 @@ def process_text(
     tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int]]
 ) -> tuple[str, list[CitationInfo]]:
     mock_docs, mock_doc_id_to_rank_map = mock_data
-    mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    final_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    display_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
     processor = CitationProcessor(
         context_docs=mock_docs,
-        doc_id_to_rank_map=mapping,
-        display_doc_order_dict=mock_doc_id_to_rank_map,
+        final_doc_id_to_rank_map=final_mapping,
+        display_doc_id_to_rank_map=display_mapping,
         stop_stream=None,
     )
 

--- a/backend/tests/unit/onyx/chat/stream_processing/test_citation_substitution.py
+++ b/backend/tests/unit/onyx/chat/stream_processing/test_citation_substitution.py
@@ -71,19 +71,22 @@ mock_doc_mapping_rerank = {
 
 
 @pytest.fixture
-def mock_data() -> tuple[list[LlmDoc], dict[str, int]]:
-    return mock_docs, mock_doc_mapping
+def mock_data() -> tuple[list[LlmDoc], dict[str, int], dict[str, int]]:
+    return mock_docs, mock_doc_mapping, mock_doc_mapping_rerank
 
 
 def process_text(
-    tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int]]
+    tokens: list[str], mock_data: tuple[list[LlmDoc], dict[str, int], dict[str, int]]
 ) -> tuple[str, list[CitationInfo]]:
-    mock_docs, mock_doc_id_to_rank_map = mock_data
-    mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    mock_docs, mock_doc_id_to_rank_map, mock_doc_id_to_rank_map_rerank = mock_data
+    final_mapping = DocumentIdOrderMapping(order_mapping=mock_doc_id_to_rank_map)
+    display_mapping = DocumentIdOrderMapping(
+        order_mapping=mock_doc_id_to_rank_map_rerank
+    )
     processor = CitationProcessor(
         context_docs=mock_docs,
-        doc_id_to_rank_map=mapping,
-        display_doc_order_dict=mock_doc_mapping_rerank,
+        final_doc_id_to_rank_map=final_mapping,
+        display_doc_id_to_rank_map=display_mapping,
         stop_stream=None,
     )
 
@@ -115,7 +118,7 @@ def process_text(
     ],
 )
 def test_citation_substitution(
-    mock_data: tuple[list[LlmDoc], dict[str, int]],
+    mock_data: tuple[list[LlmDoc], dict[str, int], dict[str, int]],
     test_name: str,
     input_tokens: list[str],
     expected_text: str,


### PR DESCRIPTION
Purpose: Alignment & renaming of objects for initial (displayed) ranking and r…e-ranking/validation citations

Comments:

 - renamed post-reranking/validation citation information consistently to final_... (example: doc_id_to_rank_map -> final_doc_id_to_rank_map)
 - changed and renamed objects containing initial ranking information (now: display_...) consistent with final rankings (final_...). Specifically, {} to [] for displayed_search_results
 - for CitationInfo, changed citation_num from 'x-th citation in response stream' to the initial position of the doc [NOTE: test implications]
-  changed tests: onyx/backend/tests/unit/onyx/chat/stream_processing/test_citation_processing.py onyx/backend/tests/unit/onyx/chat/stream_processing/test_citation_substitution.py

## Description
[Provide a brief description of the changes in this PR]


## How Has This Been Tested?
- Tested using the unit tests, including the the test_citation_substitution 
- Testing using simple sample document where citation displayed on first position is not valid.


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
 - https://github.com/onyx-dot-app/onyx/pull/3421


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
