### PR TITLE
Ensure metadata overrides file contents

### DIFF
--- a/web/src/app/chat/documentSidebar/ChatDocumentDisplay.tsx
+++ b/web/src/app/chat/documentSidebar/ChatDocumentDisplay.tsx
@@ -7,7 +7,7 @@ import { DocumentUpdatedAtBadge } from "@/components/search/DocumentUpdatedAtBad
 import { MetadataBadge } from "@/components/MetadataBadge";
 import { WebResultIcon } from "@/components/WebResultIcon";
 import { Dispatch, SetStateAction } from "react";
-import { ValidSources } from "@/lib/types";
+import { openDocument } from "@/lib/search/utils";
 
 interface DocumentDisplayProps {
   closeSidebar: () => void;
@@ -73,14 +73,6 @@ export function ChatDocumentDisplay({
     return null;
   }
 
-  const handleViewFile = async () => {
-    if (document.source_type == ValidSources.File && setPresentingDocument) {
-      setPresentingDocument(document);
-    } else if (document.link) {
-      window.open(document.link, "_blank");
-    }
-  };
-
   const hasMetadata =
     document.updated_at || Object.keys(document.metadata).length > 0;
   return (
@@ -91,7 +83,7 @@ export function ChatDocumentDisplay({
         }`}
       >
         <button
-          onClick={handleViewFile}
+          onClick={() => openDocument(document, setPresentingDocument)}
           className="cursor-pointer text-left flex flex-col px-2 py-1.5"
         >
           <div className="line-clamp-1 mb-1 flex h-6 items-center gap-2 text-xs">

--- a/web/src/components/chat_search/sources/SourceCard.tsx
+++ b/web/src/components/chat_search/sources/SourceCard.tsx
@@ -2,9 +2,7 @@ import { WebResultIcon } from "@/components/WebResultIcon";
 import { SourceIcon } from "@/components/SourceIcon";
 import { OnyxDocument } from "@/lib/search/interfaces";
 import { truncateString } from "@/lib/utils";
-import { SetStateAction } from "react";
-import { Dispatch } from "react";
-import { ValidSources } from "@/lib/types";
+import { openDocument } from "@/lib/search/utils";
 
 export default function SourceCard({
   doc,
@@ -16,13 +14,7 @@ export default function SourceCard({
   return (
     <div
       key={doc.document_id}
-      onClick={() => {
-        if (doc.source_type == ValidSources.File && setPresentingDocument) {
-          setPresentingDocument(doc);
-        } else if (doc.link) {
-          window.open(doc.link, "_blank");
-        }
-      }}
+      onClick={() => openDocument(doc, setPresentingDocument)}
       className="cursor-pointer text-left overflow-hidden flex flex-col gap-0.5 rounded-sm px-3 py-2.5 hover:bg-background-125 bg-background-100 w-[200px]"
     >
       <div className="line-clamp-1 font-semibold text-ellipsis  text-text-900  flex h-6 items-center gap-2 text-sm">

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -22,6 +22,7 @@ import { WarningCircle } from "@phosphor-icons/react";
 import TextView from "../chat_search/TextView";
 import { SearchResultIcon } from "../SearchResultIcon";
 import { ValidSources } from "@/lib/types";
+import { openDocument } from "@/lib/search/utils";
 
 export const buildDocumentSummaryDisplay = (
   matchHighlights: string[],
@@ -428,19 +429,15 @@ export function CompactDocumentCard({
   url,
   updatePresentingDocument,
 }: {
-  document: LoadedOnyxDocument;
+  document: OnyxDocument;
   icon?: React.ReactNode;
   url?: string;
-  updatePresentingDocument: (documentIndex: LoadedOnyxDocument) => void;
+  updatePresentingDocument: (document: OnyxDocument) => void;
 }) {
   return (
     <div
       onClick={() => {
-        if (document.source_type === ValidSources.File) {
-          updatePresentingDocument(document);
-        } else if (document.link) {
-          window.open(document.link, "_blank");
-        }
+        openDocument(document, updatePresentingDocument);
       }}
       className="max-w-[250px] cursor-pointer pb-0 pt-0 mt-0 flex gap-y-0  flex-col  content-start items-start gap-0 "
     >

--- a/web/src/components/search/results/Citation.tsx
+++ b/web/src/components/search/results/Citation.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { CompactDocumentCard } from "../DocumentDisplay";
-import { LoadedOnyxDocument } from "@/lib/search/interfaces";
+import { LoadedOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
 import {
   Tooltip,
   TooltipContent,
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ValidSources } from "@/lib/types";
+import { openDocument } from "@/lib/search/utils";
 
 export function Citation({
   children,
@@ -21,7 +22,7 @@ export function Citation({
   link?: string;
   children?: JSX.Element | string | null | ReactNode;
   index?: number;
-  updatePresentingDocument: (documentIndex: LoadedOnyxDocument) => void;
+  updatePresentingDocument: (document: OnyxDocument) => void;
   document: LoadedOnyxDocument;
   icon?: React.ReactNode;
   url?: string;
@@ -30,20 +31,12 @@ export function Citation({
     ? children?.toString().split("[")[1].split("]")[0]
     : index;
 
-  const onClick = () => {
-    if (document.source_type == ValidSources.File) {
-      updatePresentingDocument(document);
-    } else {
-      window.open(link || document.link, "_blank");
-    }
-  };
-
   return (
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
           <div
-            onMouseDown={onClick}
+            onClick={() => openDocument(document, updatePresentingDocument)}
             className="inline-flex items-center cursor-pointer transition-all duration-200 ease-in-out"
           >
             <span className="flex items-center justify-center w-6 h-6 text-[11px] font-medium text-gray-700 bg-gray-100 rounded-full border border-gray-300 hover:bg-gray-200 hover:text-gray-900 shadow-sm">

--- a/web/src/lib/search/utils.ts
+++ b/web/src/lib/search/utils.ts
@@ -1,5 +1,10 @@
-import { Tag } from "../types";
-import { Filters, SourceMetadata } from "./interfaces";
+import { Tag, ValidSources } from "../types";
+import {
+  Filters,
+  LoadedOnyxDocument,
+  OnyxDocument,
+  SourceMetadata,
+} from "./interfaces";
 import { DateRangePickerValue } from "@/app/ee/admin/performance/DateRangeSelector";
 
 export const buildFilters = (
@@ -22,3 +27,16 @@ export const buildFilters = (
 export function endsWithLetterOrNumber(str: string) {
   return /[a-zA-Z0-9]$/.test(str);
 }
+
+// If we have a link, open it in a new tab (including if it's a file)
+// If above fails and we have a file, update the presenting document
+export const openDocument = (
+  document: OnyxDocument,
+  updatePresentingDocument?: (document: OnyxDocument) => void
+) => {
+  if (document.link) {
+    window.open(document.link, "_blank");
+  } else if (document.source_type === ValidSources.File) {
+    updatePresentingDocument?.(document);
+  }
+};


### PR DESCRIPTION
## Description
We need to ensure the metadata tags we support override the new `file preview` functionality  (https://github.com/onyx-dot-app/onyx/pull/3113)
- Metadata docs:`https://docs.onyx.app/connectors/file#adding-metadata`



## How Has This Been Tested?
- Various web sources, various .txt files with links, and various .txt files without links


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
