### PR TITLE
AWS extraneous error fix

### DIFF
--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -271,9 +271,20 @@ class DefaultMultiLLM(LLM):
         # variables. We'll also try passing them in, since litellm just ignores
         # addtional kwargs (and some kwargs MUST be passed in rather than set as
         # env variables)
+
+        # Create a dictionary for model-specific arguments if it's None
+        model_kwargs = model_kwargs or {}
+
+        # Filter out empty or None values from custom_config before use
         if custom_config:
-            for k, v in custom_config.items():
+            filtered_config = {k: v for k, v in custom_config.items() if v}
+
+            # Set non-empty config entries as environment variables for litellm
+            for k, v in filtered_config.items():
                 os.environ[k] = v
+
+            # Update model_kwargs with remaining non-empty config
+            model_kwargs.update(filtered_config)
 
         model_kwargs = model_kwargs or {}
         if custom_config:

--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -286,9 +286,6 @@ class DefaultMultiLLM(LLM):
             # Update model_kwargs with remaining non-empty config
             model_kwargs.update(filtered_config)
 
-        model_kwargs = model_kwargs or {}
-        if custom_config:
-            model_kwargs.update(custom_config)
         if extra_headers:
             model_kwargs.update({"extra_headers": extra_headers})
         if extra_body:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -57,7 +57,7 @@ def test_llm_configuration(
     )
 
     functions_with_args: list[tuple[Callable, tuple]] = [(test_llm, (llm,))]
-
+    print(llm.config.__dict__)
     if (
         test_llm_request.fast_default_model_name
         and test_llm_request.fast_default_model_name

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -57,7 +57,6 @@ def test_llm_configuration(
     )
 
     functions_with_args: list[tuple[Callable, tuple]] = [(test_llm, (llm,))]
-    print(llm.config.__dict__)
     if (
         test_llm_request.fast_default_model_name
         and test_llm_request.fast_default_model_name

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -238,7 +238,7 @@ services:
     volumes:
       - ../data/certbot/conf:/etc/letsencrypt
       - ../data/certbot/www:/var/www/certbot
-    logging::wq
+    logging:
       driver: json-file
       options:
         max-size: "50m"
@@ -260,6 +260,3 @@ volumes:
   # Created by the container itself
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-
-
-


### PR DESCRIPTION
## Description

- Filter out empty or None values in custom_config so we don’t set empty AWS credentials as environment variables.  
- Addresses an issue where Bedrock rejected requests that contained extraneous or empty credential fields (e.g., AWS_ACCESS_KEY_ID=“”).  

Should fix  https://github.com/onyx-dot-app/onyx/issues/3444


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Accepted Risk (provide if relevant)
N/A


## Related Issue(s) (provide if relevant)
N/A


## Mental Checklist:
- All of the automated tests pass
- All PR comments are addressed and marked resolved
- If there are migrations, they have been rebased to latest main
- If there are new dependencies, they are added to the requirements
- If there are new environment variables, they are added to all of the deployment methods
- If there are new APIs that don't require auth, they are added to PUBLIC_ENDPOINT_SPECS
- Docker images build and basic functionalities work
- Author has done a final read through of the PR right before merge

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
