### PR TITLE
Made sure confluence connector recursive by page includes top level page

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -99,14 +99,13 @@ class ConfluenceConnector(LoadConnector, PollConnector, SlimConnector):
         # Remove trailing slash from wiki_base if present
         self.wiki_base = wiki_base.rstrip("/")
 
-        # if nothing is provided, we will fetch all pages
-        base_cql_page_query = "type=page"
-
         """
-        Only one of the following options should be specified so
+        If nothing is provided, we default to fetching all pages
+        Only one or none of the following options should be specified so
             the order shouldn't matter
-        However, we use elif to ensure that only of the following is provided
+        However, we use elif to ensure that only of the following is enforced
         """
+        base_cql_page_query = "type=page"
         if cql_query:
             base_cql_page_query = cql_query
         elif page_id:

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -64,7 +64,7 @@ class ConfluenceConnector(LoadConnector, PollConnector, SlimConnector):
         is_cloud: bool,
         space: str = "",
         page_id: str = "",
-        index_recursively: bool = True,
+        index_recursively: bool = False,
         cql_query: str | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
         continue_on_failure: bool = CONTINUE_ON_CONNECTOR_FAILURE,
@@ -84,18 +84,22 @@ class ConfluenceConnector(LoadConnector, PollConnector, SlimConnector):
 
         # if nothing is provided, we will fetch all pages
         cql_page_query = "type=page"
+
+        """
+        Only one of the following options should be specified so
+            the order shouldn't matter
+        However, we use elif to ensure that only of the following is provided
+        """
         if cql_query:
-            # if a cql_query is provided, we will use it to fetch the pages
             cql_page_query = cql_query
         elif page_id:
-            # if a cql_query is not provided, we will use the page_id to fetch the page
             if index_recursively:
-                cql_page_query += f" and ancestor='{page_id}'"
+                cql_page_query += f" and (ancestor='{page_id}' or id='{page_id}')"
             else:
                 cql_page_query += f" and id='{page_id}'"
         elif space:
-            # if no cql_query or page_id is provided, we will use the space to fetch the pages
-            cql_page_query += f" and space='{quote(space)}'"
+            uri_safe_space = quote(space)
+            cql_page_query += f" and space='{uri_safe_space}'"
 
         self.cql_page_query = cql_page_query
         self.cql_time_filter = ""


### PR DESCRIPTION
## Description
now the recursive query also includes the top level page, not just the children


## How Has This Been Tested?
Tested on main with a recursive page on a page with no children and got 0 docs. after the change now i get 1 doc which is what is desired


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
