### PR TITLE
Curators can now update the curator relationship

### DIFF
--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from operator import and_
 from uuid import UUID
 
+from fastapi import HTTPException
 from sqlalchemy import delete
 from sqlalchemy import func
 from sqlalchemy import Select
@@ -119,6 +120,59 @@ def _cleanup_document_set__user_group_relationships__no_commit(
             DocumentSet__UserGroup.user_group_id == user_group_id
         )
     )
+
+
+def validate_object_creation_for_user(
+    db_session: Session,
+    user: User | None,
+    target_group_ids: list[int] | None = None,
+    object_is_public: bool | None = None,
+    object_is_perm_sync: bool | None = None,
+) -> None:
+    """
+    All users can create/edit permission synced objects if they don't specify a group
+    All admin actions are allowed.
+    Prevents non-admins from creating/editing:
+    - public objects
+    - objects with no groups
+    - objects that belong to a group they don't curate
+    """
+    if object_is_perm_sync and not target_group_ids:
+        return
+
+    if not user or user.role == UserRole.ADMIN:
+        return
+
+    if object_is_public:
+        detail = "User does not have permission to create public credentials"
+        logger.error(detail)
+        raise HTTPException(
+            status_code=400,
+            detail=detail,
+        )
+    if not target_group_ids:
+        detail = "Curators must specify 1+ groups"
+        logger.error(detail)
+        raise HTTPException(
+            status_code=400,
+            detail=detail,
+        )
+
+    user_curated_groups = fetch_user_groups_for_user(
+        db_session=db_session,
+        user_id=user.id,
+        # Global curators can curate all groups they are member of
+        only_curator_groups=user.role != UserRole.GLOBAL_CURATOR,
+    )
+    user_curated_group_ids = set([group.id for group in user_curated_groups])
+    target_group_ids_set = set(target_group_ids)
+    if not target_group_ids_set.issubset(user_curated_group_ids):
+        detail = "Curators cannot control groups they don't curate"
+        logger.error(detail)
+        raise HTTPException(
+            status_code=400,
+            detail=detail,
+        )
 
 
 def fetch_user_group(db_session: Session, user_group_id: int) -> UserGroup | None:

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -440,52 +440,20 @@ def remove_curator_status__no_commit(db_session: Session, user: User) -> None:
     _validate_curator_status__no_commit(db_session, [user])
 
 
-def _validate_curator_relationship_update(
+def _validate_curator_relationship_update_requester(
     db_session: Session,
     user_group_id: int,
-    target_user: User,
     user_making_change: User | None = None,
 ) -> None:
     """
-    This function will raise an error if:
-    - the target user is an admin
-    - the target user is a global_curator
-    - the user making the change does not have the necessary permissions to update the curator relationship.
-    - the user making the change is not a curator in the group they are
-        trying to update the curator relationship for.
-    - the user making the change is not an admin or a curator/global_curator for the group they are
-        trying to update the curator relationship for.
+    This function validates that the user making the change has the necessary permissions
+    to update the curator relationship for the target user in the given user group.
     """
-    if target_user.role == UserRole.ADMIN:
-        raise ValueError(
-            f"User '{target_user.email}' is an admin and therefore has all permissions "
-            "of a curator. If you'd like this user to only have curator permissions, "
-            "you must update their role to BASIC then assign them to be CURATOR in the "
-            "appropriate groups."
-        )
-    if target_user.role == UserRole.GLOBAL_CURATOR:
-        raise ValueError(
-            f"User '{target_user.email}' is a global_curator and therefore has all "
-            "permissions of a curator for all groups. If you'd like this user to only "
-            "have curator permissions for a specific group, you must update their role "
-            "to BASIC then assign them to be CURATOR in the appropriate groups."
-        )
 
     if user_making_change is None or user_making_change.role == UserRole.ADMIN:
         return
 
-    requested_user_groups = fetch_user_groups_for_user(
-        db_session=db_session,
-        user_id=target_user.id,
-        only_curator_groups=False,
-    )
-
-    group_ids = [group.id for group in requested_user_groups]
-    if user_group_id not in group_ids:
-        raise ValueError(
-            f"target user {target_user.email} is not in group '{user_group_id}'"
-        )
-
+    # check if the user making the change is a curator in the group they are changing the curator relationship for
     user_making_change_curator_groups = fetch_user_groups_for_user(
         db_session=db_session,
         user_id=user_making_change.id,
@@ -494,7 +462,6 @@ def _validate_curator_relationship_update(
         # for any group they are a member of
         only_curator_groups=user_making_change.role == UserRole.CURATOR,
     )
-
     requestor_curator_group_ids = [
         group.id for group in user_making_change_curator_groups
     ]
@@ -502,6 +469,49 @@ def _validate_curator_relationship_update(
         raise ValueError(
             f"user making change {user_making_change.email} is not a curator,"
             f" admin, or global_curator for group '{user_group_id}'"
+        )
+
+
+def _validate_curator_relationship_update_request(
+    db_session: Session,
+    user_group_id: int,
+    target_user: User,
+) -> None:
+    """
+    This function validates that the curator_relationship_update request itself is valid.
+    """
+    if target_user.role == UserRole.ADMIN:
+        raise ValueError(
+            f"User '{target_user.email}' is an admin and therefore has all permissions "
+            "of a curator. If you'd like this user to only have curator permissions, "
+            "you must update their role to BASIC then assign them to be CURATOR in the "
+            "appropriate groups."
+        )
+    elif target_user.role == UserRole.GLOBAL_CURATOR:
+        raise ValueError(
+            f"User '{target_user.email}' is a global_curator and therefore has all "
+            "permissions of a curator for all groups. If you'd like this user to only "
+            "have curator permissions for a specific group, you must update their role "
+            "to BASIC then assign them to be CURATOR in the appropriate groups."
+        )
+    elif target_user.role not in [UserRole.CURATOR, UserRole.BASIC]:
+        raise ValueError(
+            f"This endpoint can only be used to update the curator relationship for "
+            "users with the CURATOR or BASIC role. \n"
+            f"Target user: {target_user.email} \n"
+            f"Target user role: {target_user.role} \n"
+        )
+
+    # check if the target user is in the group they are changing the curator relationship for
+    requested_user_groups = fetch_user_groups_for_user(
+        db_session=db_session,
+        user_id=target_user.id,
+        only_curator_groups=False,
+    )
+    group_ids = [group.id for group in requested_user_groups]
+    if user_group_id not in group_ids:
+        raise ValueError(
+            f"target user {target_user.email} is not in group '{user_group_id}'"
         )
 
 
@@ -515,14 +525,20 @@ def update_user_curator_relationship(
     if not target_user:
         raise ValueError(f"User with id '{set_curator_request.user_id}' not found")
 
-    _validate_curator_relationship_update(
+    _validate_curator_relationship_update_request(
         db_session=db_session,
         user_group_id=user_group_id,
         target_user=target_user,
+    )
+
+    _validate_curator_relationship_update_requester(
+        db_session=db_session,
+        user_group_id=user_group_id,
         user_making_change=user_making_change,
     )
+
     logger.info(
-        f"user_making_change={user_making_change.email} is "
+        f"user_making_change={user_making_change.email if user_making_change else 'None'} is "
         f"updating the curator relationship for user={target_user.email} "
         f"in group={user_group_id} to is_curator={set_curator_request.is_curator}"
     )

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -83,7 +83,7 @@ def patch_user_group(
 def set_user_curator(
     user_group_id: int,
     set_curator_request: SetCuratorRequest,
-    _: User | None = Depends(current_admin_user),
+    user: User | None = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     try:
@@ -91,6 +91,7 @@ def set_user_curator(
             db_session=db_session,
             user_group_id=user_group_id,
             set_curator_request=set_curator_request,
+            user_making_change=user,
         )
     except ValueError as e:
         logger.error(f"Error setting user curator: {e}")

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -510,7 +510,7 @@ def associate_credential_to_connector(
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
     fetch_ee_implementation_or_noop(
-        "onyx.db.user_group", "validate_user_creation_permissions", None
+        "onyx.db.user_group", "validate_object_creation_for_user", None
     )(
         db_session=db_session,
         user=user,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -680,7 +680,7 @@ def create_connector_from_model(
         _validate_connector_allowed(connector_data.source)
 
         fetch_ee_implementation_or_noop(
-            "onyx.db.user_group", "validate_user_creation_permissions", None
+            "onyx.db.user_group", "validate_object_creation_for_user", None
         )(
             db_session=db_session,
             user=user,
@@ -716,7 +716,7 @@ def create_connector_with_mock_credential(
     tenant_id: str = Depends(get_current_tenant_id),
 ) -> StatusResponse:
     fetch_ee_implementation_or_noop(
-        "onyx.db.user_group", "validate_user_creation_permissions", None
+        "onyx.db.user_group", "validate_object_creation_for_user", None
     )(
         db_session=db_session,
         user=user,
@@ -776,7 +776,7 @@ def update_connector_from_model(
     try:
         _validate_connector_allowed(connector_data.source)
         fetch_ee_implementation_or_noop(
-            "onyx.db.user_group", "validate_user_creation_permissions", None
+            "onyx.db.user_group", "validate_object_creation_for_user", None
         )(
             db_session=db_session,
             user=user,

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -122,7 +122,7 @@ def create_credential_from_model(
 ) -> ObjectCreationIdResponse:
     if not _ignore_credential_permissions(credential_info.source):
         fetch_ee_implementation_or_noop(
-            "onyx.db.user_group", "validate_user_creation_permissions", None
+            "onyx.db.user_group", "validate_object_creation_for_user", None
         )(
             db_session=db_session,
             user=user,

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -31,7 +31,7 @@ def create_document_set(
     db_session: Session = Depends(get_session),
 ) -> int:
     fetch_ee_implementation_or_noop(
-        "onyx.db.user_group", "validate_user_creation_permissions", None
+        "onyx.db.user_group", "validate_object_creation_for_user", None
     )(
         db_session=db_session,
         user=user,
@@ -56,7 +56,7 @@ def patch_document_set(
     db_session: Session = Depends(get_session),
 ) -> None:
     fetch_ee_implementation_or_noop(
-        "onyx.db.user_group", "validate_user_creation_permissions", None
+        "onyx.db.user_group", "validate_object_creation_for_user", None
     )(
         db_session=db_session,
         user=user,


### PR DESCRIPTION
## Description
Curators can now promote basic users to curators of a group and demote them 
curators can also demote themselves but a modal pops up asking for confirmation:

![Screen Recording 2024-12-21 at 9 01 51 AM](https://github.com/user-attachments/assets/c224402e-ddd6-41d3-a48e-607a5b499625)

## How Has This Been Tested?
Watch the video. A in top right is admin. other 2 accounts are curator/basic


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
