### PR TITLE
Fix logo rendering

### DIFF
--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -103,12 +103,14 @@ export const LogoIcon = ({
   className = defaultTailwindCSS,
   src,
 }: LogoIconProps) => (
-  <div
+  <Image
     style={{ width: `${size}px`, height: `${size}px` }}
     className={`w-[${size}px] h-[${size}px] ` + className}
-  >
-    <Image src={src} alt="Logo" width="96" height="96" />
-  </div>
+    src={src}
+    alt="Logo"
+    width="96"
+    height="96"
+  />
 );
 
 export const AssistantsIconSkeleton = ({


### PR DESCRIPTION
## Description
Previously, our div would cause issues with React Markdown's parsing. We should return Images as individual components
Before
<img width="255" alt="Screenshot 2024-12-22 at 2 08 27 PM" src="https://github.com/user-attachments/assets/f6009d2c-ab85-4f43-a478-9abe287899c4" />

## How Has This Been Tested?
Various logos


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
