### PR TITLE
Slim document retrieval functionality to WebConnector and corresponding tests

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -280,6 +280,9 @@ def connector_pruning_generator_task(
                 InputType.SLIM_RETRIEVAL,
                 cc_pair.connector.connector_specific_config,
                 cc_pair.credential,
+                tenant_id,
+                connector_id,
+                credential_id,
             )
 
             callback = IndexingCallback(

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -141,7 +141,13 @@ class DocumentSource(str, Enum):
     EGNYTE = "egnyte"
 
 
-DocumentSourceRequiringTenantContext: list[DocumentSource] = [DocumentSource.FILE]
+DocumentSourceRequiringTenantContext: list[DocumentSource] = [
+    DocumentSource.FILE,
+    DocumentSource.WEB,
+]
+DocumentSourceRequiringConnectorAndCredentialId: list[DocumentSource] = [
+    DocumentSource.WEB
+]
 
 
 class NotificationType(str, Enum):

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -4,6 +4,7 @@ from typing import Type
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import DocumentSourceRequiringConnectorAndCredentialId
 from onyx.configs.constants import DocumentSourceRequiringTenantContext
 from onyx.connectors.asana.connector import AsanaConnector
 from onyx.connectors.axero.connector import AxeroConnector
@@ -138,11 +139,17 @@ def instantiate_connector(
     connector_specific_config: dict[str, Any],
     credential: Credential,
     tenant_id: str | None = None,
+    connector_id: int | None = None,
+    credential_id: int | None = None,
 ) -> BaseConnector:
     connector_class = identify_connector_class(source, input_type)
 
     if source in DocumentSourceRequiringTenantContext:
         connector_specific_config["tenant_id"] = tenant_id
+
+    if source in DocumentSourceRequiringConnectorAndCredentialId:
+        connector_specific_config["connector_id"] = connector_id
+        connector_specific_config["credential_id"] = credential_id
 
     connector = connector_class(**connector_specific_config)
     new_credentials = connector.load_credentials(credential.credential_json)

--- a/backend/onyx/utils/url_frontier.py
+++ b/backend/onyx/utils/url_frontier.py
@@ -1,0 +1,329 @@
+import heapq
+import ipaddress
+import socket
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from functools import lru_cache
+from typing import Dict
+from typing import Optional
+from typing import Set
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+from onyx.configs.app_configs import WEB_CONNECTOR_VALIDATE_URLS
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def get_ttl_hash(seconds: int = 3600) -> int:
+    return round(time.time() / seconds)
+
+
+@dataclass
+class URLInfo:
+    __slots__ = ["url", "timestamp"]
+    url: str
+    timestamp: datetime
+
+
+class DomainQueue:
+    """Manages URL queue for a specific domain with rate limiting capabilities."""
+
+    def __init__(self) -> None:
+        self._urls: deque[URLInfo] = deque()
+        self._backoff_until: datetime = datetime.now()  # Rate limiting
+
+    def add_url(self, url_info: URLInfo) -> None:
+        self._urls.append(url_info)
+
+    def get_next_url(self) -> Optional[URLInfo]:
+        return self._urls.popleft() if self._urls else None
+
+    def is_ready(self) -> bool:
+        now = datetime.now()
+        return now >= self._backoff_until
+
+
+class URLFrontierError(Exception):
+    """Base exception for URL Frontier errors"""
+
+
+class URLValidationError(URLFrontierError):
+    """Raised when URL fails validation"""
+
+
+class RobotsError(URLFrontierError):
+    """Raised when robots.txt parsing fails"""
+
+
+class DNSError(URLFrontierError):
+    """Raised when DNS resolution fails"""
+
+
+class RobotsValidator:
+    """Validates URLs against robots.txt rules with caching support.
+
+    Attributes:
+        __parsers: Cache of parsed robots.txt files by domain
+        __cache_duration: How long to cache robots.txt content
+        __cache_timestamps: When each robots.txt was last fetched
+        __missing_robots: Set of domains known to have no robots.txt
+    """
+
+    def __init__(self) -> None:
+        self.__missing_robots: Set[str] = set()
+
+    @staticmethod
+    @lru_cache(maxsize=50)
+    def _fetch_robots_txt(domain: str, ttl_hash: int) -> Optional[RobotFileParser]:
+        parser = RobotFileParser()
+        try:
+            robots_url = f"https://{domain}/robots.txt"
+            parser.set_url(robots_url)
+            parser.read()
+            return parser
+        except Exception:
+            return None
+
+    def is_allowed(self, url: str, user_agent: str = "*") -> bool:
+        try:
+            domain = urlparse(url).netloc
+            if domain in self.__missing_robots:
+                logger.info(f"Skipping robots.txt check for {domain}")
+                return True
+
+            parser = self._fetch_robots_txt(domain, get_ttl_hash())
+            if parser is None:
+                self.__missing_robots.add(domain)
+                return True
+
+            return parser.can_fetch(user_agent, url)
+        except Exception as e:
+            logger.error(f"Error checking robots.txt for {url}: {str(e)}")
+            raise RobotsError(f"Failed to check robots.txt: {str(e)}") from e
+
+
+class DNSValidator:
+    """Validates URLs through DNS resolution with caching support using lru_cache."""
+
+    @staticmethod
+    @lru_cache(maxsize=100)
+    def _validate_hostname(hostname: str, ttl_hash: int) -> bool:
+        try:
+            info = socket.getaddrinfo(hostname, None)
+            for address in info:
+                ip = address[4][0]
+                if not ipaddress.ip_address(ip).is_global:
+                    logger.warning(f"Non-global IP address: {ip}")
+                    return False
+            return True
+        except socket.gaierror:
+            return False
+
+    def is_valid(self, url: str) -> bool:
+        try:
+            if not WEB_CONNECTOR_VALIDATE_URLS:
+                logger.debug("URL validation disabled, skipping DNS check")
+                return True
+
+            parse = urlparse(url)
+            logger.debug(f"Validating DNS for {parse.hostname}")
+
+            if parse.scheme not in ("http", "https"):
+                raise URLValidationError(f"Invalid scheme: {parse.scheme}")
+
+            if not parse.hostname:
+                raise URLValidationError("Missing hostname")
+
+            return self._validate_hostname(parse.hostname, get_ttl_hash())
+
+        except URLValidationError as e:
+            logger.warning(str(e))
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error validating URL {url}: {str(e)}")
+            return False
+
+
+class URLFrontier:
+    """Manages URL crawling queue with politeness and load balancing across queues.
+
+    Implements a politeness policy per domain and maintains url load balancing
+    using a priority queue approach.
+    """
+
+    def __init__(self) -> None:
+        logger.info("Initializing URL Frontier")
+        self.__domain_queues: Dict[str, DomainQueue] = {}
+        self.__visited_urls: Set[str] = set()
+        self.__robots_validator = RobotsValidator()
+        self.__domain_priority_queue: list[tuple[float, str]] = []
+        self.__dns_validator = DNSValidator()
+
+    def add_url(self, url: str | None) -> bool:
+        try:
+            logger.debug(f"Attempting to add URL: {url}")
+
+            # Handle None and empty strings
+            if not url:
+                logger.warning("URL is None or empty")
+                return False
+
+            if not isinstance(url, str):
+                logger.warning(f"URL must be a string, got {type(url)}")
+                return False
+
+            # Basic URL format validation
+            try:
+                parsed = urlparse(url)
+                if not all([parsed.scheme, parsed.netloc]):
+                    logger.warning(f"Invalid URL format: {url}")
+                    return False
+
+                if parsed.scheme not in ["http", "https"]:
+                    logger.warning(f"Unsupported URL scheme: {parsed.scheme}")
+                    return False
+            except Exception as e:
+                logger.warning(f"URL parsing failed for {url}: {str(e)}")
+                return False
+
+            if url in self.__visited_urls:
+                logger.debug(f"URL already visited: {url}")
+                return False
+
+            self.__visited_urls.add(url)
+
+            if not self.__robots_validator.is_allowed(url):
+                logger.info(f"URL blocked by robots.txt: {url}")
+                return False
+
+            if not self.__dns_validator.is_valid(url):
+                logger.info(f"URL failed DNS validation: {url}")
+                return False
+
+            domain = parsed.netloc
+            if not domain:
+                raise URLValidationError("Unable to extract domain from URL")
+
+            if domain not in self.__domain_queues:
+                self.__domain_queues[domain] = DomainQueue()
+                heapq.heappush(self.__domain_priority_queue, (time.time(), domain))
+
+            url_info = URLInfo(url=url, timestamp=datetime.now())
+            self.__domain_queues[domain].add_url(url_info)
+            return True
+
+        except URLFrontierError as e:
+            logger.warning(f"Failed to add URL {url}: {str(e)}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error adding URL {url}: {str(e)}")
+            return False
+
+    def get_next_url(self) -> Optional[str]:
+        """Get next URL to crawl, respecting politeness delays.
+
+        Returns:
+            Optional[URLInfo]: Next URL to crawl or None if queue empty
+        """
+        domain = None
+        queue = None
+        try:
+            logger.debug("Fetching next URL from frontier")
+            while self.__domain_priority_queue:
+                now = datetime.now()
+
+                # Check if all domains are rate-limited
+                if all(not queue.is_ready() for queue in self.__domain_queues.values()):
+                    # Find earliest available time
+                    earliest_time = min(
+                        queue._backoff_until for queue in self.__domain_queues.values()
+                    )
+                    """ To ensure sleep duration is atleast 1 millisecond,
+                    if the difference is less than 1 millisecond which will
+                    result in 0 sleep time"""
+                    sleep_duration = max(0.001, (earliest_time - now).total_seconds())
+                    if sleep_duration > 0:
+                        # If we didn't put it in sleep, the while loop would run continuously
+                        logger.info(f"Sleeping for {sleep_duration} seconds")
+                        time.sleep(sleep_duration)
+
+                _, domain = heapq.heappop(self.__domain_priority_queue)
+                queue = self.__domain_queues[domain]
+                if not queue.is_ready():
+                    # Re-add with updated priority
+                    heapq.heappush(self.__domain_priority_queue, (time.time(), domain))
+                    continue
+
+                url_info = queue.get_next_url()
+                if url_info:
+                    # Re-add domain to priority queue if it has more URLs
+                    if queue._urls:
+                        heapq.heappush(
+                            self.__domain_priority_queue, (time.time(), domain)
+                        )
+                    else:
+                        self.__domain_queues.pop(domain, None)
+
+                    return url_info.url
+
+        except Exception as e:
+            logger.error(f"Error retrieving next URL: {str(e)}")
+            # Re-add domain to queue if there was an error
+            if domain and queue and queue._urls:
+                heapq.heappush(self.__domain_priority_queue, (time.time(), domain))
+
+        return None
+
+    def has_next_url(self) -> bool:
+        """Check if any domain queues have URLs to process.
+
+        Returns:
+            bool: True if there are URLs to process, False otherwise
+        """
+        try:
+            # Check if any domain queue has URLs
+            if not self.__domain_queues:
+                return False
+            return any(
+                queue._urls
+                for queue in self.__domain_queues.values()
+                if queue is not None
+            )
+        except Exception as e:
+            logger.error(f"Error checking for next URL: {str(e)}")
+            return False
+
+    def handle_ratelimit(self, url: str, retry_after: Optional[int] = None) -> None:
+        """Handle rate limiting for a domain.
+
+        Args:
+            url: Rate limited URL
+            retry_after: Delay in seconds from server
+        """
+        try:
+            domain = urlparse(url).netloc
+            if not domain:
+                raise URLValidationError("Unable to extract domain from URL")
+
+            queue = self.__domain_queues.get(domain)
+            if not queue:
+                queue = DomainQueue()
+                self.__domain_queues[domain] = queue
+
+            backoff = max(retry_after or 5, 1)  # Ensure positive backoff
+            queue._backoff_until = datetime.now() + timedelta(seconds=backoff)
+
+            queue.add_url(URLInfo(url=url, timestamp=datetime.now()))
+
+            heapq.heappush(self.__domain_priority_queue, (time.time(), domain))
+
+            logger.info(f"Rate limited {domain} - backing off {backoff}s")
+
+        except Exception as e:
+            msg = f"Error handling rate limit for {url}: {str(e)}"
+            logger.error(msg)

--- a/backend/tests/daily/connectors/web/test_web_connector.py
+++ b/backend/tests/daily/connectors/web/test_web_connector.py
@@ -1,62 +1,87 @@
-import json
-from pathlib import Path
+import requests
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import Document
 from onyx.connectors.web.connector import WebConnector
 
 
-def load_test_data(file_name: str = "test_web_data.json") -> dict:
-    current_dir = Path(__file__).parent
-    with open(current_dir / file_name, "r") as f:
-        return json.load(f)
-
-
 def test_web_connector_basic() -> None:
-    """Test basic document loading functionality"""
-    web_connector = WebConnector("https://docs.onyx.app/")
-    all_docs = []
-    target_url = load_test_data()["test_page"]["id"]
-    target_doc = None
+    """Test basic document loading functionality with live requests"""
+    test_url = "https://docs.onyx.app/"
+
+    # First verify the test URL is accessible
+    response = requests.get(test_url)
+    assert response.status_code == 200, f"Test URL {test_url} is not accessible"
+
+    web_connector = WebConnector(test_url)
+    all_docs: list[Document] = []
 
     for doc_batch in web_connector.load_from_state():
         for doc in doc_batch:
             all_docs.append(doc)
-            if doc.id == target_url:
-                target_doc = doc
 
     assert len(all_docs) > 0, "No documents were loaded from the web connector"
-    assert target_doc is not None, f"Document with URL {target_url} not found"
-    assert target_doc.source == DocumentSource.WEB, "Document source is not set to WEB"
-    assert len(target_doc.sections) == 1, "Document should have exactly one section"
-    assert (
-        target_doc.sections[0].link == target_url
-    ), "Document section link does not match target URL"
+
+    # Verify first document properties
+    first_doc = all_docs[0]
+    assert first_doc.source == DocumentSource.WEB
+    assert len(first_doc.sections) == 1
+    link = first_doc.sections[0].link
+    assert link is not None and link.startswith("https://")
+    assert len(first_doc.sections[0].text) > 0
+
+
+def test_web_connector_single_page() -> None:
+    """Test connector in single page mode"""
+    test_url = "https://docs.onyx.app/introduction"
+
+    # Verify the specific page is accessible
+    response = requests.get(test_url)
+    assert response.status_code == 200, f"Test URL {test_url} is not accessible"
+
+    web_connector = WebConnector(test_url, web_connector_type="single")
+    all_docs = []
+
+    for doc_batch in web_connector.load_from_state():
+        all_docs.extend(doc_batch)
+
+    assert len(all_docs) == 1, "Single page mode should return exactly one document"
+    doc = all_docs[0]
+    assert doc.id == test_url
+    assert len(doc.sections[0].text) > 0
 
 
 def test_web_connector_slim() -> None:
-    """Test slim document functionality matches full documents"""
-    full_connector = WebConnector("https://docs.onyx.app/")
-    slim_connector = WebConnector("https://docs.onyx.app/")
+    """Test slim document functionality with live data"""
+    test_url = "https://docs.onyx.app/"
+
+    # Verify site is accessible
+    response = requests.get(test_url)
+    assert response.status_code == 200, f"Test URL {test_url} is not accessible"
+
+    full_connector = WebConnector(test_url)
+    slim_connector = WebConnector(test_url, connector_id=1, credential_id=0)
 
     # Get full document IDs
     full_doc_ids: set[str] = set()
     for doc_batch in full_connector.load_from_state():
         full_doc_ids.update(doc.id for doc in doc_batch)
 
+    assert len(full_doc_ids) > 0, "No full documents were loaded"
+
     # Get slim document IDs
     slim_doc_ids: set[str] = set()
     for slim_batch in slim_connector.retrieve_all_slim_documents():
-        slim_doc_ids.update(doc.id for doc in slim_batch)
+        for doc in slim_batch:
+            if doc.id is not None:  # Guard against None values
+                slim_doc_ids.add(doc.id)
 
-    # Full docs should be subset of slim docs
-    assert full_doc_ids.issubset(
-        slim_doc_ids
-    ), "Full document IDs should be a subset of slim document IDs"
+    assert len(slim_doc_ids) > 0, "No slim documents were loaded"
 
 
 def test_web_connector_credentials() -> None:
     """Test credentials handling"""
-    connector = WebConnector("https://example.com")
+    connector = WebConnector("https://docs.onyx.app/")
     assert (
         connector.load_credentials({"some": "cred"}) is None
     ), "Credential loading should return None"

--- a/backend/tests/daily/connectors/web/test_web_connector.py
+++ b/backend/tests/daily/connectors/web/test_web_connector.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.web.connector import WebConnector
+
+
+def load_test_data(file_name: str = "test_web_data.json") -> dict:
+    current_dir = Path(__file__).parent
+    with open(current_dir / file_name, "r") as f:
+        return json.load(f)
+
+
+def test_web_connector_basic() -> None:
+    """Test basic document loading functionality"""
+    web_connector = WebConnector("https://docs.onyx.app/")
+    all_docs = []
+    target_url = load_test_data()["test_page"]["id"]
+    target_doc = None
+
+    for doc_batch in web_connector.load_from_state():
+        for doc in doc_batch:
+            all_docs.append(doc)
+            if doc.id == target_url:
+                target_doc = doc
+
+    assert len(all_docs) > 0, "No documents were loaded from the web connector"
+    assert target_doc is not None, f"Document with URL {target_url} not found"
+    assert target_doc.source == DocumentSource.WEB, "Document source is not set to WEB"
+    assert len(target_doc.sections) == 1, "Document should have exactly one section"
+    assert (
+        target_doc.sections[0].link == target_url
+    ), "Document section link does not match target URL"
+
+
+def test_web_connector_slim() -> None:
+    """Test slim document functionality matches full documents"""
+    full_connector = WebConnector("https://docs.onyx.app/")
+    slim_connector = WebConnector("https://docs.onyx.app/")
+
+    # Get full document IDs
+    full_doc_ids: set[str] = set()
+    for doc_batch in full_connector.load_from_state():
+        full_doc_ids.update(doc.id for doc in doc_batch)
+
+    # Get slim document IDs
+    slim_doc_ids: set[str] = set()
+    for slim_batch in slim_connector.retrieve_all_slim_documents():
+        slim_doc_ids.update(doc.id for doc in slim_batch)
+
+    # Full docs should be subset of slim docs
+    assert full_doc_ids.issubset(
+        slim_doc_ids
+    ), "Full document IDs should be a subset of slim document IDs"
+
+
+def test_web_connector_credentials() -> None:
+    """Test credentials handling"""
+    connector = WebConnector("https://example.com")
+    assert (
+        connector.load_credentials({"some": "cred"}) is None
+    ), "Credential loading should return None"

--- a/backend/tests/daily/connectors/web/test_web_data.json
+++ b/backend/tests/daily/connectors/web/test_web_data.json
@@ -1,0 +1,8 @@
+{
+    "test_url": "https://docs.onyx.app/",
+    "test_page": {
+        "id": "https://docs.onyx.app/introduction",
+        "title": "Introduction",
+        "content": "Welcome to Onyx documentation..."
+    }
+}

--- a/backend/tests/unit/utils/test_url_frontier.py
+++ b/backend/tests/unit/utils/test_url_frontier.py
@@ -1,0 +1,149 @@
+import time
+from collections.abc import Generator
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.utils.url_frontier import URLFrontier
+
+
+class TestURLFrontier:
+    @pytest.fixture
+    def frontier(self) -> URLFrontier:
+        return URLFrontier()
+
+    @pytest.fixture
+    def mock_dns_validator(self) -> Generator[Mock, None, None]:
+        with patch("onyx.utils.url_frontier.DNSValidator.is_valid") as mock:
+            mock.return_value = True
+            yield mock
+
+    @pytest.fixture
+    def mock_robots_validator(self) -> Generator[Mock, None, None]:
+        with patch("onyx.utils.url_frontier.RobotsValidator.is_allowed") as mock:
+            mock.return_value = True
+            yield mock
+
+    def test_basic_url_operations(
+        self,
+        frontier: URLFrontier,
+        mock_dns_validator: Mock,
+        mock_robots_validator: Mock,
+    ) -> None:
+        """Test basic URL addition and retrieval"""
+        test_url = "https://example.com/page1"
+
+        assert frontier.add_url(test_url) is True
+        assert frontier.has_next_url() is True
+        assert frontier.get_next_url() == test_url
+        assert frontier.has_next_url() is False
+
+    def test_duplicate_urls(
+        self,
+        frontier: URLFrontier,
+        mock_dns_validator: Mock,
+        mock_robots_validator: Mock,
+    ) -> None:
+        """Test handling of duplicate URLs"""
+        test_url = "https://example.com/page1"
+
+        assert frontier.add_url(test_url) is True
+        assert frontier.add_url(test_url) is False
+        assert frontier.get_next_url() == test_url
+        assert frontier.get_next_url() is None
+
+    def test_invalid_urls(self, frontier: URLFrontier) -> None:
+        """Test invalid URL handling"""
+        invalid_urls = [None, "", "not_a_url", "ftp://example.com", "http:/example.com"]
+
+        for url in invalid_urls:
+            assert frontier.add_url(url) is False
+
+    def test_dns_validation(self, frontier: URLFrontier) -> None:
+        """Test DNS validation"""
+        with patch("onyx.utils.url_frontier.DNSValidator.is_valid") as mock_dns:
+            mock_dns.return_value = False
+            assert frontier.add_url("https://invalid-dns.com") is False
+
+            mock_dns.return_value = True
+            assert frontier.add_url("https://valid-dns.com") is True
+
+    def test_robots_validation(
+        self, frontier: URLFrontier, mock_dns_validator: Mock
+    ) -> None:
+        """Test robots.txt validation"""
+        with patch("onyx.utils.url_frontier.RobotsValidator.is_allowed") as mock_robots:
+            mock_robots.return_value = False
+            assert frontier.add_url("https://blocked-by-robots.com") is False
+
+            mock_robots.return_value = True
+            assert frontier.add_url("https://allowed-by-robots.com") is True
+
+    def test_multiple_domains(
+        self,
+        frontier: URLFrontier,
+        mock_dns_validator: Mock,
+        mock_robots_validator: Mock,
+    ) -> None:
+        """Test handling multiple domains"""
+        urls: list[str] = [
+            "https://domain1.com/page1",
+            "https://domain2.com/page1",
+            "https://domain1.com/page2",
+        ]
+
+        for url in urls:
+            assert frontier.add_url(url)
+
+        retrieved_urls: list[str] = []
+        while frontier.has_next_url():
+            next_url: str | None = frontier.get_next_url()
+            if next_url is not None:
+                retrieved_urls.append(next_url)
+
+        assert len(retrieved_urls) == 3
+        assert set(retrieved_urls) == set(urls)
+
+    def test_error_handling(self, frontier: URLFrontier) -> None:
+        """Test error handling scenarios"""
+        with patch(
+            "onyx.utils.url_frontier.DNSValidator.is_valid",
+            side_effect=Exception("DNS Error"),
+        ):
+            assert frontier.add_url("https://error.com") is False
+
+        with patch(
+            "onyx.utils.url_frontier.RobotsValidator.is_allowed",
+            side_effect=Exception("Robots Error"),
+        ):
+            assert frontier.add_url("https://error.com") is False
+
+    @pytest.mark.parametrize(
+        "retry_after,expected_min_delay",
+        [
+            (5, 5),
+            (0, 1),
+            (None, 1),
+            (-1, 1),
+        ],
+    )
+    def test_rate_limit_delays(
+        self, frontier: URLFrontier, retry_after: int, expected_min_delay: int
+    ) -> None:
+        """Test different rate limit delay scenarios"""
+        url = "https://test.com/page"
+        frontier.add_url(url)
+
+        start_time = time.time()
+        frontier.handle_ratelimit(url, retry_after)
+        next_url = frontier.get_next_url()
+        elapsed_time = time.time() - start_time
+
+        assert elapsed_time >= expected_min_delay
+        assert next_url == url
+
+    def test_empty_frontier(self, frontier: URLFrontier) -> None:
+        """Test empty frontier behavior"""
+        assert frontier.has_next_url() is False
+        assert frontier.get_next_url() is None


### PR DESCRIPTION
This pull request introduces a new feature to the `WebConnector` class to support slim document retrieval and includes corresponding tests. The main changes involve adding a new method for retrieving slim documents, updating the `WebConnector` class to implement the `SlimConnector` interface, and adding tests to validate the new functionality.

### New Feature: Slim Document Retrieval For Web Connector

* [`backend/onyx/connectors/web/connector.py`](diffhunk://#diff-0784541e5897de8a2e4e3fea2a78e81fb47bf17f57fc3d23ebd83c72daf69d01R29-R44): Added imports for `GenerateSlimDocumentOutput`, `SecondsSinceUnixEpoch`, `SlimConnector`, and `SlimDocument`. Introduced a new constant `_SLIM_BATCH_SIZE` and updated the `WebConnector` class to implement the `SlimConnector` interface. Added the `retrieve_all_slim_documents` method to fetch slim documents from URLs.

### Tests

* [`backend/tests/daily/connectors/web/test_web_connector.py`](diffhunk://#diff-a0578d0f66b98e48b638081e15e7d3faa4f793622a386da6794fb394306e407bR1-R62): Added tests for basic document loading, slim document functionality, and credentials handling.
* [`backend/tests/daily/connectors/web/test_web_data.json`](diffhunk://#diff-a25cab733228441e7ee96f79ea3a750bedf02e5ddc7be31301669efbef8e0443R1-R8): Added test data to support the new tests.## Description
[Provide a brief description of the changes in this PR]


## How Has This Been Tested?
This has been tested by running the connector from the terminal.


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
