### PR TITLE
Feature/indexing limiters

### DIFF
--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -107,11 +107,15 @@ class TenantRedis(redis.Redis):
             "sadd",
             "srem",
             "scard",
+            "zadd",
+            "zrem",
+            "zremrangebyscore",
+            "zrank",
         ]  # Regular methods that need simple prefixing
 
         if item == "scan_iter":
             return self._prefix_scan_iter(original_attr)
-        elif item in methods_to_wrap and callable(original_attr):
+        if item in methods_to_wrap and callable(original_attr):
             return self._prefix_method(original_attr)
         return original_attr
 


### PR DESCRIPTION
## Description
Fixes DAN-1223.

Uses a semaphore in Redis to prevent more than 6 workers at a time.
delays a task by 30 minutes if the semaphore cannot be acquired.
retries for a task are capped at 64.
Index attempt is marked as canceled in the DB if this occurs.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
