### PR TITLE
Added logging for permissions upsert queue length

### DIFF
--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -777,6 +777,12 @@ def monitor_vespa_sync(self: Task, tenant_id: str | None) -> bool:
         n_permissions_sync = celery_get_queue_length(
             OnyxCeleryQueues.CONNECTOR_DOC_PERMISSIONS_SYNC, r_celery
         )
+        n_external_group_sync = celery_get_queue_length(
+            OnyxCeleryQueues.CONNECTOR_EXTERNAL_GROUP_SYNC, r_celery
+        )
+        n_permissions_upsert = celery_get_queue_length(
+            OnyxCeleryQueues.DOC_PERMISSIONS_UPSERT, r_celery
+        )
 
         prefetched = celery_get_unacked_task_ids(
             OnyxCeleryQueues.CONNECTOR_INDEXING, r_celery
@@ -790,6 +796,8 @@ def monitor_vespa_sync(self: Task, tenant_id: str | None) -> bool:
             f"deletion={n_deletion} "
             f"pruning={n_pruning} "
             f"permissions_sync={n_permissions_sync} "
+            f"external_group_sync={n_external_group_sync} "
+            f"permissions_upsert={n_permissions_upsert} "
         )
 
         # scan and monitor activity to completion

--- a/backend/onyx/redis/redis_connector_doc_perm_sync.py
+++ b/backend/onyx/redis/redis_connector_doc_perm_sync.py
@@ -162,7 +162,7 @@ class RedisConnectorPermissionSync:
                 ),
                 queue=OnyxCeleryQueues.DOC_PERMISSIONS_UPSERT,
                 task_id=custom_task_id,
-                priority=OnyxCeleryPriority.MEDIUM,
+                priority=OnyxCeleryPriority.HIGH,
             )
             async_results.append(result)
 


### PR DESCRIPTION
## Description
- Added logging for permissions upsert queue length
- Increased queue priority for permission sync upsert


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
