### PR TITLE
Latex for $10 and $100

### DIFF
--- a/web/src/app/chat/message/codeUtils.ts
+++ b/web/src/app/chat/message/codeUtils.ts
@@ -60,18 +60,25 @@ export function extractCodeText(
   return codeText || "";
 }
 
-// We must preprocess LaTeX in the LLM output to avoid math formatting
-// while skipping inline replacements if it appears to be purely numeric.
+// We must preprocess LaTeX in the LLM output to avoid improper formatting
 export const preprocessLaTeX = (content: string) => {
-  // Replace block-level LaTeX delimiters \[ \] with $$ $$
-  const blockProcessedContent = content.replace(
+  // 1) Escape dollar signs used outside of LaTeX context
+  const escapedCurrencyContent = content.replace(
+    /\$(\d+(?:\.\d*)?)/g,
+    (_, p1) => `\\$${p1}`
+  );
+
+  // 2) Replace block-level LaTeX delimiters \[ \] with $$ $$
+  const blockProcessedContent = escapedCurrencyContent.replace(
     /\\\[([\s\S]*?)\\\]/g,
     (_, equation) => `$$${equation}$$`
   );
-  // Replace inline LaTeX delimiters \( \) with $ $
+
+  // 3) Replace inline LaTeX delimiters \( \) with $ $
   const inlineProcessedContent = blockProcessedContent.replace(
     /\\\(([\s\S]*?)\\\)/g,
     (_, equation) => `$${equation}$`
   );
+
   return inlineProcessedContent;
 };

--- a/web/src/app/chat/message/codeUtils.ts
+++ b/web/src/app/chat/message/codeUtils.ts
@@ -60,7 +60,8 @@ export function extractCodeText(
   return codeText || "";
 }
 
-// This is a temporary solution to preprocess LaTeX in  LLM output
+// We must preprocess LaTeX in the LLM output to avoid math formatting
+// while skipping inline replacements if it appears to be purely numeric.
 export const preprocessLaTeX = (content: string) => {
   // Replace block-level LaTeX delimiters \[ \] with $$ $$
   const blockProcessedContent = content.replace(


### PR DESCRIPTION
## Description
Fixes case where LLM outputs $ naturally and is incorrectly latex-formatted by plugin.
Now, as part of pre-processing text, we escape naturally occuring $s which occur outside of the context of latex equations
<img width="596" alt="Screenshot 2025-01-03 at 11 47 50 AM" src="https://github.com/user-attachments/assets/870dcf6f-10fd-411a-bd43-b418d5a8cd0a" />

<img width="689" alt="Screenshot 2025-01-03 at 11 47 57 AM" src="https://github.com/user-attachments/assets/b3dfb230-0d0a-4c2d-a21e-2feb18bbdbe3" />

## How Has This Been Tested?
- Ask for various strings in response like `Respond with exactly $100 is more than $10" and various Latex equations- ensure all are formatted properly


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
