### PR TITLE
Move google-cloud-aiplatform to default requirements to support verte…

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -14,6 +14,7 @@ fastapi-users==12.1.3
 fastapi-users-db-sqlalchemy==5.0.0
 filelock==3.15.4
 google-api-python-client==2.86.0
+google-cloud-aiplatform==1.58.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0
 # GPT4All library has issues running on Macs and python:3.11.4-slim-bookworm

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -2,7 +2,6 @@ black==23.3.0
 boto3-stubs[s3]==1.34.133
 celery-types==0.19.0
 cohere==5.6.1
-google-cloud-aiplatform==1.58.0
 lxml==5.3.0
 lxml_html_clean==0.2.2
 mypy-extensions==1.0.0


### PR DESCRIPTION
…x AI llama

## Description
Fixes `litellm.BadRequestError: VertexAIException BadRequestError - vertexai import failed please run `pip install -U "google-cloud-aiplatform>=1.38"`` when trying to use Vertex + Llama


## How Has This Been Tested?
Container build


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
