### PR TITLE
Auth fix + Registration Clarity

### DIFF
--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -46,6 +46,7 @@ def register_tenant_users(tenant_id: str, number_of_users: int) -> stripe.Subscr
     """
     Send a request to the control service to register the number of users for a tenant.
     """
+    return None
     if not STRIPE_PRICE_ID:
         raise Exception("STRIPE_PRICE_ID is not set")
 

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -46,7 +46,7 @@ def register_tenant_users(tenant_id: str, number_of_users: int) -> stripe.Subscr
     """
     Send a request to the control service to register the number of users for a tenant.
     """
-    return None
+
     if not STRIPE_PRICE_ID:
         raise Exception("STRIPE_PRICE_ID is not set")
 

--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -40,21 +40,24 @@ def send_email(
 
 
 def send_user_email_invite(user_email: str, current_user: User) -> None:
-    subject = "Invitation to Join Onyx Workspace"
+    subject = "Invitation to Join Onyx Organization"
     body = dedent(
         f"""\
         Hello,
 
-        You have been invited to join a workspace on Onyx.
+        You have been invited to join an organization on Onyx.
 
-        To join the workspace, please visit the following link:
+        To join the organization, please visit the following link:
 
-        {WEB_DOMAIN}/auth/login
+        {WEB_DOMAIN}/auth/signup?email={user_email}
+
+        You'll be asked to set a password or login with Google to complete your registration.
 
         Best regards,
         The Onyx Team
     """
     )
+
     send_email(user_email, subject, body, current_user.email)
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -46,7 +46,6 @@ from httpx_oauth.integrations.fastapi import OAuth2AuthorizeCallback
 from httpx_oauth.oauth2 import BaseOAuth2
 from httpx_oauth.oauth2 import OAuth2Token
 from pydantic import BaseModel
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
@@ -413,8 +412,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             existing_oauth_account,  # type: ignore
                             oauth_account_dict,
                         )
-
-                await db_session.execute(text(f'SET search_path = "{tenant_id}"'))
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -395,11 +395,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
                     # Explicitly set the Postgres schema for this session to ensure
                     # OAuth account creation happens in the correct tenant schema
-                    await db_session.execute(text(f'SET search_path = "{tenant_id}"'))
 
                     # Add OAuth account
                     await self.user_db.add_oauth_account(user, oauth_account_dict)
-
                     await self.on_after_register(user, request)
 
             else:
@@ -415,11 +413,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             existing_oauth_account,  # type: ignore
                             oauth_account_dict,
                         )
-            await db_session.execute(text(f'SET search_path = "{tenant_id}"'))
+
+                await db_session.execute(text(f'SET search_path = "{tenant_id}"'))
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled
-
             if expires_at and TRACK_EXTERNAL_IDP_EXPIRY:
                 oidc_expiry = datetime.fromtimestamp(expires_at, tz=timezone.utc)
                 await self.user_db.update(

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -415,6 +415,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             existing_oauth_account,  # type: ignore
                             oauth_account_dict,
                         )
+            await db_session.execute(text(f'SET search_path = "{tenant_id}"'))
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled

--- a/backend/onyx/db/engine.py
+++ b/backend/onyx/db/engine.py
@@ -366,7 +366,7 @@ async def get_async_session_with_tenant(
     engine = get_sqlalchemy_async_engine()
     async_session_factory = sessionmaker(
         bind=engine, expire_on_commit=False, class_=AsyncSession
-    )
+    )  # type: ignore
 
     async def _set_search_path(session: AsyncSession, tenant_id: str) -> None:
         await session.execute(text(f'SET search_path = "{tenant_id}"'))
@@ -374,7 +374,7 @@ async def get_async_session_with_tenant(
     async with async_session_factory() as session:
         # Register an event listener that is called whenever a new transaction starts
         @event.listens_for(session.sync_session, "after_begin")
-        def after_begin(session_, transaction, connection):
+        def after_begin(session_: Any, transaction: Any, connection: Any) -> None:
             # Because the event is sync, we can't directly await here.
             # Instead we queue up an asyncio task to ensures
             # the next statement sets the search_path

--- a/backend/onyx/db/engine.py
+++ b/backend/onyx/db/engine.py
@@ -399,38 +399,6 @@ async def get_async_session_with_tenant(
             yield session
 
 
-# @asynccontextmanager
-# async def get_async_session_with_tenant(
-#     tenant_id: str | None = None,
-# ) -> AsyncGenerator[AsyncSession, None]:
-#     if tenant_id is None:
-#         tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
-
-#     if not is_valid_schema_name(tenant_id):
-#         logger.error(f"Invalid tenant ID: {tenant_id}")
-#         raise Exception("Invalid tenant ID")
-
-#     engine = get_sqlalchemy_async_engine()
-#     async_session_factory = sessionmaker(
-#         bind=engine, expire_on_commit=False, class_=AsyncSession
-#     )  # type: ignore
-
-#     async with async_session_factory() as session:
-#         try:
-#             await session.execute(text(f'SET search_path = "{tenant_id}"'))
-#             if POSTGRES_IDLE_SESSIONS_TIMEOUT:
-#                 await session.execute(
-#                     text(
-#                         f"SET SESSION idle_in_transaction_session_timeout = {POSTGRES_IDLE_SESSIONS_TIMEOUT}"
-#                     )
-#                 )
-#         except Exception:
-#             logger.exception("Error setting search_path.")
-#             raise
-#         else:
-#             yield session
-
-
 @contextmanager
 def get_session_with_default_tenant() -> Generator[Session, None, None]:
     tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()

--- a/backend/onyx/db/engine.py
+++ b/backend/onyx/db/engine.py
@@ -376,14 +376,13 @@ async def get_async_session_with_tenant(
         @event.listens_for(session.sync_session, "after_begin")
         def after_begin(session_, transaction, connection):
             # Because the event is sync, we can't directly await here.
-            # Instead we queue up an asyncio task or do something that ensures
+            # Instead we queue up an asyncio task to ensures
             # the next statement sets the search_path
             session_.do_orm_execute = lambda state: connection.exec_driver_sql(
                 f'SET search_path = "{tenant_id}"'
             )
 
         try:
-            # Optionally do an initial SET search_path
             await _set_search_path(session, tenant_id)
 
             if POSTGRES_IDLE_SESSIONS_TIMEOUT:

--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -19,11 +19,13 @@ export function EmailPasswordForm({
   shouldVerify,
   referralSource,
   nextUrl,
+  defaultEmail,
 }: {
   isSignup?: boolean;
   shouldVerify?: boolean;
   referralSource?: string;
   nextUrl?: string | null;
+  defaultEmail?: string | null;
 }) {
   const { user } = useUser();
   const { popup, setPopup } = usePopup();
@@ -34,7 +36,7 @@ export function EmailPasswordForm({
       {popup}
       <Formik
         initialValues={{
-          email: "",
+          email: defaultEmail || "",
           password: "",
         }}
         validationSchema={Yup.object().shape({

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -22,6 +22,10 @@ const Page = async (props: {
     ? searchParams?.next[0]
     : searchParams?.next || null;
 
+  const defaultEmail = Array.isArray(searchParams?.email)
+    ? searchParams?.email[0]
+    : searchParams?.email || null;
+
   // catch cases where the backend is completely unreachable here
   // without try / catch, will just raise an exception and the page
   // will not render
@@ -93,6 +97,7 @@ const Page = async (props: {
             isSignup
             shouldVerify={authTypeMetadata?.requiresVerification}
             nextUrl={nextUrl}
+            defaultEmail={defaultEmail}
           />
         </div>
       </>


### PR DESCRIPTION
## Description
- User registration clarity:  Updated email and pre-populated auth page with their email
- Make sure each new transaction immediately sets the schema (search_path) to the tenant’s schema in async session
- Needed a workaround-ish solution for the above- "after_begin"  since we can't use direct async awaits.

Fixes  https://linear.app/danswer/issue/DAN-1232/cloud-user-invite-not-working 

Previously, we did this somewhat manually since FastAPI Users manually commits the transaction for the user db in various places. This led to some inconsistencies in auth flows

## How Has This Been Tested?
- Invite and login as a previously external permission user and Slack user
- Login and register in multi tenant scenario

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
