### PR TITLE
Improved indexing

### DIFF
--- a/backend/alembic/versions/2955778aa44c_add_chunk_count_to_document.py
+++ b/backend/alembic/versions/2955778aa44c_add_chunk_count_to_document.py
@@ -1,0 +1,24 @@
+"""add chunk count to document
+
+Revision ID: 2955778aa44c
+Revises: c0aab6edb6dd
+Create Date: 2025-01-04 11:39:43.268612
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2955778aa44c"
+down_revision = "c0aab6edb6dd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("document", sa.Column("chunk_count", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("document", "chunk_count")

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -101,8 +101,11 @@ class DocumentBase(BaseModel):
     source: DocumentSource | None = None
     semantic_identifier: str  # displayed in the UI as the main identifier for the doc
     metadata: dict[str, str | list[str]]
+
     # UTC time
     doc_updated_at: datetime | None = None
+    chunk_count: int | None = None
+
     # Owner, creator, etc.
     primary_owners: list[BasicExpertInfo] | None = None
     # Assignee, space owner, etc.

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -418,14 +418,14 @@ def update_docs_last_modified__no_commit(
 
 def update_docs_chunk_count__no_commit(
     document_ids: list[str],
-    document_id_to_current_chunks_indexed: dict[str, int],
+    doc_id_to_chunk_count: dict[str, int],
     db_session: Session,
 ) -> None:
     documents_to_update = (
         db_session.query(DbDocument).filter(DbDocument.id.in_(document_ids)).all()
     )
     for doc in documents_to_update:
-        doc.chunk_count = document_id_to_current_chunks_indexed[doc.id]
+        doc.chunk_count = doc_id_to_chunk_count[doc.id]
 
 
 def mark_document_as_modified(

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -612,3 +612,13 @@ def get_document(
     stmt = select(DbDocument).where(DbDocument.id == document_id)
     doc: DbDocument | None = db_session.execute(stmt).scalar_one_or_none()
     return doc
+
+
+def fetch_chunk_counts_for_documents(
+    document_ids: list[str],
+    db_session: Session,
+) -> dict[str, int]:
+    stmt = select(DbDocument.id, DbDocument.chunk_count).where(
+        DbDocument.id.in_(document_ids)
+    )
+    return db_session.execute(stmt).all()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -494,6 +494,10 @@ class Document(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # Number of chunks in the document (in Vespa)
+    # Only null for documents indexed prior to this change
+    chunk_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # last time any vespa relevant row metadata or the doc changed.
     # does not include last_synced
     last_modified: Mapped[datetime.datetime | None] = mapped_column(

--- a/backend/onyx/document_index/document_index_utils.py
+++ b/backend/onyx/document_index/document_index_utils.py
@@ -3,9 +3,11 @@ import uuid
 
 from sqlalchemy.orm import Session
 
-from onyx.context.search.models import InferenceChunk
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
+from onyx.document_index.vespa.indexing_utils import DOCUMENT_ID_ENDPOINT
+from onyx.document_index.vespa.shared_utils.utils import get_vespa_http_client
+from onyx.indexing.models import DocChunkIDInformation
 from onyx.indexing.models import DocMetadataAwareIndexChunk
 
 
@@ -36,49 +38,122 @@ def translate_boost_count_to_multiplier(boost: int) -> float:
     return 2 / (1 + math.exp(-1 * boost / 3))
 
 
-def get_uuid_from_chunk(
-    chunk: DocMetadataAwareIndexChunk, mini_chunk_ind: int = 0
+def _check_for_chunk_existence(vespa_chunk_id, index_name: str) -> bool:
+    vespa_url = f"{DOCUMENT_ID_ENDPOINT.format(index_name=index_name)}/{vespa_chunk_id}"
+    with get_vespa_http_client(no_timeout=True) as http_client:
+        res = http_client.get(vespa_url)
+        return res.status_code == 200
+
+
+def check_for_final_chunk_existence(
+    document_id_info: DocChunkIDInformation, start_index: int, index_name: str
+) -> int:
+    index = start_index
+    while True:
+        doc_chunk_id = get_uuid_from_chunk_info_old(
+            document_id=document_id_info.doc_id,
+            chunk_id=index,
+            large_chunk_reference_ids=[],
+        )
+        if not _check_for_chunk_existence(doc_chunk_id, index_name):
+            return index
+
+        index += 1
+
+
+def assemble_document_chunk_info(
+    document_id_info_list: list[DocChunkIDInformation],
+    tenant_id: str | None,
+    large_chunks_enabled: bool,
+) -> list[uuid.UUID, None, None]:
+    doc_chunk_ids = []
+
+    for document_id_info in document_id_info_list:
+        for chunk_index in enumerate(
+            range(document_id_info.chunk_start_index, document_id_info.chunk_end_index)
+        ):
+            doc_chunk_ids.append(
+                get_uuid_from_chunk_info(
+                    document_id=document_id_info.doc_id,
+                    chunk_id=chunk_index,
+                    tenant_id=tenant_id,
+                    large_chunk_id=document_id_info.large_chunk_id,
+                )
+            )
+
+            if (
+                large_chunks_enabled
+                and document_id_info.old_version
+                and chunk_index % 4 == 0
+            ):
+                chunk_id = chunk_index / 4
+                large_chunk_reference_ids = [
+                    chunk_id + i
+                    for i in range(4)
+                    if chunk_id + i < document_id_info.chunk_end_index
+                ]
+                doc_chunk_ids.append(
+                    get_uuid_from_chunk_info_old(
+                        document_id=document_id_info.doc_id,
+                        chunk_id=chunk_id,
+                        large_chunk_reference_ids=large_chunk_reference_ids,
+                    )
+                )
+
+    return doc_chunk_ids
+
+
+def get_uuid_from_chunk_info(
+    *,
+    document_id: str,
+    chunk_id: int,
+    tenant_id: str | None,
+    large_chunk_id: int | None = None,
 ) -> uuid.UUID:
-    doc_str = (
-        chunk.document_id
-        if isinstance(chunk, InferenceChunk)
-        else chunk.source_document.id
-    )
+    doc_str = document_id
+
     # Web parsing URL duplicate catching
     if doc_str and doc_str[-1] == "/":
         doc_str = doc_str[:-1]
 
     chunk_index = (
-        "large_" + str(chunk.large_chunk_id)
-        if chunk.large_chunk_id
-        else str(chunk.chunk_id)
+        "large_" + str(large_chunk_id) if large_chunk_id is not None else str(chunk_id)
     )
-    unique_identifier_string = "_".join([doc_str, chunk_index, str(mini_chunk_ind)])
-    if chunk.tenant_id:
-        unique_identifier_string += "_" + chunk.tenant_id
+    unique_identifier_string = "_".join([doc_str, chunk_index])
+    if tenant_id:
+        unique_identifier_string += "_" + tenant_id
 
     return uuid.uuid5(uuid.NAMESPACE_X500, unique_identifier_string)
 
 
-# def get_uuid_from_chunk(
-#     chunk: IndexChunk | InferenceChunk, mini_chunk_ind: int = 0
-# ) -> uuid.UUID:
-#     doc_str = (
-#         chunk.document_id
-#         if isinstance(chunk, InferenceChunk)
-#         else chunk.source_document.id
-#     )
-#     # Web parsing URL duplicate catching
-#     if doc_str and doc_str[-1] == "/":
-#         doc_str = doc_str[:-1]
-#     unique_identifier_string = "_".join(
-#         [doc_str, str(chunk.chunk_id), str(mini_chunk_ind)]
-#     )
-#     if chunk.large_chunk_reference_ids:
-#         unique_identifier_string += "_large" + "_".join(
-#             [
-#                 str(referenced_chunk_id)
-#                 for referenced_chunk_id in chunk.large_chunk_reference_ids
-#             ]
-#         )
-#     return uuid.uuid5(uuid.NAMESPACE_X500, unique_identifier_string)
+def get_uuid_from_chunk_info_old(
+    *, document_id: str, chunk_id: int, large_chunk_reference_ids: list[str] = []
+) -> uuid.UUID:
+    doc_str = document_id
+
+    # Web parsing URL duplicate catching
+    if doc_str and doc_str[-1] == "/":
+        doc_str = doc_str[:-1]
+    unique_identifier_string = "_".join([doc_str, str(chunk_id), "0"])
+    if large_chunk_reference_ids:
+        unique_identifier_string += "_large" + "_".join(
+            [
+                str(referenced_chunk_id)
+                for referenced_chunk_id in large_chunk_reference_ids
+            ]
+        )
+    return uuid.uuid5(uuid.NAMESPACE_X500, unique_identifier_string)
+
+
+def get_uuid_from_chunk(chunk: DocMetadataAwareIndexChunk) -> uuid.UUID:
+    return get_uuid_from_chunk_info(
+        chunk.source_document.id, chunk.chunk_id, chunk.large_chunk_id, chunk.tenant_id
+    )
+
+
+def get_uuid_from_chunk_old(
+    chunk: DocMetadataAwareIndexChunk, large_chunk_reference_ids: list[str] = []
+) -> uuid.UUID:
+    return get_uuid_from_chunk_info_old(
+        chunk.source_document.id, chunk.chunk_id, large_chunk_reference_ids
+    )

--- a/backend/onyx/document_index/document_index_utils.py
+++ b/backend/onyx/document_index/document_index_utils.py
@@ -1,5 +1,6 @@
 import math
 import uuid
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -40,7 +41,7 @@ def assemble_document_chunk_info(
     document_id_info_list: list[DocChunkIDInformation],
     tenant_id: str | None,
     large_chunks_enabled: bool,
-) -> list[uuid.UUID]:
+) -> list[UUID]:
     doc_chunk_ids = []
 
     for document_id_info in document_id_info_list:
@@ -97,7 +98,7 @@ def get_uuid_from_chunk_info(
     chunk_id: int,
     tenant_id: str | None,
     large_chunk_id: int | None = None,
-) -> uuid.UUID:
+) -> UUID:
     doc_str = document_id
 
     # Web parsing URL duplicate catching
@@ -116,7 +117,7 @@ def get_uuid_from_chunk_info(
 
 def get_uuid_from_chunk_info_old(
     *, document_id: str, chunk_id: int, large_chunk_reference_ids: list[int] = []
-) -> uuid.UUID:
+) -> UUID:
     doc_str = document_id
 
     # Web parsing URL duplicate catching
@@ -144,7 +145,7 @@ def get_uuid_from_chunk(chunk: DocMetadataAwareIndexChunk) -> uuid.UUID:
 
 def get_uuid_from_chunk_old(
     chunk: DocMetadataAwareIndexChunk, large_chunk_reference_ids: list[int] = []
-) -> uuid.UUID:
+) -> UUID:
     return get_uuid_from_chunk_info_old(
         document_id=chunk.source_document.id,
         chunk_id=chunk.chunk_id,

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -41,8 +41,8 @@ class IndexBatchParams:
     Information necessary for efficiently indexing a batch of documents
     """
 
-    doc_id_to_previous_chunks_indexed: dict[str, int | None]
-    doc_id_to_current_chunks_indexed: dict[str, int]
+    doc_id_to_previous_chunk_cnt: dict[str, int | None]
+    doc_id_to_new_chunk_cnt: dict[str, int]
     tenant_id: str | None
     large_chunks_enabled: bool
 

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -36,6 +36,38 @@ class VespaChunkRequest:
 
 
 @dataclass
+class IndexBatchParams:
+    """
+    Information necessary for efficiently indexing a batch of documents
+    """
+
+    doc_id_to_previous_chunks_indexed: dict[str, int | None]
+    doc_id_to_current_chunks_indexed: dict[str, int]
+    tenant_id: str | None
+    large_chunks_enabled: bool
+
+
+@dataclass
+class MinimalDocumentIndexingInfo:
+    """
+    Minimal information necessary for indexing a document
+    """
+
+    doc_id: str
+    chunk_start_index: int
+
+
+@dataclass
+class EnrichedDocumentIndexingInfo(MinimalDocumentIndexingInfo):
+    """
+    Enriched information necessary for indexing a document, including version and chunk range.
+    """
+
+    old_version: bool
+    chunk_end_index: int
+
+
+@dataclass
 class DocumentMetadata:
     """
     Document information that needs to be inserted into Postgres on first time encountering this
@@ -148,10 +180,7 @@ class Indexable(abc.ABC):
     def index(
         self,
         chunks: list[DocMetadataAwareIndexChunk],
-        document_id_to_previous_chunks_indexed: dict[str, int | None],
-        document_id_to_current_chunks_indexed: dict[str, int],
-        tenant_id: str | None,
-        large_chunks_enabled: bool,
+        index_batch_params: IndexBatchParams,
     ) -> set[DocumentInsertionRecord]:
         """
         Takes a list of document chunks and indexes them in the document index
@@ -198,15 +227,15 @@ class Deletable(abc.ABC):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def delete(self, doc_ids: list[str]) -> None:
-        """
-        Given a list of document ids, hard delete them from the document index
+    # @abc.abstractmethod
+    # def delete(self, doc_ids: list[str]) -> None:
+    #     """
+    #     Given a list of document ids, hard delete them from the document index
 
-        Parameters:
-        - doc_ids: list of document ids as specified by the connector
-        """
-        raise NotImplementedError
+    #     Parameters:
+    #     - doc_ids: list of document ids as specified by the connector
+    #     """
+    #     raise NotImplementedError
 
 
 class Updatable(abc.ABC):

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -214,7 +214,7 @@ class Indexable(abc.ABC):
 
 class Deletable(abc.ABC):
     """
-    Class must implement the ability to delete document by their unique document ids.
+    Class must implement the ability to delete document by a given unique document id.
     """
 
     @abc.abstractmethod
@@ -226,16 +226,6 @@ class Deletable(abc.ABC):
         - doc_id: document id as specified by the connector
         """
         raise NotImplementedError
-
-    # @abc.abstractmethod
-    # def delete(self, doc_ids: list[str]) -> None:
-    #     """
-    #     Given a list of document ids, hard delete them from the document index
-
-    #     Parameters:
-    #     - doc_ids: list of document ids as specified by the connector
-    #     """
-    #     raise NotImplementedError
 
 
 class Updatable(abc.ABC):

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -148,6 +148,10 @@ class Indexable(abc.ABC):
     def index(
         self,
         chunks: list[DocMetadataAwareIndexChunk],
+        document_id_to_previous_chunks_indexed: dict[str, int | None],
+        document_id_to_current_chunks_indexed: dict[str, int],
+        tenant_id: str | None,
+        large_chunks_enabled: bool,
     ) -> set[DocumentInsertionRecord]:
         """
         Takes a list of document chunks and indexes them in the document index
@@ -168,6 +172,8 @@ class Indexable(abc.ABC):
         Parameters:
         - chunks: Document chunks with all of the information needed for indexing to the document
                 index.
+        - tenant_id: The tenant id of the user whose chunks are being indexed
+        - large_chunks_enabled: Whether large chunks are enabled
 
         Returns:
             List of document ids which map to unique documents and are used for deduping chunks

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -148,7 +148,6 @@ class Indexable(abc.ABC):
     def index(
         self,
         chunks: list[DocMetadataAwareIndexChunk],
-        fresh_index: bool = False,
     ) -> set[DocumentInsertionRecord]:
         """
         Takes a list of document chunks and indexes them in the document index
@@ -166,14 +165,9 @@ class Indexable(abc.ABC):
         only needs to index chunks into the PRIMARY index. Do not update the secondary index here,
         it is done automatically outside of this code.
 
-        NOTE: The fresh_index parameter, when set to True, assumes no documents have been previously
-        indexed for the given index/tenant. This can be used to optimize the indexing process for
-        new or empty indices.
-
         Parameters:
         - chunks: Document chunks with all of the information needed for indexing to the document
                 index.
-        - fresh_index: Boolean indicating whether this is a fresh index with no existing documents.
 
         Returns:
             List of document ids which map to unique documents and are used for deduping chunks

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -3,9 +3,6 @@ import concurrent.futures
 import httpx
 from retry import retry
 
-from onyx.document_index.vespa.chunk_retrieval import (
-    get_all_vespa_ids_for_document_id,
-)
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.document_index.vespa_constants import NUM_THREADS
 from onyx.utils.logger import setup_logger
@@ -23,28 +20,21 @@ def _retryable_http_delete(http_client: httpx.Client, url: str) -> None:
 
 
 @retry(tries=3, delay=1, backoff=2)
-def _delete_vespa_doc_chunks(
-    document_id: str, index_name: str, http_client: httpx.Client
+def _delete_vespa_chunk(
+    doc_chunk_id: str, index_name: str, http_client: httpx.Client
 ) -> None:
-    doc_chunk_ids = get_all_vespa_ids_for_document_id(
-        document_id=document_id,
-        index_name=index_name,
-        get_large_chunks=True,
-    )
-
-    for chunk_id in doc_chunk_ids:
-        try:
-            _retryable_http_delete(
-                http_client,
-                f"{DOCUMENT_ID_ENDPOINT.format(index_name=index_name)}/{chunk_id}",
-            )
-        except httpx.HTTPStatusError as e:
-            logger.error(f"Failed to delete chunk, details: {e.response.text}")
-            raise
+    try:
+        _retryable_http_delete(
+            http_client,
+            f"{DOCUMENT_ID_ENDPOINT.format(index_name=index_name)}/{doc_chunk_id}",
+        )
+    except httpx.HTTPStatusError as e:
+        logger.error(f"Failed to delete chunk, details: {e.response.text}")
+        raise
 
 
-def delete_vespa_docs(
-    document_ids: list[str],
+def delete_vespa_chunks(
+    doc_chunk_ids: list[str],
     index_name: str,
     http_client: httpx.Client,
     executor: concurrent.futures.ThreadPoolExecutor | None = None,
@@ -56,13 +46,13 @@ def delete_vespa_docs(
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS)
 
     try:
-        doc_deletion_future = {
+        chunk_deletion_future = {
             executor.submit(
-                _delete_vespa_doc_chunks, doc_id, index_name, http_client
-            ): doc_id
-            for doc_id in document_ids
+                _delete_vespa_chunk, doc_chunk_id, index_name, http_client
+            ): doc_chunk_id
+            for doc_chunk_id in doc_chunk_ids
         }
-        for future in concurrent.futures.as_completed(doc_deletion_future):
+        for future in concurrent.futures.as_completed(chunk_deletion_future):
             # Will raise exception if the deletion raised an exception
             future.result()
 

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -1,6 +1,6 @@
 import concurrent.futures
-import uuid
 from typing import cast
+from uuid import UUID
 
 import httpx
 from retry import retry
@@ -24,7 +24,7 @@ def _retryable_http_delete(http_client: httpx.Client, url: str) -> None:
 
 @retry(tries=3, delay=1, backoff=2)
 def _delete_vespa_chunk(
-    doc_chunk_id: uuid.UUID, index_name: str, http_client: httpx.Client
+    doc_chunk_id: UUID, index_name: str, http_client: httpx.Client
 ) -> None:
     try:
         _retryable_http_delete(
@@ -37,7 +37,7 @@ def _delete_vespa_chunk(
 
 
 def delete_vespa_chunks(
-    doc_chunk_ids: list[uuid.UUID],
+    doc_chunk_ids: list[UUID],
     index_name: str,
     http_client: httpx.Client,
     executor: concurrent.futures.ThreadPoolExecutor | None = None,

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -5,7 +5,7 @@ from uuid import UUID
 import httpx
 from retry import retry
 
-from onyx.document_index.vespa.indexing_utils import _check_for_chunk_existence
+from onyx.document_index.vespa.indexing_utils import _does_doc_chunk_exist
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.document_index.vespa_constants import NUM_THREADS
 from onyx.utils.logger import setup_logger
@@ -42,7 +42,7 @@ def delete_vespa_chunks(
     http_client: httpx.Client,
     executor: concurrent.futures.ThreadPoolExecutor | None = None,
 ) -> None:
-    if not _check_for_chunk_existence(doc_chunk_ids[0], index_name):
+    if not _does_doc_chunk_exist(doc_chunk_ids[0], index_name, http_client):
         raise ValueError(f"Chunk {doc_chunk_ids[0]} does not exist in Vespa!!!")
 
     external_executor = True

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -305,13 +305,6 @@ class VespaIndex(DocumentIndex):
                 f"Failed to prepare Vespa Onyx Indexes. Response: {response.text}"
             )
 
-    # class DocChunkIDInformation(BaseModel):
-    #     doc_id: str
-    #     old_version: bool
-    #     chunk_start_index: int
-    #     chunk_end_index: int
-    #     large_chunk_id: int | None
-
     def index(
         self,
         chunks: list[DocMetadataAwareIndexChunk],

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -41,9 +41,6 @@ from onyx.document_index.vespa.chunk_retrieval import query_vespa
 from onyx.document_index.vespa.deletion import delete_vespa_docs
 from onyx.document_index.vespa.indexing_utils import batch_index_vespa_chunks
 from onyx.document_index.vespa.indexing_utils import clean_chunk_id_copy
-from onyx.document_index.vespa.indexing_utils import (
-    get_existing_documents_from_chunks,
-)
 from onyx.document_index.vespa.shared_utils.utils import get_vespa_http_client
 from onyx.document_index.vespa.shared_utils.utils import (
     replace_invalid_doc_id_characters,
@@ -324,29 +321,16 @@ class VespaIndex(DocumentIndex):
             concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor,
             get_vespa_http_client() as http_client,
         ):
-            if not fresh_index:
-                # Check for existing documents, existing documents need to have all of their chunks deleted
-                # prior to indexing as the document size (num chunks) may have shrunk
-                first_chunks = [
-                    chunk for chunk in cleaned_chunks if chunk.chunk_id == 0
-                ]
-                for chunk_batch in batch_generator(first_chunks, BATCH_SIZE):
-                    existing_docs.update(
-                        get_existing_documents_from_chunks(
-                            chunks=chunk_batch,
-                            index_name=self.index_name,
-                            http_client=http_client,
-                            executor=executor,
-                        )
-                    )
+            # if not fresh_index:
 
-                for doc_id_batch in batch_generator(existing_docs, BATCH_SIZE):
-                    delete_vespa_docs(
-                        document_ids=doc_id_batch,
-                        index_name=self.index_name,
-                        http_client=http_client,
-                        executor=executor,
-                    )
+            # Delete old Vespa documents
+            # for doc_id_batch in batch_generator(existing_docs, BATCH_SIZE):
+            #     delete_vespa_docs(
+            #         document_ids=doc_id_batch,
+            #         index_name=self.index_name,
+            #         http_client=http_client,
+            #         executor=executor,
+            #     )
 
             for chunk_batch in batch_generator(cleaned_chunks, BATCH_SIZE):
                 batch_index_vespa_chunks(

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -328,16 +328,16 @@ class VespaIndex(DocumentIndex):
                     old_doc_ids.add(doc_id)
 
             doc_chunk_ids_to_delete = []
-            # We need the chunk counts for the current docs (for referencing during this step
-            #  and also for updating DB)
+            # We need the number of chunks for the current docs
+            # (for referencing during this step and also for updating DB)
 
             # For those that have no count info, we need to iterate through indices in chunks
-            #  (starting past current number, until chunk does not exist)
+            # (starting past current number, until chunk does not exist)
             # Then, we can add that to the document_id_to_chunk_count.
 
             # Once we have all the chunk counts (and whether or not large chunks are enabled),
             # we can generate the chunk IDs for every chunk and delete every single one.
-            #  (though we'll need to trakc hwich ones are using hte old system and which ones are using the new one)
+            # (though we'll need to track which ones are using the old system and which ones are using the new one)
 
             # Delete old Vespa documents
             for doc_chunk_ids_batch in batch_generator(

--- a/backend/onyx/document_index/vespa/indexing_utils.py
+++ b/backend/onyx/document_index/vespa/indexing_utils.py
@@ -187,8 +187,7 @@ def _index_vespa_chunk(
     if multitenant:
         if chunk.tenant_id:
             vespa_document_fields[TENANT_ID] = chunk.tenant_id
-    print("indeixng to vespa")
-    print(vespa_chunk_id)
+
     vespa_url = f"{DOCUMENT_ID_ENDPOINT.format(index_name=index_name)}/{vespa_chunk_id}"
     logger.debug(f'Indexing to URL "{vespa_url}"')
     res = http_client.post(

--- a/backend/onyx/document_index/vespa_constants.py
+++ b/backend/onyx/document_index/vespa_constants.py
@@ -35,6 +35,8 @@ DOCUMENT_ID_ENDPOINT = (
     f"{VESPA_APP_CONTAINER_URL}/document/v1/default/{{index_name}}/docid"
 )
 
+# the default document id endpoint is http://localhost:8080/document/v1/default/danswer_chunk/docid
+
 SEARCH_ENDPOINT = f"{VESPA_APP_CONTAINER_URL}/search/"
 
 NUM_THREADS = (

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -220,6 +220,7 @@ class Chunker:
                 metadata_suffix_semantic=metadata_suffix_semantic,
                 metadata_suffix_keyword=metadata_suffix_keyword,
                 mini_chunk_texts=self._get_mini_chunk_texts(text),
+                large_chunk_id=None,
             )
 
         for section_idx, section in enumerate(document.sections):

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -73,25 +73,25 @@ def _get_metadata_suffix_for_document_index(
     return metadata_semantic, metadata_keyword
 
 
-def _combine_chunks(chunks: list[DocAwareChunk], index: int) -> DocAwareChunk:
+def _combine_chunks(chunks: list[DocAwareChunk], large_chunk_id: int) -> DocAwareChunk:
     merged_chunk = DocAwareChunk(
         source_document=chunks[0].source_document,
-        chunk_id=index,
+        chunk_id=chunks[0].chunk_id,
         blurb=chunks[0].blurb,
         content=chunks[0].content,
         source_links=chunks[0].source_links or {},
-        section_continuation=(index > 0),
+        section_continuation=(chunks[0].chunk_id > 0),
         title_prefix=chunks[0].title_prefix,
         metadata_suffix_semantic=chunks[0].metadata_suffix_semantic,
         metadata_suffix_keyword=chunks[0].metadata_suffix_keyword,
-        large_chunk_reference_ids=[chunks[0].chunk_id],
+        large_chunk_reference_ids=[chunk.chunk_id for chunk in chunks],
         mini_chunk_texts=None,
+        large_chunk_id=large_chunk_id,
     )
 
     offset = 0
     for i in range(1, len(chunks)):
         merged_chunk.content += SECTION_SEPARATOR + chunks[i].content
-        merged_chunk.large_chunk_reference_ids.append(chunks[i].chunk_id)
 
         offset += len(SECTION_SEPARATOR) + len(chunks[i - 1].content)
         for link_offset, link_text in (chunks[i].source_links or {}).items():
@@ -103,18 +103,12 @@ def _combine_chunks(chunks: list[DocAwareChunk], index: int) -> DocAwareChunk:
 
 
 def generate_large_chunks(chunks: list[DocAwareChunk]) -> list[DocAwareChunk]:
-    large_chunks = [
-        _combine_chunks(chunks[i : i + LARGE_CHUNK_RATIO], idx)
-        for idx, i in enumerate(range(0, len(chunks), LARGE_CHUNK_RATIO))
-        if len(chunks[i : i + LARGE_CHUNK_RATIO]) > 1
-    ]
-    # Print chunk ID and large chunk reference IDs for each chunk
-    for chunk in large_chunks:
-        print(f"Chunk ID: {chunk.chunk_id}")
-        print("Large Chunk Reference IDs:")
-        for ref_id in chunk.large_chunk_reference_ids:
-            print(f"  - {ref_id}")
-        print("---")  # Separator for readability
+    large_chunks = []
+    for idx, i in enumerate(range(0, len(chunks), LARGE_CHUNK_RATIO)):
+        chunk_group = chunks[i : i + LARGE_CHUNK_RATIO]
+        if len(chunk_group) > 1:
+            large_chunk = _combine_chunks(chunk_group, idx)
+            large_chunks.append(large_chunk)
     return large_chunks
 
 

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -108,6 +108,13 @@ def generate_large_chunks(chunks: list[DocAwareChunk]) -> list[DocAwareChunk]:
         for idx, i in enumerate(range(0, len(chunks), LARGE_CHUNK_RATIO))
         if len(chunks[i : i + LARGE_CHUNK_RATIO]) > 1
     ]
+    # Print chunk ID and large chunk reference IDs for each chunk
+    for chunk in large_chunks:
+        print(f"Chunk ID: {chunk.chunk_id}")
+        print("Large Chunk Reference IDs:")
+        for ref_id in chunk.large_chunk_reference_ids:
+            print(f"  - {ref_id}")
+        print("---")  # Separator for readability
     return large_chunks
 
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -468,10 +468,7 @@ def build_indexing_pipeline(
         multipass
         and
         # Only local models that supports larger context are from Nomic
-        (
-            embedder.provider_type is not None
-            or embedder.model_name.startswith("nomic-ai")
-        )
+        (embedder.model_name.startswith("nomic-ai"))
         and
         # Cohere does not support larger context they recommend not going above 512 tokens
         embedder.provider_type != EmbeddingProvider.COHERE

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -383,7 +383,7 @@ def index_doc_batch(
             )
         }
 
-        doc_id_to_previous_chunks_indexed: dict[str, int | None] = {
+        doc_id_to_previous_chunk_cnt: dict[str, int | None] = {
             document_id: chunk_count
             for document_id, chunk_count in fetch_chunk_counts_for_documents(
                 document_ids=updatable_ids,
@@ -391,7 +391,7 @@ def index_doc_batch(
             )
         }
 
-        doc_id_to_current_chunks_indexed: dict[str, int] = {
+        doc_id_to_new_chunk_cnt: dict[str, int] = {
             document_id: len(
                 [
                     chunk
@@ -433,8 +433,8 @@ def index_doc_batch(
         insertion_records = document_index.index(
             chunks=access_aware_chunks,
             index_batch_params=IndexBatchParams(
-                doc_id_to_previous_chunks_indexed=doc_id_to_previous_chunks_indexed,
-                doc_id_to_current_chunks_indexed=doc_id_to_current_chunks_indexed,
+                doc_id_to_previous_chunk_cnt=doc_id_to_previous_chunk_cnt,
+                doc_id_to_new_chunk_cnt=doc_id_to_new_chunk_cnt,
                 tenant_id=tenant_id,
                 large_chunks_enabled=chunker.enable_large_chunks,
             ),
@@ -465,7 +465,7 @@ def index_doc_batch(
 
         update_docs_chunk_count__no_commit(
             document_ids=updatable_ids,
-            doc_id_to_chunk_count=doc_id_to_current_chunks_indexed,
+            doc_id_to_chunk_count=doc_id_to_new_chunk_cnt,
             db_session=db_session,
         )
 

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -47,6 +47,8 @@ class DocAwareChunk(BaseChunk):
 
     mini_chunk_texts: list[str] | None
 
+    large_chunk_id: int | None
+
     large_chunk_reference_ids: list[int] = Field(default_factory=list)
 
     def to_short_descriptor(self) -> str:

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -152,3 +152,11 @@ class IndexingSetting(EmbeddingModelDetail):
             index_name=search_settings.index_name,
             multipass_indexing=search_settings.multipass_indexing,
         )
+
+
+class DocChunkIDInformation(BaseModel):
+    doc_id: str
+    old_version: bool
+    chunk_start_index: int
+    chunk_end_index: int
+    large_chunk_id: int | None

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -152,13 +152,3 @@ class IndexingSetting(EmbeddingModelDetail):
             index_name=search_settings.index_name,
             multipass_indexing=search_settings.multipass_indexing,
         )
-
-
-class MinimalDocChunkIDInformation(BaseModel):
-    doc_id: str
-    chunk_start_index: int
-
-
-class DocChunkIDInformation(MinimalDocChunkIDInformation):
-    old_version: bool
-    chunk_end_index: int

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -154,9 +154,11 @@ class IndexingSetting(EmbeddingModelDetail):
         )
 
 
-class DocChunkIDInformation(BaseModel):
+class MinimalDocChunkIDInformation(BaseModel):
     doc_id: str
-    old_version: bool
     chunk_start_index: int
+
+
+class DocChunkIDInformation(MinimalDocChunkIDInformation):
+    old_version: bool
     chunk_end_index: int
-    large_chunk_id: int | None

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -217,7 +217,7 @@ def seed_initial_documents(
     # as we just sent over the Vespa schema and there is a slight delay
 
     index_with_retries = retry_builder(tries=15)(document_index.index)
-    index_with_retries(chunks=chunks, fresh_index=cohere_enabled)
+    index_with_retries(chunks=chunks)
 
     # Mock a run for the UI even though it did not actually call out to anything
     mock_successful_index_attempt(

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -25,6 +25,7 @@ from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.index_attempt import mock_successful_index_attempt
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.factory import get_default_document_index
+from onyx.document_index.interfaces import IndexBatchParams
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocMetadataAwareIndexChunk
@@ -220,10 +221,12 @@ def seed_initial_documents(
     index_with_retries = retry_builder(tries=15)(document_index.index)
     index_with_retries(
         chunks=chunks,
-        document_id_to_previous_chunks_indexed={},
-        document_id_to_current_chunks_indexed={},
-        large_chunks_enabled=False,
-        tenant_id=tenant_id,
+        index_batch_params=IndexBatchParams(
+            doc_id_to_previous_chunks_indexed={},
+            doc_id_to_current_chunks_indexed={},
+            large_chunks_enabled=False,
+            tenant_id=tenant_id,
+        ),
     )
 
     # Mock a run for the UI even though it did not actually call out to anything

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -86,6 +86,7 @@ def _create_indexable_chunks(
             access=default_public_access,
             document_sets=set(),
             boost=DEFAULT_BOOST,
+            large_chunk_id=None,
         )
         chunks.append(chunk)
 
@@ -217,7 +218,13 @@ def seed_initial_documents(
     # as we just sent over the Vespa schema and there is a slight delay
 
     index_with_retries = retry_builder(tries=15)(document_index.index)
-    index_with_retries(chunks=chunks)
+    index_with_retries(
+        chunks=chunks,
+        document_id_to_previous_chunks_indexed={},
+        document_id_to_current_chunks_indexed={},
+        large_chunks_enabled=False,
+        tenant_id=tenant_id,
+    )
 
     # Mock a run for the UI even though it did not actually call out to anything
     mock_successful_index_attempt(

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -222,8 +222,8 @@ def seed_initial_documents(
     index_with_retries(
         chunks=chunks,
         index_batch_params=IndexBatchParams(
-            doc_id_to_previous_chunks_indexed={},
-            doc_id_to_current_chunks_indexed={},
+            doc_id_to_previous_chunk_cnt={},
+            doc_id_to_new_chunk_cnt={},
             large_chunks_enabled=False,
             tenant_id=tenant_id,
         ),

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -695,13 +695,13 @@ def create_connector_from_model(
             connector_data=connector_base,
         )
 
-        create_milestone_and_report(
-            user=user,
-            distinct_id=user.email if user else tenant_id or "N/A",
-            event_type=MilestoneRecordType.CREATED_CONNECTOR,
-            properties=None,
-            db_session=db_session,
-        )
+        # create_milestone_and_report(
+        #     user=user,
+        #     distinct_id=user.email if user else tenant_id or "N/A",
+        #     event_type=MilestoneRecordType.CREATED_CONNECTOR,
+        #     properties=None,
+        #     db_session=db_session,
+        # )
 
         return connector_response
     except ValueError as e:

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -695,13 +695,13 @@ def create_connector_from_model(
             connector_data=connector_base,
         )
 
-        # create_milestone_and_report(
-        #     user=user,
-        #     distinct_id=user.email if user else tenant_id or "N/A",
-        #     event_type=MilestoneRecordType.CREATED_CONNECTOR,
-        #     properties=None,
-        #     db_session=db_session,
-        # )
+        create_milestone_and_report(
+            user=user,
+            distinct_id=user.email if user else tenant_id or "N/A",
+            event_type=MilestoneRecordType.CREATED_CONNECTOR,
+            properties=None,
+            db_session=db_session,
+        )
 
         return connector_response
     except ValueError as e:

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -72,7 +72,7 @@ def _unsafe_deletion(
             break
 
         document_ids = [document.id for document in documents]
-        document_index.delete(doc_ids=document_ids)
+        # document_index.delete(doc_ids=document_ids)
         delete_documents_complete__no_commit(
             db_session=db_session,
             document_ids=document_ids,

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -72,7 +72,9 @@ def _unsafe_deletion(
             break
 
         document_ids = [document.id for document in documents]
-        # document_index.delete(doc_ids=document_ids)
+        for doc_id in document_ids:
+            document_index.delete_single(doc_id)
+
         delete_documents_complete__no_commit(
             db_session=db_session,
             document_ids=document_ids,

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -17,13 +17,13 @@ from onyx.connectors.models import Document
 from onyx.db.engine import get_session_context_manager
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.vespa.index import VespaIndex
+from onyx.indexing.indexing_pipeline import IndexBatchParams
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.indexing.models import IndexChunk
 from onyx.utils.timing import log_function_time
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.model_server_models import Embedding
-
 
 TOTAL_DOC_SETS = 8
 TOTAL_ACL_ENTRIES_PER_CATEGORY = 80
@@ -107,10 +107,12 @@ def do_insertion(
 ) -> None:
     insertion_records = vespa_index.index(
         chunks=all_chunks,
-        document_id_to_previous_chunks_indexed={},
-        document_id_to_current_chunks_indexed={},
-        tenant_id=POSTGRES_DEFAULT_SCHEMA,
-        large_chunks_enabled=False,
+        index_batch_params=IndexBatchParams(
+            doc_id_to_previous_chunks_indexed={},
+            doc_id_to_current_chunks_indexed={},
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            large_chunks_enabled=False,
+        ),
     )
     print(f"Indexed {len(insertion_records)} documents.")
     print(

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -108,8 +108,8 @@ def do_insertion(
     insertion_records = vespa_index.index(
         chunks=all_chunks,
         index_batch_params=IndexBatchParams(
-            doc_id_to_previous_chunks_indexed={},
-            doc_id_to_current_chunks_indexed={},
+            doc_id_to_previous_chunk_cnt={},
+            doc_id_to_new_chunk_cnt={},
             tenant_id=POSTGRES_DEFAULT_SCHEMA,
             large_chunks_enabled=False,
         ),

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -68,6 +68,8 @@ def generate_dummy_chunk(
             mini_chunk_embeddings=[],
         ),
         title_embedding=generate_random_embedding(embedding_dim),
+        large_chunk_id=None,
+        large_chunk_reference_ids=[],
     )
 
     document_set_names = []
@@ -103,7 +105,13 @@ def generate_dummy_chunk(
 def do_insertion(
     vespa_index: VespaIndex, all_chunks: list[DocMetadataAwareIndexChunk]
 ) -> None:
-    insertion_records = vespa_index.index(all_chunks)
+    insertion_records = vespa_index.index(
+        chunks=all_chunks,
+        document_id_to_previous_chunks_indexed={},
+        document_id_to_current_chunks_indexed={},
+        tenant_id=POSTGRES_DEFAULT_SCHEMA,
+        large_chunks_enabled=False,
+    )
     print(f"Indexed {len(insertion_records)} documents.")
     print(
         f"New documents: {sum(1 for record in insertion_records if not record.already_existed)}"

--- a/backend/tests/integration/common_utils/vespa.py
+++ b/backend/tests/integration/common_utils/vespa.py
@@ -1,6 +1,6 @@
 import requests
 
-from onyx.document_index.vespa.index import DOCUMENT_ID_ENDPOINT
+from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 
 
 class vespa_fixture:

--- a/backend/tests/unit/onyx/indexing/test_embedder.py
+++ b/backend/tests/unit/onyx/indexing/test_embedder.py
@@ -61,6 +61,7 @@ def test_default_indexing_embedder_embed_chunks(mock_embedding_model: Mock) -> N
             metadata_suffix_keyword="",
             mini_chunk_texts=None,
             large_chunk_reference_ids=[],
+            large_chunk_id=None,
         )
     ]
 


### PR DESCRIPTION
## Description
For indexing:
- Document: new value `chunk_count`
- If no `chunk_count`, we can just assume that it has the old UUID system (including non tenancy):
	- If large chunks enabled, generate the UUID based on the old UUID logic + large chunk reference IDs
- If `chunk_count`, can infer UUIDs + exact values for deletion

## How Has This Been Tested?
In multi tenant and single-tenant scenario:
- Index various docs
- Increase size of doc
- Decrease size of doc
- Ensure proper doc chunk IDs are deleted in Vespa
- Do the above specifically when migrating from main to this branch

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
