### PR TITLE
fix white labelling empty string

### DIFF
--- a/web/src/app/ee/admin/whitelabeling/WhitelabelingForm.tsx
+++ b/web/src/app/ee/admin/whitelabeling/WhitelabelingForm.tsx
@@ -73,7 +73,9 @@ export function WhitelabelingForm() {
         }}
         validationSchema={Yup.object().shape({
           auto_scroll: Yup.boolean().nullable(),
-          application_name: Yup.string().nullable(),
+          application_name: Yup.string()
+            .nullable()
+            .length(0, "Application name is required"),
           use_custom_logo: Yup.boolean().required(),
           use_custom_logotype: Yup.boolean().required(),
           custom_header_content: Yup.string().nullable(),


### PR DESCRIPTION
## Description
If user sets " " as text and then resets to default, still interpreted as empty string for browser tab name. This fixes that by requiring either empty input or properly set


## How Has This Been Tested?
<img width="297" alt="Screenshot 2025-01-05 at 2 40 47 PM" src="https://github.com/user-attachments/assets/7b0190c4-9565-4baf-a78d-f95113fd549c" />

[Describe the tests you ran to verify your changes]


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
