### PR TITLE
Prefix Fix

### DIFF
--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -109,7 +109,6 @@ def get_application() -> FastAPI:
         include_auth_router_with_prefix(
             application,
             saml_router,
-            prefix="/auth/saml",
         )
 
     # RBAC / group access control

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -157,7 +157,10 @@ def include_router_with_global_prefix_prepended(
 
 
 def include_auth_router_with_prefix(
-    application: FastAPI, router: APIRouter, prefix: str, tags: list[str] | None = None
+    application: FastAPI,
+    router: APIRouter,
+    prefix: str | None = None,
+    tags: list[str] | None = None,
 ) -> None:
     """Wrapper function to include an 'auth' router with prefix + rate-limiting dependencies."""
     final_tags = tags or ["auth"]


### PR DESCRIPTION
## Description
- Prevent duplicate auth prefixes. SAML router prefix should be defined within server file.


## How Has This Been Tested?
- Spin up SAML on main- observe `RuntimeError: Did not find user dependency in private route - APIRoute(path='/auth/saml/auth/saml/authorize', name='saml_login', methods=['GET'])`
- Spin up with this code- observe fix


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
