### PR TITLE
prevent other tests from interfering with existing google drive tests

### DIFF
--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -123,19 +123,17 @@ SPECIAL_FILE_ID_TO_CONTENT_MAP: dict[int, str] = {
 file_name_template = "file_{}.txt"
 file_text_template = "This is file {}"
 
+# This is done to prevent different tests from interfering with each other
+# So each test type should have its own valid prefix
+_VALID_PREFIX = "file_"
+
 
 def print_discrepencies(
     expected: set[str],
     retrieved: set[str],
-    valid_prefixes: set[str],
 ) -> None:
     # Filter retrieved set to only include valid prefixed items
-    filtered_retrieved = {
-        name
-        for name in retrieved
-        if any(name.startswith(prefix) for prefix in valid_prefixes)
-    }
-
+    filtered_retrieved = {name for name in retrieved if name.startswith(_VALID_PREFIX)}
     if expected != filtered_retrieved:
         print(expected)
         print(filtered_retrieved)
@@ -145,7 +143,7 @@ def print_discrepencies(
         print(expected - filtered_retrieved)
 
 
-def get_file_content(file_id: int) -> str:
+def _get_expected_file_content(file_id: int) -> str:
     if file_id in SPECIAL_FILE_ID_TO_CONTENT_MAP:
         return SPECIAL_FILE_ID_TO_CONTENT_MAP[file_id]
 
@@ -155,25 +153,40 @@ def get_file_content(file_id: int) -> str:
 def assert_retrieved_docs_match_expected(
     retrieved_docs: list[Document],
     expected_file_ids: Sequence[int],
-    valid_prefixes: set[str] = {"file_"},
 ) -> None:
     expected_file_names = {
         file_name_template.format(file_id) for file_id in expected_file_ids
     }
-    expected_file_texts = {get_file_content(file_id) for file_id in expected_file_ids}
+    expected_file_texts = {
+        _get_expected_file_content(file_id) for file_id in expected_file_ids
+    }
 
-    retrieved_file_names = set([doc.semantic_identifier for doc in retrieved_docs])
-    retrieved_texts = set(
+    # Filter out invalid prefixes to prevent different tests from interfering with each other
+    valid_retrieved_docs = [
+        doc
+        for doc in retrieved_docs
+        if doc.semantic_identifier.startswith(_VALID_PREFIX)
+    ]
+    valid_retrieved_file_names = set(
+        [doc.semantic_identifier for doc in valid_retrieved_docs]
+    )
+    valid_retrieved_texts = set(
         [
             " - ".join([section.text for section in doc.sections])
-            for doc in retrieved_docs
+            for doc in valid_retrieved_docs
         ]
     )
 
     # Check file names
-    print_discrepencies(expected_file_names, retrieved_file_names, valid_prefixes)
-    assert expected_file_names == retrieved_file_names
+    print_discrepencies(
+        expected=expected_file_names,
+        retrieved=valid_retrieved_file_names,
+    )
+    assert expected_file_names == valid_retrieved_file_names
 
     # Check file texts
-    print_discrepencies(expected_file_texts, retrieved_texts, valid_prefixes)
-    assert expected_file_texts == retrieved_texts
+    print_discrepencies(
+        expected=expected_file_texts,
+        retrieved=valid_retrieved_texts,
+    )
+    assert expected_file_texts == valid_retrieved_texts

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -128,12 +128,16 @@ file_text_template = "This is file {}"
 _VALID_PREFIX = "file_"
 
 
+def filter_invalid_prefixes(names: set[str]) -> set[str]:
+    return {name for name in names if name.startswith(_VALID_PREFIX)}
+
+
 def print_discrepencies(
     expected: set[str],
     retrieved: set[str],
 ) -> None:
     # Filter retrieved set to only include valid prefixed items
-    filtered_retrieved = {name for name in retrieved if name.startswith(_VALID_PREFIX)}
+    filtered_retrieved = filter_invalid_prefixes(retrieved)
     if expected != filtered_retrieved:
         print(expected)
         print(filtered_retrieved)

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -124,14 +124,25 @@ file_name_template = "file_{}.txt"
 file_text_template = "This is file {}"
 
 
-def print_discrepencies(expected: set[str], retrieved: set[str]) -> None:
-    if expected != retrieved:
+def print_discrepencies(
+    expected: set[str],
+    retrieved: set[str],
+    valid_prefixes: set[str],
+) -> None:
+    # Filter retrieved set to only include valid prefixed items
+    filtered_retrieved = {
+        name
+        for name in retrieved
+        if any(name.startswith(prefix) for prefix in valid_prefixes)
+    }
+
+    if expected != filtered_retrieved:
         print(expected)
-        print(retrieved)
+        print(filtered_retrieved)
         print("Extra:")
-        print(retrieved - expected)
+        print(filtered_retrieved - expected)
         print("Missing:")
-        print(expected - retrieved)
+        print(expected - filtered_retrieved)
 
 
 def get_file_content(file_id: int) -> str:
@@ -142,7 +153,9 @@ def get_file_content(file_id: int) -> str:
 
 
 def assert_retrieved_docs_match_expected(
-    retrieved_docs: list[Document], expected_file_ids: Sequence[int]
+    retrieved_docs: list[Document],
+    expected_file_ids: Sequence[int],
+    valid_prefixes: set[str] = {"file_"},
 ) -> None:
     expected_file_names = {
         file_name_template.format(file_id) for file_id in expected_file_ids
@@ -158,9 +171,9 @@ def assert_retrieved_docs_match_expected(
     )
 
     # Check file names
-    print_discrepencies(expected_file_names, retrieved_file_names)
+    print_discrepencies(expected_file_names, retrieved_file_names, valid_prefixes)
     assert expected_file_names == retrieved_file_names
 
     # Check file texts
-    print_discrepencies(expected_file_texts, retrieved_texts)
+    print_discrepencies(expected_file_texts, retrieved_texts, valid_prefixes)
     assert expected_file_texts == retrieved_texts

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -136,15 +136,13 @@ def print_discrepencies(
     expected: set[str],
     retrieved: set[str],
 ) -> None:
-    # Filter retrieved set to only include valid prefixed items
-    filtered_retrieved = filter_invalid_prefixes(retrieved)
-    if expected != filtered_retrieved:
+    if expected != retrieved:
         print(expected)
-        print(filtered_retrieved)
+        print(retrieved)
         print("Extra:")
-        print(filtered_retrieved - expected)
+        print(retrieved - expected)
         print("Missing:")
-        print(expected - filtered_retrieved)
+        print(expected - retrieved)
 
 
 def _get_expected_file_content(file_id: int) -> str:

--- a/backend/tests/daily/connectors/google_drive/test_slim_docs.py
+++ b/backend/tests/daily/connectors/google_drive/test_slim_docs.py
@@ -15,6 +15,7 @@ from tests.daily.connectors.google_drive.consts_and_utils import ADMIN_EMAIL
 from tests.daily.connectors.google_drive.consts_and_utils import ADMIN_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import ADMIN_FOLDER_3_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import file_name_template
+from tests.daily.connectors.google_drive.consts_and_utils import filter_invalid_prefixes
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_1_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_2_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_1_FILE_IDS
@@ -81,7 +82,8 @@ def assert_correct_access_for_user(
     all_accessible_ids = expected_access_ids + PUBLIC_RANGE
     expected_file_names = {file_name_template.format(i) for i in all_accessible_ids}
 
-    print_discrepencies(expected_file_names, retrieved_file_names)
+    filtered_retrieved_file_names = filter_invalid_prefixes(retrieved_file_names)
+    print_discrepencies(expected_file_names, filtered_retrieved_file_names)
 
     assert expected_file_names == retrieved_file_names
 
@@ -172,8 +174,9 @@ def test_all_permissions(
     }
 
     # Should get everything
-    print_discrepencies(expected_file_names, found_file_names)
-    assert expected_file_names == found_file_names
+    filtered_retrieved_file_names = filter_invalid_prefixes(found_file_names)
+    print_discrepencies(expected_file_names, filtered_retrieved_file_names)
+    assert expected_file_names == filtered_retrieved_file_names
 
     group_map = get_group_map(google_drive_connector)
 

--- a/backend/tests/daily/connectors/google_drive/test_slim_docs.py
+++ b/backend/tests/daily/connectors/google_drive/test_slim_docs.py
@@ -85,7 +85,7 @@ def assert_correct_access_for_user(
     filtered_retrieved_file_names = filter_invalid_prefixes(retrieved_file_names)
     print_discrepencies(expected_file_names, filtered_retrieved_file_names)
 
-    assert expected_file_names == retrieved_file_names
+    assert expected_file_names == filtered_retrieved_file_names
 
 
 # This function is supposed to map to the group_sync.py file for the google drive connector


### PR DESCRIPTION
## Description
- now the thing being tested for is determined by the prefix of the test for google drive tests. This is done to allow other tests to be performed without breaking the existing tests.


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
