### PR TITLE
Make datetime.now() UTC timezone aware

### DIFF
--- a/backend/onyx/server/gpts/api.py
+++ b/backend/onyx/server/gpts/api.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter
 from fastapi import Depends
@@ -23,7 +23,7 @@ router = APIRouter(prefix="/gpts")
 
 def time_ago(dt: datetime) -> str:
     # Calculate time difference
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     diff = now - dt
 
     # Convert difference to minutes


### PR DESCRIPTION
## Description

Right now, an API call to this route fails with the following error: `TypeError: can't subtract offset-naive and offset-aware datetimes`.

To fix this, we make datetime.now() UTC timezone aware.


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
