### PR TITLE
Fixes docker logs helper text in run-nginx.sh

### DIFF
--- a/deployment/data/nginx/run-nginx.sh
+++ b/deployment/data/nginx/run-nginx.sh
@@ -5,7 +5,7 @@ envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME' < "/etc/nginx/con
 echo "Waiting for API server to boot up; this may take a minute or two..."
 echo "If this takes more than ~5 minutes, check the logs of the API server container for errors with the following command:"
 echo
-echo "docker logs onyx-stack_api_server-1"
+echo "docker logs onyx-stack-api_server-1"
 echo
 
 while true; do


### PR DESCRIPTION
## Description
The docker container name is slightly wrong, and this commit fixes it.


## How Has This Been Tested?
No testing, it's a string change


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [x] This PR should be backported (make sure to check that the backport attempt succeeds)
