### PR TITLE
added missing dependency, missing api key placeholder, updated docs

### DIFF
--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -29,6 +29,7 @@ REQUIRE_EMAIL_VERIFICATION=False
 
 # Set these so if you wipe the DB, you don't end up having to go through the UI every time
 GEN_AI_API_KEY=<REPLACE THIS>
+OPENAI_API_KEY=<REPLACE THIS>
 # If answer quality isn't important for dev, use gpt-4o-mini since it's cheaper
 GEN_AI_MODEL_VERSION=gpt-4o
 FAST_GEN_AI_MODEL_VERSION=gpt-4o

--- a/CONTRIBUTING_VSCODE.md
+++ b/CONTRIBUTING_VSCODE.md
@@ -17,9 +17,10 @@ Before starting, make sure the Docker Daemon is running.
 1. Open the Debug view in VSCode (Cmd+Shift+D on macOS)
 2. From the dropdown at the top, select "Clear and Restart External Volumes and Containers" and press the green play button
 3. From the dropdown at the top, select "Run All Onyx Services" and press the green play button
-4. Now, you can navigate to onyx in your browser (default is http://localhost:3000) and start using the app
-5. You can set breakpoints by clicking to the left of line numbers to help debug while the app is running
-6. Use the debug toolbar to step through code, inspect variables, etc.
+4. CD into web, run "npm i" followed by npm run dev.
+5. Now, you can navigate to onyx in your browser (default is http://localhost:3000) and start using the app
+6. You can set breakpoints by clicking to the left of line numbers to help debug while the app is running
+7. Use the debug toolbar to step through code, inspect variables, etc.
 
 ## Features
 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -44,6 +44,7 @@ oauthlib==3.2.2
 openai==1.55.3
 openpyxl==3.1.2
 playwright==1.41.2
+prometheus-client==0.21.0
 psutil==5.9.5
 psycopg2-binary==2.9.9
 pyairtable==3.0.1


### PR DESCRIPTION
## Description
When I followed https://github.com/onyx-dot-app/onyx/blob/main/CONTRIBUTING_VSCODE.md, I was getting a module not found error on Ubuntu.
Had to install node modules and run nextjs which weren't mentioned on the doc above.
Further, I had to add a Open AI Keys to env to get it to work. 


## How Has This Been Tested?
Got the Slack bot and the Chat to work on my local Ubuntu.
