### PR TITLE
Fix search tool bug

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -900,6 +900,11 @@ export function AssistantEditor({
                                       }`}
                                     >
                                       <Switch
+                                        checked={
+                                          values.enabled_tools_map[
+                                            searchTool.id
+                                          ]
+                                        }
                                         size="sm"
                                         onCheckedChange={(checked) => {
                                           setShowSearchTool(checked);


### PR DESCRIPTION
## Description
Fixes https://linear.app/danswer/issue/DAN-1273/assistants-w-search-tool-enabled-have-knowledge-disabled-in-new-chat


## How Has This Been Tested?
[Describe the tests you ran to verify your changes]


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
