### PR TITLE
Slackbot optimization

### DIFF
--- a/backend/onyx/onyxbot/slack/config.py
+++ b/backend/onyx/onyxbot/slack/config.py
@@ -66,6 +66,6 @@ TENANT_HEARTBEAT_INTERVAL = (
 TENANT_HEARTBEAT_EXPIRATION = (
     30  # How long before a tenant's heartbeat expires, allowing other pods to take over
 )
-TENANT_ACQUISITION_INTERVAL = 60  # How often pods attempt to acquire unprocessed tenants and checks for new tokens
+TENANT_ACQUISITION_INTERVAL = 10  # How often pods attempt to acquire unprocessed tenants and checks for new tokens
 
 MAX_TENANTS_PER_POD = int(os.getenv("MAX_TENANTS_PER_POD", 50))

--- a/backend/onyx/onyxbot/slack/config.py
+++ b/backend/onyx/onyxbot/slack/config.py
@@ -66,6 +66,6 @@ TENANT_HEARTBEAT_INTERVAL = (
 TENANT_HEARTBEAT_EXPIRATION = (
     30  # How long before a tenant's heartbeat expires, allowing other pods to take over
 )
-TENANT_ACQUISITION_INTERVAL = 10  # How often pods attempt to acquire unprocessed tenants and checks for new tokens
+TENANT_ACQUISITION_INTERVAL = 60  # How often pods attempt to acquire unprocessed tenants and checks for new tokens
 
 MAX_TENANTS_PER_POD = int(os.getenv("MAX_TENANTS_PER_POD", 50))

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -352,7 +352,7 @@ class SlackbotHandler:
                         )
                         self._remove_tenant(tenant_id)
 
-                        # IMPORTANT: Release the lock here (in the same scope it was acquired)
+                        # NOTE: We release the lock here (in the same scope it was acquired)
                         if tenant_id in self.redis_locks and not DEV_MODE:
                             try:
                                 self.redis_locks[tenant_id].release()

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -274,7 +274,7 @@ class SlackbotHandler:
                 ex=TENANT_LOCK_EXPIRATION,
             )
             if not acquired and not DEV_MODE:
-                logger.debugg(
+                logger.debug(
                     f"Another pod holds the lock for tenant {tenant_id}, skipping."
                 )
                 continue
@@ -337,7 +337,7 @@ class SlackbotHandler:
                         logger.info(
                             f"Tenant {tenant_id} no longer has Slack bots. Removing."
                         )
-                        self._remove_tenant(tenant_id, redis_client)
+                        self._remove_tenant(tenant_id)
                         if not DEV_MODE:
                             redis_client.delete(OnyxRedisLocks.SLACK_BOT_LOCK)
 

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -195,7 +195,7 @@ class SlackbotHandler:
         # If the tokens are missing or empty, close the socket client and remove them.
         if not slack_bot_tokens:
             logger.debug(
-                f"No Slack bot tokens found for tenant={tenant_id}, app={bot.id}"
+                f"No Slack bot tokens found for tenant={tenant_id}, bot {bot.id}"
             )
             if tenant_bot_pair in self.socket_clients:
                 asyncio.run(self.socket_clients[tenant_bot_pair].close())
@@ -210,7 +210,7 @@ class SlackbotHandler:
         if not tokens_exist or tokens_changed:
             if tokens_exist:
                 logger.info(
-                    f"Slack Bot tokens changed for tenant={tenant_id}, app={bot.id}; reconnecting"
+                    f"Slack Bot tokens changed for tenant={tenant_id}, bot {bot.id}; reconnecting"
                 )
             else:
                 # Warm up the model if needed

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -301,7 +301,7 @@ class SlackbotHandler:
                                 tenant_id=tenant_id,
                                 bot=bot,
                             )
-                    else:
+                    elif not DEV_MODE:
                         # If no Slack bots, release lock immediately
                         redis_client.delete(OnyxRedisLocks.SLACK_BOT_LOCK)
                         logger.debug(
@@ -394,7 +394,7 @@ class SlackbotHandler:
         process_slack_event = create_process_slack_event()
         socket_client.socket_mode_request_listeners.append(process_slack_event)  # type: ignore
 
-        # Establish a WebSocket connection
+        # Establish a WebSocket connection to the Socket Mode servers
         logger.info(
             f"Connecting socket client for tenant: {tenant_id}, app: {slack_bot_id}"
         )
@@ -436,7 +436,7 @@ class SlackbotHandler:
             except Exception as e:
                 logger.error(f"Error releasing lock for tenant {tenant_id}: {e}")
 
-        # Wait for background threads to finish
+        # Wait for background threads to finish (with a timeout)
         logger.info("Waiting for background threads to finish...")
         self.acquire_thread.join(timeout=5)
         self.heartbeat_thread.join(timeout=5)

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -352,11 +352,11 @@ class SlackbotHandler:
             return
 
         # Close all socket clients for this tenant
-        for (t_id, slack_bot_id), client in list(self.socket_clients.items()):
-            if t_id == tenant_id:
+        for (tenant_id, slack_bot_id), client in list(self.socket_clients.items()):
+            if tenant_id == tenant_id:
                 asyncio.run(client.close())
-                del self.socket_clients[(t_id, slack_bot_id)]
-                del self.slack_bot_tokens[(t_id, slack_bot_id)]
+                del self.socket_clients[(tenant_id, slack_bot_id)]
+                del self.slack_bot_tokens[(tenant_id, slack_bot_id)]
                 logger.info(
                     f"Stopped SocketModeClient for tenant: {tenant_id}, app: {slack_bot_id}"
                 )


### PR DESCRIPTION
## Description
Fixes https://linear.app/danswer/issue/DAN-1275/slack-bot-not-working-with-on-our-cloud

Fixes cloud slackbot "acquiring" many tenants

- Centralize removal logic
- Use self.tenant_ids to track genuinely active tenants - only consider tenants with slackbots "active"


## How Has This Been Tested?
- Single tenant + multiple slackbots
- Multi tenant + multiple Slackbots + delete slackbots


## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
