### PR TITLE
Pass in tenant_id to kv_store in monitoring job

### DIFF
--- a/backend/onyx/key_value_store/factory.py
+++ b/backend/onyx/key_value_store/factory.py
@@ -2,7 +2,7 @@ from onyx.key_value_store.interface import KeyValueStore
 from onyx.key_value_store.store import PgRedisKVStore
 
 
-def get_kv_store() -> KeyValueStore:
+def get_kv_store(tenant_id: str | None = None) -> KeyValueStore:
     # In the Multi Tenant case, the tenant context is picked up automatically, it does not need to be passed in
     # It's read from the global thread level variable
-    return PgRedisKVStore()
+    return PgRedisKVStore(tenant_id=tenant_id)

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -212,7 +212,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     if not MULTI_TENANT:
         # We cache this at the beginning so there is no delay in the first telemetry
-        get_or_generate_uuid()
+        get_or_generate_uuid(tenant_id=None)
 
         # If we are multi-tenant, we need to only set up initial public tables
         with Session(engine) as db_session:


### PR DESCRIPTION
## Description

We weren't passing in the right tenant ID for cloud-monitoring -> silent telemetry failures.

https://linear.app/danswer/issue/DAN-1296/fix-monitoring-telemetry-on-our-cloud

## How Has This Been Tested?

`kubectl cp`ed the files over to the monitoring pod and ran:

```
>>> from telemetry import optional_telemetry, RecordType
>>> data = {'metric_name': 'sync_start_latency_seconds', 'float_value': 0.0}
>>> optional_telemetry(record_type=RecordType.METRIC, data=data, user_id=None, tenant_id='<SOME_TENANT>')
```

Then verified we got the expected packet on the telemetry server.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
