### PR TITLE
Add basic passthrough auth

### DIFF
--- a/backend/alembic/versions/f1ca58b2f2ec_add_passthrough_auth_to_tool.py
+++ b/backend/alembic/versions/f1ca58b2f2ec_add_passthrough_auth_to_tool.py
@@ -1,0 +1,33 @@
+"""add passthrough auth to tool
+
+Revision ID: f1ca58b2f2ec
+Revises: c7bf5721733e
+Create Date: 2024-03-19
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f1ca58b2f2ec"
+down_revision: Union[str, None] = "c7bf5721733e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add passthrough_auth column to tool table with default value of False
+    op.add_column(
+        "tool",
+        sa.Column(
+            "passthrough_auth", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Remove passthrough_auth column from tool table
+    op.drop_column("tool", "passthrough_auth")

--- a/backend/alembic/versions/f1ca58b2f2ec_add_passthrough_auth_to_tool.py
+++ b/backend/alembic/versions/f1ca58b2f2ec_add_passthrough_auth_to_tool.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     op.add_column(
         "tool",
         sa.Column(
-            "passthrough_auth", sa.Boolean(), nullable=False, server_default="false"
+            "passthrough_auth", sa.Boolean(), nullable=False, server_default=sa.false()
         ),
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1430,6 +1430,8 @@ class Tool(Base):
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), nullable=True
     )
+    # whether to pass through the user's OAuth token as Authorization header
+    passthrough_auth: Mapped[bool] = mapped_column(Boolean, default=False)
 
     user: Mapped[User | None] = relationship("User", back_populates="custom_tools")
     # Relationship to Persona through the association table

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -38,6 +38,7 @@ def create_tool(
     custom_headers: list[Header] | None,
     user_id: UUID | None,
     db_session: Session,
+    passthrough_auth: bool = False,
 ) -> Tool:
     new_tool = Tool(
         name=name,
@@ -48,6 +49,7 @@ def create_tool(
         if custom_headers
         else [],
         user_id=user_id,
+        passthrough_auth=passthrough_auth,
     )
     db_session.add(new_tool)
     db_session.commit()
@@ -62,6 +64,7 @@ def update_tool(
     custom_headers: list[Header] | None,
     user_id: UUID | None,
     db_session: Session,
+    passthrough_auth: bool | None = None,
 ) -> Tool:
     tool = get_tool_by_id(tool_id, db_session)
     if tool is None:
@@ -79,6 +82,8 @@ def update_tool(
         tool.custom_headers = [
             cast(HeaderItemDict, header.model_dump()) for header in custom_headers
         ]
+    if passthrough_auth is not None:
+        tool.passthrough_auth = passthrough_auth
     db_session.commit()
 
     return tool

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -38,7 +38,7 @@ def create_tool(
     custom_headers: list[Header] | None,
     user_id: UUID | None,
     db_session: Session,
-    passthrough_auth: bool = False,
+    passthrough_auth: bool,
 ) -> Tool:
     new_tool = Tool(
         name=name,
@@ -64,7 +64,7 @@ def update_tool(
     custom_headers: list[Header] | None,
     user_id: UUID | None,
     db_session: Session,
-    passthrough_auth: bool | None = None,
+    passthrough_auth: bool | None,
 ) -> Tool:
     tool = get_tool_by_id(tool_id, db_session)
     if tool is None:

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -55,6 +55,7 @@ def create_custom_tool(
         custom_headers=tool_data.custom_headers,
         user_id=user.id if user else None,
         db_session=db_session,
+        passthrough_auth=tool_data.passthrough_auth,
     )
     return ToolSnapshot.from_model(tool)
 
@@ -76,6 +77,7 @@ def update_custom_tool(
         custom_headers=tool_data.custom_headers,
         user_id=user.id if user else None,
         db_session=db_session,
+        passthrough_auth=tool_data.passthrough_auth,
     )
     return ToolSnapshot.from_model(updated_tool)
 

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -41,6 +41,16 @@ def _validate_tool_definition(definition: dict[str, Any]) -> None:
         raise HTTPException(status_code=400, detail=str(e))
 
 
+def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> None:
+    if tool_data.passthrough_auth and tool_data.custom_headers:
+        for header in tool_data.custom_headers:
+            if header.key.lower() == "authorization":
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot use passthrough auth with custom authorization headers",
+                )
+
+
 @admin_router.post("/custom")
 def create_custom_tool(
     tool_data: CustomToolCreate,
@@ -48,6 +58,7 @@ def create_custom_tool(
     user: User | None = Depends(current_admin_user),
 ) -> ToolSnapshot:
     _validate_tool_definition(tool_data.definition)
+    _validate_auth_settings(tool_data)
     tool = create_tool(
         name=tool_data.name,
         description=tool_data.description,
@@ -69,6 +80,7 @@ def update_custom_tool(
 ) -> ToolSnapshot:
     if tool_data.definition:
         _validate_tool_definition(tool_data.definition)
+    _validate_auth_settings(tool_data)
     updated_tool = update_tool(
         tool_id=tool_id,
         name=tool_data.name,

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -13,6 +13,7 @@ class ToolSnapshot(BaseModel):
     display_name: str
     in_code_tool_id: str | None
     custom_headers: list[Any] | None
+    passthrough_auth: bool
 
     @classmethod
     def from_model(cls, tool: Tool) -> "ToolSnapshot":
@@ -24,6 +25,7 @@ class ToolSnapshot(BaseModel):
             display_name=tool.display_name or tool.name,
             in_code_tool_id=tool.in_code_tool_id,
             custom_headers=tool.custom_headers,
+            passthrough_auth=tool.passthrough_auth,
         )
 
 
@@ -37,6 +39,7 @@ class CustomToolCreate(BaseModel):
     description: str | None = None
     definition: dict[str, Any]
     custom_headers: list[Header] | None = None
+    passthrough_auth: bool = False
 
 
 class CustomToolUpdate(BaseModel):
@@ -44,3 +47,4 @@ class CustomToolUpdate(BaseModel):
     description: str | None = None
     definition: dict[str, Any] | None = None
     custom_headers: list[Header] | None = None
+    passthrough_auth: bool | None = None

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -39,7 +39,7 @@ class CustomToolCreate(BaseModel):
     description: str | None = None
     definition: dict[str, Any]
     custom_headers: list[Header] | None = None
-    passthrough_auth: bool = False
+    passthrough_auth: bool
 
 
 class CustomToolUpdate(BaseModel):
@@ -47,4 +47,4 @@ class CustomToolUpdate(BaseModel):
     description: str | None = None
     definition: dict[str, Any] | None = None
     custom_headers: list[Header] | None = None
-    passthrough_auth: bool = False
+    passthrough_auth: bool | None = None

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -47,4 +47,4 @@ class CustomToolUpdate(BaseModel):
     description: str | None = None
     definition: dict[str, Any] | None = None
     custom_headers: list[Header] | None = None
-    passthrough_auth: bool | None = None
+    passthrough_auth: bool = False

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -146,6 +146,11 @@ def construct_tools(
     """Constructs tools based on persona configuration and available APIs"""
     tool_dict: dict[int, list[Tool]] = {}
 
+    # Get user's OAuth token if available
+    user_oauth_token = None
+    if user and user.oauth_accounts:
+        user_oauth_token = user.oauth_accounts[0].access_token
+
     for db_tool_model in persona.tools:
         if db_tool_model.in_code_tool_id:
             tool_cls = get_built_in_tool_by_id(
@@ -235,6 +240,9 @@ def construct_tools(
                         header_dict_to_header_list(
                             custom_tool_config.additional_headers or {}
                         )
+                    ),
+                    user_oauth_token=(
+                        user_oauth_token if db_tool_model.passthrough_auth else None
                     ),
                 ),
             )

--- a/web/src/app/admin/tools/ToolEditor.tsx
+++ b/web/src/app/admin/tools/ToolEditor.tsx
@@ -331,11 +331,11 @@ function ToolForm({
                       htmlFor="passthrough_auth"
                       className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                     >
-                      Pass through user's OAuth token
+                      Pass through user&apos;s OAuth token
                     </label>
                     <p className="text-xs text-subtle mt-1">
-                      When enabled, the user's OAuth token will be passed as the
-                      Authorization header for all API calls
+                      When enabled, the user&apos;s OAuth token will be passed
+                      as the Authorization header for all API calls
                     </p>
                   </div>
                 </div>

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -1,7 +1,6 @@
 "use client";
 import {
   ConnectorIndexingStatus,
-  OAuthSlackCallbackResponse,
   DocumentBoostStatus,
   Tag,
   UserGroup,
@@ -20,15 +19,10 @@ import { AllUsersResponse } from "./types";
 import { Credential } from "./connectors/credentials";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
 import { PersonaLabel } from "@/app/admin/assistants/interfaces";
-import {
-  LLMProvider,
-  LLMProviderDescriptor,
-} from "@/app/admin/configuration/llm/interfaces";
+import { LLMProviderDescriptor } from "@/app/admin/configuration/llm/interfaces";
 import { isAnthropic } from "@/app/admin/configuration/llm/interfaces";
 import { getSourceMetadata } from "./sources";
-import { buildFilters } from "./search/utils";
-import { AuthTypeMetadata } from "./userSS";
-import { AuthType } from "./constants";
+import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "./constants";
 
 const CREDENTIAL_URL = "/api/manage/admin/credential";
 
@@ -461,6 +455,10 @@ export function useAuthType(): AuthType | null {
     "/api/auth/type",
     errorHandlingFetcher
   );
+
+  if (NEXT_PUBLIC_CLOUD_ENABLED) {
+    return "cloud";
+  }
 
   if (error || !data) {
     return null;

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -27,6 +27,8 @@ import {
 import { isAnthropic } from "@/app/admin/configuration/llm/interfaces";
 import { getSourceMetadata } from "./sources";
 import { buildFilters } from "./search/utils";
+import { AuthTypeMetadata } from "./userSS";
+import { AuthType } from "./constants";
 
 const CREDENTIAL_URL = "/api/manage/admin/credential";
 
@@ -452,6 +454,19 @@ export function useLlmOverride(
     temperature,
     updateTemperature,
   };
+}
+
+export function useAuthType(): AuthType | null {
+  const { data, error } = useSWR<{ auth_type: AuthType }>(
+    "/api/auth/type",
+    errorHandlingFetcher
+  );
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data.auth_type;
 }
 
 /* 

--- a/web/src/lib/tools/edit.ts
+++ b/web/src/lib/tools/edit.ts
@@ -11,6 +11,7 @@ export async function createCustomTool(toolData: {
   description?: string;
   definition: Record<string, any>;
   custom_headers: { key: string; value: string }[];
+  passthrough_auth: boolean;
 }): Promise<ApiResponse<ToolSnapshot>> {
   try {
     const response = await fetch("/api/admin/tool/custom", {
@@ -41,6 +42,7 @@ export async function updateCustomTool(
     description?: string;
     definition?: Record<string, any>;
     custom_headers: { key: string; value: string }[];
+    passthrough_auth: boolean;
   }
 ): Promise<ApiResponse<ToolSnapshot>> {
   try {

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -13,6 +13,9 @@ export interface ToolSnapshot {
 
   // only specified for Custom Tools. ID of the tool in the codebase.
   in_code_tool_id: string | null;
+
+  // whether to pass through the user's OAuth token as Authorization header
+  passthrough_auth: boolean;
 }
 
 export interface MethodSpec {


### PR DESCRIPTION
## Description

Add support for passing through OAuth headers. 

https://linear.app/danswer/issue/DAN-1298/adding-passthrough-auth-for-tool-calls

## How Has This Been Tested?

Tested manually creating a tool using passthrough auth and verifying that we got the expected access token.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
