### PR TITLE
Add model updates

### DIFF
--- a/backend/danswer/background/celery/apps/primary.py
+++ b/backend/danswer/background/celery/apps/primary.py
@@ -265,5 +265,6 @@ celery_app.autodiscover_tasks(
         "danswer.background.celery.tasks.pruning",
         "danswer.background.celery.tasks.shared",
         "danswer.background.celery.tasks.vespa",
+        "danswer.background.celery.tasks.llm_model_update",
     ]
 )

--- a/backend/danswer/background/celery/tasks/beat_schedule.py
+++ b/backend/danswer/background/celery/tasks/beat_schedule.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from typing import Any
 
+from backend.danswer.configs.app_configs import LLM_MODEL_UPDATE_API_URL
+
 from danswer.configs.constants import DanswerCeleryPriority
 
 
@@ -54,6 +56,19 @@ tasks_to_schedule = [
         "options": {"priority": DanswerCeleryPriority.HIGH},
     },
 ]
+
+# Only add the LLM model update task if the API URL is configured
+if LLM_MODEL_UPDATE_API_URL:
+    tasks_to_schedule.append(
+        {
+            "name": "check-for-llm-model-update",
+            "task": "check_for_llm_model_update",
+            "schedule": timedelta(hours=1),  # Check every hour
+            "options": {
+                "priority": DanswerCeleryPriority.LOW,
+            },
+        }
+    )
 
 
 def get_tasks_to_schedule() -> list[dict[str, Any]]:

--- a/backend/danswer/background/celery/tasks/beat_schedule.py
+++ b/backend/danswer/background/celery/tasks/beat_schedule.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 from typing import Any
 
-from backend.danswer.configs.app_configs import LLM_MODEL_UPDATE_API_URL
-
+from danswer.configs.app_configs import LLM_MODEL_UPDATE_API_URL
 from danswer.configs.constants import DanswerCeleryPriority
 
 

--- a/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
@@ -1,0 +1,104 @@
+from typing import Any
+
+import requests
+from celery import shared_task
+from celery import Task
+
+from danswer.background.celery.apps.app_base import task_logger
+from danswer.configs.app_configs import JOB_TIMEOUT
+from danswer.configs.app_configs import LLM_MODEL_UPDATE_API_URL
+from danswer.db.engine import get_session_with_tenant
+from danswer.db.models import LLMProvider
+
+
+def _process_model_list_response(model_list_json: Any) -> list[str]:
+    # Handle case where response is wrapped in a "data" field
+    if isinstance(model_list_json, dict) and "data" in model_list_json:
+        model_list_json = model_list_json["data"]
+
+    if not isinstance(model_list_json, list):
+        raise ValueError(
+            f"Invalid response from API - expected list, got {type(model_list_json)}"
+        )
+
+    # Handle both string list and object list cases
+    model_names: list[str] = []
+    for item in model_list_json:
+        if isinstance(item, str):
+            model_names.append(item)
+        elif isinstance(item, dict) and "model_name" in item:
+            model_names.append(item["model_name"])
+        else:
+            raise ValueError(
+                f"Invalid item in model list - expected string or dict with model_name, got {type(item)}"
+            )
+
+    return model_names
+
+
+@shared_task(
+    name="check_for_llm_model_update",
+    soft_time_limit=JOB_TIMEOUT,
+    trail=False,
+    bind=True,
+)
+def check_for_llm_model_update(self: Task, *, tenant_id: str | None) -> bool | None:
+    if not LLM_MODEL_UPDATE_API_URL:
+        raise ValueError("LLM model update API URL not configured")
+
+    # First fetch the models from the API
+    try:
+        response = requests.get(LLM_MODEL_UPDATE_API_URL)
+        response.raise_for_status()
+        available_models = _process_model_list_response(response.json())
+        task_logger.info(f"Found available models: {available_models}")
+
+    except Exception:
+        task_logger.exception("Failed to fetch models from API.")
+        return None
+
+    # Then update the database with the fetched models
+    with get_session_with_tenant(tenant_id) as db_session:
+        # Get the default LLM provider
+        default_provider = (
+            db_session.query(LLMProvider)
+            .filter(LLMProvider.is_default_provider.is_(True))
+            .first()
+        )
+
+        if not default_provider:
+            task_logger.warning("No default LLM provider found")
+            return None
+
+        # log change if any
+        old_models = set(default_provider.model_names or [])
+        new_models = set(available_models)
+        added_models = new_models - old_models
+        removed_models = old_models - new_models
+
+        if added_models:
+            task_logger.info(f"Adding models: {sorted(added_models)}")
+        if removed_models:
+            task_logger.info(f"Removing models: {sorted(removed_models)}")
+
+        # Update the provider's model list
+        default_provider.model_names = available_models
+        # if the default model is no longer available, set it to the first model in the list
+        if default_provider.default_model_name not in available_models:
+            task_logger.info(
+                f"Default model {default_provider.default_model_name} not "
+                f"available, setting to first model in list: {available_models[0]}"
+            )
+            default_provider.default_model_name = available_models[0]
+        if default_provider.fast_default_model_name not in available_models:
+            task_logger.info(
+                f"Fast default model {default_provider.fast_default_model_name} "
+                f"not available, setting to first model in list: {available_models[0]}"
+            )
+            default_provider.fast_default_model_name = available_models[0]
+        db_session.commit()
+
+        if added_models or removed_models:
+            task_logger.info("Updated model list for default provider.")
+
+    return True

--- a/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
@@ -98,6 +98,7 @@ def check_for_llm_model_update(self: Task, *, tenant_id: str | None) -> bool | N
 
         # Update the provider's model list
         default_provider.model_names = available_models
+        default_provider.display_model_names = available_models
         # if the default model is no longer available, set it to the first model in the list
         if default_provider.default_model_name not in available_models:
             task_logger.info(

--- a/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/danswer/background/celery/tasks/llm_model_update/tasks.py
@@ -13,8 +13,16 @@ from danswer.db.models import LLMProvider
 
 def _process_model_list_response(model_list_json: Any) -> list[str]:
     # Handle case where response is wrapped in a "data" field
-    if isinstance(model_list_json, dict) and "data" in model_list_json:
-        model_list_json = model_list_json["data"]
+    if isinstance(model_list_json, dict):
+        if "data" in model_list_json:
+            model_list_json = model_list_json["data"]
+        elif "models" in model_list_json:
+            model_list_json = model_list_json["models"]
+        else:
+            raise ValueError(
+                "Invalid response from API - expected dict with 'data' or "
+                f"'models' field, got {type(model_list_json)}"
+            )
 
     if not isinstance(model_list_json, list):
         raise ValueError(
@@ -26,11 +34,18 @@ def _process_model_list_response(model_list_json: Any) -> list[str]:
     for item in model_list_json:
         if isinstance(item, str):
             model_names.append(item)
-        elif isinstance(item, dict) and "model_name" in item:
-            model_names.append(item["model_name"])
+        elif isinstance(item, dict):
+            if "model_name" in item:
+                model_names.append(item["model_name"])
+            elif "id" in item:
+                model_names.append(item["id"])
+            else:
+                raise ValueError(
+                    f"Invalid item in model list - expected dict with model_name or id, got {type(item)}"
+                )
         else:
             raise ValueError(
-                f"Invalid item in model list - expected string or dict with model_name, got {type(item)}"
+                f"Invalid item in model list - expected string or dict, got {type(item)}"
             )
 
     return model_names

--- a/backend/danswer/configs/app_configs.py
+++ b/backend/danswer/configs/app_configs.py
@@ -468,6 +468,8 @@ AZURE_DALLE_API_KEY = os.environ.get("AZURE_DALLE_API_KEY")
 AZURE_DALLE_API_BASE = os.environ.get("AZURE_DALLE_API_BASE")
 AZURE_DALLE_DEPLOYMENT_NAME = os.environ.get("AZURE_DALLE_DEPLOYMENT_NAME")
 
+# LLM Model Update API endpoint
+LLM_MODEL_UPDATE_API_URL = os.environ.get("LLM_MODEL_UPDATE_API_URL")
 
 # Use managed Vespa (Vespa Cloud). If set, must also set VESPA_CLOUD_URL, VESPA_CLOUD_CERT_PATH and VESPA_CLOUD_KEY_PATH
 MANAGED_VESPA = os.environ.get("MANAGED_VESPA", "").lower() == "true"

--- a/backend/tests/integration/tests/seeding/test_seeding.py
+++ b/backend/tests/integration/tests/seeding/test_seeding.py
@@ -1,0 +1,118 @@
+import json
+import os
+from tempfile import NamedTemporaryFile
+
+import requests
+
+from danswer.db.engine import get_session_context_manager
+from danswer.db.models import Tool
+from danswer.server.features.persona.models import CreatePersonaRequest
+from danswer.server.manage.llm.models import LLMProviderUpsertRequest
+from danswer.server.settings.models import Settings
+from ee.danswer.server.enterprise_settings.models import EnterpriseSettings
+from ee.danswer.server.seeding import SeedConfiguration
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_seeding(reset: None) -> None:
+    # Create admin user
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    # Create temporary files for testing
+    with (
+        NamedTemporaryFile(mode="w", suffix=".json") as tool_file,
+        NamedTemporaryFile(mode="w", suffix=".svg") as logo_file,
+    ):
+        # Write test tool definition
+        tool_definition = {
+            "openapi": "3.0.0",
+            "info": {"title": "Test Tool", "version": "1.0.0"},
+            "paths": {},
+        }
+        json.dump(tool_definition, tool_file)
+        tool_file.flush()
+
+        # Write test logo
+        logo_file.write("<svg>Test Logo</svg>")
+        logo_file.flush()
+
+        # Create seed configuration
+        seed_config = SeedConfiguration(
+            llms=[
+                LLMProviderUpsertRequest(
+                    model_name="test-model",
+                    model_provider="test-provider",
+                    api_key="test-key",
+                )
+            ],
+            personas=[
+                CreatePersonaRequest(
+                    name="Test Persona",
+                    description="A test persona",
+                    num_chunks=5,
+                )
+            ],
+            settings=Settings(
+                enable_experimental_features=True,
+            ),
+            enterprise_settings=EnterpriseSettings(
+                disable_source_filters=True,
+            ),
+            seeded_logo_path=logo_file.name,
+            custom_tools=[
+                {
+                    "name": "test-tool",
+                    "description": "A test tool",
+                    "definition_path": tool_file.name,
+                }
+            ],
+        )
+
+        # Set environment variable with seed configuration
+        os.environ["ENV_SEED_CONFIGURATION"] = seed_config.model_dump_json()
+
+        # Verify seeded LLM
+        response = requests.get(
+            f"{API_SERVER_URL}/manage/llm-providers",
+            headers=admin_user.headers,
+        )
+        assert response.status_code == 200
+        llms = response.json()
+        assert any(llm["model_name"] == "test-model" for llm in llms)
+
+        # Verify seeded persona
+        response = requests.get(
+            f"{API_SERVER_URL}/personas",
+            headers=admin_user.headers,
+        )
+        assert response.status_code == 200
+        personas = response.json()
+        assert any(persona["name"] == "Test Persona" for persona in personas)
+
+        # Verify seeded tool
+        with get_session_context_manager() as db_session:
+            tools = db_session.query(Tool).all()
+            assert any(tool.name == "test-tool" for tool in tools)
+
+        # Verify settings
+        response = requests.get(
+            f"{API_SERVER_URL}/settings",
+            headers=admin_user.headers,
+        )
+        assert response.status_code == 200
+        settings = response.json()
+        assert settings["enable_experimental_features"] is True
+
+        # Verify enterprise settings
+        response = requests.get(
+            f"{API_SERVER_URL}/enterprise-settings",
+            headers=admin_user.headers,
+        )
+        assert response.status_code == 200
+        ee_settings = response.json()
+        assert ee_settings["disable_source_filters"] is True
+
+        # Clean up
+        os.environ.pop("ENV_SEED_CONFIGURATION", None)

--- a/backend/tests/unit/danswer/celery/llm_model_update/test_llm_model_update.py
+++ b/backend/tests/unit/danswer/celery/llm_model_update/test_llm_model_update.py
@@ -1,0 +1,92 @@
+import pytest
+
+from danswer.background.celery.tasks.llm_model_update.tasks import (
+    _process_model_list_response,
+)
+
+
+@pytest.mark.parametrize(
+    "input_data,expected_result,expected_error,error_match",
+    [
+        # Success cases
+        (
+            ["gpt-4", "gpt-3.5-turbo", "claude-2"],
+            ["gpt-4", "gpt-3.5-turbo", "claude-2"],
+            None,
+            None,
+        ),
+        (
+            [
+                {"model_name": "gpt-4", "other_field": "value"},
+                {"model_name": "gpt-3.5-turbo", "other_field": "value"},
+            ],
+            ["gpt-4", "gpt-3.5-turbo"],
+            None,
+            None,
+        ),
+        (
+            [
+                {"id": "gpt-4", "other_field": "value"},
+                {"id": "gpt-3.5-turbo", "other_field": "value"},
+            ],
+            ["gpt-4", "gpt-3.5-turbo"],
+            None,
+            None,
+        ),
+        (
+            {"data": ["gpt-4", "gpt-3.5-turbo"]},
+            ["gpt-4", "gpt-3.5-turbo"],
+            None,
+            None,
+        ),
+        (
+            {"models": ["gpt-4", "gpt-3.5-turbo"]},
+            ["gpt-4", "gpt-3.5-turbo"],
+            None,
+            None,
+        ),
+        (
+            {"models": [{"id": "gpt-4"}, {"id": "gpt-3.5-turbo"}]},
+            ["gpt-4", "gpt-3.5-turbo"],
+            None,
+            None,
+        ),
+        # Error cases
+        (
+            "not a list",
+            None,
+            ValueError,
+            "Invalid response from API - expected list",
+        ),
+        (
+            {"wrong_field": []},
+            None,
+            ValueError,
+            "Invalid response from API - expected dict with 'data' or 'models' field",
+        ),
+        (
+            [{"wrong_field": "value"}],
+            None,
+            ValueError,
+            "Invalid item in model list - expected dict with model_name or id",
+        ),
+        (
+            [42],
+            None,
+            ValueError,
+            "Invalid item in model list - expected string or dict",
+        ),
+    ],
+)
+def test_process_model_list_response(
+    input_data: dict | list,
+    expected_result: list[str] | None,
+    expected_error: type[Exception] | None,
+    error_match: str | None,
+) -> None:
+    if expected_error:
+        with pytest.raises(expected_error, match=error_match):
+            _process_model_list_response(input_data)
+    else:
+        result = _process_model_list_response(input_data)
+        assert result == expected_result


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1305/support-automatic-llm-updates-for-netflix-specific-api-format-backport

This is ported over from main + adds support for a different API format.

## How Has This Been Tested?

UT + testing with LiteLLM proxy locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
