### PR TITLE
fix image edge case width screen size

### DIFF
--- a/web/src/app/assistants/mine/AssistantCard.tsx
+++ b/web/src/app/assistants/mine/AssistantCard.tsx
@@ -103,7 +103,7 @@ const AssistantCard: React.FC<{
   return (
     <div className="w-full p-2 overflow-visible pb-4 pt-3 bg-[#fefcf9] rounded shadow-[0px_0px_4px_0px_rgba(0,0,0,0.25)] flex flex-col">
       <div className="w-full flex">
-        <div className="ml-2 mr-4 mt-1 w-8 h-8">
+        <div className="ml-2 flex-none mr-2 mt-1 w-10 h-10">
           <AssistantIcon assistant={persona} size="large" />
         </div>
         <div className="flex-1 mt-1 flex flex-col">

--- a/web/src/components/assistants/AssistantIcon.tsx
+++ b/web/src/components/assistants/AssistantIcon.tsx
@@ -139,7 +139,7 @@ export function AssistantIcon({
                 alt={assistant.name}
                 src={buildImgUrl(assistant.uploaded_image_id)}
                 loading="lazy"
-                className={`object-cover object-center rounded-sm transition-opacity duration-300 ${wrapperClass}`}
+                className={`h-[${dimension}px] w-[${dimension}px] object-cover object-center rounded-sm transition-opacity duration-300 ${wrapperClass}`}
                 style={style}
               />
             ) : (


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1306/assistant-icons-not-shown-if-custom-in-explorer-specifically

## How Has This Been Tested?
With a very large email, create custom image for assistnat icon + open assistant modal + decrease screen size until icon disappears
- On main
- On this branch: verify functional

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
