### PR TITLE
Add support for overridding scopes for OIDC

### DIFF
--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -8,11 +8,15 @@ OPENID_CONFIG_URL = os.environ.get("OPENID_CONFIG_URL", "")
 # are requested from the OIDC provider. Currently used when passing
 # over access tokens to tool calls and the tool needs more scopes
 OIDC_SCOPE_OVERRIDE: list[str] | None = None
-try:
-    _OIDC_SCOPE_OVERRIDE = os.environ.get("OIDC_SCOPE_OVERRIDE", "")
-    OIDC_SCOPE_OVERRIDE = [scope.strip() for scope in _OIDC_SCOPE_OVERRIDE.split(",")]
-except Exception:
-    pass
+_OIDC_SCOPE_OVERRIDE = os.environ.get("OIDC_SCOPE_OVERRIDE")
+
+if _OIDC_SCOPE_OVERRIDE:
+    try:
+        OIDC_SCOPE_OVERRIDE = [
+            scope.strip() for scope in _OIDC_SCOPE_OVERRIDE.split(",")
+        ]
+    except Exception:
+        pass
 
 # Applicable for SAML Auth
 SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/ee/onyx/configs/saml_config"

--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -4,6 +4,16 @@ import os
 # Applicable for OIDC Auth
 OPENID_CONFIG_URL = os.environ.get("OPENID_CONFIG_URL", "")
 
+# Applicable for OIDC Auth, allows you to override the scopes that
+# are requested from the OIDC provider. Currently used when passing
+# over access tokens to tool calls and the tool needs more scopes
+OIDC_SCOPE_OVERRIDE: list[str] | None = None
+try:
+    _OIDC_SCOPE_OVERRIDE = os.environ.get("OIDC_SCOPE_OVERRIDE", "")
+    OIDC_SCOPE_OVERRIDE = [scope.strip() for scope in _OIDC_SCOPE_OVERRIDE.split(",")]
+except Exception:
+    pass
+
 # Applicable for SAML Auth
 SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/ee/onyx/configs/saml_config"
 

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.openid import OpenID
 
+from ee.onyx.configs.app_configs import OIDC_SCOPE_OVERRIDE
 from ee.onyx.configs.app_configs import OPENID_CONFIG_URL
 from ee.onyx.server.analytics.api import router as analytics_router
 from ee.onyx.server.auth_check import check_ee_router_auth
@@ -88,7 +89,14 @@ def get_application() -> FastAPI:
         include_auth_router_with_prefix(
             application,
             create_onyx_oauth_router(
-                OpenID(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, OPENID_CONFIG_URL),
+                OpenID(
+                    OAUTH_CLIENT_ID,
+                    OAUTH_CLIENT_SECRET,
+                    OPENID_CONFIG_URL,
+                    # defaults to None, leaving it up to the lib
+                    # to determine the base scopes
+                    base_scopes=OIDC_SCOPE_OVERRIDE,
+                ),
                 auth_backend,
                 USER_AUTH_SECRET,
                 associate_by_email=True,

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from httpx_oauth.clients.google import GoogleOAuth2
+from httpx_oauth.clients.openid import BASE_SCOPES
 from httpx_oauth.clients.openid import OpenID
 
 from ee.onyx.configs.app_configs import OIDC_SCOPE_OVERRIDE
@@ -93,9 +94,8 @@ def get_application() -> FastAPI:
                     OAUTH_CLIENT_ID,
                     OAUTH_CLIENT_SECRET,
                     OPENID_CONFIG_URL,
-                    # defaults to None, leaving it up to the lib
-                    # to determine the base scopes
-                    base_scopes=OIDC_SCOPE_OVERRIDE,
+                    # BASE_SCOPES is the same as not setting this
+                    base_scopes=OIDC_SCOPE_OVERRIDE or BASE_SCOPES,
                 ),
                 auth_backend,
                 USER_AUTH_SECRET,


### PR DESCRIPTION
## Description

Allows you to override the scopes that are requested from the OIDC provider. Currently used when passing through access tokens to tool calls and the tool needs more scopes.

https://linear.app/danswer/issue/DAN-1323/add-support-for-requesting-additional-oidcoauth-scopes-via-env

## How Has This Been Tested?

Tested regular OIDC + set breakpoint and verified additional scopes were indeed passed in to the lib.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
