### PR TITLE
Fix #3764: Dynamically handle default branch in GitLab connector

### DIFF
--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -88,27 +88,33 @@ def _convert_issue_to_document(issue: Any) -> Document:
 def _convert_code_to_document(
     project: Project, file: Any, url: str, projectName: str, projectOwner: str
 ) -> Document:
+    # Dynamically get the default branch from the project object
+    default_branch = project.default_branch
+
+    # Fetch the file content using the correct branch
     file_content_obj = project.files.get(
-        file_path=file["path"], ref="master"
-    )  # Replace 'master' with your branch name if needed
+        file_path=file["path"], ref=default_branch  # Use the default branch
+    )
     try:
         file_content = file_content_obj.decode().decode("utf-8")
     except UnicodeDecodeError:
         file_content = file_content_obj.decode().decode("latin-1")
 
-    file_url = f"{url}/{projectOwner}/{projectName}/-/blob/master/{file['path']}"  # Construct the file URL
+    # Construct the file URL dynamically using the default branch
+    file_url = f"{url}/{projectOwner}/{projectName}/-/blob/{default_branch}/{file['path']}"
+
+    # Create and return a Document object
     doc = Document(
         id=file["id"],
         sections=[Section(link=file_url, text=file_content)],
         source=DocumentSource.GITLAB,
         semantic_identifier=file["name"],
-        doc_updated_at=datetime.now().replace(
-            tzinfo=timezone.utc
-        ),  # Use current time as updated_at
-        primary_owners=[],  # Fill this as needed
+        doc_updated_at=datetime.now().replace(tzinfo=timezone.utc),
+        primary_owners=[],  # Add owners if needed
         metadata={"type": "CodeFile"},
     )
     return doc
+
 
 
 def _should_exclude(path: str) -> bool:


### PR DESCRIPTION
# Description
This PR fixes an issue in the Onyx GitLab connector where the branch was hardcoded as master. This caused 404 errors when working with repositories that use a different default branch, such as main.

The solution dynamically retrieves the repository's default branch using the GitLab API and replaces hardcoded master references throughout the connector.

Key changes include:

Using project.default_branch to fetch the correct branch dynamically.
Updating the file URL construction to use the dynamically determined branch.
Ensuring compatibility with repositories that do not use master as their default branch.

# How Has This Been Tested?
Manually tested the connector with repositories using main as the default branch.
Confirmed that the connector successfully fetches file content and constructs valid URLs for files in repositories with different branch configurations.
Verified that repositories with master as the default branch continue to work without issues.