### PR TITLE
Input shortcut fix in multi tenant case

### DIFF
--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -193,13 +193,13 @@ def fetch_input_prompts_by_user(
     """
     Returns all prompts belonging to the user or public prompts,
     excluding those the user has specifically disabled.
+    Also, if `user_id` is None and AUTH_TYPE is DISABLED, then all prompts are returned.
     """
 
-    # Start with a basic query for InputPrompt
     query = select(InputPrompt)
 
-    # If we have a user, left join to InputPrompt__User so we can check "disabled"
     if user_id is not None:
+        # If we have a user, left join to InputPrompt__User to check "disabled"
         IPU = aliased(InputPrompt__User)
         query = query.join(
             IPU,
@@ -208,29 +208,33 @@ def fetch_input_prompts_by_user(
         )
 
         # Exclude disabled prompts
-        # i.e. keep only those where (IPU.disabled is NULL or False)
         query = query.where(or_(IPU.disabled.is_(None), IPU.disabled.is_(False)))
 
         if include_public:
-            # user-owned or public
+            # Return either user-owned or public prompts
             query = query.where(
-                (InputPrompt.user_id == user_id) | (InputPrompt.is_public)
+                or_(
+                    InputPrompt.user_id == user_id,
+                    InputPrompt.is_public,
+                )
             )
         else:
-            # only user-owned prompts
+            # Return only user-owned prompts
             query = query.where(InputPrompt.user_id == user_id)
 
-    # If no user is logged in, get all prompts (public and private)
-    if user_id is None and AUTH_TYPE == AuthType.DISABLED:
-        query = query.where(True)  # type: ignore
-
-    # If no user is logged in but we want to include public prompts
-    elif include_public:
-        query = query.where(InputPrompt.is_public)
+    else:
+        # user_id is None
+        if AUTH_TYPE == AuthType.DISABLED:
+            # If auth is disabled, return all prompts
+            query = query.where(True)  # type: ignore
+        elif include_public:
+            # If we need only public prompts while no user is logged in
+            query = query.where(InputPrompt.is_public)
 
     if active is not None:
         query = query.where(InputPrompt.active == active)
 
+    print(query)
     return list(db_session.scalars(query).all())
 
 

--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -211,7 +211,7 @@ def fetch_input_prompts_by_user(
         query = query.where(or_(IPU.disabled.is_(None), IPU.disabled.is_(False)))
 
         if include_public:
-            # Return either user-owned or public prompts
+            # Return both user-owned and public prompts
             query = query.where(
                 or_(
                     InputPrompt.user_id == user_id,
@@ -231,10 +231,11 @@ def fetch_input_prompts_by_user(
             # Anonymous usage
             query = query.where(InputPrompt.is_public)
 
+        # Default to returning all prompts
+
     if active is not None:
         query = query.where(InputPrompt.active == active)
 
-    print(query)
     return list(db_session.scalars(query).all())
 
 

--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -228,7 +228,7 @@ def fetch_input_prompts_by_user(
             # If auth is disabled, return all prompts
             query = query.where(True)  # type: ignore
         elif include_public:
-            # If we need only public prompts while no user is logged in
+            # Anonymous usage
             query = query.where(InputPrompt.is_public)
 
     if active is not None:

--- a/backend/onyx/server/features/input_prompt/api.py
+++ b/backend/onyx/server/features/input_prompt/api.py
@@ -32,6 +32,7 @@ def list_input_prompts(
     include_public: bool = True,
     db_session: Session = Depends(get_session),
 ) -> list[InputPromptSnapshot]:
+    print("FETCHING INPUT PROMPTS")
     user_prompts = fetch_input_prompts_by_user(
         user_id=user.id if user is not None else None,
         db_session=db_session,

--- a/backend/onyx/server/features/input_prompt/api.py
+++ b/backend/onyx/server/features/input_prompt/api.py
@@ -32,7 +32,6 @@ def list_input_prompts(
     include_public: bool = True,
     db_session: Session = Depends(get_session),
 ) -> list[InputPromptSnapshot]:
-    print("FETCHING INPUT PROMPTS")
     user_prompts = fetch_input_prompts_by_user(
         user_id=user.id if user is not None else None,
         db_session=db_session,


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1335/input-prompts-not-showing-up

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
