### PR TITLE
Search tool no results bugfix

### DIFF
--- a/backend/onyx/tools/tool_implementations/internet_search/internet_search_tool.py
+++ b/backend/onyx/tools/tool_implementations/internet_search/internet_search_tool.py
@@ -220,6 +220,13 @@ class InternetSearchTool(Tool):
         )
         results = response.json()
 
+        # If no hits, Bing does not include the webPages key
+        search_results = (
+            results["webPages"]["value"][: self.num_results]
+            if "webPages" in results
+            else []
+        )
+
         return InternetSearchResponse(
             revised_query=query,
             internet_results=[
@@ -228,7 +235,7 @@ class InternetSearchTool(Tool):
                     link=result["url"],
                     snippet=result["snippet"],
                 )
-                for result in results["webPages"]["value"][: self.num_results]
+                for result in search_results
             ],
         )
 

--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -910,28 +910,11 @@ export function AssistantEditor({
 
                     {internetSearchTool && (
                       <>
-                        <div className="flex items-center content-start mb-2">
-                          <Checkbox
-                            size="sm"
-                            id={`enabled_tools_map.${internetSearchTool.id}`}
-                            checked={
-                              values.enabled_tools_map[internetSearchTool.id]
-                            }
-                            onCheckedChange={() => {
-                              toggleToolInValues(internetSearchTool.id);
-                            }}
-                            name={`enabled_tools_map.${internetSearchTool.id}`}
-                          />
-                          <div className="flex flex-col ml-2">
-                            <span className="text-sm">
-                              {internetSearchTool.display_name}
-                            </span>
-                            <span className="text-xs text-subtle">
-                              Access real-time information and search the web
-                              for up-to-date results
-                            </span>
-                          </div>
-                        </div>
+                        <BooleanFormField
+                          name={`enabled_tools_map.${internetSearchTool.id}`}
+                          label={internetSearchTool.display_name}
+                          subtext="Access real-time information and search the web for up-to-date results"
+                        />
                       </>
                     )}
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-539/handle-no-results-in-internet-search-tool-potential-issue-with-flow-in

Bing API doesn't return webPage key if no results https://stackoverflow.com/questions/44546052/issue-with-bing-search-api-which-returns-only-relatedsearches-and-not-webpages

## How Has This Been Tested?

- Obscure query before + after

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
