### PR TITLE
Fix Sharepoint Folder Parsing

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 from typing import Optional
+from urllib.parse import unquote
 
 import msal  # type: ignore
 from office365.graph_client import GraphClient  # type: ignore
@@ -82,7 +83,9 @@ class SharepointConnector(LoadConnector, PollConnector):
                 sites_index = parts.index("sites")
                 site_url = "/".join(parts[: sites_index + 2])
                 folder = (
-                    parts[sites_index + 2] if len(parts) > sites_index + 2 else None
+                    unquote(parts[sites_index + 2])
+                    if len(parts) > sites_index + 2
+                    else None
                 )
                 site_data_list.append(
                     SiteData(url=site_url, folder=folder, sites=[], driveitems=[])

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -83,10 +83,13 @@ class SharepointConnector(LoadConnector, PollConnector):
                 sites_index = parts.index("sites")
                 site_url = "/".join(parts[: sites_index + 2])
                 folder = (
-                    unquote(parts[sites_index + 2])
+                    "/".join(unquote(part) for part in parts[sites_index + 2 :])
                     if len(parts) > sites_index + 2
                     else None
                 )
+                # Handling for new URL structure
+                if folder and folder.startswith("Shared Documents/"):
+                    folder = folder[len("Shared Documents/") :]
                 site_data_list.append(
                     SiteData(url=site_url, folder=folder, sites=[], driveitems=[])
                 )
@@ -114,11 +117,19 @@ class SharepointConnector(LoadConnector, PollConnector):
                         query = query.filter(filter_str)
                     driveitems = query.execute_query()
                     if element.folder:
+                        expected_path = f"/root:/{element.folder}"
                         filtered_driveitems = [
                             item
                             for item in driveitems
-                            if element.folder in item.parent_reference.path
+                            if item.parent_reference.path.endswith(expected_path)
                         ]
+                        if len(filtered_driveitems) == 0:
+                            all_paths = [
+                                item.parent_reference.path for item in driveitems
+                            ]
+                            logger.warning(
+                                f"Nothing found for folder '{expected_path}' in any of valid paths: {all_paths}"
+                            )
                         element.driveitems.extend(filtered_driveitems)
                     else:
                         element.driveitems.extend(driveitems)

--- a/web/src/components/admin/connectors/Field.tsx
+++ b/web/src/components/admin/connectors/Field.tsx
@@ -77,7 +77,9 @@ export function LabelWithTooltip({
 }
 
 export function SubLabel({ children }: { children: string | JSX.Element }) {
-  return <div className="text-xs text-subtle">{children}</div>;
+  return (
+    <div className="text-xs text-subtle whitespace-pre-line">{children}</div>
+  );
 }
 
 export function ManualErrorMessage({ children }: { children: string }) {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -481,7 +481,9 @@ Hint: Use the singular form of the object name (e.g., 'Opportunity' instead of '
         name: "sites",
         optional: true,
         description: `• If no sites are specified, all sites in your organization will be indexed (Sites.Read.All permission required).
+
 • Specifying 'https://onyxai.sharepoint.com/sites/support' for example will only index documents within this site.
+
 • Specifying 'https://onyxai.sharepoint.com/sites/support/subfolder' for example will only index documents within this folder.
 `,
       },


### PR DESCRIPTION
## Description
https://linear.app/danswer/issue/DAN-1342/sharepoint-cant-index-folders

Sharepoint Folders aren't getting parsed correctly

## How Has This Been Tested?
Verified against our own Sharepoint (with some hacks since data format has changed)

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
