### PR TITLE
Slack Reenable DM

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -205,6 +205,13 @@ def handle_message(
                 text="The OnyxBot slash command is not enabled for this channel",
                 thread_ts=None,
             )
+            return False
+
+    if is_bot_msg:
+        if not sender_id:
+            logger.error("No sender id found for Slack slash command, nobody to DM to.")
+            return False
+        send_to = [sender_id]
 
     try:
         send_msg_ack_to_user(message_info, client)

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -869,6 +869,8 @@ def create_process_slack_event() -> (
                 elif req.payload.get("type") == "view_submission":
                     return view_routing(req, client)
             elif req.type == "events_api" or req.type == "slash_commands":
+                # If you see dispatch_failed, it could be because of a conflict in the slash command
+                # as in more than 1 app is trying to use that one.
                 return process_message(req, client)
         except Exception:
             logger.exception("Failed to process slack event")


### PR DESCRIPTION
## Description
Slash commands in Slack were broken, did not treat as DM response

## How Has This Been Tested?
Tested previously, just didn't get PR in.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
