### PR TITLE
allow to configure sharepoint access token

### DIFF
--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -170,9 +170,10 @@ export interface SalesforceCredentialJson {
 }
 
 export interface SharepointCredentialJson {
-  sp_client_id: string;
-  sp_client_secret: string;
-  sp_directory_id: string;
+  sp_client_id: string | null;
+  sp_client_secret: string | null;
+  sp_directory_id: string | null;
+  sp_access_token: string | null;
 }
 
 export interface AsanaCredentialJson {
@@ -271,6 +272,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
     sp_client_id: "",
     sp_client_secret: "",
     sp_directory_id: "",
+    sp_access_token: "",
   } as SharepointCredentialJson,
   asana: {
     asana_api_token_secret: "",
@@ -450,6 +452,7 @@ export const credentialDisplayNames: Record<string, string> = {
   sp_client_id: "SharePoint Client ID",
   sp_client_secret: "SharePoint Client Secret",
   sp_directory_id: "SharePoint Directory ID",
+  sp_access_token: "SharePoint Access Token",
 
   // Asana
   asana_api_token_secret: "Asana API Token",


### PR DESCRIPTION
## Description

This allow to use an access token directly instead of requiring to create client credentials via the azure portal.

Such an access token can be obtained without any special permissions by opening the desired sharepoint site and extracting the token with the browser developer tools from the request to the `/token` endpoint.

Such an access token is typically only valid for 1h, but this is enough for a one-time import.

## How Has This Been Tested?

Successfully imported our Sharepoint Site into our local Onyx instance.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
