### PR TITLE
Helm chart refactoring

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@v4.2.0
       with:
-        version: v3.14.4
+        version: v3.17.0
       
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.6.1
+      uses: helm/chart-testing-action@v2.7.0
 
     # even though we specify chart-dirs in ct.yaml, it isn't used by ct for the list-changed command...
     - name: Run chart-testing (list-changed)
@@ -37,22 +37,6 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
         fi
 
-#     rkuo: I don't think we need python?
-#     - name: Set up Python
-#       uses: actions/setup-python@v5
-#       with:
-#         python-version: '3.11'
-#         cache: 'pip'
-#         cache-dependency-path: |
-#           backend/requirements/default.txt
-#           backend/requirements/dev.txt
-#           backend/requirements/model_server.txt
-#     - run: |
-#         python -m pip install --upgrade pip
-#         pip install --retries 5 --timeout 30 -r backend/requirements/default.txt
-#         pip install --retries 5 --timeout 30 -r backend/requirements/dev.txt
-#         pip install --retries 5 --timeout 30 -r backend/requirements/model_server.txt
-
     # lint all charts if any changes were detected
     - name: Run chart-testing (lint)
       if: steps.list-changed.outputs.changed == 'true'
@@ -62,7 +46,7 @@ jobs:
 
     - name: Create kind cluster
       if: steps.list-changed.outputs.changed == 'true'
-      uses: helm/kind-action@v1.10.0
+      uses: helm/kind-action@v1.12.0
 
     - name: Run chart-testing (install)
       if: steps.list-changed.outputs.changed == 'true'

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
 version: 0.2.1
-appVersion: "latest"
+appVersion: v0.19.0-cloud.43
 annotations:
   category: Productivity
   licenses: MIT

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -6,7 +6,7 @@ sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
 version: 0.2.1
-appVersion: v0.19.0-cloud.43
+appVersion: latest
 annotations:
   category: Productivity
   licenses: MIT

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -45,10 +45,10 @@ spec:
             - |
               alembic upgrade head &&
               echo "Starting Onyx Api Server" &&
-              uvicorn onyx.main:app --host 0.0.0.0 --port 8080
+              uvicorn onyx.main:app --host 0.0.0.0 --port {{ .Values.api.containerPorts.server }}
           ports:
             - name: api-server-port
-              containerPort: {{ .Values.api.service.port }}
+              containerPort: {{ .Values.api.containerPorts.server }}
               protocol: TCP
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/api-service.yaml
+++ b/deployment/helm/charts/onyx/templates/api-service.yaml
@@ -11,10 +11,10 @@ metadata:
 spec:
   type: {{ .Values.api.service.type }}
   ports:
-    - port: {{ .Values.api.service.port }}
-      targetPort: api-server-port
+    - port: {{ .Values.api.service.servicePort }}
+      targetPort: {{ .Values.api.service.targetPort }}
       protocol: TCP
-      name: api-server-port
+      name: {{ .Values.api.service.portName }}
   selector:
     {{- include "onyx-stack.selectorLabels" . | nindent 4 }}
     {{- if .Values.api.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -26,11 +26,13 @@ spec:
     spec:
       containers:
       - name: indexing-model-server
-        image: onyxdotapp/onyx-model-server:latest
+        image: "{{ .Values.indexCapability.image.repository }}:{{ .Values.indexCapability.image.tag | default .Chart.AppVersion }}"           
         imagePullPolicy: IfNotPresent
-        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000", "--limit-concurrency", "10" ]
+        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.indexCapability.containerPorts.server }}", "--limit-concurrency", "{{ .Values.indexCapability.limitConcurrency }}" ]
         ports:
-        - containerPort: 9000
+        - name: model-server
+          containerPort: {{ .Values.indexCapability.containerPorts.server }}
+          protocol: TCP
         envFrom:
           - configMapRef:
               name: {{ .Values.config.envConfigMapName }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "onyx-stack.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.indexCapability.replicaCount }}
   selector:
     matchLabels:
       {{- include "onyx-stack.selectorLabels" . | nindent 6 }}
@@ -25,9 +25,9 @@ spec:
         {{- end }}
     spec:
       containers:
-      - name: indexing-model-server
+      - name: {{ .Values.indexCapability.name }}
         image: "{{ .Values.indexCapability.image.repository }}:{{ .Values.indexCapability.image.tag | default .Chart.AppVersion }}"           
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.indexCapability.image.pullPolicy }}
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.indexCapability.containerPorts.server }}", "--limit-concurrency", "{{ .Values.indexCapability.limitConcurrency }}" ]
         ports:
         - name: model-server

--- a/deployment/helm/charts/onyx/templates/indexing-model-pvc.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.indexCapability.indexingModelPVC.name }}
 spec:
+  storageClassName: {{ .Values.persistent.storageClassName }}
   accessModes:
     - {{ .Values.indexCapability.indexingModelPVC.accessMode | quote }}
   resources:

--- a/deployment/helm/charts/onyx/templates/indexing-model-service.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-service.yaml
@@ -11,8 +11,8 @@ spec:
     {{- toYaml .Values.indexCapability.deploymentLabels | nindent 4 }}
     {{- end }}
   ports:
-    - name: {{ .Values.indexCapability.service.name }}
+    - name: {{ .Values.indexCapability.service.portName }}
       protocol: TCP
-      port: {{ .Values.indexCapability.service.port }}
-      targetPort: {{ .Values.indexCapability.service.port }}
+      port: {{ .Values.indexCapability.service.servicePort  }}
+      targetPort: {{ .Values.indexCapability.service.targetPort }}
   type: {{ .Values.indexCapability.service.type }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -3,14 +3,14 @@ kind: Deployment
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-inference-model
   labels:
-    {{- range .Values.inferenceCapability.deployment.labels }}
+    {{- range .Values.inferenceCapability.labels }}
     {{ .key }}: {{ .value }}
     {{- end }}
 spec:
-  replicas: {{ .Values.inferenceCapability.deployment.replicas }}
+  replicas: {{ .Values.inferenceCapability.replicaCount }}
   selector:
     matchLabels:
-      {{- range .Values.inferenceCapability.deployment.labels }}
+      {{- range .Values.inferenceCapability.labels }}
       {{ .key }}: {{ .value }}
       {{- end }}
   template:
@@ -22,12 +22,12 @@ spec:
     spec:
       containers:
       - name: model-server-inference
-        image: "{{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.inferenceCapability.deployment.image.pullPolicy }}
-        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.inferenceCapability.deployment.containerPorts.server }}" ]
+        image: "{{ .Values.inferenceCapability.image.repository }}:{{ .Values.inferenceCapability.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.inferenceCapability.image.pullPolicy }}
+        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.inferenceCapability.containerPorts.server }}" ]
         ports:
         - name: model-server
-          containerPort: {{ .Values.inferenceCapability.deployment.containerPorts.server }}
+          containerPort: {{ .Values.inferenceCapability.containerPorts.server }}
           protocol: TCP
         envFrom:
         - configMapRef:
@@ -35,12 +35,12 @@ spec:
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
         volumeMounts:
-        {{- range .Values.inferenceCapability.deployment.volumeMounts }}
+        {{- range .Values.inferenceCapability.volumeMounts }}
         - name: {{ .name }}
           mountPath: {{ .mountPath }}
         {{- end }}
       volumes:
-      {{- range .Values.inferenceCapability.deployment.volumes }}
+      {{- range .Values.inferenceCapability.volumes }}
       - name: {{ .name }}
         persistentVolumeClaim:
           claimName: {{ .persistentVolumeClaim.claimName }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -21,12 +21,14 @@ spec:
         {{- end }}
     spec:
       containers:
-      - name: {{ .Values.inferenceCapability.service.name }}
-        image: {{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag }}
+      - name: model-server-inference
+        image: "{{ .Values.inferenceCapability.deployment.image.repository }}:{{ .Values.inferenceCapability.deployment.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.inferenceCapability.deployment.image.pullPolicy }}
-        command: {{ toYaml .Values.inferenceCapability.deployment.command | nindent 14 }}
+        command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.inferenceCapability.deployment.containerPorts.server }}" ]
         ports:
-        - containerPort: {{ .Values.inferenceCapability.service.port }}
+        - name: model-server
+          containerPort: {{ .Values.inferenceCapability.deployment.containerPorts.server }}
+          protocol: TCP
         envFrom:
         - configMapRef:
             name: {{ .Values.config.envConfigMapName }}

--- a/deployment/helm/charts/onyx/templates/inference-model-pvc.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.inferenceCapability.pvc.name }}
 spec:
+  storageClassName: {{ .Values.persistent.storageClassName }}
   accessModes: 
     {{- toYaml .Values.inferenceCapability.pvc.accessModes | nindent 4 }}
   resources:

--- a/deployment/helm/charts/onyx/templates/inference-model-service.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-service.yaml
@@ -10,6 +10,6 @@ spec:
       protocol: TCP
       name: {{ .Values.inferenceCapability.service.portName }}
   selector:
-    {{- range .Values.inferenceCapability.deployment.labels }}
+    {{- range .Values.inferenceCapability.labels }}
     {{ .key }}: {{ .value }}
     {{- end }}

--- a/deployment/helm/charts/onyx/templates/inference-model-service.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-service.yaml
@@ -5,10 +5,10 @@ metadata:
 spec:
   type: {{ .Values.inferenceCapability.service.type }}
   ports:
-    - port: {{ .Values.inferenceCapability.service.port }}
-      targetPort: {{ .Values.inferenceCapability.service.port }}
+    - port: {{ .Values.inferenceCapability.service.servicePort}}
+      targetPort: {{ .Values.inferenceCapability.service.targetPort }}
       protocol: TCP
-      name: {{ .Values.inferenceCapability.service.name }}
+      name: {{ .Values.inferenceCapability.service.portName }}
   selector:
     {{- range .Values.inferenceCapability.deployment.labels }}
     {{ .key }}: {{ .value }}

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -5,11 +5,11 @@ metadata:
 data:
   nginx.conf: |
     upstream api_server {
-        server {{ include "onyx-stack.fullname" . }}-api-service:{{ .Values.api.service.port }} fail_timeout=0;
+        server {{ include "onyx-stack.fullname" . }}-api-service:{{ .Values.api.service.servicePort }} fail_timeout=0;
     }
 
     upstream web_server {
-        server {{ include "onyx-stack.fullname" . }}-webserver:{{ .Values.webserver.service.port }} fail_timeout=0;
+        server {{ include "onyx-stack.fullname" . }}-webserver:{{ .Values.webserver.service.servicePort }} fail_timeout=0;
     }
 
     server {

--- a/deployment/helm/charts/onyx/templates/tests/test-connection.yaml
+++ b/deployment/helm/charts/onyx/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "onyx-stack.fullname" . }}-webserver:{{ .Values.webserver.service.port }}']
+      args: ['{{ include "onyx-stack.fullname" . }}-webserver:{{ .Values.webserver.service.servicePort }}']
   restartPolicy: Never

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.webserver.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.webserver.service.port }}
+              containerPort: {{ .Values.webserver.containerPorts.server }}
               protocol: TCP
           resources:
             {{- toYaml .Values.webserver.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/webserver-service.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-service.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   type: {{ .Values.webserver.service.type }}
   ports:
-    - port: {{ .Values.webserver.service.port }}
-      targetPort: http
+    - port: {{ .Values.webserver.service.servicePort }}
+      targetPort: {{ .Values.webserver.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -17,7 +17,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 persistent:
-  storageClassName: ebsstorage
+  storageClassName: ""
 
 inferenceCapability:
   service:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -10,8 +10,8 @@ postgresql:
   auth:
     existingSecret: onyx-secrets
     secretKeys:
-      adminPasswordKey: postgres_password # overwriting as postgres typically expects 'postgres-password'
-
+      # overwriting as postgres typically expects 'postgres-password'
+      adminPasswordKey: postgres_password
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -40,7 +40,7 @@ inferenceCapability:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
     pullPolicy: IfNotPresent
-  containerPorts: 
+  containerPorts:
     server: 9000
   volumeMounts:
     - name: inference-model-storage
@@ -143,7 +143,7 @@ webserver:
 
   containerPorts:
     server: 3000
-  
+
   service:
     type: ClusterIP
     servicePort: 3000
@@ -319,15 +319,15 @@ background:
 
 vespa:
   volumeClaimTemplates:
-     - metadata:
-         name: vespa-storage
-       spec:
-         accessModes:
-           - ReadWriteOnce
-         storageClassName: ""
-         resources:
-           requests:
-             storage: 1Gi
+    - metadata:
+        name: vespa-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ""
+        resources:
+          requests:
+            storage: 1Gi
   enabled: true
   replicaCount: 1
   image:
@@ -404,9 +404,9 @@ redis:
 
 
 auth:
-  # for storing smtp, oauth, slack, and other secrets
+  # existingSecret onyx-secret for storing smtp, oauth, slack, and other secrets
   # keys are lowercased version of env vars (e.g. SMTP_USER -> smtp_user)
-  existingSecret: "" # onyx-secrets
+  existingSecret: ""
   # optionally override the secret keys to reference in the secret
   # this is used to populate the env vars in individual deployments
   # the values here reference the keys in secrets below
@@ -430,14 +430,22 @@ auth:
     redis_password: "password"
 
 configMap:
-  AUTH_TYPE: "disabled" # Change this for production uses unless Onyx is only accessible behind VPN
-  SESSION_EXPIRE_TIME_SECONDS: "86400" # 1 Day Default
-  VALID_EMAIL_DOMAINS: "" # Can be something like onyx.app, as an extra double-check
-  SMTP_SERVER: "" # For sending verification emails, if unspecified then defaults to 'smtp.gmail.com'
-  SMTP_PORT: "" # For sending verification emails, if unspecified then defaults to '587'
-  SMTP_USER: "" # 'your-email@company.com'
-  # SMTP_PASS: ""  # 'your-gmail-password'
-  EMAIL_FROM: "" # 'your-email@company.com' SMTP_USER missing used instead
+  # Change this for production uses unless Onyx is only accessible behind VPN
+  AUTH_TYPE: "disabled"
+  # 1 Day Default
+  SESSION_EXPIRE_TIME_SECONDS: "86400"
+  # Can be something like onyx.app, as an extra double-check
+  VALID_EMAIL_DOMAINS: ""
+  # For sending verification emails, if unspecified then defaults to 'smtp.gmail.com'
+  SMTP_SERVER: ""
+  # For sending verification emails, if unspecified then defaults to '587'
+  SMTP_PORT: ""
+# 'your-email@company.com'
+  SMTP_USER: ""
+  # 'your-gmail-password'
+  # SMTP_PASS: ""
+  # 'your-email@company.com' SMTP_USER missing used instead
+  EMAIL_FROM: ""
   # Gen AI Settings
   GEN_AI_MAX_TOKENS: ""
   QA_TIMEOUT: "60"
@@ -479,7 +487,7 @@ configMap:
   DANSWER_BOT_DISABLE_DOCS_ONLY_ANSWER: ""
   DANSWER_BOT_DISPLAY_ERROR_MSGS: ""
   DANSWER_BOT_RESPOND_EVERY_CHANNEL: ""
-  DANSWER_BOT_DISABLE_COT: "" # Currently unused
+  DANSWER_BOT_DISABLE_COT: ""
   NOTIFY_SLACKBOT_NO_ANSWER: ""
   # Logging
   # Optional Telemetry, please keep it on (nothing sensitive is collected)? <3
@@ -490,7 +498,8 @@ configMap:
   LOG_DANSWER_MODEL_INTERACTIONS: ""
   LOG_VESPA_TIMING_INFORMATION: ""
   # Shared or Non-backend Related
-  WEB_DOMAIN: "http://localhost:3000" # for web server and api server
-  DOMAIN: "localhost" # for nginx
+  WEB_DOMAIN: "http://localhost:3000"
+  # DOMAIN used by nginx
+  DOMAIN: "localhost"
   # Chat Configs
   HARD_DELETE_CHATS: ""

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -3,11 +3,8 @@
 # Declare variables to be passed into your templates.
 
 postgresql:
-  global:
-    storageClass: ebsstorage
   primary:
     persistence:
-      storageClass: ebsstorage
       size: 5Gi
   enabled: true
   auth:
@@ -33,26 +30,25 @@ inferenceCapability:
     accessModes:
       - ReadWriteOnce
     storage: 3Gi
-  deployment:
-    name: inference-model-server-deployment
-    replicas: 1
-    labels:
-      - key: app
-        value: inference-model-server
-    image:
-      repository: onyxdotapp/onyx-model-server
-      # Overrides the image tag whose default is the chart appVersion.
-      tag: ""
-      pullPolicy: IfNotPresent
-    containerPorts: 
-      server: 9000
-    volumeMounts:
-      - name: inference-model-storage
-        mountPath: /root/.cache
-    volumes:
-      - name: inference-model-storage
-        persistentVolumeClaim:
-          claimName: inference-model-pvc
+  name: inference-model-server
+  replicaCount: 1
+  labels:
+    - key: app
+      value: inference-model-server
+  image:
+    repository: onyxdotapp/onyx-model-server
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+    pullPolicy: IfNotPresent
+  containerPorts: 
+    server: 9000
+  volumeMounts:
+    - name: inference-model-storage
+      mountPath: /root/.cache
+  volumes:
+    - name: inference-model-storage
+      persistentVolumeClaim:
+        claimName: inference-model-pvc
   podLabels:
     - key: app
       value: inference-model-server
@@ -63,6 +59,8 @@ indexCapability:
     type: ClusterIP
     servicePort: 9000
     targetPort: 9000
+  replicaCount: 1
+  name: indexing-model-server
   deploymentLabels:
     app: indexing-model-server
   podLabels:
@@ -86,6 +84,7 @@ indexCapability:
     repository: onyxdotapp/onyx-model-server
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+    pullPolicy: IfNotPresent
   limitConcurrency: 10
 config:
   envConfigMapName: env-configmap
@@ -167,7 +166,7 @@ webserver:
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
 
   # Additional volumes on the output Deployment definition.
   volumes: []
@@ -239,7 +238,7 @@ api:
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
 
   # Additional volumes on the output Deployment definition.
   volumes: []
@@ -300,7 +299,7 @@ background:
     minReplicas: 1
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
 
   # Additional volumes on the output Deployment definition.
   volumes: []
@@ -319,6 +318,16 @@ background:
   tolerations: []
 
 vespa:
+  volumeClaimTemplates:
+     - metadata:
+         name: vespa-storage
+       spec:
+         accessModes:
+           - ReadWriteOnce
+         storageClassName: ""
+         resources:
+           requests:
+             storage: 1Gi
   enabled: true
   replicaCount: 1
   image:
@@ -393,14 +402,6 @@ redis:
 #  #    hosts:
 #  #      - chart-example.local
 
-persistence:
-  vespa:
-    enabled: true
-    existingClaim: ""
-    storageClassName: ebsstorage
-    accessModes:
-      - ReadWriteOnce
-    size: 5Gi
 
 auth:
   # for storing smtp, oauth, slack, and other secrets

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -2,15 +2,32 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+postgresql:
+  global:
+    storageClass: ebsstorage
+  primary:
+    persistence:
+      storageClass: ebsstorage
+      size: 5Gi
+  enabled: true
+  auth:
+    existingSecret: onyx-secrets
+    secretKeys:
+      adminPasswordKey: postgres_password # overwriting as postgres typically expects 'postgres-password'
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+persistent:
+  storageClassName: ebsstorage
+
 inferenceCapability:
   service:
-    name: inference-model-server-service
+    portName: modelserver
     type: ClusterIP
-    port: 9000
+    servicePort: 9000
+    targetPort: 9000
   pvc:
     name: inference-model-pvc
     accessModes:
@@ -24,18 +41,11 @@ inferenceCapability:
         value: inference-model-server
     image:
       repository: onyxdotapp/onyx-model-server
-      tag: latest
+      # Overrides the image tag whose default is the chart appVersion.
+      tag: ""
       pullPolicy: IfNotPresent
-    command:
-      [
-        "uvicorn",
-        "model_server.main:app",
-        "--host",
-        "0.0.0.0",
-        "--port",
-        "9000",
-      ]
-    port: 9000
+    containerPorts: 
+      server: 9000
     volumeMounts:
       - name: inference-model-storage
         mountPath: /root/.cache
@@ -49,15 +59,18 @@ inferenceCapability:
 
 indexCapability:
   service:
+    portName: modelserver
     type: ClusterIP
-    port: 9000
-    name: indexing-model-server-port
+    servicePort: 9000
+    targetPort: 9000
   deploymentLabels:
     app: indexing-model-server
   podLabels:
     app: indexing-model-server
   indexingOnly: "True"
   podAnnotations: {}
+  containerPorts:
+    server: 9000
   volumeMounts:
     - name: indexing-model-storage
       mountPath: /root/.cache
@@ -69,7 +82,11 @@ indexCapability:
     name: indexing-model-storage
     accessMode: "ReadWriteOnce"
     storage: "3Gi"
-
+  image:
+    repository: onyxdotapp/onyx-model-server
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: ""
+  limitConcurrency: 10
 config:
   envConfigMapName: env-configmap
 
@@ -83,16 +100,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-
-postgresql:
-  primary:
-    persistence:
-      size: 5Gi
-  enabled: true
-  auth:
-    existingSecret: onyx-secrets
-    secretKeys:
-      adminPasswordKey: postgres_password # overwriting as postgres typically expects 'postgres-password'
 
 nginx:
   containerPorts:
@@ -135,9 +142,13 @@ webserver:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  containerPorts:
+    server: 3000
+  
   service:
     type: ClusterIP
-    port: 3000
+    servicePort: 3000
+    targetPort: http
 
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -189,6 +200,9 @@ api:
     scope: onyx-backend
     app: api-server
 
+  containerPorts:
+    server: 8080
+
   podSecurityContext:
     {}
     # fsGroup: 2000
@@ -204,7 +218,9 @@ api:
 
   service:
     type: ClusterIP
-    port: 8080
+    servicePort: 8080
+    targetPort: api-server-port
+    portName: api-server-port
 
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -247,7 +263,7 @@ background:
     repository: onyxdotapp/onyx-backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: latest
+    tag: ""
   podAnnotations: {}
   podLabels:
     scope: onyx-backend
@@ -381,7 +397,7 @@ persistence:
   vespa:
     enabled: true
     existingClaim: ""
-    storageClassName: ""
+    storageClassName: ebsstorage
     accessModes:
       - ReadWriteOnce
     size: 5Gi


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

I used eksctl cli to provision a eks cluster in aws. The following is the config.yaml that I used to provision the cluster.  

apiVersion: eksctl.io/v1alpha5
kind: ClusterConfig

metadata:
  name: onyx-cluster
  region: us-west-1

nodeGroups:
  - name: ng-1
    instanceType: m5.large
    desiredCapacity: 1
    maxSize: 2
    minSize: 1
    volumeSize: 80
    ssh:
      allow: true # will use ~/.ssh/id_rsa.pub as the default ssh key
  - name: ng-2
    instanceType: m5.xlarge
    desiredCapacity: 1
    maxSize: 2
    minSize: 1
    volumeSize: 100
    ssh:
      publicKeyPath: ~/.ssh/id_rsa.pub
    iam:
      withAddonPolicies:
        imageBuilder: true
        autoScaler: true
        externalDNS: true
        certManager: true
        appMesh: true
        appMeshPreview: true
        ebs: true
        fsx: true
        efs: true
        awsLoadBalancerController: true
        xRay: true
        cloudWatch: true

addonsConfig:
  autoApplyPodIdentityAssociations: true

addons:
  - name: aws-ebs-csi-driver
    version: latest
    useDefaultPodIdentityAssociations: true
  - name: eks-pod-identity-agent
    version: latest
    useDefaultPodIdentityAssociations: true

iam:  
  podIdentityAssociations: 
  - namespace: default
    serviceAccountName: default
    permissionPolicyARNs:
      - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
    permissionPolicy:
      Version: "2012-10-17"
      Statement:
      - Effect: Allow
        Action:
        - "autoscaling:DescribeAutoScalingGroups"
        - "autoscaling:DescribeAutoScalingInstances"
        - "autoscaling:DescribeLaunchConfigurations"
        - "autoscaling:DescribeTags"
        - "autoscaling:SetDesiredCapacity"
        - "autoscaling:TerminateInstanceInAutoScalingGroup"
        - "ec2:DescribeLaunchTemplateVersions"
        Resource: '*'


The following are the commands used to provision a cluster, pull in latest sub-charts, and install onyx onto the new EKS cluster.

eksctl create cluster -f config.yaml # creates the 2 node eks cluster

helm upgrade dependency # upgrades the sub-charts

helm install onyx . # installs the onyx apps onto the cluster


[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
