### PR TITLE
removed logic to search first message, fixed query override

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -254,6 +254,7 @@ def _get_force_search_settings(
             and new_msg_req.retrieval_options.run_search
             == OptionalSearchSetting.ALWAYS,
             new_msg_req.search_doc_ids,
+            new_msg_req.query_override is not None,
             DISABLE_LLM_CHOOSE_SEARCH,
         ]
     )
@@ -498,14 +499,6 @@ def stream_chat_message_objects(
                         f"Final message id: {final_msg.id}, "
                         f"existing assistant message id: {existing_assistant_message_id}"
                     )
-
-        # Disable Query Rephrasing for the first message
-        # This leads to a better first response since the LLM rephrasing the question
-        # leads to worst search quality
-        if not history_msgs:
-            new_msg_req.query_override = (
-                new_msg_req.query_override or new_msg_req.message
-            )
 
         # load all files needed for this chat chain in memory
         files = load_all_chat_files(


### PR DESCRIPTION
## Description
https://linear.app/danswer/issue/DAN-1353/query-override-fix-for-api

- No more logic to run the original user message as-is. This wasn't actually happening in the current state of main, and we decided to leave it this way.
- Now query override actually works again, i.e. when one hits process_message.py through a message request, it makes the search tool use that query. This will now only happen when someone is directly hitting our API due to the first bullet point.

## How Has This Been Tested?

tested in UI and unit tested, although nothing works unless I set ToolCallSummary to have class Config: arbitrary_types_allowed = True. Didn't add that to the PR since I assume it's a package version thing, but we should probably look at it at some point.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
