### PR TITLE
reranking improvement

### DIFF
--- a/backend/onyx/agents/agent_search/deep_search_a/expanded_retrieval/nodes/doc_reranking.py
+++ b/backend/onyx/agents/agent_search/deep_search_a/expanded_retrieval/nodes/doc_reranking.py
@@ -36,8 +36,17 @@ def doc_reranking(
     if agent_a_config.search_tool is None:
         raise ValueError("search_tool must be provided for agentic search")
     with get_session_context_manager() as db_session:
+        # we ignore some of the user specified fields since this search is
+        # internal to agentic search, but we still want to pass through
+        # persona (for stuff like document sets) and rerank settings
+        # (to not make an unnecessary db call).
+        search_request = SearchRequest(
+            query=question,
+            persona=agent_a_config.search_request.persona,
+            rerank_settings=agent_a_config.search_request.rerank_settings,
+        )
         _search_query = retrieval_preprocessing(
-            search_request=SearchRequest(query=question),
+            search_request=search_request,
             user=agent_a_config.search_tool.user,  # bit of a hack
             llm=agent_a_config.fast_llm,
             db_session=db_session,


### PR DESCRIPTION
## Description

Previously we were passing in a SearchQuery with mostly default values when running the preprocessing needed before reranking. Most of what is done in preprocessing isn't really necessary for us, but there are things like filtering document sets based on persona that are important that we still do. Also, the previous code was making a new db call to get the search settings each time reranking was called; we fix that by passing in reranking

## How Has This Been Tested?

ran in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
