### PR TITLE
Tool id constants

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -73,9 +73,10 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { DeleteEntityModal } from "@/components/modals/DeleteEntityModal";
 import { DeletePersonaButton } from "./[id]/DeletePersonaButton";
 import Title from "@/components/ui/title";
+import { SEARCH_TOOL_ID } from "@/app/chat/tools/constants";
 
 function findSearchTool(tools: ToolSnapshot[]) {
-  return tools.find((tool) => tool.in_code_tool_id === "SearchTool");
+  return tools.find((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID);
 }
 
 function findImageGenerationTool(tools: ToolSnapshot[]) {

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -14,7 +14,7 @@ import CardSection from "@/components/admin/CardSection";
 import { useRouter } from "next/navigation";
 import { Persona } from "@/app/admin/assistants/interfaces";
 import { StandardAnswerCategoryResponse } from "@/components/standardAnswers/getStandardAnswerCategoriesIfEE";
-import { SEARCH_TOOL_NAME } from "@/app/chat/tools/constants";
+import { SEARCH_TOOL_ID, SEARCH_TOOL_NAME } from "@/app/chat/tools/constants";
 import { SlackChannelConfigFormFields } from "./SlackChannelConfigFormFields";
 
 export const SlackChannelConfigCreationForm = ({
@@ -36,16 +36,12 @@ export const SlackChannelConfigCreationForm = ({
   const existingSlackBotUsesPersona = existingSlackChannelConfig?.persona
     ? !isPersonaASlackBotPersona(existingSlackChannelConfig.persona)
     : false;
-  const knowledgePersona = personas.find((persona) => persona.id === 0);
-
-  const documentSetContainsSync = (documentSet: DocumentSet) =>
-    documentSet.cc_pair_descriptors.some(
-      (descriptor) => descriptor.access_type === "sync"
-    );
 
   const searchEnabledAssistants = useMemo(() => {
     return personas.filter((persona) => {
-      return persona.tools.some((tool) => tool.name == SEARCH_TOOL_NAME);
+      return persona.tools.some(
+        (tool) => tool.in_code_tool_id == SEARCH_TOOL_ID
+      );
     });
   }, [personas]);
 

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -51,7 +51,7 @@ export function SlackChannelConfigFormFields({
   setPopup,
 }: SlackChannelConfigFormFieldsProps) {
   const router = useRouter();
-  const { values, setFieldValue, isSubmitting } = useFormikContext<any>();
+  const { values, setFieldValue } = useFormikContext<any>();
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [viewUnselectableSets, setViewUnselectableSets] = useState(false);
   const [viewSyncEnabledAssistants, setViewSyncEnabledAssistants] =
@@ -315,6 +315,7 @@ export function SlackChannelConfigFormFields({
                 )}
               </>
             </SubLabel>
+
             <SelectorFormField
               name="persona_id"
               options={availableAssistants.map((persona) => ({

--- a/web/src/app/assistants/ToolsDisplay.tsx
+++ b/web/src/app/assistants/ToolsDisplay.tsx
@@ -1,5 +1,6 @@
 import { FiImage, FiSearch } from "react-icons/fi";
 import { Persona } from "../admin/assistants/interfaces";
+import { SEARCH_TOOL_ID } from "../chat/tools/constants";
 
 export function AssistantTools({
   assistant,
@@ -13,7 +14,9 @@ export function AssistantTools({
   return (
     <div className="relative text-xs overflow-x-hidden flex text-subtle">
       <span
-        className={`${assistant.tools.length > 0 && "py-1"}  ${!list ? "font-semibold" : "text-subtle text-sm"}`}
+        className={`${assistant.tools.length > 0 && "py-1"}  ${
+          !list ? "font-semibold" : "text-subtle text-sm"
+        }`}
       >
         Tools:
       </span>{" "}
@@ -22,7 +25,7 @@ export function AssistantTools({
       ) : (
         <div className="ml-1 flex flex-wrap gap-1">
           {assistant.tools.map((tool, ind) => {
-            if (tool.name === "SearchTool") {
+            if (tool.name === SEARCH_TOOL_ID) {
               return (
                 <div
                   key={ind}
@@ -79,7 +82,13 @@ export function AssistantTools({
                   w-fit 
                   flex
                   items-center
-                  ${hovered ? "bg-background-300" : list ? "bg-background-125" : "bg-background-100"}`}
+                  ${
+                    hovered
+                      ? "bg-background-300"
+                      : list
+                        ? "bg-background-125"
+                        : "bg-background-100"
+                  }`}
                 >
                   <div className="flex gap-x-1">{tool.name}</div>
                 </div>

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -91,7 +91,11 @@ import { DeleteEntityModal } from "../../components/modals/DeleteEntityModal";
 import { MinimalMarkdown } from "@/components/chat_search/MinimalMarkdown";
 import ExceptionTraceModal from "@/components/modals/ExceptionTraceModal";
 
-import { SEARCH_TOOL_NAME } from "./tools/constants";
+import {
+  INTERNET_SEARCH_TOOL_ID,
+  SEARCH_TOOL_ID,
+  SEARCH_TOOL_NAME,
+} from "./tools/constants";
 import { useUser } from "@/components/user/UserProvider";
 import { ApiKeyModal } from "@/components/llm/ApiKeyModal";
 import BlurBackground from "./shared_chat_search/BlurBackground";
@@ -272,8 +276,8 @@ export function ChatPage({
     ? parseFloat(search_param_temperature)
     : selectedAssistant?.tools.some(
           (tool) =>
-            tool.in_code_tool_id === "SearchTool" ||
-            tool.in_code_tool_id === "InternetSearchTool"
+            tool.in_code_tool_id === SEARCH_TOOL_ID ||
+            tool.in_code_tool_id === INTERNET_SEARCH_TOOL_ID
         )
       ? 0
       : 0.7;
@@ -1842,7 +1846,7 @@ export function ChatPage({
   useEffect(() => {
     if (liveAssistant) {
       const hasSearchTool = liveAssistant.tools.some(
-        (tool) => tool.in_code_tool_id === "SearchTool"
+        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
       );
       setRetrievalEnabled(hasSearchTool);
       if (!hasSearchTool) {
@@ -1854,7 +1858,7 @@ export function ChatPage({
   const [retrievalEnabled, setRetrievalEnabled] = useState(() => {
     if (liveAssistant) {
       return liveAssistant.tools.some(
-        (tool) => tool.in_code_tool_id === "SearchTool"
+        (tool) => tool.in_code_tool_id === SEARCH_TOOL_ID
       );
     }
     return false;

--- a/web/src/app/chat/lib.tsx
+++ b/web/src/app/chat/lib.tsx
@@ -24,6 +24,9 @@ import { Persona } from "../admin/assistants/interfaces";
 import { ReadonlyURLSearchParams } from "next/navigation";
 import { SEARCH_PARAM_NAMES } from "./searchParams";
 import { Settings } from "../admin/settings/interfaces";
+import { INTERNET_SEARCH_TOOL_ID } from "./tools/constants";
+import { SEARCH_TOOL_ID } from "./tools/constants";
+import { IIMAGE_GENERATION_TOOL_ID } from "./tools/constants";
 
 interface ChatRetentionInfo {
   chatRetentionDays: number;
@@ -572,14 +575,14 @@ export function personaIncludesRetrieval(selectedPersona: Persona) {
   return selectedPersona.tools.some(
     (tool) =>
       tool.in_code_tool_id &&
-      ["SearchTool", "InternetSearchTool"].includes(tool.in_code_tool_id)
+      [SEARCH_TOOL_ID, INTERNET_SEARCH_TOOL_ID].includes(tool.in_code_tool_id)
   );
 }
 
 export function personaIncludesImage(selectedPersona: Persona) {
   return selectedPersona.tools.some(
     (tool) =>
-      tool.in_code_tool_id && tool.in_code_tool_id == "ImageGenerationTool"
+      tool.in_code_tool_id && tool.in_code_tool_id == IIMAGE_GENERATION_TOOL_ID
   );
 }
 

--- a/web/src/app/chat/tools/constants.ts
+++ b/web/src/app/chat/tools/constants.ts
@@ -1,3 +1,7 @@
 export const SEARCH_TOOL_NAME = "run_search";
 export const INTERNET_SEARCH_TOOL_NAME = "run_internet_search";
 export const IMAGE_GENERATION_TOOL_NAME = "run_image_generation";
+
+export const SEARCH_TOOL_ID = "SearchTool";
+export const IIMAGE_GENERATION_TOOL_ID = "ImageGenerationTool";
+export const INTERNET_SEARCH_TOOL_ID = "InternetSearchTool";

--- a/web/src/app/chat/tools/constants.ts
+++ b/web/src/app/chat/tools/constants.ts
@@ -1,7 +1,9 @@
+// Tool names as referenced by tool results / tool calls
 export const SEARCH_TOOL_NAME = "run_search";
 export const INTERNET_SEARCH_TOOL_NAME = "run_internet_search";
 export const IMAGE_GENERATION_TOOL_NAME = "run_image_generation";
 
+// In-code tool IDs that also correspond to the tool's name when associated with a persona
 export const SEARCH_TOOL_ID = "SearchTool";
 export const IIMAGE_GENERATION_TOOL_ID = "ImageGenerationTool";
 export const INTERNET_SEARCH_TOOL_ID = "InternetSearchTool";

--- a/web/src/components/assistants/AssistantCards.tsx
+++ b/web/src/components/assistants/AssistantCards.tsx
@@ -7,6 +7,8 @@ import { FiBookmark, FiImage, FiSearch } from "react-icons/fi";
 import { MdDragIndicator } from "react-icons/md";
 
 import { Badge } from "../ui/badge";
+import { IIMAGE_GENERATION_TOOL_ID } from "@/app/chat/tools/constants";
+import { SEARCH_TOOL_ID } from "@/app/chat/tools/constants";
 
 export const AssistantCard = ({
   assistant,
@@ -19,14 +21,14 @@ export const AssistantCard = ({
 }) => {
   const renderBadgeContent = (tool: { name: string }) => {
     switch (tool.name) {
-      case "SearchTool":
+      case SEARCH_TOOL_ID:
         return (
           <>
             <FiSearch className="h-3 w-3 my-auto" />
             <span>Search</span>
           </>
         );
-      case "ImageGenerationTool":
+      case IIMAGE_GENERATION_TOOL_ID:
         return (
           <>
             <FiImage className="h-3 w-3 my-auto" />


### PR DESCRIPTION
## Description

Built in tools have equivalent `name` as `built_in_tool_id`, not the tool's `_NAME` attribute

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
