### PR TITLE
Optimize /persona query

### DIFF
--- a/backend/ee/onyx/server/tenants/api.py
+++ b/backend/ee/onyx/server/tenants/api.py
@@ -111,6 +111,7 @@ async def login_as_anonymous_user(
     token = generate_anonymous_user_jwt_token(tenant_id)
 
     response = Response()
+    response.delete_cookie("fastapiusersauth")
     response.set_cookie(
         key=ANONYMOUS_USER_COOKIE_NAME,
         value=token,

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -11,7 +11,7 @@ from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import aliased
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
@@ -291,8 +291,9 @@ def get_personas_for_user(
     include_deleted: bool = False,
     joinedload_all: bool = False,
 ) -> Sequence[Persona]:
-    stmt = select(Persona).distinct()
-    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
+    stmt = select(Persona)
+    stmt = _add_user_filters(stmt, user, get_editable)
+
     if not include_default:
         stmt = stmt.where(Persona.builtin_persona.is_(False))
     if not include_slack_bot_personas:
@@ -302,14 +303,47 @@ def get_personas_for_user(
 
     if joinedload_all:
         stmt = stmt.options(
-            joinedload(Persona.prompts),
-            joinedload(Persona.tools),
-            joinedload(Persona.document_sets),
-            joinedload(Persona.groups),
-            joinedload(Persona.users),
+            selectinload(Persona.prompts),
+            selectinload(Persona.tools),
+            selectinload(Persona.document_sets),
+            selectinload(Persona.groups),
+            selectinload(Persona.users),
+            selectinload(Persona.labels),
         )
 
-    return db_session.execute(stmt).unique().scalars().all()
+    results = db_session.execute(stmt).scalars().all()
+    return results
+
+
+# def get_personas_for_user(
+#     # if user is `None` assume the user is an admin or auth is disabled
+#     user: User | None,
+#     db_session: Session,
+#     get_editable: bool = True,
+#     include_default: bool = True,
+#     include_slack_bot_personas: bool = False,
+#     include_deleted: bool = False,
+#     joinedload_all: bool = False,
+# ) -> Sequence[Persona]:
+#     stmt = select(Persona).distinct()
+#     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
+#     if not include_default:
+#         stmt = stmt.where(Persona.builtin_persona.is_(False))
+#     if not include_slack_bot_personas:
+#         stmt = stmt.where(not_(Persona.name.startswith(SLACK_BOT_PERSONA_PREFIX)))
+#     if not include_deleted:
+#         stmt = stmt.where(Persona.deleted.is_(False))
+
+#     if joinedload_all:
+#         stmt = stmt.options(
+#             joinedload(Persona.prompts),
+#             joinedload(Persona.tools),
+#             joinedload(Persona.document_sets),
+#             joinedload(Persona.groups),
+#             joinedload(Persona.users),
+#         )
+
+#     return db_session.execute(stmt).unique().scalars().all()
 
 
 def get_personas(db_session: Session) -> Sequence[Persona]:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -315,37 +315,6 @@ def get_personas_for_user(
     return results
 
 
-# def get_personas_for_user(
-#     # if user is `None` assume the user is an admin or auth is disabled
-#     user: User | None,
-#     db_session: Session,
-#     get_editable: bool = True,
-#     include_default: bool = True,
-#     include_slack_bot_personas: bool = False,
-#     include_deleted: bool = False,
-#     joinedload_all: bool = False,
-# ) -> Sequence[Persona]:
-#     stmt = select(Persona).distinct()
-#     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
-#     if not include_default:
-#         stmt = stmt.where(Persona.builtin_persona.is_(False))
-#     if not include_slack_bot_personas:
-#         stmt = stmt.where(not_(Persona.name.startswith(SLACK_BOT_PERSONA_PREFIX)))
-#     if not include_deleted:
-#         stmt = stmt.where(Persona.deleted.is_(False))
-
-#     if joinedload_all:
-#         stmt = stmt.options(
-#             joinedload(Persona.prompts),
-#             joinedload(Persona.tools),
-#             joinedload(Persona.document_sets),
-#             joinedload(Persona.groups),
-#             joinedload(Persona.users),
-#         )
-
-#     return db_session.execute(stmt).unique().scalars().all()
-
-
 def get_personas(db_session: Session) -> Sequence[Persona]:
     stmt = select(Persona).distinct()
     stmt = stmt.where(not_(Persona.name.startswith(SLACK_BOT_PERSONA_PREFIX)))


### PR DESCRIPTION
## Description

https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html

-  Prevent the query result from exploding in size, so we no longer need `.distinct()`.  

Fixes https://linear.app/danswer/issue/DAN-1382/fix-slow-query

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
