### PR TITLE
Airtable fix

### DIFF
--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -368,10 +368,8 @@ class AirtableConnector(LoadConnector):
                         logger.exception(f"Failed to process record {record['id']}")
                         raise e
 
-            # After batch is complete, yield if we've hit the batch size
-            if len(record_documents) >= self.batch_size:
-                yield record_documents
-                record_documents = []
+            yield record_documents
+            record_documents = []
 
         # Yield any remaining records
         if record_documents:


### PR DESCRIPTION
## Description

If a row in a batch didn't contain any attachments, then we would skip the batch.

## How Has This Been Tested?

ran locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
