### PR TITLE
Fix chat image upload double read

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -713,8 +713,6 @@ def upload_files_for_chat(
             else ChatFileType.PLAIN_TEXT
         )
 
-        file_content = file.file.read()  # Read the file content
-
         if file_type == ChatFileType.IMAGE:
             file_content_io = file.file
             # NOTE: Image conversion to JPEG used to be enforced here.
@@ -723,7 +721,7 @@ def upload_files_for_chat(
             # 2. Maintain transparency in formats like PNG
             # 3. Ameliorate issue with file conversion
         else:
-            file_content_io = io.BytesIO(file_content)
+            file_content_io = io.BytesIO(file.file.read())
 
         new_content_type = file.content_type
 
@@ -741,7 +739,7 @@ def upload_files_for_chat(
         # to re-extract it every time we send a message
         if file_type == ChatFileType.DOC:
             extracted_text = extract_file_text(
-                file=io.BytesIO(file_content),  # use the bytes we already read
+                file=file_content_io, # use the bytes we already read
                 file_name=file.filename or "",
             )
             text_file_id = str(uuid.uuid4())


### PR DESCRIPTION
## Description

Fixes https://github.com/onyx-dot-app/onyx/issues/3888

There is a bug which breaks image uploads in chats:

<img width="418" alt="Screenshot 2025-02-04 at 11 21 20 am" src="https://github.com/user-attachments/assets/bda16588-be1c-4ef6-8787-d9d43f5f6566" />
<img width="797" alt="Screenshot 2025-02-04 at 11 21 08 am" src="https://github.com/user-attachments/assets/fa773415-27a8-408d-bf69-579d45ad94a6" />

I believe this was caused by a change in 2ad86aa which causes an IO stream based on an image file to be read again without resetting the stream back to the beginning (first read in chat_backend.py, [upload_files_for_chat](https://github.com/onyx-dot-app/onyx/blob/715359c12060957bb37b7df545359b4b444d8ab6/backend/onyx/server/query_and_chat/chat_backend.py#L716), and then again in pg_file_store.py, [create_populate_lobj](https://github.com/onyx-dot-app/onyx/blob/715359c12060957bb37b7df545359b4b444d8ab6/backend/onyx/db/pg_file_store.py#L53)). Non image files are treated differently and thus are unaffected.

## How Has This Been Tested?

Tested both PDF and image uploading.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
