### PR TITLE
Fix extra __init__ file + allow adding API keys to user groups

### DIFF
--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -171,13 +171,14 @@ def list_all_users(
     accepted_page: int | None = None,
     slack_users_page: int | None = None,
     invited_page: int | None = None,
+    include_api_keys: bool = False,
     _: User | None = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> AllUsersResponse:
     users = [
         user
         for user in get_all_users(db_session, email_filter_string=q)
-        if not is_api_key_email_address(user.email)
+        if (include_api_keys or not is_api_key_email_address(user.email))
     ]
 
     slack_users = [user for user in users if user.role == UserRole.SLACK_USER]

--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -304,7 +304,7 @@ export function AssistantEditor({
   const [isRequestSuccessful, setIsRequestSuccessful] = useState(false);
 
   const { data: userGroups } = useUserGroups();
-  // const { data: allUsers } = useUsers() as {
+  // const { data: allUsers } = useUsers({ includeApiKeys: false }) as {
   //   data: MinimalUserSnapshot[] | undefined;
   // };
 

--- a/web/src/app/ee/admin/groups/[groupId]/page.tsx
+++ b/web/src/app/ee/admin/groups/[groupId]/page.tsx
@@ -28,7 +28,7 @@ const Page = (props: { params: Promise<{ groupId: string }> }) => {
     data: users,
     isLoading: userIsLoading,
     error: usersError,
-  } = useUsers();
+  } = useUsers({ includeApiKeys: true });
   const {
     data: ccPairs,
     isLoading: isCCPairsLoading,

--- a/web/src/app/ee/admin/groups/page.tsx
+++ b/web/src/app/ee/admin/groups/page.tsx
@@ -28,7 +28,7 @@ const Main = () => {
     data: users,
     isLoading: userIsLoading,
     error: usersError,
-  } = useUsers();
+  } = useUsers({ includeApiKeys: true });
 
   const { isAdmin } = useUser();
 

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -342,8 +342,12 @@ export function useFilters(): FilterManager {
   };
 }
 
-export const useUsers = () => {
-  const url = "/api/manage/users";
+interface UseUsersParams {
+  includeApiKeys: boolean;
+}
+
+export const useUsers = ({ includeApiKeys }: UseUsersParams) => {
+  const url = `/api/manage/users?include_api_keys=${includeApiKeys}`;
 
   const swrResponse = useSWR<AllUsersResponse>(url, errorHandlingFetcher);
 


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1410/support-adding-api-keys-to-use-groups

## How Has This Been Tested?

Tested locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
