### PR TITLE
Fix issue causing file connector to fail

### DIFF
--- a/backend/onyx/document_index/document_index_utils.py
+++ b/backend/onyx/document_index/document_index_utils.py
@@ -142,6 +142,8 @@ def get_uuid_from_chunk_info(
     tenant_id: str | None,
     large_chunk_id: int | None = None,
 ) -> UUID:
+    """NOTE: be VERY carefuly about changing this function. If changed without a migration,
+    this can cause deletion/update/insertion to function incorrectly."""
     doc_str = document_id
 
     # Web parsing URL duplicate catching

--- a/backend/onyx/document_index/vespa/indexing_utils.py
+++ b/backend/onyx/document_index/vespa/indexing_utils.py
@@ -242,9 +242,9 @@ def batch_index_vespa_chunks(
 def clean_chunk_id_copy(
     chunk: DocMetadataAwareIndexChunk,
 ) -> DocMetadataAwareIndexChunk:
-    clean_chunk = chunk.copy(
+    clean_chunk = chunk.model_copy(
         update={
-            "source_document": chunk.source_document.copy(
+            "source_document": chunk.source_document.model_copy(
                 update={
                     "id": replace_invalid_doc_id_characters(chunk.source_document.id)
                 }

--- a/backend/onyx/document_index/vespa/shared_utils/utils.py
+++ b/backend/onyx/document_index/vespa/shared_utils/utils.py
@@ -45,7 +45,9 @@ def is_text_character(codepoint: int) -> bool:
 
 
 def replace_invalid_doc_id_characters(text: str) -> str:
-    """Replaces invalid document ID characters in text."""
+    """Replaces invalid document ID characters in text.
+    NOTE: this must be called at the start of every vespa-related operation or else we
+    risk discrepancies -> silent failures on deletion/update/insertion."""
     # There may be a more complete set of replacements that need to be made but Vespa docs are unclear
     # and users only seem to be running into this error with single quotes
     return text.replace("'", "_")

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -33,11 +33,6 @@ import EditPropertyModal from "@/components/modals/EditPropertyModal";
 
 import * as Yup from "yup";
 
-// since the uploaded files are cleaned up after some period of time
-// re-indexing will not work for the file connector. Also, it would not
-// make sense to re-index, since the files will not have changed.
-const CONNECTOR_TYPES_THAT_CANT_REINDEX: ValidSources[] = [ValidSources.File];
-
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -268,21 +263,18 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
         {ccPair.is_editable_for_current_user && (
           <div className="ml-auto flex gap-x-2">
-            {!CONNECTOR_TYPES_THAT_CANT_REINDEX.includes(
-              ccPair.connector.source
-            ) && (
-              <ReIndexButton
-                ccPairId={ccPair.id}
-                connectorId={ccPair.connector.id}
-                credentialId={ccPair.credential.id}
-                isDisabled={
-                  ccPair.indexing ||
-                  ccPair.status === ConnectorCredentialPairStatus.PAUSED
-                }
-                isIndexing={ccPair.indexing}
-                isDeleting={isDeleting}
-              />
-            )}
+            <ReIndexButton
+              ccPairId={ccPair.id}
+              connectorId={ccPair.connector.id}
+              credentialId={ccPair.credential.id}
+              isDisabled={
+                ccPair.indexing ||
+                ccPair.status === ConnectorCredentialPairStatus.PAUSED
+              }
+              isIndexing={ccPair.indexing}
+              isDeleting={isDeleting}
+            />
+
             {!isDeleting && <ModifyStatusButtonCluster ccPair={ccPair} />}
           </div>
         )}


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1414/file-connector-failing-due-to-successful-doc-ids-=-setupdatable-ids

Document ID modification internal to Vespa -> returning different document IDs than passed in -> causes 

```
        successful_doc_ids = {record.document_id for record in insertion_records}
        if successful_doc_ids != set(updatable_ids):
            raise RuntimeError(
                f"Some documents were not successfully indexed. "
                f"Updatable IDs: {updatable_ids}, "
                f"Successful IDs: {successful_doc_ids}"
            )
```

to fail.

Also includes some additional comments + enabling re-indexing on the file connector.

## How Has This Been Tested?

Tested with a batch of files that I knew previously failed. Then verified it worked after the fix.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
