### PR TITLE
Add special case to `time_str_to_utc` to handle invalid tz names

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -1,4 +1,5 @@
 import re
+import string
 from collections.abc import Callable
 from collections.abc import Iterator
 from datetime import datetime
@@ -6,6 +7,7 @@ from datetime import timezone
 from typing import TypeVar
 
 from dateutil.parser import parse
+from dateutil.parser import parserinfo
 
 from onyx.configs.app_configs import CONNECTOR_LOCALHOST_OVERRIDE
 from onyx.configs.constants import IGNORE_FOR_QA
@@ -15,6 +17,14 @@ from onyx.utils.text_processing import is_valid_email
 
 T = TypeVar("T")
 U = TypeVar("U")
+
+
+def _is_valid_tzname(tz_name_str: str) -> bool:
+    # based on dateutil.parser _could_be_tzname
+    return len(tz_name_str) <= 5 and (
+        all(x in string.ascii_uppercase for x in tz_name_str)
+        or tz_name_str in parserinfo.UTCZONE
+    )
 
 
 def datetime_to_utc(dt: datetime) -> datetime:
@@ -38,6 +48,22 @@ def time_str_to_utc(datetime_str: str) -> datetime:
         if "0000" in datetime_str:
             datetime_str = datetime_str.replace(" 0000", " +0000")
             dt = parse(datetime_str)
+        elif (
+            len(
+                matches := list(
+                    match
+                    for match in re.findall(r"\+\d{4} \(([^)]*)\)", datetime_str)
+                    if not _is_valid_tzname(match)
+                )
+            )
+            == 1
+        ):
+            # Where a string contains both an offset AND a timezone name BUT the name is invalid: remove the name
+            # e.g.
+            # Thu, 23 Jan 2025 10:58:32 +0300 (+03) -> Thu, 23 Jan 2025 10:58:32 +0300
+            # Sat, 25 Jan 2025 05:15:30 +1100 (AUSNSW) -> Sat, 25 Jan 2025 05:15:30 +1100
+            fixed_dt_str = datetime_str.replace(f" ({matches[0]})", "")
+            dt = parse(fixed_dt_str)
         else:
             raise
 

--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -60,8 +60,8 @@ def time_str_to_utc(datetime_str: str) -> datetime:
         ):
             # Where a string contains both an offset AND a timezone name BUT the name is invalid: remove the name
             # e.g.
-            # Thu, 23 Jan 2025 10:58:32 +0300 (+03) -> Thu, 23 Jan 2025 10:58:32 +0300
-            # Sat, 25 Jan 2025 05:15:30 +1100 (AUSNSW) -> Sat, 25 Jan 2025 05:15:30 +1100
+            # +0300 (+03) -> +0300
+            # +1100 (AUSNSW) -> +1100
             fixed_dt_str = datetime_str.replace(f" ({matches[0]})", "")
             dt = parse(fixed_dt_str)
         else:

--- a/backend/tests/unit/onyx/connectors/gmail/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/gmail/test_connector.py
@@ -42,6 +42,7 @@ def test_build_time_range_query() -> None:
 
 def test_time_str_to_utc() -> None:
     str_to_dt = {
+        # well-formed strings:
         "Tue, 5 Oct 2021 09:38:25 GMT": datetime.datetime(
             2021, 10, 5, 9, 38, 25, tzinfo=datetime.timezone.utc
         ),
@@ -56,6 +57,19 @@ def test_time_str_to_utc() -> None:
         ),
         "22 Mar 2020 20:12:18 +0000 (GMT)": datetime.datetime(
             2020, 3, 22, 20, 12, 18, tzinfo=datetime.timezone.utc
+        ),
+        # malformed strings, which should be fixed automatically:
+        # 0000 corrected to +0000
+        "22 Mar 2020 20:12:18 0000": datetime.datetime(
+            2020, 3, 22, 20, 12, 18, tzinfo=datetime.timezone.utc
+        ),
+        # invalid (+03) removed
+        "Thu, 23 Jan 2025 11:04:48 +0300 (+03)": datetime.datetime(
+            2025, 1, 23, 8, 4, 48, tzinfo=datetime.timezone.utc
+        ),
+        # invalid (AUSNSW) removed
+        "Sat, 25 Jan 2025 05:15:30 +1100 (AUSNSW)": datetime.datetime(
+            2025, 1, 24, 18, 15, 30, tzinfo=datetime.timezone.utc
         ),
     }
     for strptime, expected_datetime in str_to_dt.items():


### PR DESCRIPTION
## Description

See https://github.com/onyx-dot-app/onyx/issues/3921

tl;dr: malformed date strings are being returned from the Gmail API and being passed to the `time_str_to_utc` function here: https://github.com/onyx-dot-app/onyx/blob/5c7487e91f38a850bd386cf2b6769aa9ebb82951/backend/onyx/connectors/gmail/connector.py#L182

This is the least obtrusive solution I could come up with:
- if a datestring doesn't parse, see if it contains an offset followed by something in parens (`+1234 (SOMETHING)`)
- if the thing in parens is not a valid tz name, remove it parse the date with just the offset

Another option would be to use fuzzy parsing (i.e. `dt = parse(datetime_str, fuzzy=True)`) but that risks causing surprising behaviour elsewhere, given how widely this util is used.

## How Has This Been Tested?

Added unit tests.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
