### PR TITLE
Add  default slack bot disabling

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1742,6 +1742,7 @@ class ChannelConfig(TypedDict):
     # If empty list, follow up with no tags
     follow_up_tags: NotRequired[list[str]]
     show_continue_in_web_ui: NotRequired[bool]  # defaults to False
+    disabled: NotRequired[bool]  # defaults to False
 
 
 class SlackChannelConfig(Base):
@@ -1765,6 +1766,7 @@ class SlackChannelConfig(Base):
     is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     persona: Mapped[Persona | None] = relationship("Persona")
+
     slack_bot: Mapped["SlackBot"] = relationship(
         "SlackBot",
         back_populates="slack_channel_configs",

--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -182,7 +182,6 @@ def update_slack_channel_config(
         )
 
     # update the config
-    print("CHANNEL CONFIG IS 2 ", slack_channel_config.channel_config)
     slack_channel_config.persona_id = persona_id
     slack_channel_config.channel_config = channel_config
     slack_channel_config.standard_answer_categories = list(

--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -151,6 +151,7 @@ def update_slack_channel_config(
     channel_config: ChannelConfig,
     standard_answer_category_ids: list[int],
     enable_auto_filters: bool,
+    disabled: bool,
 ) -> SlackChannelConfig:
     slack_channel_config = db_session.scalar(
         select(SlackChannelConfig).where(
@@ -181,6 +182,7 @@ def update_slack_channel_config(
         )
 
     # update the config
+    print("CHANNEL CONFIG IS 2 ", slack_channel_config.channel_config)
     slack_channel_config.persona_id = persona_id
     slack_channel_config.channel_config = channel_config
     slack_channel_config.standard_answer_categories = list(

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -180,6 +180,13 @@ def handle_message(
         )
         return False
 
+    if slack_channel_config.channel_config.get("disabled") and not bypass_filters:
+        logger.info(
+            "Skipping message since the channel is configured such that "
+            "OnyxBot is disabled"
+        )
+        return False
+
     # List of user id to send message to, if None, send to everyone in channel
     send_to: list[str] | None = None
     missing_users: list[str] | None = None

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -806,6 +806,7 @@ def process_message(
                 and slack_channel_config.channel_config.get("follow_up_tags")
                 is not None
             )
+
             feedback_reminder_id = schedule_feedback_reminder(
                 details=details, client=client.web_client, include_followup=follow_up
             )

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -187,6 +187,7 @@ class SlackChannelConfigCreationRequest(BaseModel):
     response_type: SlackBotResponseType
     # XXX this is going away soon
     standard_answer_categories: list[int] = Field(default_factory=list)
+    disabled: bool = False
 
     @field_validator("answer_filters", mode="before")
     @classmethod

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -145,13 +145,11 @@ def patch_slack_channel_config(
     db_session: Session = Depends(get_session),
     _: User | None = Depends(current_admin_user),
 ) -> SlackChannelConfig:
-    print("GETTING CHANNEL CONFIG")
     channel_config = _form_channel_config(
         db_session=db_session,
         slack_channel_config_creation_request=slack_channel_config_creation_request,
         current_slack_channel_config_id=slack_channel_config_id,
     )
-    print("CHANNEL CONFIG IS ", channel_config)
 
     persona_id = None
     if slack_channel_config_creation_request.persona_id is not None:

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -93,6 +93,8 @@ def _form_channel_config(
         "respond_to_bots"
     ] = slack_channel_config_creation_request.respond_to_bots
 
+    channel_config["disabled"] = slack_channel_config_creation_request.disabled
+
     return channel_config
 
 
@@ -143,11 +145,13 @@ def patch_slack_channel_config(
     db_session: Session = Depends(get_session),
     _: User | None = Depends(current_admin_user),
 ) -> SlackChannelConfig:
+    print("GETTING CHANNEL CONFIG")
     channel_config = _form_channel_config(
         db_session=db_session,
         slack_channel_config_creation_request=slack_channel_config_creation_request,
         current_slack_channel_config_id=slack_channel_config_id,
     )
+    print("CHANNEL CONFIG IS ", channel_config)
 
     persona_id = None
     if slack_channel_config_creation_request.persona_id is not None:
@@ -194,6 +198,7 @@ def patch_slack_channel_config(
         channel_config=channel_config,
         standard_answer_category_ids=slack_channel_config_creation_request.standard_answer_categories,
         enable_auto_filters=slack_channel_config_creation_request.enable_auto_filters,
+        disabled=slack_channel_config_creation_request.disabled,
     )
     return SlackChannelConfig.from_model(slack_channel_config_model)
 

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -124,6 +124,8 @@ export const SlackChannelConfigCreationForm = ({
             : existingSlackChannelConfig?.persona
               ? "document_sets"
               : "all_public",
+          disabled:
+            existingSlackChannelConfig?.channel_config?.disabled ?? false,
         }}
         validationSchema={Yup.object().shape({
           slack_bot_id: Yup.number().required(),
@@ -170,6 +172,7 @@ export const SlackChannelConfigCreationForm = ({
               "non_search_assistant",
             ])
             .required(),
+          disabled: Yup.boolean().optional().default(false),
         })}
         onSubmit={async (values, formikHelpers) => {
           formikHelpers.setSubmitting(true);
@@ -195,6 +198,7 @@ export const SlackChannelConfigCreationForm = ({
               (category: any) => category.id
             ),
             response_type: values.response_type as SlackBotResponseType,
+            disabled: values.disabled ?? false,
           };
 
           if (!cleanedValues.still_need_help_enabled) {

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -197,9 +197,27 @@ export function SlackChannelConfigFormFields({
     <>
       <div className="w-full">
         {isDefault && (
-          <Badge variant="agent" className="bg-blue-100 text-blue-800">
-            Default Configuration
-          </Badge>
+          <>
+            <Badge variant="agent" className="bg-blue-100 text-blue-800">
+              Default Configuration
+            </Badge>
+            <p className="mt-2 text-sm text-gray-600">
+              This default configuration will apply across all Slack channels
+              the bot is added to in the Slack workspace, as well as direct
+              messages (DMs), unless disabled.
+            </p>
+            <div className="mt-4 p-4 bg-gray-100 rounded-md border border-gray-300">
+              <CheckFormField
+                name="disabled"
+                label="Disable Default Configuration"
+              />
+              <p className="mt-2 text-sm text-gray-600 italic">
+                Warning: Disabling the default configuration means the bot won't
+                respond in Slack channels or DMs unless explicitly configured
+                for them.
+              </p>
+            </div>
+          </>
         )}
         {!isDefault && (
           <>

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -212,9 +212,9 @@ export function SlackChannelConfigFormFields({
                 label="Disable Default Configuration"
               />
               <p className="mt-2 text-sm text-gray-600 italic">
-                Warning: Disabling the default configuration means the bot won't
-                respond in Slack channels or DMs unless explicitly configured
-                for them.
+                Warning: Disabling the default configuration means the bot
+                won&apos;t respond in Slack channels or DMs unless explicitly
+                configured for them.
               </p>
             </div>
           </>

--- a/web/src/app/admin/bots/[bot-id]/lib.ts
+++ b/web/src/app/admin/bots/[bot-id]/lib.ts
@@ -21,6 +21,7 @@ interface SlackChannelConfigCreationRequest {
   usePersona: boolean;
   response_type: SlackBotResponseType;
   standard_answer_categories: number[];
+  disabled: boolean;
 }
 
 const buildFiltersFromCreationRequest = (
@@ -54,6 +55,7 @@ const buildRequestBodyFromCreationRequest = (
       : { document_sets: creationRequest.document_sets }),
     response_type: creationRequest.response_type,
     standard_answer_categories: creationRequest.standard_answer_categories,
+    disabled: creationRequest.disabled,
   });
 };
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -252,6 +252,7 @@ export interface ChannelConfig {
   respond_member_group_list?: string[];
   answer_filters?: AnswerFilterOption[];
   follow_up_tags?: string[];
+  disabled?: boolean;
 }
 
 export type SlackBotResponseType = "quotes" | "citations";


### PR DESCRIPTION
## Description

Let users disable default slackbot 
<img width="854" alt="Screenshot 2025-02-07 at 10 33 17 AM" src="https://github.com/user-attachments/assets/9999ac42-173b-48c3-80d0-fd991f6f8197" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
