### PR TITLE
Fix starter message overflow

### DIFF
--- a/web/src/components/assistants/StarterMessage.tsx
+++ b/web/src/components/assistants/StarterMessage.tsx
@@ -48,7 +48,6 @@ export function StarterMessages({
                       flex-col gap-2 rounded-md
                       text-input-text hover:text-text
                       border
-
                       dark:bg-transparent
                       dark:border-neutral-700
                       dark:hover:bg-background-150
@@ -58,11 +57,16 @@ export function StarterMessages({
                       text-[15px] shadow-xs transition
                       enabled:hover:bg-background-dark/75
                       disabled:cursor-not-allowed
-                      line-clamp-3
+                      overflow-hidden
+                      break-all
+                      truncate
+                      text-ellipsis
                     `}
-                    style={{ height: "5.4rem" }}
+                    style={{ height: "5.6rem" }}
                   >
-                    {starterMessage.name}
+                    <div className="overflow-hidden text-ellipsis line-clamp-3 pr-1 pb-1">
+                      {starterMessage.name}
+                    </div>
                   </button>
                 </div>
               ))}


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1437/improve-overflow-on-starter-messages

Now looks like:

![Screenshot 2025-02-10 at 4 21 13 PM](https://github.com/user-attachments/assets/1fb339b4-18c4-4668-8722-7084107d960a)

## How Has This Been Tested?

Locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
