### PR TITLE
Fix for red background

### DIFF
--- a/web/src/app/assistants/mine/AssistantCard.tsx
+++ b/web/src/app/assistants/mine/AssistantCard.tsx
@@ -147,7 +147,7 @@ const AssistantCard: React.FC<{
               )}
             </div>
             {isOwnedByUser && (
-              <div className="flex ml-2 relative  items-center gap-x-2">
+              <div className="flex ml-2 relative items-center gap-x-2">
                 <Popover modal>
                   <PopoverTrigger>
                     <button
@@ -157,9 +157,7 @@ const AssistantCard: React.FC<{
                       <FiMoreHorizontal size={16} />
                     </button>
                   </PopoverTrigger>
-                  <PopoverContent
-                    className={`w-32 z-[10000] p-2 hover:bg-red-400`}
-                  >
+                  <PopoverContent className={`w-32 z-[10000] p-2`}>
                     <div className="flex flex-col text-sm space-y-1">
                       <button
                         onClick={isOwnedByUser ? handleEdit : undefined}


### PR DESCRIPTION
## Description

Previously became red.

https://linear.app/danswer/issue/DAN-1438/red-background-color-on-assistant-option-hover

## How Has This Been Tested?

Tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
