### PR TITLE
Reduce errors in workers

### DIFF
--- a/backend/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -15,7 +15,6 @@ from pydantic import ValidationError
 from redis import Redis
 from redis.exceptions import LockError
 from redis.lock import Lock as RedisLock
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.connector_credential_pair import get_all_auto_sync_cc_pairs
@@ -463,20 +462,11 @@ def update_external_document_permissions_task(
 
     try:
         with get_session_with_tenant(tenant_id) as db_session:
-            try:
-                # Add the users to the DB if they don't exist
-                batch_add_ext_perm_user_if_not_exists(
-                    db_session=db_session,
-                    emails=list(external_access.external_user_emails),
-                )
-            except IntegrityError:
-                db_session.rollback()
-                task_logger.error(
-                    "IntegrityError (likely 'UniqueViolation') occurred while adding users. "
-                    f"Emails: {list(external_access.external_user_emails)}. Retrying once."
-                )
-                return False
-
+            batch_add_ext_perm_user_if_not_exists(
+                db_session=db_session,
+                emails=list(external_access.external_user_emails),
+                continue_on_error=True,
+            )
             # Then upsert the document's external permissions
             created_new_doc = upsert_document_external_perms(
                 db_session=db_session,

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -420,6 +420,7 @@ def _collect_sync_metrics(db_session: Session, redis_std: Redis) -> list[Metric]
       - Throughput (docs/min) (only if success)
       - Raw start/end times for each sync
     """
+
     one_hour_ago = get_db_current_time(db_session) - timedelta(hours=1)
 
     # Get all sync records that ended in the last hour
@@ -587,6 +588,10 @@ def _collect_sync_metrics(db_session: Session, redis_std: Redis) -> list[Metric]
                 entity = db_session.scalar(
                     select(UserGroup).where(UserGroup.id == sync_record.entity_id)
                 )
+            else:
+                # Only user groups and document set sync records have
+                #  an associated entity we can use for latency metrics
+                continue
 
             if entity is None:
                 task_logger.error(
@@ -777,7 +782,7 @@ def cloud_check_alembic() -> bool | None:
 
                     tenant_to_revision[tenant_id] = result_scalar
                 except Exception:
-                    task_logger.warning(f"Tenant {tenant_id} has no revision!")
+                    task_logger.error(f"Tenant {tenant_id} has no revision!")
                     tenant_to_revision[tenant_id] = ALEMBIC_NULL_REVISION
 
         # get the total count of each revision

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -39,19 +39,6 @@ def get_message_link(
     return permalink
 
 
-def _make_slack_api_call_logged(
-    call: Callable[..., SlackResponse],
-) -> Callable[..., SlackResponse]:
-    @wraps(call)
-    def logged_call(**kwargs: Any) -> SlackResponse:
-        logger.debug(f"Making call to Slack API '{call.__name__}' with args '{kwargs}'")
-        result = call(**kwargs)
-        logger.debug(f"Call to Slack API '{call.__name__}' returned '{result}'")
-        return result
-
-    return logged_call
-
-
 def _make_slack_api_call_paginated(
     call: Callable[..., SlackResponse],
 ) -> Callable[..., Generator[dict[str, Any], None, None]]:
@@ -127,18 +114,14 @@ def make_slack_api_rate_limited(
 def make_slack_api_call_w_retries(
     call: Callable[..., SlackResponse], **kwargs: Any
 ) -> SlackResponse:
-    return basic_retry_wrapper(
-        make_slack_api_rate_limited(_make_slack_api_call_logged(call))
-    )(**kwargs)
+    return basic_retry_wrapper(make_slack_api_rate_limited(call))(**kwargs)
 
 
 def make_paginated_slack_api_call_w_retries(
     call: Callable[..., SlackResponse], **kwargs: Any
 ) -> Generator[dict[str, Any], None, None]:
     return _make_slack_api_call_paginated(
-        basic_retry_wrapper(
-            make_slack_api_rate_limited(_make_slack_api_call_logged(call))
-        )
+        basic_retry_wrapper(make_slack_api_rate_limited(call))
     )(**kwargs)
 
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -21,10 +21,7 @@ from onyx.db.models import Persona__User
 from onyx.db.models import SamlAccount
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
-from onyx.setup import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
-
-logger = setup_logger()
 
 
 def validate_user_role_update(requested_role: UserRole, current_role: UserRole) -> None:
@@ -292,9 +289,6 @@ def batch_add_ext_perm_user_if_not_exists(
         db_session.commit()
     except IntegrityError:
         db_session.rollback()
-        logger.warning(
-            "IntegrityError occurred during batch insert. Falling back to individual inserts."
-        )
         if not continue_on_error:
             raise
         for user in new_users:
@@ -303,7 +297,6 @@ def batch_add_ext_perm_user_if_not_exists(
                 db_session.commit()
             except IntegrityError:
                 db_session.rollback()
-                logger.warning(f"Skipping duplicate user: {user.email}")
                 continue
     # Fetch all users again to ensure we have the most up-to-date list
     all_users, _ = _get_users_by_emails(db_session, lower_emails)

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -571,20 +571,20 @@ class VespaIndex(DocumentIndex):
         update_dict: dict[str, dict] = {"fields": {}}
 
         if fields.boost is not None:
-            update_dict["fields"]["boost"] = {"assign": fields.boost}
+            update_dict["fields"][BOOST] = {"assign": fields.boost}
 
         if fields.document_sets is not None:
-            update_dict["fields"]["document_sets"] = {
+            update_dict["fields"][DOCUMENT_SETS] = {
                 "assign": {document_set: 1 for document_set in fields.document_sets}
             }
 
         if fields.access is not None:
-            update_dict["fields"]["access_control_list"] = {
+            update_dict["fields"][ACCESS_CONTROL_LIST] = {
                 "assign": {acl_entry: 1 for acl_entry in fields.access.to_acl()}
             }
 
         if fields.hidden is not None:
-            update_dict["fields"]["hidden"] = {"assign": fields.hidden}
+            update_dict["fields"][HIDDEN] = {"assign": fields.hidden}
 
         if not update_dict["fields"]:
             logger.error("Update request received but nothing to update.")
@@ -603,8 +603,6 @@ class VespaIndex(DocumentIndex):
             )
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
-            # Optional: inspect the error message for "Rejecting execution due to overload"
-            # or check e.response.status_code (e.g., 429 or 503).
             logger.error(
                 f"Failed to update doc chunk {doc_chunk_id} (doc_id={doc_id}). "
                 f"Details: {e.response.text}"


### PR DESCRIPTION
## Description

This is a general pass at reducing the number of unnecessary / spammy error logs in our backgrounds pods. Each exception has a link to a relevant example in Grafana + the relevant change

#### Primary Worker
[Tenant ID exceptions](https://g-dfa4b7be0c.grafana-workspace.us-east-2.amazonaws.com/explore?schemaVersion=1&panes=%7B%22g7r%22:%7B%22datasource%22:%22ce39t0tyjl6o0b%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bjob%3D%5C%22danswer%2Fcelery-worker-primary%5C%22%7D%20%7C%3D%20%60ERROR%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22ce39t0tyjl6o0b%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

 Fixed miscellaneous tenant ID exceptions
- Updated and added alerting in Alembic check to identify schemas without proper tables + deleted tenant-less schemas 

#### Monitoring worker
[Entity exception](https://g-dfa4b7be0c.grafana-workspace.us-east-2.amazonaws.com/explore?schemaVersion=1&panes=%7B%22g7r%22:%7B%22datasource%22:%22ce39t0tyjl6o0b%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bjob%3D%5C%22danswer%2Fcelery-worker-primary%5C%22%7D%20%7C%3D%20%60ERROR%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22ce39t0tyjl6o0b%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

- Updated monitoring logic to avoid logging this as an error for sync record types with no related entity

#### Heavy Worker
[Dupe external email issue](https://g-dfa4b7be0c.grafana-workspace.us-east-2.amazonaws.com/goto/V3v0XjKNg?orgId=1)
Error ended up being that we have concurrent tasks creating the same external user email
- Just log error and return false in the task to minimize logspam

Some pretty excessive Slack spam https://g-dfa4b7be0c.grafana-workspace.us-east-2.amazonaws.com/goto/Jnc1ujFHR?orgId=1)
- Remove logspam

#### Light Worker
[View in Grafana](https://g-dfa4b7be0c.grafana-workspace.us-east-2.amazonaws.com/explore?schemaVersion=1&panes=%7B%22g7r%22:%7B%22datasource%22:%22ce39t0tyjl6o0b%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bjob%3D%5C%22danswer%2Fcelery-worker-light%5C%22%7D%20%7C%3D%20%60ERROR%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22ce39t0tyjl6o0b%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)


```
Exception: Failed to update doc chunk 304652f0-2e46-5705-94ef-6a22ea003c55 (doc_id=https://www.1955apache.com/blog/jl-audio-kick-panels). Details: {"pathId":"/document/v1/default/danswer_chunk_cohere_embed_english_v3_0/docid/304652f0-2e46-5705-94ef-6a22ea003c55","message":"Rejecting execution due to overload: 100 requests already enqueued"}
```

- Retries for document chunk updates


## How Has This Been Tested?

- Locally- various background flows

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
