### PR TITLE
updated rerank function arguments

### DIFF
--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -61,6 +61,8 @@ class SearchPipeline:
         rerank_metrics_callback: Callable[[RerankMetricsContainer], None] | None = None,
         prompt_config: PromptConfig | None = None,
     ):
+        # NOTE: The Search Request contains a lot of fields that are overrides, many of them can be None
+        # and typically are None. The preprocessing will fetch default values to replace these empty overrides.
         self.search_request = search_request
         self.user = user
         self.llm = llm

--- a/backend/onyx/context/search/postprocessing/postprocessing.py
+++ b/backend/onyx/context/search/postprocessing/postprocessing.py
@@ -165,7 +165,7 @@ def semantic_reranking(
     return list(ranked_chunks), list(ranked_indices)
 
 
-def reranking_is_runnable(rerank_settings: RerankingDetails | None) -> bool:
+def should_rerank(rerank_settings: RerankingDetails | None) -> bool:
     """Based on the RerankingDetails model, only run rerank if the following conditions are met:
     - rerank_model_name is not None
     - num_rerank is greater than 0
@@ -269,7 +269,7 @@ def search_postprocessing(
 
     rerank_task_id = None
     sections_yielded = False
-    if reranking_is_runnable(search_query.rerank_settings):
+    if should_rerank(search_query.rerank_settings):
         post_processing_tasks.append(
             FunctionCall(
                 rerank_sections,


### PR DESCRIPTION
## Description

Updated reranking function to not require a whole SearchQuery, but a more narrow set
(query_str and rerank_settings)

Changes have been propagated up, staring with  semantic_reranking at the bottom.


## How Has This Been Tested?

Tested locally with one query and both Basic Search and Agent Search 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
