### PR TITLE
add nano and vim to base image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,9 @@ RUN apt-get update && \
         libuuid1=2.38.1-5+deb12u1 \
         libxmlsec1-dev \
         pkg-config \
-        gcc && \
+        gcc \
+        nano \
+        vim && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
## Description
Fixes DAN-1449.
https://linear.app/danswer/issue/DAN-1449/add-vim-and-nano-to-backend-image

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
