### PR TITLE
Color fix / width

### DIFF
--- a/web/src/components/credentials/actions/CreateCredential.tsx
+++ b/web/src/components/credentials/actions/CreateCredential.tsx
@@ -194,7 +194,7 @@ export default function CreateCredential({
               for information on setting up this connector.
             </p>
           )}
-          <CardSection className="w-full items-start bg-blue-200 !border-0 mt-4 flex flex-col gap-y-6">
+          <CardSection className="w-full items-start  dark:bg-neutral-900 mt-4 flex flex-col gap-y-6">
             <TextFormField
               name="name"
               placeholder="(Optional) credential name.."
@@ -215,7 +215,7 @@ export default function CreateCredential({
               />
             ))}
             {!swapConnector && (
-              <div className="mt-4 flex flex-col sm:flex-row justify-between items-end">
+              <div className="mt-4 flex w-full flex-col sm:flex-row justify-between items-end">
                 <div className="w-full sm:w-3/4 mb-4 sm:mb-0">
                   {isPaidEnterpriseFeaturesEnabled && (
                     <div className="flex flex-col items-start">


### PR DESCRIPTION
## Description
https://linear.app/danswer/issue/DAN-1450/weird-look-on-credential-form

<img width="893" alt="Screenshot 2025-02-13 at 6 09 17 PM" src="https://github.com/user-attachments/assets/b9e14108-59b5-4d17-a1ca-ad46b8731809" />

<img width="826" alt="Screenshot 2025-02-13 at 6 09 10 PM" src="https://github.com/user-attachments/assets/6d3ec592-ea94-4325-895a-06af7d4023a0" />




## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
