### PR TITLE
Seeding count issue

### DIFF
--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -105,6 +105,7 @@ def document_by_cc_pair_cleanup_task(
                     tenant_id=tenant_id,
                     chunk_count=chunk_count,
                 )
+
                 delete_documents_complete__no_commit(
                     db_session=db_session,
                     document_ids=[document_id],

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -17,8 +17,6 @@ CONTENT_SUMMARY = "content_summary"
 @retry(tries=10, delay=1, backoff=2)
 def _retryable_http_delete(http_client: httpx.Client, url: str) -> None:
     res = http_client.delete(url)
-    print("in the retryable http delete", res)
-    print("status is", res.status_code)
     res.raise_for_status()
 
 

--- a/backend/onyx/document_index/vespa/deletion.py
+++ b/backend/onyx/document_index/vespa/deletion.py
@@ -17,6 +17,8 @@ CONTENT_SUMMARY = "content_summary"
 @retry(tries=10, delay=1, backoff=2)
 def _retryable_http_delete(http_client: httpx.Client, url: str) -> None:
     res = http_client.delete(url)
+    print("in the retryable http delete", res)
+    print("status is", res.status_code)
     res.raise_for_status()
 
 

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -47,14 +47,12 @@ def _create_indexable_chunks(
 ) -> tuple[list[Document], list[DocMetadataAwareIndexChunk]]:
     ids_to_documents = {}
     chunks = []
-    chunk_count_by_doc_id = {}
     for preprocessed_doc in preprocessed_docs:
-        doc_id = preprocessed_doc["url"]  # For Web connector, the URL is the ID
-        chunk_count_by_doc_id[doc_id] = chunk_count_by_doc_id.get(doc_id, 0) + 1
-
         document = Document(
-            id=doc_id,
-            sections=[Section(text=preprocessed_doc["content"], link=doc_id)],
+            id=preprocessed_doc["url"],  # For Web connector, the URL is the ID
+            sections=[
+                Section(text=preprocessed_doc["content"], link=preprocessed_doc["url"])
+            ],
             source=DocumentSource.WEB,
             semantic_identifier=preprocessed_doc["title"],
             metadata={},

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -50,6 +50,8 @@ def _create_indexable_chunks(
     for preprocessed_doc in preprocessed_docs:
         document = Document(
             id=preprocessed_doc["url"],  # For Web connector, the URL is the ID
+            # The section is not really used past this point since we have already done the other processing
+            # for the chunking and embedding.
             sections=[
                 Section(text=preprocessed_doc["content"], link=preprocessed_doc["url"])
             ],

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -245,12 +245,11 @@ def seed_initial_documents(
 
     # Since we bypass the indexing flow, we need to manually update the chunk count
     for doc in docs:
-        print("Updating chunk count for doc", doc.id, "to", doc.chunk_count)
         db_session.execute(
             update(DbDocument)
             .where(DbDocument.id == doc.id)
             .values(chunk_count=doc.chunk_count)
         )
 
-    db_session.commit()  # KEY!
+    db_session.commit()
     kv_store.store(KV_DOCUMENTS_SEEDED_KEY, True)


### PR DESCRIPTION
## Description

Current issue:
- Chunk count not properly counted, not updated
- This leads to seeded docs not being deleted by our background processes as we assume their UUIDs were generated with the "old" system (we use presence of chunk counts to deleting the UUID process)

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
