### PR TITLE
no reranking if local model w/o GPU for Agent Search

### DIFF
--- a/backend/onyx/agents/agent_search/models.py
+++ b/backend/onyx/agents/agent_search/models.py
@@ -67,6 +67,7 @@ class GraphSearchConfig(BaseModel):
     # Whether to allow creation of refinement questions (and entity extraction, etc.)
     allow_refinement: bool = True
     skip_gen_ai_answer_generation: bool = False
+    allow_agent_reranking: bool = False
 
 
 class GraphConfig(BaseModel):

--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from collections.abc import Callable
-from typing import cast
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -84,12 +83,11 @@ class Answer:
 
         rerank_settings = search_request.rerank_settings
 
-        rerank_config_is_local = (
-            rerank_settings is not None and rerank_settings.rerank_provider_type is None
+        using_cloud_reranking = (
+            rerank_settings is not None
+            and rerank_settings.rerank_provider_type is not None
         )
-        allow_agent_reranking = (
-            cast(bool, gpu_status_request()) or rerank_config_is_local
-        )
+        allow_agent_reranking = gpu_status_request() or using_cloud_reranking
 
         self.graph_inputs = GraphInputs(
             search_request=search_request,
@@ -105,7 +103,6 @@ class Answer:
             force_use_tool=force_use_tool,
             using_tool_calling_llm=using_tool_calling_llm,
         )
-        assert db_session, "db_session must be provided for agentic persistence"
         self.graph_persistence = GraphPersistence(
             db_session=db_session,
             chat_session_id=chat_session_id,

--- a/backend/tests/unit/onyx/chat/test_skip_gen_ai.py
+++ b/backend/tests/unit/onyx/chat/test_skip_gen_ai.py
@@ -36,7 +36,12 @@ def test_skip_gen_ai_answer_generation_flag(
     mock_search_tool: SearchTool,
     answer_style_config: AnswerStyleConfig,
     prompt_config: PromptConfig,
+    mocker: MockerFixture,
 ) -> None:
+    mocker.patch(
+        "onyx.chat.answer.gpu_status_request",
+        return_value=True,
+    )
     question = config["question"]
     skip_gen_ai_answer_generation = config["skip_gen_ai_answer_generation"]
 


### PR DESCRIPTION
## Description

If there is no GPU and a local reranking model is used, we will not rerank.

Implemented using:
 -  rerank_settings.rerank_type is None
 - gpu_status_request() used at the beginning of the  call. 
 - new variable graph_config.behavior.allow_agent_reranking
 as indicators

Linear: 
https://linear.app/danswer/issue/DAN-1454/disable-re-ranking-in-agent-search-if-local-model-wo-gpu-is-used

## How Has This Been Tested?

Tested locally on Mac w/ GPU and at scale.onyx w/o GPU. In the scale test, reranking was omitted.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
