### PR TITLE
Connector validation

### DIFF
--- a/backend/alembic/versions/acaab4ef4507_remove_inactive_ccpair_status_on_.py
+++ b/backend/alembic/versions/acaab4ef4507_remove_inactive_ccpair_status_on_.py
@@ -1,0 +1,29 @@
+"""remove inactive ccpair status on downgrade
+
+Revision ID: acaab4ef4507
+Revises: b7a7eee5aa15
+Create Date: 2025-02-16 18:21:41.330212
+
+"""
+from alembic import op
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.enums import ConnectorCredentialPairStatus
+from sqlalchemy import update
+
+# revision identifiers, used by Alembic.
+revision = "acaab4ef4507"
+down_revision = "b7a7eee5aa15"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    op.execute(
+        update(ConnectorCredentialPair)
+        .where(ConnectorCredentialPair.status == ConnectorCredentialPairStatus.INVALID)
+        .values(status=ConnectorCredentialPairStatus.ACTIVE)
+    )

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -431,6 +431,7 @@ def connector_pruning_generator_task(
                 f"cc_pair={cc_pair_id} "
                 f"connector_source={cc_pair.connector.source}"
             )
+
             runnable_connector = instantiate_connector(
                 db_session,
                 cc_pair.connector.source,

--- a/backend/onyx/connectors/dropbox/connector.py
+++ b/backend/onyx/connectors/dropbox/connector.py
@@ -4,12 +4,16 @@ from typing import Any
 
 from dropbox import Dropbox  # type: ignore
 from dropbox.exceptions import ApiError  # type:ignore
+from dropbox.exceptions import AuthError  # type:ignore
 from dropbox.files import FileMetadata  # type:ignore
 from dropbox.files import FolderMetadata  # type:ignore
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import ConnectorValidationError
+from onyx.connectors.interfaces import CredentialInvalidError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import InsufficientPermissionsError
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
@@ -140,6 +144,29 @@ class DropboxConnector(LoadConnector, PollConnector):
             yield batch
 
         return None
+
+    def validate_connector_settings(self) -> None:
+        if self.dropbox_client is None:
+            raise ConnectorMissingCredentialError("Dropbox credentials not loaded.")
+
+        try:
+            self.dropbox_client.files_list_folder(path="", limit=1)
+        except AuthError as e:
+            logger.exception("Failed to validate Dropbox credentials")
+            raise CredentialInvalidError(f"Dropbox credential is invalid: {e.error}")
+        except ApiError as e:
+            if (
+                e.error is not None
+                and "insufficient_permissions" in str(e.error).lower()
+            ):
+                raise InsufficientPermissionsError(
+                    "Your Dropbox token does not have sufficient permissions."
+                )
+            raise ConnectorValidationError(
+                f"Unexpected Dropbox error during validation: {e.user_message_text or e}"
+            )
+        except Exception as e:
+            raise Exception(f"Unexpected error during Dropbox settings validation: {e}")
 
 
 if __name__ == "__main__":

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -12,7 +12,6 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import SlimDocument
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 
-
 SecondsSinceUnixEpoch = float
 
 GenerateDocumentsOutput = Iterator[list[Document]]
@@ -44,6 +43,14 @@ class BaseConnector(abc.ABC):
             else:
                 raise RuntimeError(custom_parser_req_msg)
         return metadata_lines
+
+    def validate_connector_settings(self) -> None:
+        """
+        Override this if your connector needs to validate credentials or settings.
+        Raise an exception if invalid, otherwise do nothing.
+
+        Default is a no-op (always successful).
+        """
 
 
 # Large set update or reindex, generally pulling a complete state or from a savestate file
@@ -139,3 +146,46 @@ class CheckpointConnector(BaseConnector):
         ```
         """
         raise NotImplementedError
+
+
+class ConnectorValidationError(Exception):
+    """General exception for connector validation errors."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)
+
+
+class UnexpectedError(Exception):
+    """Raised when an unexpected error occurs during connector validation.
+
+    Unexpected errors don't necessarily mean the credential is invalid,
+    but rather that there was an error during the validation process
+    or we encountered a currently unhandled error case.
+    """
+
+    def __init__(self, message: str = "Unexpected error during connector validation"):
+        super().__init__(message)
+
+
+class CredentialInvalidError(ConnectorValidationError):
+    """Raised when a connector's credential is invalid."""
+
+    def __init__(self, message: str = "Credential is invalid"):
+        super().__init__(message)
+
+
+class CredentialExpiredError(ConnectorValidationError):
+    """Raised when a connector's credential is expired."""
+
+    def __init__(self, message: str = "Credential has expired"):
+        super().__init__(message)
+
+
+class InsufficientPermissionsError(ConnectorValidationError):
+    """Raised when the credential does not have sufficient API permissions."""
+
+    def __init__(
+        self, message: str = "Insufficient permissions for the requested operation"
+    ):
+        super().__init__(message)

--- a/backend/onyx/connectors/onyx_jira/connector.py
+++ b/backend/onyx/connectors/onyx_jira/connector.py
@@ -12,8 +12,11 @@ from onyx.configs.app_configs import JIRA_CONNECTOR_LABELS_TO_SKIP
 from onyx.configs.app_configs import JIRA_CONNECTOR_MAX_TICKET_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.interfaces import ConnectorValidationError
+from onyx.connectors.interfaces import CredentialExpiredError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import InsufficientPermissionsError
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
@@ -271,6 +274,40 @@ class JiraConnector(LoadConnector, PollConnector, SlimConnector):
                 slim_doc_batch = []
 
         yield slim_doc_batch
+
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira")
+
+        if not self._jira_project:
+            raise ConnectorValidationError(
+                "Invalid connector settings: 'jira_project' must be provided."
+            )
+
+        try:
+            self.jira_client.project(self._jira_project)
+
+        except Exception as e:
+            status_code = getattr(e, "status_code", None)
+
+            if status_code == 401:
+                raise CredentialExpiredError(
+                    "Jira credential appears to be expired or invalid (HTTP 401)."
+                )
+            elif status_code == 403:
+                raise InsufficientPermissionsError(
+                    "Your Jira token does not have sufficient permissions for this project (HTTP 403)."
+                )
+            elif status_code == 404:
+                raise ConnectorValidationError(
+                    f"Jira project not found with key: {self._jira_project}"
+                )
+            elif status_code == 429:
+                raise ConnectorValidationError(
+                    "Validation failed due to Jira rate-limits being exceeded. Please try again later."
+                )
+            else:
+                raise Exception(f"Unexpected Jira error during validation: {e}")
 
 
 if __name__ == "__main__":

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -14,6 +14,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.google_utils.shared_constants import (
     DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY,
 )
+from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import Credential__UserGroup
@@ -244,6 +245,10 @@ def swap_credentials_connector(
     # Update the existing pair with the new credential
     existing_pair.credential_id = new_credential_id
     existing_pair.credential = new_credential
+
+    # Update ccpair status if it's in INVALID state
+    if existing_pair.status == ConnectorCredentialPairStatus.INVALID:
+        existing_pair.status = ConnectorCredentialPairStatus.ACTIVE
 
     # Commit the changes
     db_session.commit()

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -73,6 +73,7 @@ class ConnectorCredentialPairStatus(str, PyEnum):
     ACTIVE = "ACTIVE"
     PAUSED = "PAUSED"
     DELETING = "DELETING"
+    INVALID = "INVALID"
 
     def is_active(self) -> bool:
         return self == ConnectorCredentialPairStatus.ACTIVE

--- a/backend/tests/integration/common_utils/managers/connector.py
+++ b/backend/tests/integration/common_utils/managers/connector.py
@@ -30,7 +30,8 @@ class ConnectorManager:
             name=name,
             source=source,
             input_type=input_type,
-            connector_specific_config=connector_specific_config or {},
+            connector_specific_config=connector_specific_config
+            or {"file_locations": []},
             access_type=access_type,
             groups=groups or [],
         )

--- a/web/src/app/admin/configuration/search/UpgradingPage.tsx
+++ b/web/src/app/admin/configuration/search/UpgradingPage.tsx
@@ -67,12 +67,13 @@ export default function UpgradingPage({
   };
   const statusOrder: Record<ValidStatuses, number> = useMemo(
     () => ({
-      failed: 0,
-      canceled: 1,
-      completed_with_errors: 2,
-      not_started: 3,
-      in_progress: 4,
-      success: 5,
+      invalid: 0,
+      failed: 1,
+      canceled: 2,
+      completed_with_errors: 3,
+      not_started: 4,
+      in_progress: 5,
+      success: 6,
     }),
     []
   );

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexButton.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexButton.tsx
@@ -4,9 +4,14 @@ import { PopupSpec, usePopup } from "@/components/admin/connectors/Popup";
 import { Button } from "@/components/ui/button";
 import Text from "@/components/ui/text";
 import { triggerIndexing } from "./lib";
+import { mutate } from "swr";
+import { buildCCPairInfoUrl, getTooltipMessage } from "./lib";
 import { useState } from "react";
 import { Modal } from "@/components/Modal";
 import { Separator } from "@/components/ui/separator";
+import { ConnectorCredentialPairStatus } from "./types";
+import { CCPairStatus } from "@/components/Status";
+import { getCCPairStatusMessage } from "@/lib/ccPair";
 
 function ReIndexPopup({
   connectorId,
@@ -83,16 +88,16 @@ export function ReIndexButton({
   ccPairId,
   connectorId,
   credentialId,
-  isDisabled,
   isIndexing,
-  isDeleting,
+  isDisabled,
+  ccPairStatus,
 }: {
   ccPairId: number;
   connectorId: number;
   credentialId: number;
-  isDisabled: boolean;
   isIndexing: boolean;
-  isDeleting: boolean;
+  isDisabled: boolean;
+  ccPairStatus: ConnectorCredentialPairStatus;
 }) {
   const { popup, setPopup } = usePopup();
   const [reIndexPopupVisible, setReIndexPopupVisible] = useState(false);
@@ -115,18 +120,14 @@ export function ReIndexButton({
         onClick={() => {
           setReIndexPopupVisible(true);
         }}
-        disabled={isDisabled || isDeleting}
-        tooltip={
-          isDeleting
-            ? "Cannot index while connector is deleting"
-            : isIndexing
-              ? "Indexing is already in progress"
-              : isDisabled
-                ? "Connector must be re-enabled before indexing"
-                : undefined
+        disabled={
+          isDisabled ||
+          ccPairStatus == ConnectorCredentialPairStatus.DELETING ||
+          ccPairStatus == ConnectorCredentialPairStatus.PAUSED
         }
+        tooltip={getCCPairStatusMessage(isDisabled, isIndexing, ccPairStatus)}
       >
-        Index
+        Re-Index
       </Button>
     </>
   );

--- a/web/src/app/admin/connector/[ccPairId]/lib.ts
+++ b/web/src/app/admin/connector/[ccPairId]/lib.ts
@@ -40,3 +40,24 @@ export async function triggerIndexing(
   }
   mutate(buildCCPairInfoUrl(ccPairId));
 }
+
+export function getTooltipMessage(
+  isInvalid: boolean,
+  isDeleting: boolean,
+  isIndexing: boolean,
+  isDisabled: boolean
+): string | undefined {
+  if (isInvalid) {
+    return "Connector is in an invalid state. Please update the credentials or configuration before re-indexing.";
+  }
+  if (isDeleting) {
+    return "Cannot index while connector is deleting";
+  }
+  if (isIndexing) {
+    return "Indexing is already in progress";
+  }
+  if (isDisabled) {
+    return "Connector must be re-enabled before indexing";
+  }
+  return undefined;
+}

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -43,6 +43,7 @@ import IndexAttemptErrorsModal from "./IndexAttemptErrorsModal";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
 import { IndexAttemptSnapshot } from "@/lib/types";
 import { Spinner } from "@/components/Spinner";
+import { Callout } from "@/components/ui/callout";
 
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
@@ -363,6 +364,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
           <div className="ml-auto flex gap-x-2">
             <ReIndexButton
               ccPairId={ccPair.id}
+              ccPairStatus={ccPair.status}
               connectorId={ccPair.connector.id}
               credentialId={ccPair.credential.id}
               isDisabled={
@@ -370,7 +372,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
                 ccPair.status === ConnectorCredentialPairStatus.PAUSED
               }
               isIndexing={ccPair.indexing}
-              isDeleting={isDeleting}
             />
 
             {!isDeleting && <ModifyStatusButtonCluster ccPair={ccPair} />}
@@ -379,8 +380,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
       </div>
       <CCPairStatus
         status={ccPair.last_index_attempt_status || "not_started"}
-        disabled={ccPair.status === ConnectorCredentialPairStatus.PAUSED}
-        isDeleting={isDeleting}
+        ccPairStatus={ccPair.status}
       />
       <div className="text-sm mt-1">
         Creator:{" "}
@@ -424,6 +424,16 @@ function Main({ ccPairId }: { ccPairId: number }) {
             />
           </>
         )}
+
+      {ccPair.status === ConnectorCredentialPairStatus.INVALID && (
+        <div className="mt-2">
+          <Callout type="warning" title="Invalid Connector State">
+            This connector is in an invalid state. Please update your
+            credentials or create a new connector before re-indexing.
+          </Callout>
+        </div>
+      )}
+
       <Separator />
       <ConfigDisplay
         connectorSpecificConfig={ccPair.connector.connector_specific_config}

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -12,6 +12,7 @@ export enum ConnectorCredentialPairStatus {
   ACTIVE = "ACTIVE",
   PAUSED = "PAUSED",
   DELETING = "DELETING",
+  INVALID = "INVALID",
 }
 
 export interface CCPairFullInfo {

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -418,7 +418,7 @@ export default function AddConnector({
           } else {
             const errorData = await linkCredentialResponse.json();
             setPopup({
-              message: errorData.message,
+              message: errorData.message || errorData.detail,
               type: "error",
             });
           }

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -159,6 +159,19 @@ function ConnectorRow({
           Paused
         </Badge>
       );
+    } else if (
+      ccPairsIndexingStatus.cc_pair_status ===
+      ConnectorCredentialPairStatus.INVALID
+    ) {
+      return (
+        <Badge
+          tooltip="Connector is in an invalid state. Please update the credentials or create a new connector."
+          circle
+          variant="invalid"
+        >
+          Invalid
+        </Badge>
+      );
     }
 
     // ACTIVE case

--- a/web/src/components/HoverPopup.tsx
+++ b/web/src/components/HoverPopup.tsx
@@ -8,58 +8,32 @@ interface HoverPopupProps {
   style?: "basic" | "dark";
 }
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 export const HoverPopup = ({
   mainContent,
   popupContent,
   classNameModifications,
   direction = "bottom",
-  style = "basic",
 }: HoverPopupProps) => {
-  const [hovered, setHovered] = useState(false);
-
-  let popupDirectionClass;
-  let popupStyle = {};
-  switch (direction) {
-    case "left":
-      popupDirectionClass = "top-0 left-0 transform";
-      popupStyle = { transform: "translateX(calc(-100% - 5px))" };
-      break;
-    case "left-top":
-      popupDirectionClass = "bottom-0 left-0";
-      popupStyle = { transform: "translate(calc(-100% - 5px), 0)" };
-      break;
-    case "bottom":
-      popupDirectionClass = "top-0 left-0 mt-6 pt-2";
-      break;
-    case "top":
-      popupDirectionClass = "top-0 left-0 translate-y-[-100%] pb-2";
-      break;
-  }
-
   return (
-    <div
-      className="relative flex"
-      onMouseEnter={() => {
-        setHovered(true);
-      }}
-      onMouseLeave={() => setHovered(false)}
-    >
-      {hovered && (
-        <div
-          className={`absolute ${popupDirectionClass} z-30`}
-          style={popupStyle}
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div>{mainContent}</div>
+        </TooltipTrigger>
+        <TooltipContent
+          side={direction === "left-top" ? "left" : direction}
+          className={classNameModifications}
         >
-          <div
-            className={
-              `px-3 py-2 rounded bg-background border border-border` +
-              (classNameModifications || "")
-            }
-          >
-            {popupContent}
-          </div>
-        </div>
-      )}
-      <div>{mainContent}</div>
-    </div>
+          {popupContent}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -10,6 +10,7 @@ import {
   FiPauseCircle,
 } from "react-icons/fi";
 import { HoverPopup } from "./HoverPopup";
+import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
 
 export function IndexAttemptStatus({
   status,
@@ -70,6 +71,12 @@ export function IndexAttemptStatus({
         Canceled
       </Badge>
     );
+  } else if (status === "invalid") {
+    badge = (
+      <Badge variant="invalid" icon={FiAlertTriangle}>
+        Invalid
+      </Badge>
+    );
   } else {
     badge = (
       <Badge variant="outline" icon={FiMinus}>
@@ -83,27 +90,31 @@ export function IndexAttemptStatus({
 
 export function CCPairStatus({
   status,
-  disabled,
-  isDeleting,
+  ccPairStatus,
   size = "md",
 }: {
   status: ValidStatuses;
-  disabled: boolean;
-  isDeleting: boolean;
+  ccPairStatus: ConnectorCredentialPairStatus;
   size?: "xs" | "sm" | "md" | "lg";
 }) {
   let badge;
 
-  if (isDeleting) {
+  if (ccPairStatus == ConnectorCredentialPairStatus.DELETING) {
     badge = (
       <Badge variant="destructive" icon={FiAlertTriangle}>
         Deleting
       </Badge>
     );
-  } else if (disabled) {
+  } else if (ccPairStatus == ConnectorCredentialPairStatus.PAUSED) {
     badge = (
       <Badge variant="paused" icon={FiPauseCircle}>
         Paused
+      </Badge>
+    );
+  } else if (ccPairStatus == ConnectorCredentialPairStatus.INVALID) {
+    badge = (
+      <Badge variant="invalid" icon={FiAlertTriangle}>
+        Invalid
       </Badge>
     );
   } else if (status === "failed") {

--- a/web/src/components/credentials/CredentialSection.tsx
+++ b/web/src/components/credentials/CredentialSection.tsx
@@ -79,14 +79,24 @@ export default function CredentialSection({
     selectedCredential: Credential<any>,
     connectorId: number
   ) => {
-    await swapCredential(selectedCredential.id, connectorId);
-    mutate(buildSimilarCredentialInfoURL(sourceType));
-    refresh();
+    const response = await swapCredential(selectedCredential.id, connectorId);
+    if (response.ok) {
+      mutate(buildSimilarCredentialInfoURL(sourceType));
+      refresh();
 
-    setPopup({
-      message: "Swapped credential succesfully!",
-      type: "success",
-    });
+      setPopup({
+        message: "Swapped credential successfully!",
+        type: "success",
+      });
+    } else {
+      const errorData = await response.json();
+      setPopup({
+        message: `Issue swapping credential: ${
+          errorData.detail || errorData.message || "Unknown error"
+        }`,
+        type: "error",
+      });
+    }
   };
 
   const onUpdateCredential = async (

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
@@ -8,6 +13,8 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
+        invalid:
+          "border-orange-200 bg-orange-50 text-orange-600 dark:border-orange-700 dark:bg-orange-900 dark:text-orange-50",
         outline:
           "border-neutral-200 bg-neutral-50 text-neutral-600 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-50",
         purple:
@@ -57,11 +64,13 @@ function Badge({
   icon: Icon,
   size = "sm",
   circle,
+  tooltip,
   ...props
 }: BadgeProps & {
   icon?: React.ElementType;
   size?: "sm" | "md" | "xs";
   circle?: boolean;
+  tooltip?: string;
 }) {
   const sizeClasses = {
     sm: "px-2.5 py-0.5 text-xs",
@@ -69,7 +78,7 @@ function Badge({
     xs: "px-1.5 py-0.25 text-[.5rem]",
   };
 
-  return (
+  const BadgeContent = (
     <div
       className={cn(
         "flex-none inline-flex items-center whitespace-nowrap overflow-hidden",
@@ -98,6 +107,21 @@ function Badge({
       <span className="truncate">{props.children}</span>
     </div>
   );
+
+  if (tooltip) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{BadgeContent}</TooltipTrigger>
+          <TooltipContent>
+            <p>{tooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return BadgeContent;
 }
 
 export { Badge, badgeVariants };

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -88,7 +88,6 @@ export interface ButtonProps
   tooltip?: string;
   reverse?: boolean;
 }
-
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
@@ -124,7 +123,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       return (
         <TooltipProvider>
           <Tooltip>
-            <TooltipTrigger asChild>{button}</TooltipTrigger>
+            <TooltipTrigger>
+              <div>{button}</div>
+            </TooltipTrigger>
             <TooltipContent showTick={true}>
               <p>{tooltip}</p>
             </TooltipContent>

--- a/web/src/lib/ccPair.ts
+++ b/web/src/lib/ccPair.ts
@@ -46,3 +46,23 @@ export async function setCCPairStatus(
       });
   }
 }
+
+export const getCCPairStatusMessage = (
+  isDisabled: boolean,
+  isIndexing: boolean,
+  ccPairStatus: ConnectorCredentialPairStatus
+) => {
+  if (ccPairStatus === ConnectorCredentialPairStatus.INVALID) {
+    return "Connector is in an invalid state. Please update the credentials or configuration before re-indexing.";
+  }
+  if (ccPairStatus === ConnectorCredentialPairStatus.DELETING) {
+    return "Cannot index while connector is deleting";
+  }
+  if (isIndexing) {
+    return "Indexing is already in progress";
+  }
+  if (isDisabled) {
+    return "Connector must be re-enabled before indexing";
+  }
+  return undefined;
+};

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -98,6 +98,7 @@ export type ValidInputTypes =
   | "event"
   | "slim_retrieval";
 export type ValidStatuses =
+  | "invalid"
   | "success"
   | "completed_with_errors"
   | "canceled"


### PR DESCRIPTION
## Description

Adds connector validation for ccpair creation / credential swapping.

New enum for ccpair status: `invalid`- marks ccpairs which have an invalid configuaiton

https://github.com/user-attachments/assets/50b80ccb-e2e8-4648-ae0c-6b27fea31edd



## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
