### PR TITLE
Content of .xlsl are not properly read during indexing.

### DIFF
--- a/backend/onyx/connectors/google_drive/models.py
+++ b/backend/onyx/connectors/google_drive/models.py
@@ -5,6 +5,10 @@ from typing import Any
 class GDriveMimeType(str, Enum):
     DOC = "application/vnd.google-apps.document"
     SPREADSHEET = "application/vnd.google-apps.spreadsheet"
+    SPREADSHEET_OPEN_FORMAT = (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    SPREADSHEET_MS_EXCEL = "application/vnd.ms-excel"
     PDF = "application/pdf"
     WORD_DOC = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     PPT = "application/vnd.google-apps.presentation"


### PR DESCRIPTION
## Description
Problem:
Based on the Slack thread: https://onyx-dot-app.slack.com/archives/C056265VB1N/p1739853716830199?thread_ts=1733379700.624259&cid=C056265VB1N
Spreadsheets that are uploaded to Google Drive (which get a MIME of `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`) end up having empty content, resulting inaccurate search results.
Solution:
Download the file and use pandas to extract the data and apply the same transforms as if it is a `application/vnd.google-apps.spreadsheet`.


## How Has This Been Tested?
Smoke tested the following and all passed.

- Created a Google Drive connector for a specific folder with a mix of `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` and  `application/vnd.google-apps.spreadsheet` files which was then connected to a bot and it correctly performed search.
- Updated the test `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` file and verified the search results were uptodate when `Run Update` as well as `Run complete re-indexing` were performed. 
