### PR TITLE
Adjust behavior when display_model_names is null

### DIFF
--- a/web/src/app/chat/input/LLMPopover.tsx
+++ b/web/src/app/chat/input/LLMPopover.tsx
@@ -5,7 +5,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ChatInputOption } from "./ChatInputOption";
-import { defaultModelsByProvider, getDisplayNameForModel } from "@/lib/hooks";
+import { getDisplayNameForModel } from "@/lib/hooks";
 import {
   checkLLMSupportsImageInput,
   destructureValue,
@@ -61,23 +61,22 @@ export default function LLMPopover({
       llmOptionsByProvider[llmProvider.provider] = [];
     }
 
-    (
-      llmProvider.display_model_names ||
-      defaultModelsByProvider[llmProvider.provider]
-    ).forEach((modelName) => {
-      if (!uniqueModelNames.has(modelName)) {
-        uniqueModelNames.add(modelName);
-        llmOptionsByProvider[llmProvider.provider].push({
-          name: modelName,
-          value: structureValue(
-            llmProvider.name,
-            llmProvider.provider,
-            modelName
-          ),
-          icon: getProviderIcon(llmProvider.provider, modelName),
-        });
+    (llmProvider.display_model_names || llmProvider.model_names).forEach(
+      (modelName) => {
+        if (!uniqueModelNames.has(modelName)) {
+          uniqueModelNames.add(modelName);
+          llmOptionsByProvider[llmProvider.provider].push({
+            name: modelName,
+            value: structureValue(
+              llmProvider.name,
+              llmProvider.provider,
+              modelName
+            ),
+            icon: getProviderIcon(llmProvider.provider, modelName),
+          });
+        }
       }
-    });
+    );
   });
 
   const llmOptions = Object.entries(llmOptionsByProvider).flatMap(


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

Tested locally, behavior is the same for standard use cases.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
