### PR TITLE
Agent search history displayed answer

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -190,7 +190,8 @@ def create_chat_chain(
             and previous_message.message_type == MessageType.ASSISTANT
             and mainline_messages
         ):
-            mainline_messages[-1] = current_message
+            if current_message.refined_answer_improvement:
+                mainline_messages[-1] = current_message
         else:
             mainline_messages.append(current_message)
 

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -142,6 +142,15 @@ class MessageResponseIDInfo(BaseModel):
     reserved_assistant_message_id: int
 
 
+class AgentMessageIDInfo(BaseModel):
+    level: int
+    message_id: int
+
+
+class AgenticMessageResponseIDInfo(BaseModel):
+    agentic_message_ids: list[AgentMessageIDInfo]
+
+
 class StreamingError(BaseModel):
     error: str
     stack_trace: str | None = None

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -23,6 +23,7 @@ class PreviousMessage(BaseModel):
     message_type: MessageType
     files: list[InMemoryChatFile]
     tool_call: ToolCallFinalResult | None
+    refined_answer_improvement: bool | None
 
     @classmethod
     def from_chat_message(
@@ -47,6 +48,7 @@ class PreviousMessage(BaseModel):
             )
             if chat_message.tool_call
             else None,
+            refined_answer_improvement=chat_message.refined_answer_improvement,
         )
 
     def to_langchain_msg(self) -> BaseMessage:

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -23,6 +23,7 @@ import {
   SubQuestionDetail,
   constructSubQuestions,
   DocumentsResponse,
+  AgenticMessageResponseIDInfo,
 } from "./interfaces";
 
 import Prism from "prismjs";
@@ -1420,11 +1421,8 @@ export function ChatPage({
           } else {
             const { user_message_id, frozenMessageMap } = initialFetchDetails;
             if (Object.hasOwn(packet, "agentic_message_ids")) {
-              const agenticMessageIds = (
-                packet as unknown as any as {
-                  agentic_message_ids: { level: number; message_id: number }[];
-                }
-              ).agentic_message_ids;
+              const agenticMessageIds = (packet as AgenticMessageResponseIDInfo)
+                .agentic_message_ids;
               const level1MessageId = agenticMessageIds.find(
                 (item) => item.level === 1
               )?.message_id;

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -2875,11 +2875,7 @@ export function ChatPage({
                                           currentAlternativeAssistant
                                         }
                                         messageId={message.messageId}
-                                        content={
-                                          message.message +
-                                          " " +
-                                          message.messageId
-                                        }
+                                        content={message.message}
                                         files={message.files}
                                         query={
                                           messageHistory[i]?.query || undefined

--- a/web/src/app/chat/interfaces.ts
+++ b/web/src/app/chat/interfaces.ts
@@ -155,6 +155,15 @@ export interface MessageResponseIDInfo {
   reserved_assistant_message_id: number;
 }
 
+export interface AgentMessageIDInfo {
+  level: number;
+  message_id: number;
+}
+
+export interface AgenticMessageResponseIDInfo {
+  agentic_message_ids: AgentMessageIDInfo[];
+}
+
 export interface DocumentsResponse {
   top_documents: OnyxDocument[];
   rephrased_query: string | null;

--- a/web/src/app/chat/lib.tsx
+++ b/web/src/app/chat/lib.tsx
@@ -25,6 +25,7 @@ import {
   RetrievalType,
   StreamingError,
   ToolCallMetadata,
+  AgenticMessageResponseIDInfo,
 } from "./interfaces";
 import { Persona } from "../admin/assistants/interfaces";
 import { ReadonlyURLSearchParams } from "next/navigation";
@@ -154,7 +155,8 @@ export type PacketType =
   | AgentAnswerPiece
   | SubQuestionPiece
   | ExtendedToolResponse
-  | RefinedAnswerImprovement;
+  | RefinedAnswerImprovement
+  | AgenticMessageResponseIDInfo;
 
 export async function* sendMessage({
   regenerate,


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1464/use-refined-answer-if-improvement-in-history-in-agent-search

Use the refined answer as message history when it is better, otherwise stick with the original answer

## How Has This Been Tested?

to be tested by joachim

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
