### PR TITLE
Add Missing Date and Message-ID Headers to Ensure Email Delivery (Fix #4066)

### DIFF
--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -2,6 +2,7 @@ import smtplib
 from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate, make_msgid
 
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.app_configs import EMAIL_FROM
@@ -152,6 +153,8 @@ def send_email(
     msg["To"] = user_email
     if mail_from:
         msg["From"] = mail_from
+    msg["Date"] = formatdate(localtime=True)
+    msg["Message-ID"] = make_msgid()
 
     part_text = MIMEText(text_body, "plain")
     part_html = MIMEText(html_body, "html")


### PR DESCRIPTION
**Summary**

This PR fixes the issue where emails sent through send_email() were not being delivered due to missing required headers. Adding the Date and Message-ID headers ensures proper email metadata, preventing certain email providers (e.g., Gmail) from rejecting or discarding emails.

**Fix Implemented**

Imported formatdate and make_msgid from email.utils
Added:
```
msg["Date"] = formatdate(localtime=True)
msg["Message-ID"] = make_msgid()
```
to ensure emails have the required headers.

**Related Issue**

Closes #4066

**Testing**

✅ Verified emails are now delivered correctly.
✅ Checked SMTP debug logs (set_debuglevel(1)) and confirmed correct email metadata.
✅ Ensured emails arrive in both inbox and spam folder across different email providers.