### PR TITLE
don't spam the logs with texts on auth errors

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -97,12 +97,22 @@ class CloudEmbedding:
                 )
             return final_embeddings
         except Exception as e:
-            error_string = (
-                f"Error embedding text with OpenAI: {str(e)} \n"
-                f"Model: {model} \n"
-                f"Provider: {self.provider} \n"
-                f"Texts: {texts}"
-            )
+            if isinstance(e, openai.AuthenticationError):
+                # Don't log text on authentication errors
+                error_string = (
+                    f"Exception embedding text with OpenAI - openai.AuthenticationError: "
+                    f"Model: {model} "
+                    f"Provider: {self.provider} "
+                    f"Exception: {e}"
+                )
+            else:
+                error_string = (
+                    f"Exception embedding text with OpenAI:"
+                    f"Model: {model} \n"
+                    f"Provider: {self.provider} \n"
+                    f"Exception: {e} \n"
+                    f"Texts: {texts}"
+                )
             logger.error(error_string)
             raise RuntimeError(error_string)
 

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -97,23 +97,18 @@ class CloudEmbedding:
                 )
             return final_embeddings
         except Exception as e:
-            if isinstance(e, openai.AuthenticationError):
-                # Don't log text on authentication errors
-                error_string = (
-                    f"Exception embedding text with OpenAI - openai.AuthenticationError: "
-                    f"Model: {model} "
-                    f"Provider: {self.provider} "
-                    f"Exception: {e}"
-                )
-            else:
-                error_string = (
-                    f"Exception embedding text with OpenAI:"
-                    f"Model: {model} \n"
-                    f"Provider: {self.provider} \n"
-                    f"Exception: {e} \n"
-                    f"Texts: {texts}"
-                )
+            error_string = (
+                f"Exception embedding text with OpenAI - {type(e)}: "
+                f"Model: {model} "
+                f"Provider: {self.provider} "
+                f"Exception: {e}"
+            )
             logger.error(error_string)
+
+            # only log text when it's not an authentication error.
+            if not isinstance(e, openai.AuthenticationError):
+                logger.debug(f"Exception texts: {texts}")
+
             raise RuntimeError(error_string)
 
     async def _embed_cohere(


### PR DESCRIPTION
## Description

Fixes DAN-1478.
https://linear.app/danswer/issue/DAN-1478/dont-spam-the-logs-with-embedding-text-when-we-get-auth-errors-to-a

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
