### PR TITLE
make Settings model match db

### DIFF
--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -47,8 +47,8 @@ class Settings(BaseModel):
     anonymous_user_enabled: bool | None = None
     pro_search_enabled: bool | None = None
 
-    temperature_override_enabled: bool = False
-    auto_scroll: bool = False
+    temperature_override_enabled: bool | None = False
+    auto_scroll: bool | None = False
 
 
 class UserSettings(Settings):


### PR DESCRIPTION
## Description

Backend errors causing misconfigured message due to newly nullable settings being loaded into pydantic models without matching None type as a possibility

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
