### PR TITLE
Fix starter message editing

### DIFF
--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -113,7 +113,6 @@ export function AssistantEditor({
   documentSets,
   user,
   defaultPublic,
-  redirectType,
   llmProviders,
   tools,
   shouldAddAssistantToUserPreferences,
@@ -124,7 +123,6 @@ export function AssistantEditor({
   documentSets: DocumentSet[];
   user: User | null;
   defaultPublic: boolean;
-  redirectType: SuccessfulPersonaUpdateRedirectType;
   llmProviders: FullLLMProvider[];
   tools: ToolSnapshot[];
   shouldAddAssistantToUserPreferences?: boolean;
@@ -502,7 +500,7 @@ export function AssistantEditor({
             )
             .map((message: { message: string; name?: string }) => ({
               message: message.message,
-              name: message.name || message.message,
+              name: message.message,
             }));
 
           // don't set groups if marked as public

--- a/web/src/app/assistants/edit/[id]/page.tsx
+++ b/web/src/app/assistants/edit/[id]/page.tsx
@@ -21,11 +21,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         <div className="px-32">
           <div className="mx-auto container">
             <CardSection className="!border-none !bg-transparent !ring-none">
-              <AssistantEditor
-                {...values}
-                defaultPublic={false}
-                redirectType={SuccessfulPersonaUpdateRedirectType.CHAT}
-              />
+              <AssistantEditor {...values} defaultPublic={false} />
             </CardSection>
           </div>
         </div>

--- a/web/src/app/assistants/new/page.tsx
+++ b/web/src/app/assistants/new/page.tsx
@@ -26,7 +26,6 @@ export default async function Page() {
               <AssistantEditor
                 {...values}
                 defaultPublic={false}
-                redirectType={SuccessfulPersonaUpdateRedirectType.CHAT}
                 shouldAddAssistantToUserPreferences={true}
               />
             </CardSection>


### PR DESCRIPTION
## Description

We expose name / message as a single value for end-users (built in starter messages can modify both). Currently, updated message doesn't update name– should both have same value.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
