### PR TITLE
Stuck job monitoring for perm sync, pruning, and deletion

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -27,10 +27,8 @@ from onyx.document_index.vespa.shared_utils.utils import wait_for_vespa_with_tim
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_credential_pair import RedisConnectorCredentialPair
-from onyx.redis.redis_connector_delete import RedisConnectorDelete
 from onyx.redis.redis_connector_doc_perm_sync import RedisConnectorPermissionSync
 from onyx.redis.redis_connector_ext_group_sync import RedisConnectorExternalGroupSync
-from onyx.redis.redis_connector_prune import RedisConnectorPrune
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import get_shared_redis_client
@@ -160,17 +158,17 @@ def on_task_postrun(
             r.srem(rug.taskset_key, task_id)
         return
 
-    if task_id.startswith(RedisConnectorDelete.PREFIX):
-        cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
-        if cc_pair_id is not None:
-            RedisConnectorDelete.remove_from_taskset(int(cc_pair_id), task_id, r)
-        return
+    # if task_id.startswith(RedisConnectorDelete.PREFIX):
+    #     cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
+    #     if cc_pair_id is not None:
+    #         RedisConnectorDelete.remove_from_taskset(int(cc_pair_id), task_id, r)
+    #     return
 
-    if task_id.startswith(RedisConnectorPrune.SUBTASK_PREFIX):
-        cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
-        if cc_pair_id is not None:
-            RedisConnectorPrune.remove_from_taskset(int(cc_pair_id), task_id, r)
-        return
+    # if task_id.startswith(RedisConnectorPrune.SUBTASK_PREFIX):
+    #     cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
+    #     if cc_pair_id is not None:
+    #         RedisConnectorPrune.remove_from_taskset(int(cc_pair_id), task_id, r)
+    #     return
 
     if task_id.startswith(RedisConnectorPermissionSync.SUBTASK_PREFIX):
         cc_pair_id = RedisConnector.get_id_from_task_id(task_id)

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -27,8 +27,10 @@ from onyx.document_index.vespa.shared_utils.utils import wait_for_vespa_with_tim
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_credential_pair import RedisConnectorCredentialPair
+from onyx.redis.redis_connector_delete import RedisConnectorDelete
 from onyx.redis.redis_connector_doc_perm_sync import RedisConnectorPermissionSync
 from onyx.redis.redis_connector_ext_group_sync import RedisConnectorExternalGroupSync
+from onyx.redis.redis_connector_prune import RedisConnectorPrune
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import get_shared_redis_client
@@ -158,17 +160,17 @@ def on_task_postrun(
             r.srem(rug.taskset_key, task_id)
         return
 
-    # if task_id.startswith(RedisConnectorDelete.PREFIX):
-    #     cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
-    #     if cc_pair_id is not None:
-    #         RedisConnectorDelete.remove_from_taskset(int(cc_pair_id), task_id, r)
-    #     return
+    if task_id.startswith(RedisConnectorDelete.PREFIX):
+        cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
+        if cc_pair_id is not None:
+            RedisConnectorDelete.remove_from_taskset(int(cc_pair_id), task_id, r)
+        return
 
-    # if task_id.startswith(RedisConnectorPrune.SUBTASK_PREFIX):
-    #     cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
-    #     if cc_pair_id is not None:
-    #         RedisConnectorPrune.remove_from_taskset(int(cc_pair_id), task_id, r)
-    #     return
+    if task_id.startswith(RedisConnectorPrune.SUBTASK_PREFIX):
+        cc_pair_id = RedisConnector.get_id_from_task_id(task_id)
+        if cc_pair_id is not None:
+            RedisConnectorPrune.remove_from_taskset(int(cc_pair_id), task_id, r)
+        return
 
     if task_id.startswith(RedisConnectorPermissionSync.SUBTASK_PREFIX):
         cc_pair_id = RedisConnector.get_id_from_task_id(task_id)

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -307,6 +307,9 @@ def monitor_connector_deletion_taskset(
                 # NOTE(rkuo): if this happens, documents somehow got added while
                 # deletion was in progress. Likely a bug gating off pruning and indexing
                 # work before deletion starts.
+                # This may also happen if a subtask `DOCUMENT_BY_CC_PAIR_CLEANUP_TASK` does not successfully complete
+                # but we clear the fence after a timeout.
+                # In this case, we will re-attempt deletion of the remaining documents.
                 task_logger.warning(
                     "Connector deletion - documents still found after taskset completion. "
                     "Clearing the current deletion attempt and allowing deletion to restart: "

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -271,6 +271,7 @@ def monitor_connector_deletion_taskset(
     if fence_data.num_tasks is None:
         # the fence is setting up but isn't ready yet
         return
+    redis_connector.delete.detect_stuck_subtasks(cc_pair_id, r)
 
     remaining = redis_connector.delete.get_remaining()
     task_logger.info(

--- a/backend/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -812,6 +812,9 @@ def monitor_ccpair_permissions_taskset(
     if not payload:
         return
 
+    # Check for stuck subtasks
+    redis_connector.permissions.detect_stuck_subtasks(cc_pair_id, r)
+
     remaining = redis_connector.permissions.get_remaining()
     task_logger.info(
         f"Permissions sync progress: "

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -532,6 +532,9 @@ def monitor_ccpair_pruning_taskset(
     if initial is None:
         return
 
+    # Check for stuck subtasks
+    redis_connector.prune.detect_stuck_subtasks(cc_pair_id, r)
+
     remaining = redis_connector.prune.get_remaining()
     task_logger.info(
         f"Connector pruning progress: cc_pair={cc_pair_id} remaining={remaining} initial={initial}"

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -18,6 +18,7 @@ from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.connector_credential_pair import get_connector_credential_pair
 from onyx.db.document import delete_document_by_connector_credential_pair__no_commit
 from onyx.db.document import delete_documents_complete__no_commit
 from onyx.db.document import fetch_chunk_count_for_document
@@ -25,6 +26,13 @@ from onyx.db.document import get_document
 from onyx.db.document import get_document_connector_count
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
+from onyx.db.document_external_access import batch_add_ext_perm_user_if_not_exists
+from onyx.db.document_external_access import DocExternalAccess
+from onyx.db.document_external_access import DocumentSource
+from onyx.db.document_external_access import (
+    upsert_document_by_connector_credential_pair,
+)
+from onyx.db.document_external_access import upsert_document_external_perms
 from onyx.db.document_set import fetch_document_sets_for_document
 from onyx.db.engine import get_all_tenant_ids
 from onyx.db.engine import get_session_with_current_tenant
@@ -32,6 +40,8 @@ from onyx.db.search_settings import get_active_search_settings
 from onyx.document_index.factory import get_default_document_index
 from onyx.document_index.interfaces import VespaDocumentFields
 from onyx.httpx.httpx_pool import HttpxPool
+from onyx.redis.redis_connector_permission_sync import RedisConnectorPermissionSync
+from onyx.redis.redis_connector_prune import RedisConnectorPrune
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
@@ -43,6 +53,8 @@ DOCUMENT_BY_CC_PAIR_CLEANUP_MAX_RETRIES = 3
 # 5 seconds more than RetryDocumentIndex STOP_AFTER+MAX_WAIT
 LIGHT_SOFT_TIME_LIMIT = 105
 LIGHT_TIME_LIMIT = LIGHT_SOFT_TIME_LIMIT + 15
+
+DOCUMENT_PERMISSIONS_UPDATE_MAX_RETRIES = 3
 
 
 @shared_task(
@@ -80,6 +92,25 @@ def document_by_cc_pair_cleanup_task(
 
     try:
         with get_session_with_current_tenant() as db_session:
+            cc_pair = get_connector_credential_pair(
+                db_session=db_session,
+                connector_id=connector_id,
+                credential_id=credential_id,
+            )
+            if not cc_pair:
+                task_logger.warning(
+                    f"cc_pair not found for {connector_id} {credential_id}"
+                )
+                return False
+
+            request_id = (
+                self.request.id if self.request.id is not None else "missing-task-id"
+            )
+
+            RedisConnectorPrune.update_subtask_heartbeat(
+                cc_pair.id, request_id, get_redis_client()
+            )
+
             action = "skip"
             chunks_affected = 0
 
@@ -219,6 +250,9 @@ def document_by_cc_pair_cleanup_task(
                 mark_document_as_modified(document_id, db_session)
         return False
 
+    # On completion, remove subtask ID from taskset
+    request_id = self.request.id if self.request.id is not None else "missing-task-id"
+    RedisConnectorPrune.remove_from_taskset(cc_pair.id, request_id, get_redis_client())
     return True
 
 
@@ -299,5 +333,91 @@ def cloud_beat_task_generator(
         f"task={task_name} "
         f"num_tenants={len(tenant_ids)} "
         f"elapsed={time_elapsed:.2f}"
+    )
+    return True
+
+
+@shared_task(
+    name=OnyxCeleryTask.UPDATE_EXTERNAL_DOCUMENT_PERMISSIONS_TASK,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=DOCUMENT_PERMISSIONS_UPDATE_MAX_RETRIES,
+    bind=True,
+)
+def update_external_document_permissions_task(
+    self: Task,
+    tenant_id: str | None,
+    serialized_doc_external_access: dict,
+    source_string: str,
+    connector_id: int,
+    credential_id: int,
+) -> bool:
+    start = time.monotonic()
+
+    document_external_access = DocExternalAccess.from_dict(
+        serialized_doc_external_access
+    )
+    doc_id = document_external_access.doc_id
+    external_access = document_external_access.external_access
+
+    try:
+        with get_session_with_current_tenant() as db_session:
+            cc_pair = get_connector_credential_pair(
+                db_session=db_session,
+                connector_id=connector_id,
+                credential_id=credential_id,
+            )
+            if not cc_pair:
+                task_logger.warning(
+                    f"cc_pair not found for {connector_id} {credential_id}"
+                )
+                return False
+
+            # Update heartbeat upon task start
+            RedisConnectorPermissionSync.update_subtask_heartbeat(
+                cc_pair.id, self.request.id, get_redis_client()
+            )
+
+            # Add the users to the DB if they don't exist
+            batch_add_ext_perm_user_if_not_exists(
+                db_session=db_session,
+                emails=list(external_access.external_user_emails),
+                continue_on_error=True,
+            )
+            # Then upsert the document's external permissions
+            created_new_doc = upsert_document_external_perms(
+                db_session=db_session,
+                doc_id=doc_id,
+                external_access=external_access,
+                source_type=DocumentSource(source_string),
+            )
+
+            if created_new_doc:
+                # If a new document was created, we associate it with the cc_pair
+                upsert_document_by_connector_credential_pair(
+                    db_session=db_session,
+                    connector_id=connector_id,
+                    credential_id=credential_id,
+                    document_ids=[doc_id],
+                )
+
+            elapsed = time.monotonic() - start
+            task_logger.info(
+                f"connector_id={connector_id} "
+                f"doc={doc_id} "
+                f"action=update_permissions "
+                f"elapsed={elapsed:.2f}"
+            )
+
+    except Exception:
+        task_logger.exception(
+            f"Exception in update_external_document_permissions_task: "
+            f"connector_id={connector_id} doc_id={doc_id}"
+        )
+        return False
+
+    # On completion, remove subtask ID from taskset and creation hash
+    RedisConnectorPermissionSync.remove_from_taskset(
+        cc_pair.id, self.request.id, get_redis_client()
     )
     return True

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -62,7 +62,7 @@ def document_by_cc_pair_cleanup_task(
     document_id: str,
     connector_id: int,
     credential_id: int,
-    flow_type: str | None,
+    flow_type: str,  # "prune" or "delete"
     tenant_id: str | None,
 ) -> bool:
     """A lightweight subtask used to clean up document to cc pair relationships.

--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -18,6 +18,7 @@ from onyx.configs.constants import OnyxRedisConstants
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.document import construct_document_select_for_connector_credential_pair
 from onyx.db.models import Document as DbDocument
+from onyx.redis.redis_pool import SCAN_ITER_COUNT_DEFAULT
 
 
 class RedisConnectorDeletePayload(BaseModel):
@@ -32,6 +33,8 @@ class RedisConnectorDelete:
     PREFIX = "connectordeletion"
     FENCE_PREFIX = f"{PREFIX}_fence"  # "connectordeletion_fence"
     TASKSET_PREFIX = f"{PREFIX}_taskset"  # "connectordeletion_taskset"
+    SUBTASK_CREATION_TIMES_PREFIX = f"{PREFIX}_subtask_creation_times"
+    SUBTASK_HEARTBEAT_PREFIX = f"{PREFIX}_subtask_heartbeat"
 
     def __init__(self, tenant_id: str | None, id: int, redis: redis.Redis) -> None:
         self.tenant_id: str | None = tenant_id
@@ -40,6 +43,9 @@ class RedisConnectorDelete:
 
         self.fence_key: str = f"{self.FENCE_PREFIX}_{id}"
         self.taskset_key = f"{self.TASKSET_PREFIX}_{id}"
+
+        self.subtask_creation_times_key = f"{self.SUBTASK_CREATION_TIMES_PREFIX}_{id}"
+        self.subtask_heartbeat_prefix = f"{self.SUBTASK_HEARTBEAT_PREFIX}_{id}"
 
     def taskset_clear(self) -> None:
         self.redis.delete(self.taskset_key)
@@ -120,6 +126,11 @@ class RedisConnectorDelete:
             # note that for the moment we are using a single taskset key, not differentiated by cc_pair id
             self.redis.sadd(self.taskset_key, custom_task_id)
 
+            # Record creation time in a dedicated hash
+            self.redis.hset(
+                self.subtask_creation_times_key, custom_task_id, str(time.time())
+            )
+
             # Priority on sync's triggered by new indexing should be medium
             result = celery_app.send_task(
                 OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_CLEANUP_TASK,
@@ -127,6 +138,7 @@ class RedisConnectorDelete:
                     document_id=doc.id,
                     connector_id=cc_pair.connector_id,
                     credential_id=cc_pair.credential_id,
+                    flow_type="delete",
                     tenant_id=self.tenant_id,
                 ),
                 queue=OnyxCeleryQueues.CONNECTOR_DELETION,
@@ -147,8 +159,57 @@ class RedisConnectorDelete:
     @staticmethod
     def remove_from_taskset(id: int, task_id: str, r: redis.Redis) -> None:
         taskset_key = f"{RedisConnectorDelete.TASKSET_PREFIX}_{id}"
+        creation_times_key = (
+            f"{RedisConnectorDelete.SUBTASK_CREATION_TIMES_PREFIX}_{id}"
+        )
+
         r.srem(taskset_key, task_id)
-        return
+        r.hdel(creation_times_key, task_id)
+
+    @staticmethod
+    def update_subtask_heartbeat(id: int, task_id: str, r: redis.Redis) -> None:
+        """
+        Subtask calls this to mark 'I am alive'.
+        """
+        heartbeat_key = (
+            f"{RedisConnectorDelete.SUBTASK_HEARTBEAT_PREFIX}_{id}:{task_id}"
+        )
+        r.set(heartbeat_key, time.time(), ex=300)  # e.g. 5-min TTL
+
+    @staticmethod
+    def detect_stuck_subtasks(
+        id: int, r: redis.Redis, threshold_s: float = 600
+    ) -> None:
+        """
+        Called by monitor_connector_deletion_taskset to remove stale or never-started subtasks.
+        """
+        taskset_key = f"{RedisConnectorDelete.TASKSET_PREFIX}_{id}"
+        creation_times_key = (
+            f"{RedisConnectorDelete.SUBTASK_CREATION_TIMES_PREFIX}_{id}"
+        )
+        heartbeat_prefix = f"{RedisConnectorDelete.SUBTASK_HEARTBEAT_PREFIX}_{id}"
+
+        now = time.time()
+        for subtask_id_bytes in r.sscan_iter(
+            taskset_key, count=SCAN_ITER_COUNT_DEFAULT
+        ):
+            subtask_id = subtask_id_bytes.decode("utf-8")
+            hb_key = f"{heartbeat_prefix}:{subtask_id}"
+            last_beat = r.get(hb_key)
+
+            if last_beat:
+                # Compare times
+                if now - float(last_beat) > threshold_s:
+                    # stale
+                    r.srem(taskset_key, subtask_id)
+                    r.hdel(creation_times_key, subtask_id)
+            else:
+                # fallback to creation time
+                creation_time_raw = r.hget(creation_times_key, subtask_id)
+                if creation_time_raw:
+                    if now - float(creation_time_raw) > threshold_s:
+                        r.srem(taskset_key, subtask_id)
+                        r.hdel(creation_times_key, subtask_id)
 
     @staticmethod
     def reset_all(r: redis.Redis) -> None:

--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -202,7 +202,7 @@ class RedisConnectorDelete:
                     r.hdel(creation_times_key, subtask_id)
             else:
                 # fallback to creation time
-                creation_time_raw = r.hget(creation_times_key, subtask_id)
+                creation_time_raw = cast(bytes, r.hget(creation_times_key, subtask_id))
                 if creation_time_raw:
                     if now - float(creation_time_raw) > threshold_s:
                         r.srem(taskset_key, subtask_id)

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
-from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_PRUNING_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
@@ -251,25 +250,39 @@ class RedisConnectorPrune:
         for subtask_id_bytes in r.sscan_iter(taskset_key):
             subtask_id = subtask_id_bytes.decode("utf-8")
             heartbeat_key = f"{heartbeat_prefix}:{subtask_id}"
-            last_beat = r.get(heartbeat_key)
-            if last_beat:
-                last_beat_str = last_beat.decode("utf-8")
-                if now - float(last_beat_str) > threshold_s:
-                    r.srem(taskset_key, subtask_id)
-                    r.hdel(creation_times_key, subtask_id)
-                    task_logger.warning(
-                        f"Pruning subtask {subtask_id} stale (heartbeat > {threshold_s}s). Removed."
+            last_beat_raw = r.get(heartbeat_key)
+            if last_beat_raw is not None:
+                if isinstance(last_beat_raw, bytes):
+                    last_beat_str = last_beat_raw.decode("utf-8")
+                else:
+                    last_beat_str = str(last_beat_raw)
+
+                try:
+                    last_beat_val = float(last_beat_str)
+                    if now - last_beat_val > threshold_s:
+                        r.srem(taskset_key, subtask_id)
+                        r.hdel(creation_times_key, subtask_id)
+                except ValueError:
+                    raise ValueError(
+                        f"Failed to convert heartbeat to float: {last_beat_str}"
                     )
             else:
                 # Fallback: use creation time if no heartbeat exists
                 creation_time_raw = r.hget(creation_times_key, subtask_id)
-                if creation_time_raw:
-                    creation_time_str = creation_time_raw.decode("utf-8")
-                    if now - float(creation_time_str) > threshold_s:
-                        r.srem(taskset_key, subtask_id)
-                        r.hdel(creation_times_key, subtask_id)
-                        task_logger.warning(
-                            f"Pruning subtask {subtask_id} never heartbeated (created > {threshold_s}s). Removed."
+                if creation_time_raw is not None:
+                    if isinstance(creation_time_raw, bytes):
+                        creation_time_str = creation_time_raw.decode("utf-8")
+                    else:
+                        creation_time_str = str(creation_time_raw)
+
+                    try:
+                        creation_time_val = float(creation_time_str)
+                        if now - creation_time_val > threshold_s:
+                            r.srem(taskset_key, subtask_id)
+                            r.hdel(creation_times_key, subtask_id)
+                    except ValueError:
+                        raise ValueError(
+                            f"Failed to convert creation time to float: {creation_time_str}"
                         )
 
     @staticmethod

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -65,7 +65,9 @@ class RedisConnectorPrune:
         self.generator_progress_key = f"{self.GENERATOR_PROGRESS_PREFIX}_{id}"
         self.generator_complete_key = f"{self.GENERATOR_COMPLETE_PREFIX}_{id}"
 
-        self.taskset_key = f"{self.TASKSET_PREFIX}_{id}"
+        self.taskset_key = (
+            f"{self.TASKSET_PREFIX}_{id}"  # connectorpruning_taskset_{id}
+        )
 
         self.subtask_prefix: str = f"{self.SUBTASK_PREFIX}_{id}"
         self.active_key = f"{self.ACTIVE_PREFIX}_{id}"
@@ -203,6 +205,7 @@ class RedisConnectorPrune:
                     document_id=doc_id,
                     connector_id=cc_pair.connector_id,
                     credential_id=cc_pair.credential_id,
+                    flow_type="prune",
                     tenant_id=self.tenant_id,
                 ),
                 queue=OnyxCeleryQueues.CONNECTOR_DELETION,


### PR DESCRIPTION
## Description

Helps account for OOMkilled and random process shutdowns.


• Task Tracking:
  - Records start times in Redis (e.g. `self.redis.hset(..., time.time())`)
  - Updates heartbeats during execution (`RedisConnectorPrune.update_subtask_heartbeat(...)`)

• Stuck Task Detection:
  - Implements `detect_stuck_subtasks` for various operations
  - Removes stale subtask IDs based on time thresholds

Update monitoring (e.g. `monitor_ccpair_pruning_taskset` to check for stuck tasks using above info)

• Time Management:
  - Sets TTLs (e.g., 5 minutes for heartbeats, 10 minutes for stuck detection)


## How Has This Been Tested?

- Force subtasks to die, observe the fence being removed after death + timing out

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
