### PR TITLE
Improve viewable assistant logic

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -101,11 +101,7 @@ def _add_user_filters(
         )
     else:
         # Group the public persona conditions
-        public_condition = (
-            Persona.is_public
-            == True & Persona.is_visible  # noqa: E712
-            == True  # noqa: E712
-        )
+        public_condition = Persona.is_public == True & Persona.is_visible  # noqa: E712
 
         where_clause |= public_condition
         where_clause |= Persona__User.user_id == user.id

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -100,9 +100,16 @@ def _add_user_filters(
             .correlate(Persona)
         )
     else:
-        where_clause |= Persona.is_public == True  # noqa: E712
-        where_clause &= Persona.is_visible == True  # noqa: E712
+        # Group the public persona conditions
+        public_condition = (
+            Persona.is_public
+            == True & Persona.is_visible  # noqa: E712
+            == True  # noqa: E712
+        )
+
+        where_clause |= public_condition
         where_clause |= Persona__User.user_id == user.id
+
     where_clause |= Persona.user_id == user.id
 
     return stmt.where(where_clause)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -101,7 +101,9 @@ def _add_user_filters(
         )
     else:
         # Group the public persona conditions
-        public_condition = Persona.is_public == True & Persona.is_visible  # noqa: E712
+        public_condition = (Persona.is_public == True) & (  # noqa: E712
+            Persona.is_visible == True  # noqa: E712
+        )
 
         where_clause |= public_condition
         where_clause |= Persona__User.user_id == user.id


### PR DESCRIPTION
## Description

Thank you to Emesron!


Fix an issue with the visibility filters for personas:

1. Previously, the code first OR'd `is_public` then AND'd `is_visible` to the entire `where_clause`, which didn't correctly group the conditions. Now we properly group them together to ensure personas must be both public AND visible.

Users should be able to see:
- Public and visible personas
- Personas shared with them via user groups
- Personas they created directly

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
