### PR TITLE
slight improvements to user group endpoints

### DIFF
--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -32,12 +32,15 @@ def list_user_groups(
     db_session: Session = Depends(get_session),
 ) -> list[UserGroup]:
     if user is None or user.role == UserRole.ADMIN:
-        user_groups = fetch_user_groups(db_session, only_up_to_date=False)
+        user_groups = fetch_user_groups(
+            db_session, only_up_to_date=False, eager_load_all=True
+        )
     else:
         user_groups = fetch_user_groups_for_user(
             db_session=db_session,
             user_id=user.id,
             only_curator_groups=user.role == UserRole.CURATOR,
+            eager_load_all=True,
         )
     return [UserGroup.from_model(user_group) for user_group in user_groups]
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -23,6 +23,8 @@ from onyx.configs.chat_configs import CONTEXT_CHUNKS_BELOW
 from onyx.configs.constants import NotificationType
 from onyx.context.search.enums import RecencyBiasSetting
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import DocumentSet
 from onyx.db.models import Persona
 from onyx.db.models import Persona__User
@@ -332,10 +334,16 @@ def get_personas_for_user(
         stmt = stmt.options(
             selectinload(Persona.prompts),
             selectinload(Persona.tools),
-            selectinload(Persona.document_sets),
             selectinload(Persona.groups),
             selectinload(Persona.users),
             selectinload(Persona.labels),
+            selectinload(Persona.document_sets)
+            .selectinload(DocumentSet.connector_credential_pairs)
+            .selectinload(ConnectorCredentialPair.credential),
+            selectinload(Persona.document_sets)
+            .selectinload(DocumentSet.connector_credential_pairs)
+            .joinedload(ConnectorCredentialPair.connector)
+            .contains_eager(Connector.credentials),
         )
 
     results = db_session.execute(stmt).scalars().all()

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -221,7 +221,7 @@ def index_doc_batch_prepare(
         else documents
     )
     if len(updatable_docs) != len(documents):
-        updatable_doc_ids = [doc.id for doc in updatable_docs]
+        updatable_doc_ids = {doc.id for doc in updatable_docs}
         skipped_doc_ids = [
             doc.id for doc in documents if doc.id not in updatable_doc_ids
         ]

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -78,7 +78,7 @@ USERS_PAGE_SIZE = 10
 @router.patch("/manage/set-user-role")
 def set_user_role(
     user_role_update_request: UserRoleUpdateRequest,
-    current_user: User = Depends(current_admin_user),
+    current_user: User | None = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_to_update = get_user_by_email(
@@ -98,7 +98,7 @@ def set_user_role(
         current_role=current_role,
     )
 
-    if user_to_update.id == current_user.id:
+    if current_user and user_to_update.id == current_user.id:
         raise HTTPException(
             status_code=400,
             detail="An admin cannot demote themselves from admin role!",


### PR DESCRIPTION
## Description

Customer was having long load times from user-group and persona endpoints; these changes improve performance by about ~30% in some cases (worst I saw was equivalent performance to the non-eager loading version). 

## How Has This Been Tested?

This was tested with about 10,000 users, 100 user groups, and 500 personas. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
