### PR TITLE
add overflow-auto to show all content in Modal

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -90,6 +90,7 @@ export function Modal({
           flex
           flex-col
           ${heightOverride ? `h-${heightOverride}` : "max-h-[90vh]"}
+          overflow-auto
         `}
       >
         {onOutsideClick && !hideCloseButton && (


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

noticed that lots of modals overflow past the max height, which makes the modal unusable.

relates to: https://github.com/onyx-dot-app/onyx/issues/698

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

opened devtools and added `overflow-auto`, which let me scroll to the remaining content

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
