### PR TITLE
Ephemeral slack messages as responses to user questions

### DIFF
--- a/backend/ee/onyx/onyxbot/slack/handlers/handle_standard_answers.py
+++ b/backend/ee/onyx/onyxbot/slack/handlers/handle_standard_answers.py
@@ -22,7 +22,7 @@ from onyx.onyxbot.slack.blocks import get_restate_blocks
 from onyx.onyxbot.slack.constants import GENERATE_ANSWER_BUTTON_ACTION_ID
 from onyx.onyxbot.slack.handlers.utils import send_team_member_message
 from onyx.onyxbot.slack.models import SlackMessageInfo
-from onyx.onyxbot.slack.utils import respond_in_thread
+from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
 from onyx.onyxbot.slack.utils import update_emote_react
 from onyx.utils.logger import OnyxLoggingAdapter
 from onyx.utils.logger import setup_logger
@@ -216,7 +216,7 @@ def _handle_standard_answers(
         all_blocks = restate_question_blocks + answer_blocks
 
         try:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=message_info.channel_to_respond,
                 receiver_ids=receiver_ids,
@@ -231,6 +231,7 @@ def _handle_standard_answers(
                     client=client,
                     channel=message_info.channel_to_respond,
                     thread_ts=slack_thread_id,
+                    receiver_ids=receiver_ids,
                 )
 
             return True

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -72,6 +72,11 @@ def make_slack_api_rate_limited(
     @wraps(call)
     def rate_limited_call(**kwargs: Any) -> SlackResponse:
         last_exception = None
+
+        if "thread_ts" in kwargs:
+            if kwargs["thread_ts"] is None:
+                kwargs.pop("thread_ts", None)
+
         for _ in range(max_retries):
             try:
                 # Make the API call

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -73,10 +73,6 @@ def make_slack_api_rate_limited(
     def rate_limited_call(**kwargs: Any) -> SlackResponse:
         last_exception = None
 
-        if "thread_ts" in kwargs:
-            if kwargs["thread_ts"] is None:
-                kwargs.pop("thread_ts", None)
-
         for _ in range(max_retries):
             try:
                 # Make the API call

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1790,6 +1790,7 @@ class ChannelConfig(TypedDict):
     channel_name: str | None  # None for default channel config
     respond_tag_only: NotRequired[bool]  # defaults to False
     respond_to_bots: NotRequired[bool]  # defaults to False
+    is_ephemeral: NotRequired[bool]  # defaults to False
     respond_member_group_list: NotRequired[list[str]]
     answer_filters: NotRequired[list[AllowedAnswerFilters]]
     # If None then no follow up

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -154,14 +154,26 @@ def _build_ephemeral_publication_block(
             "thread_to_respond": respond_ts,
         },
         "channel_conf": {
-            "channel_name": channel_conf.get("channel_name"),
-            "respond_tag_only": channel_conf.get("respond_tag_only"),
-            "respond_to_bots": channel_conf.get("respond_to_bots"),
-            "is_ephemeral": channel_conf.get("is_ephemeral"),
-            "respond_member_group_list": channel_conf.get("respond_member_group_list"),
-            "answer_filters": channel_conf.get("answer_filters"),
-            "follow_up_tags": channel_conf.get("follow_up_tags"),
-            "show_continue_in_web_ui": channel_conf.get("show_continue_in_web_ui"),
+            "channel_name": channel_conf.get("channel_name") if channel_conf else None,
+            "respond_tag_only": channel_conf.get("respond_tag_only")
+            if channel_conf
+            else None,
+            "respond_to_bots": channel_conf.get("respond_to_bots")
+            if channel_conf
+            else None,
+            "is_ephemeral": channel_conf.get("is_ephemeral") if channel_conf else None,
+            "respond_member_group_list": channel_conf.get("respond_member_group_list")
+            if channel_conf
+            else None,
+            "answer_filters": channel_conf.get("answer_filters")
+            if channel_conf
+            else None,
+            "follow_up_tags": channel_conf.get("follow_up_tags")
+            if channel_conf
+            else None,
+            "show_continue_in_web_ui": channel_conf.get("show_continue_in_web_ui")
+            if channel_conf
+            else None,
         },
     }
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -122,6 +122,12 @@ def _build_ephemeral_publication_block(
     if not chat_message_id:
         raise ValueError("Chat message id is required to change the ephemeral message")
 
+    if message_info is None:
+        raise ValueError("Message info is required to change the ephemeral message")
+
+    if channel_conf is None:
+        raise ValueError("Channel config is required to change the ephemeral message")
+
     # check whether the message is in a thread
     if (
         message_info is not None
@@ -137,39 +143,27 @@ def _build_ephemeral_publication_block(
 
     action_values_ephemeral_message_channel_config = (
         ActionValuesEphemeralMessageChannelConfig(
-            channel_name=channel_conf.get("channel_name") if channel_conf else None,
-            respond_tag_only=channel_conf.get("respond_tag_only")
-            if channel_conf
-            else None,
-            respond_to_bots=channel_conf.get("respond_to_bots")
-            if channel_conf
-            else None,
-            is_ephemeral=channel_conf.get("is_ephemeral", False)
-            if channel_conf
-            else False,
-            respond_member_group_list=channel_conf.get("respond_member_group_list")
-            if channel_conf
-            else None,
-            answer_filters=channel_conf.get("answer_filters") if channel_conf else None,
-            follow_up_tags=channel_conf.get("follow_up_tags") if channel_conf else None,
-            show_continue_in_web_ui=channel_conf.get("show_continue_in_web_ui", False)
-            if channel_conf
-            else False,
+            channel_name=channel_conf.get("channel_name"),
+            respond_tag_only=channel_conf.get("respond_tag_only"),
+            respond_to_bots=channel_conf.get("respond_to_bots"),
+            is_ephemeral=channel_conf.get("is_ephemeral", False),
+            respond_member_group_list=channel_conf.get("respond_member_group_list"),
+            answer_filters=channel_conf.get("answer_filters"),
+            follow_up_tags=channel_conf.get("follow_up_tags"),
+            show_continue_in_web_ui=channel_conf.get("show_continue_in_web_ui", False),
         )
     )
 
     action_values_ephemeral_message_message_info = (
         ActionValuesEphemeralMessageMessageInfo(
-            bypass_filters=message_info.bypass_filters if message_info else None,
-            channel_to_respond=message_info.channel_to_respond
-            if message_info
-            else None,
-            msg_to_respond=message_info.msg_to_respond if message_info else None,
-            email=message_info.email if message_info else None,
-            sender_id=message_info.sender_id if message_info else None,
-            thread_messages=message_info.thread_messages if message_info else None,
-            is_bot_msg=message_info.is_bot_msg if message_info else None,
-            is_bot_dm=message_info.is_bot_dm if message_info else None,
+            bypass_filters=message_info.bypass_filters,
+            channel_to_respond=message_info.channel_to_respond,
+            msg_to_respond=message_info.msg_to_respond,
+            email=message_info.email,
+            sender_id=message_info.sender_id,
+            thread_messages=None,
+            is_bot_msg=message_info.is_bot_msg,
+            is_bot_dm=message_info.is_bot_dm,
             thread_to_respond=respond_ts,
         )
     )

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -182,7 +182,7 @@ def _build_ephemeral_publication_block(
         elements=[
             ButtonElement(
                 action_id=SHOW_EVERYONE_ACTION_ID,
-                text=f"📢 Show Everyone in {channel_thread_str}",
+                text=f"📢 Share with Everyone in {channel_thread_str} (Caution!)",
                 value=json.dumps(value_dict),
             ),
             ButtonElement(
@@ -191,7 +191,6 @@ def _build_ephemeral_publication_block(
                 value=json.dumps(value_dict),
             ),
         ],
-        others={"my_data": "my_data"},
     )
 
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -135,6 +135,7 @@ def _build_ephemeral_publication_block(
         respond_ts = original_question_ts
         channel_thread_str = "Thread"
 
+    # This is a dict as a key component, channel_conf, as a TypeDict itself
     value_dict: dict[str, Any] = {
         "original_question_ts": original_question_ts,
         "feedback_reminder_id": feedback_reminder_id,

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -127,10 +127,8 @@ def _build_ephemeral_publication_block(
         and (message_info.msg_to_respond == message_info.thread_to_respond)
     ):
         respond_ts = None
-        channel_thread_str = "Channel"
     else:
         respond_ts = original_question_ts
-        channel_thread_str = "Thread"
 
     action_values_ephemeral_message_channel_config = (
         ActionValuesEphemeralMessageChannelConfig(
@@ -172,7 +170,7 @@ def _build_ephemeral_publication_block(
         elements=[
             ButtonElement(
                 action_id=SHOW_EVERYONE_ACTION_ID,
-                text=f"📢 Share with Everyone in {channel_thread_str} (Caution!)",
+                text="📢 Share with Everyone",
                 value=action_values_ephemeral_message.model_dump_json(),
             ),
             ButtonElement(

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -161,7 +161,7 @@ def _build_ephemeral_publication_block(
             msg_to_respond=message_info.msg_to_respond,
             email=message_info.email,
             sender_id=message_info.sender_id,
-            thread_messages=None,
+            thread_messages=[],
             is_bot_msg=message_info.is_bot_msg,
             is_bot_dm=message_info.is_bot_dm,
             thread_to_respond=respond_ts,

--- a/backend/onyx/onyxbot/slack/constants.py
+++ b/backend/onyx/onyxbot/slack/constants.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 LIKE_BLOCK_ACTION_ID = "feedback-like"
 DISLIKE_BLOCK_ACTION_ID = "feedback-dislike"
+SHOW_EVERYONE_ACTION_ID = "show-everyone"
+KEEP_TO_YOURSELF_ACTION_ID = "keep-to-yourself"
 CONTINUE_IN_WEB_UI_ACTION_ID = "continue-in-web-ui"
 FEEDBACK_DOC_BUTTON_BLOCK_ACTION_ID = "feedback-doc-button"
 IMMEDIATE_RESOLVED_BUTTON_ACTION_ID = "immediate-resolved-button"

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -298,7 +298,9 @@ def handle_publish_ephemeral_message_button(
             respond_in_thread_or_channel(
                 client=client.web_client,
                 channel=channel_id,
-                receiver_ids=None,
+                receiver_ids=channel_conf.get(
+                    "respond_member_group_list"
+                ),  # If respond_member_group_list is set, send to them. TODO: check!
                 text="Hello! Onyx has some results for you!",
                 blocks=all_blocks,
                 thread_ts=original_question_ts,

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -75,9 +75,8 @@ def _convert_db_doc_id_to_document_ids(
     return citation_list_with_document_id
 
 
-def _build_citation_list(
-    citation_dict: dict[int, int] | None, chat_message_detail: ChatMessageDetail
-) -> list[CitationInfo]:
+def _build_citation_list(chat_message_detail: ChatMessageDetail) -> list[CitationInfo]:
+    citation_dict = chat_message_detail.citations
     if citation_dict is None:
         return []
     else:
@@ -248,8 +247,7 @@ def handle_publish_ephemeral_message_button(
 
         # construct the proper citation format and then the answer in the suitable format
         # we need to construct the blocks.
-        citation_dict = chat_message_detail.citations
-        citation_list = _build_citation_list(citation_dict, chat_message_detail)
+        citation_list = _build_citation_list(chat_message_detail)
 
         onyx_bot_answer = ChatOnyxBotResponse(
             answer=chat_message_detail.message,

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -296,9 +296,7 @@ def handle_publish_ephemeral_message_button(
             respond_in_thread_or_channel(
                 client=client.web_client,
                 channel=channel_id,
-                receiver_ids=channel_conf.get(
-                    "respond_member_group_list"
-                ),  # If respond_member_group_list is set, send to them. TODO: check!
+                receiver_ids=None,  # If respond_member_group_list is set, send to them. TODO: check!
                 text="Hello! Onyx has some results for you!",
                 blocks=all_blocks,
                 thread_ts=original_question_ts,

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -221,9 +221,7 @@ def handle_publish_ephemeral_message_button(
 
     user_email = value_dict.get("message_info", {}).get("email")
 
-    chat_message_id = json.loads(req.payload["actions"][0]["value"]).get(
-        "chat_message_id"
-    )
+    chat_message_id = value_dict.get("chat_message_id")
 
     # Obtain onyx_user and chat_message information
     if not chat_message_id:

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -227,7 +227,7 @@ def handle_publish_ephemeral_message_button(
     if not chat_message_id:
         raise ValueError("Missing chat_message_id in the payload")
 
-    with get_session_with_tenant(tenant_id=client.tenant_id) as db_session:
+    with get_session_with_current_tenant() as db_session:
         onyx_user = get_user_by_email(user_email, db_session)
         if not onyx_user:
             raise ValueError("Cannot determine onyx_user_id from email in payload")
@@ -282,7 +282,6 @@ def handle_publish_ephemeral_message_button(
         # remove handling of empheremal block and add AI feedback.
         all_blocks = build_slack_response_blocks(
             answer=onyx_bot_answer,
-            tenant_id=client.tenant_id,
             message_info=slack_message_info,
             channel_conf=channel_conf,
             use_citations=True,
@@ -313,7 +312,6 @@ def handle_publish_ephemeral_message_button(
 
         changed_blocks = build_slack_response_blocks(
             answer=onyx_bot_answer,
-            tenant_id=client.tenant_id,
             message_info=slack_message_info,
             channel_conf=channel_conf,
             use_citations=True,

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -219,6 +219,11 @@ def handle_message(
         if message_info.email:
             add_slack_user_if_not_exists(db_session, message_info.email)
 
+        # If the message is ephemeral, send it to the sender only
+        if slack_channel_config.channel_config.get("is_ephemeral"):
+            if sender_id:
+                send_to = [sender_id]
+
         # first check if we need to respond with a standard answer
         used_standard_answer = handle_standard_answers(
             message_info=message_info,

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -18,7 +18,7 @@ from onyx.onyxbot.slack.handlers.handle_standard_answers import (
 from onyx.onyxbot.slack.models import SlackMessageInfo
 from onyx.onyxbot.slack.utils import fetch_slack_user_ids_from_emails
 from onyx.onyxbot.slack.utils import fetch_user_ids_from_groups
-from onyx.onyxbot.slack.utils import respond_in_thread
+from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
 from onyx.onyxbot.slack.utils import slack_usage_report
 from onyx.onyxbot.slack.utils import update_emote_react
 from onyx.utils.logger import setup_logger
@@ -29,7 +29,7 @@ logger_base = setup_logger()
 
 def send_msg_ack_to_user(details: SlackMessageInfo, client: WebClient) -> None:
     if details.is_bot_msg and details.sender_id:
-        respond_in_thread(
+        respond_in_thread_or_channel(
             client=client,
             channel=details.channel_to_respond,
             thread_ts=details.msg_to_respond,
@@ -202,7 +202,7 @@ def handle_message(
     # which would just respond to the sender
     if send_to and is_bot_msg:
         if sender_id:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
                 receiver_ids=[sender_id],
@@ -219,12 +219,8 @@ def handle_message(
         if message_info.email:
             add_slack_user_if_not_exists(db_session, message_info.email)
 
-        # If the message is ephemeral, send it to the sender only
-        if slack_channel_config.channel_config.get("is_ephemeral"):
-            if sender_id:
-                send_to = [sender_id]
-
         # first check if we need to respond with a standard answer
+        # standard answers should be published in a thread
         used_standard_answer = handle_standard_answers(
             message_info=message_info,
             receiver_ids=send_to,

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -85,6 +85,7 @@ def handle_regular_answer(
 
     # Capture whether response mode for channel is ephemeral
     send_as_ephemeral = slack_channel_config.channel_config.get("is_ephemeral", False)
+    public_only = slack_channel_config.persona is None
 
     # If the channel mis configured to respond with an ephemeral message,
     # or the message is a dm to the Onyx bot,we should use the proper user from the email
@@ -92,7 +93,7 @@ def handle_regular_answer(
     # to public docs as other people in the channel can see the response.
 
     user = None
-    if message_info.is_bot_dm or send_as_ephemeral:
+    if (message_info.is_bot_dm or send_as_ephemeral) and not public_only:
         if message_info.email:
             with get_session_with_current_tenant() as db_session:
                 user = get_user_by_email(message_info.email, db_session)

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -33,7 +33,7 @@ from onyx.onyxbot.slack.blocks import build_slack_response_blocks
 from onyx.onyxbot.slack.handlers.utils import send_team_member_message
 from onyx.onyxbot.slack.handlers.utils import slackify_message_thread
 from onyx.onyxbot.slack.models import SlackMessageInfo
-from onyx.onyxbot.slack.utils import respond_in_thread
+from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
 from onyx.onyxbot.slack.utils import SlackRateLimiter
 from onyx.onyxbot.slack.utils import update_emote_react
 from onyx.server.query_and_chat.models import CreateChatMessageRequest
@@ -87,6 +87,18 @@ def handle_regular_answer(
         if message_info.email:
             with get_session_with_current_tenant() as db_session:
                 user = get_user_by_email(message_info.email, db_session)
+
+    send_as_ephemeral = slack_channel_config.channel_config.get("is_ephemeral", False)
+    target_thread_ts = (
+        None
+        if send_as_ephemeral and len(message_info.thread_messages) < 2
+        else message_ts_to_respond_to
+    )
+    target_receiver_ids = (
+        [message_info.sender_id]
+        if message_info.sender_id and send_as_ephemeral
+        else receiver_ids
+    )
 
     document_set_names: list[str] | None = None
     prompt = None
@@ -219,12 +231,13 @@ def handle_regular_answer(
         # Optionally, respond in thread with the error message, Used primarily
         # for debugging purposes
         if should_respond_with_error_msgs:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
-                receiver_ids=None,
+                receiver_ids=target_receiver_ids,
                 text=f"Encountered exception when trying to answer: \n\n```{e}```",
-                thread_ts=message_ts_to_respond_to,
+                thread_ts=target_thread_ts,
+                send_as_ephemeral=send_as_ephemeral,
             )
 
         # In case of failures, don't keep the reaction there permanently
@@ -242,17 +255,18 @@ def handle_regular_answer(
     if answer is None:
         assert DISABLE_GENERATIVE_AI is True
         try:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
-                receiver_ids=receiver_ids,
+                receiver_ids=target_receiver_ids,
                 text="Hello! Onyx has some results for you!",
                 blocks=[
                     SectionBlock(
                         text="Onyx is down for maintenance.\nWe're working hard on recharging the AI!"
                     )
                 ],
-                thread_ts=message_ts_to_respond_to,
+                thread_ts=target_thread_ts,
+                send_as_ephemeral=send_as_ephemeral,
                 # don't unfurl, since otherwise we will have 5+ previews which makes the message very long
                 unfurl=False,
             )
@@ -261,17 +275,16 @@ def handle_regular_answer(
             # the ephemeral message. This also will give the user a notification which ephemeral message does not.
 
             # If the channel is ephemeral, we don't need to send a message to the user since they will already see the message
-            if receiver_ids and not slack_channel_config.channel_config.get(
-                "is_ephemeral"
-            ):
-                respond_in_thread(
+            if target_receiver_ids and not send_as_ephemeral:
+                respond_in_thread_or_channel(
                     client=client,
                     channel=channel,
                     text=(
                         "👋 Hi, we've just gathered and forwarded the relevant "
                         + "information to the team. They'll get back to you shortly!"
                     ),
-                    thread_ts=message_ts_to_respond_to,
+                    thread_ts=target_thread_ts,
+                    send_as_ephemeral=send_as_ephemeral,
                 )
 
             return False
@@ -320,12 +333,13 @@ def handle_regular_answer(
         # Optionally, respond in thread with the error message
         # Used primarily for debugging purposes
         if should_respond_with_error_msgs:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
-                receiver_ids=None,
+                receiver_ids=target_receiver_ids,
                 text="Found no documents when trying to answer. Did you index any documents?",
-                thread_ts=message_ts_to_respond_to,
+                thread_ts=target_thread_ts,
+                send_as_ephemeral=send_as_ephemeral,
             )
         return True
 
@@ -353,14 +367,26 @@ def handle_regular_answer(
         # Optionally, respond in thread with the error message
         # Used primarily for debugging purposes
         if should_respond_with_error_msgs:
-            respond_in_thread(
+            respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
-                receiver_ids=None,
+                receiver_ids=target_receiver_ids,
                 text="Found no citations or quotes when trying to answer.",
-                thread_ts=message_ts_to_respond_to,
+                thread_ts=target_thread_ts,
+                send_as_ephemeral=send_as_ephemeral,
             )
         return True
+
+    if (
+        send_as_ephemeral
+        and target_receiver_ids is not None
+        and len(target_receiver_ids) == 1
+    ):
+        offer_ephemeral_publication = True
+        skip_ai_feedback = True
+    else:
+        offer_ephemeral_publication = False
+        skip_ai_feedback = False
 
     all_blocks = build_slack_response_blocks(
         message_info=message_info,
@@ -369,20 +395,21 @@ def handle_regular_answer(
         use_citations=True,  # No longer supporting quotes
         feedback_reminder_id=feedback_reminder_id,
         expecting_search_result=expecting_search_result,
+        offer_ephemeral_publication=offer_ephemeral_publication,
+        skip_ai_feedback=skip_ai_feedback,
     )
 
     try:
-        respond_in_thread(
+        respond_in_thread_or_channel(
             client=client,
             channel=channel,
-            receiver_ids=[message_info.sender_id]
-            if message_info.is_bot_msg and message_info.sender_id
-            else receiver_ids,
+            receiver_ids=target_receiver_ids,
             text="Hello! Onyx has some results for you!",
             blocks=all_blocks,
-            thread_ts=message_ts_to_respond_to,
+            thread_ts=target_thread_ts,
             # don't unfurl, since otherwise we will have 5+ previews which makes the message very long
             unfurl=False,
+            send_as_ephemeral=send_as_ephemeral,
         )
 
         # For DM (ephemeral message), we need to create a thread via a normal message so the user can see
@@ -390,14 +417,17 @@ def handle_regular_answer(
         # if there is no message_ts_to_respond_to, and we have made it this far, then this is a /onyx message
         # so we shouldn't send_team_member_message
         if (
-            receiver_ids
+            target_receiver_ids
             and message_ts_to_respond_to is not None
-            and not slack_channel_config.channel_config.get("is_ephemeral")
+            and not send_as_ephemeral
+            and target_thread_ts is not None
         ):
             send_team_member_message(
                 client=client,
                 channel=channel,
-                thread_ts=message_ts_to_respond_to,
+                thread_ts=target_thread_ts,
+                receiver_ids=target_receiver_ids,
+                send_as_ephemeral=send_as_ephemeral,
             )
 
         return False

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -82,7 +82,20 @@ def handle_regular_answer(
 
     message_ts_to_respond_to = message_info.msg_to_respond
     is_bot_msg = message_info.is_bot_msg
-    user = None
+
+    # If the channel mis configured to respond with an ephemeral message,
+    # then we should use the proper user from the email
+    # Otherwise - if not ephemeral - we MUST None as the user to restrict to public docs
+    # as other people in the channel can see the response.
+    if slack_channel_config.channel_config.get("is_ephemeral", False):
+        with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+            if message_info.email:
+                user = get_user_by_email(message_info.email, db_session)
+            else:
+                user = None
+    else:
+        user = None
+
     if message_info.is_bot_dm:
         if message_info.email:
             with get_session_with_current_tenant() as db_session:

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -259,7 +259,11 @@ def handle_regular_answer(
 
             # For DM (ephemeral message), we need to create a thread via a normal message so the user can see
             # the ephemeral message. This also will give the user a notification which ephemeral message does not.
-            if receiver_ids:
+
+            # If the channel is ephemeral, we don't need to send a message to the user since they will already see the message
+            if receiver_ids and not slack_channel_config.channel_config.get(
+                "is_ephemeral"
+            ):
                 respond_in_thread(
                     client=client,
                     channel=channel,
@@ -385,7 +389,11 @@ def handle_regular_answer(
         # the ephemeral message. This also will give the user a notification which ephemeral message does not.
         # if there is no message_ts_to_respond_to, and we have made it this far, then this is a /onyx message
         # so we shouldn't send_team_member_message
-        if receiver_ids and message_ts_to_respond_to is not None:
+        if (
+            receiver_ids
+            and message_ts_to_respond_to is not None
+            and not slack_channel_config.channel_config.get("is_ephemeral")
+        ):
             send_team_member_message(
                 client=client,
                 channel=channel,

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -83,8 +83,13 @@ def handle_regular_answer(
     message_ts_to_respond_to = message_info.msg_to_respond
     is_bot_msg = message_info.is_bot_msg
 
-    # Capture whether response mode for channel is ephemeral
-    send_as_ephemeral = slack_channel_config.channel_config.get("is_ephemeral", False)
+    # Capture whether response mode for channel is ephemeral. Even if the channel is set
+    # to respond with an ephemeral message, we still send as non-ephemeral if
+    # the message is a dm with the Onyx bot.
+    send_as_ephemeral = (
+        slack_channel_config.channel_config.get("is_ephemeral", False)
+        and not message_info.is_bot_dm
+    )
 
     # If the channel mis configured to respond with an ephemeral message,
     # or the message is a dm to the Onyx bot, we should use the proper onyx user from the email.

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -394,7 +394,7 @@ def handle_regular_answer(
         skip_ai_feedback = True
     else:
         offer_ephemeral_publication = False
-        skip_ai_feedback = False
+        skip_ai_feedback = False if feedback_reminder_id else True
 
     all_blocks = build_slack_response_blocks(
         message_info=message_info,

--- a/backend/onyx/onyxbot/slack/handlers/utils.py
+++ b/backend/onyx/onyxbot/slack/handlers/utils.py
@@ -43,6 +43,6 @@ def send_team_member_message(
             + "information to the team. They'll get back to you shortly!"
         ),
         thread_ts=thread_ts,
-        receiver_ids=receiver_ids,
+        receiver_ids=None,
         send_as_ephemeral=send_as_ephemeral,
     )

--- a/backend/onyx/onyxbot/slack/handlers/utils.py
+++ b/backend/onyx/onyxbot/slack/handlers/utils.py
@@ -2,7 +2,7 @@ from slack_sdk import WebClient
 
 from onyx.chat.models import ThreadMessage
 from onyx.configs.constants import MessageType
-from onyx.onyxbot.slack.utils import respond_in_thread
+from onyx.onyxbot.slack.utils import respond_in_thread_or_channel
 
 
 def slackify_message_thread(messages: list[ThreadMessage]) -> str:
@@ -32,8 +32,10 @@ def send_team_member_message(
     client: WebClient,
     channel: str,
     thread_ts: str,
+    receiver_ids: list[str] | None = None,
+    send_as_ephemeral: bool = False,
 ) -> None:
-    respond_in_thread(
+    respond_in_thread_or_channel(
         client=client,
         channel=channel,
         text=(
@@ -41,4 +43,6 @@ def send_team_member_message(
             + "information to the team. They'll get back to you shortly!"
         ),
         thread_ts=thread_ts,
+        receiver_ids=receiver_ids,
+        send_as_ephemeral=send_as_ephemeral,
     )

--- a/backend/onyx/onyxbot/slack/models.py
+++ b/backend/onyx/onyxbot/slack/models.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 from onyx.chat.models import ThreadMessage
@@ -13,3 +15,37 @@ class SlackMessageInfo(BaseModel):
     bypass_filters: bool  # User has tagged @OnyxBot
     is_bot_msg: bool  # User is using /OnyxBot
     is_bot_dm: bool  # User is direct messaging to OnyxBot
+
+
+# Models used to encode the relevant data for the ephemeral message actions
+class ActionValuesEphemeralMessageMessageInfo(BaseModel):
+    bypass_filters: bool | None
+    channel_to_respond: str | None
+    msg_to_respond: str | None
+    email: str | None
+    sender_id: str | None
+    thread_messages: list[ThreadMessage] | None
+    is_bot_msg: bool | None
+    is_bot_dm: bool | None
+    thread_to_respond: str | None
+
+
+class ActionValuesEphemeralMessageChannelConfig(BaseModel):
+    channel_name: str | None
+    respond_tag_only: bool | None
+    respond_to_bots: bool | None
+    is_ephemeral: bool
+    respond_member_group_list: list[str] | None
+    answer_filters: list[
+        Literal["well_answered_postfilter", "questionmark_prefilter"]
+    ] | None
+    follow_up_tags: list[str] | None
+    show_continue_in_web_ui: bool
+
+
+class ActionValuesEphemeralMessage(BaseModel):
+    original_question_ts: str | None
+    feedback_reminder_id: str | None
+    chat_message_id: int
+    message_info: ActionValuesEphemeralMessageMessageInfo
+    channel_conf: ActionValuesEphemeralMessageChannelConfig

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -547,7 +547,7 @@ def read_slack_thread(
 
                 # If auto-detected filters are on, use the second block for the actual answer
                 # The first block is the auto-detected filters
-                if message.startswith("_Filters"):
+                if message is not None and message.startswith("_Filters"):
                     if len(blocks) < 2:
                         logger.warning(f"Only filter blocks found: {reply}")
                         continue

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -302,10 +302,8 @@ def build_feedback_id(
 
 
 def build_publish_ephemeral_message_id(
-    original_question_ts: str | None = None,
+    original_question_ts: str,
 ) -> str:
-    if original_question_ts is None:
-        raise ValueError("Original question timestamp is required")
     return "publish_ephemeral_message__" + original_question_ts
 
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -184,7 +184,7 @@ def _build_error_block(error_message: str) -> Block:
     backoff=2,
     logger=cast(logging.Logger, logger),
 )
-def respond_in_thread(
+def respond_in_thread_or_channel(
     client: WebClient,
     channel: str,
     thread_ts: str | None,
@@ -193,6 +193,7 @@ def respond_in_thread(
     receiver_ids: list[str] | None = None,
     metadata: Metadata | None = None,
     unfurl: bool = True,
+    send_as_ephemeral: bool | None = True,
 ) -> list[str]:
     if not text and not blocks:
         raise ValueError("One of `text` or `blocks` must be provided")
@@ -236,6 +237,7 @@ def respond_in_thread(
         message_ids.append(response["message_ts"])
     else:
         slack_call = make_slack_api_rate_limited(client.chat_postEphemeral)
+
         for receiver in receiver_ids:
             try:
                 response = slack_call(
@@ -297,6 +299,14 @@ def build_feedback_id(
         feedback_id = str(message_id)
 
     return unique_prefix + ID_SEPARATOR + feedback_id
+
+
+def build_publish_ephemeral_message_id(
+    original_question_ts: str | None = None,
+) -> str:
+    if original_question_ts is None:
+        raise ValueError("Original question timestamp is required")
+    return "publish_ephemeral_message__" + original_question_ts
 
 
 def build_continue_in_web_ui_id(
@@ -611,7 +621,7 @@ class SlackRateLimiter:
     def notify(
         self, client: WebClient, channel: str, position: int, thread_ts: str | None
     ) -> None:
-        respond_in_thread(
+        respond_in_thread_or_channel(
             client=client,
             channel=channel,
             receiver_ids=None,

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -181,6 +181,7 @@ class SlackChannelConfigCreationRequest(BaseModel):
     channel_name: str
     respond_tag_only: bool = False
     respond_to_bots: bool = False
+    is_ephemeral: bool = False
     show_continue_in_web_ui: bool = False
     enable_auto_filters: bool = False
     # If no team members, assume respond in the channel to everyone

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -71,6 +71,15 @@ def _form_channel_config(
             "also respond to a predetermined set of users."
         )
 
+    if (
+        slack_channel_config_creation_request.is_ephemeral
+        and slack_channel_config_creation_request.respond_member_group_list
+    ):
+        raise ValueError(
+            "Cannot set OnyxBot to respond to users in a private (ephemeral) message "
+            "and also respond to a selected list of users."
+        )
+
     channel_config: ChannelConfig = {
         "channel_name": cleaned_channel_name,
     }

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -91,6 +91,8 @@ def _form_channel_config(
         "respond_to_bots"
     ] = slack_channel_config_creation_request.respond_to_bots
 
+    channel_config["is_ephemeral"] = slack_channel_config_creation_request.is_ephemeral
+
     channel_config["disabled"] = slack_channel_config_creation_request.disabled
 
     return channel_config

--- a/backend/scripts/document_seeding_prep.py
+++ b/backend/scripts/document_seeding_prep.py
@@ -161,17 +161,21 @@ overview_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/overview",
     title=overview_title,
     content=overview,
-    title_embedding=model.encode(f"search_document: {overview_title}"),
-    content_embedding=model.encode(f"search_document: {overview_title}\n{overview}"),
+    title_embedding=list(model.encode(f"search_document: {overview_title}")),
+    content_embedding=list(
+        model.encode(f"search_document: {overview_title}\n{overview}")
+    ),
 )
 
 enterprise_search_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/enterprise_search",
     title=enterprise_search_title,
     content=enterprise_search_1,
-    title_embedding=model.encode(f"search_document: {enterprise_search_title}"),
-    content_embedding=model.encode(
-        f"search_document: {enterprise_search_title}\n{enterprise_search_1}"
+    title_embedding=list(model.encode(f"search_document: {enterprise_search_title}")),
+    content_embedding=list(
+        model.encode(
+            f"search_document: {enterprise_search_title}\n{enterprise_search_1}"
+        )
     ),
 )
 
@@ -179,9 +183,11 @@ enterprise_search_doc_2 = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/enterprise_search",
     title=enterprise_search_title,
     content=enterprise_search_2,
-    title_embedding=model.encode(f"search_document: {enterprise_search_title}"),
-    content_embedding=model.encode(
-        f"search_document: {enterprise_search_title}\n{enterprise_search_2}"
+    title_embedding=list(model.encode(f"search_document: {enterprise_search_title}")),
+    content_embedding=list(
+        model.encode(
+            f"search_document: {enterprise_search_title}\n{enterprise_search_2}"
+        )
     ),
     chunk_ind=1,
 )
@@ -190,9 +196,9 @@ ai_platform_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/ai_platform",
     title=ai_platform_title,
     content=ai_platform,
-    title_embedding=model.encode(f"search_document: {ai_platform_title}"),
-    content_embedding=model.encode(
-        f"search_document: {ai_platform_title}\n{ai_platform}"
+    title_embedding=list(model.encode(f"search_document: {ai_platform_title}")),
+    content_embedding=list(
+        model.encode(f"search_document: {ai_platform_title}\n{ai_platform}")
     ),
 )
 
@@ -200,9 +206,9 @@ customer_support_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/support",
     title=customer_support_title,
     content=customer_support,
-    title_embedding=model.encode(f"search_document: {customer_support_title}"),
-    content_embedding=model.encode(
-        f"search_document: {customer_support_title}\n{customer_support}"
+    title_embedding=list(model.encode(f"search_document: {customer_support_title}")),
+    content_embedding=list(
+        model.encode(f"search_document: {customer_support_title}\n{customer_support}")
     ),
 )
 
@@ -210,17 +216,17 @@ sales_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/sales",
     title=sales_title,
     content=sales,
-    title_embedding=model.encode(f"search_document: {sales_title}"),
-    content_embedding=model.encode(f"search_document: {sales_title}\n{sales}"),
+    title_embedding=list(model.encode(f"search_document: {sales_title}")),
+    content_embedding=list(model.encode(f"search_document: {sales_title}\n{sales}")),
 )
 
 operations_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/operations",
     title=operations_title,
     content=operations,
-    title_embedding=model.encode(f"search_document: {operations_title}"),
-    content_embedding=model.encode(
-        f"search_document: {operations_title}\n{operations}"
+    title_embedding=list(model.encode(f"search_document: {operations_title}")),
+    content_embedding=list(
+        model.encode(f"search_document: {operations_title}\n{operations}")
     ),
 )
 

--- a/backend/scripts/document_seeding_prep.py
+++ b/backend/scripts/document_seeding_prep.py
@@ -161,21 +161,17 @@ overview_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/overview",
     title=overview_title,
     content=overview,
-    title_embedding=list(model.encode(f"search_document: {overview_title}")),
-    content_embedding=list(
-        model.encode(f"search_document: {overview_title}\n{overview}")
-    ),
+    title_embedding=model.encode(f"search_document: {overview_title}"),
+    content_embedding=model.encode(f"search_document: {overview_title}\n{overview}"),
 )
 
 enterprise_search_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/enterprise_search",
     title=enterprise_search_title,
     content=enterprise_search_1,
-    title_embedding=list(model.encode(f"search_document: {enterprise_search_title}")),
-    content_embedding=list(
-        model.encode(
-            f"search_document: {enterprise_search_title}\n{enterprise_search_1}"
-        )
+    title_embedding=model.encode(f"search_document: {enterprise_search_title}"),
+    content_embedding=model.encode(
+        f"search_document: {enterprise_search_title}\n{enterprise_search_1}"
     ),
 )
 
@@ -183,11 +179,9 @@ enterprise_search_doc_2 = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/enterprise_search",
     title=enterprise_search_title,
     content=enterprise_search_2,
-    title_embedding=list(model.encode(f"search_document: {enterprise_search_title}")),
-    content_embedding=list(
-        model.encode(
-            f"search_document: {enterprise_search_title}\n{enterprise_search_2}"
-        )
+    title_embedding=model.encode(f"search_document: {enterprise_search_title}"),
+    content_embedding=model.encode(
+        f"search_document: {enterprise_search_title}\n{enterprise_search_2}"
     ),
     chunk_ind=1,
 )
@@ -196,9 +190,9 @@ ai_platform_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/ai_platform",
     title=ai_platform_title,
     content=ai_platform,
-    title_embedding=list(model.encode(f"search_document: {ai_platform_title}")),
-    content_embedding=list(
-        model.encode(f"search_document: {ai_platform_title}\n{ai_platform}")
+    title_embedding=model.encode(f"search_document: {ai_platform_title}"),
+    content_embedding=model.encode(
+        f"search_document: {ai_platform_title}\n{ai_platform}"
     ),
 )
 
@@ -206,9 +200,9 @@ customer_support_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/support",
     title=customer_support_title,
     content=customer_support,
-    title_embedding=list(model.encode(f"search_document: {customer_support_title}")),
-    content_embedding=list(
-        model.encode(f"search_document: {customer_support_title}\n{customer_support}")
+    title_embedding=model.encode(f"search_document: {customer_support_title}"),
+    content_embedding=model.encode(
+        f"search_document: {customer_support_title}\n{customer_support}"
     ),
 )
 
@@ -216,17 +210,17 @@ sales_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/sales",
     title=sales_title,
     content=sales,
-    title_embedding=list(model.encode(f"search_document: {sales_title}")),
-    content_embedding=list(model.encode(f"search_document: {sales_title}\n{sales}")),
+    title_embedding=model.encode(f"search_document: {sales_title}"),
+    content_embedding=model.encode(f"search_document: {sales_title}\n{sales}"),
 )
 
 operations_doc = SeedPresaveDocument(
     url="https://docs.onyx.app/more/use_cases/operations",
     title=operations_title,
     content=operations,
-    title_embedding=list(model.encode(f"search_document: {operations_title}")),
-    content_embedding=list(
-        model.encode(f"search_document: {operations_title}\n{operations}")
+    title_embedding=model.encode(f"search_document: {operations_title}"),
+    content_embedding=model.encode(
+        f"search_document: {operations_title}\n{operations}"
     ),
 )
 

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -83,6 +83,8 @@ export const SlackChannelConfigCreationForm = ({
           respond_tag_only:
             existingSlackChannelConfig?.channel_config?.respond_tag_only ||
             false,
+          is_ephemeral:
+            existingSlackChannelConfig?.channel_config?.is_ephemeral || false,
           respond_to_bots:
             existingSlackChannelConfig?.channel_config?.respond_to_bots ||
             false,
@@ -135,6 +137,7 @@ export const SlackChannelConfigCreationForm = ({
           questionmark_prefilter_enabled: Yup.boolean().required(),
           respond_tag_only: Yup.boolean().required(),
           respond_to_bots: Yup.boolean().required(),
+          is_ephemeral: Yup.boolean().required(),
           show_continue_in_web_ui: Yup.boolean().required(),
           enable_auto_filters: Yup.boolean().required(),
           respond_member_group_list: Yup.array().of(Yup.string()).required(),

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -599,8 +599,10 @@ export function SlackChannelConfigFormFields({
               />
               <CheckFormField
                 name="is_ephemeral"
-                label="Respond to user as ephemeral message"
-                tooltip="If set, OnyxBot will respond only to the user as an ephemeral message"
+                label="Respond to user in a private (ephemeral) message"
+                tooltip="If set, OnyxBot will respond only to the user in a private (ephemeral) message. If you also 
+                chose 'Search' Assistant above, selecting this option will make documents that are private to the user 
+                available for their queries."
               />
 
               <TextArrayField

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -642,11 +642,14 @@ export function SlackChannelConfigFormFields({
                   Privacy Alert
                 </Label>
                 <p className="text-sm text-text-darker mb-4">
-                  Please note that at least one of the documents accessible by
-                  your OnyxBot is marked as private and may contain sensitive
-                  information. These documents will be accessible to all users
-                  of this OnyxBot. Ensure this aligns with your intended
-                  document sharing policy.
+                  Please note that if the private (ephemeral) response is *not
+                  selected*, only public documents within the selected document
+                  sets will be accessible for user queries. If the private
+                  (ephemeral) response *is selected*, user quries can also
+                  leverage documents that the user has already been granted
+                  access to. Note that users will be able to share the response
+                  with others in the channel, so please ensure that this is
+                  aligned with your company sharing policies.
                 </p>
                 <div className="space-y-2">
                   <h4 className="text-sm text-text font-medium">

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -597,6 +597,11 @@ export function SlackChannelConfigFormFields({
                 label="Respond to Bot messages"
                 tooltip="If not set, OnyxBot will always ignore messages from Bots"
               />
+              <CheckFormField
+                name="is_ephemeral"
+                label="Respond to as ephemeral message"
+                tooltip="If set, OnyxBot will respond only to the user as an ephemeral message"
+              />
 
               <TextArrayField
                 name="respond_member_group_list"

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -599,7 +599,7 @@ export function SlackChannelConfigFormFields({
               />
               <CheckFormField
                 name="is_ephemeral"
-                label="Respond to as ephemeral message"
+                label="Respond to user as ephemeral message"
                 tooltip="If set, OnyxBot will respond only to the user as an ephemeral message"
               />
 

--- a/web/src/app/admin/bots/[bot-id]/lib.ts
+++ b/web/src/app/admin/bots/[bot-id]/lib.ts
@@ -14,6 +14,7 @@ interface SlackChannelConfigCreationRequest {
   answer_validity_check_enabled: boolean;
   questionmark_prefilter_enabled: boolean;
   respond_tag_only: boolean;
+  is_ephemeral: boolean;
   respond_to_bots: boolean;
   show_continue_in_web_ui: boolean;
   respond_member_group_list: string[];
@@ -45,6 +46,7 @@ const buildRequestBodyFromCreationRequest = (
     channel_name: creationRequest.channel_name,
     respond_tag_only: creationRequest.respond_tag_only,
     respond_to_bots: creationRequest.respond_to_bots,
+    is_ephemeral: creationRequest.is_ephemeral,
     show_continue_in_web_ui: creationRequest.show_continue_in_web_ui,
     enable_auto_filters: creationRequest.enable_auto_filters,
     respond_member_group_list: creationRequest.respond_member_group_list,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -273,6 +273,7 @@ export interface ChannelConfig {
   channel_name: string;
   respond_tag_only?: boolean;
   respond_to_bots?: boolean;
+  is_ephemeral?: boolean;
   show_continue_in_web_ui?: boolean;
   respond_member_group_list?: string[];
   answer_filters?: AnswerFilterOption[];


### PR DESCRIPTION
## Description

We want to enable our customers to configure an Onyx bot for a channel such that the bot is able to respond as an ephemeral message to the user who is asking the question. That provides us with the ability to leverage documents for the search that a user has private access to, not just documents that are public to everyone.  

See details in the current design doc.

Ticket: https://linear.app/danswer/issue/DAN-1489/enable-ephemeral-replies-by-answer-bot-in-group-channels

## How Has This Been Tested?

Locally:
 - set up new bot in test mode
 - configured two channels, one with the new is_ephemeral parameter=True, the other one set to false
 - for each, I sent a request to the bot from
     - the channel
     - a thread
 - in the channel with the ephemeral setting I check for both question sources (channel vs thread) the button clicks 'Shae with Channel', and 'Keep for Yourself.
 
 Key test cases:
  - are the documents properly transferred
  - are the new locations correct 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
