### PR TITLE
Cleaner palette for dark mode index attempt failure

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -455,15 +455,15 @@ function Main({ ccPairId }: { ccPairId: number }) {
           <Title>Indexing Attempts</Title>
         </div>
         {indexAttemptErrors && indexAttemptErrors.total_items > 0 && (
-          <Alert className="border-alert bg-yellow-50 my-2">
-            <AlertCircle className="h-4 w-4 text-yellow-700" />
-            <AlertTitle className="text-yellow-950 font-semibold">
+          <Alert className="border-alert bg-yellow-50 dark:bg-yellow-800 my-2">
+            <AlertCircle className="h-4 w-4 text-yellow-700 dark:text-yellow-500" />
+            <AlertTitle className="text-yellow-950 dark:text-yellow-200 font-semibold">
               Some documents failed to index
             </AlertTitle>
-            <AlertDescription className="text-yellow-900">
+            <AlertDescription className="text-yellow-900 dark:text-yellow-300">
               {isResolvingErrors ? (
                 <span>
-                  <span className="text-sm text-yellow-700 animate-pulse">
+                  <span className="text-sm text-yellow-700 dark:text-yellow-400 da animate-pulse">
                     Resolving failures
                   </span>
                 </span>
@@ -471,7 +471,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
                 <>
                   We ran into some issues while processing some documents.{" "}
                   <b
-                    className="text-link cursor-pointer"
+                    className="text-link cursor-pointer dark:text-blue-300"
                     onClick={() => setShowIndexAttemptErrors(true)}
                   >
                     View details.

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -10,8 +10,8 @@ const alertVariants = cva(
       variant: {
         broken:
           "border-red-500/50 text-red-500 dark:border-red-500 [&>svg]:text-red-500 dark:border-red-900/50 dark:text-red-100 dark:dark:border-red-900 dark:[&>svg]:text-red-700 bg-red-50 dark:bg-red-950",
-        ark: "border-amber-400/50 text-amber-400 dark:border-amber-400 [&>svg]:text-amber-400 dark:border-amber-800/50 dark:text-amber-800 dark:dark:border-amber-800 dark:[&>svg]:text-amber-800 bg-amber-50 dark:bg-amber-950",
-        info: "border-black/50 dark:border-black dark:border-black/50 dark:dark:border-black",
+        ark: "border-amber-500/50 text-amber-500 dark:border-amber-500 [&>svg]:text-amber-500 dark:border-amber-900/50 dark:text-amber-900 dark:dark:border-amber-900 dark:[&>svg]:text-amber-900 bg-amber-50 dark:bg-amber-950",
+        info: "border-[#fff]/50 dark:border-[#fff] dark:border-[#fff]/50 dark:dark:border-[#fff]",
         default:
           "bg-neutral-50 text-neutral-darker dark:bg-neutral-950 dark:text-text",
         destructive:


### PR DESCRIPTION
## Description

Fixes the below 

<img width="978" alt="Screenshot 2025-02-28 at 4 08 29 PM" src="https://github.com/user-attachments/assets/4d71a47b-9bbc-4519-9517-d4b604180bd1" />

Updated to the following

<img width="1047" alt="Screenshot 2025-02-28 at 4 09 19 PM" src="https://github.com/user-attachments/assets/3b5fcdd2-c1cf-46aa-934b-279a0b57864b" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
