### PR TITLE
fix js console issues

### DIFF
--- a/web/src/app/chat/input/LLMPopover.tsx
+++ b/web/src/app/chat/input/LLMPopover.tsx
@@ -115,10 +115,7 @@ export default function LLMPopover({
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <button
-          className="dark:text-[#fff] text-[#000] focus:outline-none"
-          data-testid="llm-popover-trigger"
-        >
+        <div>
           <ChatInputOption
             minimize
             toggle
@@ -138,7 +135,7 @@ export default function LLMPopover({
             )}
             tooltipContent="Switch models"
           />
-        </button>
+        </div>
       </PopoverTrigger>
       <PopoverContent
         align="start"
@@ -177,17 +174,19 @@ export default function LLMPopover({
                   {llmManager.imageFilesPresent &&
                     !checkLLMSupportsImageInput(name) && (
                       <TooltipProvider>
-                        <Tooltip delayDuration={0}>
-                          <TooltipTrigger className="my-auto flex items-center ml-auto">
-                            <FiAlertTriangle className="text-alert" size={16} />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p className="text-xs">
-                              This LLM is not vision-capable and cannot process
-                              image files present in your chat session.
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
+                          <Tooltip delayDuration={0}>
+                            <TooltipTrigger asChild className="my-auto flex items-center ml-auto">
+                              <div>
+                                <FiAlertTriangle className="text-alert" size={16} />
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p className="text-xs">
+                                This LLM is not vision-capable and cannot process
+                                image files present in your chat session.
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
                       </TooltipProvider>
                     )}
                 </button>

--- a/web/src/components/search/filtering/FilterPopup.tsx
+++ b/web/src/components/search/filtering/FilterPopup.tsx
@@ -252,7 +252,7 @@ export function FilterPopup({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button>{trigger}</button>
+        <div>{trigger}</div>
       </PopoverTrigger>
       <PopoverContent
         className="bg-background w-[400px] p-0 shadow-lg"


### PR DESCRIPTION
## Description

Fixes npm console issues:

```
Error: In HTML, <button> cannot be a descendant of <button>.
This will cause a hydration error.

  ...
    <FilterPopup availableSources={[...]} availableDocumentSets={[...]} availableTags={[...]} filterManager={{...}} ...>
      <Popover>
        <Popper __scopePopper={{Popper:[...]}}>
          <PopperProvider scope={{Popper:[...]}} anchor={null} onAnchorChange={function bound dispatchSetState}>
            <PopoverProvider scope={undefined} contentId="radix-:r4:" triggerRef={{current:null}} open={false} ...>
              <PopoverTrigger asChild={true}>
                <PopperAnchor asChild={true} __scopePopper={{Popper:[...]}}>
                  <Primitive.div asChild={true} ref={function}>
                    <Slot ref={function}>
                      <SlotClone ref={function}>
                        <Primitive.button type="button" aria-haspopup="dialog" aria-expanded={false} ...>
                          <Slot type="button" aria-haspopup="dialog" aria-expanded={false} aria-controls="radix-:r4:" ...>
                            <SlotClone type="button" aria-haspopup="dialog" aria-expanded={false} ...>
>                             <button
>                               type="button"
>                               aria-haspopup="dialog"
>                               aria-expanded={false}
>                               aria-controls="radix-:r4:"
>                               data-state="closed"
>                               onClick={function handleEvent}
>                               ref={function}
>                             >
                                ...
                                  <Primitive.button aria-describedby={undefined} data-state="closed" type="button" ...>
                                    <Slot aria-describedby={undefined} data-state="closed" type="button" ...>
                                      <SlotClone aria-describedby={undefined} data-state="closed" type="button" ...>
>                                       <button
>                                         ref={function}
>                                         className={"\n            relative \n            cursor-pointer \n         ..."}
>                                         onClick={function handleEvent}
>                                         aria-describedby={undefined}
>                                         data-state="closed"
>                                         type="button"
>                                         onPointerMove={function handleEvent}
>                                         onPointerLeave={function handleEvent}
>                                         onPointerDown={function handleEvent}
>                                         onFocus={function handleEvent}
>                                         onBlur={function handleEvent}
>                                       >
              ...

    at createUnhandledError (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_ce20a02f._.js:879:71)
    at handleClientError (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_ce20a02f._.js:1052:56)
    at console.error (http://localhost:3000/_next/static/chunks/node_modules_next_dist_client_ce20a02f._.js:1191:56)
    at validateDOMNesting (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:1881:372)
    at completeWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7309:25)
    at runWithFiberInDEV (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:1326:74)
    at completeUnitOfWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8052:23)
    at performUnitOfWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7989:28)
    at workLoopSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7879:40)
    at renderRootSync (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7862:13)
    at performWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7603:212)
    at performSyncWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8573:9)
    at flushSyncWorkAcrossRoots_impl (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8493:316)
    at flushSpawnedWork (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8274:13)
    at commitRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8136:13)
    at commitRootWhenReady (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7700:9)
    at performWorkOnRoot (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:7678:25)
    at performWorkOnRootViaSchedulerTask (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_react-dom_1f56dc06._.js:8565:9)
    at MessagePort.performWorkUntilDeadline (http://localhost:3000/_next/static/chunks/node_modules_next_dist_compiled_38d265cf._.js:1956:64)
    at button (<anonymous>)
    at ChatInputOption (http://localhost:3000/_next/static/chunks/src_app_chat_input_caaad9cf._.js:29:233)
    at Slot (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:6819:206)
    at Primitive.button (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:7388:210)
    at TooltipTrigger (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:11215:213)
    at Slot (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:6819:206)
    at Primitive.div (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:7388:210)
    at PopperAnchor (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:10390:226)
    at TooltipTrigger (http://localhost:3000/_next/static/chunks/node_modules_326b0768._.js:11212:206)
    at _c (http://localhost:3000/_next/static/chunks/_bace4b77._.js:8148:460)
    at ChatInputOption (http://localhost:3000/_next/static/chunks/src_app_chat_input_caaad9cf._.js:27:219)
    at ChatInputBar (http://localhost:3000/_next/static/chunks/src_app_chat_input_caaad9cf._.js:1456:260)
    at children (http://localhost:3000/_next/static/chunks/src_app_chat_ChatPage_tsx_e7c7eaeb._.js:2370:279)
    at Dropzone (http://localhost:3000/_next/static/chunks/node_modules_41788350._.js:16745:386)
    at ChatPage (http://localhost:3000/_next/static/chunks/src_app_chat_ChatPage_tsx_e7c7eaeb._.js:1897:294)
    at content (http://localhost:3000/_next/static/chunks/src_app_chat_a4083078._.js:4924:246)
    at FunctionalWrapper (http://localhost:3000/_next/static/chunks/src_components_6b0f4c0a._.js:8215:23)
    at WrappedChat (http://localhost:3000/_next/static/chunks/src_app_chat_a4083078._.js:4922:214)
    at Page (rsc://React/Server/file:///home/egomes/photon/ccoe/synapse/danswer-ee/web/.next/server/chunks/ssr/_d5495f1c._.js?16:133:263)
```
