### PR TITLE
Eliminate extremely long log line for large checkpointds

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from enum import Enum
 from typing import Any
@@ -208,7 +209,7 @@ class ConnectorCheckpoint(BaseModel):
         """String representation of the checkpoint, with truncation for large checkpoint content."""
         MAX_CHECKPOINT_CONTENT_CHARS = 1000
 
-        content_str = str(self.checkpoint_content)
+        content_str = json.dumps(self.checkpoint_content)
         if len(content_str) > MAX_CHECKPOINT_CONTENT_CHARS:
             content_str = content_str[: MAX_CHECKPOINT_CONTENT_CHARS - 3] + "..."
         return f"ConnectorCheckpoint(checkpoint_content={content_str}, has_more={self.has_more})"

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -204,6 +204,15 @@ class ConnectorCheckpoint(BaseModel):
     def build_dummy_checkpoint(cls) -> "ConnectorCheckpoint":
         return ConnectorCheckpoint(checkpoint_content={}, has_more=True)
 
+    def __str__(self) -> str:
+        """String representation of the checkpoint, with truncation for large checkpoint content."""
+        MAX_CHECKPOINT_CONTENT_CHARS = 1000
+
+        content_str = str(self.checkpoint_content)
+        if len(content_str) > MAX_CHECKPOINT_CONTENT_CHARS:
+            content_str = content_str[: MAX_CHECKPOINT_CONTENT_CHARS - 3] + "..."
+        return f"ConnectorCheckpoint(checkpoint_content={content_str}, has_more={self.has_more})"
+
 
 class DocumentFailure(BaseModel):
     document_id: str


### PR DESCRIPTION
## Description

^

Log is here: https://github.com/danswer-ai/danswer/blob/main/backend/onyx/background/indexing/run_indexing.py#L430-L432

## How Has This Been Tested?

Tested indexing locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
