### PR TITLE
better drive url cleaning

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -60,7 +60,7 @@ def _extract_str_list_from_comma_str(string: str | None) -> list[str]:
 
 
 def _extract_ids_from_urls(urls: list[str]) -> list[str]:
-    return [urlparse(url).path.split("/")[-1] for url in urls]
+    return [urlparse(url).path.strip("/").split("/")[-1] for url in urls]
 
 
 def _convert_single_file(

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -60,7 +60,7 @@ def _extract_str_list_from_comma_str(string: str | None) -> list[str]:
 
 
 def _extract_ids_from_urls(urls: list[str]) -> list[str]:
-    return [urlparse(url).path.split("/")[-1].split("?")[0] for url in urls]
+    return [urlparse(url).path.split("/")[-1] for url in urls]
 
 
 def _convert_single_file(

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -4,6 +4,7 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any
+from urllib.parse import urlparse
 
 from google.oauth2.credentials import Credentials as OAuthCredentials  # type: ignore
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials  # type: ignore
@@ -59,7 +60,7 @@ def _extract_str_list_from_comma_str(string: str | None) -> list[str]:
 
 
 def _extract_ids_from_urls(urls: list[str]) -> list[str]:
-    return [url.split("/")[-1] for url in urls]
+    return [urlparse(url).path.split("/")[-1].split("?")[0] for url in urls]
 
 
 def _convert_single_file(


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1564/drive-folder-url-id-parsing

If a user accidentally or purposefully includes params in the drvie folder url they want connected, we should strip off the params when extracting the folder id.

## How Has This Been Tested?

hopefully integration tests cover this, if not I'll run it in the UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
