### PR TITLE
safe handling for mediaType in confluence connector in all places

### DIFF
--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -311,7 +311,7 @@ def convert_attachment_to_content(
       2. Extracts or summarizes content
       3. Returns (content_text, stored_file_name) or None if we should skip it
     """
-    media_type = attachment["metadata"]["mediaType"]
+    media_type = attachment.get("metadata", {}).get("mediaType", "")
     # Quick check for unsupported types:
     if media_type.startswith("video/") or media_type == "application/gliffy+json":
         logger.warning(
@@ -534,6 +534,10 @@ def attachment_to_file_record(
         download_link, absolute=True, not_json_response=True
     )
 
+    file_type = attachment.get("metadata", {}).get(
+        "mediaType", "application/octet-stream"
+    )
+
     # Save image to file store
     file_name = f"confluence_attachment_{attachment['id']}"
     lobj_oid = create_populate_lobj(BytesIO(image_data), db_session)
@@ -541,7 +545,7 @@ def attachment_to_file_record(
         file_name=file_name,
         display_name=attachment["title"],
         file_origin=FileOrigin.OTHER,
-        file_type=attachment["metadata"]["mediaType"],
+        file_type=file_type,
         lobj_oid=lobj_oid,
         db_session=db_session,
         commit=True,


### PR DESCRIPTION
## Description

Fixes DAN-1578.
https://linear.app/danswer/issue/DAN-1578/handle-mediatype-in-confluence-connector-safely

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
