### PR TITLE
possible fix for confluence query filter

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -72,11 +72,10 @@ _ATTACHMENT_EXTENSIONS_TO_FILTER_OUT = [
     "mp3",
     "wav",
 ]
-_FULL_EXTENSION_FILTER_STRING = "".join(
-    [
-        f" and title!~'*.{extension}'"
-        for extension in _ATTACHMENT_EXTENSIONS_TO_FILTER_OUT
-    ]
+
+_ATTACHMENT_EXTENSION_REGEX_GROUP = "|".join(_ATTACHMENT_EXTENSIONS_TO_FILTER_OUT)
+_FULL_EXTENSION_FILTER_STRING = (
+    f" and title !~ '.*\\.({_ATTACHMENT_EXTENSION_REGEX_GROUP})$'"
 )
 
 


### PR DESCRIPTION
## Description

Fixes DAN-1570. (We hope)
https://linear.app/danswer/issue/DAN-1570/search-issues-in-older-versions-of-confluence

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
