### PR TITLE
add proper boolean validation to field

### DIFF
--- a/web/src/components/credentials/lib.ts
+++ b/web/src/components/credentials/lib.ts
@@ -16,7 +16,15 @@ export function createValidationSchema(json_values: Record<string, any>) {
 
     const displayName = getDisplayNameForCredentialKey(key);
 
-    if (json_values[key] === null) {
+    if (typeof json_values[key] === "boolean") {
+      // Ensure false is considered valid
+      schemaFields[key] = Yup.boolean()
+        .nullable()
+        .default(false)
+        .transform((value, originalValue) =>
+          originalValue === undefined ? false : value
+        );
+    } else if (json_values[key] === null) {
       // Field is optional:
       schemaFields[key] = Yup.string()
         .trim()


### PR DESCRIPTION
## Description

Fixes DAN-1584.
https://linear.app/danswer/issue/DAN-1584/fix-salesforce-credential-validator

didn't work properly with boolean field, form could not submit unless sandbox checkbox was manually modified

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
