### PR TITLE
Github connector: Add an `include_code` option and index code

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -261,7 +261,8 @@ class GithubConnector(LoadConnector, PollConnector):
                 logger.error(f"Rate limit exceeded too many times while fetching contents for {directory} in {repo.name}")
                 return  # Exit after too many retries
 
-        code_files = _get_files_recursively("")  # Start from the root directory
+        # Skip files >1MB
+        code_files = (f for f in _get_files_recursively("") if f.size < 1_000_000)
         doc_batch: list[Document] = []
         for file in code_files:
             try:

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -38,7 +38,7 @@ langchainhub==0.1.21
 langgraph==0.2.72
 langgraph-checkpoint==2.0.13
 langgraph-sdk==0.1.44
-litellm==1.63.8
+litellm==1.63.11
 lxml==5.3.0
 lxml_html_clean==0.2.2
 llama-index==0.9.45

--- a/backend/scripts/add_connector_creation_script.py
+++ b/backend/scripts/add_connector_creation_script.py
@@ -119,6 +119,7 @@ def main() -> None:
         connector_specific_config={
             "repo_owner": "example-owner",
             "repo_name": "example-repo",
+            "include_code": True,
             "include_prs": True,
             "include_issues": True,
         },

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -216,6 +216,14 @@ export const connectorConfigs: Record<
       },
       {
         type: "checkbox",
+        query: "Include code?",
+        label: "Include code?",
+        description: "Index code from repositories",
+        name: "include_code",
+        optional: true,
+      },
+      {
+        type: "checkbox",
         query: "Include pull requests?",
         label: "Include pull requests?",
         description: "Index pull requests from repositories",
@@ -1361,6 +1369,7 @@ export interface WebConfig {
 export interface GithubConfig {
   repo_owner: string;
   repositories: string; // Comma-separated list of repository names
+  include_code: boolean;
   include_prs: boolean;
   include_issues: boolean;
 }


### PR DESCRIPTION
## Description

Index the code in your Github repositories. Also, adds an `include_code` option to the settings screen.

Addresses feature request: https://github.com/onyx-dot-app/onyx/issues/4025

## How Has This Been Tested?

1. Add a new Github connector
2. Specify the details and configure the connector
3. When setting up the options, check the "Include code?" box
4. Let the connector run
5. Verify that code files are being included using the Explorer tool

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

## Notes
- Documentation update: https://github.com/onyx-dot-app/documentation/pull/189
