### PR TITLE
Small slack bot fixes

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -170,7 +170,8 @@ def handle_message(
         respond_tag_only = channel_conf.get("respond_tag_only") or False
         respond_member_group_list = channel_conf.get("respond_member_group_list", None)
 
-    if respond_tag_only and not bypass_filters:
+    # NOTE: always respond in the DMs, as long the default config is not disabled.
+    if respond_tag_only and not bypass_filters and not is_bot_dm:
         logger.info(
             "Skipping message since the channel is configured such that "
             "OnyxBot only responds to tags"

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -261,9 +261,6 @@ def create_bot(
     # Create a default Slack channel config
     default_channel_config = ChannelConfig(
         channel_name=None,
-        respond_member_group_list=[],
-        answer_filters=[],
-        follow_up_tags=[],
         respond_tag_only=True,
     )
     insert_slack_channel_config(


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1624/investigate-slack-bot-not-answering-for-frc.

Also switches default slack bot behavior to not show "Still needs help" option.

## How Has This Been Tested?

Tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
