### PR TITLE
typing fix

### DIFF
--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -177,7 +177,8 @@ def _get_tickets_page(
 
 def _fetch_author(client: ZendeskClient, author_id: str) -> BasicExpertInfo | None:
     # Skip fetching if author_id is invalid
-    if not author_id or author_id == "-1":
+    # cast to str to avoid issues with zendesk changing their types
+    if not author_id or str(author_id) == "-1":
         return None
 
     try:

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -175,7 +175,9 @@ def _get_tickets_page(
     )
 
 
-def _fetch_author(client: ZendeskClient, author_id: str) -> BasicExpertInfo | None:
+def _fetch_author(
+    client: ZendeskClient, author_id: str | int
+) -> BasicExpertInfo | None:
     # Skip fetching if author_id is invalid
     # cast to str to avoid issues with zendesk changing their types
     if not author_id or str(author_id) == "-1":


### PR DESCRIPTION
## Description

We were seeing some logs where we were requesting .../users/-1, which the code explicitly guards against. We believe the only way this is possible is if the value of author_id when it reaches _fetch_author was the int -1 instead of the expected string, so we simply cast it during the check to catch this case.

## How Has This Been Tested?

Going to rely on automated tests for this one, as all it does is codify our assumption that the id used is a string

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
