### PR TITLE
refactor tests for Highspot connector to use mocking for API key retr…

### DIFF
--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -2,6 +2,8 @@ import json
 import os
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -40,10 +42,13 @@ def highspot_connector() -> HighspotConnector:
     return connector
 
 
-@pytest.mark.xfail(
-    reason="Accessing postgres that isn't available in connector only tests",
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
 )
-def test_highspot_connector_basic(highspot_connector: HighspotConnector) -> None:
+def test_highspot_connector_basic(
+    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector
+) -> None:
     """Test basic functionality of the Highspot connector."""
     all_docs: list[Document] = []
     test_data = load_test_data()
@@ -76,10 +81,13 @@ def test_highspot_connector_basic(highspot_connector: HighspotConnector) -> None
         assert len(section.text) > 0
 
 
-@pytest.mark.xfail(
-    reason="Possibly accessing postgres that isn't available in connector only tests",
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key",
+    return_value=None,
 )
-def test_highspot_connector_slim(highspot_connector: HighspotConnector) -> None:
+def test_highspot_connector_slim(
+    mock_get_api_key: MagicMock, highspot_connector: HighspotConnector
+) -> None:
     """Test slim document retrieval."""
     # Get all doc IDs from the full connector
     all_full_doc_ids = set()


### PR DESCRIPTION
## Description
This pull request updates the `backend/tests/daily/connectors/highspot/test_highspot_connector.py` file to manage the test context for file extraction in environments where Redis is unavailable. The most important changes include importing necessary mocking tools and adding patches to the test functions.

Improvements to testing:

* Imported `MagicMock` and `patch` from `unittest.mock` to enable mocking in tests.
* Modified the `test_highspot_connector_basic` function to use `patch` for mocking the `get_unstructured_api_key` method and added `MagicMock` as a parameter.
* Modified the `test_highspot_connector_slim` function to use `patch` for mocking the `get_unstructured_api_key` method and added `MagicMock` as a parameter.

## How Has This Been Tested?
I verified the changes by running the test after stopping both Redis and Postgres, and the test passed successfully.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
