### PR TITLE
fix broken function call

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -909,6 +909,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointConnector[GoogleDriveCheckpo
                 self.creds,
                 self.primary_admin_email,
                 self.allow_images,
+                self.size_threshold,
             )
 
             # Fetch files in batches


### PR DESCRIPTION
## Description

Fixes DAN-1651.
https://linear.app/danswer/issue/DAN-1651/google-drive-partial-function-call-broke

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
