### PR TITLE
Fix session touching

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -73,7 +73,6 @@ from onyx.db.chat import get_or_create_root_message
 from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
-from onyx.db.chat import update_chat_session_timestamp
 from onyx.db.engine import get_session_context_manager
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
@@ -1070,8 +1069,6 @@ def stream_chat_message_objects(
             prev_message = next_answer_message
 
         logger.debug("Committing messages")
-        # Explicitly update the timestamp on the chat session
-        update_chat_session_timestamp(chat_session_id, db_session)
         db_session.commit()  # actually save user / assistant message
 
         yield AgenticMessageResponseIDInfo(agentic_message_ids=agentic_message_ids)

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -73,6 +73,7 @@ from onyx.db.chat import get_or_create_root_message
 from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
+from onyx.db.chat import update_chat_session_timestamp
 from onyx.db.engine import get_session_context_manager
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
@@ -1069,6 +1070,8 @@ def stream_chat_message_objects(
             prev_message = next_answer_message
 
         logger.debug("Committing messages")
+        # Explicitly update the timestamp on the chat session
+        update_chat_session_timestamp(chat_session_id, db_session)
         db_session.commit()  # actually save user / assistant message
 
         yield AgenticMessageResponseIDInfo(agentic_message_ids=agentic_message_ids)

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -73,7 +73,7 @@ from onyx.db.chat import get_or_create_root_message
 from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
-from onyx.db.chat import update_chat_session_timestamp
+from onyx.db.chat import update_chat_session_updated_at_timestamp
 from onyx.db.engine import get_session_context_manager
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
@@ -1071,7 +1071,7 @@ def stream_chat_message_objects(
 
         logger.debug("Committing messages")
         # Explicitly update the timestamp on the chat session
-        update_chat_session_timestamp(chat_session_id, db_session)
+        update_chat_session_updated_at_timestamp(chat_session_id, db_session)
         db_session.commit()  # actually save user / assistant message
 
         yield AgenticMessageResponseIDInfo(agentic_message_ids=agentic_message_ids)

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from typing import Any
 from typing import cast
 from typing import Tuple
@@ -1089,3 +1090,19 @@ def log_agent_sub_question_results(
             db_session.commit()
 
     return None
+
+
+def update_chat_session_timestamp(chat_session_id: UUID, db_session: Session) -> None:
+    """
+    Explicitly update the timestamp on a chat session without modifying other fields.
+    This is useful when adding messages to a chat session to reflect recent activity.
+    """
+
+    # Direct SQL update to avoid loading the entire object if it's not already loaded
+    # This is more efficient and clearly shows the intent
+    db_session.execute(
+        update(ChatSession)
+        .where(ChatSession.id == chat_session_id)
+        .values(time_updated=datetime.now(timezone.utc))
+    )
+    # No commit - the caller is responsible for committing the transaction

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1092,14 +1092,15 @@ def log_agent_sub_question_results(
     return None
 
 
-def update_chat_session_timestamp(chat_session_id: UUID, db_session: Session) -> None:
+def update_chat_session_updated_at_timestamp(
+    chat_session_id: UUID, db_session: Session
+) -> None:
     """
     Explicitly update the timestamp on a chat session without modifying other fields.
     This is useful when adding messages to a chat session to reflect recent activity.
     """
 
     # Direct SQL update to avoid loading the entire object if it's not already loaded
-    # This is more efficient and clearly shows the intent
     db_session.execute(
         update(ChatSession)
         .where(ChatSession.id == chat_session_id)

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 from typing import Any
 from typing import cast
 from typing import Tuple
@@ -1104,6 +1103,6 @@ def update_chat_session_updated_at_timestamp(
     db_session.execute(
         update(ChatSession)
         .where(ChatSession.id == chat_session_id)
-        .values(time_updated=datetime.now(timezone.utc))
+        .values(time_updated=func.now())
     )
     # No commit - the caller is responsible for committing the transaction

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 from typing import Any
 from typing import cast
 from typing import Tuple
@@ -1090,19 +1089,3 @@ def log_agent_sub_question_results(
             db_session.commit()
 
     return None
-
-
-def update_chat_session_timestamp(chat_session_id: UUID, db_session: Session) -> None:
-    """
-    Explicitly update the timestamp on a chat session without modifying other fields.
-    This is useful when adding messages to a chat session to reflect recent activity.
-    """
-
-    # Direct SQL update to avoid loading the entire object if it's not already loaded
-    # This is more efficient and clearly shows the intent
-    db_session.execute(
-        update(ChatSession)
-        .where(ChatSession.id == chat_session_id)
-        .values(time_updated=datetime.now(timezone.utc))
-    )
-    # No commit - the caller is responsible for committing the transaction


### PR DESCRIPTION
## Description

Chat sessions are not updated their updated time when chat messages are inserted

Fixes https://linear.app/danswer/issue/DAN-1662/chat-history-ordering

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
