### PR TITLE
minor improvement to fireflies connector

### DIFF
--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -45,6 +45,8 @@ _FIREFLIES_API_QUERY = """
     }
 """
 
+ONE_HOUR = 3600
+
 
 def _create_doc_from_transcript(transcript: dict) -> Document | None:
     sections: List[TextSection] = []
@@ -106,6 +108,8 @@ def _create_doc_from_transcript(transcript: dict) -> Document | None:
     )
 
 
+# If not all transcripts are being indexed, try using a more-recently-generated
+# API key.
 class FirefliesConnector(PollConnector, LoadConnector):
     def __init__(self, batch_size: int = INDEX_BATCH_SIZE) -> None:
         self.batch_size = batch_size
@@ -191,6 +195,9 @@ class FirefliesConnector(PollConnector, LoadConnector):
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> GenerateDocumentsOutput:
+        # add some leeway to account for any timezone funkiness and/or bad handling
+        # of start time on the Fireflies side
+        start = max(0, start - ONE_HOUR)
         start_datetime = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.000Z"
         )

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -45,7 +45,7 @@ _FIREFLIES_API_QUERY = """
     }
 """
 
-ONE_HOUR = 3600
+ONE_MINUTE = 60
 
 
 def _create_doc_from_transcript(transcript: dict) -> Document | None:
@@ -197,7 +197,7 @@ class FirefliesConnector(PollConnector, LoadConnector):
     ) -> GenerateDocumentsOutput:
         # add some leeway to account for any timezone funkiness and/or bad handling
         # of start time on the Fireflies side
-        start = max(0, start - ONE_HOUR)
+        start = max(0, start - ONE_MINUTE)
         start_datetime = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.000Z"
         )


### PR DESCRIPTION
## Description

Addresses https://linear.app/danswer/issue/DAN-1556/address-missing-fireflies-docs-in-our-cloud
Mostly comments for future connector users; it appears that in some cases the fireflies connector silently doesn't retrieve certain transcripts with certain (potentially old) API keys. I also noticed that even doing a full re-indexing with the old api key pulled in a few new transcripts, which might point to some small timing issues. 

## How Has This Been Tested?

Tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
