### PR TITLE
DELETE endpoint for ingestion docs

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -587,6 +587,7 @@ def delete_documents_complete__no_commit(
     """This completely deletes the documents from the db, including all foreign key relationships"""
 
     # Start by deleting the chunk stats for the documents
+    # BUG: Is there a reason this is called twice?
     delete_chunk_stats_by_connector_credential_pair__no_commit(
         db_session=db_session,
         document_ids=document_ids,

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -202,6 +202,9 @@ def delete_ingestion_doc(
         filters=IndexFilters(access_control_list=None, tenant_id=tenant_id),
     )
 
+    # TODO: add error recovery so that if any of these operations fail,
+    #       we can revert back to the original state with all documents
+    #       and chunks intact.
     file_store = get_default_file_store(db_session)
     for chunk in chunks:
         if chunk.image_file_name:

--- a/backend/onyx/server/onyx_api/models.py
+++ b/backend/onyx/server/onyx_api/models.py
@@ -13,6 +13,10 @@ class IngestionResult(BaseModel):
     already_existed: bool
 
 
+class DeleteIngestionResult(BaseModel):
+    document_id: str
+
+
 class DocMinimalInfo(BaseModel):
     document_id: str
     semantic_id: str

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -683,6 +683,8 @@ def upload_files_for_chat(
             raise HTTPException(status_code=400, detail="File content type is required")
 
         if file.content_type not in allowed_content_types:
+            # BUG: The error detail code here seems incorrect: it seems like it only ever generates
+            # `Unsupported document file type` for any file type.
             if file.content_type in image_content_types:
                 error_detail = "Unsupported image file type. Supported image types include .jpg, .jpeg, .png, .webp."
             elif file.content_type in text_content_types:


### PR DESCRIPTION
## Description

Added a DELETE endpoint to the ingestion docs on the MIT version of Onyx that fully deletes a document and associated images from the vector index and the Postgres database.

## How Has This Been Tested?

Locally tested with documents with text-only sections, image-only sections, and combined sections. Verified that data was deleted in database tables, vector index, and file store.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
