### PR TITLE
fix: ensure base_url ends with a trailing slash

### DIFF
--- a/backend/onyx/connectors/highspot/client.py
+++ b/backend/onyx/connectors/highspot/client.py
@@ -75,7 +75,7 @@ class HighspotClient:
 
         self.key = key
         self.secret = secret
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/") + "/"
         self.timeout = timeout
 
         # Set up session with retry logic


### PR DESCRIPTION
This pull request includes a small but important change to the `backend/onyx/connectors/highspot/client.py` file. The change ensures that the `base_url` attribute always ends with a single slash, which helps prevent potential issues with URL concatenation.

* [`backend/onyx/connectors/highspot/client.py`](diffhunk://#diff-0672c9a2a137bd7353a70a5f9aad26c7157de341dec4cb1ad2c522bbcbf78436L78-R78): Modified the `base_url` initialization to ensure it always ends with a single slash by using `rstrip("/")` and appending a slash.## Description

## How Has This Been Tested?
Tested by running it in the terminal


- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
