### PR TITLE
ensure bedrock model contains API key

### DIFF
--- a/web/src/app/admin/embeddings/RerankingFormPage.tsx
+++ b/web/src/app/admin/embeddings/RerankingFormPage.tsx
@@ -457,7 +457,7 @@ const RerankingDetailsForm = forwardRef<
                             ...values,
                             rerank_api_key: value,
                           });
-                          setFieldValue("api_key", value);
+                          setFieldValue("rerank_api_key", value);
                         }}
                         type="password"
                         label={

--- a/web/src/app/admin/embeddings/RerankingFormPage.tsx
+++ b/web/src/app/admin/embeddings/RerankingFormPage.tsx
@@ -76,7 +76,7 @@ const RerankingDetailsForm = forwardRef<
           function (value) {
             const { rerank_provider_type } = this.parent;
             return (
-              rerank_provider_type !== RerankerProvider.COHERE ||
+              rerank_provider_type === RerankerProvider.LITELLM ||
               (value !== null && value !== "")
             );
           }


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1592/aws-re-ranking-bugged
We previously allowed users to create a bedrock reranker with an empty API key, letting them finish updating their settings and only later during search getting an error that no API key was set.

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
