### PR TITLE
Enable Support for LiteLLM Customer feature

### DIFF
--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/nodes/generate_sub_answer.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/nodes/generate_sub_answer.py
@@ -121,6 +121,7 @@ def generate_sub_answer(
                 prompt=msg,
                 timeout_override=AGENT_TIMEOUT_CONNECT_LLM_SUBANSWER_GENERATION,
                 max_tokens=AGENT_MAX_TOKENS_SUBANSWER_GENERATION,
+                user_id=graph_config.tooling.user_id,
             ):
                 # TODO: in principle, the answer here COULD contain images, but we don't support that yet
                 content = message.content

--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_initial_answer/nodes/generate_initial_answer.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_initial_answer/nodes/generate_initial_answer.py
@@ -283,6 +283,7 @@ def generate_initial_answer(
                 max_tokens=AGENT_MAX_TOKENS_ANSWER_GENERATION
                 if _should_restrict_tokens(model.config)
                 else None,
+                user_id=graph_config.tooling.user_id,
             ):
                 # TODO: in principle, the answer here COULD contain images, but we don't support that yet
                 content = message.content

--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_sub_answers/nodes/decompose_orig_question.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_sub_answers/nodes/decompose_orig_question.py
@@ -143,6 +143,7 @@ def decompose_orig_question(
                 msg,
                 timeout_override=AGENT_TIMEOUT_CONNECT_LLM_SUBQUESTION_GENERATION,
                 max_tokens=AGENT_MAX_TOKENS_SUBQUESTION_GENERATION,
+                user_id=graph_config.tooling.user_id,
             ),
             dispatch_subquestion(0, writer),
             sep_callback=dispatch_subquestion_sep(0, writer),

--- a/backend/onyx/agents/agent_search/deep_search/main/nodes/create_refined_sub_questions.py
+++ b/backend/onyx/agents/agent_search/deep_search/main/nodes/create_refined_sub_questions.py
@@ -146,6 +146,7 @@ def create_refined_sub_questions(
                 msg,
                 timeout_override=AGENT_TIMEOUT_CONNECT_LLM_REFINED_SUBQUESTION_GENERATION,
                 max_tokens=AGENT_MAX_TOKENS_SUBQUESTION_GENERATION,
+                user_id=graph_config.tooling.user_id,
             ),
             dispatch_subquestion(1, writer),
             sep_callback=dispatch_subquestion_sep(1, writer),

--- a/backend/onyx/agents/agent_search/deep_search/main/nodes/generate_validate_refined_answer.py
+++ b/backend/onyx/agents/agent_search/deep_search/main/nodes/generate_validate_refined_answer.py
@@ -310,6 +310,7 @@ def generate_validate_refined_answer(
             max_tokens=AGENT_MAX_TOKENS_ANSWER_GENERATION
             if _should_restrict_tokens(model.config)
             else None,
+            user_id=graph_config.tooling.user_id,
         ):
             # TODO: in principle, the answer here COULD contain images, but we don't support that yet
             content = message.content
@@ -417,6 +418,7 @@ def generate_validate_refined_answer(
             prompt=msg,
             timeout_override=AGENT_TIMEOUT_CONNECT_LLM_REFINED_ANSWER_VALIDATION,
             max_tokens=AGENT_MAX_TOKENS_VALIDATION,
+            user_id=graph_config.tooling.user_id,
         )
         refined_answer_quality = binary_string_test_after_answer_separator(
             text=cast(str, validation_response.content),

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/expand_queries.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/expand_queries.py
@@ -98,6 +98,7 @@ def expand_queries(
                 prompt=msg,
                 timeout_override=AGENT_TIMEOUT_CONNECT_LLM_QUERY_REWRITING_GENERATION,
                 max_tokens=AGENT_MAX_TOKENS_SUBQUERY_GENERATION,
+                user_id=graph_config.tooling.user_id,
             ),
             dispatch_subquery(level, question_num, writer),
         )

--- a/backend/onyx/agents/agent_search/models.py
+++ b/backend/onyx/agents/agent_search/models.py
@@ -36,6 +36,7 @@ class GraphTooling(BaseModel):
     # force tool args IF the tool is used
     force_use_tool: ForceUseTool
     using_tool_calling_llm: bool = False
+    user_id: str | None = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -154,6 +154,7 @@ def choose_tool(
             else None
         ),
         structured_response_format=structured_response_format,
+        user_id=agent_config.tooling.user_id,
     )
 
     tool_message = process_llm_stream(

--- a/backend/onyx/agents/agent_search/orchestration/nodes/use_tool_response.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/use_tool_response.py
@@ -64,6 +64,7 @@ def basic_use_tool_response(
         stream = llm.stream(
             prompt=new_prompt_builder.build(),
             structured_response_format=structured_response_format,
+            user_id=agent_config.tooling.user_id,
         )
 
         # For now, we don't do multiple tool calls, so we ignore the tool_message

--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -61,6 +61,7 @@ class Answer:
         skip_gen_ai_answer_generation: bool = False,
         is_connected: Callable[[], bool] | None = None,
         use_agentic_search: bool = False,
+        user_id: str | None = None,
     ) -> None:
         self.is_connected: Callable[[], bool] | None = is_connected
         self._processed_stream: (list[AnswerPacket] | None) = None
@@ -117,6 +118,7 @@ class Answer:
             tools=tools or [],
             force_use_tool=force_use_tool,
             using_tool_calling_llm=using_tool_calling_llm,
+            user_id=user_id,
         )
         self.graph_persistence = GraphPersistence(
             db_session=db_session,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -422,6 +422,8 @@ def stream_chat_message_objects(
         ordered_user_files = None
 
         user_id = user.id if user is not None else None
+        # Use placeholder if user is not authenticated (anonymous)
+        user_email = user.email if user is not None else "anonymous_user"
 
         chat_session = get_chat_session_by_id(
             chat_session_id=new_msg_req.chat_session_id,
@@ -1031,6 +1033,7 @@ def stream_chat_message_objects(
             tools=tools,
             db_session=db_session,
             use_agentic_search=new_msg_req.use_agentic_search,
+            user_id=user_email,
         )
 
         # reference_db_search_docs = None

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -26,6 +26,9 @@ APP_API_PREFIX = os.environ.get("API_PREFIX", "")
 
 SKIP_WARM_UP = os.environ.get("SKIP_WARM_UP", "").lower() == "true"
 
+# Whether to send user ID (email or placeholder) to enable LiteLLM Customer Feature for budget tracking/control (https://docs.litellm.ai/docs/proxy/customers)
+SEND_USER_ID_TO_LLM = os.environ.get("SEND_USER_ID_TO_LLM", "").lower() == "true"
+
 #####
 # User Facing Features Configs
 #####

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -92,6 +92,7 @@ class LLM(abc.ABC):
         structured_response_format: dict | None = None,
         timeout_override: int | None = None,
         max_tokens: int | None = None,
+        user_id: str | None = None,
     ) -> BaseMessage:
         self._precall(prompt)
         # TODO add a postcall to log model outputs independent of concrete class
@@ -103,6 +104,7 @@ class LLM(abc.ABC):
             structured_response_format,
             timeout_override,
             max_tokens,
+            user_id,
         )
 
     @abc.abstractmethod
@@ -114,6 +116,7 @@ class LLM(abc.ABC):
         structured_response_format: dict | None = None,
         timeout_override: int | None = None,
         max_tokens: int | None = None,
+        user_id: str | None = None,
     ) -> BaseMessage:
         raise NotImplementedError
 
@@ -125,6 +128,7 @@ class LLM(abc.ABC):
         structured_response_format: dict | None = None,
         timeout_override: int | None = None,
         max_tokens: int | None = None,
+        user_id: str | None = None,
     ) -> Iterator[BaseMessage]:
         self._precall(prompt)
         # TODO add a postcall to log model outputs independent of concrete class
@@ -136,6 +140,7 @@ class LLM(abc.ABC):
             structured_response_format,
             timeout_override,
             max_tokens,
+            user_id,
         )
 
         tokens = []
@@ -156,5 +161,6 @@ class LLM(abc.ABC):
         structured_response_format: dict | None = None,
         timeout_override: int | None = None,
         max_tokens: int | None = None,
+        user_id: str | None = None,
     ) -> Iterator[BaseMessage]:
         raise NotImplementedError


### PR DESCRIPTION
## Description

This patch enables the usage of LiteLLM Customer feature (via an OpenAI provider) by sending out the user id as part of the LLM call.

## How Has This Been Tested?

When enabled, the user email should be received by LiteLLM and show up as a customer entry.
