### PR TITLE
Simpler approach

### DIFF
--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -376,6 +376,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             db_session=alternate_db_session or self.db_session,
             prompt_config=self.prompt_config,
             retrieved_sections_callback=retrieved_sections_callback,
+            contextual_pruning_config=self.contextual_pruning_config,
         )
 
         search_query_info = SearchQueryInfo(
@@ -447,6 +448,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             db_session=self.db_session,
             bypass_acl=self.bypass_acl,
             prompt_config=self.prompt_config,
+            contextual_pruning_config=self.contextual_pruning_config,
         )
 
         # Log what we're doing


### PR DESCRIPTION
In the Search pipeline, we need to first prune, and then merge. This desired behavior was not adhered to anymore and has been re-established.

 prompt_config and contextual_pruning _config both need to be set for this to work.

This fix is also related to https://linear.app/danswer/issue/DAN-1626/dalberg-projects-not-being-foundcited-as-expected
## Description

Key changes:
 - passed contextual_pruning_config to Search pipeline
 - used prune_and_merge to create final chunks
 - if prompt_config not done or contextual_pruning_config not available, default to earlier behavior of calling _merge_sections

## How Has This Been Tested?

Locally. Tested with default Search, and then also an Assistant that does not do AI filtering

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
