### PR TITLE
add prometheus metrics endpoints via helper package

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -8,6 +8,7 @@ import sentry_sdk
 import torch
 import uvicorn
 from fastapi import FastAPI
+from prometheus_fastapi_instrumentator import Instrumentator
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from transformers import logging as transformer_logging  # type:ignore
@@ -111,6 +112,9 @@ def get_model_app() -> FastAPI:
     application.include_router(management_router)
     application.include_router(encoders_router)
     application.include_router(custom_models_router)
+
+    # Initialize and instrument the app
+    Instrumentator().instrument(application).expose(application)
 
     return application
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -16,6 +16,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from httpx_oauth.clients.google import GoogleOAuth2
+from prometheus_fastapi_instrumentator import Instrumentator
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from sqlalchemy.orm import Session
@@ -423,6 +424,9 @@ def get_application() -> FastAPI:
 
     # Ensure all routes have auth enabled or are explicitly marked as public
     check_router_auth(application)
+
+    # Initialize and instrument the app
+    Instrumentator().instrument(application).expose(application)
 
     return application
 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -96,3 +96,4 @@ mistune==0.8.4
 sentry-sdk==2.14.0
 prometheus_client==0.21.0
 fastapi-limiter==0.1.6
+prometheus_fastapi_instrumentator==7.1.0


### PR DESCRIPTION
## Description

Fixes DAN-1744.
https://linear.app/danswer/issue/DAN-1744/add-prometheus-metrics-endpoints-to-fastapi-servers

Will help get rid of spurious 404's in our monitoring and actually provide some useful metrics to boot.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
