### PR TITLE
Adding research topics for better search context

### DIFF
--- a/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a2_research_object_source.py
+++ b/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a2_research_object_source.py
@@ -61,7 +61,11 @@ def research_object_source(
             raise ValueError("Agent 2 task not found")
 
         agent_2_time_cutoff = extract_section(
-            agent_2_instructions, "Time Cutoff:", "Output Objective:"
+            agent_2_instructions, "Time Cutoff:", "Research Topics:"
+        )
+
+        agent_2_research_topics = extract_section(
+            agent_2_instructions, "Research Topics:", "Output Objective"
         )
 
         agent_2_output_objective = extract_section(
@@ -100,7 +104,7 @@ def research_object_source(
     document_sources = [document_source] if document_source else None
 
     retrieved_docs = research(
-        question=object,
+        question=f"{agent_2_research_topics} for {object}",
         search_tool=search_tool,
         document_sources=document_sources,
         time_cutoff=agent_2_source_start_time,

--- a/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a2_research_object_source.py
+++ b/backend/onyx/agents/agent_search/dc_search_analysis/nodes/a2_research_object_source.py
@@ -103,8 +103,15 @@ def research_object_source(
 
     document_sources = [document_source] if document_source else None
 
+    if len(question.strip()) > 0:
+        research_area = f"{question} for {object}"
+    elif agent_2_research_topics and len(agent_2_research_topics.strip()) > 0:
+        research_area = f"{agent_2_research_topics} for {object}"
+    else:
+        research_area = object
+
     retrieved_docs = research(
-        question=f"{agent_2_research_topics} for {object}",
+        question=research_area,
         search_tool=search_tool,
         document_sources=document_sources,
         time_cutoff=agent_2_source_start_time,


### PR DESCRIPTION
## Description

Using the question to focus the object search during the research phase, and adding a field called 'Research Topics' in the Agent Instructions that is used to focus search if question has not been provided.

This is a small fix to https://linear.app/danswer/issue/DAN-1750/simple-divide-and-conquer-assistant-to-support-some-customer-use-cases

## How Has This Been Tested?

Locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
