### PR TITLE
unconditionally set completion

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -837,14 +837,13 @@ class GoogleDriveConnector(SlimConnector, CheckpointConnector[GoogleDriveCheckpo
             return
 
         for file in drive_files:
-            if file.error is None:
-                checkpoint.completion_map[file.user_email].update(
-                    stage=file.completion_stage,
-                    completed_until=datetime.fromisoformat(
-                        file.drive_file[GoogleFields.MODIFIED_TIME.value]
-                    ).timestamp(),
-                    completed_until_parent_id=file.parent_id,
-                )
+            checkpoint.completion_map[file.user_email].update(
+                stage=file.completion_stage,
+                completed_until=datetime.fromisoformat(
+                    file.drive_file[GoogleFields.MODIFIED_TIME.value]
+                ).timestamp(),
+                completed_until_parent_id=file.parent_id,
+            )
             yield file
 
     def _manage_oauth_retrieval(


### PR DESCRIPTION
## Description

Should fix drive id not set in checkpoint; previously when a user failed to index a folder (which is fairly common due to permissions issues) the folder id was not set in the checkpoint. The necessary information for the checkpoint is yielded on error too, 

## How Has This Been Tested?

Tests tbd

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
