### PR TITLE
slack permission tests are enterprise only

### DIFF
--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -82,9 +82,6 @@ def test_highspot_connector_basic(
         assert len(section.text) > 0
 
 
-@pytest.mark.xfail(
-    reason="failing, needs fix",
-)
 @patch(
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,
@@ -109,6 +106,9 @@ def test_highspot_connector_slim(
     assert len(all_slim_doc_ids) > 0
 
 
+@pytest.mark.xfail(
+    reason="failing, needs fix",
+)
 @patch(
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,

--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -82,6 +82,9 @@ def test_highspot_connector_basic(
         assert len(section.text) > 0
 
 
+@pytest.mark.xfail(
+    reason="failing, needs fix",
+)
 @patch(
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,

--- a/backend/tests/integration/connector_job_tests/slack/test_permission_sync.py
+++ b/backend/tests/integration/connector_job_tests/slack/test_permission_sync.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import pytest
+
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
@@ -23,6 +25,12 @@ from tests.integration.common_utils.vespa import vespa_fixture
 from tests.integration.connector_job_tests.slack.slack_api_utils import SlackManager
 
 
+# NOTE(rkuo): it isn't yet clear if the reason these were previously xfail'd
+# still exists. May need to xfail again if flaky (DAN-789)
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission tests are enterprise only",
+)
 def test_slack_permission_sync(
     reset: None,
     vespa_client: vespa_fixture,
@@ -218,6 +226,12 @@ def test_slack_permission_sync(
     assert private_message not in onyx_doc_message_strings
 
 
+# NOTE(rkuo): it isn't yet clear if the reason these were previously xfail'd
+# still exists. May need to xfail again if flaky (DAN-789)
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Permission tests are enterprise only",
+)
 def test_slack_group_permission_sync(
     reset: None,
     vespa_client: vespa_fixture,


### PR DESCRIPTION
## Description

Fixes DAN-1759.
https://linear.app/danswer/issue/DAN-1759/fix-slack-permission-tests-being-in-mit-tests

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
