### PR TITLE
update test expectations for Highspot connector

### DIFF
--- a/backend/onyx/connectors/highspot/connector.py
+++ b/backend/onyx/connectors/highspot/connector.py
@@ -350,6 +350,9 @@ class HighspotConnector(LoadConnector, PollConnector, SlimConnector):
                 return default_content
 
             else:
+                logger.warning(
+                    f"Item {item_id} has unsupported format: {file_extension}"
+                )
                 return default_content
 
         except HighspotClientError as e:

--- a/backend/tests/daily/connectors/highspot/test_highspot_connector.py
+++ b/backend/tests/daily/connectors/highspot/test_highspot_connector.py
@@ -106,9 +106,11 @@ def test_highspot_connector_slim(
     assert len(all_slim_doc_ids) > 0
 
 
-@pytest.mark.xfail(
-    reason="failing, needs fix",
-)
+"""This test might fail because of how Highspot handles changes to the document's
+"updated at" property. It is marked as expected to fail until we can confirm the behavior."""
+
+
+@pytest.mark.xfail(reason="Highspot is not returning updated documents as expected.")
 @patch(
     "onyx.file_processing.extract_file_text.get_unstructured_api_key",
     return_value=None,

--- a/backend/tests/daily/connectors/highspot/test_highspot_data.json
+++ b/backend/tests/daily/connectors/highspot/test_highspot_data.json
@@ -3,8 +3,8 @@
     "semantic_identifier": "Highspot in Action _ Salesforce Integration",
     "link": "https://www.highspot.com/items/67cd8eb35d3ee0487de2e704",
     "poll_source": {
-        "target_doc_id":"67ef9edcc3f40b2bf3d816a8",
-        "semantic_identifier":"A Brief Introduction To AI",
-        "link":"https://www.highspot.com/items/67ef9edcc3f40b2bf3d816a8"
+        "target_doc_id":"67efb452c3f40bcca2b48ca5",
+        "semantic_identifier":"Introduction to Intelligent Agents",
+        "link":"https://www.highspot.com/items/67efb452c3f40bcca2b48ca5"
     }
 }


### PR DESCRIPTION
This pull request includes updates to the Highspot connector and its associated tests. The changes focus on logging unsupported formats, updating test expectations, and modifying test data.

### Highspot Connector Updates:

* Added a warning log for unsupported file formats in the `_get_item_content` method of the Highspot connector.

### Test Updates:

* Updated the `test_highspot_connector_poll_source`  to provide a more detailed explanation for the expected failure due to Highspot's handling of document updates.
* Modified the test data in `test_highspot_data.json` to reflect updated document identifiers and links.

## How Has This Been Tested?
By running test class.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
