### PR TITLE
chore: Add pyright configuration values to help it find the venv

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,8 +16,8 @@ disable_error_code = ["var-annotated"]
 [tool.ruff]
 ignore = []
 line-length = 130
-select = [
-    "E",
-    "F",
-    "W",
-]
+select = ["E", "F", "W"]
+
+[tool.pyright]
+venvPath = "../.."
+venv = ".venv"


### PR DESCRIPTION
## Description

This PR adds two values to the `backend/pyproject.toml` to help `pyright` find the path to the `.venv` file.

Addresses: https://linear.app/danswer/issue/DAN-1704/built-in-gemini-vertex-ai-support.

## How Has This Been Tested?

`pyright` works. No further testing required.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
