### PR TITLE
Handle exception for token cost calculation

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -498,14 +498,20 @@ def get_llm_contextual_cost(
     num_input_tokens += num_tokens + num_docs * DOCUMENT_SUMMARY_TOKEN_ESTIMATE
     num_output_tokens += num_docs * MAX_CONTEXT_TOKENS
 
-    usd_per_prompt, usd_per_completion = litellm.cost_per_token(
-        model=llm.config.model_name,
-        prompt_tokens=num_input_tokens,
-        completion_tokens=num_output_tokens,
-    )
+    try:
+        usd_per_prompt, usd_per_completion = litellm.cost_per_token(
+            model=llm.config.model_name,
+            prompt_tokens=num_input_tokens,
+            completion_tokens=num_output_tokens,
+        )
+    except Exception:
+        logger.exception(
+            f"An unexpected error occurred while calculating cost for model {llm.config.model_name} (potentially due to malformed name). Assuming cost is 0."
+        )
+        return 0
+
     # Costs are in USD dollars per million tokens
     return usd_per_prompt + usd_per_completion
-
 
 def get_llm_max_tokens(
     model_map: dict,


### PR DESCRIPTION
## Description

The code for token cost calculation fails in some cases when using a LiteLLM proxy due to mismatch with the provider+model naming. For now, just handle this exception and assume cost 0 when that happens instead of breaking the flow - A more precise, LiteLLM proxy based cost calculation (relying in the `/model/info`) LiteLLM Proxy implementation will be needed for accurate cost tracking.

## How Has This Been Tested?

Test enabling Contextual RAG LLM when a non-standard model name is used in the LLM connector (Ie. `claude-3.5-haiku@20241022`)