### PR TITLE
fix: Remove advanced options toggle if enterprise features are not enabled

### DIFF
--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -26,6 +26,7 @@ import { PopupSpec } from "@/components/admin/connectors/Popup";
 import * as Yup from "yup";
 import isEqual from "lodash/isEqual";
 import { IsPublicGroupSelector } from "@/components/IsPublicGroupSelector";
+import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 
 function customConfigProcessing(customConfigsList: [string, string][]) {
   const customConfig: { [key: string]: string } = {};
@@ -90,6 +91,8 @@ export function CustomLLMProviderUpdateForm({
     groups: Yup.array().of(Yup.number()),
     deployment_name: Yup.string().nullable(),
   });
+
+  const isPaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
 
   return (
     <Formik
@@ -305,13 +308,13 @@ export function CustomLLMProviderUpdateForm({
                               <Field
                                 name={`custom_config_list[${index}][0]`}
                                 className={`
-                                  border 
-                                  border-border 
-                                  bg-background 
-                                  rounded 
-                                  w-full 
-                                  py-2 
-                                  px-3 
+                                  border
+                                  border-border
+                                  bg-background
+                                  rounded
+                                  w-full
+                                  py-2
+                                  px-3
                                   mr-4
                                 `}
                                 autoComplete="off"
@@ -328,13 +331,13 @@ export function CustomLLMProviderUpdateForm({
                               <Field
                                 name={`custom_config_list[${index}][1]`}
                                 className={`
-                                  border 
-                                  border-border 
-                                  bg-background 
-                                  rounded 
-                                  w-full 
-                                  py-2 
-                                  px-3 
+                                  border
+                                  border-border
+                                  bg-background
+                                  rounded
+                                  w-full
+                                  py-2
+                                  px-3
                                   mr-4
                                 `}
                                 autoComplete="off"
@@ -404,8 +407,8 @@ export function CustomLLMProviderUpdateForm({
             <TextFormField
               name="default_model_name"
               subtext={`
-              The model to use by default for this provider unless 
-              otherwise specified. Must be one of the models listed 
+              The model to use by default for this provider unless
+              otherwise specified. Must be one of the models listed
               above.`}
               label="Default Model"
               placeholder="E.g. gpt-4"
@@ -414,28 +417,31 @@ export function CustomLLMProviderUpdateForm({
             {!existingLlmProvider?.deployment_name && (
               <TextFormField
                 name="fast_default_model_name"
-                subtext={`The model to use for lighter flows like \`LLM Chunk Filter\` 
-                for this provider. If not set, will use 
+                subtext={`The model to use for lighter flows like \`LLM Chunk Filter\`
+                for this provider. If not set, will use
                 the Default Model configured above.`}
                 label="[Optional] Fast Model"
                 placeholder="E.g. gpt-4"
               />
             )}
 
-            <Separator />
+            {isPaidEnterpriseFeaturesEnabled && (
+              <>
+                <Separator />
+                <AdvancedOptionsToggle
+                  showAdvancedOptions={showAdvancedOptions}
+                  setShowAdvancedOptions={setShowAdvancedOptions}
+                />
 
-            <AdvancedOptionsToggle
-              showAdvancedOptions={showAdvancedOptions}
-              setShowAdvancedOptions={setShowAdvancedOptions}
-            />
-
-            {showAdvancedOptions && (
-              <IsPublicGroupSelector
-                formikProps={formikProps}
-                objectName="LLM Provider"
-                publicToWhom="all users"
-                enforceGroupSelection={true}
-              />
+                {showAdvancedOptions && (
+                  <IsPublicGroupSelector
+                    formikProps={formikProps}
+                    objectName="LLM Provider"
+                    publicToWhom="all users"
+                    enforceGroupSelection={true}
+                  />
+                )}
+              </>
             )}
 
             <div>

--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -92,7 +92,7 @@ export function CustomLLMProviderUpdateForm({
     deployment_name: Yup.string().nullable(),
   });
 
-  const isPaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
+  const arePaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
 
   return (
     <Formik
@@ -425,7 +425,7 @@ export function CustomLLMProviderUpdateForm({
               />
             )}
 
-            {isPaidEnterpriseFeaturesEnabled && (
+            {arePaidEnterpriseFeaturesEnabled && (
               <>
                 <Separator />
                 <AdvancedOptionsToggle


### PR DESCRIPTION
## Description

When adding a new custom LLM provider, the model contains an "Advanced Options" toggle at the bottom. However, for non-enterprise users, the dropdown will be empty. However, the *toggle* still exists; it just expands to *nothing*.

This PR removes that toggle if enterprise features are not enabled.

Addresses: https://linear.app/danswer/issue/DAN-1789/remove-advanced-options-toggle-if-paid-enterprise-features-are-not

## How Has This Been Tested?

UI fix; only visually tested.

## Screenshots

Before:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/5e50c2f5-cc87-4c6b-9a7e-9fc2d9163483" />


After:
<img width="999" alt="image" src="https://github.com/user-attachments/assets/d4fa02b9-d9b6-40a1-8f5b-2b3128e9f191" />