### PR TITLE
Google drive perm sync fixes

### DIFF
--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -25,7 +25,7 @@ FILE_FIELDS = (
     "shortcutDetails, owners(emailAddress), size)"
 )
 SLIM_FILE_FIELDS = (
-    "nextPageToken, files(mimeType, driveId, id, name, permissions(emailAddress, type), "
+    "nextPageToken, files(mimeType, driveId, id, name, permissions(emailAddress, type, domain), "
     "permissionIds, webViewLink, owners(emailAddress))"
 )
 FOLDER_FIELDS = "nextPageToken, files(id, name, permissions, modifiedTime, webViewLink, shortcutDetails)"


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1793/permissions-in-google-drive-specific-folders-dont-seem-to-be-working

## How Has This Been Tested?

Tested with a specific folder (https://drive.google.com/drive/u/1/folders/1kdUdS16nuqtWt4IvZnVncTGSFRP9XHCy)

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
