### PR TITLE
Fix: Limit chat filter of Document Sets to Assistant's configuration

### DIFF
--- a/web/src/app/chat/input/ChatInputBar.tsx
+++ b/web/src/app/chat/input/ChatInputBar.tsx
@@ -826,7 +826,12 @@ export function ChatInputBar({
                 {retrievalEnabled && (
                   <FilterPopup
                     availableSources={availableSources}
-                    availableDocumentSets={availableDocumentSets}
+                    availableDocumentSets={
+                      selectedAssistant.document_sets &&
+                      selectedAssistant.document_sets.length > 0
+                        ? selectedAssistant.document_sets
+                        : availableDocumentSets
+                    }
                     availableTags={availableTags}
                     filterManager={filterManager}
                     trigger={


### PR DESCRIPTION
## Description

This PR modifies the Assistant functionality to correctly enforce the Document Sets specified in the Assistant's configuration. Previously, even when specific Document Sets were selected for an Assistant, the chat filter allowed users to select from all available Document Sets, effectively overriding the Assistant's configuration. This change restricts the chat filter's Document Set options to only those defined in the Assistant's configuration. If no Document Sets are specified in the Assistant's configuration, the filter retains its current behavior of displaying all available Document Sets, as per the help text.

## How Has This Been Tested?

The following tests were performed:

1.  Created an Assistant with specific Document Sets selected. Verified that the chat filter only displayed these selected Document Sets.
2.  Created an Assistant without any Document Sets selected. Verified that the chat filter displayed all available Document Sets.
3.  Tested various combinations of Document Set selections and filter usage within the chat interface to ensure consistent behavior.
4.  Verified that existing functionality related to Document Sets and filtering remains unaffected.

## Backporting (check the box to trigger backport action)

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check