### PR TITLE
ensure individual search tool runs do not affect each other

### DIFF
--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -135,7 +135,7 @@ class Chunker:
         mini_chunk_size: int = MINI_CHUNK_SIZE,
         callback: IndexingHeartbeatInterface | None = None,
     ) -> None:
-        # importing llama_index uses a lot of RAM, so we only import it when needed
+        # importing llama_index uses a lot of RAM, so we only import it when needed.
         from llama_index.core.node_parser import SentenceSplitter
 
         self.include_metadata = include_metadata

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -1,5 +1,3 @@
-from llama_index.core.node_parser import SentenceSplitter
-
 from onyx.configs.app_configs import AVERAGE_SUMMARY_EMBEDDINGS
 from onyx.configs.app_configs import BLURB_SIZE
 from onyx.configs.app_configs import LARGE_CHUNK_RATIO
@@ -137,6 +135,8 @@ class Chunker:
         mini_chunk_size: int = MINI_CHUNK_SIZE,
         callback: IndexingHeartbeatInterface | None = None,
     ) -> None:
+        # importing llama_index uses a lot of RAM, so we only import it when needed
+        from llama_index.core.node_parser import SentenceSplitter
 
         self.include_metadata = include_metadata
         self.chunk_token_limit = chunk_token_limit

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import time
 from collections.abc import Callable
@@ -319,7 +320,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             return
 
         # Create a copy of the retrieval options with user_file_ids if provided
-        retrieval_options = self.retrieval_options
+        retrieval_options = copy.deepcopy(self.retrieval_options)
         if (user_file_ids or user_folder_ids) and retrieval_options:
             # Create a copy to avoid modifying the original
             filters = (


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1797/search-tool-retrieval-options-overwrite

Previously when an instance of the search tool was run, the search tool instance's retrieval options were overwritten by search-specific ones.Now we deepcopy so this doesn't happen.

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
