### PR TITLE
Expanded basic search

### DIFF
--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -44,38 +44,37 @@ def _create_history_str(prompt_builder: AnswerPromptBuilder) -> str:
     history_segments = []
     for msg in prompt_builder.message_history:
         if isinstance(msg, HumanMessage):
-            role = "user"
+            role = "User"
         elif isinstance(msg, AIMessage):
-            role = "assistant"
+            role = "Assistant"
         else:
             continue
-        history_segments.append(f"{role.capitalize()}:\n {msg.content}\n\n")
+        history_segments.append(f"{role}:\n {msg.content}\n\n")
     return "\n".join(history_segments)
 
 
 def _expand_query(
     query: str,
-    type: Literal["keyword", "semantic"],
+    expansion_type: Literal["keyword", "semantic"],
     prompt_builder: AnswerPromptBuilder,
 ) -> str:
 
     history_str = _create_history_str(prompt_builder)
 
+    if expansion_type not in ["keyword", "semantic"]:
+        raise ValueError(f"Invalid query expansion type: {expansion_type}")
+
     if history_str:
-        if type == "keyword":
+        if expansion_type == "keyword":
             base_prompt = QUERY_KEYWORD_EXPANSION_WITH_HISTORY_PROMPT
-        elif type == "semantic":
-            base_prompt = QUERY_SEMANTIC_EXPANSION_WITH_HISTORY_PROMPT
         else:
-            raise ValueError(f"Invalid query type: {type}")
+            base_prompt = QUERY_SEMANTIC_EXPANSION_WITH_HISTORY_PROMPT
         expansion_prompt = base_prompt.format(question=query, history=history_str)
     else:
-        if type == "keyword":
+        if expansion_type == "keyword":
             base_prompt = QUERY_KEYWORD_EXPANSION_WITHOUT_HISTORY_PROMPT
-        elif type == "semantic":
-            base_prompt = QUERY_SEMANTIC_EXPANSION_WITHOUT_HISTORY_PROMPT
         else:
-            raise ValueError(f"Invalid query type: {type}")
+            base_prompt = QUERY_SEMANTIC_EXPANSION_WITHOUT_HISTORY_PROMPT
         expansion_prompt = base_prompt.format(question=query)
 
     msg = HumanMessage(content=expansion_prompt)

--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -66,12 +66,16 @@ def _expand_query(
             base_prompt = QUERY_KEYWORD_EXPANSION_WITH_HISTORY_PROMPT
         elif type == "semantic":
             base_prompt = QUERY_SEMANTIC_EXPANSION_WITH_HISTORY_PROMPT
+        else:
+            raise ValueError(f"Invalid query type: {type}")
         expansion_prompt = base_prompt.format(question=query, history=history_str)
     else:
         if type == "keyword":
             base_prompt = QUERY_KEYWORD_EXPANSION_WITHOUT_HISTORY_PROMPT
         elif type == "semantic":
             base_prompt = QUERY_SEMANTIC_EXPANSION_WITHOUT_HISTORY_PROMPT
+        else:
+            raise ValueError(f"Invalid query type: {type}")
         expansion_prompt = base_prompt.format(question=query)
 
     msg = HumanMessage(content=expansion_prompt)

--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -18,6 +18,7 @@ from onyx.chat.tool_handling.tool_response_handler import get_tool_by_name
 from onyx.chat.tool_handling.tool_response_handler import (
     get_tool_call_for_non_tool_calling_llm_impl,
 )
+from onyx.configs.chat_configs import USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH
 from onyx.context.search.preprocessing.preprocessing import query_analysis
 from onyx.context.search.retrieval.search_runner import get_query_embedding
 from onyx.llm.factory import get_default_llms
@@ -136,18 +137,20 @@ def choose_tool(
             agent_config.inputs.search_request.query,
         )
 
-        expanded_keyword_thread = run_in_background(
-            _expand_query,
-            agent_config.inputs.search_request.query,
-            "keyword",
-            prompt_builder,
-        )
-        expanded_semantic_thread = run_in_background(
-            _expand_query,
-            agent_config.inputs.search_request.query,
-            "semantic",
-            prompt_builder,
-        )
+        if USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH:
+
+            expanded_keyword_thread = run_in_background(
+                _expand_query,
+                agent_config.inputs.search_request.query,
+                "keyword",
+                prompt_builder,
+            )
+            expanded_semantic_thread = run_in_background(
+                _expand_query,
+                agent_config.inputs.search_request.query,
+                "semantic",
+                prompt_builder,
+            )
 
     structured_response_format = agent_config.inputs.structured_response_format
     tools = [

--- a/backend/onyx/agents/agent_search/shared_graph_utils/models.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/models.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel
@@ -153,3 +154,8 @@ class AnswerGenerationDocuments(BaseModel):
 
 
 BaseMessage_Content = str | list[str | dict[str, Any]]
+
+
+class QueryExpansionType(Enum):
+    KEYWORD = "keyword"
+    SEMANTIC = "semantic"

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -99,6 +99,6 @@ VESPA_SEARCHER_THREADS = int(os.environ.get("VESPA_SEARCHER_THREADS") or 2)
 
 # Whether or not to use the semantic & keyword search expansions for Basic Search
 USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH = (
-    os.environ.get("USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH", "true").lower()
+    os.environ.get("USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH", "false").lower()
     == "true"
 )

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -96,3 +96,9 @@ BING_API_KEY = os.environ.get("BING_API_KEY") or None
 ENABLE_CONNECTOR_CLASSIFIER = os.environ.get("ENABLE_CONNECTOR_CLASSIFIER", False)
 
 VESPA_SEARCHER_THREADS = int(os.environ.get("VESPA_SEARCHER_THREADS") or 2)
+
+# Whether or not to use the semantic & keyword search expansions for Basic Search
+USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH = (
+    os.environ.get("USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH", "true").lower()
+    == "true"
+)

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -18,9 +18,15 @@ from onyx.indexing.models import IndexingSetting
 from shared_configs.enums import RerankerProvider
 from shared_configs.model_server_models import Embedding
 
+
 MAX_METRICS_CONTENT = (
     200  # Just need enough characters to identify where in the doc the chunk is
 )
+
+
+class QueryExpansions(BaseModel):
+    keywords_expansions: list[str] | None = None
+    semantic_expansions: list[str] | None = None
 
 
 class RerankingDetails(BaseModel):
@@ -139,6 +145,8 @@ class ChunkContext(BaseModel):
 class SearchRequest(ChunkContext):
     query: str
 
+    expanded_queries: QueryExpansions | None = None
+
     search_type: SearchType = SearchType.SEMANTIC
 
     human_selected_filters: BaseFilters | None = None
@@ -186,6 +194,8 @@ class SearchQuery(ChunkContext):
     model_config = ConfigDict(frozen=True)
 
     precomputed_query_embedding: Embedding | None = None
+
+    expanded_queries: QueryExpansions | None = None
 
 
 class RetrievalDetails(ChunkContext):

--- a/backend/onyx/context/search/preprocessing/preprocessing.py
+++ b/backend/onyx/context/search/preprocessing/preprocessing.py
@@ -36,7 +36,6 @@ from onyx.utils.timing import log_function_time
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
-
 logger = setup_logger()
 
 
@@ -264,4 +263,5 @@ def retrieval_preprocessing(
         chunks_below=chunks_below,
         full_doc=search_request.full_doc,
         precomputed_query_embedding=search_request.precomputed_query_embedding,
+        expanded_queries=search_request.expanded_queries,
     )

--- a/backend/onyx/context/search/preprocessing/preprocessing.py
+++ b/backend/onyx/context/search/preprocessing/preprocessing.py
@@ -20,7 +20,7 @@ from onyx.context.search.models import SearchRequest
 from onyx.context.search.preprocessing.access_filters import (
     build_access_filters_for_user,
 )
-from onyx.context.search.retrieval.search_runner import (
+from onyx.context.search.utils import (
     remove_stop_words_and_punctuation,
 )
 from onyx.db.models import User

--- a/backend/onyx/context/search/retrieval/search_runner.py
+++ b/backend/onyx/context/search/retrieval/search_runner.py
@@ -243,7 +243,7 @@ def doc_index_retrieval(
         # Use original query embedding for keyword retrieval embedding
         keyword_embeddings = [query_embedding]
 
-        # Note: we generally prepped earlietrfor multiple expansions, but for now we only use one.
+        # Note: we generally prepped earlier for multiple expansions, but for now we only use one.
         top_keyword_chunks_thread = run_in_background(
             _get_top_chunks,
             document_index,
@@ -280,13 +280,15 @@ def doc_index_retrieval(
         if query.search_type == SearchType.SEMANTIC:
             top_semantic_chunks = wait_on_background(top_semantic_chunks_thread)
 
+        all_top_chunks = top_base_chunks + top_keyword_chunks
+
         # use all three retrieval methods to retrieve top chunks
+
         if query.search_type == SearchType.SEMANTIC:
-            top_chunks = _dedupe_chunks(
-                top_base_chunks + top_keyword_chunks + top_semantic_chunks
-            )
-        else:
-            top_chunks = _dedupe_chunks(top_base_chunks + top_keyword_chunks)
+
+            all_top_chunks += top_semantic_chunks
+
+        top_chunks = _dedupe_chunks(all_top_chunks)
 
     else:
 

--- a/backend/onyx/context/search/retrieval/search_runner.py
+++ b/backend/onyx/context/search/retrieval/search_runner.py
@@ -1,5 +1,6 @@
 import string
 from collections.abc import Callable
+from typing import Literal
 
 import nltk  # type:ignore
 from nltk.corpus import stopwords  # type:ignore
@@ -49,6 +50,7 @@ def _get_top_chunks(
     hybrid_alpha: float,
     time_decay_multiplier: float,
     num_to_retrieve: int,
+    ranking_profile_type: Literal["keyword", "semantic"],
     offset: int,
 ) -> list[InferenceChunk]:
 
@@ -60,6 +62,7 @@ def _get_top_chunks(
         hybrid_alpha=hybrid_alpha,
         time_decay_multiplier=time_decay_multiplier,
         num_to_retrieve=num_to_retrieve,
+        ranking_profile_type=ranking_profile_type,
         offset=offset,
     )
 
@@ -210,6 +213,7 @@ def doc_index_retrieval(
             HYBRID_ALPHA_KEYWORD,
             query.recency_bias_multiplier,
             query.num_hits,
+            "keyword",
             query.offset,
         )
 
@@ -223,6 +227,7 @@ def doc_index_retrieval(
             HYBRID_ALPHA,
             query.recency_bias_multiplier,
             query.num_hits,
+            "semantic",
             query.offset,
         )
 
@@ -243,6 +248,7 @@ def doc_index_retrieval(
             hybrid_alpha=query.hybrid_alpha,
             time_decay_multiplier=query.recency_bias_multiplier,
             num_to_retrieve=query.num_hits,
+            ranking_profile_type="semantic",
             offset=query.offset,
         )
 

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -1,5 +1,9 @@
+import string
 from collections.abc import Sequence
 from typing import TypeVar
+
+from nltk.corpus import stopwords  # type:ignore
+from nltk.tokenize import word_tokenize  # type:ignore
 
 from onyx.chat.models import SectionRelevancePiece
 from onyx.context.search.models import InferenceChunk
@@ -136,3 +140,19 @@ def chunks_or_sections_to_search_docs(
     ]
 
     return search_docs
+
+
+def remove_stop_words_and_punctuation(keywords: list[str]) -> list[str]:
+    try:
+        # Re-tokenize using the NLTK tokenizer for better matching
+        query = " ".join(keywords)
+        stop_words = set(stopwords.words("english"))
+        word_tokens = word_tokenize(query)
+        text_trimmed = [
+            word
+            for word in word_tokens
+            if (word.casefold() not in stop_words and word not in string.punctuation)
+        ]
+        return text_trimmed or word_tokens
+    except Exception:
+        return keywords

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -2,6 +2,7 @@ import abc
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+from typing import Literal
 
 from onyx.access.models import DocumentAccess
 from onyx.configs.chat_configs import TITLE_CONTENT_RATIO
@@ -352,6 +353,7 @@ class HybridCapable(abc.ABC):
         hybrid_alpha: float,
         time_decay_multiplier: float,
         num_to_retrieve: int,
+        ranking_profile_type: Literal["keyword", "semantic"],
         offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunkUncleaned]:

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from onyx.access.models import DocumentAccess
+from onyx.configs.chat_configs import TITLE_CONTENT_RATIO
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import InferenceChunkUncleaned
 from onyx.db.enums import EmbeddingPrecision
@@ -352,6 +353,7 @@ class HybridCapable(abc.ABC):
         time_decay_multiplier: float,
         num_to_retrieve: int,
         offset: int = 0,
+        title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunkUncleaned]:
         """
         Run hybrid search and return a list of inference chunks.

--- a/backend/onyx/document_index/interfaces.py
+++ b/backend/onyx/document_index/interfaces.py
@@ -2,9 +2,9 @@ import abc
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
-from typing import Literal
 
 from onyx.access.models import DocumentAccess
+from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionType
 from onyx.configs.chat_configs import TITLE_CONTENT_RATIO
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import InferenceChunkUncleaned
@@ -353,7 +353,7 @@ class HybridCapable(abc.ABC):
         hybrid_alpha: float,
         time_decay_multiplier: float,
         num_to_retrieve: int,
-        ranking_profile_type: Literal["keyword", "semantic"],
+        ranking_profile_type: QueryExpansionType,
         offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunkUncleaned]:

--- a/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd
+++ b/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd
@@ -176,7 +176,7 @@ schema DANSWER_CHUNK_NAME {
         match-features: recency_bias
     }
 
-    rank-profile hybrid_searchVARIABLE_DIM inherits default, default_rank {
+    rank-profile hybrid_search_semantic_base_VARIABLE_DIM inherits default, default_rank {
         inputs {
             query(query_embedding) tensor<float>(x[VARIABLE_DIM])
         }
@@ -192,7 +192,75 @@ schema DANSWER_CHUNK_NAME {
 
         # First phase must be vector to allow hits that have no keyword matches
         first-phase {
-            expression: closeness(field, embeddings)
+            expression: query(title_content_ratio) * closeness(field, title_embedding) + (1 - query(title_content_ratio)) * closeness(field, embeddings)
+        }
+
+        # Weighted average between Vector Search and BM-25
+        global-phase {
+            expression {
+                (
+                    # Weighted Vector Similarity Score
+                    (
+                        query(alpha) * (
+                            (query(title_content_ratio) * normalize_linear(title_vector_score))
+                            +
+                            ((1 - query(title_content_ratio)) * normalize_linear(closeness(field, embeddings)))
+                        )
+                    )
+
+                    +
+
+                    # Weighted Keyword Similarity Score
+                    # Note: for the BM25 Title score, it requires decent stopword removal in the query
+                    # This needs to be the case so there aren't irrelevant titles being normalized to a score of 1
+                    (
+                        (1 - query(alpha)) * (
+                            (query(title_content_ratio) * normalize_linear(bm25(title)))
+                            +
+                            ((1 - query(title_content_ratio)) * normalize_linear(bm25(content)))
+                        )
+                    )
+                )
+                # Boost based on user feedback
+                * document_boost
+                # Decay factor based on time document was last updated
+                * recency_bias
+                # Boost based on aggregated boost calculation
+                * aggregated_chunk_boost
+            }
+            rerank-count: 1000
+        }
+
+        match-features {
+            bm25(title)
+            bm25(content)
+            closeness(field, title_embedding)
+            closeness(field, embeddings)
+            document_boost
+            recency_bias
+            aggregated_chunk_boost
+            closest(embeddings)
+        }
+    }
+
+
+    rank-profile hybrid_search_keyword_base_VARIABLE_DIM inherits default, default_rank {
+        inputs {
+            query(query_embedding) tensor<float>(x[VARIABLE_DIM])
+        }
+
+        function title_vector_score() {
+            expression {
+                # If no good matching titles, then it should use the context embeddings rather than having some
+                # irrelevant title have a vector score of 1. This way at least it will be the doc with the highest
+                # matching content score getting the full score
+                max(closeness(field, embeddings), closeness(field, title_embedding))
+            }
+        }
+
+        # First phase must be vector to allow hits that have no keyword matches
+        first-phase {
+            expression: query(title_content_ratio) * bm25(title) + (1 - query(title_content_ratio)) * bm25(content)
         }
 
         # Weighted average between Vector Search and BM-25

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -13,13 +13,13 @@ from datetime import timedelta
 from typing import BinaryIO
 from typing import cast
 from typing import List
-from typing import Literal
 from uuid import UUID
 
 import httpx  # type: ignore
 import requests  # type: ignore
 from retry import retry
 
+from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionType
 from onyx.configs.chat_configs import DOC_TIME_DECAY
 from onyx.configs.chat_configs import NUM_RETURNED_HITS
 from onyx.configs.chat_configs import TITLE_CONTENT_RATIO
@@ -801,7 +801,7 @@ class VespaIndex(DocumentIndex):
         hybrid_alpha: float,
         time_decay_multiplier: float,
         num_to_retrieve: int,
-        ranking_profile_type: Literal["keyword", "semantic"],
+        ranking_profile_type: QueryExpansionType,
         offset: int = 0,
         title_content_ratio: float | None = TITLE_CONTENT_RATIO,
     ) -> list[InferenceChunkUncleaned]:
@@ -820,7 +820,7 @@ class VespaIndex(DocumentIndex):
 
         final_query = " ".join(final_keywords) if final_keywords else query
 
-        if ranking_profile_type == "keyword":
+        if ranking_profile_type == QueryExpansionType.KEYWORD:
             ranking_profile = f"hybrid_search_keyword_base_{len(query_embedding)}"
         else:
             ranking_profile = f"hybrid_search_semantic_base_{len(query_embedding)}"

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -806,6 +806,7 @@ class VespaIndex(DocumentIndex):
         vespa_where_clauses = build_vespa_filters(filters)
         # Needs to be at least as much as the value set in Vespa schema config
         target_hits = max(10 * num_to_retrieve, 1000)
+
         yql = (
             YQL_BASE.format(index_name=self.index_name)
             + vespa_where_clauses

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -246,3 +246,35 @@ Please give a short succinct summary of the entire document. Answer only with th
 summary and nothing else. """
 
 DOCUMENT_SUMMARY_TOKEN_ESTIMATE = 29
+
+
+QUERY_EXPANSION_WITHOUT_HISTORY_PROMPT = """
+Please rephrase the following user question as a {type} query that would be appropraite for a \
+search engine.
+
+Here is the user question:
+{question}
+
+Respond with EXACTLY and ONLY one rephrased query.
+
+Rephrased query for search engine:
+""".strip()
+
+
+QUERY_EXPANSION_WITH_HISTORY_PROMPT = """
+Following a previous message history, a user created a follow-up question/query.
+Please rephrase that question/query as a {type} query \
+that would be appropraite for a SEARCH ENGINE. Only use the information provided \
+from the history that is relevant to provide the relevant context for the search query, \
+meaning that the repharsed search query should be a stuitable stand-alone search query.
+
+Here is the relevant previous message history:
+{history}
+
+Here is the user question:
+{question}
+
+Respond with EXACTLY and ONLY one rephrased query.
+
+Rephrased query for search engine:
+""".strip()

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -249,7 +249,7 @@ DOCUMENT_SUMMARY_TOKEN_ESTIMATE = 29
 
 
 QUERY_SEMANTIC_EXPANSION_WITHOUT_HISTORY_PROMPT = """
-Please rephrase the following user question/query as a semantic query that would be appropraite for a \
+Please rephrase the following user question/query as a semantic query that would be appropriate for a \
 search engine.
 
 Note:
@@ -268,9 +268,9 @@ Rephrased question/query for search engine:
 QUERY_SEMANTIC_EXPANSION_WITH_HISTORY_PROMPT = """
 Following a previous message history, a user created a follow-up question/query.
 Please rephrase that question/query as a semantic query \
-that would be appropraite for a SEARCH ENGINE. Only use the information provided \
+that would be appropriate for a SEARCH ENGINE. Only use the information provided \
 from the history that is relevant to provide the relevant context for the search query, \
-meaning that the repharsed search query should be a stuitable stand-alone search query.
+meaning that the rephrased search query should be a suitable stand-alone search query.
 
 Note:
  - do not change the meaning of the question! Specifically, if the query is a an instruction, keep it \
@@ -289,7 +289,7 @@ Rephrased query for search engine:
 
 
 QUERY_KEYWORD_EXPANSION_WITHOUT_HISTORY_PROMPT = """
-Please rephrase the following user question as a keyword query that would be appropraite for a \
+Please rephrase the following user question as a keyword query that would be appropriate for a \
 search engine.
 
 Here is the user question:
@@ -304,9 +304,9 @@ Rephrased query for search engine:
 QUERY_KEYWORD_EXPANSION_WITH_HISTORY_PROMPT = """
 Following a previous message history, a user created a follow-up question/query.
 Please rephrase that question/query as a keyword query \
-that would be appropraite for a SEARCH ENGINE. Only use the information provided \
+that would be appropriate for a SEARCH ENGINE. Only use the information provided \
 from the history that is relevant to provide the relevant context for the search query, \
-meaning that the repharsed search query should be a stuitable stand-alone search query.
+meaning that the rephrased search query should be a suitable stand-alone search query.
 
 Here is the relevant previous message history:
 {history}

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -248,8 +248,48 @@ summary and nothing else. """
 DOCUMENT_SUMMARY_TOKEN_ESTIMATE = 29
 
 
-QUERY_EXPANSION_WITHOUT_HISTORY_PROMPT = """
-Please rephrase the following user question as a {type} query that would be appropraite for a \
+QUERY_SEMANTIC_EXPANSION_WITHOUT_HISTORY_PROMPT = """
+Please rephrase the following user question/query as a semantic query that would be appropraite for a \
+search engine.
+
+Note:
+ - do not change the meaning of the question! Specifically, if the query is a an instruction, keep it \
+as an instruction!
+
+Here is the user question/query:
+{question}
+
+Respond with EXACTLY and ONLY one rephrased question/query.
+
+Rephrased question/query for search engine:
+""".strip()
+
+
+QUERY_SEMANTIC_EXPANSION_WITH_HISTORY_PROMPT = """
+Following a previous message history, a user created a follow-up question/query.
+Please rephrase that question/query as a semantic query \
+that would be appropraite for a SEARCH ENGINE. Only use the information provided \
+from the history that is relevant to provide the relevant context for the search query, \
+meaning that the repharsed search query should be a stuitable stand-alone search query.
+
+Note:
+ - do not change the meaning of the question! Specifically, if the query is a an instruction, keep it \
+as an instruction!
+
+Here is the relevant previous message history:
+{history}
+
+Here is the user question:
+{question}
+
+Respond with EXACTLY and ONLY one rephrased query.
+
+Rephrased query for search engine:
+""".strip()
+
+
+QUERY_KEYWORD_EXPANSION_WITHOUT_HISTORY_PROMPT = """
+Please rephrase the following user question as a keyword query that would be appropraite for a \
 search engine.
 
 Here is the user question:
@@ -261,9 +301,9 @@ Rephrased query for search engine:
 """.strip()
 
 
-QUERY_EXPANSION_WITH_HISTORY_PROMPT = """
+QUERY_KEYWORD_EXPANSION_WITH_HISTORY_PROMPT = """
 Following a previous message history, a user created a follow-up question/query.
-Please rephrase that question/query as a {type} query \
+Please rephrase that question/query as a keyword query \
 that would be appropraite for a SEARCH ENGINE. Only use the information provided \
 from the history that is relevant to provide the relevant context for the search query, \
 meaning that the repharsed search query should be a stuitable stand-alone search query.

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -11,6 +11,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.context.search.enums import SearchType
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import InferenceSection
+from onyx.context.search.models import QueryExpansions
 from shared_configs.model_server_models import Embedding
 
 
@@ -79,6 +80,7 @@ class SearchToolOverrideKwargs(BaseModel):
     )
     document_sources: list[DocumentSource] | None = None
     time_cutoff: datetime | None = None
+    expanded_queries: QueryExpansions | None = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -307,6 +307,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             ordering_only = use_alt_not_None(override_kwargs.ordering_only, False)
             document_sources = override_kwargs.document_sources
             time_cutoff = override_kwargs.time_cutoff
+            expanded_queries = override_kwargs.expanded_queries
 
         # Fast path for ordering-only search
         if ordering_only:
@@ -391,6 +392,8 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 precomputed_query_embedding=precomputed_query_embedding,
                 precomputed_is_keyword=precomputed_is_keyword,
                 precomputed_keywords=precomputed_keywords,
+                # add expanded queries
+                expanded_queries=expanded_queries,
             ),
             user=self.user,
             llm=self.llm,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -295,6 +295,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         ordering_only = False
         document_sources = None
         time_cutoff = None
+        expanded_queries = None
         if override_kwargs:
             force_no_rerank = use_alt_not_None(override_kwargs.force_no_rerank, False)
             alternate_db_session = override_kwargs.alternate_db_session

--- a/backend/scripts/query_time_check/test_query_times.py
+++ b/backend/scripts/query_time_check/test_query_times.py
@@ -5,6 +5,7 @@ RUN THIS AFTER SEED_DUMMY_DOCS.PY
 import random
 import time
 
+from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionType
 from onyx.configs.constants import DocumentSource
 from onyx.configs.model_configs import DOC_EMBEDDING_DIM
 from onyx.context.search.models import IndexFilters
@@ -96,6 +97,7 @@ def test_hybrid_retrieval_times(
             hybrid_alpha=0.5,
             time_decay_multiplier=1.0,
             num_to_retrieve=50,
+            ranking_profile_type=QueryExpansionType.SEMANTIC,
             offset=0,
             title_content_ratio=0.5,
         )


### PR DESCRIPTION
## Description

PR for the expanded Basic Search. 
Linear: https://linear.app/danswer/issue/DAN-1806/new-query-expansion-for-basic-search

Core idea:

A) Create two search ranking profiles, one has phase 1 as semantic, the other keyword based

B) Modify Basic Search Pipeline 
 - At the outset, for standard Search we get - parallelized - one additional keyword expansion and one additional semantic expansion. (No expansion for agentic search)
 - if the the query is deemed to be 'keyword', we ignore the semantic expansion and just:
     - search in the original form with original values  (where the first phase is semantic)
     - Search with the keyword expansion, using the original embedding vector, but use a keyword 1st phase ranking
     - combine the 2 results, each ranked by their scores
 - if the the query is deemed to be 'semantic', we include the semantic expansion and:
    - search in the original form with original values  (where the first phase is semantic)
    - Search with the keyword expansion, using the original embedding vector, but use a keyword 1st phase ranking
AND search ALSO for the semantic expansion with its own embedding vector and the original ranking profile
   - combine the 3 results, each scored by themselves

The environment variable USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH must be set to 'true' to activate the expansion.

## How Has This Been Tested?

Locally and on Scale

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
