### PR TITLE
fix font for dark mode

### DIFF
--- a/web/src/components/health/healthcheck.tsx
+++ b/web/src/components/health/healthcheck.tsx
@@ -211,7 +211,7 @@ export const HealthCheckBanner = () => {
     return null;
   } else {
     return (
-      <div className="fixed top-0 left-0 z-[101] w-full text-xs mx-auto bg-gradient-to-r from-red-900 to-red-700 p-2 rounded-sm border-hidden text-text-200">
+      <div className="fixed top-0 left-0 z-[101] w-full text-xs mx-auto bg-gradient-to-r from-red-900 to-red-700 p-2 rounded-sm border-hidden text-neutral-50 dark:text-neutral-100">
         <p className="font-bold pb-1">The backend is currently unavailable.</p>
 
         <p className="px-1">


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1812/backend-unavailable-message-unreadable-in-dark-mode
Backend unavailable message was unreadable in dark mode

## How Has This Been Tested?

Ran in UI
<img width="436" alt="Screenshot 2025-04-14 at 1 27 11 PM" src="https://github.com/user-attachments/assets/19b710ee-8d4d-4845-907f-5b153b5c386b" />

<img width="502" alt="Screenshot 2025-04-14 at 1 32 37 PM" src="https://github.com/user-attachments/assets/5d8df649-b5b4-460f-b926-16ce25c7316b" />


## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
