### PR TITLE
fix: Remove alert upon submission of LLM Provider

### DIFF
--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -413,11 +413,7 @@ export function LLMProviderUpdateForm({
           {testError && <Text className="text-error mt-2">{testError}</Text>}
 
           <div className="flex w-full mt-4">
-            <Button
-              onClick={() => alert(JSON.stringify(formikProps.errors))}
-              type="submit"
-              variant="submit"
-            >
+            <Button type="submit" variant="submit">
               {isTesting ? (
                 <LoadingAnimation text="Testing" />
               ) : existingLlmProvider ? (


### PR DESCRIPTION
## Description

When an LLM Provider is enabled, an `alert` is fired which prints a dict. This was probably left in during development. This PR removes that.

Addresses: https://linear.app/danswer/issue/DAN-1824/remove-alert-upon-enablement-editing-of-an-llm-provider.

## How Has This Been Tested?

This simply removes a print-out. Manually tested. No further testing required.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
