### PR TITLE
small improvement to checking for image attachments

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -373,11 +373,23 @@ class ConfluenceConnector(
             cql=attachment_query,
             expand=",".join(_ATTACHMENT_EXPANSION_FIELDS),
         ):
-            attachment["metadata"].get("mediaType", "")
+            media_type: str = attachment.get("metadata", {}).get("mediaType", "")
+
+            # TODO(rkuo): this check is partially redundant with validate_attachment_filetype
+            # but doing the check here avoids an unnecessary download. Due for refactoring.
+            if not self.allow_images:
+                if media_type.startswith("image/"):
+                    logger.info(
+                        f"Skipping attachment because allow images is False: {attachment['title']}"
+                    )
+                    continue
+
             if not validate_attachment_filetype(
                 attachment,
             ):
-                logger.info(f"Skipping attachment: {attachment['title']}")
+                logger.info(
+                    f"Skipping attachment because it is not an accepted file type: {attachment['title']}"
+                )
                 continue
 
             logger.info(f"Processing attachment: {attachment['title']}")

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -376,6 +376,7 @@ class ConfluenceConnector(
             media_type: str = attachment.get("metadata", {}).get("mediaType", "")
 
             # TODO(rkuo): this check is partially redundant with validate_attachment_filetype
+            # and checks in convert_attachment_to_content/process_attachment
             # but doing the check here avoids an unnecessary download. Due for refactoring.
             if not self.allow_images:
                 if media_type.startswith("image/"):

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -59,15 +59,16 @@ def validate_attachment_filetype(
     """
     Validates if the attachment is a supported file type.
     """
-    attachment.get("metadata", {})
     media_type = attachment.get("metadata", {}).get("mediaType", "")
-
     if media_type.startswith("image/"):
         return is_valid_image_type(media_type)
 
     # For non-image files, check if we support the extension
     title = attachment.get("title", "")
     extension = Path(title).suffix.lstrip(".").lower() if "." in title else ""
+
+    # NOTE(rkuo): Why doesn't this check
+    # ACCEPTED_PLAIN_TEXT_FILE_EXTENSIONS or ACCEPTED_DOCUMENT_FILE_EXTENSIONS?
     return extension in ["pdf", "doc", "docx", "txt", "md", "rtf"]
 
 

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -34,7 +34,11 @@ from onyx.db.models import PGFileStore
 from onyx.db.pg_file_store import create_populate_lobj
 from onyx.db.pg_file_store import save_bytes_to_pgfilestore
 from onyx.db.pg_file_store import upsert_pgfilestore
-from onyx.file_processing.extract_file_text import extract_file_text
+from onyx.file_processing.extract_file_text import (
+    OnyxExtensionType,
+    extract_file_text,
+    is_accepted_file_ext,
+)
 from onyx.file_processing.file_validation import is_valid_image_type
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.utils.logger import setup_logger
@@ -67,9 +71,9 @@ def validate_attachment_filetype(
     title = attachment.get("title", "")
     extension = Path(title).suffix.lstrip(".").lower() if "." in title else ""
 
-    # NOTE(rkuo): Why doesn't this check
-    # ACCEPTED_PLAIN_TEXT_FILE_EXTENSIONS or ACCEPTED_DOCUMENT_FILE_EXTENSIONS?
-    return extension in ["pdf", "doc", "docx", "txt", "md", "rtf"]
+    return is_accepted_file_ext(
+        "." + extension, OnyxExtensionType.Plain | OnyxExtensionType.Document
+    )
 
 
 class AttachmentProcessingResult(BaseModel):


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1816/confluence-image-attachments-being-downloaded-unexpectedly

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
