### PR TITLE
attempt to remove redis usage from daily test

### DIFF
--- a/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
@@ -91,6 +91,8 @@ def test_confluence_connector_restriction_handling(
     # Set a mock credential ID
     mock_cc_pair.credential_id = 1
 
+    mock_cc_pair.connector.set_credentials_provider = MagicMock()
+
     # Call the confluence_doc_sync function directly with the mock cc_pair
     doc_access_generator = confluence_doc_sync(mock_cc_pair, None)
     doc_access_list = list(doc_access_generator)


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1833/confluence-daily-test-uses-redis

## How Has This Been Tested?

n/a (testing code only, it works if the tests pass)

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
