### PR TITLE
ping with keep alive

### DIFF
--- a/backend/onyx/background/celery/tasks/indexing/utils.py
+++ b/backend/onyx/background/celery/tasks/indexing/utils.py
@@ -129,6 +129,8 @@ class IndexingCallbackBase(IndexingHeartbeatInterface):
         return False
 
     def progress(self, tag: str, amount: int) -> None:
+        """Amount isn't used yet."""
+
         # rkuo: this shouldn't be necessary yet because we spawn the process this runs inside
         # with daemon=True. It seems likely some indexing tasks will need to spawn other processes
         # eventually, which daemon=True prevents, so leave this code in until we're ready to test it.

--- a/backend/onyx/background/indexing/run_indexing.py
+++ b/backend/onyx/background/indexing/run_indexing.py
@@ -451,6 +451,11 @@ def _run_indexing(
                     if callback.should_stop():
                         raise ConnectorStopSignal("Connector stop signal detected")
 
+                    # NOTE: this progress callback runs on every loop. We've seen cases
+                    # where we loop many times with no new documents and eventually time
+                    # out, so only doing the callback after indexing isn't sufficient.
+                    callback.progress("_run_indexing", 0)
+
                 # TODO: should we move this into the above callback instead?
                 with get_session_with_current_tenant() as db_session_temp:
                     # will exception if the connector/index attempt is marked as paused/failed

--- a/backend/onyx/indexing/indexing_heartbeat.py
+++ b/backend/onyx/indexing/indexing_heartbeat.py
@@ -12,4 +12,7 @@ class IndexingHeartbeatInterface(ABC):
 
     @abstractmethod
     def progress(self, tag: str, amount: int) -> None:
-        """Send progress updates to the caller."""
+        """Send progress updates to the caller.
+        Amount can be a positive number to indicate progress or <= 0
+        just to act as a keep-alive.
+        """


### PR DESCRIPTION
## Description

Ref https://linear.app/danswer/issue/DAN-1838/slack-timing-out-and-indexing-0-documents

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
