### PR TITLE
add emails to retry with on 403

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -40,6 +40,7 @@ from onyx.connectors.google_drive.models import RetrievedDriveFile
 from onyx.connectors.google_drive.models import StageCompletion
 from onyx.connectors.google_utils.google_auth import get_google_creds
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
+from onyx.connectors.google_utils.google_utils import get_file_owners
 from onyx.connectors.google_utils.google_utils import GoogleFields
 from onyx.connectors.google_utils.resources import get_admin_service
 from onyx.connectors.google_utils.resources import get_drive_service
@@ -949,7 +950,8 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                     (
                         convert_func,
                         (
-                            file.user_email,
+                            [file.user_email, self.primary_admin_email]
+                            + get_file_owners(file.drive_file),
                             file.drive_file,
                         ),
                     )

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -43,6 +43,8 @@ logger = setup_logger()
 SMART_CHIP_CHAR = "\ue907"
 WEB_VIEW_LINK_KEY = "webViewLink"
 
+MAX_RETRIEVER_EMAILS = 20
+
 # Mapping of Google Drive mime types to export formats
 GOOGLE_MIME_TYPES_TO_EXPORT = {
     GDriveMimeType.DOC.value: "text/plain",
@@ -317,7 +319,7 @@ def convert_drive_item_to_document(
     doc_or_failure = None
     # use seen instead of list(set()) to avoid re-ordering the retriever emails
     seen = set()
-    for retriever_email in retriever_emails:
+    for retriever_email in retriever_emails[:MAX_RETRIEVER_EMAILS]:
         if retriever_email in seen:
             continue
         seen.add(retriever_email)

--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -97,6 +97,17 @@ def _execute_with_retry(request: Any) -> Any:
     raise Exception(f"Failed to execute request after {max_attempts} attempts")
 
 
+def get_file_owners(file: GoogleDriveFileType) -> list[str]:
+    """
+    Get the owners of a file if the attribute is present.
+    """
+    return [
+        owner.get("emailAddress")
+        for owner in file.get("owners", [])
+        if owner.get("emailAddress")
+    ]
+
+
 def execute_paginated_retrieval(
     retrieval_function: Callable,
     list_key: str | None = None,

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -2,9 +2,11 @@ import time
 from collections.abc import Sequence
 
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
+from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
 from onyx.connectors.models import TextSection
 from tests.daily.connectors.utils import load_all_docs_from_checkpoint_connector
+from tests.daily.connectors.utils import load_everything_from_checkpoint_connector
 
 ALL_FILES = list(range(0, 60))
 SHARED_DRIVE_FILES = list(range(20, 25))
@@ -25,6 +27,8 @@ FOLDER_2_1_FILE_IDS = list(range(50, 55))
 FOLDER_2_2_FILE_IDS = list(range(55, 60))
 SECTIONS_FILE_IDS = [61]
 FOLDER_3_FILE_IDS = list(range(62, 65))
+
+DONWLOAD_REVOKED_FILE_ID = 21
 
 PUBLIC_FOLDER_RANGE = FOLDER_1_2_FILE_IDS
 PUBLIC_FILE_IDS = list(range(55, 57))
@@ -230,6 +234,16 @@ def assert_expected_docs_in_retrieved_docs(
 
 def load_all_docs(connector: GoogleDriveConnector) -> list[Document]:
     return load_all_docs_from_checkpoint_connector(
+        connector,
+        0,
+        time.time(),
+    )
+
+
+def load_all_docs_with_failures(
+    connector: GoogleDriveConnector,
+) -> list[Document | ConnectorFailure]:
+    return load_everything_from_checkpoint_connector(
         connector,
         0,
         time.time(),

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -38,10 +38,14 @@ def _check_for_error(
         for failure in retrieved_docs_failures
         if isinstance(failure, ConnectorFailure)
     ]
-    assert len(retrieved_failures) == 1
-    fail_msg = retrieved_failures[0].failure_message
-    assert "HttpError 403" in fail_msg
-    assert f"file_{DONWLOAD_REVOKED_FILE_ID}.txt" in fail_msg
+    assert len(retrieved_failures) <= 1
+
+    # current behavior is to fail silently for 403s; leaving this here for when we revert
+    # if all 403s get fixed
+    if len(retrieved_failures) == 1:
+        fail_msg = retrieved_failures[0].failure_message
+        assert "HttpError 403" in fail_msg
+        assert f"file_{DONWLOAD_REVOKED_FILE_ID}.txt" in fail_msg
 
     expected_file_ids.remove(DONWLOAD_REVOKED_FILE_ID)
     return retrieved_docs

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -69,8 +69,8 @@ def test_all(
     ]
     assert len(retrieved_failures) == 1
     fail_msg = retrieved_failures[0].failure_message
-    assert "403 Client Error: Forbidden" in fail_msg
-    assert str(DONWLOAD_REVOKED_FILE_ID) in fail_msg
+    assert "HttpError 403" in fail_msg
+    assert f"file_{DONWLOAD_REVOKED_FILE_ID}.txt" in fail_msg
 
     expected_file_ids.remove(DONWLOAD_REVOKED_FILE_ID)
 

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -234,10 +234,9 @@ def test_shared_drive_folder(
         shared_drive_urls=None,
         my_drive_emails=None,
     )
-    retrieved_docs_failures = load_all_docs_with_failures(connector)
+    retrieved_docs = load_all_docs(connector)
 
     expected_file_ids = FOLDER_1_FILE_IDS + FOLDER_1_1_FILE_IDS + FOLDER_1_2_FILE_IDS
-    retrieved_docs = _check_for_error(retrieved_docs_failures, expected_file_ids)
     assert_expected_docs_in_retrieved_docs(
         retrieved_docs=retrieved_docs,
         expected_file_ids=expected_file_ids,

--- a/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
@@ -197,7 +197,7 @@ def test_thread_safe_dict_concurrent_access() -> None:
         for i in range(iterations):
             key = str(i % 5)  # Use 5 different keys
             # Get current value or 0 if not exists, increment, then store
-            d[key] = d.get(key, 0) + 1
+            d.atomic_get_set(key, lambda x: x + 1, 0)
 
     # Create and start threads
     threads = []


### PR DESCRIPTION
## Description

Addresses https://linear.app/danswer/issue/DAN-1814/indrive-drive-issues
we've seen many cases of our doc conversion threads failing to download a file from google drive impersonating the user that originally listed the file. In these cases, we now also try downloading using the admin email and the emails of all owners of the file.

## How Has This Been Tested?

Tested in the UI, and our connector tests are now indexing a file that a user can see but cannot download.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
