### PR TITLE
feat: Add assistant name to UI

### DIFF
--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -95,7 +95,7 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
       <CardSection className="mt-4">
         <Title>Chat Session Details</Title>
 
-        <Text className="flex flex-wrap whitespace-normal mt-1 text-s">
+        <Text className="flex flex-wrap whitespace-normal mt-1 text-sm">
           {chatSessionSnapshot.assistant_name}
         </Text>
         <Text className="flex flex-wrap whitespace-normal mt-1 text-xs">

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -95,6 +95,9 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
       <CardSection className="mt-4">
         <Title>Chat Session Details</Title>
 
+        <Text className="flex flex-wrap whitespace-normal mt-1 text-s">
+          {chatSessionSnapshot.assistant_name}
+        </Text>
         <Text className="flex flex-wrap whitespace-normal mt-1 text-xs">
           {chatSessionSnapshot.user_email &&
             `${chatSessionSnapshot.user_email}, `}


### PR DESCRIPTION
## Description

This PR adds the `assistant_name` to the "Chat Sessions Details" page inside of the "Query History" section.

Addresses: https://linear.app/danswer/issue/DAN-1796/add-assistant-into-query-history-display.

## How Has This Been Tested?

UI change; visually tested and confirmed to work.