### PR TITLE
fix: LaTeX processing issue in #4570

### DIFF
--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -342,12 +342,7 @@ export const AIMessage = ({
     }
     const processed = preprocessLaTeX(content);
 
-    // Escape $ that are preceded by a space and followed by a non-$ character
-    const escapedDollarSigns = processed.replace(/([\s])\$([^\$])/g, "$1\\$$2");
-
-    return (
-      escapedDollarSigns + (!isComplete && !toolCallGenerating ? " [*]() " : "")
-    );
+    return processed + (!isComplete && !toolCallGenerating ? " [*]() " : "");
   };
 
   const finalContentProcessed = processContent(finalContent as string);


### PR DESCRIPTION
## Description

fix #4570: simplify LaTeX processing by removing unnecessary dollar sign escaping

## How Has This Been Tested?

Has been tested on local machine. The issue has been fixed.

![image](https://github.com/user-attachments/assets/566ad3ba-b8b0-4b71-a1c2-3f331064524f)


## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
