### PR TITLE
Restrict API access to non-public Assistants

### DIFF
--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -198,6 +198,10 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 DocumentSet.from_model(document_set_model)
                 for document_set_model in persona.document_sets
             ],
+            users=[
+                MinimalUserSnapshot(id=user.id, email=user.email)
+                for user in persona.users
+            ],
             search_start_date=persona.search_start_date,
             prompts=[PromptSnapshot.from_model(prompt) for prompt in persona.prompts],
             llm_relevance_filter=persona.llm_relevance_filter,

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -203,11 +203,6 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 DocumentSet.from_model(document_set_model)
                 for document_set_model in persona.document_sets
             ],
-            users=[
-                MinimalUserSnapshot(id=user.id, email=user.email)
-                for user in persona.users
-            ],
-            groups=[user_group.id for user_group in persona.groups],
             num_chunks=persona.num_chunks,
             search_start_date=persona.search_start_date,
             prompts=[PromptSnapshot.from_model(prompt) for prompt in persona.prompts],

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -202,6 +202,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 MinimalUserSnapshot(id=user.id, email=user.email)
                 for user in persona.users
             ],
+            groups=[user_group.id for user_group in persona.groups],
             search_start_date=persona.search_start_date,
             prompts=[PromptSnapshot.from_model(prompt) for prompt in persona.prompts],
             llm_relevance_filter=persona.llm_relevance_filter,

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -282,7 +282,6 @@ def create_new_chat_session(
             status_code=400,
             detail="The given user does not have access to this Persona.",
         )
-        return
 
     try:
         new_chat_session = create_chat_session(


### PR DESCRIPTION
## Description

I'm using an API key to access Onyx, sending it queries and returning the response. I ran into two issues when doing this:

#### API Keys can access all Assistants
API keys show up as users in the "Access" section for an Assistant:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/847cb549-360e-4a18-9849-5036781928ff" />
If an Assistant is not marked as public and is granted only to specific users, they can still access and use that Assistant through calls to `/create-chat-session`. This could grant them access to Document Sets and knowledge they should not have access to through the front end.

This was addressed by adding a check to ensure the user making the request to `/create-chat-session` has access to the persona they are trying to request. It also ensures the Persona is marked as visible – this may not be desired, but there is no other way to disable the built-in Assistants without adding this check.

## How Has This Been Tested?

I've tested this by:
1. Create an API key that is granted "Basic" access
2. Create a custom Assistant. Ensure it is not public. Grant your API key user access.
3. Visit `/create-chat-session` using your API key as a bearer token. You should get an ID.
4. Edit the custom Assistant. Ensure your API key user is visible. Previously, it would not show up here. Revoke your API key's user access. 
5. Visit `/create-chat-session` using your API key as a bearer token. You should not get an ID and should get an error.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
