### PR TITLE
Bugfix/slack bot channel config

### DIFF
--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -366,8 +366,8 @@ def get_all_channels_from_slack_api(
     _: User | None = Depends(current_admin_user),
 ) -> list[SlackChannel]:
     """
-    NOTE: This endpoint is temporarily unused due to needing more fleshing out. Raising an
-    exception when the channels list is too large is too aggressive.
+    Returns a list of available slack channels for the slack bot, limited to
+    SLACK_MAX_RETURNED_CHANNELS.
 
     Fetches all channels in the Slack workspace using the conversations_list API.
     This includes both public and private channels that are visible to the app,

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -36,6 +36,8 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import create_milestone_and_report
 from shared_configs.contextvars import get_current_tenant_id
 
+SLACK_API_CHANNELS_PER_PAGE = 100
+SLACK_MAX_RETURNED_CHANNELS = 500
 
 logger = setup_logger()
 
@@ -355,10 +357,6 @@ def list_bot_configs(
     ]
 
 
-MAX_SLACK_PAGES = 5
-SLACK_API_CHANNELS_PER_PAGE = 100
-
-
 @router.get(
     "/admin/slack-app/bots/{bot_id}/channels",
 )
@@ -368,6 +366,9 @@ def get_all_channels_from_slack_api(
     _: User | None = Depends(current_admin_user),
 ) -> list[SlackChannel]:
     """
+    NOTE: This endpoint is temporarily unused due to needing more fleshing out. Raising an
+    exception when the channels list is too large is too aggressive.
+
     Fetches all channels in the Slack workspace using the conversations_list API.
     This includes both public and private channels that are visible to the app,
     not just the ones the bot is a member of.
@@ -380,15 +381,12 @@ def get_all_channels_from_slack_api(
         )
 
     client = WebClient(token=tokens["bot_token"], timeout=1)
-    all_channels = []
+    all_channels: list[dict] = []
     next_cursor = None
-    current_page = 0
 
     try:
         # Use conversations_list to get all channels in the workspace (including ones the bot is not a member of)
-        while current_page < MAX_SLACK_PAGES:
-            current_page += 1
-
+        while len(all_channels) < SLACK_MAX_RETURNED_CHANNELS:
             # Make API call with cursor if we have one
             if next_cursor:
                 response = client.conversations_list(
@@ -415,15 +413,12 @@ def get_all_channels_from_slack_api(
             ):
                 next_cursor = response["response_metadata"]["next_cursor"]
                 if next_cursor:
-                    if current_page == MAX_SLACK_PAGES:
-                        raise HTTPException(
-                            status_code=400,
-                            detail="Workspace has too many channels to paginate over in this call.",
-                        )
                     continue
 
             # If we get here, no more pages
             break
+
+        del all_channels[SLACK_MAX_RETURNED_CHANNELS:]  # truncate the list
 
         channels = [
             SlackChannel(id=channel["id"], name=channel["name"])

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -273,6 +273,10 @@ def reset_postgres(
             logger.warning(
                 f"Postgres downgrade timed out, retrying... ({_ + 1}/{NUM_TRIES})"
             )
+        except RuntimeError:
+            logger.warning(
+                f"Postgres downgrade exceptioned, retrying... ({_ + 1}/{NUM_TRIES})"
+            )
 
     if not success:
         raise RuntimeError("Postgres downgrade failed after 10 timeouts.")

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -203,9 +203,7 @@ export function SlackChannelConfigFormFields({
 
     let helpText = `Select a channel from the dropdown list or type any channel name in directly.`;
     if (channelOptions.length >= 500) {
-      return (
-        `Retrieved the first ${channelOptions.length} channels. ` + helpText
-      );
+      return `${helpText} (Retrieved the first ${channelOptions.length} channels.)`;
     }
 
     return helpText;

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -190,6 +190,27 @@ export function SlackChannelConfigFormFields({
     }
   );
 
+  // Define the helper text based on the state
+  const channelHelperText = useMemo(() => {
+    if (isLoading || error) {
+      // No helper text needed during loading or if there's an error
+      // (error message is shown separately)
+      return null;
+    }
+    if (!channelOptions || channelOptions.length === 0) {
+      return "No channels found. You can type any channel name in directly.";
+    }
+
+    let helpText = `Select a channel from the dropdown list or type any channel name in directly.`;
+    if (channelOptions.length >= 500) {
+      return (
+        `Retrieved the first ${channelOptions.length} channels. ` + helpText
+      );
+    }
+
+    return helpText;
+  }, [isLoading, error, channelOptions]);
+
   if (isLoading) {
     return <ThreeDotsLoader />;
   }
@@ -257,11 +278,11 @@ export function SlackChannelConfigFormFields({
                     />
                   )}
                 </Field>
-                <p className="mt-2 text-sm dark:text-neutral-400 text-neutral-600">
-                  Note: This list shows existing public and private channels (up
-                  to 500). You can either select from the list or type any
-                  channel name directly.
-                </p>
+                {channelHelperText && (
+                  <p className="mt-2 text-sm dark:text-neutral-400 text-neutral-600">
+                    {channelHelperText}
+                  </p>
+                )}
               </>
             )}
           </>


### PR DESCRIPTION
## Description

truncate returned list instead of erroring.
friendly messaging on client side.

Fixes https://linear.app/danswer/issue/DAN-1865/slack-page-always-shows-failed-to-fetch-slack-channels-please-enter.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
