### PR TITLE
fix: Slack formatting bug

### DIFF
--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -88,7 +88,7 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
 
 def _clean_markdown_link_text(text: str) -> str:
     # Remove any newlines within the text
-    return text.replace("\n", " ").strip()
+    return format_slack_message(text).replace("\n", " ").strip()
 
 
 def _build_qa_feedback_block(

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -3,8 +3,7 @@ from mistune import Renderer  # type: ignore
 
 
 def format_slack_message(message: str | None) -> str:
-    renderer = Markdown(renderer=SlackRenderer())
-    return renderer.render(message)
+    return Markdown(renderer=SlackRenderer()).render(message)
 
 
 class SlackRenderer(Renderer):


### PR DESCRIPTION
## Description

Fixes bug in which slack sources would not be formatted correctly if `<` or `>` characters were included in the document title.

Addresses: https://linear.app/danswer/issue/DAN-1815/bad-citing-in-slack-bot-for-docs-with-or-in-the-titleurl.

## How Has This Been Tested?

Visually tested through Slack.