### PR TITLE
fix: Fix the `add_model_configuration` migration by removing duplicate model-names during insertion

### DIFF
--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -1,7 +1,7 @@
 """Add model-configuration table
 
 Revision ID: 7a70b7664e37
-Revises: cf90764725d8
+Revises: d961aca62eb3
 Create Date: 2025-04-10 15:00:35.984669
 
 """

--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -1,4 +1,4 @@
-"""Add models-configuration table
+"""Add model-configuration table
 
 Revision ID: 7a70b7664e37
 Revises: cf90764725d8
@@ -58,16 +58,13 @@ def upgrade() -> None:
 
     for llm_provider in llm_providers:
         provider_id = llm_provider[0]
-        model_names = llm_provider[1] or []
-        display_model_names = llm_provider[2] or []
-
-        # Create a set of display models for quick lookup
-        display_set = set(display_model_names)
+        model_names_set = set(llm_provider[1] or [])
+        display_names_set = set(llm_provider[2] or [])
 
         # Insert all models from model_names
-        for model_name in model_names:
+        for model_name in model_names_set:
             # If model is in display_model_names, set is_visible to True
-            is_visible = model_name in display_set
+            is_visible = model_name in display_names_set
 
             connection.execute(
                 model_configuration_table.insert().values(


### PR DESCRIPTION
## Description

It is possible for llm_provider.model_names to contain duplicate values (e.g., {model-a, model-a}. However, the new schema requires that the (provider_name, model_name) tuple be unique (i.e., no duplicate model names for a certain provider).

When migrating the llm_provider.model_names over to the new model_configurations table, the existence of duplicates will cause a problem in the uniqueness guarantees of the model_configurations table.

This PR solves that problem by converting the `llm_provider.model_names` into a set first in the migration script prior to inserting into the database table.

Addresses: https://linear.app/danswer/issue/DAN-1869/fix-duplicate-model-names-from-throwing-an-error-during-db-migration.

## How Has This Been Tested?

Ran migrations up and down.