### PR TITLE
Confluence server api time fix

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -483,8 +483,8 @@ class ConfluenceConnector(
             limit=2 * self.batch_size,
         ):
             # create checkpoint after enough documents have been processed
-            if yield_count >= self.batch_size:
-                return checkpoint
+            # if yield_count >= self.batch_size:
+            #     return checkpoint
 
             if page["id"] in prev_doc_ids:
                 # There are a few seconds of fuzziness in the request,

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -493,12 +493,12 @@ class ConfluenceConnector(
 
             ts = datetime_from_string(page["version"]["when"]).timestamp()
 
-            if ts < checkpoint.last_updated:
-                logger.warning(
-                    f"Confluence Returned results out of order. Request start time: {start_ts}, "
-                    f"current item time: {ts}, checkpoint.last_updated: {checkpoint.last_updated}"
-                )
-                continue
+            # if ts < checkpoint.last_updated:
+            #     logger.warning(
+            #         f"Confluence Returned results out of order. Request start time: {start_ts}, "
+            #         f"current item time: {ts}, checkpoint.last_updated: {checkpoint.last_updated}"
+            #     )
+            #     continue
 
             # Build doc from page
             doc_or_failure = self._convert_page_to_document(page)

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -481,7 +481,6 @@ class ConfluenceConnector(
                 next_page_callback=store_next_page_start,
             )
         ):
-
             # Build doc from page
             doc_or_failure = self._convert_page_to_document(page)
 
@@ -540,7 +539,6 @@ class ConfluenceConnector(
         Return 'slim' docs (IDs + minimal permission data).
         Does not fetch actual text. Used primarily for incremental permission sync.
         """
-        print("Retrieving all slim documents")
         doc_metadata_list: list[SlimDocument] = []
         restrictions_expand = ",".join(_RESTRICTIONS_EXPANSION_FIELDS)
 

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -501,9 +501,11 @@ class OnyxConfluence:
             # results returned BUT will not apply this to the start parameter.
             # This will cause us to miss results.
             updated_start = get_start_param_from_url(url_suffix)
+
             for result in results:
                 updated_start += 1
                 if next_page_callback:
+                    print(f"updated_start: {updated_start}, url_suffix: {url_suffix}")
                     next_page_callback(updated_start)
                 yield result
 
@@ -540,7 +542,7 @@ class OnyxConfluence:
         """
         expand_string = f"&expand={expand}" if expand else ""
         cql_url = f"rest/api/content/search?cql={cql}{expand_string}"
-        if start:
+        if not self._is_cloud and start:
             cql_url = update_param_in_path(cql_url, "start", str(start))
         yield from self._paginate_url(
             cql_url, limit, next_page_callback=next_page_callback

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -392,7 +392,6 @@ class OnyxConfluence:
 
     def __getattr__(self, name: str) -> Any:
         """Dynamically intercept attribute/method access."""
-        print("hello")
         attr = getattr(self._confluence, name, None)
         if attr is None:
             # The underlying Confluence client doesn't have this attribute
@@ -413,14 +412,13 @@ class OnyxConfluence:
             self._make_rate_limited_confluence_method(name, self._credentials_provider)
         )
 
-        print(f"Returning rate limited method for {name}")
-
         return rate_limited_method
 
     def _paginate_url(
         self,
         url_suffix: str,
         limit: int | None = None,
+        # Called with the "start" param to use to resume from the last retrieved page
         next_page_callback: Callable[[int], None] | None = None,
     ) -> Iterator[dict[str, Any]]:
         """
@@ -534,6 +532,7 @@ class OnyxConfluence:
         expand: str | None = None,
         limit: int | None = None,
         start: int = 0,
+        # Called with the "start" param to use to resume from the last retrieved page
         next_page_callback: Callable[[int], None] | None = None,
     ) -> Iterator[dict[str, Any]]:
         """
@@ -559,7 +558,6 @@ class OnyxConfluence:
         The limit only applies to the top level query.
         All expansion paginations use default pagination limit (defined by Atlassian).
         """
-        print(f"Paginating through expansions for {cql}")
 
         def _traverse_and_update(data: dict | list) -> None:
             if isinstance(data, dict):
@@ -576,7 +574,6 @@ class OnyxConfluence:
         for confluence_object in self.paginated_cql_retrieval(cql, expand, limit):
             _traverse_and_update(confluence_object)
             yield confluence_object
-            print(f"Yielded {confluence_object}")
 
     def paginated_cql_user_retrieval(
         self,

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -506,7 +506,6 @@ class OnyxConfluence:
             # the configured server, it will artificially limit the amount of
             # results returned BUT will not apply this to the start parameter.
             # This will cause us to miss results.
-            # print(f"next_response: {next_response}")
             old_url_suffix = url_suffix
             updated_start = get_start_param_from_url(old_url_suffix)
             url_suffix = cast(str, next_response.get("_links", {}).get("next", ""))

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -524,9 +524,7 @@ def get_single_param_from_url(url: str, param: str) -> str | None:
 def get_start_param_from_url(url: str) -> int:
     """Get the start parameter from a url"""
     start_str = get_single_param_from_url(url, "start")
-    if start_str is None:
-        return 0
-    return int(start_str)
+    return int(start_str) if start_str else 0
 
 
 def update_param_in_path(path: str, param: str, value: str) -> str:

--- a/backend/tests/daily/connectors/confluence/test_confluence_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_basic.py
@@ -13,14 +13,6 @@ from onyx.connectors.credentials_provider import OnyxStaticCredentialsProvider
 from onyx.connectors.models import Document
 from tests.daily.connectors.utils import load_all_docs_from_checkpoint_connector
 
-EXPIRED_CURSOR = (
-    r"/rest/api/content/search?next=true&"
-    r"cursor=_f_MzI%3D_sa_WzE3MzIxMTcwMDEwMDAsIlx0MjEzODQzOTc4IEdZcmVXMz1TTltVJ3FJOjZKTjM9IGNwIl0%3D&"
-    r"expand=body.storage.value%2Cversion%2Cspace%2Cmetadata.labels%2Chistory.lastUpdated&limit=32&"
-    r"start=32&cql=type%3Dpage%20and%20lastmodified%20%3E%3D%20%272024-09-21%2015%3A16%27%20and%20"
-    r"lastmodified%20%3C%3D%20%272025-04-26%2009%3A49%27%20order%20by%20lastmodified%20asc"
-)
-
 
 @pytest.fixture
 def confluence_connector(space: str) -> ConfluenceConnector:

--- a/backend/tests/daily/connectors/confluence/test_confluence_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_basic.py
@@ -13,6 +13,14 @@ from onyx.connectors.credentials_provider import OnyxStaticCredentialsProvider
 from onyx.connectors.models import Document
 from tests.daily.connectors.utils import load_all_docs_from_checkpoint_connector
 
+EXPIRED_CURSOR = (
+    r"/rest/api/content/search?next=true&"
+    r"cursor=_f_MzI%3D_sa_WzE3MzIxMTcwMDEwMDAsIlx0MjEzODQzOTc4IEdZcmVXMz1TTltVJ3FJOjZKTjM9IGNwIl0%3D&"
+    r"expand=body.storage.value%2Cversion%2Cspace%2Cmetadata.labels%2Chistory.lastUpdated&limit=32&"
+    r"start=32&cql=type%3Dpage%20and%20lastmodified%20%3E%3D%20%272024-09-21%2015%3A16%27%20and%20"
+    r"lastmodified%20%3C%3D%20%272025-04-26%2009%3A49%27%20order%20by%20lastmodified%20asc"
+)
+
 
 @pytest.fixture
 def confluence_connector(space: str) -> ConfluenceConnector:

--- a/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
@@ -117,5 +117,5 @@ def test_paginated_cql_user_retrieval_no_overrides_cloud() -> None:
 
         # Check that the cloud-specific user search URL is called
         mock_paginate.assert_called_once_with(
-            "rest/api/search/user?cql=type=user", None, auto_paginate=True
+            "rest/api/search/user?cql=type=user", None
         )

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -149,7 +149,7 @@ def test_load_from_checkpoint_happy_path(
         # First page response
         MagicMock(
             json=lambda: {
-                "results": [mock_page1, mock_page2, mock_page3],
+                "results": [mock_page1, mock_page2],
                 "_links": {"next": "rest/api/content/search?cql=type=page&start=3"},
             }
         ),
@@ -157,7 +157,7 @@ def test_load_from_checkpoint_happy_path(
         MagicMock(json=lambda: {"results": []}),
         MagicMock(json=lambda: {"results": []}),
         MagicMock(json=lambda: {"results": []}),
-        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": [mock_page3]}),
         MagicMock(json=lambda: {"results": []}),
         MagicMock(json=lambda: {"results": []}),
     ]
@@ -416,11 +416,6 @@ def test_checkpoint_progress(
     outputs = load_everything_from_checkpoint_connector(
         confluence_connector, 0, end_time
     )
-
-    for output in outputs:
-        print(output)
-        print()
-        print()
 
     first_checkpoint = outputs[0].next_checkpoint
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -41,19 +41,16 @@ def space_key() -> str:
 
 
 @pytest.fixture
-def mock_confluence_client() -> MagicMock:
+def mock_confluence_client() -> OnyxConfluence:
     """Create a mock Confluence client with proper typing"""
-    mock = MagicMock(spec=OnyxConfluence)
-    # Initialize with empty results for common methods
-    mock.paginated_cql_retrieval.return_value = []
-    mock.get_all_spaces = MagicMock()
-    mock.get_all_spaces.return_value = {"results": []}
-    return mock
+    return OnyxConfluence(
+        is_cloud=False, url="test", credentials_provider=MagicMock(), timeout=None
+    )
 
 
 @pytest.fixture
 def confluence_connector(
-    confluence_base_url: str, space_key: str, mock_confluence_client: MagicMock
+    confluence_base_url: str, space_key: str, mock_confluence_client: OnyxConfluence
 ) -> Generator[ConfluenceConnector, None, None]:
     """Create a Confluence connector with a mock client"""
     connector = ConfluenceConnector(
@@ -146,16 +143,23 @@ def test_load_from_checkpoint_happy_path(
     # Mock paginated_cql_retrieval to return our mock pages
     confluence_client = confluence_connector._confluence_client
     assert confluence_client is not None, "bad test setup"
-    paginated_cql_mock = cast(MagicMock, confluence_client.paginated_cql_retrieval)
-    paginated_cql_mock.side_effect = [
-        [mock_page1, mock_page2, mock_page3],
-        [],  # comments
-        [],  # attachments
-        [],  # comments
-        [],  # attachments
-        [mock_page3],
-        [],  # comments
-        [],  # attachments
+    get_mock = MagicMock()
+    confluence_client.get = get_mock  # type: ignore
+    get_mock.side_effect = [
+        # First page response
+        MagicMock(
+            json=lambda: {
+                "results": [mock_page1, mock_page2, mock_page3],
+                "_links": {"next": "rest/api/content/search?cql=type=page&start=3"},
+            }
+        ),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
     ]
 
     # Call load_from_checkpoint
@@ -176,9 +180,8 @@ def test_load_from_checkpoint_happy_path(
     assert isinstance(document2, Document)
     assert document2.id == f"{confluence_connector.wiki_base}/spaces/TEST/pages/2"
     assert checkpoint_output1.next_checkpoint == ConfluenceCheckpoint(
-        last_updated=first_updated.timestamp(),
+        next_start=2,
         has_more=True,
-        last_seen_doc_ids=["1", "2"],
     )
 
     checkpoint_output2 = outputs[1]
@@ -187,7 +190,8 @@ def test_load_from_checkpoint_happy_path(
     assert isinstance(document3, Document)
     assert document3.id == f"{confluence_connector.wiki_base}/spaces/TEST/pages/3"
     assert checkpoint_output2.next_checkpoint == ConfluenceCheckpoint(
-        last_updated=last_updated.timestamp(), has_more=False, last_seen_doc_ids=["3"]
+        next_start=3,
+        has_more=False,
     )
 
 
@@ -203,8 +207,32 @@ def test_load_from_checkpoint_with_page_processing_error(
     # Mock paginated_cql_retrieval to return our mock pages
     confluence_client = confluence_connector._confluence_client
     assert confluence_client is not None, "bad test setup"
-    paginated_cql_mock = cast(MagicMock, confluence_client.paginated_cql_retrieval)
-    paginated_cql_mock.return_value = [mock_page1, mock_page2]
+    get_mock = MagicMock()
+    confluence_client.get = get_mock  # type: ignore
+    get_mock.side_effect = [
+        # First page response
+        MagicMock(
+            json=lambda: {
+                "results": [mock_page1, mock_page2],
+                "_links": {"next": "rest/api/content/search?cql=type=page&start=2"},
+            }
+        ),
+        # Comments for page 1
+        MagicMock(json=lambda: {"results": []}),
+        # Attachments for page 1
+        MagicMock(json=lambda: {"results": []}),
+        # Comments for page 2
+        MagicMock(json=lambda: {"results": []}),
+        # Attachments for page 2
+        MagicMock(json=lambda: {"results": []}),
+        # Second page response (empty)
+        MagicMock(
+            json=lambda: {
+                "results": [],
+                "_links": {},
+            }
+        ),
+    ]
 
     # Mock _convert_page_to_document to fail for the second page
     def mock_convert_side_effect(page: dict[str, Any]) -> Document | ConnectorFailure:
@@ -268,12 +296,24 @@ def test_retrieve_all_slim_documents(
     confluence_client = confluence_connector._confluence_client
     assert confluence_client is not None, "bad test setup"
 
-    paginated_cql_mock = cast(MagicMock, confluence_client.cql_paginate_all_expansions)
-    paginated_cql_mock.side_effect = [[mock_page1, mock_page2], [], []]
+    get_mock = MagicMock()
+    confluence_client.get = get_mock  # type: ignore
+    get_mock.side_effect = [
+        # First page response
+        MagicMock(
+            json=lambda: {
+                "results": [mock_page1, mock_page2],
+                "_links": {"next": "rest/api/content/search?cql=type=page&start=2"},
+            }
+        ),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+    ]
 
     # Call retrieve_all_slim_documents
     batches = list(confluence_connector.retrieve_all_slim_documents(0, 100))
-    assert paginated_cql_mock.call_count == 3
+    assert get_mock.call_count == 4
 
     # Check that a batch with 2 documents was returned
     assert len(batches) == 1
@@ -340,24 +380,35 @@ def test_checkpoint_progress(
     # Set up mocked pages with different timestamps
     earlier_timestamp = datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc)
     later_timestamp = datetime(2023, 1, 2, 12, 0, tzinfo=timezone.utc)
+    latest_timestamp = datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)
     mock_page1 = create_mock_page(
         id="1", title="Page 1", updated=earlier_timestamp.isoformat()
     )
     mock_page2 = create_mock_page(
         id="2", title="Page 2", updated=later_timestamp.isoformat()
     )
+    mock_page3 = create_mock_page(
+        id="3", title="Page 3", updated=latest_timestamp.isoformat()
+    )
 
     # Mock paginated_cql_retrieval to return our mock pages
     confluence_client = confluence_connector._confluence_client
     assert confluence_client is not None, "bad test setup"
-    paginated_cql_mock = cast(MagicMock, confluence_client.paginated_cql_retrieval)
-    paginated_cql_mock.side_effect = [
-        [mock_page1, mock_page2],  # Return both pages
-        [],  # No comments for page 1
-        [],  # No attachments for page 1
-        [],  # No comments for page 2
-        [],  # No attachments for page 2
-        [],  # No more pages
+    get_mock = MagicMock()
+    confluence_client.get = get_mock  # type: ignore
+    get_mock.side_effect = [
+        # First page response
+        MagicMock(
+            json=lambda: {
+                "results": [mock_page1, mock_page2],
+                "_links": {"next": "rest/api/content/search?cql=type=page&start=2"},
+            }
+        ),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
     ]
 
     # First run - process both pages
@@ -366,15 +417,15 @@ def test_checkpoint_progress(
         confluence_connector, 0, end_time
     )
 
-    assert len(outputs) == 1
+    for output in outputs:
+        print(output)
+        print()
+        print()
 
     first_checkpoint = outputs[0].next_checkpoint
 
-    assert first_checkpoint == ConfluenceCheckpoint(
-        last_updated=later_timestamp.timestamp(),
-        has_more=False,
-        last_seen_doc_ids=["1", "2"],
-    )
+    assert first_checkpoint.next_start == 2
+    assert not outputs[-1].next_checkpoint.has_more
 
     assert len(outputs[0].items) == 2
     assert isinstance(outputs[0].items[0], Document)
@@ -382,19 +433,19 @@ def test_checkpoint_progress(
     assert isinstance(outputs[0].items[1], Document)
     assert outputs[0].items[1].semantic_identifier == "Page 2"
 
-    latest_timestamp = datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc)
-    mock_page3 = create_mock_page(
-        id="3", title="Page 3", updated=latest_timestamp.isoformat()
-    )
     # Second run - same time range but with checkpoint from first run
     # Reset the mock to return the same pages
-    paginated_cql_mock.side_effect = [
-        [mock_page1, mock_page2, mock_page3],  # Return both pages
-        [],  # No comments for page 1
-        [],  # No attachments for page 1
-        [],  # No comments for page 2
-        [],  # No attachments for page 2
-        [],  # No more pages
+    get_mock.side_effect = [
+        # First page response
+        MagicMock(
+            json=lambda: {
+                "results": [mock_page3],
+                "_links": {"next": "rest/api/content/search?cql=type=page&start=3"},
+            }
+        ),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
+        MagicMock(json=lambda: {"results": []}),
     ]
 
     # Use the checkpoint from first run
@@ -409,7 +460,6 @@ def test_checkpoint_progress(
     assert isinstance(outputs_with_checkpoint[0].items[0], Document)
     assert outputs_with_checkpoint[0].items[0].semantic_identifier == "Page 3"
     assert outputs_with_checkpoint[0].next_checkpoint == ConfluenceCheckpoint(
-        last_updated=latest_timestamp.timestamp(),
+        next_start=3,
         has_more=False,
-        last_seen_doc_ids=["3"],
     )


### PR DESCRIPTION
## Description

Addresses https://linear.app/danswer/issue/DAN-1899/confluence-documents-indexed-not-matching-total-docs
(and a series of other confluence customer issues)

There's an issue with the Confluence Server API; there doesn't appear to be a consistent field in page responses that mirrors the "lastmodified" key used during the query. This means that sometimes the field in response pages that we use for lastmodified can be outside the specified range. To fix this, we're switching to page-start-based checkpointing for confluence server.

Confluence Cloud  ALSO returns slightly wrong lastmodified values (though in testing they were less off than server), and uses cursor-based pagination. We currently believe that confluence uses a stateless model for cursor pagination, so the cursors never expire.

So, the current approach is to only store the "next page url" in the checkpoint. 

## How Has This Been Tested?

Ran in UI + unit tests

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
