### PR TITLE
fix: Fix migration issue in which display-model-names were not being appropriately set

### DIFF
--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -38,6 +38,8 @@ def upgrade() -> None:
         sa.column("id", sa.Integer),
         sa.column("model_names", postgresql.ARRAY(sa.String)),
         sa.column("display_model_names", postgresql.ARRAY(sa.String)),
+        sa.column("default_model_name", sa.String),
+        sa.column("fast_default_model_name", sa.String),
     )
     model_configuration_table = sa.sql.table(
         "model_configuration",
@@ -60,6 +62,13 @@ def upgrade() -> None:
         provider_id = llm_provider[0]
         model_names_set = set(llm_provider[1] or [])
         display_names_set = set(llm_provider[2] or [])
+        default_model_name = llm_provider[3]
+        fast_default_model_name = llm_provider[4]
+
+        model_names_set.add(default_model_name)
+        model_names_set.add(fast_default_model_name)
+        display_names_set.add(default_model_name)
+        display_names_set.add(fast_default_model_name)
 
         # Insert all models from model_names
         for model_name in model_names_set:

--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -112,8 +112,11 @@ def upgrade() -> None:
     llm_providers = connection.execute(
         sa.select(
             llm_provider_table.c.id,
+            llm_provider_table.c.provider,
             llm_provider_table.c.model_names,
             llm_provider_table.c.display_model_names,
+            llm_provider_table.c.default_model_name,
+            llm_provider_table.c.fast_default_model_name,
         )
     ).fetchall()
 

--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -19,7 +19,7 @@ branch_labels = None
 depends_on = None
 
 
-def resolve(
+def _resolve(
     provider_name: str,
     model_names: list[str] | None,
     display_model_names: list[str] | None,
@@ -125,7 +125,7 @@ def upgrade() -> None:
         default_model_name = llm_provider[4]
         fast_default_model_name = llm_provider[5]
 
-        model_configurations = resolve(
+        model_configurations = _resolve(
             provider_name=provider_name,
             model_names=model_names,
             display_model_names=display_model_names,

--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -10,18 +10,13 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-from onyx.llm.llm_provider_options import PROVIDER_TO_MODELS_MAP
+from onyx.llm.llm_provider_options import fetch_model_names_for_provider_as_set
 
 # revision identifiers, used by Alembic.
 revision = "7a70b7664e37"
 down_revision = "d961aca62eb3"
 branch_labels = None
 depends_on = None
-
-
-def get(provider_name: str) -> set[str] | None:
-    model_names: list[str] | None = PROVIDER_TO_MODELS_MAP.get(provider_name)
-    return set(model_names) if model_names else None
 
 
 def resolve(
@@ -41,16 +36,16 @@ def resolve(
 
     # if only the model-names are defined,
     elif models and not display_models:
-        new = get(provider_name)
+        new = fetch_model_names_for_provider_as_set(provider_name)
         display_models = models.union(new) if new else set(models)
 
     # if only the display-model-names are defined, then
     elif not models and display_models:
-        new = get(provider_name)
+        new = fetch_model_names_for_provider_as_set(provider_name)
         models = display_models.union(new) if new else set(display_models)
 
     else:
-        new = get(provider_name)
+        new = fetch_model_names_for_provider_as_set(provider_name)
         models = set(new) if new else set()
         display_models = set(new) if new else set()
 

--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -36,18 +36,36 @@ def resolve(
 
     # if only the model-names are defined,
     elif models and not display_models:
-        new = fetch_model_names_for_provider_as_set(provider_name)
-        display_models = models.union(new) if new else set(models)
+        default_models_for_provider = fetch_model_names_for_provider_as_set(
+            provider_name
+        )
+        display_models = (
+            models.union(default_models_for_provider)
+            if default_models_for_provider
+            else set(models)
+        )
 
     # if only the display-model-names are defined, then
     elif not models and display_models:
-        new = fetch_model_names_for_provider_as_set(provider_name)
-        models = display_models.union(new) if new else set(display_models)
+        default_models_for_provider = fetch_model_names_for_provider_as_set(
+            provider_name
+        )
+        models = (
+            display_models.union(default_models_for_provider)
+            if default_models_for_provider
+            else set(display_models)
+        )
 
     else:
-        new = fetch_model_names_for_provider_as_set(provider_name)
-        models = set(new) if new else set()
-        display_models = set(new) if new else set()
+        default_models_for_provider = fetch_model_names_for_provider_as_set(
+            provider_name
+        )
+        models = (
+            set(default_models_for_provider) if default_models_for_provider else set()
+        )
+        display_models = (
+            set(default_models_for_provider) if default_models_for_provider else set()
+        )
 
     models.add(default_model_name)
     models.add(fast_default_model_name)

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -126,6 +126,10 @@ VERTEXAI_MODEL_NAMES = [
     "gemini-1.5-flash-001",
     "gemini-1.5-flash-002",
 ]
+VERTEXAI_VISIBLE_MODEL_NAMES = [
+    VERTEXAI_DEFAULT_MODEL,
+    VERTEXAI_DEFAULT_FAST_MODEL,
+]
 
 
 _PROVIDER_TO_MODELS_MAP = {
@@ -133,6 +137,13 @@ _PROVIDER_TO_MODELS_MAP = {
     BEDROCK_PROVIDER_NAME: BEDROCK_MODEL_NAMES,
     ANTHROPIC_PROVIDER_NAME: ANTHROPIC_MODEL_NAMES,
     VERTEXAI_PROVIDER_NAME: VERTEXAI_MODEL_NAMES,
+}
+
+_PROVIDER_TO_VISIBLE_MODELS_MAP = {
+    OPENAI_PROVIDER_NAME: OPEN_AI_VISIBLE_MODEL_NAMES,
+    BEDROCK_PROVIDER_NAME: [],
+    ANTHROPIC_PROVIDER_NAME: ANTHROPIC_VISIBLE_MODEL_NAMES,
+    VERTEXAI_PROVIDER_NAME: VERTEXAI_VISIBLE_MODEL_NAMES,
 }
 
 
@@ -233,3 +244,12 @@ def fetch_models_for_provider(provider_name: str) -> list[str]:
 def fetch_model_names_for_provider_as_set(provider_name: str) -> set[str] | None:
     model_names: list[str] | None = _PROVIDER_TO_MODELS_MAP.get(provider_name)
     return set(model_names) if model_names else None
+
+
+def fetch_visible_model_names_for_provider_as_set(
+    provider_name: str,
+) -> set[str] | None:
+    visible_model_names: list[str] | None = _PROVIDER_TO_VISIBLE_MODELS_MAP.get(
+        provider_name
+    )
+    return set(visible_model_names) if visible_model_names else None

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -128,7 +128,7 @@ VERTEXAI_MODEL_NAMES = [
 ]
 
 
-PROVIDER_TO_MODELS_MAP = {
+_PROVIDER_TO_MODELS_MAP = {
     OPENAI_PROVIDER_NAME: OPEN_AI_MODEL_NAMES,
     BEDROCK_PROVIDER_NAME: BEDROCK_MODEL_NAMES,
     ANTHROPIC_PROVIDER_NAME: ANTHROPIC_MODEL_NAMES,
@@ -227,4 +227,9 @@ def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
 
 
 def fetch_models_for_provider(provider_name: str) -> list[str]:
-    return PROVIDER_TO_MODELS_MAP.get(provider_name, [])
+    return _PROVIDER_TO_MODELS_MAP.get(provider_name, [])
+
+
+def fetch_model_names_for_provider_as_set(provider_name: str) -> set[str] | None:
+    model_names: list[str] | None = _PROVIDER_TO_MODELS_MAP.get(provider_name)
+    return set(model_names) if model_names else None

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -128,7 +128,7 @@ VERTEXAI_MODEL_NAMES = [
 ]
 
 
-_PROVIDER_TO_MODELS_MAP = {
+PROVIDER_TO_MODELS_MAP = {
     OPENAI_PROVIDER_NAME: OPEN_AI_MODEL_NAMES,
     BEDROCK_PROVIDER_NAME: BEDROCK_MODEL_NAMES,
     ANTHROPIC_PROVIDER_NAME: ANTHROPIC_MODEL_NAMES,
@@ -227,4 +227,4 @@ def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
 
 
 def fetch_models_for_provider(provider_name: str) -> list[str]:
-    return _PROVIDER_TO_MODELS_MAP.get(provider_name, [])
+    return PROVIDER_TO_MODELS_MAP.get(provider_name, [])


### PR DESCRIPTION
## Description

Migration did not address the case in which:

- `model_names = []` and `display_model_names = []`
- `default_model_name = "some-model"` and `fast_default_model_name = "some-fast-model"`

I.e., the case in which the default and fast-default models were specified, but they *did not* exist inside of the `model_names` or `display_model_names` lists.

The reason why this bug was pushed was because of incorrect assumptions; I assumed that `model_names` and `display_model_names` would *always* contain the `default_model_name` and `fast_default_model_name`. I.e., I assumed that:

$`(default\_model\_name \in model\_names)`$
and
$`(default\_model\_name \in display\_model\_names)`$
and
$`(fast\_default\_model\_name \in model\_name)`$
and
$`(fast\_default\_model\_name \in display\_model\_names)`$

However, this was apparently not an invariant that was necessary to enforce (not sure why, though).

As such, this push towards data normalization resulted in a lossy migration in which the `display_model_names` data was lost.

This PR aims to fix that error. It appropriately appends `default_model_name` and `fast_default_model_name` to the `model_names` and `display_model_names` sets prior to iteratively inserting into the new database table.

Addresses: https://linear.app/danswer/issue/DAN-1874/fix-migration-script-to-properly-transform-display-model-namesto-the.

## How Has This Been Tested?

TODO!