### PR TITLE
fix priority on vespa metadata sync

### DIFF
--- a/backend/onyx/redis/redis_document_set.py
+++ b/backend/onyx/redis/redis_document_set.py
@@ -91,7 +91,7 @@ class RedisDocumentSet(RedisObjectHelper):
                 kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
                 queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
                 task_id=custom_task_id,
-                priority=OnyxCeleryPriority.LOW,
+                priority=OnyxCeleryPriority.MEDIUM,
             )
 
             num_tasks_sent += 1

--- a/backend/onyx/redis/redis_usergroup.py
+++ b/backend/onyx/redis/redis_usergroup.py
@@ -102,7 +102,7 @@ class RedisUserGroup(RedisObjectHelper):
                 kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
                 queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
                 task_id=custom_task_id,
-                priority=OnyxCeleryPriority.LOW,
+                priority=OnyxCeleryPriority.MEDIUM,
             )
 
             num_tasks_sent += 1


### PR DESCRIPTION
## Description

using different priorities here is causing the queue to starve out some tasks. Make them all medium.

Fixes https://linear.app/danswer/issue/DAN-1901/fix-some-sync-priority

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
