### PR TITLE
fix provisioning and don't spawn tasks which could result in a race c…

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -406,7 +406,6 @@ class OnyxCeleryTask:
     )
 
     # Tenant pre-provisioning
-    PRE_PROVISION_TENANT = f"{ONYX_CLOUD_CELERY_TASK_PREFIX}_pre_provision_tenant"
     UPDATE_USER_FILE_FOLDER_METADATA = "update_user_file_folder_metadata"
 
     CHECK_FOR_CONNECTOR_DELETION = "check_for_connector_deletion_task"


### PR DESCRIPTION
…ondition

## Description

Task was not being discovered correctly.
Also had a design issue where it would continue to dispatch new tenants if the queue was backed up.  Performing the check and the provisioning together fixes this.

Fixes https://linear.app/danswer/issue/DAN-1876/tenant-pre-provisioning-is-broken

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
