### PR TITLE
Add ticket number indexing to Jira connector

### DIFF
--- a/backend/onyx/connectors/onyx_jira/connector.py
+++ b/backend/onyx/connectors/onyx_jira/connector.py
@@ -154,6 +154,8 @@ def process_jira_issue(
     if issuetype := best_effort_get_field_from_issue(issue, _FIELD_ISSUETYPE):
         metadata_dict[_FIELD_ISSUETYPE] = issuetype.name
 
+    metadata_dict[_FIELD_KEY] = issue.key
+
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],


### PR DESCRIPTION
## Description

Currently the Jira connector doesn't index ticket numbers, which means that you can only refer to tickets by their titles, NOT their numbers, when chatting with Onyx. Users typically want to refer to tickets by their numbers, so this limits the utility of the connector.  See issue #4605.

## How Has This Been Tested?

Tested a project with a Jira connector both with and without the code in this PR.  Without this code, we could not refer to tickets by their numbers in an Onyx search (e.g. "Tell me about ST-1234").  We were able to refer to tickets by their numbers with this code in place, *after* reindexing all documents for that connector.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
