### PR TITLE
linear dupe docs fix

### DIFF
--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -244,14 +244,14 @@ def get_all_files_in_my_drive_and_shared(
     if not include_shared_with_me:
         folder_query += " and 'me' in owners"
     found_folders = False
-    for file in execute_paginated_retrieval(
+    for folder in execute_paginated_retrieval(
         retrieval_function=service.files().list,
         list_key="files",
         corpora="user",
         fields=SLIM_FILE_FIELDS if is_slim else FILE_FIELDS,
         q=folder_query,
     ):
-        update_traversed_ids_func(file[GoogleFields.ID])
+        update_traversed_ids_func(folder[GoogleFields.ID])
         found_folders = True
     if found_folders:
         update_traversed_ids_func(get_root_folder_id(service))

--- a/backend/onyx/connectors/linear/connector.py
+++ b/backend/onyx/connectors/linear/connector.py
@@ -271,7 +271,7 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
                         },
                     )
                 )
-                yield documents
+            yield documents
 
             endCursor = response_json["data"]["issues"]["pageInfo"]["endCursor"]
             has_more = response_json["data"]["issues"]["pageInfo"]["hasNextPage"]


### PR DESCRIPTION
## Description

Addresses https://linear.app/danswer/issue/DAN-1903/linear-dedupe-docs
We were sending batches with a single new doc to the indexing pipeline; now each batch has a full batch_size documents

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
