### PR TITLE
Bugfix/chat images

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,3 +10,5 @@ vespa-app.zip
 dynamic_config_storage/
 celerybeat-schedule*
 onyx/connectors/salesforce/data/
+.test.env
+

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -184,10 +184,10 @@ async def run_async_migrations() -> None:
             except Exception as e:
                 logger.error(f"Error migrating schema {schema}: {e}")
                 if not continue_on_error:
-                    logger.error("--continue is not set, raising exception!")
+                    logger.error("--continue=true is not set, raising exception!")
                     raise
 
-                logger.warning("--continue is set, continuing to next schema.")
+                logger.warning("--continue=true is set, continuing to next schema.")
 
     else:
         try:

--- a/backend/alembic/versions/5c448911b12f_add_content_type_to_userfile.py
+++ b/backend/alembic/versions/5c448911b12f_add_content_type_to_userfile.py
@@ -1,0 +1,24 @@
+"""Add content type to UserFile
+
+Revision ID: 5c448911b12f
+Revises: 7a70b7664e37
+Create Date: 2025-04-25 16:59:48.182672
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "5c448911b12f"
+down_revision = "47a07e1a38f1"
+branch_labels: None = None
+depends_on: None = None
+
+
+def upgrade() -> None:
+    op.add_column("user_file", sa.Column("content_type", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("user_file", "content_type")

--- a/backend/alembic/versions/5c448911b12f_add_content_type_to_userfile.py
+++ b/backend/alembic/versions/5c448911b12f_add_content_type_to_userfile.py
@@ -1,7 +1,7 @@
 """Add content type to UserFile
 
 Revision ID: 5c448911b12f
-Revises: 7a70b7664e37
+Revises: 47a07e1a38f1
 Create Date: 2025-04-25 16:59:48.182672
 
 """

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2477,6 +2477,7 @@ class UserFile(Base):
         "ConnectorCredentialPair", back_populates="user_file"
     )
     link_url: Mapped[str | None] = mapped_column(String, nullable=True)
+    content_type: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 """

--- a/backend/onyx/db/user_documents.py
+++ b/backend/onyx/db/user_documents.py
@@ -40,6 +40,10 @@ def create_user_files(
     db_session: Session,
     link_url: str | None = None,
 ) -> list[UserFile]:
+    """NOTE(rkuo): This function can take -1 (RECENT_DOCS_FOLDER_ID for folder_id.
+    Document what this does?
+    """
+
     # NOTE: At the moment, zip metadata is not used for user files.
     # Should revisit to decide whether this should be a feature.
     upload_response = upload_files(files, db_session)
@@ -69,7 +73,10 @@ def upload_files_to_user_files_with_indexing(
     db_session: Session,
     trigger_index: bool = True,
 ) -> list[UserFile]:
-    """Create user files and trigger immediate indexing"""
+    """NOTE(rkuo): This function can take -1 (RECENT_DOCS_FOLDER_ID for folder_id.
+    Document what this does?
+
+    Create user files and trigger immediate indexing"""
     # Create the user files first
     user_files = create_user_files(files, folder_id, user, db_session)
 

--- a/backend/onyx/db/user_documents.py
+++ b/backend/onyx/db/user_documents.py
@@ -54,6 +54,7 @@ def create_user_files(
             name=file.filename,
             token_count=None,
             link_url=link_url,
+            content_type=file.content_type,
         )
         db_session.add(new_file)
         user_files.append(new_file)
@@ -61,7 +62,7 @@ def create_user_files(
     return user_files
 
 
-def create_user_file_with_indexing(
+def upload_files_to_user_files_with_indexing(
     files: List[UploadFile],
     folder_id: int | None,
     user: User,

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -36,6 +36,7 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# NOTE(rkuo): Unify this with upload_files_for_chat and file_valiation.py
 TEXT_SECTION_SEPARATOR = "\n\n"
 
 ACCEPTED_PLAIN_TEXT_FILE_EXTENSIONS = [

--- a/backend/onyx/file_processing/file_validation.py
+++ b/backend/onyx/file_processing/file_validation.py
@@ -2,6 +2,8 @@
 Centralized file type validation utilities.
 """
 
+# NOTE(rkuo): Unify this with upload_files_for_chat and extract_file_text
+
 # Standard image MIME types supported by most vision LLMs
 IMAGE_MIME_TYPES = [
     "image/png",

--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -14,6 +14,9 @@ class ChatFileType(str, Enum):
     # Plain text only contain the text
     PLAIN_TEXT = "plain_text"
     CSV = "csv"
+
+    # NOTE(rkuo): don't understand the motivation for this
+    # "user knowledge" is not a file type, it's a source or intent
     USER_KNOWLEDGE = "user_knowledge"
 
 

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -173,7 +173,7 @@ def undelete_persona(
     )
 
 
-# used for assistat profile pictures
+# used for assistant profile pictures
 @admin_router.post("/upload-image")
 def upload_file(
     file: UploadFile,

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -76,6 +76,7 @@ from onyx.secondary_llm_flows.chat_session_naming import (
 )
 from onyx.server.documents.models import ConnectorBase
 from onyx.server.documents.models import CredentialBase
+from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
 from onyx.server.query_and_chat.models import ChatFeedbackRequest
 from onyx.server.query_and_chat.models import ChatMessageIdentifier
 from onyx.server.query_and_chat.models import ChatRenameRequest
@@ -96,6 +97,7 @@ from onyx.server.query_and_chat.models import SearchFeedbackRequest
 from onyx.server.query_and_chat.models import UpdateChatSessionTemperatureRequest
 from onyx.server.query_and_chat.models import UpdateChatSessionThreadRequest
 from onyx.server.query_and_chat.token_limit import check_token_rate_limits
+from onyx.utils.file_types import UploadMimeTypes
 from onyx.utils.headers import get_custom_tool_additional_request_headers
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import create_milestone_and_report
@@ -663,51 +665,43 @@ def upload_files_for_chat(
 ) -> dict[str, list[FileDescriptor]]:
 
     # NOTE(rkuo): Unify this with file_validation.py and extract_file_text.py
-    image_content_types = {"image/jpeg", "image/png", "image/webp"}
-    csv_content_types = {"text/csv"}
-    text_content_types = {
-        "text/plain",
-        "text/markdown",
-        "text/x-markdown",
-        "text/x-config",
-        "text/tab-separated-values",
-        "application/json",
-        "application/xml",
-        "text/xml",
-        "application/x-yaml",
-    }
-    document_content_types = {
-        "application/pdf",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "message/rfc822",
-        "application/epub+zip",
-    }
+    # image_content_types = {"image/jpeg", "image/png", "image/webp"}
+    # csv_content_types = {"text/csv"}
+    # text_content_types = {
+    #     "text/plain",
+    #     "text/markdown",
+    #     "text/x-markdown",
+    #     "text/x-config",
+    #     "text/tab-separated-values",
+    #     "application/json",
+    #     "application/xml",
+    #     "text/xml",
+    #     "application/x-yaml",
+    # }
+    # document_content_types = {
+    #     "application/pdf",
+    #     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    #     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    #     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    #     "message/rfc822",
+    #     "application/epub+zip",
+    # }
 
-    allowed_content_types = (
-        image_content_types.union(text_content_types)
-        .union(document_content_types)
-        .union(csv_content_types)
-    )
+    # allowed_content_types = (
+    #     image_content_types.union(text_content_types)
+    #     .union(document_content_types)
+    #     .union(csv_content_types)
+    # )
 
     for file in files:
         if not file.content_type:
             raise HTTPException(status_code=400, detail="File content type is required")
 
-        if file.content_type not in allowed_content_types:
-            if file.content_type in image_content_types:
-                error_detail = "Unsupported image file type. Supported image types include .jpg, .jpeg, .png, .webp."
-            elif file.content_type in text_content_types:
-                error_detail = "Unsupported text file type."
-            elif file.content_type in csv_content_types:
-                error_detail = "Unsupported CSV file type."
-            else:
-                error_detail = "Unsupported document file type."
-            raise HTTPException(status_code=400, detail=error_detail)
+        if file.content_type not in UploadMimeTypes.ALLOWED_MIME_TYPES:
+            raise HTTPException(status_code=400, detail="Unsupported file type.")
 
         if (
-            file.content_type in image_content_types
+            file.content_type in UploadMimeTypes.IMAGE_MIME_TYPES
             and file.size
             and file.size > 20 * 1024 * 1024
         ):
@@ -720,19 +714,7 @@ def upload_files_for_chat(
 
     file_info: list[tuple[str, str | None, ChatFileType]] = []
     for file in files:
-        file_type = (
-            ChatFileType.IMAGE
-            if file.content_type in image_content_types
-            else (
-                ChatFileType.CSV
-                if file.content_type in csv_content_types
-                else (
-                    ChatFileType.DOC
-                    if file.content_type in document_content_types
-                    else ChatFileType.PLAIN_TEXT
-                )
-            )
-        )
+        file_type = mime_type_to_chat_file_type(file.content_type)
 
         file_content = file.file.read()  # Read the file content
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -661,6 +661,8 @@ def upload_files_for_chat(
     db_session: Session = Depends(get_session),
     user: User | None = Depends(current_user),
 ) -> dict[str, list[FileDescriptor]]:
+
+    # NOTE(rkuo): Unify this with file_validation.py and extract_file_text.py
     image_content_types = {"image/jpeg", "image/png", "image/webp"}
     csv_content_types = {"text/csv"}
     text_content_types = {

--- a/backend/onyx/server/query_and_chat/chat_utils.py
+++ b/backend/onyx/server/query_and_chat/chat_utils.py
@@ -1,0 +1,18 @@
+from onyx.file_store.models import ChatFileType
+from onyx.utils.file_types import UploadMimeTypes
+
+
+def mime_type_to_chat_file_type(mime_type: str | None) -> ChatFileType:
+    if mime_type is None:
+        return ChatFileType.PLAIN_TEXT
+
+    if mime_type in UploadMimeTypes.IMAGE_MIME_TYPES:
+        return ChatFileType.IMAGE
+
+    if mime_type in UploadMimeTypes.CSV_MIME_TYPES:
+        return ChatFileType.CSV
+
+    if mime_type in UploadMimeTypes.DOCUMENT_MIME_TYPES:
+        return ChatFileType.DOC
+
+    return ChatFileType.PLAIN_TEXT

--- a/backend/onyx/server/user_documents/api.py
+++ b/backend/onyx/server/user_documents/api.py
@@ -31,13 +31,13 @@ from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.models import UserFolder
 from onyx.db.user_documents import calculate_user_files_token_count
-from onyx.db.user_documents import create_user_file_with_indexing
 from onyx.db.user_documents import create_user_files
 from onyx.db.user_documents import get_user_file_indexing_status
 from onyx.db.user_documents import share_file_with_assistant
 from onyx.db.user_documents import share_folder_with_assistant
 from onyx.db.user_documents import unshare_file_with_assistant
 from onyx.db.user_documents import unshare_folder_with_assistant
+from onyx.db.user_documents import upload_files_to_user_files_with_indexing
 from onyx.file_processing.html_utils import web_html_cleanup
 from onyx.server.documents.connector import trigger_indexing_for_cc_pair
 from onyx.server.documents.models import ConnectorBase
@@ -156,7 +156,7 @@ def upload_user_files(
 
     try:
         # Use our consolidated function that handles indexing properly
-        user_files = create_user_file_with_indexing(
+        user_files = upload_files_to_user_files_with_indexing(
             files, folder_id or -1, user, db_session
         )
 

--- a/backend/onyx/server/user_documents/models.py
+++ b/backend/onyx/server/user_documents/models.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import UserFile
 from onyx.db.models import UserFolder
+from onyx.file_store.models import ChatFileType
+from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
 
 
 class UserFileStatus(str, PyEnum):
@@ -17,6 +19,7 @@ class UserFileStatus(str, PyEnum):
     REINDEXING = "REINDEXING"
 
 
+# this maps to FileResponse on the front end
 class UserFileSnapshot(BaseModel):
     id: int
     name: str
@@ -30,6 +33,7 @@ class UserFileSnapshot(BaseModel):
     indexed: bool
     link_url: str | None
     status: UserFileStatus
+    chat_file_type: ChatFileType
 
     @classmethod
     def from_model(cls, model: UserFile) -> "UserFileSnapshot":
@@ -73,6 +77,7 @@ class UserFileSnapshot(BaseModel):
                 else False
             ),
             link_url=model.link_url,
+            chat_file_type=mime_type_to_chat_file_type(model.content_type),
         )
 
 

--- a/backend/onyx/utils/file_types.py
+++ b/backend/onyx/utils/file_types.py
@@ -1,0 +1,28 @@
+class UploadMimeTypes:
+    IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/webp"}
+    CSV_MIME_TYPES = {"text/csv"}
+    TEXT_MIME_TYPES = {
+        "text/plain",
+        "text/markdown",
+        "text/x-markdown",
+        "text/x-config",
+        "text/tab-separated-values",
+        "application/json",
+        "application/xml",
+        "text/xml",
+        "application/x-yaml",
+    }
+    DOCUMENT_MIME_TYPES = {
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "message/rfc822",
+        "application/epub+zip",
+    }
+
+    ALLOWED_MIME_TYPES = (
+        IMAGE_MIME_TYPES.union(TEXT_MIME_TYPES)
+        .union(DOCUMENT_MIME_TYPES)
+        .union(CSV_MIME_TYPES)
+    )

--- a/backend/onyx/utils/file_types.py
+++ b/backend/onyx/utils/file_types.py
@@ -21,8 +21,6 @@ class UploadMimeTypes:
         "application/epub+zip",
     }
 
-    ALLOWED_MIME_TYPES = (
-        IMAGE_MIME_TYPES.union(TEXT_MIME_TYPES)
-        .union(DOCUMENT_MIME_TYPES)
-        .union(CSV_MIME_TYPES)
+    ALLOWED_MIME_TYPES = IMAGE_MIME_TYPES.union(
+        TEXT_MIME_TYPES, DOCUMENT_MIME_TYPES, CSV_MIME_TYPES
     )

--- a/web/src/app/chat/input/ChatInputBar.tsx
+++ b/web/src/app/chat/input/ChatInputBar.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
 import { FiPlusCircle, FiPlus, FiInfo, FiX, FiFilter } from "react-icons/fi";
 import { FiLoader } from "react-icons/fi";
 import { ChatInputOption } from "./ChatInputOption";
@@ -39,6 +39,7 @@ import { AgenticToggle } from "./AgenticToggle";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
 import { getProviderIcon } from "@/app/admin/configuration/llm/interfaces";
 import { useDocumentsContext } from "../my-documents/DocumentsContext";
+import { UploadIntent } from "../ChatPage";
 
 const MAX_INPUT_HEIGHT = 200;
 export const SourceChip2 = ({
@@ -187,7 +188,7 @@ interface ChatInputBarProps {
   setAlternativeAssistant: (alternativeAssistant: Persona | null) => void;
   toggleDocumentSidebar: () => void;
   setFiles: (files: FileDescriptor[]) => void;
-  handleFileUpload: (files: File[]) => void;
+  handleFileUpload: (files: File[], intent: UploadIntent) => void;
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
   filterManager: FilterManager;
   availableSources: SourceMetadata[];
@@ -237,6 +238,13 @@ export function ChatInputBar({
     setCurrentMessageFiles,
   } = useDocumentsContext();
 
+  // Create a Set of IDs from currentMessageFiles for efficient lookup
+  // Assuming FileDescriptor.id corresponds conceptually to FileResponse.file_id or FileResponse.id
+  const currentMessageFileIds = useMemo(
+    () => new Set(currentMessageFiles.map((f) => String(f.id))), // Ensure IDs are strings for comparison
+    [currentMessageFiles]
+  );
+
   const settings = useContext(SettingsContext);
   useEffect(() => {
     const textarea = textAreaRef.current;
@@ -261,7 +269,7 @@ export function ChatInputBar({
       }
       if (pastedFiles.length > 0) {
         event.preventDefault();
-        handleFileUpload(pastedFiles);
+        handleFileUpload(pastedFiles, UploadIntent.ATTACH_TO_MESSAGE);
       }
     }
   };
@@ -662,14 +670,21 @@ export function ChatInputBar({
                       />
                     ))}
 
-                  {selectedFiles.map((file) => (
-                    <SourceChip
-                      key={file.id}
-                      icon={<FileIcon size={16} />}
-                      title={file.name}
-                      onRemove={() => removeSelectedFile(file)}
-                    />
-                  ))}
+                  {/* This is excluding image types because they get rendered differently via currentMessageFiles.map
+                  Seems quite hacky ... all rendering should probably be done in one place? */}
+                  {selectedFiles.map(
+                    (file) =>
+                      !currentMessageFileIds.has(
+                        String(file.file_id || file.id)
+                      ) && (
+                        <SourceChip
+                          key={file.id}
+                          icon={<FileIcon size={16} />}
+                          title={file.name}
+                          onRemove={() => removeSelectedFile(file)}
+                        />
+                      )
+                  )}
                   {selectedFolders.map((folder) => (
                     <SourceChip
                       key={folder.id}

--- a/web/src/app/chat/my-documents/DocumentsContext.tsx
+++ b/web/src/app/chat/my-documents/DocumentsContext.tsx
@@ -11,7 +11,7 @@ import React, {
 } from "react";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import * as documentsService from "@/services/documentsService";
-import { FileDescriptor } from "../interfaces";
+import { ChatFileType, FileDescriptor } from "../interfaces";
 
 export interface FolderResponse {
   id: number;
@@ -29,6 +29,7 @@ export enum FileStatus {
   REINDEXING = "REINDEXING",
 }
 
+// this maps to UserFileSnapshot on the back end
 export type FileResponse = {
   id: number;
   name: string;
@@ -45,6 +46,7 @@ export type FileResponse = {
   file_type?: string;
   link_url?: string | null;
   status: FileStatus;
+  chat_file_type: ChatFileType;
 };
 
 export interface FileUploadResponse {

--- a/web/src/lib/userSS.ts
+++ b/web/src/lib/userSS.ts
@@ -25,7 +25,7 @@ export const getAuthTypeMetadataSS = async (): Promise<AuthTypeMetadata> => {
 
   let authType: AuthType;
 
-  // Override fasapi users auth so we can use both
+  // Override fastapi users auth so we can use both
   if (NEXT_PUBLIC_CLOUD_ENABLED) {
     authType = "cloud";
   } else {


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1850/cannot-upload-images-or-screenshots-into-chat-and-get-answers

Fixes image chips and inline image in first message and LLM analysis.
Still outstanding: images after the first message don't appear inline unless chat is fully reloaded.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
