### PR TITLE
Add retry logic to BookStackApiClient with backoff.

### DIFF
--- a/backend/onyx/connectors/bookstack/client.py
+++ b/backend/onyx/connectors/bookstack/client.py
@@ -2,6 +2,11 @@ from typing import Any
 
 import requests
 
+import random
+import time
+
+RETRYABLE_STATUSES = {502, 503, 504}
+
 
 class BookStackClientRequestFailedError(ConnectionError):
     def __init__(self, status: int, error: str) -> None:
@@ -20,29 +25,54 @@ class BookStackApiClient:
         base_url: str,
         token_id: str,
         token_secret: str,
+        max_retries: int = 5,
+        backoff_factor: float = 2.0,
     ) -> None:
         self.base_url = base_url
         self.token_id = token_id
         self.token_secret = token_secret
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
 
     def get(self, endpoint: str, params: dict[str, str]) -> dict[str, Any]:
         url: str = self._build_url(endpoint)
         headers = self._build_headers()
-        response = requests.get(url, headers=headers, params=params)
+        retries = 0
+        while retries  <= self.max_retries:
+            try: 
+                response = requests.get(url, headers=headers, params=params)
 
-        try:
-            json = response.json()
-        except Exception:
-            json = {}
+                try:
+                    json = response.json()
+                except Exception:
+                    json = {}
 
-        if response.status_code >= 300:
-            error = response.reason
-            response_error = json.get("error", {}).get("message", "")
-            if response_error:
-                error = response_error
-            raise BookStackClientRequestFailedError(response.status_code, error)
+                if response.status_code >= 300:
+                    error = response.reason
+                    response_error = json.get("error", {}).get("message", "")
+                    if response_error:
+                        error = response_error
+                    
+                    raise BookStackClientRequestFailedError(response.status_code, error)
 
-        return json
+                return json
+            except BookStackClientRequestFailedError as e:
+                if e.status_code not in RETRYABLE_STATUSES:
+                    raise e
+                retries += 1
+                if retries > self.max_retries:
+                    raise
+                sleep_time = self.backoff_factor * (2 ** (retries - 1)) + random.uniform(0, 1)
+                time.sleep(sleep_time)
+            except requests.RequestException as e:
+                retries += 1
+                print(retries)
+                if retries > self.max_retries:
+                    raise BookStackClientRequestFailedError(503, str(e))
+                sleep_time = self.backoff_factor * (2 ** (retries - 1)) + random.uniform(0, 1)
+                time.sleep(sleep_time)
+
+        raise BookStackClientRequestFailedError(500, "Maximum retries exceeded with no successful response")
 
     def _build_headers(self) -> dict[str, str]:
         auth = "Token " + self.token_id + ":" + self.token_secret


### PR DESCRIPTION
## Description

Basic code to handle retries for certain response status codes (502,503,504), in the Bookstack client.py, in response to the #4381 issue. 

## How Has This Been Tested?

This functionality has been tested using unit tests with mocked HTTP responses to simulate various scenarios, including successful responses, client errors (e.g., 401), server errors (e.g., 500), and retryable errors (502 ,503, 504). The requests.get method was patched using unittest.mock.patch to control the responses and validate that the BookStackApiClient correctly handles retries, raises appropriate errors, and returns the expected results. Each test case checks specific behaviors, such as retry logic, error handling, and success recovery.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
