### PR TITLE
Fix LLM API key

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -70,7 +70,7 @@ def test_llm_configuration(
             name=test_llm_request.name, db_session=db_session
         )
         # if an API key is not provided, use the existing provider's API key
-        if existing_provider and test_api_key is None:
+        if existing_provider and not test_llm_request.api_key_changed:
             test_api_key = existing_provider.api_key
 
     # For this "testing" workflow, we do *not* need the actual `max_input_tokens`.

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -28,7 +28,10 @@ class TestLLMRequest(BaseModel):
     fast_default_model_name: str | None = None
     deployment_name: str | None = None
 
-    model_configurations: list["ModelConfigurationUpsertRequest"] = []
+    model_configurations: list["ModelConfigurationUpsertRequest"]
+
+    # if try and use the existing API key
+    api_key_changed: bool
 
 
 class LLMProviderDescriptor(BaseModel):

--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/admin/connectors/Field";
 import { useState } from "react";
 import { useSWRConfig } from "swr";
-import { LLMProviderView, ModelConfiguration } from "./interfaces";
+import { LLMProviderView } from "./interfaces";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
 import * as Yup from "yup";
 import isEqual from "lodash/isEqual";

--- a/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/CustomLLMProviderUpdateForm.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/admin/connectors/Field";
 import { useState } from "react";
 import { useSWRConfig } from "swr";
-import { LLMProviderView } from "./interfaces";
+import { LLMProviderView, ModelConfiguration } from "./interfaces";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
 import * as Yup from "yup";
 import isEqual from "lodash/isEqual";
@@ -69,17 +69,16 @@ export function CustomLLMProviderUpdateForm({
     model_configurations: existingLlmProvider?.model_configurations.map(
       (modelConfiguration) => ({
         ...modelConfiguration,
-        max_input_tokens:
-          modelConfiguration.max_input_tokens ??
-          ("" as string | number | null | undefined),
+        max_input_tokens: modelConfiguration.max_input_tokens ?? null,
       })
-    ) ?? [{ name: "", is_visible: true, max_input_tokens: "" }],
+    ) ?? [{ name: "", is_visible: true, max_input_tokens: null }],
     custom_config_list: existingLlmProvider?.custom_config
       ? Object.entries(existingLlmProvider.custom_config)
       : [],
     is_public: existingLlmProvider?.is_public ?? true,
     groups: existingLlmProvider?.groups ?? [],
     deployment_name: existingLlmProvider?.deployment_name ?? null,
+    api_key_changed: false,
   };
 
   // Setup validation schema if required
@@ -114,15 +113,20 @@ export function CustomLLMProviderUpdateForm({
       onSubmit={async (values, { setSubmitting }) => {
         setSubmitting(true);
 
-        values.model_configurations.forEach((modelConfiguration) => {
-          if (
-            modelConfiguration.max_input_tokens === "" ||
-            modelConfiguration.max_input_tokens === null ||
-            modelConfiguration.max_input_tokens === undefined
-          ) {
-            modelConfiguration.max_input_tokens = null;
-          }
-        });
+        // build final payload
+        const finalValues = { ...values };
+        finalValues.model_configurations = finalValues.model_configurations.map(
+          (modelConfiguration) => ({
+            ...modelConfiguration,
+            max_input_tokens:
+              modelConfiguration.max_input_tokens === null ||
+              modelConfiguration.max_input_tokens === undefined
+                ? null
+                : modelConfiguration.max_input_tokens,
+            supports_image_input: false, // doesn't matter, not used
+          })
+        );
+        finalValues.api_key_changed = values.api_key !== initialValues.api_key;
 
         if (values.model_configurations.length === 0) {
           const fullErrorMsg = "At least one model name is required";

--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -75,7 +75,7 @@ export function LLMProviderUpdateForm({
       ),
     is_public: existingLlmProvider?.is_public ?? true,
     groups: existingLlmProvider?.groups ?? [],
-    model_configurations: [] as ModelConfiguration[],
+    model_configurations: existingLlmProvider?.model_configurations ?? [],
     deployment_name: existingLlmProvider?.deployment_name,
     api_key_changed: false,
 
@@ -136,7 +136,6 @@ export function LLMProviderUpdateForm({
         max_input_tokens: Yup.number().nullable().optional(),
       })
     ),
-    api_key_changed: Yup.boolean(),
   });
 
   return (
@@ -146,10 +145,10 @@ export function LLMProviderUpdateForm({
       onSubmit={async (values, { setSubmitting }) => {
         setSubmitting(true);
 
-        values.api_key_changed = values.api_key !== initialValues.api_key;
-
+        // build final payload
         const visibleModels = new Set(values.selected_model_names);
-        values.model_configurations = llmProviderDescriptor.llm_names.map(
+        const finalValues = { ...values };
+        finalValues.model_configurations = llmProviderDescriptor.llm_names.map(
           (name) =>
             ({
               name,
@@ -157,8 +156,8 @@ export function LLMProviderUpdateForm({
               max_input_tokens: null,
             }) as ModelConfiguration
         );
-
-        delete values.selected_model_names;
+        delete finalValues.selected_model_names;
+        finalValues.api_key_changed = values.api_key !== initialValues.api_key;
 
         // test the configuration
         if (!isEqual(values, initialValues)) {
@@ -171,7 +170,7 @@ export function LLMProviderUpdateForm({
             },
             body: JSON.stringify({
               provider: llmProviderDescriptor.name,
-              ...values,
+              ...finalValues,
             }),
           });
           setIsTesting(false);
@@ -194,9 +193,10 @@ export function LLMProviderUpdateForm({
             },
             body: JSON.stringify({
               provider: llmProviderDescriptor.name,
-              ...values,
+              ...finalValues,
               fast_default_model_name:
-                values.fast_default_model_name || values.default_model_name,
+                finalValues.fast_default_model_name ||
+                finalValues.default_model_name,
             }),
           }
         );

--- a/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
+++ b/web/src/app/admin/configuration/llm/LLMProviderUpdateForm.tsx
@@ -160,7 +160,7 @@ export function LLMProviderUpdateForm({
         finalValues.api_key_changed = values.api_key !== initialValues.api_key;
 
         // test the configuration
-        if (!isEqual(values, initialValues)) {
+        if (!isEqual(finalValues, initialValues)) {
           setIsTesting(true);
 
           const response = await fetch("/api/admin/llm/test", {


### PR DESCRIPTION
## Description

Fixes a few things:

1. Model configurations were getting wiped on every update (set to empty list).
2. You could not edit an LLM provider easily. If you tried to re-submit, it would try and use the "masked key" and fail.
3. We ran the "test" call on every update, even if nothing had changed.

Fixes https://linear.app/danswer/issue/DAN-1912/fix-misc-model-configuration-stuff

## How Has This Been Tested?

Tested locally. In the future, might want to add e2e tests for these.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
