### PR TITLE
Add support for restrictions w/o any access

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/doc_sync.py
@@ -169,7 +169,7 @@ def _get_space_permissions(
 
 def _extract_read_access_restrictions(
     confluence_client: OnyxConfluence, restrictions: dict[str, Any]
-) -> tuple[set[str], set[str]]:
+) -> tuple[set[str], set[str], bool]:
     """
     Converts a page's restrictions dict into an ExternalAccess object.
     If there are no restrictions, then return None
@@ -180,6 +180,9 @@ def _extract_read_access_restrictions(
     # Extract the users with read access
     read_access_user = read_access_restrictions.get("user", {})
     read_access_user_jsons = read_access_user.get("results", [])
+    # any items found means that there is a restriction
+    found_any_restriction = bool(read_access_user_jsons)
+
     read_access_user_emails = []
     for user in read_access_user_jsons:
         # If the user has an email, then add it to the list
@@ -208,11 +211,17 @@ def _extract_read_access_restrictions(
     # Extract the groups with read access
     read_access_group = read_access_restrictions.get("group", {})
     read_access_group_jsons = read_access_group.get("results", [])
+    # any items found means that there is a restriction
+    found_any_restriction |= bool(read_access_group_jsons)
     read_access_group_names = [
         group["name"] for group in read_access_group_jsons if group.get("name")
     ]
 
-    return set(read_access_user_emails), set(read_access_group_names)
+    return (
+        set(read_access_user_emails),
+        set(read_access_group_names),
+        found_any_restriction,
+    )
 
 
 def _get_all_page_restrictions(
@@ -229,14 +238,19 @@ def _get_all_page_restrictions(
     found_user_emails: set[str] = set()
     found_group_names: set[str] = set()
 
-    found_user_emails, found_group_names = _extract_read_access_restrictions(
-        confluence_client=confluence_client,
-        restrictions=perm_sync_data.get("restrictions", {}),
+    # NOTE: need the found_any_restriction, since we can find restrictions
+    # but not be able to extract any user emails or group names
+    # in this case, we should just give no access
+    found_user_emails, found_group_names, found_any_page_level_restriction = (
+        _extract_read_access_restrictions(
+            confluence_client=confluence_client,
+            restrictions=perm_sync_data.get("restrictions", {}),
+        )
     )
     # if there are individual page-level restrictions, then this is the accurate
     # restriction for the page. You cannot both have page-level restrictions AND
     # inherit restrictions from the parent.
-    if bool(found_user_emails or found_group_names):
+    if found_any_page_level_restriction:
         return ExternalAccess(
             external_user_emails=found_user_emails,
             external_user_group_ids=found_group_names,

--- a/backend/ee/onyx/external_permissions/confluence/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/doc_sync.py
@@ -263,19 +263,18 @@ def _get_all_page_restrictions(
     # we want the restrictions from the immediate parent to take precedence, so we should
     # reverse the list
     for ancestor in reversed(ancestors):
-        ancestor_user_emails, ancestor_group_names = _extract_read_access_restrictions(
+        (
+            ancestor_user_emails,
+            ancestor_group_names,
+            found_any_restrictions_in_ancestor,
+        ) = _extract_read_access_restrictions(
             confluence_client=confluence_client,
             restrictions=ancestor.get("restrictions", {}),
         )
-        if not ancestor_user_emails and not ancestor_group_names:
-            # This ancestor has no restrictions, so it has no effect on
-            # the page's restrictions, so we ignore it
-            continue
-
-        # if inheriting restrictions from the parent, then the first one we run into
-        # should be applied (the reason why we'd traverse more than one ancestor is if
-        # the ancestor also is in "inherit" mode.)
-        if ancestor_user_emails or ancestor_group_names:
+        if found_any_restrictions_in_ancestor:
+            # if inheriting restrictions from the parent, then the first one we run into
+            # should be applied (the reason why we'd traverse more than one ancestor is if
+            # the ancestor also is in "inherit" mode.)
             return ExternalAccess(
                 external_user_emails=ancestor_user_emails,
                 external_user_group_ids=ancestor_group_names,


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1863/confluence-permission-sync-weirdness

## How Has This Been Tested?

Haven't been able to re-create this situation, so it's mostly just 👀 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
