### PR TITLE
Encode S3 object keys to avoid broken citation links

### DIFF
--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -4,6 +4,7 @@ from datetime import timezone
 from io import BytesIO
 from typing import Any
 from typing import Optional
+from urllib.parse import quote
 
 import boto3  # type: ignore
 from botocore.client import Config  # type: ignore
@@ -164,8 +165,6 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             raise ConnectorMissingCredentialError("Blob storage")
 
         # Encode the key while preserving forward slashes
-        from urllib.parse import quote
-
         encoded_key = quote(key, safe="/")
 
         if self.bucket_type == BlobType.R2:

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -163,21 +163,26 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         if self.s3_client is None:
             raise ConnectorMissingCredentialError("Blob storage")
 
+        # Encode the key while preserving forward slashes
+        from urllib.parse import quote
+
+        encoded_key = quote(key, safe="/")
+
         if self.bucket_type == BlobType.R2:
             account_id = self.s3_client.meta.endpoint_url.split("//")[1].split(".")[0]
-            return f"https://{account_id}.r2.cloudflarestorage.com/{self.bucket_name}/{key}"
+            return f"https://{account_id}.r2.cloudflarestorage.com/{self.bucket_name}/{encoded_key}"
 
         elif self.bucket_type == BlobType.S3:
             region = self.s3_client.meta.region_name
-            return f"https://{self.bucket_name}.s3.{region}.amazonaws.com/{key}"
+            return f"https://{self.bucket_name}.s3.{region}.amazonaws.com/{encoded_key}"
 
         elif self.bucket_type == BlobType.GOOGLE_CLOUD_STORAGE:
-            return f"https://storage.cloud.google.com/{self.bucket_name}/{key}"
+            return f"https://storage.cloud.google.com/{self.bucket_name}/{encoded_key}"
 
         elif self.bucket_type == BlobType.OCI_STORAGE:
             namespace = self.s3_client.meta.endpoint_url.split("//")[1].split(".")[0]
             region = self.s3_client.meta.region_name
-            return f"https://objectstorage.{region}.oraclecloud.com/n/{namespace}/b/{self.bucket_name}/o/{key}"
+            return f"https://objectstorage.{region}.oraclecloud.com/n/{namespace}/b/{self.bucket_name}/o/{encoded_key}"
 
         else:
             raise ValueError(f"Unsupported bucket type: {self.bucket_type}")


### PR DESCRIPTION
## Description

This is a draft PR for addressing #4631, the current solution can work but requires to re-index files from BlobStorageConnector since the new URLs may different from previous verison.

## How Has This Been Tested?

I have checked on both S3 and R2. Will test on GOOGLE_CLOUD_STORAGE and OCI_STORAGE later.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
