### PR TITLE
Fix race condition with archived channels

### DIFF
--- a/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
+++ b/backend/alembic/versions/7a70b7664e37_add_model_configuration_table.py
@@ -27,7 +27,7 @@ def _resolve(
     model_names: list[str] | None,
     display_model_names: list[str] | None,
     default_model_name: str,
-    fast_default_model_name: str,
+    fast_default_model_name: str | None,
 ) -> set[tuple[str, bool]]:
     models = set(model_names) if model_names else None
     display_models = set(display_model_names) if display_model_names else None
@@ -94,9 +94,11 @@ def _resolve(
     # It is possible that `default_model_name` is not in `models` and is not in `display_models`.
     # It is also possible that `fast_default_model_name` is not in `models` and is not in `display_models`.
     models.add(default_model_name)
-    models.add(fast_default_model_name)
+    if fast_default_model_name:
+        models.add(fast_default_model_name)
     display_models.add(default_model_name)
-    display_models.add(fast_default_model_name)
+    if fast_default_model_name:
+        display_models.add(fast_default_model_name)
 
     return set([(model, model in display_models) for model in models])
 

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -16,7 +16,8 @@ from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
-basic_retry_wrapper = retry_builder()
+# retry after 0.1, 1.2, 3.4, 7.8, 16.6, 34.2 seconds
+basic_retry_wrapper = retry_builder(tries=7)
 # number of messages we request per page when fetching paginated slack messages
 _SLACK_LIMIT = 900
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1913/archived-channel-failures

## How Has This Been Tested?

Created channel, set breakpoint at `client.conversations_join` in `_get_messages`, then archived it. Verified the index attempt was a success.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
