### PR TITLE
github cursor pagination

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -1,5 +1,6 @@
 import copy
 import time
+from collections.abc import Callable
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
@@ -33,12 +34,14 @@ from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 ITEMS_PER_PAGE = 100
+CURSOR_LOG_FREQUENCY = 100
 
 _MAX_NUM_RATE_LIMIT_RETRIES = 5
 
@@ -52,26 +55,139 @@ def _sleep_after_rate_limit_exception(github_client: Github) -> None:
     time.sleep(sleep_time.seconds)
 
 
+# Cases
+# X (from start) standard run, no fallback to cursor-based pagination
+# X (from start) standard run errors, fallback to cursor-based pagination
+#  X error in the middle of a page
+#  X no errors: run to completion
+# X (from checkpoint) standard run, no fallback to cursor-based pagination
+# X (from checkpoint) continue from cursor-based pagination
+#  - retrying
+#  - no retrying
+
+# things to check:
+# checkpoint state on return
+# checkpoint progress (no infinite loop)
+
+
+def _paginate_until_error(
+    git_objs: Callable[[], PaginatedList[PullRequest | Issue]],
+    cursor_url: str | None,
+    prev_num_objs: int,
+    cursor_url_callback: Callable[[str | None, int], None],
+    retrying: bool = False,
+) -> Generator[PullRequest | Issue | ConnectorFailure, None, None]:
+    num_objs = prev_num_objs
+    pag_list = git_objs()
+    if cursor_url:
+        pag_list.__nextUrl = cursor_url
+    elif retrying:
+        # if we are retrying, we want to skip the objects retrieved
+        # over previous calls. Unfortunately, this WILL retrieve all
+        # pages before the one we are resuming from, so we really
+        # don't want this case to be hit often
+        logger.warning(
+            "Retrying from a previous cursor-based pagination call. "
+            "This will retrieve all pages before the one we are resuming from, "
+            "which may take a while and consume many API calls."
+        )
+        pag_list = pag_list[prev_num_objs:]
+        num_objs = 0
+
+    try:
+        # this for loop handles cursor-based pagination
+        for issue_or_pr in pag_list:
+            num_objs += 1
+            yield issue_or_pr
+            # used to store the current cursor url in the checkpoint. This value
+            # is updated during iteration over pag_list.
+            cursor_url_callback(pag_list.__nextUrl, num_objs)
+
+            if num_objs % CURSOR_LOG_FREQUENCY == 0:
+                logger.info(
+                    f"Retrieved {num_objs} objects with current cursor url: {pag_list.__nextUrl}"
+                )
+
+    except Exception as e:
+        logger.exception(f"Error during cursor-based pagination: {e}")
+        if num_objs > 0:
+            yield ConnectorFailure(
+                failed_entity=EntityFailure(
+                    entity_id="cursor_based_pagination",
+                ),
+                failure_message=str(e),
+            )
+            return
+
+        if pag_list.__nextUrl is not None and not retrying:
+            logger.info(
+                "Assuming that this error is due to cursor "
+                "expiration because no objects were retrieved. "
+                "Retrying from the first page."
+            )
+            yield from _paginate_until_error(
+                git_objs, None, prev_num_objs, cursor_url_callback, retrying=True
+            )
+            return
+
+        # for no cursor url or if we reach this point after a retry, raise the error
+        raise
+
+
+# git_objs should produce a fresh PaginatedList each time it's called.
+# We don't want to use the same object for cursor-based pagination
+# after a partial offset-based pagination call. We expect the cursor-based approach
+# to repeat at most one page of work from the offset-based approach.
 def _get_batch_rate_limited(
-    git_objs: PaginatedList, page_num: int, github_client: Github, attempt_num: int = 0
-) -> list[PullRequest | Issue]:
+    git_objs: Callable[[], PaginatedList],
+    page_num: int,
+    cursor_url: str | None,
+    prev_num_objs: int,
+    cursor_url_callback: Callable[[str | None, int], None],
+    github_client: Github,
+    attempt_num: int = 0,
+) -> Generator[PullRequest | Issue | ConnectorFailure, None, None]:
     if attempt_num > _MAX_NUM_RATE_LIMIT_RETRIES:
         raise RuntimeError(
             "Re-tried fetching batch too many times. Something is going wrong with fetching objects from Github"
         )
-
     try:
-        objs = list(git_objs.get_page(page_num))
+        if cursor_url:
+            # when this is set, we are resuming from an earlier
+            # cursor-based pagination call.
+            yield from _paginate_until_error(
+                git_objs, cursor_url, prev_num_objs, cursor_url_callback
+            )
+            return
+        objs = list(git_objs().get_page(page_num))
         # fetch all data here to disable lazy loading later
         # this is needed to capture the rate limit exception here (if one occurs)
         for obj in objs:
             if hasattr(obj, "raw_data"):
                 getattr(obj, "raw_data")
-        return objs
+        yield from objs
     except RateLimitExceededException:
         _sleep_after_rate_limit_exception(github_client)
-        return _get_batch_rate_limited(
-            git_objs, page_num, github_client, attempt_num + 1
+        yield from _get_batch_rate_limited(
+            git_objs,
+            page_num,
+            cursor_url,
+            prev_num_objs,
+            cursor_url_callback,
+            github_client,
+            attempt_num + 1,
+        )
+    except GithubException as e:
+        if not (e.status == 422 and "cursor" in (e.message or "")):
+            raise
+        # Fallback to a cursor-based pagination strategy
+        # This can happen for "large datasets," but there's no documentation
+        # On the error on the web as far as we can tell.
+        # Error message:
+        # "Pagination with the page parameter is not supported for large datasets,
+        # please use cursor based pagination (after/before)"
+        yield from _paginate_until_error(
+            git_objs, cursor_url, prev_num_objs, cursor_url_callback
         )
 
 
@@ -141,6 +257,18 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
 
     cached_repo_ids: list[int] | None = None
     cached_repo: SerializedRepository | None = None
+
+    # Used for the fallback cursor-based pagination strategy
+    num_retrieved: int
+    cursor_url: str | None = None
+
+    def reset(self) -> None:
+        """
+        Resets curr_page, num_retrieved, and cursor_url to their initial values (0, 0, None)
+        """
+        self.curr_page = 0
+        self.num_retrieved = 0
+        self.cursor_url = None
 
 
 class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
@@ -229,7 +357,10 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
             # Try to get organization first
             try:
                 org = github_client.get_organization(self.repo_owner)
-                return list(org.get_repos())
+                # return list(org.get_repos())
+                return [x for x in list(org.get_repos()) if x.name == "ffe"]
+            # TODO: remove
+
             except GithubException:
                 # If not an org, try as a user
                 user = github_client.get_user(self.repo_owner)
@@ -266,11 +397,12 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
                 checkpoint.has_more = False
                 return checkpoint
 
-            checkpoint.cached_repo_ids = sorted([repo.id for repo in repos])
+            curr_repo = repos.pop()
+            checkpoint.cached_repo_ids = [repo.id for repo in repos]
             checkpoint.cached_repo = SerializedRepository(
-                id=checkpoint.cached_repo_ids[0],
-                headers=repos[0].raw_headers,
-                raw_data=repos[0].raw_data,
+                id=curr_repo.id,
+                headers=curr_repo.raw_headers,
+                raw_data=curr_repo.raw_data,
             )
             checkpoint.stage = GithubConnectorStage.PRS
             checkpoint.curr_page = 0
@@ -299,26 +431,44 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
             repo_id = checkpoint.cached_repo.id
             repo = self.github_client.get_repo(repo_id)
 
+        def cursor_url_callback(cursor_url: str | None, num_objs: int) -> None:
+            checkpoint.cursor_url = cursor_url
+            checkpoint.num_retrieved = num_objs
+
+        # TODO: all PRs are also issues, so we should be able to _only_ get issues
+        # and then filter appropriately whenever include_issues is True
         if self.include_prs and checkpoint.stage == GithubConnectorStage.PRS:
             logger.info(f"Fetching PRs for repo: {repo.name}")
-            pull_requests = repo.get_pulls(
-                state=self.state_filter, sort="updated", direction="desc"
-            )
 
-            doc_batch: list[Document] = []
+            def pull_requests_func():
+                return repo.get_pulls(
+                    state=self.state_filter, sort="updated", direction="desc"
+                )
+
             pr_batch = _get_batch_rate_limited(
-                pull_requests, checkpoint.curr_page, self.github_client
+                pull_requests_func,
+                checkpoint.curr_page,
+                checkpoint.cursor_url,
+                checkpoint.num_retrieved,
+                cursor_url_callback,
+                self.github_client,
             )
-            checkpoint.curr_page += 1
+            checkpoint.curr_page += 1  # NOTE: not used for cursor-based fallback
             done_with_prs = False
+            num_prs = 0
+            pr = None
             for pr in pr_batch:
+                num_prs += 1
+                if isinstance(pr, ConnectorFailure):
+                    yield pr
+                    continue
+
                 # we iterate backwards in time, so at this point we stop processing prs
                 if (
                     start is not None
                     and pr.updated_at
                     and pr.updated_at.replace(tzinfo=timezone.utc) < start
                 ):
-                    yield from doc_batch
                     done_with_prs = True
                     break
                 # Skip PRs updated after the end date
@@ -329,7 +479,7 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
                 ):
                     continue
                 try:
-                    doc_batch.append(_convert_pr_to_document(cast(PullRequest, pr)))
+                    yield _convert_pr_to_document(cast(PullRequest, pr))
                 except Exception as e:
                     error_msg = f"Error converting PR to document: {e}"
                     logger.exception(error_msg)
@@ -342,37 +492,63 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
                     )
                     continue
 
-            # if we found any PRs on the page, yield any associated documents and return the checkpoint
-            if not done_with_prs and len(pr_batch) > 0:
-                yield from doc_batch
+            # If we reach this point with a cursor url in the checkpoint, we were using
+            # the fallback cursor-based pagination strategy. That strategy continues until
+            # a connectorfailure occurs, so if the last pr was NOT a connectorfailure, we
+            # are done with prs.
+            cursor_mode_done_with_prs = checkpoint.cursor_url and not isinstance(
+                pr, ConnectorFailure
+            )
+
+            # if we found any PRs on the page and there are more PRs to get, return the checkpoint.
+            # In offset mode, while indexing without time constraints, the pr batch
+            # will be empty when we're done.
+            if num_prs > 0 and not done_with_prs and not cursor_mode_done_with_prs:
                 return checkpoint
 
             # if we went past the start date during the loop or there are no more
             # prs to get, we move on to issues
             checkpoint.stage = GithubConnectorStage.ISSUES
-            checkpoint.curr_page = 0
+            checkpoint.reset()
+
+            if cursor_mode_done_with_prs:
+                # save the checkpoint after changing stage; next run will continue from issues
+                return checkpoint
 
         checkpoint.stage = GithubConnectorStage.ISSUES
 
         if self.include_issues and checkpoint.stage == GithubConnectorStage.ISSUES:
             logger.info(f"Fetching issues for repo: {repo.name}")
-            issues = repo.get_issues(
-                state=self.state_filter, sort="updated", direction="desc"
-            )
 
-            doc_batch = []
-            issue_batch = _get_batch_rate_limited(
-                issues, checkpoint.curr_page, self.github_client
+            def issues_func():
+                return repo.get_issues(
+                    state=self.state_filter, sort="updated", direction="desc"
+                )
+
+            issue_batch = list(
+                _get_batch_rate_limited(
+                    issues_func,
+                    checkpoint.curr_page,
+                    checkpoint.cursor_url,
+                    checkpoint.num_retrieved,
+                    cursor_url_callback,
+                    self.github_client,
+                )
             )
             checkpoint.curr_page += 1
             done_with_issues = False
-            for issue in cast(list[Issue], issue_batch):
+            num_issues = 0
+            for issue in issue_batch:
+                num_issues += 1
+                if isinstance(issue, ConnectorFailure):
+                    yield issue
+                    continue
+                issue = cast(Issue, issue)
                 # we iterate backwards in time, so at this point we stop processing prs
                 if (
                     start is not None
                     and issue.updated_at.replace(tzinfo=timezone.utc) < start
                 ):
-                    yield from doc_batch
                     done_with_issues = True
                     break
                 # Skip PRs updated after the end date
@@ -384,10 +560,11 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
 
                 if issue.pull_request is not None:
                     # PRs are handled separately
+                    # TODO: but they shouldn't always be
                     continue
 
                 try:
-                    doc_batch.append(_convert_issue_to_document(issue))
+                    yield _convert_issue_to_document(issue)
                 except Exception as e:
                     error_msg = f"Error converting issue to document: {e}"
                     logger.exception(error_msg)
@@ -401,17 +578,23 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
                     )
                     continue
 
-            # if we found any issues on the page, yield them and return the checkpoint
-            if not done_with_issues and len(issue_batch) > 0:
-                yield from doc_batch
+            cursor_mode_done_with_issues = checkpoint.cursor_url and not isinstance(
+                issue, ConnectorFailure
+            )
+            # if we found any issues on the page, and we're not done, return the checkpoint
+            if (
+                num_issues > 0
+                and not done_with_issues
+                and not cursor_mode_done_with_issues
+            ):
                 return checkpoint
 
             # if we went past the start date during the loop or there are no more
             # issues to get, we move on to the next repo
             checkpoint.stage = GithubConnectorStage.PRS
-            checkpoint.curr_page = 0
+            checkpoint.reset()
 
-        checkpoint.has_more = len(checkpoint.cached_repo_ids) > 1
+        checkpoint.has_more = len(checkpoint.cached_repo_ids) > 0
         if checkpoint.cached_repo_ids:
             next_id = checkpoint.cached_repo_ids.pop()
             next_repo = self.github_client.get_repo(next_id)
@@ -553,7 +736,7 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
 
     def build_dummy_checkpoint(self) -> GithubConnectorCheckpoint:
         return GithubConnectorCheckpoint(
-            stage=GithubConnectorStage.PRS, curr_page=0, has_more=True
+            stage=GithubConnectorStage.PRS, curr_page=0, has_more=True, num_retrieved=0
         )
 
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1915/github-pagination-errors
(hopefully)

We've been seeing weird cases of 
```
github.GithubException.GithubException: 422 {"message": "Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before)" ...
```

This is intended to fix the issue using pagination as described here: https://github.com/orgs/community/discussions/69826#cursor-based-pagination

The intended approach is:
Each indexing attempt will first (if we don't have stored cursor) try to use page-based, then if it fails (or a prev cursor stored) will try to use that cursor until an error occurs. If the cursor is expired we hit the nasty case of "just need to run through everything", but otherwise we return the next checkpoint after the first failure or index completion.

## How Has This Been Tested?

Unfortunately I couldn't reproduce the issue in local testing, so the best we have for now is automated tests TBD. Tested in the UI that the standard case (offset-based pagination) still works.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
