### PR TITLE
fix: Remove `cursor-help` for tooltip

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexingAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexingAttemptsTable.tsx
@@ -82,7 +82,7 @@ export function IndexingAttemptsTable({
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="cursor-help flex items-center">
+                      <span className="flex items-center">
                         Total Docs
                         <InfoIcon className="ml-1 w-4 h-4" />
                       </span>


### PR DESCRIPTION
## Description

This PR removes `cursor-help` as an attribute for the tooltip hoverable.

Addresses: https://linear.app/danswer/issue/DAN-1888/only-on-this-info-hover-we-change-the-cursor-to-a-question-mark-lets.

## How Has This Been Tested?

This is a pure UI change; manually tested to make sure cursor doesn't turn into a question mark.

## Screenshots

Before:

![cursor-help](https://github.com/user-attachments/assets/66c94730-89c2-43a4-b3ec-a518dd44739c)

After:

![updated](https://github.com/user-attachments/assets/68f0780a-8ef0-4b12-b270-8b3ec62f9e16)
