### PR TITLE
drive file deduping

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -67,7 +67,6 @@ from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.threadpool_concurrency import parallel_yield
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.threadpool_concurrency import ThreadSafeDict
-from onyx.utils.threadpool_concurrency import ThreadSafeSet
 
 logger = setup_logger()
 # TODO: Improve this by using the batch utility: https://googleapis.github.io/google-api-python-client/docs/batch.html
@@ -1180,7 +1179,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             retrieved_folder_and_drive_ids=set(),
             completion_stage=DriveRetrievalStage.START,
             completion_map=ThreadSafeDict(),
-            all_retrieved_file_ids=ThreadSafeSet(),
+            all_retrieved_file_ids=set(),
             has_more=True,
         )
 

--- a/backend/onyx/connectors/google_drive/models.py
+++ b/backend/onyx/connectors/google_drive/models.py
@@ -9,7 +9,6 @@ from pydantic import field_validator
 from onyx.connectors.interfaces import ConnectorCheckpoint
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.utils.threadpool_concurrency import ThreadSafeDict
-from onyx.utils.threadpool_concurrency import ThreadSafeSet
 
 
 class GDriveMimeType(str, Enum):
@@ -140,7 +139,7 @@ class GoogleDriveCheckpoint(ConnectorCheckpoint):
     # processed_folder_file_ids: ThreadSafeDict[str, set[str]] = ThreadSafeDict()
 
     # maps file id to at most 5 users that can see the file
-    all_retrieved_file_ids: ThreadSafeSet[str]
+    all_retrieved_file_ids: set[str]
 
     # cached version of the drive and folder ids to retrieve
     drive_ids_to_retrieve: list[str] | None = None
@@ -161,17 +160,3 @@ class GoogleDriveCheckpoint(ConnectorCheckpoint):
         return ThreadSafeDict(
             {k: StageCompletion.model_validate(val) for k, val in v.items()}
         )
-
-    @field_serializer("all_retrieved_file_ids")
-    def serialize_all_retrieved_file_ids(
-        self, all_retrieved_file_ids: ThreadSafeSet[str], _info: Any
-    ) -> set[str]:
-        return all_retrieved_file_ids._set
-
-    @field_validator("all_retrieved_file_ids", mode="before")
-    def validate_all_retrieved_file_ids(cls, v: Any) -> ThreadSafeSet[str]:
-        if isinstance(v, set):
-            return ThreadSafeSet(v)
-        if isinstance(v, ThreadSafeSet):
-            return v
-        raise ValueError("all_retrieved_file_ids must be a set")

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Callable
 from collections.abc import Iterator
 from collections.abc import MutableMapping
+from collections.abc import MutableSet
 from collections.abc import Sequence
 from concurrent.futures import as_completed
 from concurrent.futures import FIRST_COMPLETED
@@ -168,6 +169,40 @@ class ThreadSafeDict(MutableMapping[KT, VT]):
             new_val = value_callback(val)
             self._dict[key] = new_val
             return val, new_val
+
+
+class ThreadSafeSet(MutableSet[VT]):
+    def __init__(self, input_set: set[VT] | None = None) -> None:
+        self._set: set[VT] = input_set or set()
+        self.lock = threading.Lock()
+
+    def add(self, value: VT) -> None:
+        with self.lock:
+            self._set.add(value)
+
+    def discard(self, value: VT) -> None:
+        with self.lock:
+            self._set.discard(value)
+
+    def __contains__(self, value: object) -> bool:
+        with self.lock:
+            return value in self._set
+
+    def __iter__(self) -> Iterator[VT]:
+        with self.lock:
+            return iter(self._set)
+
+    def __len__(self) -> int:
+        with self.lock:
+            return len(self._set)
+
+    def clear(self) -> None:
+        with self.lock:
+            self._set.clear()
+
+    def copy(self) -> set[VT]:
+        with self.lock:
+            return self._set.copy()
 
 
 class CallableProtocol(Protocol):

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -6,7 +6,6 @@ import uuid
 from collections.abc import Callable
 from collections.abc import Iterator
 from collections.abc import MutableMapping
-from collections.abc import MutableSet
 from collections.abc import Sequence
 from concurrent.futures import as_completed
 from concurrent.futures import FIRST_COMPLETED
@@ -169,40 +168,6 @@ class ThreadSafeDict(MutableMapping[KT, VT]):
             new_val = value_callback(val)
             self._dict[key] = new_val
             return val, new_val
-
-
-class ThreadSafeSet(MutableSet[VT]):
-    def __init__(self, input_set: set[VT] | None = None) -> None:
-        self._set: set[VT] = input_set or set()
-        self.lock = threading.Lock()
-
-    def add(self, value: VT) -> None:
-        with self.lock:
-            self._set.add(value)
-
-    def discard(self, value: VT) -> None:
-        with self.lock:
-            self._set.discard(value)
-
-    def __contains__(self, value: object) -> bool:
-        with self.lock:
-            return value in self._set
-
-    def __iter__(self) -> Iterator[VT]:
-        with self.lock:
-            return iter(self._set)
-
-    def __len__(self) -> int:
-        with self.lock:
-            return len(self._set)
-
-    def clear(self) -> None:
-        with self.lock:
-            self._set.clear()
-
-    def copy(self) -> set[VT]:
-        with self.lock:
-            return self._set.copy()
 
 
 class CallableProtocol(Protocol):


### PR DESCRIPTION
## Description

Fix possible duplicate retrievals across the drive connector. We now store a set of all retrieved file ids, so in theory it is Impossible for duplicate retrievals to happen. Also caught a performance issue in the drive id iterator; previously it was possible for two users to try to retrieve from the same drive at once when resuming from a checkpoint. 

## How Has This Been Tested?

TBD

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
