### PR TITLE
id not set in checkpoint FINAL

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -68,7 +68,7 @@ def _fetch_permissions_for_permission_ids(
         retrieval_function=drive_service.permissions().list,
         list_key="permissions",
         fileId=doc_id,
-        fields="permissions(id, emailAddress, type, domain)",
+        fields="permissions(id, emailAddress, type, domain),nextPageToken",
         supportsAllDrives=True,
         continue_on_404_or_403=True,
     )

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -107,7 +107,7 @@ def _map_group_email_to_member_emails(
             admin_service.members().list,
             list_key="members",
             groupKey=group_email,
-            fields="members(email)",
+            fields="members(email),nextPageToken",
         ):
             group_member_emails.add(member["email"])
 

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -51,7 +51,7 @@ def _get_drive_members(
                 drive_service.permissions().list,
                 list_key="permissions",
                 fileId=drive_id,
-                fields="permissions(emailAddress, type)",
+                fields="permissions(emailAddress, type),nextPageToken",
                 supportsAllDrives=True,
                 # can only set `useDomainAdminAccess` to true if the user
                 # is an admin

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -168,6 +168,9 @@ def gdrive_group_sync(
         admin_service, google_drive_connector.google_domain
     )
 
+    for group_emails, _ in drive_id_to_members_map.values():
+        all_group_emails.update(group_emails)
+
     # Map group emails to their members
     group_email_to_member_emails_map = _map_group_email_to_member_emails(
         admin_service, all_group_emails

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -173,9 +173,6 @@ def gdrive_group_sync(
         admin_service, google_drive_connector.google_domain
     )
 
-    # for group_emails, _ in drive_id_to_members_map.values():
-    #     all_group_emails.update(group_emails)
-
     # Map group emails to their members
     group_email_to_member_emails_map = _map_group_email_to_member_emails(
         admin_service, all_group_emails

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -127,6 +127,11 @@ def _build_onyx_groups(
     for drive_id, (group_emails, user_emails) in drive_id_to_members_map.items():
         all_member_emails: set[str] = user_emails
         for group_email in group_emails:
+            if group_email not in group_email_to_member_emails_map:
+                logger.warning(
+                    f"Group email {group_email} not found in group_email_to_member_emails_map"
+                )
+                continue
             all_member_emails.update(group_email_to_member_emails_map[group_email])
         onyx_groups.append(
             ExternalUserGroup(
@@ -168,8 +173,8 @@ def gdrive_group_sync(
         admin_service, google_drive_connector.google_domain
     )
 
-    for group_emails, _ in drive_id_to_members_map.values():
-        all_group_emails.update(group_emails)
+    # for group_emails, _ in drive_id_to_members_map.values():
+    #     all_group_emails.update(group_emails)
 
     # Map group emails to their members
     group_email_to_member_emails_map = _map_group_email_to_member_emails(

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -12,6 +12,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.google_utils.google_auth import get_google_creds
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
+from onyx.connectors.google_utils.google_utils import execute_single_retrieval
 from onyx.connectors.google_utils.resources import get_admin_service
 from onyx.connectors.google_utils.resources import get_gmail_service
 from onyx.connectors.google_utils.shared_constants import (
@@ -301,7 +302,7 @@ class GmailConnector(LoadConnector, PollConnector, SlimConnector):
                 q=query,
                 continue_on_404_or_403=True,
             ):
-                full_threads = execute_paginated_retrieval(
+                full_threads = execute_single_retrieval(
                     retrieval_function=gmail_service.users().threads().get,
                     list_key=None,
                     userId=user_email,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1050,6 +1050,9 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                 if len(files_batch) < self.batch_size:
                     continue
 
+                logger.info(
+                    f"Yielding batch of {len(files_batch)} files; num seen doc ids: {len(checkpoint.all_retrieved_file_ids)}"
+                )
                 yield from _yield_batch(files_batch)
                 files_batch = []
 

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -492,9 +492,14 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             if resuming:
                 drive_id = curr_stage.current_folder_or_drive_id
                 if drive_id is None:
-                    raise ValueError("drive id not set in checkpoint")
-                resume_start = curr_stage.completed_until
-                yield from _yield_from_drive(drive_id, resume_start)
+                    logger.warning(
+                        f"drive id not set in checkpoint for user {user_email}. "
+                        "This happens occasionally when the connector is interrupted "
+                        "and resumed."
+                    )
+                else:
+                    resume_start = curr_stage.completed_until
+                    yield from _yield_from_drive(drive_id, resume_start)
                 # Don't enter resuming case for folder retrieval
                 resuming = False
 
@@ -536,9 +541,14 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             if resuming:
                 folder_id = curr_stage.current_folder_or_drive_id
                 if folder_id is None:
-                    raise ValueError("folder id not set in checkpoint")
-                resume_start = curr_stage.completed_until
-                yield from _yield_from_folder_crawl(folder_id, resume_start)
+                    logger.warning(
+                        f"folder id not set in checkpoint for user {user_email}. "
+                        "This happens occasionally when the connector is interrupted "
+                        "and resumed."
+                    )
+                else:
+                    resume_start = curr_stage.completed_until
+                    yield from _yield_from_folder_crawl(folder_id, resume_start)
                 last_processed_folder = folder_id
 
             skipping_seen_folders = last_processed_folder is not None

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -377,7 +377,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                     cv.notify_all()
 
             # when entering the iterator with a previous id in the checkpoint, the user
-            # just finished that drive from a previous run.
+            # has just finished that drive from a previous run.
             if (
                 completion.stage == DriveRetrievalStage.MY_DRIVE_FILES
                 and completion.current_folder_or_drive_id is not None

--- a/backend/tests/daily/connectors/google_drive/test_slim_docs.py
+++ b/backend/tests/daily/connectors/google_drive/test_slim_docs.py
@@ -101,7 +101,7 @@ def get_group_map(google_drive_connector: GoogleDriveConnector) -> dict[str, lis
         admin_service.groups().list,
         list_key="groups",
         domain=google_drive_connector.google_domain,
-        fields="groups(email)",
+        fields="groups(email),nextPageToken",
     ):
         # The id is the group email
         group_email = group["email"]
@@ -112,7 +112,7 @@ def get_group_map(google_drive_connector: GoogleDriveConnector) -> dict[str, lis
             admin_service.members().list,
             list_key="members",
             groupKey=group_email,
-            fields="members(email)",
+            fields="members(email),nextPageToken",
         ):
             group_member_emails.append(member["email"])
         group_map[group_email] = group_member_emails


### PR DESCRIPTION
## Description

It is not impossible for indexing to error because drive id is not set in checkpoint. I am convinced that these errors occur due to rare states where a user Just Finished their My Drive but has not started the next stage, meaning it is correct to simply continue on to the next stage when this happens.

## How Has This Been Tested?

n/a, this should only reduce errors.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
