### PR TITLE
refactor: Replace asyncio.run with direct close calls for socket clients

### DIFF
--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import signal
 import sys
@@ -224,7 +223,7 @@ class SlackbotHandler:
                 f"No Slack bot tokens found for tenant={tenant_id}, bot {bot.id}"
             )
             if tenant_bot_pair in self.socket_clients:
-                asyncio.run(self.socket_clients[tenant_bot_pair].close())
+                self.socket_clients[tenant_bot_pair].close()
                 del self.socket_clients[tenant_bot_pair]
                 del self.slack_bot_tokens[tenant_bot_pair]
             return
@@ -252,7 +251,7 @@ class SlackbotHandler:
 
             # Close any existing connection first
             if tenant_bot_pair in self.socket_clients:
-                asyncio.run(self.socket_clients[tenant_bot_pair].close())
+                self.socket_clients[tenant_bot_pair].close()
 
             self.start_socket_client(bot.id, tenant_id, slack_bot_tokens)
 
@@ -405,7 +404,7 @@ class SlackbotHandler:
         # Close all socket clients for this tenant
         for (t_id, slack_bot_id), client in list(self.socket_clients.items()):
             if t_id == tenant_id:
-                asyncio.run(client.close())
+                client.close()
                 del self.socket_clients[(t_id, slack_bot_id)]
                 del self.slack_bot_tokens[(t_id, slack_bot_id)]
                 logger.info(
@@ -484,7 +483,7 @@ class SlackbotHandler:
     def stop_socket_clients(self) -> None:
         logger.info(f"Stopping {len(self.socket_clients)} socket clients")
         for (tenant_id, slack_bot_id), client in list(self.socket_clients.items()):
-            asyncio.run(client.close())
+            client.close()
             logger.info(
                 f"Stopped SocketModeClient for tenant: {tenant_id}, app: {slack_bot_id}"
             )


### PR DESCRIPTION
## Description

This pull request refactors the socket client closure handling in the listener class of the Slackbot. Previously, the synchronous close() method was incorrectly wrapped using `asyncio.run()`, which expects a coroutine. This misuse led to the following runtime error:

```
ERROR: listener.py 193: Error in Slack acquisition: a coroutine was expected, got None
Traceback (most recent call last):
  File "onyx/onyxbot/slack/listener.py", line 182, in acquire_tenants_loop
    self.acquire_tenants()
  File "onyx/onyxbot/slack/listener.py", line 377, in acquire_tenants
    self._remove_tenant(tenant_id)
  File "onyx/onyxbot/slack/listener.py", line 408, in _remove_tenant
    asyncio.run(client.close())
  File "/opt/homebrew/Cellar/python@3.11/3.11.12/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
                      ^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.12/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/runners.py", line 89, in run
    raise ValueError("a coroutine was expected, got {!r}".format(coro))
ValueError: a coroutine was expected, got None
```
**Fix**
The fix removes the use of asyncio.run() and directly invokes the synchronous close() method, which resolves the issue. This change ensures that no coroutine is incorrectly awaited, preventing the error described above.


## How Has This Been Tested?

This tested by deleting the slackbot from UI.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
