### PR TITLE
fix: chat starter message spacing and admin sidebar padding

### DIFF
--- a/web/src/components/admin/connectors/AdminSidebar.tsx
+++ b/web/src/components/admin/connectors/AdminSidebar.tsx
@@ -26,7 +26,7 @@ export function AdminSidebar({ collections }: { collections: Collection[] }) {
   const enterpriseSettings = combinedSettings.enterpriseSettings;
 
   return (
-    <div className="text-text-settings-sidebar pl-0">
+    <div className="text-text-settings-sidebar pl-4">
       <nav className="space-y-2">
         <div className="w-full ml-4  mt-1 h-8 justify-start mb-4 flex">
           <LogoComponent

--- a/web/src/components/assistants/StarterMessage.tsx
+++ b/web/src/components/assistants/StarterMessage.tsx
@@ -21,7 +21,7 @@ export function StarterMessages({
         ${
           isMobile
             ? "gap-x-2 w-2/3 justify-between"
-            : "justify-center max-w-[750px] items-start"
+            : "justify-center max-w-[750px] items-start gap-x-4"
         }
         flex
       mt-6


### PR DESCRIPTION
## Description
- add spacing between assistant start messages on chat page
- add left padding on admin sidebar items
- add gap between document upload type buttons
Screen recording 👇🏻

https://github.com/user-attachments/assets/0867a64a-f329-4e99-ace3-82253c05b643



[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
