### PR TITLE
Add LRU cache to get_model_map

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -3,6 +3,7 @@ import io
 import json
 from collections.abc import Callable
 from collections.abc import Iterator
+from functools import lru_cache
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
@@ -384,6 +385,7 @@ def test_llm(llm: LLM) -> str | None:
     return error_msg
 
 
+@lru_cache(maxsize=1)  # the copy.deepcopy is expensive, so we cache the result
 def get_model_map() -> dict:
     starting_map = copy.deepcopy(cast(dict, litellm.model_cost))
 


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

Compared speed of `/llm/provider` endpoint before/after. Is ~25x speedup (~2.5 seconds -> ~100ms).

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
