### PR TITLE
fixes foreign key violation

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -28,6 +28,9 @@ from onyx.db.connector_credential_pair import add_deletion_failure_message
 from onyx.db.connector_credential_pair import (
     delete_connector_credential_pair__no_commit,
 )
+from onyx.db.connector_credential_pair import (
+    delete_userfile_for_cc_pair__no_commit,
+)
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
 from onyx.db.document import (
@@ -467,6 +470,12 @@ def monitor_connector_deletion_taskset(
             # Expire the cc_pair to ensure SQLAlchemy doesn't try to manage its state
             # related to the deleted DocumentByConnectorCredentialPair during commit
             db_session.expire(cc_pair)
+
+            # delete the userfile for the cc_pair
+            delete_userfile_for_cc_pair__no_commit(
+                db_session=db_session,
+                cc_pair_id=cc_pair_id,
+            )
 
             # finally, delete the cc-pair
             delete_connector_credential_pair__no_commit(

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -29,7 +29,7 @@ from onyx.db.connector_credential_pair import (
     delete_connector_credential_pair__no_commit,
 )
 from onyx.db.connector_credential_pair import (
-    delete_userfile_for_cc_pair__no_commit,
+    delete_userfiles_for_cc_pair__no_commit,
 )
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
@@ -471,8 +471,8 @@ def monitor_connector_deletion_taskset(
             # related to the deleted DocumentByConnectorCredentialPair during commit
             db_session.expire(cc_pair)
 
-            # delete the userfile for the cc_pair
-            delete_userfile_for_cc_pair__no_commit(
+            # delete all userfiles for the cc_pair
+            delete_userfiles_for_cc_pair__no_commit(
                 db_session=db_session,
                 cc_pair_id=cc_pair_id,
             )

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -715,7 +715,7 @@ def get_connector_credential_pairs_with_user_files(
     )
 
 
-def delete_userfile_for_cc_pair__no_commit(
+def delete_userfiles_for_cc_pair__no_commit(
     db_session: Session,
     cc_pair_id: int,
 ) -> None:

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -713,3 +713,11 @@ def get_connector_credential_pairs_with_user_files(
         .distinct()
         .all()
     )
+
+
+def delete_userfile_for_cc_pair__no_commit(
+    db_session: Session,
+    cc_pair_id: int,
+) -> None:
+    stmt = delete(UserFile).where(UserFile.cc_pair_id == cc_pair_id)
+    db_session.execute(stmt)


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1946/foreign-key-violation-when-deleting-connector

We were seeing a foreign key violation during attempts at connector deletion When there were still user files associated with the connector.

## How Has This Been Tested?

n/a, seems pretty basic

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
