### PR TITLE
make 404s skippable

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -332,7 +332,7 @@ def convert_drive_item_to_document(
             or isinstance(doc_or_failure, Document)
             or not (
                 isinstance(doc_or_failure.exception, HttpError)
-                and doc_or_failure.exception.status_code == 403
+                and doc_or_failure.exception.status_code in [403, 404]
             )
         ):
             return doc_or_failure


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1947/drive-404s-on-file-retrieval
In some cases for read only files, retrievers get a 404 when trying to download. This PR lets us retry as other possible retrievers when this happens.

## How Has This Been Tested?

n/a, pretty basic. Ideally we could reproduce the 404s in our testing environment and add a connector test.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
