### PR TITLE
fix github cursor pagination infinite loop

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -541,6 +541,7 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
             # In offset mode, while indexing without time constraints, the pr batch
             # will be empty when we're done.
             used_cursor = checkpoint.cursor_url is not None
+            logger.info(f"Fetched {num_prs} PRs for repo: {repo.name}")
             if num_prs > 0 and not done_with_prs and not used_cursor:
                 return checkpoint
 
@@ -552,8 +553,6 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
             if used_cursor:
                 # save the checkpoint after changing stage; next run will continue from issues
                 return checkpoint
-
-        logger.info(f"Fetched {num_prs} PRs for repo: {repo.name}")
 
         checkpoint.stage = GithubConnectorStage.ISSUES
 
@@ -609,6 +608,7 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
                     )
                     continue
 
+            logger.info(f"Fetched {num_issues} issues for repo: {repo.name}")
             # if we found any issues on the page, and we're not done, return the checkpoint.
             # don't return if we're using cursor-based pagination to avoid infinite loops
             if num_issues > 0 and not done_with_issues and not checkpoint.cursor_url:
@@ -618,8 +618,6 @@ class GithubConnector(CheckpointedConnector[GithubConnectorCheckpoint]):
             # issues to get, we move on to the next repo
             checkpoint.stage = GithubConnectorStage.PRS
             checkpoint.reset()
-
-        logger.info(f"Fetched {num_issues} issues for repo: {repo.name}")
 
         checkpoint.has_more = len(checkpoint.cached_repo_ids) > 0
         if checkpoint.cached_repo_ids:

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -6,7 +6,7 @@ faker==37.1.0
 lxml==5.3.0
 lxml_html_clean==0.2.2
 mypy-extensions==1.0.0
-mypy==mypy-1.16.0+dev.79ff4ff3cedd6ca2786bdf8a8d531e944c51758a
+mypy==1.13.0
 pandas-stubs==2.2.3.241009
 pandas==2.2.3
 posthog==3.7.4

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -6,7 +6,7 @@ faker==37.1.0
 lxml==5.3.0
 lxml_html_clean==0.2.2
 mypy-extensions==1.0.0
-mypy==1.15.0
+mypy==mypy-1.16.0+dev.79ff4ff3cedd6ca2786bdf8a8d531e944c51758a
 pandas-stubs==2.2.3.241009
 pandas==2.2.3
 posthog==3.7.4


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1950/github-cursor-pagination-infinite-loop-fix
Fix an issue where the cursor-based pagination for github resulted in an infinite loop due to returning a checkpoint too early

## How Has This Been Tested?

tested manually, automated test of no infinite loop tbd

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
