### PR TITLE
Add user_id to get chat session response

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1042,9 +1042,6 @@ async def double_check_user(
     include_expired: bool = False,
     allow_anonymous_access: bool = False,
 ) -> User | None:
-    if is_user_admin(user):
-        return None
-
     if optional:
         return user
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1042,6 +1042,9 @@ async def double_check_user(
     include_expired: bool = False,
     allow_anonymous_access: bool = False,
 ) -> User | None:
+    if is_user_admin(user):
+        return None
+
     if optional:
         return user
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -236,6 +236,7 @@ def get_chat_session(
     )
 
     return ChatSessionDetailResponse(
+        user_id=chat_session.user_id,
         chat_session_id=session_id,
         description=chat_session.description,
         persona_id=chat_session.persona_id,

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -274,6 +274,7 @@ class ChatSessionDetailResponse(BaseModel):
     shared_status: ChatSessionSharedStatus
     current_alternate_model: str | None
     current_temperature_override: float | None
+    user_id: UUID | None
 
 
 # This one is not used anymore


### PR DESCRIPTION
## Description

This PR adds the user_id of the chat session to the response, in the case where the user_id is unknown when requesting for the chat session data

## How Has This Been Tested?

Ran in service and validated response reported back the chat's user id

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
