### PR TITLE
light worker discovers beat task

### DIFF
--- a/backend/ee/onyx/background/celery/apps/primary.py
+++ b/backend/ee/onyx/background/celery/apps/primary.py
@@ -134,5 +134,6 @@ celery_app.autodiscover_tasks(
     [
         "ee.onyx.background.celery.tasks.doc_permission_syncing",
         "ee.onyx.background.celery.tasks.external_group_syncing",
+        "ee.onyx.background.celery.tasks.cloud",
     ]
 )

--- a/backend/onyx/background/celery/apps/beat.py
+++ b/backend/onyx/background/celery/apps/beat.py
@@ -256,9 +256,3 @@ def on_setup_logging(
 
 celery_app.conf.beat_scheduler = DynamicTenantScheduler
 celery_app.conf.task_default_base = app_base.TenantAwareTask
-
-celery_app.autodiscover_tasks(
-    [
-        "ee.onyx.background.celery.tasks.cloud",
-    ]
-)

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -113,6 +113,5 @@ celery_app.autodiscover_tasks(
         "onyx.background.celery.tasks.doc_permission_syncing",
         "onyx.background.celery.tasks.user_file_folder_sync",
         "onyx.background.celery.tasks.indexing",
-        "ee.onyx.background.celery.tasks.cloud",
     ]
 )

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -113,5 +113,6 @@ celery_app.autodiscover_tasks(
         "onyx.background.celery.tasks.doc_permission_syncing",
         "onyx.background.celery.tasks.user_file_folder_sync",
         "onyx.background.celery.tasks.indexing",
+        "ee.onyx.background.celery.tasks.cloud",
     ]
 )


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1966/beat-cloud-task-unregistered
In the recent decoupling of EE form non-EE, we ended up with an unregistered task: `cloud_generate_beat_tasks`. This fixes that (hopefully)

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
