### PR TITLE
Use LiteLLM DB for determining model tool capability

### DIFF
--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -6,21 +6,25 @@ from onyx.configs.app_configs import AZURE_DALLE_API_KEY
 from onyx.db.connector import check_connectors_exist
 from onyx.db.document import check_docs_exist
 from onyx.db.models import LLMProvider
+from onyx.llm.utils import get_model_map, _find_model_obj
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.tools.tool import Tool
 
 
-OPEN_AI_TOOL_CALLING_MODELS = {
-    "gpt-3.5-turbo",
-    "gpt-4-turbo",
-    "gpt-4",
-    "gpt-4o",
-    "gpt-4o-mini",
-}
-
-
 def explicit_tool_calling_supported(model_provider: str, model_name: str) -> bool:
-    return model_provider == "openai" and model_name in OPEN_AI_TOOL_CALLING_MODELS
+    model_map = get_model_map()
+    model_obj = _find_model_obj(
+        model_map=model_map,
+        provider=model_provider,
+        model_name=model_name,
+    )
+
+    if model_obj:
+        # Check if the model_obj from litellm.model_cost indicates support for function calling
+        if model_obj.get("supports_function_calling"):
+            return True
+    
+    return False
 
 
 def compute_tool_tokens(tool: Tool, llm_tokenizer: BaseTokenizer) -> int:

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -19,12 +19,7 @@ def explicit_tool_calling_supported(model_provider: str, model_name: str) -> boo
         model_name=model_name,
     )
 
-    if model_obj:
-        # Check if the model_obj from litellm.model_cost indicates support for function calling
-        if model_obj.get("supports_function_calling"):
-            return True
-    
-    return False
+    return model_obj.get("supports_function_calling", False) if model_obj else False
 
 
 def compute_tool_tokens(tool: Tool, llm_tokenizer: BaseTokenizer) -> int:

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -39,7 +39,7 @@ langchainhub==0.1.21
 langgraph==0.2.72
 langgraph-checkpoint==2.0.13
 langgraph-sdk==0.1.44
-litellm==1.66.3
+litellm==1.69.0
 lxml==5.3.0
 lxml_html_clean==0.2.2
 llama-index==0.12.28

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -14,7 +14,7 @@ torch==2.6.0
 transformers==4.49.0
 uvicorn==0.21.1
 voyageai==0.2.3
-litellm==1.66.3
+litellm==1.69.0
 sentry-sdk[fastapi,celery,starlette]==2.14.0
 aioboto3==14.0.0
 prometheus_fastapi_instrumentator==7.1.0


### PR DESCRIPTION
## Description

Use LiteLLM DB for determining model tool capability instead of using a hardcoded list.
This enables newer models (Ie. `gpt-4.1`, `gemini-2.5`) to use native tools.

## How Has This Been Tested?

Checked new models now can execute tools.