### PR TITLE
Upgrade asyncpg for Python 3.12

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1,7 +1,7 @@
 aioboto3==14.0.0
 aiohttp==3.11.16
 alembic==1.10.4
-asyncpg==0.27.0
+asyncpg==0.30.0
 atlassian-python-api==3.41.16
 beautifulsoup4==4.12.3
 boto3==1.36.23


### PR DESCRIPTION
## Description

Upgrade asyncpg library to be able to install onyx on Python 3.12.
Reference: https://github.com/onyx-dot-app/onyx/issues/734

## How Has This Been Tested?

`pip install -r requirements/default.txt`

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
