### PR TITLE
feat: parameterise client_max_body_size for ingress-nginx

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,26 +1,30 @@
 # Local testing
 
 ## One time setup
-* brew install kind
-* Ensure you have no config at ~/.kube/config
-* kind create cluster
-* mv ~/.kube/config ~/.kube/kind-config
+
+- brew install kind
+- Ensure you have no config at ~/.kube/config
+- kind create cluster
+- mv ~/.kube/config ~/.kube/kind-config
 
 ## Automated install and test with ct
-* export KUBECONFIG=~/.kube/kind-config
-* kubectl config use-context kind-kind
-* from source root run the following. This does a very basic test against the web server
-  * ct install --all --helm-extra-set-args="--set=nginx.enabled=false" --debug --config ct.yaml
+
+- export KUBECONFIG=~/.kube/kind-config
+- kubectl config use-context kind-kind
+- from source root run the following. This does a very basic test against the web server
+  - ct install --all --helm-extra-set-args="--set=nginx.enabled=false" --debug --config ct.yaml
 
 ## Test the entire cluster manually
-* helm install onyx . -n onyx --set postgresql.primary.persistence.enabled=false
-  * the postgres flag is to keep the storage ephemeral for testing, you probably don't want to set that in prod
-  * no flag for ephemeral vespa storage yet, might be good for testing
-* kubectl -n onyx port-forward service/onyx-nginx 8080:80
-  * this will forward the local port 8080 to the installed chart for you to run tests, etc.
-* When you are finished
-  * helm uninstall onyx -n onyx
-  * Vespa leaves behind a PVC - delete it if you are completely done
-    * k -n onyx get pvc
-    * k -n onyx delete pvc vespa-storage-da-vespa-0
-  * If you didn't disable Postgres persistence earlier, you may want to delete that PVC too.
+
+- helm dependency build
+- helm install onyx . -n onyx --create-namespace --set postgresql.primary.persistence.enabled=false
+  - the postgres flag is to keep the storage ephemeral for testing, you probably don't want to set that in prod
+  - no flag for ephemeral vespa storage yet, might be good for testing
+- kubectl -n onyx port-forward service/onyx-nginx 8080:80
+  - this will forward the local port 8080 to the installed chart for you to run tests, etc, you will need to use `127.0.0.1:8080` (`localhost:8080` wont work)
+- When you are finished
+  - helm uninstall onyx -n onyx
+  - Vespa leaves behind a PVC - delete it if you are completely done
+    - kubectl -n onyx get pvc
+    - kubectl -n onyx delete pvc vespa-storage-da-vespa-0
+  - If you didn't disable Postgres persistence earlier, you may want to delete that PVC too.

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -4,11 +4,12 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-api
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.api.clientMaxBodySize }}
     cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
 spec:
+  ingressClassName: nginx
   rules:
     - host: {{ .Values.ingress.api.host }}
       http:

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -4,10 +4,11 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-webserver
   annotations:
-    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.ingress.webserver.clientMaxBodySize }}
     cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
     kubernetes.io/tls-acme: "true"
 spec:
+  ingressClassName: nginx
   rules:
     - host: {{ .Values.ingress.webserver.host }}
       http:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -541,8 +541,10 @@ ingress:
   className: ""
   api:
     host: onyx.local
+    clientMaxBodySize: "1m"
   webserver:
     host: onyx.local
+    clientMaxBodySize: "1m"
 
 letsencrypt:
   enabled: false


### PR DESCRIPTION
## Description

This PR introduces `ingest.[api|webserver].clientMaxBodySize` which maps directly to `client_max_body_size` in `ingress-nginx` `nginx.conf` files. I did this by parameterising the value of the `nginx.ingress.kubernetes.io/proxy-body-size` annotation, which is documented [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size).

I've used `1m` as the default as this is what you get OOTB

This came about when I tried to upload a 4.5MB file to the File Connector on our Onyx deployment. Whilst the Onyx nginx has 5G, if you have an `ingess-nginx` it defaults to `1m`, this now allows folks to customise to their needs.

I've also addressed:

```
W0513 12:52:57.668026   87083 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

I've also updated the helm docs a little after local development.

## How Has This Been Tested?

* Originally manually made these changes on our `ingress-nginx` install on our cluster
* Tested on `kind` cluster locally after making changes in this repo, confirming that I can change these values and see them updated in the `ingress-nginx` `nginx.conf` files **and** that I can upload bigger files after

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
