### PR TITLE
Bugfix/usage report UUID

### DIFF
--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -5,6 +5,8 @@ from typing import IO
 from typing import Optional
 
 from fastapi_users_db_sqlalchemy import UUID_ID
+from sqlalchemy import cast
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.query_history import fetch_chat_sessions_eagerly_by_time
@@ -92,8 +94,8 @@ def get_all_usage_reports(db_session: Session) -> list[UsageReportMetadata]:
     user_ids = {r.requestor_user_id for r in usage_reports if r.requestor_user_id}
     user_emails = {
         user.id: user.email
-        for user in db_session.query(User.id, User.email)
-        .filter(User.id.in_(user_ids))
+        for user in db_session.query(User)
+        .filter(cast(User.id, UUID).in_(user_ids))
         .all()
     }
 

--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -13,6 +13,7 @@ from ee.onyx.server.reporting.usage_export_models import FlowType
 from ee.onyx.server.reporting.usage_export_models import UsageReportMetadata
 from onyx.configs.constants import MessageType
 from onyx.db.models import UsageReport
+from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
 
 
@@ -86,15 +87,27 @@ def get_all_empty_chat_message_entries(
 
 
 def get_all_usage_reports(db_session: Session) -> list[UsageReportMetadata]:
+    # Get the user emails
+    usage_reports = db_session.query(UsageReport).all()
+    user_ids = {r.requestor_user_id for r in usage_reports if r.requestor_user_id}
+    user_emails = {
+        user.id: user.email
+        for user in db_session.query(User.id, User.email)
+        .filter(User.id.in_(user_ids))
+        .all()
+    }
+
     return [
         UsageReportMetadata(
             report_name=r.report_name,
-            requestor=str(r.requestor_user_id) if r.requestor_user_id else None,
+            requestor=(
+                user_emails.get(r.requestor_user_id) if r.requestor_user_id else None
+            ),
             time_created=r.time_created,
             period_from=r.period_from,
             period_to=r.period_to,
         )
-        for r in db_session.query(UsageReport).all()
+        for r in usage_reports
     ]
 
 

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -167,7 +167,7 @@ def create_new_usage_report(
     requestor_email = requestor_user.email if requestor_user else None
 
     return UsageReportMetadata(
-        report_name=str(new_report.id),
+        report_name=new_report.report_name,
         requestor=requestor_email,
         time_created=new_report.time_created,
         period_from=new_report.period_from,

--- a/web/src/components/PageSelector.tsx
+++ b/web/src/components/PageSelector.tsx
@@ -54,18 +54,19 @@ const PageLink = ({
   <div
     className={`
     select-none
-    inline-block 
-    text-sm 
-    border 
-    px-3 
-    py-1 
-    leading-5 
-    -ml-px 
+    inline-block
+    text-sm
+    border
+    px-3
+    py-1
+    leading-5
+    -ml-px
     border-border
+    ${unclickable ? "text-text-200" : ""}
     ${!unclickable ? "hover:bg-accent-background-hovered" : ""}
     ${!unclickable ? "cursor-pointer" : ""}
-    first:ml-0 
-    first:rounded-l-md 
+    first:ml-0
+    first:rounded-l-md
     last:rounded-r-md
     ${active ? "bg-background-200" : ""}
   `}
@@ -103,6 +104,7 @@ export const PageSelector = ({
     <div style={{ display: "inline-block" }}>
       <PageLink
         linkText="‹"
+        unclickable={currentPage === 1}
         pageChangeHandler={() => {
           onPageChange(Math.max(currentPage - 1, 1));
           modifiedScrollUp();
@@ -139,6 +141,7 @@ export const PageSelector = ({
       })}
       <PageLink
         linkText="›"
+        unclickable={currentPage === totalPages}
         pageChangeHandler={() => {
           onPageChange(Math.min(currentPage + 1, totalPages));
           modifiedScrollUp();


### PR DESCRIPTION
## Description
[DAN-1747](https://linear.app/danswer/issue/DAN-1747/dont-use-random-uids-for-ui)

- Changed `create_new_usage_report` and `get_all_usage_reports` to return the username of the person who made the report instead of their user_id in the requestor field.
- Changed frontend to disable and gray out arrows when they shouldn't be active (e.g., left arrow disabled on 1st page, right arrow disabled on last page)

<img width="1096" alt="image" src="https://github.com/user-attachments/assets/782186b8-736a-430f-8d93-b7a3ef383826" />

## How Has This Been Tested?

- Tested UI with 0, 1, 2, and 3 pages of reports
- Tested system generated and user generated reports

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
