### PR TITLE
UI fixes

### DIFF
--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -230,6 +230,7 @@ export function SlackChannelConfigFormFields({
               <CheckFormField
                 name="disabled"
                 label="Disable Default Configuration"
+                labelClassName="text-neutral-900"
               />
               <p className="mt-2 text-sm text-neutral-600 italic">
                 Warning: Disabling the default configuration means the bot
@@ -565,7 +566,7 @@ export function SlackChannelConfigFormFields({
 
         <AccordionItem className="mt-4" value="general-options">
           <AccordionTrigger>General Configuration</AccordionTrigger>
-          <AccordionContent>
+          <AccordionContent className="overflow-visible">
             <div className="space-y-4">
               <CheckFormField
                 name="show_continue_in_web_ui"

--- a/web/src/components/ui/CheckField.tsx
+++ b/web/src/components/ui/CheckField.tsx
@@ -15,6 +15,7 @@ import {
 interface CheckFieldProps {
   name: string;
   label: string;
+  labelClassName?: string;
   sublabel?: string;
   size?: "sm" | "md" | "lg";
   tooltip?: string;
@@ -28,6 +29,7 @@ export const CheckFormField: React.FC<CheckFieldProps> = ({
   sublabel,
   size = "md",
   tooltip,
+  labelClassName,
   ...props
 }) => {
   const [field, , helpers] = useField<boolean>({ name, type: "checkbox" });
@@ -74,7 +76,12 @@ export const CheckFormField: React.FC<CheckFieldProps> = ({
           className="flex flex-col cursor-pointer"
           onClick={handleClick}
         >
-          <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+          <span
+            className={cn(
+              "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+              labelClassName
+            )}
+          >
             {label}
           </span>
           {sublabel && (

--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -28,7 +28,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-3.5 w-3.5 rounded-full border border-background-200 border-background-900 text-neutral-900 ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-background-800 dark:border-background-50 dark:text-neutral-50 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300",
+        "aspect-square h-3.5 w-3.5 rounded-full border border-background-900 text-neutral-900 ring-offset-white focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-background-800 dark:text-neutral-50 dark:ring-offset-neutral-950 dark:focus-visible:ring-neutral-300",
         className
       )}
       {...props}


### PR DESCRIPTION
## Description
Adjusted the CSS of slack config form for dark mode.

## How Has This Been Tested?
By looking into the UI
### Before Changes
<img width="1498" alt="Screenshot 2025-05-14 at 8 14 58 PM" src="https://github.com/user-attachments/assets/5c8d0531-c20b-4518-8935-36863b907217" />

### After Changes
<img width="1503" alt="Screenshot 2025-05-14 at 8 08 56 PM" src="https://github.com/user-attachments/assets/9a73e99b-843d-468a-9f7c-cdf92cfd076c" />

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
