### PR TITLE
fix: Add Teams env-variables

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -81,6 +81,11 @@ env:
   # Slack
   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
+  # Teams
+  TEAMS_APPLICATION_ID: ${{ secrets.TEAMS_APPLICATION_ID }}
+  TEAMS_DIRECTORY_ID: ${{ secrets.TEAMS_DIRECTORY_ID }}
+  TEAMS_SECRET: ${{ secrets.TEAMS_SECRET }}
+
 jobs:
   connectors-check:
     # See https://runs-on.com/runners/linux/


### PR DESCRIPTION
## Description

Add Teams environment variables to workflow.

Addresses: https://linear.app/danswer/issue/DAN-1976/add-teams-environment-variables-to-connector-testing-workflow-file.

## How Has This Been Tested?

CI/CD change; doesn't need to be tested.