### PR TITLE
fix connector tests and drive indexing

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -484,6 +484,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                     DriveRetrievalStage.MY_DRIVE_FILES,
                 )
             curr_stage.stage = DriveRetrievalStage.SHARED_DRIVE_FILES
+            curr_stage.current_folder_or_drive_id = None
             return  # resume from next stage on the next run
 
         if curr_stage.stage == DriveRetrievalStage.SHARED_DRIVE_FILES:
@@ -532,6 +533,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                     return  # resume from this drive on the next run
                 yield from _yield_from_drive(drive_id, start)
             curr_stage.stage = DriveRetrievalStage.FOLDER_FILES
+            curr_stage.current_folder_or_drive_id = None
             return  # resume from next stage on the next run
 
         # In the folder files section of service account retrieval we take extra care

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -334,7 +334,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
     def make_drive_id_iterator(
         self, drive_ids: list[str], checkpoint: GoogleDriveCheckpoint
     ) -> Callable[[str], Iterator[str]]:
-        cv = threading.Condition()
+        status_lock = threading.Lock()
 
         in_progress_drive_ids = {
             completion.current_folder_or_drive_id: user_email
@@ -351,8 +351,8 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             else:
                 drive_id_status[drive_id] = DriveIdStatus.AVAILABLE
 
-        def _get_available_drive_id(processed_ids: set[str]) -> tuple[str | None, bool]:
-            found_future_work = False
+        def _get_available_drive_id(processed_ids: set[str]) -> str | None:
+            future_work = None
             for drive_id, status in drive_id_status.items():
                 if drive_id in self._retrieved_folder_and_drive_ids:
                     drive_id_status[drive_id] = DriveIdStatus.FINISHED
@@ -361,17 +361,17 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                     continue
 
                 if status == DriveIdStatus.AVAILABLE:
-                    return drive_id, True
+                    return drive_id
                 elif status == DriveIdStatus.IN_PROGRESS:
                     logger.debug(f"Drive id in progress: {drive_id}")
-                    found_future_work = True
-            return None, found_future_work
+                    future_work = drive_id
+            return future_work
 
         def drive_id_iterator(thread_id: str) -> Iterator[str]:
             completion = checkpoint.completion_map[thread_id]
 
             def record_drive_processing(drive_id: str) -> None:
-                with cv:
+                with status_lock:
                     completion.processed_drive_ids.add(drive_id)
                     if drive_id in drive_id_status:
                         drive_id_status[drive_id] = (
@@ -383,8 +383,6 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
                         f"Drive id finished: {drive_id}, user email: {thread_id},"
                         f"processed drive ids: {len(completion.processed_drive_ids)}"
                     )
-                    # wake up other threads waiting for work
-                    cv.notify_all()
 
             # when entering the iterator with a previous id in the checkpoint, the user
             # has just finished that drive from a previous run.
@@ -396,18 +394,10 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             # continue iterating until this thread has no more work to do
             while True:
                 # this locks operations on _retrieved_ids and drive_id_status
-                with cv:
-                    available_drive_id, found_future_work = _get_available_drive_id(
+                with status_lock:
+                    available_drive_id = _get_available_drive_id(
                         completion.processed_drive_ids
                     )
-
-                    # wait while there is no work currently available but still drives that may need processing
-                    while available_drive_id is None and found_future_work:
-                        cv.wait()
-                        available_drive_id, found_future_work = _get_available_drive_id(
-                            completion.processed_drive_ids
-                        )
-
                     # if there is no work available and no future work, we are done
                     if available_drive_id is None:
                         return

--- a/backend/tests/daily/connectors/google_drive/consts_and_utils.py
+++ b/backend/tests/daily/connectors/google_drive/consts_and_utils.py
@@ -78,6 +78,13 @@ RESTRICTED_ACCESS_FOLDER_URL = (
     "https://drive.google.com/drive/folders/1HK4wZ16ucz8QGywlcS87Y629W7i7KdeN"
 )
 
+PADDING_DRIVE_URLS = [
+    "0AOorXE6AfJRAUk9PVA",
+    "0ANn2MSqGi74JUk9PVA",
+    "0ANI_NFCPzaRwUk9PVA",
+    "0ABu8fYjvA21dUk9PVA",
+]
+
 ADMIN_EMAIL = "admin@onyx-test.com"
 TEST_USER_1_EMAIL = "test_user_1@onyx-test.com"
 TEST_USER_2_EMAIL = "test_user_2@onyx-test.com"
@@ -144,6 +151,19 @@ SPECIAL_FILE_ID_TO_CONTENT_MAP: dict[int, str] = {
     ),
 }
 
+MISC_SHARED_DRIVE_FNAMES = [
+    "asdfasdfsfad",
+    "perm_sync_doc_0ABec4pV29sMuUk9PVA_a5ea8ec4-0440-4926-a43d-3aeef1c10bdd",
+    "perm_sync_doc_0ACOrCU1EMD1hUk9PVA_651821cb-8140-42fe-a876-1a92012375c9",
+    "perm_sync_doc_0ACOrCU1EMD1hUk9PVA_ab63b976-effb-49af-84e7-423d17a17dd7",
+    "super secret thing that test user 1 can't see",
+    "perm_sync_doc_0ABec4pV29sMuUk9PVA_419f2ef0-9815-4c69-8435-98b163c9c156",
+    "Untitled documentfsdfsdfsdf",
+    "bingle_bongle.txt",
+    "bb4.txt",
+    "bb3.txt",
+    "bb2.txt",
+]
 
 file_name_template = "file_{}.txt"
 file_text_template = "This is file {}"
@@ -179,6 +199,10 @@ def _get_expected_file_content(file_id: int) -> str:
     return file_text_template.format(file_id)
 
 
+def id_to_name(file_id: int) -> str:
+    return file_name_template.format(file_id)
+
+
 def assert_expected_docs_in_retrieved_docs(
     retrieved_docs: list[Document],
     expected_file_ids: Sequence[int],
@@ -187,9 +211,7 @@ def assert_expected_docs_in_retrieved_docs(
     it only checks to see if that the expected file id's are IN the retrieved doc list
     """
 
-    expected_file_names = {
-        file_name_template.format(file_id) for file_id in expected_file_ids
-    }
+    expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
     expected_file_texts = {
         _get_expected_file_content(file_id) for file_id in expected_file_ids
     }

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -188,7 +188,7 @@ def test_include_shared_drives_only(
 
     # 2 extra files from shared drive owned by non-admin and not shared with admin
     # TODO: switch to 54 when restricted access issue is resolved
-    assert len(retrieved_docs) == 53 or len(retrieved_docs) == 54
+    assert len(retrieved_docs) == 52 or len(retrieved_docs) == 53
 
     assert_expected_docs_in_retrieved_docs(
         retrieved_docs=retrieved_docs,

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -32,7 +32,11 @@ from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_2_2_URL
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_2_FILE_IDS
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_2_URL
 from tests.daily.connectors.google_drive.consts_and_utils import FOLDER_3_URL
+from tests.daily.connectors.google_drive.consts_and_utils import id_to_name
 from tests.daily.connectors.google_drive.consts_and_utils import load_all_docs
+from tests.daily.connectors.google_drive.consts_and_utils import (
+    MISC_SHARED_DRIVE_FNAMES,
+)
 from tests.daily.connectors.google_drive.consts_and_utils import (
     RESTRICTED_ACCESS_FOLDER_URL,
 )
@@ -115,6 +119,26 @@ def test_include_shared_drives_only_with_size_threshold(
 
     retrieved_docs = load_all_docs(connector)
 
+    expected_file_ids = (
+        SHARED_DRIVE_1_FILE_IDS
+        + FOLDER_1_FILE_IDS
+        + FOLDER_1_1_FILE_IDS
+        + FOLDER_1_2_FILE_IDS
+        + SHARED_DRIVE_2_FILE_IDS
+        + FOLDER_2_FILE_IDS
+        + FOLDER_2_1_FILE_IDS
+        + FOLDER_2_2_FILE_IDS
+        + SECTIONS_FILE_IDS
+    )
+
+    expected_file_names = {id_to_name(file_id) for file_id in expected_file_ids}
+    expected_file_names.update(MISC_SHARED_DRIVE_FNAMES)
+    retrieved_file_names = {doc.semantic_identifier for doc in retrieved_docs}
+    for name in expected_file_names - retrieved_file_names:
+        print(f"expected but did not retrieve: {name}")
+    for name in retrieved_file_names - expected_file_names:
+        print(f"retrieved but did not expect: {name}")
+
     # 2 extra files from shared drive owned by non-admin and not shared with admin
     # TODO: added a file in a "restricted" folder, which the connector sometimes succeeds at finding
     # and adding. Specifically, our shared drive retrieval logic currently assumes that
@@ -124,8 +148,8 @@ def test_include_shared_drives_only_with_size_threshold(
     # If instead someone with FULL access to the shared drive retrieves it, the connector will retrieve
     # the folder and all its files. There is currently no consistency to the order of assignment of users
     # to shared drives, so this is a heisenbug. When we guarantee that restricted folders are retrieved,
-    # we can change this to 53
-    assert len(retrieved_docs) == 52 or len(retrieved_docs) == 53
+    # we can change this to 52
+    assert len(retrieved_docs) == 51 or len(retrieved_docs) == 52
 
 
 @patch(


### PR DESCRIPTION
## Description


Fixes https://linear.app/danswer/issue/DAN-1979/drive-connector-broken
Drive connector tests were failing due to a deadlock in our shared drive indexing scheme and a file without an extensions that isn't being indexed anymore. This PR simplifies the logic and fixes the connector test.

## How Has This Been Tested?

connector tests

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
