### PR TITLE
Highlight active link in AdminSidebar based on current pathname

### DIFF
--- a/web/src/components/admin/connectors/AdminSidebar.tsx
+++ b/web/src/components/admin/connectors/AdminSidebar.tsx
@@ -20,10 +20,10 @@ interface Collection {
 
 export function AdminSidebar({ collections }: { collections: Collection[] }) {
   const combinedSettings = useContext(SettingsContext);
+  const pathname = usePathname() ?? "";
   if (!combinedSettings) {
     return null;
   }
-  const pathname = usePathname() ?? "";
   const enterpriseSettings = combinedSettings.enterpriseSettings;
 
   return (

--- a/web/src/components/admin/connectors/AdminSidebar.tsx
+++ b/web/src/components/admin/connectors/AdminSidebar.tsx
@@ -2,6 +2,7 @@
 "use client";
 import React, { useContext } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
 import { CgArrowsExpandUpLeft } from "react-icons/cg";
 import { LogoComponent } from "@/components/logo/FixedLogo";
@@ -22,7 +23,7 @@ export function AdminSidebar({ collections }: { collections: Collection[] }) {
   if (!combinedSettings) {
     return null;
   }
-
+  const pathname = usePathname() ?? "";
   const enterpriseSettings = combinedSettings.enterpriseSettings;
 
   return (
@@ -57,7 +58,12 @@ export function AdminSidebar({ collections }: { collections: Collection[] }) {
             {collection.items.map((item) => (
               <Link key={item.link} href={item.link}>
                 <button
-                  className={`text-sm text-text-700 block flex gap-x-2 items-center w-52 py-2.5 px-2 text-left hover:bg-background-settings-hover dark:hover:bg-neutral-800 rounded`}
+                  className={`text-sm text-text-700 block flex gap-x-2 items-center w-52 py-2.5 px-2 text-left hover:bg-background-settings-hover dark:hover:bg-neutral-800 rounded
+                    ${
+                      pathname.startsWith(item.link)
+                        ? "bg-background-settings-hover dark:bg-neutral-700"
+                        : ""
+                    }`}
                 >
                   {item.name}
                 </button>


### PR DESCRIPTION
This pull request enhances the `AdminSidebar` component by introducing active link highlighting based on the current pathname. 

## How Has This Been Tested?
By looking into the UI.

Before:
<img width="1725" alt="Screenshot 2025-05-15 at 7 30 28 PM" src="https://github.com/user-attachments/assets/f3eaffea-9c32-4542-8b69-3b86b1a098f6" />

After:
<img width="1728" alt="Screenshot 2025-05-15 at 7 29 12 PM" src="https://github.com/user-attachments/assets/7fb571fb-be6b-4449-93f6-201e8be8d38b" />

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
