### PR TITLE
Fix Continue Button in Connector

### DIFF
--- a/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
+++ b/web/src/app/admin/connectors/[connector]/NavigationRow.tsx
@@ -65,7 +65,7 @@ const NavigationRow = ({
       <div className="flex justify-end">
         {formStep === 0 && (
           <SquareNavigationButton
-            className="bg-blue-400 text-white py-2.5 px-3.5 disabled:bg-blue-200"
+            className="bg-blue-400 text-white py-2.5 px-3.5 disabled:bg-blue-200 disabled:text-neutral-400"
             disabled={!activatedCredential}
             onClick={nextFormStep}
           >


### PR DESCRIPTION
## Description

Made it clearer that the button is disabled
<img width="809" alt="image" src="https://github.com/user-attachments/assets/bd08a93f-9321-432f-8d73-71a48d604d3b" />

## How Has This Been Tested?

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
