### PR TITLE
fix: use ImplementationSpecific for pathType on ingress-api

### DIFF
--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -14,7 +14,7 @@ spec:
       http:
         paths:
           - path: /api(/|$)(.*)
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ include "onyx-stack.fullname" . }}-api-service


### PR DESCRIPTION
## Description

When using the Helm Charts, I observed:

```
Error: 1 error occurred:
        * admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /api(/|$)(.*) cannot be used with pathType Prefix
```

Which caused Helm to fail. Changing `pathType` from `Prefix` to `ImplementationSpecific` fixed this in `ingress-api.yml`

## How Has This Been Tested?

Applied to my helm deployment and it worked.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
