### PR TITLE
fix nltk punkt

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -85,7 +85,7 @@ Tokenizer.from_pretrained('nomic-ai/nomic-embed-text-v1')"
 # Pre-downloading NLTK for setups with limited egress
 RUN python -c "import nltk; \
 nltk.download('stopwords', quiet=True); \
-nltk.download('punkt', quiet=True);"
+nltk.download('punkt_tab', quiet=True);"
 # nltk.download('wordnet', quiet=True); introduce this back if lemmatization is needed
 
 # Set up application files


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1985/nltk-punkt-deprecated

related to https://github.com/nltk/nltk/issues/3293

```
2025-05-19 08:53:43.267	
**********************************************************************

2025-05-19 08:53:43.267	
    - '/usr/local/lib/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/lib/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/local/share/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/share/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/local/lib/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/local/share/nltk_data'
2025-05-19 08:53:43.267	
    - '/usr/local/nltk_data'
2025-05-19 08:53:43.267	
    - '/root/nltk_data'
2025-05-19 08:53:43.267	
  Searched in:
2025-05-19 08:53:43.267	

2025-05-19 08:53:43.267	
  Attempted to load tokenizers/punkt_tab/english/
2025-05-19 08:53:43.267	

2025-05-19 08:53:43.267	
  For more information see: https://www.nltk.org/data.html
2025-05-19 08:53:43.267	
  
2025-05-19 08:53:43.267	
  >>> nltk.download('punkt_tab')
2025-05-19 08:53:43.267	
  >>> import nltk
2025-05-19 08:53:43.267	

2025-05-19 08:53:43.267	
  Please use the NLTK Downloader to obtain the resource:
2025-05-19 08:53:43.267	
  Resource punkt_tab not found.
```

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
