### PR TITLE
don't fail on fake files

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -171,7 +171,7 @@ def _download_and_extract_sections_basic(
         mime_type
         == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     ):
-        text = pptx_to_text(io.BytesIO(response_call()))
+        text = pptx_to_text(io.BytesIO(response_call()), file_name=file_name)
         return [TextSection(link=link, text=text)] if text else []
 
     elif is_gdrive_image_mime_type(mime_type):

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -165,16 +165,8 @@ def _download_and_extract_sections_basic(
     elif (
         mime_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     ):
-        try:
-            text = xlsx_to_text(io.BytesIO(response_call()))
-            return [TextSection(link=link, text=text)]
-        except BadZipFile as e:
-            error_str = f"Failed to extract text from {file_name}: {e}"
-            if file_name.startswith("~"):
-                logger.debug(error_str + " (this is expected for files with ~)")
-            else:
-                logger.warning(error_str)
-            return []
+        text = xlsx_to_text(io.BytesIO(response_call()), file_name=file_name)
+        return [TextSection(link=link, text=text)] if text else []
 
     elif (
         mime_type
@@ -182,7 +174,7 @@ def _download_and_extract_sections_basic(
     ):
         try:
             text = pptx_to_text(io.BytesIO(response_call()))
-            return [TextSection(link=link, text=text)]
+            return [TextSection(link=link, text=text)] if text else []
         except BadZipFile as e:
             error_str = f"Failed to extract text from {file_name}: {e}"
             logger.warning(error_str)

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -2,7 +2,6 @@ import io
 from datetime import datetime
 from typing import Any
 from typing import cast
-from zipfile import BadZipFile
 
 from googleapiclient.errors import HttpError  # type: ignore
 from googleapiclient.http import MediaIoBaseDownload  # type: ignore
@@ -172,13 +171,8 @@ def _download_and_extract_sections_basic(
         mime_type
         == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     ):
-        try:
-            text = pptx_to_text(io.BytesIO(response_call()))
-            return [TextSection(link=link, text=text)] if text else []
-        except BadZipFile as e:
-            error_str = f"Failed to extract text from {file_name}: {e}"
-            logger.warning(error_str)
-            return []
+        text = pptx_to_text(io.BytesIO(response_call()))
+        return [TextSection(link=link, text=text)] if text else []
 
     elif is_gdrive_image_mime_type(mime_type):
         # For images, store them for later processing

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -519,7 +519,9 @@ def extract_text_and_images(
         if extension == ".pptx":
             file.seek(0)
             return ExtractionResult(
-                text_content=pptx_to_text(file), embedded_images=[], metadata={}
+                text_content=pptx_to_text(file, file_name=file_name),
+                embedded_images=[],
+                metadata={},
             )
 
         if extension == ".xlsx":

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 from typing import IO
 from typing import NamedTuple
+from zipfile import BadZipFile
 
 import chardet
 import docx  # type: ignore
@@ -332,8 +333,13 @@ def docx_to_text_and_images(
     return text_content, embedded_images
 
 
-def pptx_to_text(file: IO[Any]) -> str:
-    presentation = pptx.Presentation(file)
+def pptx_to_text(file: IO[Any], file_name: str = "") -> str:
+    try:
+        presentation = pptx.Presentation(file)
+    except BadZipFile as e:
+        error_str = f"Failed to extract text from {file_name or 'pptx file'}: {e}"
+        logger.warning(error_str)
+        return ""
     text_content = []
     for slide_number, slide in enumerate(presentation.slides, start=1):
         slide_text = f"\nSlide {slide_number}:\n"
@@ -344,8 +350,17 @@ def pptx_to_text(file: IO[Any]) -> str:
     return TEXT_SECTION_SEPARATOR.join(text_content)
 
 
-def xlsx_to_text(file: IO[Any]) -> str:
-    workbook = openpyxl.load_workbook(file, read_only=True)
+def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
+    try:
+        workbook = openpyxl.load_workbook(file, read_only=True)
+    except BadZipFile as e:
+        error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
+        if file_name.startswith("~"):
+            logger.debug(error_str + " (this is expected for files with ~)")
+        else:
+            logger.warning(error_str)
+        return ""
+
     text_content = []
     for sheet in workbook.worksheets:
         rows = []
@@ -510,7 +525,9 @@ def extract_text_and_images(
         if extension == ".xlsx":
             file.seek(0)
             return ExtractionResult(
-                text_content=xlsx_to_text(file), embedded_images=[], metadata={}
+                text_content=xlsx_to_text(file, file_name=file_name),
+                embedded_images=[],
+                metadata={},
             )
 
         if extension == ".eml":


### PR DESCRIPTION
## Description

https://linear.app/danswer/issue/DAN-1991/drive-pptx-and-xlsx-invalid-zipfile
There are cases where .xlsx and .pptx files are invalid because they are actually recovery files. We don't need the connector to fail in these cases. So, we add limited error catching that lets us skip these files.

## How Has This Been Tested?

n/a, should be strictly an improvement as it's just error handling

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
