### PR TITLE
Improve drive group sync

### DIFF
--- a/backend/alembic/versions/238b84885828_add_foreign_key_to_user__external_user_.py
+++ b/backend/alembic/versions/238b84885828_add_foreign_key_to_user__external_user_.py
@@ -1,0 +1,45 @@
+"""Add foreign key to user__external_user_group_id
+
+Revision ID: 238b84885828
+Revises: a7688ab35c45
+Create Date: 2025-05-19 17:15:33.424584
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "238b84885828"
+down_revision = "a7688ab35c45"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # First, clean up any entries that don't have a valid cc_pair_id
+    op.execute(
+        """
+        DELETE FROM user__external_user_group_id
+        WHERE cc_pair_id NOT IN (SELECT id FROM connector_credential_pair)
+        """
+    )
+
+    # Add foreign key constraint with cascade delete
+    op.create_foreign_key(
+        "fk_user__external_user_group_id_cc_pair_id",
+        "user__external_user_group_id",
+        "connector_credential_pair",
+        ["cc_pair_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    # Drop the foreign key constraint
+    op.drop_constraint(
+        "fk_user__external_user_group_id_cc_pair_id",
+        "user__external_user_group_id",
+        type_="foreignkey",
+    )

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -107,13 +107,8 @@ def _get_permissions_from_slim_doc(
         # We could fetch all ancestors of the file to get the list of folders that
         # might affect the permissions of the file, but this will get replaced with
         # an audit-log based approach in the future so not doing it now.
-        if (
-            permission.permission_details
-            and permission.permission_details.inherited_from
-        ):
-            folder_ids_to_inherit_permissions_from.add(
-                permission.permission_details.inherited_from
-            )
+        if permission.inherited_from:
+            folder_ids_to_inherit_permissions_from.add(permission.inherited_from)
 
         if permission.type == PermissionType.USER:
             if permission.email_address:

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -60,6 +60,8 @@ def _get_all_folders(
                 logger.debug(f"Folder {folder_id} has already been seen. Skipping.")
                 continue
 
+            seen_folder_ids.add(folder_id)
+
             # Check if the folder has permission IDs but no permissions
             permission_ids = folder.get("permissionIds", [])
             raw_permissions = folder.get("permissions", [])
@@ -75,7 +77,16 @@ def _get_all_folders(
                     for permission in raw_permissions
                 ]
 
+            # Don't include inherited permissions, those will be captured
+            # by the folder/shared drive itself
+            permissions = [
+                permission
+                for permission in permissions
+                if permission.inherited_from is None
+            ]
+
             if not permissions and skip_folders_without_permissions:
+                logger.debug(f"Folder {folder_id} has no permissions. Skipping.")
                 continue
 
             all_folders.append(
@@ -84,7 +95,6 @@ def _get_all_folders(
                     permissions=permissions,
                 )
             )
-            seen_folder_ids.add(folder_id)
 
     return all_folders
 

--- a/backend/ee/onyx/external_permissions/google_drive/models.py
+++ b/backend/ee/onyx/external_permissions/google_drive/models.py
@@ -57,3 +57,7 @@ class GoogleDrivePermission(BaseModel):
                 else None
             ),
         )
+
+    @property
+    def inherited_from(self) -> str | None:
+        return self.permission_details and self.permission_details.inherited_from

--- a/backend/ee/onyx/external_permissions/google_drive/models.py
+++ b/backend/ee/onyx/external_permissions/google_drive/models.py
@@ -37,7 +37,6 @@ class GoogleDrivePermission(BaseModel):
     ) -> "GoogleDrivePermission":
         # we seem to only get details for permissions that are inherited
         # we can get multiple details if a permission is inherited from multiple
-        # parents
         permission_details_list = drive_permission.get("permissionDetails", [])
         permission_details: dict[str, Any] | None = (
             permission_details_list[0] if permission_details_list else None
@@ -60,4 +59,6 @@ class GoogleDrivePermission(BaseModel):
 
     @property
     def inherited_from(self) -> str | None:
-        return self.permission_details and self.permission_details.inherited_from
+        if self.permission_details:
+            return self.permission_details.inherited_from
+        return None


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1992/reduce-of-folders-found-during-drive-group-sync

## How Has This Been Tested?

Tested with our drive locally, # of unique groups went from 469 -> 69.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
