### PR TITLE
full drive perm sync

### DIFF
--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -30,7 +30,7 @@ FILE_FIELDS = (
 )
 SLIM_FILE_FIELDS = (
     f"nextPageToken, files(mimeType, driveId, id, name, {PERMISSION_FULL_DESCRIPTION}, "
-    "permissionIds, webViewLink, owners(emailAddress))"
+    "permissionIds, webViewLink, owners(emailAddress), modifiedTime)"
 )
 FOLDER_FIELDS = "nextPageToken, files(id, name, permissions, modifiedTime, webViewLink, shortcutDetails)"
 

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -154,4 +154,21 @@ def test_gdrive_perm_sync_with_real_data(
                 f"but is accessible to {emails_with_access}. Raw result: {doc_to_raw_result_mapping[doc_id]} "
             )
 
+    # Verify that we checked every file in ACCESS_MAPPING
+    all_expected_files = set()
+    for file_ids in ACCESS_MAPPING.values():
+        all_expected_files.update(file_ids)
+
+    checked_file_ids = {
+        url_to_id_mapping[doc_id]
+        for doc_id in doc_to_email_mapping
+        if doc_id in url_to_id_mapping
+    }
+
+    assert all_expected_files == checked_file_ids, (
+        f"Not all expected files were checked. "
+        f"Missing files: {all_expected_files - checked_file_ids}, "
+        f"Extra files checked: {checked_file_ids - all_expected_files}"
+    )
+
     print(f"Checked permissions for {checked_files} files from drive_id_mapping.json")


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-1994/drive-perm-sync-cutoff
Due to some recent changes, drive perm sync wasn't pulling in permissions for all documents. This fixes that.

## How Has This Been Tested?

Fixed connector test to address the issue; test failed before PR and passes after

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
