### PR TITLE
fix: Fix chats dragging issue

### DIFF
--- a/web/src/app/chat/sessionSidebar/PagesTab.tsx
+++ b/web/src/app/chat/sessionSidebar/PagesTab.tsx
@@ -92,9 +92,8 @@ const SortableFolder: React.FC<SortableFolderProps> = (props) => {
       className="pr-3 ml-4 overflow-visible flex items-start"
       style={style}
       {...attributes}
-      {...listeners}
     >
-      <FolderDropdown ref={ref} {...props} />
+      <FolderDropdown {...listeners} ref={ref} {...props} />
     </div>
   );
 };


### PR DESCRIPTION
## Description

Dragging chats within chat-groups was not possible before because of DOM layering issues. The context for dragging chats would be completely overlaid by the context for dragging chat-groups. This PR fixes that layering issue.

Addresses: https://linear.app/danswer/issue/DAN-1877/chats-cannot-be-dragged-out-of-the-group-theyre-in.

## How Has This Been Tested?

Pure UI change; no tests were written.