### PR TITLE
Add proper support for nodeSelector, tolerations, and affinity in Helm templates

### DIFF
--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -52,3 +52,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_beat.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_beat.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_beat.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_heavy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_heavy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_heavy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-indexing.yaml
@@ -59,3 +59,15 @@ spec:
             - name: ENABLE_MULTIPASS_INDEXING
               value: "{{ .Values.celery_worker_indexing.enableMiniChunk }}"
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_indexing.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_indexing.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_indexing.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_light.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_light.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_light.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_monitoring.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_monitoring.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_monitoring.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_primary.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_primary.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_primary.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -57,3 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
+      {{- with .Values.celery_worker_user-files-indexing.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_user-files-indexing.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.celery_worker_user-files-indexing.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -57,15 +57,15 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-      {{- with .Values.celery_worker_user-files-indexing.nodeSelector }}
+      {{- with .Values.celery_worker_user_files_indexing.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.celery_worker_user-files-indexing.affinity }}
+      {{- with .Values.celery_worker_user_files_indexing.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.celery_worker_user-files-indexing.tolerations }}
+      {{- with .Values.celery_worker_user_files_indexing.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -51,3 +51,15 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .persistentVolumeClaim.claimName }}
       {{- end }}
+      {{- with .Values.indexCapability.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexCapability.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.indexCapability.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -45,3 +45,15 @@ spec:
         persistentVolumeClaim:
           claimName: {{ .persistentVolumeClaim.claimName }}
       {{- end }}
+      {{- with .Values.inferenceCapability.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.inferenceCapability.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.inferenceCapability.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -58,3 +58,15 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.webserver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webserver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webserver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
## Description

This PR adds proper support for specifying \, \, and \ settings for all Onyx components through the values.yaml file. This allows users to control where Onyx components are scheduled, which is essential for production deployments with different node types and workload separation strategies.

## Changes

- Added \, \, and \ sections to the following templates:
  - webserver-deployment.yaml
  - api-deployment.yaml
  - celery-beat.yaml
  - celery-worker-heavy.yaml
  - celery-worker-indexing.yaml
  - celery-worker-light.yaml
  - celery-worker-monitoring.yaml
  - celery-worker-primary.yaml
  - celery-worker-user-files-indexing.yaml
  - indexing-model-deployment.yaml
  - inference-model-deployment.yaml

- These settings can now be specified in values.yaml like this:
  

## Testing

Tested in a production environment with nodes that have taints. The changes successfully allow scheduling Onyx components on the appropriate nodes.

Note: This PR supersedes #4754 with improved code placement.

## Related Issues

Fixes #4753 - Add support for nodeSelector, tolerations, and affinity in Onyx Helm charts