### PR TITLE
v1 refresh drive creds during perm sync

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
+++ b/backend/ee/onyx/external_permissions/google_drive/permission_retrieval.py
@@ -1,14 +1,13 @@
-from googleapiclient.discovery import Resource  # type: ignore
-
 from ee.onyx.external_permissions.google_drive.models import GoogleDrivePermission
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
+from onyx.connectors.google_utils.resources import RefreshableDriveObject
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
 def get_permissions_by_ids(
-    drive_service: Resource,
+    drive_service: RefreshableDriveObject,
     doc_id: str,
     permission_ids: list[str],
 ) -> list[GoogleDrivePermission]:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -220,6 +220,7 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
         self._primary_admin_email: str | None = None
 
         self._creds: OAuthCredentials | ServiceAccountCredentials | None = None
+        self._creds_dict: dict[str, Any] | None = None
 
         # ids of folders and shared drives that have been traversed
         self._retrieved_folder_and_drive_ids: set[str] = set()
@@ -272,6 +273,8 @@ class GoogleDriveConnector(SlimConnector, CheckpointedConnector[GoogleDriveCheck
             credentials=credentials,
             source=DocumentSource.GOOGLE_DRIVE,
         )
+
+        self._creds_dict = new_creds_dict
 
         return new_creds_dict
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2012/refresh-drive-creds-during-perm-sync
When drive perm sync runs for a while, we sometimes get the following difficult-to-explain exception:
```
google.auth.exceptions.RefreshError: ('unauthorized_client: Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested.', {'error': 'unauthorized_client', 'error_description': 'Client is unauthorized to retrieve access tokens using this method, or client not authorized for any of the scopes requested.'})
```

This can happen several hours into permission syncing despite the fact that drive tokens auto-refresh roughly every hour. So, presumably 1 or 2 refreshes succeed, then one fails. 

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
