### PR TITLE
fix: Create new grouping for CRM connectors

### DIFF
--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -154,6 +154,8 @@ function getCategoryDescription(category: SourceCategory): string {
       return "Link to project management and task tracking tools.";
     case SourceCategory.CustomerSupport:
       return "Connect to customer support and helpdesk systems.";
+    case SourceCategory.CustomerRelationshipManagement:
+      return "Integrate with customer relationship management platforms.";
     case SourceCategory.CodeRepository:
       return "Integrate with code repositories and version control systems.";
     case SourceCategory.Storage:

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -18,13 +18,13 @@ function SourceTile({
 }) {
   return (
     <Link
-      className={`flex 
-        flex-col 
-        items-center 
-        justify-center 
-        p-4 
-        rounded-lg 
-        w-40 
+      className={`flex
+        flex-col
+        items-center
+        justify-center
+        p-4
+        rounded-lg
+        w-40
         cursor-pointer
         shadow-md
         hover:bg-accent-background-hovered

--- a/web/src/lib/search/interfaces.ts
+++ b/web/src/lib/search/interfaces.ts
@@ -165,6 +165,7 @@ export enum SourceCategory {
   Storage = "Storage",
   Wiki = "Wiki",
   CustomerSupport = "Customer Support",
+  CustomerRelationshipManagement = "Customer Relationship Management",
   Messaging = "Messaging",
   ProjectManagement = "Project Management",
   CodeRepository = "Code Repository",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -175,7 +175,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
   hubspot: {
     icon: HubSpotIcon,
     displayName: "HubSpot",
-    category: SourceCategory.CustomerSupport,
+    category: SourceCategory.CustomerRelationshipManagement,
     docs: "https://docs.onyx.app/connectors/hubspot",
   },
   document360: {
@@ -210,7 +210,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
   salesforce: {
     icon: SalesforceIcon,
     displayName: "Salesforce",
-    category: SourceCategory.CustomerSupport,
+    category: SourceCategory.CustomerRelationshipManagement,
     docs: "https://docs.onyx.app/connectors/salesforce",
   },
   sharepoint: {

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -368,7 +368,7 @@ export function getSourceMetadata(sourceType: ValidSources): SourceMetadata {
 }
 
 export function listSourceMetadata(): SourceMetadata[] {
-  /* This gives back all the viewable / common sources, primarily for 
+  /* This gives back all the viewable / common sources, primarily for
   display in the Add Connector page */
   const entries = Object.entries(SOURCE_METADATA_MAP)
     .filter(


### PR DESCRIPTION
## Description

Salesforce and Hubspot were classified as "Customer Support" tools, which they are not. This PR creates a new grouping for specifically those two connectors called "Customer Relationship Management".

## How Has This Been Tested?

Simple UI change; no tests written.