### PR TITLE
fix(discourse-connector): handle redirect issue 

### DIFF
--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -60,7 +60,7 @@ class DiscourseConnector(PollConnector):
         self.base_url = base_url
 
         self.categories = [c.lower() for c in categories] if categories else []
-        self.category_id_map: dict[int, str] = {}
+        self.category_id_map: dict[int, dict] = {}
 
         self.batch_size = batch_size
         self.permissions: DiscoursePerms | None = None
@@ -83,7 +83,7 @@ class DiscourseConnector(PollConnector):
         )
         categories = response.json()["category_list"]["categories"]
         self.category_id_map = {
-            cat["id"]: cat["name"]
+            cat["id"]: {"name": cat["name"], "slug": cat["slug"]}
             for cat in categories
             if not self.categories or cat["name"].lower() in self.categories
         }
@@ -116,7 +116,7 @@ class DiscourseConnector(PollConnector):
             sections.append(
                 TextSection(link=topic_url, text=parse_html_page_basic(post["cooked"]))
             )
-        category_name = self.category_id_map.get(topic["category_id"])
+        category_name = self.category_id_map.get(topic["category_id"], {}).get("name")
 
         metadata: dict[str, str | list[str]] = (
             {
@@ -158,9 +158,10 @@ class DiscourseConnector(PollConnector):
             topics = []
             empty_categories = []
 
-            for category_id in self.category_id_map.keys():
+            for category_id, category_dict in self.category_id_map.items():
                 category_endpoint = urllib.parse.urljoin(
-                    self.base_url, f"c/{category_id}.json?page={page}&sys=latest"
+                    self.base_url,
+                    f"c/{category_dict['slug']}/{category_id}.json?page={page}&sys=latest",
                 )
                 response = self._make_request(endpoint=category_endpoint)
                 new_topics = response.json()["topic_list"]["topics"]


### PR DESCRIPTION

## Description

When accessing a Discourse category via `<baseUrl>/c/<categoryId>.json?page={pageNumber}&sys=latest`, Discourse issues a redirect to `<baseUrl>/c/<categorySlug>/<categoryId>.json?....`. During this redirect, any numeric occurrence matching the `categoryId` in the query string is also rewritten - including the page parameter - causing incorrect behavior (e.g., `page=5` becoming `page=community/5`).

This PR updates the connector logic to use the correct category url to avoid the redirection ensuring that the query parameters remain intact.

## How to reproduce?

Try opening this link https://meta.discourse.org/c/10.json?page=10&sys=latest in the browser.  It will throw a 400 Bad Request error. When we inspect the url, we will notice the page number has been replaced by the `slug/categoryId`.

## How Has This Been Tested?

The issue was found when I was trying to sync my own discourse setup. I tested the changes by building the `background` service locally and running the sync.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
