### PR TITLE
New metadata for Jira for KG

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -88,10 +88,7 @@ class BasicExpertInfo(BaseModel):
         return "Unknown"
 
     def get_email(self) -> str | None:
-        if self.email:
-            return self.email
-
-        return None
+        return self.email or None
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BasicExpertInfo):

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -87,6 +87,12 @@ class BasicExpertInfo(BaseModel):
 
         return "Unknown"
 
+    def get_email(self) -> str | None:
+        if self.email:
+            return self.email
+
+        return None
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BasicExpertInfo):
             return False

--- a/backend/onyx/connectors/onyx_jira/connector.py
+++ b/backend/onyx/connectors/onyx_jira/connector.py
@@ -55,6 +55,14 @@ _FIELD_KEY = "key"
 _FIELD_CREATED = "created"
 _FIELD_DUEDATE = "duedate"
 _FIELD_ISSUETYPE = "issuetype"
+_FIELD_PARENT = "parent"
+_FIELD_ASSIGNEE_EMAIL = "assignee_email"
+_FIELD_CREATOR_EMAIL = "reporter_email"
+_FIELD_PROJECT = "project"
+_FIELD_PROJECT_NAME = "project_name"
+_FIELD_UPDATED = "updated"
+_FIELD_RESOLUTION_DATE = "resolutiondate"
+_FIELD_RESOLUTION_DATE_NAME = "resolution_date"
 
 
 def _perform_jql_search(
@@ -126,6 +134,8 @@ def process_jira_issue(
         if basic_expert_info := best_effort_basic_expert_info(creator):
             people.add(basic_expert_info)
             metadata_dict[_FIELD_REPORTER] = basic_expert_info.get_semantic_name()
+            metadata_dict[_FIELD_CREATOR_EMAIL] = basic_expert_info.get_email()
+
     except Exception:
         # Author should exist but if not, doesn't matter
         pass
@@ -135,6 +145,7 @@ def process_jira_issue(
         if basic_expert_info := best_effort_basic_expert_info(assignee):
             people.add(basic_expert_info)
             metadata_dict[_FIELD_ASSIGNEE] = basic_expert_info.get_semantic_name()
+            metadata_dict[_FIELD_ASSIGNEE_EMAIL] = basic_expert_info.get_email()
     except Exception:
         # Author should exist but if not, doesn't matter
         pass
@@ -149,10 +160,31 @@ def process_jira_issue(
         metadata_dict[_FIELD_LABELS] = labels
     if created := best_effort_get_field_from_issue(issue, _FIELD_CREATED):
         metadata_dict[_FIELD_CREATED] = created
+    if updated := best_effort_get_field_from_issue(issue, _FIELD_UPDATED):
+        metadata_dict[_FIELD_UPDATED] = updated
     if duedate := best_effort_get_field_from_issue(issue, _FIELD_DUEDATE):
         metadata_dict[_FIELD_DUEDATE] = duedate
     if issuetype := best_effort_get_field_from_issue(issue, _FIELD_ISSUETYPE):
         metadata_dict[_FIELD_ISSUETYPE] = issuetype.name
+    if resolutiondate := best_effort_get_field_from_issue(
+        issue, _FIELD_RESOLUTION_DATE
+    ):
+        metadata_dict[_FIELD_RESOLUTION_DATE_NAME] = resolutiondate
+
+    try:
+        parent = best_effort_get_field_from_issue(issue, _FIELD_PARENT)
+        if parent:
+            metadata_dict[_FIELD_PARENT] = parent.key
+    except Exception:
+        # Parent should exist but if not, doesn't matter
+        pass
+    try:
+        project = best_effort_get_field_from_issue(issue, _FIELD_PROJECT)
+        if project:
+            metadata_dict[_FIELD_PROJECT_NAME] = project.name
+    except Exception:
+        # Project should exist but if not, doesn't matter
+        pass
 
     return Document(
         id=page_url,

--- a/backend/tests/daily/connectors/jira/test_jira_basic.py
+++ b/backend/tests/daily/connectors/jira/test_jira_basic.py
@@ -59,11 +59,19 @@ def test_jira_connector_basic(
     assert story.source == DocumentSource.JIRA
     assert story.metadata == {
         "priority": "Medium",
-        "status": "Backlog",
+        "status": "Done",
+        "resolution": "Done",
+        "resolution_date": "2025-05-29T15:33:31.031-0700",
         "reporter": "Chris Weaver",
         "assignee": "Chris Weaver",
         "issuetype": "Story",
         "created": "2025-04-16T16:44:06.716-0700",
+        "reporter_email": "chris@onyx.app",
+        "assignee_email": "chris@onyx.app",
+        "project_name": "DailyConnectorTestProject",
+        "project": "AS",
+        "parent": "AS-4",
+        "updated": "2025-05-29T15:33:31.085-0700",
     }
     assert story.secondary_owners is None
     assert story.title == "AS-3 test123small"
@@ -86,6 +94,11 @@ def test_jira_connector_basic(
         "assignee": "Chris Weaver",
         "issuetype": "Epic",
         "created": "2025-04-16T16:55:53.068-0700",
+        "reporter_email": "founders@onyx.app",
+        "assignee_email": "chris@onyx.app",
+        "project_name": "DailyConnectorTestProject",
+        "project": "AS",
+        "updated": "2025-05-29T14:43:05.312-0700",
     }
     assert epic.secondary_owners is None
     assert epic.title == "AS-4 EPIC"


### PR DESCRIPTION
## Description

Added new metadata components for - in particular but not only - Knowledge Graph functinality.

Here is the ticket:

https://linear.app/danswer/issue/DAN-2015/augment-jira-connector-for-kg-usage

Here are the new fields:

parent (parent.key)
assignee_email	
creator_email	
updated	
resolution_date	 

## How Has This Been Tested?

Locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
