### PR TITLE
skip excel files that openpyxl fails on

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -360,6 +360,13 @@ def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
         else:
             logger.warning(error_str)
         return ""
+    except Exception as e:
+        if "File contains no valid workbook part" in str(e):
+            logger.error(
+                f"Failed to extract text from {file_name or 'xlsx file'}. This happens due to a bug in openpyxl. {e}"
+            )
+            return ""
+        raise e
 
     text_content = []
     for sheet in workbook.worksheets:


### PR DESCRIPTION
## Description

Address this issue in openpyxl: https://github.com/wireservice/csvkit/issues/834

## How Has This Been Tested?

n/a, just error handling

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
