### PR TITLE
Simplify passing in of file IDs for filtering

### DIFF
--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -111,11 +111,14 @@ class BaseFilters(BaseModel):
     document_set: list[str] | None = None
     time_cutoff: datetime | None = None
     tags: list[Tag] | None = None
+
+
+class UserFileFilters(BaseModel):
     user_file_ids: list[int] | None = None
     user_folder_ids: list[int] | None = None
 
 
-class IndexFilters(BaseFilters):
+class IndexFilters(BaseFilters, UserFileFilters):
     access_control_list: list[str] | None
     tenant_id: str | None = None
 
@@ -150,6 +153,7 @@ class SearchRequest(ChunkContext):
     search_type: SearchType = SearchType.SEMANTIC
 
     human_selected_filters: BaseFilters | None = None
+    user_file_filters: UserFileFilters | None = None
     enable_auto_detect_filters: bool | None = None
     persona: Persona | None = None
 

--- a/backend/onyx/context/search/preprocessing/preprocessing.py
+++ b/backend/onyx/context/search/preprocessing/preprocessing.py
@@ -164,13 +164,12 @@ def retrieval_preprocessing(
     user_acl_filters = (
         None if bypass_acl else build_access_filters_for_user(user, db_session)
     )
-    user_file_ids = preset_filters.user_file_ids or []
-    user_folder_ids = preset_filters.user_folder_ids or []
+    user_file_filters = search_request.user_file_filters
+    user_file_ids = user_file_filters.user_file_ids if user_file_filters else []
+    user_folder_ids = user_file_filters.user_folder_ids if user_file_filters else []
     if persona and persona.user_files:
         user_file_ids = user_file_ids + [
-            file.id
-            for file in persona.user_files
-            if file.id not in (preset_filters.user_file_ids or [])
+            file.id for file in persona.user_files if file.id not in user_file_ids
         ]
 
     final_filters = IndexFilters(

--- a/backend/onyx/context/search/preprocessing/preprocessing.py
+++ b/backend/onyx/context/search/preprocessing/preprocessing.py
@@ -165,12 +165,14 @@ def retrieval_preprocessing(
         None if bypass_acl else build_access_filters_for_user(user, db_session)
     )
     user_file_filters = search_request.user_file_filters
-    user_file_ids = user_file_filters.user_file_ids if user_file_filters else []
-    user_folder_ids = user_file_filters.user_folder_ids if user_file_filters else []
+    user_file_ids = (user_file_filters.user_file_ids or []) if user_file_filters else []
+    user_folder_ids = (
+        (user_file_filters.user_folder_ids or []) if user_file_filters else []
+    )
     if persona and persona.user_files:
-        user_file_ids = user_file_ids + [
-            file.id for file in persona.user_files if file.id not in user_file_ids
-        ]
+        user_file_ids = list(
+            set(user_file_ids) | set([file.id for file in persona.user_files])
+        )
 
     final_filters = IndexFilters(
         user_file_ids=user_file_ids,

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -326,8 +326,9 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
 
         retrieval_options = self.retrieval_options or RetrievalDetails()
         if document_sources or time_cutoff:
-            # Get retrieval_options and filters, or create if they don't exist
-            retrieval_options.filters = retrieval_options.filters or BaseFilters()
+            # if empty, just start with an empty filters object
+            if not retrieval_options.filters:
+                retrieval_options.filters = BaseFilters()
 
             # Handle document sources
             if document_sources:
@@ -348,7 +349,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                     LLMEvaluationType.SKIP if force_no_rerank else self.evaluation_type
                 ),
                 human_selected_filters=(
-                    retrieval_options.filters if self.retrieval_options else None
+                    retrieval_options.filters if retrieval_options else None
                 ),
                 user_file_filters=UserFileFilters(
                     user_file_ids=user_file_ids, user_folder_ids=user_folder_ids

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import time
 from collections.abc import Callable
@@ -32,6 +31,7 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.models import RetrievalDetails
 from onyx.context.search.models import SearchRequest
+from onyx.context.search.models import UserFileFilters
 from onyx.context.search.pipeline import SearchPipeline
 from onyx.context.search.pipeline import section_relevance_list_impl
 from onyx.db.models import Persona
@@ -324,29 +324,9 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             yield from self._build_response_for_specified_sections(query)
             return
 
-        # Create a copy of the retrieval options with user_file_ids if provided
-        retrieval_options = copy.deepcopy(self.retrieval_options)
-        if (user_file_ids or user_folder_ids) and retrieval_options:
-            # Create a copy to avoid modifying the original
-            filters = (
-                retrieval_options.filters.model_copy()
-                if retrieval_options.filters
-                else BaseFilters()
-            )
-            filters.user_file_ids = user_file_ids
-            retrieval_options = retrieval_options.model_copy(
-                update={"filters": filters}
-            )
-        elif user_file_ids or user_folder_ids:
-            # Create new retrieval options with user_file_ids
-            filters = BaseFilters(
-                user_file_ids=user_file_ids, user_folder_ids=user_folder_ids
-            )
-            retrieval_options = RetrievalDetails(filters=filters)
-
+        retrieval_options = self.retrieval_options or RetrievalDetails()
         if document_sources or time_cutoff:
             # Get retrieval_options and filters, or create if they don't exist
-            retrieval_options = retrieval_options or RetrievalDetails()
             retrieval_options.filters = retrieval_options.filters or BaseFilters()
 
             # Handle document sources
@@ -368,7 +348,10 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                     LLMEvaluationType.SKIP if force_no_rerank else self.evaluation_type
                 ),
                 human_selected_filters=(
-                    retrieval_options.filters if retrieval_options else None
+                    retrieval_options.filters if self.retrieval_options else None
+                ),
+                user_file_filters=UserFileFilters(
+                    user_file_ids=user_file_ids, user_folder_ids=user_folder_ids
                 ),
                 persona=self.persona,
                 offset=(retrieval_options.offset if retrieval_options else None),

--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -1451,9 +1451,7 @@ export function ChatPage({
           filterManager.selectedSources,
           filterManager.selectedDocumentSets,
           filterManager.timeRange,
-          filterManager.selectedTags,
-          selectedFiles.map((file) => file.id)
-          // selectedFolders.map((folder) => folder.id)
+          filterManager.selectedTags
         ),
         selectedDocumentIds: selectedDocuments
           .filter(


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2016/dalberg-no-results-found

## How Has This Been Tested?

Tested running a search with a document selected locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
