### PR TITLE
Implement Kroki Diagram Rendering

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -638,6 +638,11 @@ except json.JSONDecodeError:
 # LLM Model Update API endpoint
 LLM_MODEL_UPDATE_API_URL = os.environ.get("LLM_MODEL_UPDATE_API_URL")
 
+# Kroki service URL for diagram rendering
+# If KROKI_URL is not set, it defaults to None, and KROKI_ENABLED will be False.
+KROKI_URL = os.environ.get("KROKI_URL")
+KROKI_ENABLED = KROKI_URL is not None  # True if KROKI_URL is set, False otherwise
+
 #####
 # Enterprise Edition Configs
 #####

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -70,6 +70,7 @@ from onyx.server.features.persona.api import basic_router as persona_router
 from onyx.server.features.tool.api import admin_router as admin_tool_router
 from onyx.server.features.tool.api import router as tool_router
 from onyx.server.gpts.api import router as gpts_router
+from onyx.server.kroki.api import kroki_router
 from onyx.server.long_term_logs.long_term_logs_api import (
     router as long_term_logs_router,
 )
@@ -343,6 +344,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, long_term_logs_router)
     include_router_with_global_prefix_prepended(application, api_key_router)
     include_router_with_global_prefix_prepended(application, standard_oauth_router)
+    include_router_with_global_prefix_prepended(application, kroki_router())
 
     if AUTH_TYPE == AuthType.DISABLED:
         # Server logs this during auth setup verification step

--- a/backend/onyx/server/kroki/api.py
+++ b/backend/onyx/server/kroki/api.py
@@ -1,0 +1,144 @@
+import hashlib
+import logging
+from functools import lru_cache
+from typing import Dict, Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, Depends
+from pydantic import BaseModel
+
+from onyx.auth.users import current_user
+from onyx.configs.app_configs import KROKI_ENABLED
+from onyx.configs.app_configs import KROKI_URL
+from onyx.server.models import StatusResponse
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/kroki", dependencies=[Depends(current_user)])
+
+
+class DiagramRequest(BaseModel):
+    content: str
+
+
+class DiagramResponse(BaseModel):
+    svg: str
+
+
+class DiagramErrorResponse(BaseModel):
+    error: str
+    error_type: str
+
+
+# Supported diagram types by Kroki
+SUPPORTED_DIAGRAM_TYPES = {
+    "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
+    "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite", 
+    "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
+    "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet", 
+    "wireviz", "symbolator"
+}
+
+
+@lru_cache(maxsize=128)
+def _cached_kroki_request(diagram_type: str, content_hash: str, content: str) -> Dict[str, Any]:
+    """
+    Cached function to make requests to Kroki service.
+    Uses content hash as part of cache key to ensure same content returns cached result.
+    """
+    if not KROKI_URL:
+        raise HTTPException(status_code=503, detail="Kroki service not configured")
+    
+    try:
+        # Make request to Kroki service
+        with httpx.Client(timeout=30.0) as client:
+            response = client.post(
+                f"{KROKI_URL}/{diagram_type}/svg",
+                content=content,
+                headers={"Content-Type": "text/plain"}
+            )
+            
+            if response.status_code == 200:
+                return {"svg": response.text}
+            elif response.status_code == 400:
+                # Syntax error in diagram
+                error_msg = response.text or "Invalid diagram syntax"
+                return {"error": error_msg, "error_type": "syntax"}
+            else:
+                # Service error
+                logger.warning(f"Kroki service returned status {response.status_code}: {response.text}")
+                return {"error": "Diagram rendering failed", "error_type": "service"}
+                
+    except httpx.TimeoutException:
+        logger.warning(f"Timeout when calling Kroki service for {diagram_type}")
+        return {"error": "Diagram rendering timeout", "error_type": "service"}
+    except Exception as e:
+        logger.error(f"Error calling Kroki service for {diagram_type}: {str(e)}")
+        return {"error": "Diagram rendering failed", "error_type": "service"}
+
+
+@router.head("/health")
+def kroki_health_check() -> StatusResponse:
+    """
+    Health check endpoint to verify if Kroki functionality is available.
+    Used by frontend to detect feature availability.
+    """
+    if not KROKI_ENABLED:
+        raise HTTPException(status_code=404, detail="Kroki service not enabled")
+    
+    return StatusResponse(success=True, message="Kroki service available")
+
+
+@router.post("/{diagram_type}")
+def render_diagram(
+    diagram_type: str,
+    request: DiagramRequest
+) -> Dict[str, Any]:
+    """
+    Proxy endpoint to render diagrams via Kroki service.
+    
+    Args:
+        diagram_type: Type of diagram (mermaid, plantuml, etc.)
+        request: Request containing diagram content
+        
+    Returns:
+        Either SVG content or error information
+    """
+    if not KROKI_ENABLED:
+        raise HTTPException(status_code=404, detail="Kroki service not enabled")
+    
+    if diagram_type not in SUPPORTED_DIAGRAM_TYPES:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Unsupported diagram type: {diagram_type}. Supported types: {', '.join(sorted(SUPPORTED_DIAGRAM_TYPES))}"
+        )
+    
+    if not request.content.strip():
+        raise HTTPException(status_code=400, detail="Diagram content cannot be empty")
+    
+    # Create content hash for caching
+    content_hash = hashlib.md5(request.content.encode()).hexdigest()
+    
+    try:
+        result = _cached_kroki_request(diagram_type, content_hash, request.content)
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in render_diagram: {str(e)}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# Only register routes if Kroki is enabled
+def kroki_router() -> APIRouter:
+    """
+    Returns the Kroki router only if the feature is enabled.
+    If disabled, returns an empty router.
+    """
+    if KROKI_ENABLED:
+        logger.info(f"Kroki service enabled with URL: {KROKI_URL}")
+        return router
+    else:
+        logger.info("Kroki service disabled - KROKI_URL not configured")
+        return APIRouter()  # Empty router when disabled

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -4,6 +4,7 @@ from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.app_configs import KROKI_ENABLED
 from onyx.server.manage.models import AuthTypeResponse
 from onyx.server.manage.models import VersionResponse
 from onyx.server.models import StatusResponse
@@ -22,6 +23,7 @@ def get_auth_type() -> AuthTypeResponse:
         auth_type=AUTH_TYPE,
         requires_verification=user_needs_to_be_verified(),
         anonymous_user_enabled=anonymous_user_enabled(),
+        kroki_enabled=KROKI_ENABLED,
     )
 
 

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -42,6 +42,7 @@ class AuthTypeResponse(BaseModel):
     # users to have verified emails
     requires_verification: bool
     anonymous_user_enabled: bool | None = None
+    kroki_enabled: bool = False
 
 
 class UserPreferences(BaseModel):

--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -1,12 +1,28 @@
-import React, { useState, ReactNode, useCallback, useMemo, memo } from "react";
+import React, { useState, ReactNode, useCallback, useMemo, memo, useEffect } from "react"; // Added useEffect
 import { FiCheck, FiCopy } from "react-icons/fi";
+import KrokiDiagram from "@/components/chat/KrokiDiagram";
 
 const CODE_BLOCK_PADDING = { padding: "1rem" };
+
+// Added: List of supported diagram types by Kroki
+// This should ideally be kept in sync with the backend or a shared constants file
+const SUPPORTED_KROKI_LANGUAGES = new Set([
+  "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
+  "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite",
+  "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
+  "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet",
+  "wireviz", "symbolator"
+]);
+
+// Module-level flag to track if Kroki feature is confirmed disabled for the session
+let isKrokiFeatureConfirmedDisabled = false;
+
 
 interface CodeBlockProps {
   className?: string;
   children?: ReactNode;
   codeText: string;
+  isFallback?: boolean; // Added prop to prevent recursion
 }
 
 const MemoizedCodeLine = memo(({ content }: { content: ReactNode }) => (
@@ -17,8 +33,19 @@ export const CodeBlock = memo(function CodeBlock({
   className = "",
   children,
   codeText,
+  isFallback = false, // Default to false
 }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
+  // Local state to force re-render if isKrokiFeatureConfirmedDisabled changes
+  const [krokiDisabledSignal, setKrokiDisabledSignal] = useState(isKrokiFeatureConfirmedDisabled);
+
+  useEffect(() => {
+    // This effect ensures that if the global flag changes, this component instance re-evaluates
+    if (isKrokiFeatureConfirmedDisabled !== krokiDisabledSignal) {
+      setKrokiDisabledSignal(isKrokiFeatureConfirmedDisabled);
+    }
+  }, [krokiDisabledSignal]);
+
 
   const language = useMemo(() => {
     return className
@@ -80,8 +107,35 @@ export const CodeBlock = memo(function CodeBlock({
     );
   }
 
+  // If Kroki is not confirmed disabled, language is supported,
+  // it's a fenced code block, codeText is not empty, AND it's not already a fallback.
+  if (
+    !isFallback && // Check if this CodeBlock instance is NOT a fallback
+    !isKrokiFeatureConfirmedDisabled &&
+    language &&
+    SUPPORTED_KROKI_LANGUAGES.has(language) &&
+    typeof children !== "string" && 
+    codeText.trim() !== ""
+  ) {
+    return (
+      <KrokiDiagram
+        diagramType={language}
+        codeText={codeText}
+        onFeatureDisabled={() => {
+          if (!isKrokiFeatureConfirmedDisabled) {
+            isKrokiFeatureConfirmedDisabled = true;
+            setKrokiDisabledSignal(true); // Trigger re-render for other instances
+          }
+        }}
+      />
+    );
+  }
+
+  // Original CodeContent rendering logic for standard code blocks or when Kroki is not applicable
   const CodeContent = () => {
     if (!language) {
+      // This typically handles cases where it might be a simple preformatted block
+      // without a language, or if the language wasn't parsed correctly.
       return (
         <pre style={CODE_BLOCK_PADDING}>
           <code className={`text-sm ${className}`}>
@@ -95,6 +149,7 @@ export const CodeBlock = memo(function CodeBlock({
       );
     }
 
+    // Standard fenced code block rendering
     return (
       <pre className="overflow-x-scroll" style={CODE_BLOCK_PADDING}>
         <code className="text-xs overflow-x-auto">
@@ -108,10 +163,11 @@ export const CodeBlock = memo(function CodeBlock({
     );
   };
 
+  // Original return structure for non-Kroki code blocks
   return (
     <div className="overflow-x-hidden">
-      {language && (
-        <div className="flex mx-3 py-2 text-xs">
+      {language && typeof children !== "string" && ( // Only show header for fenced code blocks
+        <div className="flex mx-3 py-2 text-xs"> 
           {language}
           {codeText && <CopyButton />}
         </div>

--- a/web/src/app/chat/message/CodeBlock.tsx
+++ b/web/src/app/chat/message/CodeBlock.tsx
@@ -1,18 +1,9 @@
 import React, { useState, ReactNode, useCallback, useMemo, memo, useEffect } from "react"; // Added useEffect
 import { FiCheck, FiCopy } from "react-icons/fi";
 import KrokiDiagram from "@/components/chat/KrokiDiagram";
+import { KROKI_SUPPORTED_LANGUAGES } from "@/lib/kroki_constants";
 
 const CODE_BLOCK_PADDING = { padding: "1rem" };
-
-// Added: List of supported diagram types by Kroki
-// This should ideally be kept in sync with the backend or a shared constants file
-const SUPPORTED_KROKI_LANGUAGES = new Set([
-  "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
-  "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite",
-  "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
-  "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet",
-  "wireviz", "symbolator"
-]);
 
 // Module-level flag to track if Kroki feature is confirmed disabled for the session
 let isKrokiFeatureConfirmedDisabled = false;
@@ -113,7 +104,7 @@ export const CodeBlock = memo(function CodeBlock({
     !isFallback && // Check if this CodeBlock instance is NOT a fallback
     !isKrokiFeatureConfirmedDisabled &&
     language &&
-    SUPPORTED_KROKI_LANGUAGES.has(language) &&
+    KROKI_SUPPORTED_LANGUAGES.has(language) &&
     typeof children !== "string" && 
     codeText.trim() !== ""
   ) {

--- a/web/src/components/chat/KrokiDiagram.tsx
+++ b/web/src/components/chat/KrokiDiagram.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogClose,
 } from "@/components/ui/dialog"; // For fullscreen modal
+import { KROKI_SUPPORTED_LANGUAGES } from "@/lib/kroki_constants";
 
 
 interface KrokiDiagramProps {
@@ -18,14 +19,6 @@ interface KrokiDiagramProps {
   codeText: string;
   onFeatureDisabled: () => void; // Added callback prop
 }
-
-const SUPPORTED_DIAGRAM_TYPES = [
-  "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
-  "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite",
-  "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
-  "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet",
-  "wireviz", "symbolator"
-];
 
 const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFeatureDisabled }) => {
   const [svgContent, setSvgContent] = useState<string | null>(null);
@@ -140,7 +133,7 @@ const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFe
 
 
   useEffect(() => {
-    if (!SUPPORTED_DIAGRAM_TYPES.includes(diagramType)) {
+    if (!KROKI_SUPPORTED_LANGUAGES.has(diagramType)) {
       setError(`Unsupported diagram type: ${diagramType}`);
       setIsLoading(false);
       return;

--- a/web/src/components/chat/KrokiDiagram.tsx
+++ b/web/src/components/chat/KrokiDiagram.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { AlertTriangle, Loader2, Download, Copy, Maximize2, Code as CodeIcon } from 'lucide-react';
+import { Button } from "@/components/ui/button";
+import { CodeBlock } from "@/app/chat/message/CodeBlock"; // Import CodeBlock
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog"; // For fullscreen modal
+
+
+interface KrokiDiagramProps {
+  diagramType: string;
+  codeText: string;
+  onFeatureDisabled: () => void; // Added callback prop
+}
+
+const SUPPORTED_DIAGRAM_TYPES = [
+  "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
+  "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite",
+  "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
+  "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet",
+  "wireviz", "symbolator"
+];
+
+const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFeatureDisabled }) => {
+  const [svgContent, setSvgContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null); // Will store the error message
+  const [renderFallbackAsCodeBlock, setRenderFallbackAsCodeBlock] = useState(false); // New state for fallback
+  const [isLoading, setIsLoading] = useState(true);
+  const [showRawCode, setShowRawCode] = useState(false);
+  const [showFullscreenModal, setShowFullscreenModal] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [currentAppTheme, setCurrentAppTheme] = useState<'light' | 'dark'>(() => 
+    typeof window !== 'undefined' && document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+  );
+
+  // Effect to listen for theme changes on the HTML element
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+          const newTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+          setCurrentAppTheme(newTheme);
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, { attributes: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+
+  const handleDownloadSvg = useCallback(() => {
+    if (!svgContent) return;
+    const blob = new Blob([svgContent], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${diagramType}-diagram.svg`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [svgContent, diagramType]);
+
+  const handleToggleRawCode = () => {
+    setShowRawCode(prev => !prev);
+  };
+
+  const handleCopyAsImage = useCallback(async () => {
+    if (!svgContent) return;
+    setCopyStatus("Copying...");
+    try {
+      // Attempt to remove foreignObject elements to prevent canvas tainting
+      // This may affect diagrams that use HTML for text rendering (e.g., some Mermaid charts)
+      const cleanedSvgContent = svgContent.replace(/<foreignObject[\s\S]*?<\/foreignObject>/g, '');
+
+      // 1. Create an image element
+      const img = new Image();
+      img.crossOrigin = "anonymous"; 
+      const svgBlob = new Blob([cleanedSvgContent], { type: 'image/svg+xml;charset=utf-8' });
+      const url = URL.createObjectURL(svgBlob);
+  
+      img.onload = async () => {
+        // 2. Create a canvas
+        const canvas = document.createElement('canvas');
+        // Optional: Add a small padding or ensure dimensions are sufficient
+        const scale = window.devicePixelRatio || 1; // Consider device pixel ratio for sharpness
+        canvas.width = img.width * scale;
+        canvas.height = img.height * scale;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          throw new Error('Could not get canvas context');
+        }
+        ctx.scale(scale, scale);
+        ctx.drawImage(img, 0, 0);
+  
+        // 3. Convert canvas to blob
+        canvas.toBlob(async (blob) => {
+          if (!blob) {
+            throw new Error('Canvas to Blob conversion failed');
+          }
+          // 4. Use Clipboard API
+          try {
+            await navigator.clipboard.write([
+              new ClipboardItem({ 'image/png': blob })
+            ]);
+            setCopyStatus("Copied!");
+          } catch (clipErr) {
+            console.error('Clipboard API error:', clipErr);
+            setCopyStatus("Copy failed.");
+          } finally {
+            URL.revokeObjectURL(url); // Clean up object URL
+            setTimeout(() => setCopyStatus(null), 2000);
+          }
+        }, 'image/png');
+      };
+      img.onerror = () => {
+        URL.revokeObjectURL(url);
+        throw new Error('Image loading failed');
+      };
+      img.src = url;
+  
+    } catch (err) {
+      console.error("Error copying SVG as image:", err);
+      setCopyStatus(err instanceof Error ? err.message : "Error.");
+      setTimeout(() => setCopyStatus(null), 2000);
+    }
+  }, [svgContent]);
+
+
+  useEffect(() => {
+    if (!SUPPORTED_DIAGRAM_TYPES.includes(diagramType)) {
+      setError(`Unsupported diagram type: ${diagramType}`);
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchDiagram = async () => {
+      setIsLoading(true);
+      setError(null);
+      setSvgContent(null);
+
+      let processedCodeText = codeText;
+      const isDarkMode = currentAppTheme === 'dark';
+
+      if (diagramType === 'mermaid') {
+        const mermaidTheme = isDarkMode ? 'dark' : 'default';
+        processedCodeText = `%%{init: {'theme':'${mermaidTheme}'}}%%\n${codeText}`;
+      } else if ((diagramType === 'plantuml' || diagramType === 'c4plantuml') && isDarkMode) {
+        // Basic dark theme for PlantUML. For light mode, PlantUML's default is usually fine.
+        // More comprehensive themes can be very long, so keeping it simple.
+        const plantUmlDarkTheme = 'skinparam backgroundColor #333333\nskinparam shadowing false\nskinparam FontColor #FFFFFF\nskinparam ArrowColor #CCCCCC\nskinparam ActorBorderColor #CCCCCC\nskinparam ParticipantBorderColor #CCCCCC\nskinparam NoteBorderColor #CCCCCC\nskinparam ClassBorderColor #CCCCCC\n';
+        processedCodeText = `${plantUmlDarkTheme}${codeText}`;
+      }
+      // Other diagram types could be added here if simple theme injection methods are identified
+
+      try {
+        const response = await fetch(`/api/kroki/${diagramType}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ content: processedCodeText }), // Use processedCodeText
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({})); // Gracefully handle non-JSON error responses
+          const errorMessage = errorData.detail || errorData.error || `Failed to render diagram (status: ${response.status})`;
+
+          // If Kroki service itself is not found or explicitly disabled by backend
+          if (response.status === 404 || (errorMessage && errorMessage.toLowerCase().includes("kroki service not enabled"))) {
+            onFeatureDisabled();
+          }
+          throw new Error(errorMessage);
+        }
+
+        const result = await response.json();
+        if (result.svg) {
+          // SVG customization code removed as per feedback
+          setSvgContent(result.svg);
+          setRenderFallbackAsCodeBlock(false);
+        } else {
+          // Kroki returned an error in the JSON response (e.g. syntax error)
+          const krokiErrorMsg = result.error ? `Kroki Error: ${result.error} (Type: ${result.error_type})` : 'Unexpected response from Kroki service.';
+          console.warn(krokiErrorMsg);
+          setError(krokiErrorMsg); // Store error for potential display if needed, but primarily trigger fallback
+          setRenderFallbackAsCodeBlock(true);
+        }
+      } catch (err) {
+        // Network error or non-JSON error response from fetch
+        const fetchErrorMsg = err instanceof Error ? err.message : 'An unknown error occurred during fetch.';
+        console.error("Error fetching Kroki diagram:", err);
+        setError(fetchErrorMsg);
+        setRenderFallbackAsCodeBlock(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDiagram();
+  }, [diagramType, codeText, currentAppTheme, onFeatureDisabled]); // Added onFeatureDisabled to deps
+
+  if (isLoading) {
+    return (
+      <div className="kroki-diagram-loading-container flex items-center justify-center p-4 bg-white">
+        <Loader2 className="h-6 w-6 animate-spin mr-2" />
+        Rendering diagram...
+      </div>
+    );
+  }
+
+  // If rendering failed, fall back to showing the original code in a standard CodeBlock
+  if (renderFallbackAsCodeBlock) {
+    // Optionally, you could display the 'error' message above the CodeBlock if desired
+    // For now, just rendering the CodeBlock as per feedback.
+    // The CodeBlock component itself should handle its own styling including the header.
+    // Pass codeText as an array to children to ensure CodeBlock renders it as block content.
+    return (
+      <CodeBlock codeText={codeText} className={`language-${diagramType}`} isFallback={true}>
+        {[codeText]}
+      </CodeBlock>
+    );
+  }
+
+  if (svgContent) {
+    return (
+      <div className="kroki-diagram-container relative group p-2 bg-white overflow-x-auto">
+        {/* Style for the normal view SVG rendering to respect max-height and scale proportionally */}
+        <style>{`
+          .kroki-diagram-svg-render svg {
+            display: block;
+            width: auto;     /* Calculate width based on height and aspect ratio */
+            height: 100%;    /* Attempt to fill the parent container's height */
+            max-width: 100%; /* Ensure the auto-calculated width doesn't exceed parent's width */
+            margin: 0 auto;  /* Center the SVG horizontally if its width is less than the container's width */
+          }
+        `}</style>
+        <div
+          className="kroki-diagram-svg-render overflow-hidden" // Ensure no flex here, max-h-96 removed
+          dangerouslySetInnerHTML={{ __html: svgContent }}
+        />
+
+        <div className="absolute top-1 right-1 flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-slate-200 dark:bg-slate-700 p-1 rounded">
+          <Button variant="ghost" size="icon" title="Download SVG" onClick={handleDownloadSvg}>
+            <Download className="h-4 w-4 text-slate-600 dark:text-slate-300" />
+          </Button>
+          <Button variant="ghost" size="icon" title="Copy as Image" onClick={handleCopyAsImage} disabled={!!copyStatus}>
+            {copyStatus ? <span className="text-xs text-slate-700 dark:text-slate-200">{copyStatus}</span> : <Copy className="h-4 w-4 text-slate-600 dark:text-slate-300" />}
+          </Button>
+          <Button variant="ghost" size="icon" title="Fullscreen" onClick={() => setShowFullscreenModal(true)}>
+            <Maximize2 className="h-4 w-4 text-slate-600 dark:text-slate-300" />
+          </Button>
+          <Button variant="ghost" size="icon" title={showRawCode ? "Hide Code" : "Show Code"} onClick={handleToggleRawCode}>
+            <CodeIcon className="h-4 w-4 text-slate-600 dark:text-slate-300" />
+          </Button>
+        </div>
+
+        {showRawCode && (
+          // Removed h4 heading, border-t, and pt-2. 
+          // The CodeBlock itself, when isFallback=true, will have my-2 from prose styling.
+          // If further spacing adjustment is needed, it can be done here or on CodeBlock.
+          // For now, relying on CodeBlock's inherent spacing when it's a fallback.
+          <div className="mt-0"> {/* Or simply remove this div if CodeBlock's margin is sufficient */}
+            <CodeBlock codeText={codeText} className={`language-${diagramType}`} isFallback={true}>
+              {[codeText]}
+            </CodeBlock>
+          </div>
+        )}
+
+        {showFullscreenModal && (
+          <Dialog open={showFullscreenModal} onOpenChange={setShowFullscreenModal}>
+            <DialogContent className="max-w-[95vw] w-[95vw] h-[95vh] flex flex-col p-2">
+              <DialogHeader className="flex-shrink-0">
+                <DialogTitle className="truncate">Fullscreen Diagram</DialogTitle>
+                <DialogClose asChild>
+                  <Button variant="ghost" size="icon" className="absolute top-2 right-2">
+                    <Maximize2 className="h-4 w-4 transform rotate-45" /> {/* Simple close icon */}
+                  </Button>
+                </DialogClose>
+              </DialogHeader>
+              <style>{`
+                .fullscreen-svg-inner-wrapper {
+                  width: 100%; /* Ensure the wrapper takes full space */
+                  height: 100%;
+                  display: flex; /* Use flex to center the SVG child */
+                  align-items: center;
+                  justify-content: center;
+                }
+                .fullscreen-svg-inner-wrapper svg {
+                  display: block;
+                  width: 100%;   /* Attempt to fill the container's width */
+                  height: 100%;  /* Attempt to fill the container's height */
+                  /* preserveAspectRatio="xMidYMid meet" (expected from Kroki) will handle scaling */
+                }
+              `}</style>
+              <div className="flex-grow overflow-auto p-4 bg-background-50"> 
+                <div
+                  dangerouslySetInnerHTML={{ __html: svgContent }}
+                  className="fullscreen-svg-inner-wrapper" 
+                />
+              </div>
+              {/* Footer for buttons in fullscreen modal */}
+              <div className="flex-shrink-0 flex items-center justify-center space-x-2 p-2 border-t">
+                <Button variant="outline" size="sm" onClick={handleDownloadSvg}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Download SVG
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleCopyAsImage} disabled={!!copyStatus}>
+                  {copyStatus === "Copying..." && <Loader2 className="h-4 w-4 mr-2 animate-spin text-slate-700 dark:text-slate-200" />}
+                  {copyStatus === "Copied!" && <Copy className="h-4 w-4 mr-2 text-green-600 dark:text-green-400" />}
+                  {copyStatus === "Copy failed." && <AlertTriangle className="h-4 w-4 mr-2 text-red-600 dark:text-red-400" />}
+                  {!copyStatus && <Copy className="h-4 w-4 mr-2 text-slate-700 dark:text-slate-200" />}
+                  <span className="text-slate-700 dark:text-slate-200">{copyStatus ? copyStatus : "Copy as Image"}</span>
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+    );
+  }
+
+  return null; // Should not happen if logic is correct
+};
+
+export default KrokiDiagram;

--- a/web/src/components/chat/KrokiDiagram.tsx
+++ b/web/src/components/chat/KrokiDiagram.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { AlertTriangle, Loader2, Download, Copy, Maximize2, Code as CodeIcon } from 'lucide-react';
+import { AlertTriangle, Loader2, Download, Copy, Maximize2, Code as CodeIcon, ClipboardCopy } from 'lucide-react'; // Added ClipboardCopy
 import { Button } from "@/components/ui/button";
 import { CodeBlock } from "@/app/chat/message/CodeBlock"; // Import CodeBlock
 import {
@@ -28,6 +28,7 @@ const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFe
   const [showRawCode, setShowRawCode] = useState(false);
   const [showFullscreenModal, setShowFullscreenModal] = useState(false);
   const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [copyCodeStatus, setCopyCodeStatus] = useState<string | null>(null); // New state for copy code status
   const [currentAppTheme, setCurrentAppTheme] = useState<'light' | 'dark'>(() => 
     typeof window !== 'undefined' && document.documentElement.classList.contains('dark') ? 'dark' : 'light'
   );
@@ -130,6 +131,21 @@ const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFe
       setTimeout(() => setCopyStatus(null), 2000);
     }
   }, [svgContent]);
+
+  const handleCopyCode = useCallback(() => {
+    if (!codeText) return;
+    setCopyCodeStatus("Copying...");
+    navigator.clipboard.writeText(codeText)
+      .then(() => {
+        setCopyCodeStatus("Copied!");
+        setTimeout(() => setCopyCodeStatus(null), 2000);
+      })
+      .catch(err => {
+        console.error("Failed to copy code: ", err);
+        setCopyCodeStatus("Failed!");
+        setTimeout(() => setCopyCodeStatus(null), 2000);
+      });
+  }, [codeText]);
 
 
   useEffect(() => {
@@ -315,6 +331,13 @@ const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFe
                   {copyStatus === "Copy failed." && <AlertTriangle className="h-4 w-4 mr-2 text-red-600 dark:text-red-400" />}
                   {!copyStatus && <Copy className="h-4 w-4 mr-2 text-slate-700 dark:text-slate-200" />}
                   <span className="text-slate-700 dark:text-slate-200">{copyStatus ? copyStatus : "Copy as Image"}</span>
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleCopyCode} disabled={!!copyCodeStatus}>
+                  {copyCodeStatus === "Copying..." && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                  {copyCodeStatus === "Copied!" && <ClipboardCopy className="h-4 w-4 mr-2 text-green-600 dark:text-green-400" />}
+                  {copyCodeStatus === "Failed!" && <AlertTriangle className="h-4 w-4 mr-2 text-red-600 dark:text-red-400" />}
+                  {!copyCodeStatus && <ClipboardCopy className="h-4 w-4 mr-2" />}
+                  <span className="text-slate-700 dark:text-slate-200">{copyCodeStatus ? copyCodeStatus : "Copy as Code"}</span>
                 </Button>
               </div>
             </DialogContent>

--- a/web/src/components/chat/KrokiDiagram.tsx
+++ b/web/src/components/chat/KrokiDiagram.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { AlertTriangle, Loader2, Download, Copy, Maximize2, Code as CodeIcon, ClipboardCopy } from 'lucide-react'; // Added ClipboardCopy
+import { AlertTriangle, Loader2, Download, Copy, Maximize2, Code as CodeIcon, ClipboardCopy, AlertCircle, RefreshCw } from 'lucide-react'; // Added AlertCircle, RefreshCw
 import { Button } from "@/components/ui/button";
 import { CodeBlock } from "@/app/chat/message/CodeBlock"; // Import CodeBlock
 import {
@@ -223,8 +223,7 @@ const KrokiDiagram: React.FC<KrokiDiagramProps> = ({ diagramType, codeText, onFe
   if (isLoading) {
     return (
       <div className="kroki-diagram-loading-container flex items-center justify-center p-4 bg-white">
-        <Loader2 className="h-6 w-6 animate-spin mr-2" />
-        Rendering diagram...
+        <Loader2 className="h-6 w-6 animate-spin" />
       </div>
     );
   }

--- a/web/src/lib/kroki_constants.ts
+++ b/web/src/lib/kroki_constants.ts
@@ -1,0 +1,11 @@
+// Defines the set of supported diagram languages for Kroki integration.
+// This list should be kept in sync with backend configurations if possible,
+// or ideally fetched from the backend in a future enhancement.
+
+export const KROKI_SUPPORTED_LANGUAGES = new Set([
+  "blockdiag", "seqdiag", "actdiag", "nwdiag", "packetdiag", "rackdiag",
+  "graphviz", "pikchr", "erd", "excalidraw", "vega", "vegalite",
+  "ditaa", "mermaid", "nomnoml", "plantuml", "bpmn", "bytefield",
+  "wavedrom", "svgbob", "c4plantuml", "structurizr", "umlet",
+  "wireviz", "symbolator"
+]);


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows users to render various types of diagrams directly within chat messages or markdown content by leveraging an external Kroki service. Diagrams are specified using standard fenced code blocks with appropriate language identifiers. The feature includes backend processing, frontend rendering, interactive controls for diagrams, and robust error handling.


__Render Text-Based Diagrams with Kroki!__

You can now embed a wide variety of diagrams directly into your messages by providing their textual description in a code block. This feature uses the powerful Kroki service to convert your code into visual diagrams.

__How to Use:__

Ask the LLM to generate a sample code in one of the supported languages, i.e. `mermaid`

![image](https://github.com/user-attachments/assets/ba39887d-8f72-45e1-a4dc-eb56959a9416)

__Example (Mermaid Diagram):__

````markdown
```flowchart TD
    A[Start] --> B{Is it sunny?}
    B -- Yes --> C[Go outside]
    B -- No --> D[Stay inside]
    C --> E[Have fun!]
    D --> E
```
````

__Supported Diagram Types:__

A wide range of diagram types are supported, including (but not limited to):

- Mermaid (`mermaid`)
- PlantUML (`plantuml`, `c4plantuml`)
![image](https://github.com/user-attachments/assets/e44fab10-5dae-4b94-9cfb-2fde7ed43cf0)

- Graphviz (`graphviz`)
- BlockDiag family (`blockdiag`, `seqdiag`, `actdiag`, `nwdiag`)
- Vega / Vega-Lite (`vega`, `vegalite`)
![image](https://github.com/user-attachments/assets/29daf8fe-3b10-4c4d-9ed5-7cb461708419)

- Ditaa (`ditaa`)
- Erd (`erd`)
- ...and many more! (Refer to `web/src/lib/kroki_constants.ts` for the full frontend-supported list or Kroki's official documentation).

__Interactive Features:__

Once a diagram is rendered, you'll have several interactive options:

1. __Hover Controls (on the diagram):__

   - __Download SVG:__ Download the diagram as an SVG file.
   - __Copy as Image:__ Copy the diagram to your clipboard as a PNG image.
   - __Fullscreen:__ Open the diagram in a larger fullscreen modal view.
   - __Show/Hide Code:__ Toggle the visibility of the original diagram source code below the rendered image.

2. __Fullscreen Modal Controls:__

   - __Download SVG:__ Download the diagram as an SVG file.
   - __Copy as Image:__ Copy the diagram to your clipboard as a PNG image.
   - __Copy as Code:__ Copy the raw diagram source code to your clipboard.

3. __Theme Adaptation:__

   - For __Mermaid__ and __PlantUML__ diagrams, the theme (dark or light) will automatically adapt based on your current application theme settings.

__Error Handling:__

- __Fallback to Code:__ If a diagram fails to render for any reason (e.g., Kroki service issue, network error), the original source code will be displayed in a standard code block.

- __Syntax Errors:__ If the Kroki service detects a syntax error in your diagram code:

  - The raw code block will be shown.

- __Feature Disabled:__ If the Kroki service is not configured or becomes unavailable, the diagram rendering feature will be gracefully disabled for the current session to prevent repeated errors, and code blocks will render as standard text.

---

### Setup & Configuration:

1. __Ensure a Kroki Service is Accessible:__ You need a running Kroki instance. You can use the public instance at `https://kroki.io` or host your own.

2. __Set Environment Variable:__ In your backend environment, set the `KROKI_URL` variable to point to your Kroki service.

   ```bash
   export KROKI_URL="https://kroki.io" # Or your self-hosted Kroki URL
   ```

   If this variable is not set, the Kroki diagram rendering feature will be disabled.

---

### How to Test:

1. __Configure Backend:__ Ensure `KROKI_URL` is set in your backend environment.

2. __Basic Rendering:__

   - Send a message with a simple diagram, e.g.:

     ````markdown
     ```plantuml
     @startuml
     Alice -> Bob: Authentication Request
     Bob --> Alice: Authentication Response
     @enduml
     ````

     ````javascript
     ```mermaid
     graph LR
         A --- B
         B-->C;
         B-->D;
     ````

   - Verify the diagram renders correctly.

3. __Interactive Features:__

   - Test all hover controls: Download SVG, Copy as Image, Fullscreen, Show/Hide Code.
   - Test all controls within the fullscreen modal: Download SVG, Copy as Image, Copy as Code, Close button.

4. __Theme Adaptation (if applicable):__

   - Switch your application's theme between light and dark mode.
   - Verify that Mermaid and PlantUML diagrams adapt their appearance accordingly.

5. __Error Handling:__

   - __Syntax Error:__ Provide diagram code with a deliberate syntax error.

     ````markdown
     ```mermaid
     graph TD
         A -> B -> C // Missing semicolon or invalid syntax for mermaid
     ````

     - Verify the raw code block is shown.
     - Verify the red exclamation icon and error message appear below it.
     - Verify the "Retry" button appears (if the parent component is wired to provide `onRetryWithPrompt`).
     - (Manual step for now) Click "Retry" and check console/network to see if the correct prompt would be generated.

   - __Unsupported Diagram Type:__

     ````markdown
     ```myawesomediagram
     some code
     ````

     - Verify it renders as a normal code block, and no attempt is made to render via Kroki.

   - __Kroki Service Down/Disabled:__

     - Temporarily unset `KROKI_URL` in the backend or point it to an invalid URL. Restart the backend.
     - Attempt to render a diagram. Verify it falls back to a code block and that the `onFeatureDisabled` mechanism prevents further attempts (check console logs in `KrokiDiagram` for "Kroki service not enabled" or similar, and subsequent diagrams should also fallback without repeated API calls).

6. __Fallback Behavior:__ Ensure that if `codeText` is empty or only whitespace, it renders as a normal (empty) code block rather than attempting Kroki rendering.



## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
