### PR TITLE
[Connectors][Script] Resume Paused Connectors

### DIFF
--- a/backend/scripts/resume_paused_connectors.py
+++ b/backend/scripts/resume_paused_connectors.py
@@ -1,0 +1,60 @@
+import argparse
+
+import requests
+
+API_SERVER_URL = "http://localhost:3000"
+API_KEY = "onyx-api-key"  # API key here, if auth is enabled
+HEADERS = {"Content-Type": "application/json", "Authorization": f"Bearer {API_KEY}"}
+
+
+def resume_paused_connectors(
+    specific_connector_sources: list[str] | None = None,
+) -> None:
+    # Get all paused connectors
+    response = requests.get(
+        f"{API_SERVER_URL}/api/manage/admin/connector/indexing-status",
+        headers=HEADERS,
+    )
+    response.raise_for_status()
+
+    # Convert the response to a list of ConnectorIndexingStatus objects
+    connectors = [cc_pair for cc_pair in response.json()]
+
+    # If a specific connector is provided, filter the connectors to only include that one
+    if specific_connector_sources:
+        connectors = [
+            connector
+            for connector in connectors
+            if connector["connector"]["source"] in specific_connector_sources
+        ]
+
+    for connector in connectors:
+        if connector["cc_pair_status"] == "PAUSED":
+            print(f"Resuming connector: {connector['name']}")
+            response = requests.put(
+                f"{API_SERVER_URL}/api/manage/admin/cc-pair/{connector['cc_pair_id']}/status",
+                json={"status": "ACTIVE"},
+                headers=HEADERS,
+            )
+            response.raise_for_status()
+            print(f"Resumed connector: {connector['name']}")
+
+        else:
+            print(f"Connector {connector['name']} is not paused")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Resume paused connectors")
+    parser.add_argument(
+        "--connector_sources",
+        type=str.lower,
+        nargs="+",
+        help="The sources of the connectors to resume. If not provided, will resume all paused connectors.",
+    )
+    args = parser.parse_args()
+
+    resume_paused_connectors(args.connector_sources)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/resume_paused_connectors.py
+++ b/backend/scripts/resume_paused_connectors.py
@@ -8,11 +8,12 @@ HEADERS = {"Content-Type": "application/json", "Authorization": f"Bearer {API_KE
 
 
 def resume_paused_connectors(
+    api_server_url: str,
     specific_connector_sources: list[str] | None = None,
 ) -> None:
     # Get all paused connectors
     response = requests.get(
-        f"{API_SERVER_URL}/api/manage/admin/connector/indexing-status",
+        f"{api_server_url}/api/manage/admin/connector/indexing-status",
         headers=HEADERS,
     )
     response.raise_for_status()
@@ -32,7 +33,7 @@ def resume_paused_connectors(
         if connector["cc_pair_status"] == "PAUSED":
             print(f"Resuming connector: {connector['name']}")
             response = requests.put(
-                f"{API_SERVER_URL}/api/manage/admin/cc-pair/{connector['cc_pair_id']}/status",
+                f"{api_server_url}/api/manage/admin/cc-pair/{connector['cc_pair_id']}/status",
                 json={"status": "ACTIVE"},
                 headers=HEADERS,
             )
@@ -46,6 +47,12 @@ def resume_paused_connectors(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Resume paused connectors")
     parser.add_argument(
+        "--api_server_url",
+        type=str,
+        default=API_SERVER_URL,
+        help="The URL of the API server to use. If not provided, will use the default.",
+    )
+    parser.add_argument(
         "--connector_sources",
         type=str.lower,
         nargs="+",
@@ -53,7 +60,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    resume_paused_connectors(args.connector_sources)
+    resume_paused_connectors(args.api_server_url, args.connector_sources)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Creating a new script to resume all of the paused connectors that exist within your connectors. 

The script allows you to specify multiple sources (i.e. `google_drive`, `linear`) that you would only like to resume as well.

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?
This was ran locally by running the following: 

Resume all paused connectors
`cd backend && python3 scripts/resume_paused_connectors.py`

Resume all of the google drive connectors 
`cd backend && python3 scripts/resume_paused_connectors.py --connector_sources google_drive`

[Describe the tests you ran to verify your changes]
Running Onyx locally
- Started by generating an API key from the UI.
- Ensured there were paused connectors.
- Ran the commands from above and validated that the connectors were ingesting properly after resuming.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
