### PR TITLE
fix: updating gemini models

### DIFF
--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -108,7 +108,7 @@ VERTEXAI_DEFAULT_MODEL = "gemini-2.0-flash"
 VERTEXAI_DEFAULT_FAST_MODEL = "gemini-2.0-flash-lite"
 VERTEXAI_MODEL_NAMES = [
     # 2.5 pro models
-    "gemini-2.5-pro-exp-03-25",
+    "gemini-2.5-pro-preview-05-06",
     # 2.0 flash-lite models
     VERTEXAI_DEFAULT_FAST_MODEL,
     "gemini-2.0-flash-lite-001",

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -736,7 +736,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   // Google Models
 
   // 2.5 pro models
-  "gemini-2.5-pro-exp-03-25": "Gemini 2.5 Pro (Experimental March 25th)",
+  "gemini-2.5-pro-preview-05-06": "Gemini 2.5 Pro (Preview May 6th)",
 
   // 2.0 flash lite models
   "gemini-2.0-flash-lite": "Gemini 2.0 Flash Lite",
@@ -748,6 +748,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "gemini-2.0-flash": "Gemini 2.0 Flash",
   "gemini-2.0-flash-001": "Gemini 2.0 Flash (v1)",
   "gemini-2.0-flash-exp": "Gemini 2.0 Flash (Experimental)",
+  "gemini-2.5-flash-preview-05-20": "Gemini 2.5 Flash (Preview May 20th)",
   // "gemini-2.0-flash-thinking-exp-01-02":
   //   "Gemini 2.0 Flash Thinking (Experimental January 2nd)",
   // "gemini-2.0-flash-thinking-exp-01-21":


### PR DESCRIPTION
## Description
Error selecting `gemini-2.5-pro-exp-03-25` as my LLM model

<img width="832" alt="Image" src="https://github.com/user-attachments/assets/0e9fd7d6-6a07-466d-bba2-e49d447e7c4b" />

litellm.NotFoundError: VertexAIException - { "error": { "code": 404, "message": "Publisher Model `projects/xxx/locations/us-central1/publishers/google/models/gemini-2.5-pro-exp-03-25` not found.", "status": "NOT_FOUND" } }

I'm pretty sure google stopped providing this model and it should be `gemini-2.5-pro-preview-05-06`

https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro
