### PR TITLE
KG Refactor V2

### DIFF
--- a/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
+++ b/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
@@ -100,6 +100,10 @@ def upgrade() -> None:
                 ],
             },
             {"kg_variable_name": "KG_MAX_COVERAGE_DAYS", "kg_variable_values": ["90"]},
+            {
+                "kg_variable_name": "KG_MAX_PARENT_RECURSION_DEPTH",
+                "kg_variable_values": ["2"],
+            },
         ],
     )
 

--- a/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
+++ b/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
@@ -80,6 +80,7 @@ def upgrade() -> None:
             sa.column("kg_variable_values", postgresql.ARRAY(sa.String)),
         ),
         [
+            {"kg_variable_name": "KG_EXPOSED", "kg_variable_values": ["false"]},
             {"kg_variable_name": "KG_ENABLED", "kg_variable_values": ["false"]},
             {"kg_variable_name": "KG_VENDOR", "kg_variable_values": []},
             {"kg_variable_name": "KG_VENDOR_DOMAINS", "kg_variable_values": []},

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -671,6 +671,7 @@ def stream_chat_message_objects(
             raise Exception("Clustering done")
 
         elif new_msg_req.message == "kg":
+            reset_vespa_kg_index(tenant_id, index_str)
             reset_full_kg_index()
             kg_extraction(tenant_id, index_str)
             kg_clustering(tenant_id, index_str)

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -50,7 +50,6 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
     os.environ.get("KG_MAX_DEEP_SEARCH_RESULTS", "30")
 )
 
-
 _KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT: float = max(
     1e-3,
     min(1, float(os.environ.get("KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT", "0.25"))),

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -50,6 +50,10 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
     os.environ.get("KG_MAX_DEEP_SEARCH_RESULTS", "30")
 )
 
+KG_MAX_PARENT_RECURSION_DEPTH: int = int(
+    os.environ.get("KG_MAX_PARENT_RECURSION_DEPTH", "2")
+)
+
 _KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT: float = max(
     1e-3,
     min(1, float(os.environ.get("KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT", "0.25"))),

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -50,9 +50,6 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
     os.environ.get("KG_MAX_DEEP_SEARCH_RESULTS", "30")
 )
 
-KG_MAX_PARENT_RECURSION_DEPTH: int = int(
-    os.environ.get("KG_MAX_PARENT_RECURSION_DEPTH", "2")
-)
 
 _KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT: float = max(
     1e-3,

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -50,6 +50,12 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
     os.environ.get("KG_MAX_DEEP_SEARCH_RESULTS", "30")
 )
 
+
+KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH: int = int(
+    os.environ.get("KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH", "2")
+)
+
+
 _KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT: float = max(
     1e-3,
     min(1, float(os.environ.get("KG_NORMALIZATION_RERANK_UNIGRAM_WEIGHT", "0.25"))),

--- a/backend/onyx/db/entities.py
+++ b/backend/onyx/db/entities.py
@@ -46,6 +46,25 @@ def add_or_update_staging_entity(
     entity_type = entity_type.upper()
     name = name.title()
     id_name = format_entity(f"{entity_type}::{name.lower()}")
+    attributes = attributes or {}
+
+    entity_type_split = entity_type.split("-")
+    entity_class, entity_subtype = (
+        entity_type_split if len(entity_type_split) == 2 else (None, None)
+    )
+
+    entity_key = attributes.get("key")
+    entity_parent = attributes.get("parent")
+
+    keep_attributes = {
+        attr_key: attr_val
+        for attr_key, attr_val in attributes.items()
+        if not (
+            (attr_key in ("key", "parent") and entity_class)
+            or attr_key in ("object_type", "issuetype")
+            or "_email" in attr_key
+        )
+    }
 
     # Create new entity
     stmt = (
@@ -54,9 +73,13 @@ def add_or_update_staging_entity(
             id_name=id_name,
             name=name,
             entity_type_id_name=entity_type,
+            entity_class=entity_class,
+            entity_subtype=entity_subtype,
+            entity_key=entity_key,
+            parent_key=entity_parent,
             document_id=document_id,
             occurrences=occurrences,
-            attributes=attributes or {},
+            attributes=keep_attributes,
             event_time=event_time,
         )
         .on_conflict_do_update(
@@ -100,29 +123,6 @@ def transfer_entity(
     Returns:
         KGEntity: The transferred entity
     """
-
-    entity_split = entity.entity_type_id_name.split("-")
-    if len(entity_split) == 2:
-        entity_class, entity_subtype = entity.entity_type_id_name.split("-")
-    else:
-        entity_class = None
-        entity_subtype = None
-
-    entity_key = entity.attributes.get("key")
-    entity_parent = entity.attributes.get("parent")
-
-    transfer_attributes = {}
-
-    for key in entity.attributes:
-        if (
-            (key in ("key", "parent") and entity_class)
-            or (key in ("object_type", "issuetype"))
-            or "_email" in key
-        ):
-            continue
-
-        transfer_attributes[key] = entity.attributes[key]
-
     # Create the transferred entity
     stmt = (
         pg_insert(KGEntity)
@@ -131,14 +131,14 @@ def transfer_entity(
                 f"{entity.entity_type_id_name}::{uuid.uuid4().hex[:20]}"
             ),
             name=entity.name.casefold(),
-            entity_class=entity_class,
-            entity_subtype=entity_subtype,
-            entity_key=entity_key,
+            entity_class=entity.entity_class,
+            entity_subtype=entity.entity_subtype,
+            entity_key=entity.entity_key,
             alternative_names=entity.alternative_names or [],
             entity_type_id_name=entity.entity_type_id_name,
             document_id=entity.document_id,
             occurrences=entity.occurrences,
-            attributes=transfer_attributes,
+            attributes=entity.attributes,
             event_time=entity.event_time,
         )
         .on_conflict_do_update(
@@ -164,14 +164,7 @@ def transfer_entity(
     # Update transferred
     db_session.query(KGEntityExtractionStaging).filter(
         KGEntityExtractionStaging.id_name == entity.id_name
-    ).update(
-        {
-            "transferred_id_name": new_entity.id_name,
-            "entity_class": entity_class,
-            "entity_key": entity_key,
-            "parent_key": entity_parent,
-        }
-    )
+    ).update({"transferred_id_name": new_entity.id_name})
     db_session.flush()
 
     return new_entity
@@ -371,129 +364,6 @@ def delete_from_kg_entities__no_commit(
     db_session.query(KGEntity).filter(KGEntity.document_id.in_(document_ids)).delete(
         synchronize_session=False
     )
-
-
-def get_parent_child_relationships_from_extractions(
-    db_session: Session,
-) -> tuple[list[dict], list[dict]]:
-    """Get parent-child relationships from the normalized table."""
-    # entity_type not required here, will be same as parent
-    stmt = select(
-        KGEntityExtractionStaging.id_name,
-        KGEntityExtractionStaging.entity_class,
-        KGEntityExtractionStaging.entity_subtype,
-        KGEntityExtractionStaging.entity_key,
-        KGEntityExtractionStaging.parent_key,
-        KGEntityExtractionStaging.document_id,
-        KGEntityExtractionStaging.transferred_id_name,
-    ).where(KGEntityExtractionStaging.parent_key.isnot(None))
-
-    base_result = db_session.execute(stmt).fetchall()
-
-    # Get all unique parent keys
-    parent_keys = [row[4] for row in base_result if row[4] is not None]
-    child_keys = [row[3] for row in base_result if row[3] is not None]
-
-    child_parent_map = {
-        row[3]: row[4]
-        for row in base_result
-        if row[3] is not None and row[4] is not None
-    }
-
-    # Find parents and create mapping of parent_key to id_name
-    parent_id_map = {}
-    if parent_keys:
-        # parents are already transferred at this point
-        parent_stmt_normalized = select(
-            KGEntity.entity_key,
-            KGEntity.entity_class,
-            KGEntity.entity_subtype,
-            KGEntity.id_name,
-            KGEntity.document_id,
-        ).where(
-            KGEntity.entity_key.in_(parent_keys) | KGEntity.document_id.in_(parent_keys)
-        )
-        parent_normalized_result = db_session.execute(parent_stmt_normalized).fetchall()
-        parent_id_map = {
-            parent_key: {
-                "transferred_id_name": transferred_id_name,
-                "parent_subtype": parent_subtype,
-                "parent_class": parent_class,
-                "parent_document_id": parent_document_id,
-            }
-            for (
-                parent_key,
-                parent_class,
-                parent_subtype,
-                transferred_id_name,
-                parent_document_id,
-            ) in parent_normalized_result
-        }
-
-    # Create the relationship dictionary using defaultdict
-    parent_child_relationships: list[dict] = []
-    parent_child_relationship_types: list[dict] = []
-
-    # Build the relationships using the parent_id_map
-    for (
-        child_id_name,
-        child_entity_class,
-        _,
-        child_key,
-        parent_key,
-        document_id,
-        child_transferred_id_name,
-    ) in base_result:
-        if parent_key in parent_id_map:
-
-            relationship_type = "has_subcomponent"
-            parent_id_name = parent_id_map[parent_key]["transferred_id_name"]
-            parent_entity_type = parent_id_name.split("::")[0]
-            child_entity_type = child_transferred_id_name.split("::")[0]
-
-            parent_child_relationships.append(
-                {
-                    "relationship_id_name": f"{parent_id_name}__{relationship_type}__{child_transferred_id_name}",
-                    "source_document_id": document_id,
-                    "occurrences": 1,
-                }
-            )
-
-            parent_child_relationship_types.append(
-                {
-                    "source_entity_type": parent_entity_type,
-                    "relationship_type": "has_subcomponent",
-                    "target_entity_type": child_entity_type,
-                }
-            )
-
-            # add additional level of relationship if parent is also a child
-            if parent_key in child_keys:
-                grandparent_key = child_parent_map[parent_key]
-
-                grandparent_id_name = parent_id_map[grandparent_key][
-                    "transferred_id_name"
-                ]
-                grandparent_entity_type = grandparent_id_name.split("::")[0]
-                parent_document_id = parent_id_map[parent_key]["parent_document_id"]
-
-                parent_child_relationships.append(
-                    {
-                        "relationship_id_name": f"{grandparent_id_name}__{relationship_type}__{child_transferred_id_name}",
-                        "source_document_id": parent_document_id,
-                        "occurrences": 1,
-                    }
-                )
-
-                parent_child_relationship_types.append(
-                    {
-                        "source_entity_type": grandparent_entity_type,
-                        "relationship_type": "has_subcomponent",
-                        "target_entity_type": child_entity_type,
-                    }
-                )
-
-    return parent_child_relationships, parent_child_relationship_types
 
 
 def get_entity_name(db_session: Session, entity_id_name: str) -> str | None:

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -77,6 +77,8 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
             kg_config_settings.KG_MAX_PARENT_RECURSION_DEPTH = max(
                 0, int(kg_max_parent_recursion_depth_str)
             )
+        elif result.kg_variable_name == KGConfigVars.KG_EXPOSED:
+            kg_config_settings.KG_EXPOSED = result.kg_variable_values[0] == "true"
 
     return kg_config_settings
 

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -51,14 +51,11 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
             )
 
         elif result.kg_variable_name == KGConfigVars.KG_MAX_COVERAGE_DAYS:
-            kg_max_coverage_days_str: str = "10000"
-            if result.kg_variable_values:
-                kg_max_coverage_days_str = result.kg_variable_values[0] or "10000"
-                if not kg_max_coverage_days_str.isdigit():
-                    raise ValueError(
-                        f"KG_MAX_COVERAGE_DAYS is not a number: {kg_max_coverage_days_str}"
-                    )
-
+            kg_max_coverage_days_str = result.kg_variable_values[0]
+            if not kg_max_coverage_days_str.isdigit():
+                raise ValueError(
+                    f"KG_MAX_COVERAGE_DAYS is not a number: {kg_max_coverage_days_str}"
+                )
             kg_config_settings.KG_MAX_COVERAGE_DAYS = max(
                 0, int(kg_max_coverage_days_str)
             )
@@ -72,14 +69,11 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
                 result.kg_variable_values[0] == "true"
             )
         elif result.kg_variable_name == KGConfigVars.KG_MAX_PARENT_RECURSION_DEPTH:
-            kg_max_parent_recursion_depth_str: str = "2"
-            if result.kg_variable_values:
-                kg_max_parent_recursion_depth_str = result.kg_variable_values[0] or "2"
-                if not kg_max_parent_recursion_depth_str.isdigit():
-                    raise ValueError(
-                        f"KG_MAX_PARENT_RECURSION_DEPTH is not a number: {kg_max_parent_recursion_depth_str}"
-                    )
-
+            kg_max_parent_recursion_depth_str = result.kg_variable_values[0]
+            if not kg_max_parent_recursion_depth_str.isdigit():
+                raise ValueError(
+                    f"KG_MAX_PARENT_RECURSION_DEPTH is not a number: {kg_max_parent_recursion_depth_str}"
+                )
             kg_config_settings.KG_MAX_PARENT_RECURSION_DEPTH = max(
                 0, int(kg_max_parent_recursion_depth_str)
             )

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -51,10 +51,8 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
             )
 
         elif result.kg_variable_name == KGConfigVars.KG_MAX_COVERAGE_DAYS:
-            if not result.kg_variable_values:
-                kg_max_coverage_days_str: str | int = 10000
-
-            else:
+            kg_max_coverage_days_str: str = "10000"
+            if result.kg_variable_values:
                 kg_max_coverage_days_str = result.kg_variable_values[0] or "10000"
                 if not kg_max_coverage_days_str.isdigit():
                     raise ValueError(
@@ -74,12 +72,10 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
                 result.kg_variable_values[0] == "true"
             )
         elif result.kg_variable_name == KGConfigVars.KG_MAX_PARENT_RECURSION_DEPTH:
-            if not result.kg_variable_values:
-                kg_max_parent_recursion_depth_str: str | int = 2
-
-            else:
+            kg_max_parent_recursion_depth_str: str = "2"
+            if result.kg_variable_values:
                 kg_max_parent_recursion_depth_str = result.kg_variable_values[0] or "2"
-                if not kg_max_coverage_days_str.isdigit():
+                if not kg_max_parent_recursion_depth_str.isdigit():
                     raise ValueError(
                         f"KG_MAX_PARENT_RECURSION_DEPTH is not a number: {kg_max_parent_recursion_depth_str}"
                     )

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -32,7 +32,7 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
 
     kg_config_settings = KGConfigSettings()
     for result in results:
-        if result.kg_variable_name == "KG_ENABLED":
+        if result.kg_variable_name == KGConfigVars.KG_ENABLED:
             kg_config_settings.KG_ENABLED = result.kg_variable_values[0] == "true"
         elif result.kg_variable_name == KGConfigVars.KG_VENDOR:
             if len(result.kg_variable_values) > 0:
@@ -52,16 +52,18 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
 
         elif result.kg_variable_name == KGConfigVars.KG_MAX_COVERAGE_DAYS:
             if not result.kg_variable_values:
-                kg_max_coverage_days_str: str | int = 1000000
+                kg_max_coverage_days_str: str | int = 10000
 
             else:
-                kg_max_coverage_days_str = result.kg_variable_values[0] or "1000000"
+                kg_max_coverage_days_str = result.kg_variable_values[0] or "10000"
                 if not kg_max_coverage_days_str.isdigit():
                     raise ValueError(
                         f"KG_MAX_COVERAGE_DAYS is not a number: {kg_max_coverage_days_str}"
                     )
 
-            kg_config_settings.KG_MAX_COVERAGE_DAYS = int(kg_max_coverage_days_str)
+            kg_config_settings.KG_MAX_COVERAGE_DAYS = max(
+                0, int(kg_max_coverage_days_str)
+            )
 
         elif result.kg_variable_name == KGConfigVars.KG_EXTRACTION_IN_PROGRESS:
             kg_config_settings.KG_EXTRACTION_IN_PROGRESS = (
@@ -70,6 +72,20 @@ def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
         elif result.kg_variable_name == KGConfigVars.KG_CLUSTERING_IN_PROGRESS:
             kg_config_settings.KG_CLUSTERING_IN_PROGRESS = (
                 result.kg_variable_values[0] == "true"
+            )
+        elif result.kg_variable_name == KGConfigVars.KG_MAX_PARENT_RECURSION_DEPTH:
+            if not result.kg_variable_values:
+                kg_max_parent_recursion_depth_str: str | int = 2
+
+            else:
+                kg_max_parent_recursion_depth_str = result.kg_variable_values[0] or "2"
+                if not kg_max_coverage_days_str.isdigit():
+                    raise ValueError(
+                        f"KG_MAX_PARENT_RECURSION_DEPTH is not a number: {kg_max_parent_recursion_depth_str}"
+                    )
+
+            kg_config_settings.KG_MAX_PARENT_RECURSION_DEPTH = max(
+                0, int(kg_max_parent_recursion_depth_str)
             )
 
     return kg_config_settings

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -6,6 +6,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 import onyx.db.document as dbdocument
+from onyx.configs.kg_configs import KG_MAX_PARENT_RECURSION_DEPTH
 from onyx.db.models import KGEntity
 from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationship
@@ -13,9 +14,11 @@ from onyx.db.models import KGRelationshipExtractionStaging
 from onyx.db.models import KGRelationshipType
 from onyx.db.models import KGRelationshipTypeExtractionStaging
 from onyx.db.models import KGStage
-from onyx.kg.utils.formatting_utils import format_entity
 from onyx.kg.utils.formatting_utils import format_relationship
 from onyx.kg.utils.formatting_utils import generate_relationship_type
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 def add_or_update_staging_relationship(
@@ -39,18 +42,15 @@ def add_or_update_staging_relationship(
         sqlalchemy.exc.IntegrityError: If there's an error with the database operation
     """
     # Generate a unique ID for the relationship
-
+    relationship_id_name = format_relationship(relationship_id_name)
     (
         source_entity_id_name,
         relationship_string,
         target_entity_id_name,
     ) = relationship_id_name.split("__")
 
-    source_entity_id_name = format_entity(source_entity_id_name)
     source_entity_type = source_entity_id_name.split("::")[0]
-    target_entity_id_name = format_entity(target_entity_id_name)
     target_entity_type = target_entity_id_name.split("::")[0]
-    relationship_id_name = format_relationship(relationship_id_name)
     relationship_type = generate_relationship_type(relationship_id_name)
 
     # Insert the new relationship
@@ -96,84 +96,6 @@ def add_or_update_staging_relationship(
     return result
 
 
-def add_or_update_relationship(
-    db_session: Session,
-    relationship_id_name: str,
-    source_document_id: str,
-    occurrences: int = 1,
-) -> KGRelationship:
-    """
-    Add or update a new relationship to the database.
-
-    Args:
-        db_session: SQLAlchemy database session
-        relationship_id_name: The ID name of the relationship in format "source__relationship__target"
-        source_document_id: ID of the source document
-        occurrences: Number of times this relationship has been found
-    Returns:
-        The created or updated KGRelationshipExtractionStaging object
-
-    Raises:
-        sqlalchemy.exc.IntegrityError: If there's an error with the database operation
-    """
-    # Generate a unique ID for the relationship
-
-    (
-        source_entity_id_name,
-        relationship_string,
-        target_entity_id_name,
-    ) = relationship_id_name.split("__")
-
-    source_entity_id_name = format_entity(source_entity_id_name)
-    source_entity_type = source_entity_id_name.split("::")[0]
-    target_entity_id_name = format_entity(target_entity_id_name)
-    target_entity_type = target_entity_id_name.split("::")[0]
-    relationship_id_name = format_relationship(relationship_id_name)
-    relationship_type = generate_relationship_type(relationship_id_name)
-
-    # Insert the new relationship
-    stmt = (
-        postgresql.insert(KGRelationship)
-        .values(
-            {
-                "id_name": relationship_id_name,
-                "source_node": source_entity_id_name,
-                "target_node": target_entity_id_name,
-                "source_node_type": source_entity_type,
-                "target_node_type": target_entity_type,
-                "type": relationship_string.lower(),
-                "relationship_type_id_name": relationship_type,
-                "source_document": source_document_id,
-                "occurrences": occurrences,
-            }
-        )
-        .on_conflict_do_update(
-            index_elements=["id_name", "source_document"],
-            set_=dict(
-                occurrences=KGRelationship.occurrences + occurrences,
-            ),
-        )
-        .returning(KGRelationship)
-    )
-
-    result = db_session.execute(stmt).scalar()
-    if result is None:
-        raise RuntimeError(
-            f"Failed to create or increment staging relationship with id_name: {relationship_id_name}"
-        )
-
-    # Update the document's kg_stage if source_document is provided
-    if source_document_id is not None:
-        dbdocument.update_document_kg_info(
-            db_session,
-            document_id=source_document_id,
-            kg_stage=KGStage.NORMALIZED,
-        )
-    db_session.flush()  # Flush to get any DB errors early
-
-    return result
-
-
 def transfer_relationship(
     db_session: Session,
     relationship: KGRelationshipExtractionStaging,
@@ -183,8 +105,12 @@ def transfer_relationship(
     Transfer a relationship from the staging table to the normalized table.
     """
     # Translate the source and target nodes
-    source_node = entity_translations[relationship.source_node]
-    target_node = entity_translations[relationship.target_node]
+    source_node = entity_translations.get(
+        relationship.source_node, relationship.source_node
+    )
+    target_node = entity_translations.get(
+        relationship.target_node, relationship.target_node
+    )
     relationship_id_name = f"{source_node}__{relationship.type}__{target_node}"
 
     # Create the transferred relationship
@@ -285,64 +211,6 @@ def add_or_update_staging_relationship_type(
     return result
 
 
-def add_or_update_relationship_type(
-    db_session: Session,
-    source_entity_type: str,
-    relationship_type: str,
-    target_entity_type: str,
-    definition: bool = False,
-    extraction_count: int = 1,
-) -> KGRelationshipType:
-    """
-    Add a new relationship type to the database.
-
-    Args:
-        db_session: SQLAlchemy session
-        source_entity_type: Type of the source entity
-        relationship_type: Type of relationship
-        target_entity_type: Type of the target entity
-        definition: Whether this relationship type represents a definition (default False)
-
-    Returns:
-        The created KGRelationshipTypeExtractionStaging object
-    """
-
-    id_name = f"{source_entity_type.upper()}__{relationship_type}__{target_entity_type.upper()}"
-
-    # Create new relationship type
-    stmt = (
-        postgresql.insert(KGRelationshipType)
-        .values(
-            {
-                "id_name": id_name,
-                "name": relationship_type,
-                "source_entity_type_id_name": source_entity_type.upper(),
-                "target_entity_type_id_name": target_entity_type.upper(),
-                "definition": definition,
-                "occurrences": extraction_count,
-                "type": relationship_type,  # Using the relationship_type as the type
-                "active": True,  # Setting as active by default
-            }
-        )
-        .on_conflict_do_update(
-            index_elements=["id_name"],
-            set_=dict(
-                occurrences=KGRelationshipType.occurrences + extraction_count,
-            ),
-        )
-        .returning(KGRelationshipType)
-    )
-
-    result = db_session.execute(stmt).scalar()
-    if result is None:
-        raise RuntimeError(
-            f"Failed to create or increment staging relationship type with id_name: {id_name}"
-        )
-    db_session.flush()  # Flush to get any DB errors early
-
-    return result
-
-
 def transfer_relationship_type(
     db_session: Session,
     relationship_type: KGRelationshipTypeExtractionStaging,
@@ -385,6 +253,107 @@ def transfer_relationship_type(
     db_session.flush()
 
     return new_relationship_type
+
+
+def get_parent_child_relationships_and_types(
+    db_session: Session,
+) -> tuple[
+    list[KGRelationshipExtractionStaging], list[KGRelationshipTypeExtractionStaging]
+]:
+    """
+    Create parent-child relationships and relationship types from staging entities with a
+    parent key, if the parent exists in the normalized entities table. Will create relationships
+    up to KG_MAX_PARENT_RECURSION_DEPTH levels deep. E.g., if depth is 2, a relationship will be
+    created between the entity and its parent, and the entity and its grandparents (if any).
+    A relationship will not be created if the parent does not exist.
+    """
+    relationship_types: dict[str, KGRelationshipTypeExtractionStaging] = {}
+    relationships: dict[tuple[str, str | None], KGRelationshipExtractionStaging] = {}
+
+    parented_entities = (
+        db_session.query(KGEntityExtractionStaging)
+        .filter(KGEntityExtractionStaging.parent_key.isnot(None))
+        .all()
+    )
+
+    # create has_subcomponent relationships and relationship types
+    for entity in parented_entities:
+        child = entity
+
+        for i in range(KG_MAX_PARENT_RECURSION_DEPTH, 0, -1):
+            if not child.parent_key:
+                continue
+
+            parent = (
+                db_session.query(KGEntity)
+                .filter(
+                    KGEntity.entity_class == child.entity_class,
+                    KGEntity.entity_key == child.parent_key,
+                )
+                .first()
+            )
+            if parent is None:
+                logger.warning(f"Parent entity not found for {entity.id_name}")
+                break
+
+            # create the relationship type
+            relationship_type = add_or_update_staging_relationship_type(
+                db_session=db_session,
+                source_entity_type=parent.entity_type_id_name,
+                relationship_type="has_subcomponent",
+                target_entity_type=entity.entity_type_id_name,
+                definition=False,
+                extraction_count=1,
+            )
+            relationship_types[relationship_type.id_name] = relationship_type
+
+            # create the relationship
+            # (don't add it to the table as we're using the transferred id, which breaks fk constraints)
+            relationship_id_name = format_relationship(
+                f"{parent.id_name}__has_subcomponent__{entity.transferred_id_name}"
+            )
+            if (parent.id_name, entity.document_id) not in relationships:
+                (
+                    source_entity_id_name,
+                    relationship_string,
+                    target_entity_id_name,
+                ) = relationship_id_name.split("__")
+
+                source_entity_type = source_entity_id_name.split("::")[0]
+                target_entity_type = target_entity_id_name.split("::")[0]
+                relationship_type_id_name = generate_relationship_type(
+                    relationship_id_name
+                )
+                relationships[(relationship_id_name, entity.document_id)] = (
+                    KGRelationshipExtractionStaging(
+                        id_name=relationship_id_name,
+                        source_node=source_entity_id_name,
+                        target_node=target_entity_id_name,
+                        source_node_type=source_entity_type,
+                        target_node_type=target_entity_type,
+                        type=relationship_string,
+                        relationship_type_id_name=relationship_type_id_name,
+                        source_document=entity.document_id,
+                        occurrences=1,
+                    )
+                )
+            else:
+                relationships[(parent.id_name, entity.document_id)].occurrences += 1
+
+            # set parent as the next child
+            if i > 1:
+                parent_staging = (
+                    db_session.query(KGEntityExtractionStaging)
+                    .filter(
+                        KGEntityExtractionStaging.transferred_id_name == parent.id_name
+                    )
+                    .first()
+                )
+                if parent_staging is None:
+                    break
+                child = parent_staging
+
+    return list(relationships.values()), list(relationship_types.values())
 
 
 def delete_relationships_by_id_names(

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -280,7 +280,7 @@ def get_parent_child_relationships_and_types(
     for entity in parented_entities:
         child = entity
 
-        for i in range(depth, 0, -1):
+        for i in range(depth):
             if not child.parent_key:
                 break
 
@@ -341,7 +341,7 @@ def get_parent_child_relationships_and_types(
                 relationships[(parent.id_name, entity.document_id)].occurrences += 1
 
             # set parent as the next child
-            if i > 1:
+            if i < depth - 1:
                 parent_staging = (
                     db_session.query(KGEntityExtractionStaging)
                     .filter(

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -6,7 +6,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 import onyx.db.document as dbdocument
-from onyx.configs.kg_configs import KG_MAX_PARENT_RECURSION_DEPTH
 from onyx.db.models import KGEntity
 from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationship
@@ -257,14 +256,15 @@ def transfer_relationship_type(
 
 def get_parent_child_relationships_and_types(
     db_session: Session,
+    depth: int,
 ) -> tuple[
     list[KGRelationshipExtractionStaging], list[KGRelationshipTypeExtractionStaging]
 ]:
     """
-    Create parent-child relationships and relationship types from staging entities with a
-    parent key, if the parent exists in the normalized entities table. Will create relationships
-    up to KG_MAX_PARENT_RECURSION_DEPTH levels deep. E.g., if depth is 2, a relationship will be
-    created between the entity and its parent, and the entity and its grandparents (if any).
+    Create parent-child relationships and relationship types from staging entities with
+    a parent key, if the parent exists in the normalized entities table. Will create
+    relationships up to depth levels. E.g., if depth is 2, a relationship will be created
+    between the entity and its parent, and the entity and its grandparents (if any).
     A relationship will not be created if the parent does not exist.
     """
     relationship_types: dict[str, KGRelationshipTypeExtractionStaging] = {}
@@ -280,7 +280,7 @@ def get_parent_child_relationships_and_types(
     for entity in parented_entities:
         child = entity
 
-        for i in range(KG_MAX_PARENT_RECURSION_DEPTH, 0, -1):
+        for i in range(depth, 0, -1):
             if not child.parent_key:
                 break
 

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -282,7 +282,7 @@ def get_parent_child_relationships_and_types(
 
         for i in range(KG_MAX_PARENT_RECURSION_DEPTH, 0, -1):
             if not child.parent_key:
-                continue
+                break
 
             parent = (
                 db_session.query(KGEntity)

--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -94,7 +94,7 @@ def update_kg_type_dict(
     if "fields" not in dict_to_update:
         dict_to_update["fields"] = {}
     dict_to_update["fields"][kg_type] = {
-        "add": {kg_type_object: 1 for kg_type_object in value_set}
+        "assign": {kg_type_object: 1 for kg_type_object in value_set}
     }
     return dict_to_update
 

--- a/backend/onyx/document_index/vespa/kg_interactions.py
+++ b/backend/onyx/document_index/vespa/kg_interactions.py
@@ -12,8 +12,6 @@ from onyx.document_index.vespa.index import KGUChunkUpdateRequest
 from onyx.document_index.vespa.index import VespaIndex
 from onyx.utils.logger import setup_logger
 
-# from backend.onyx.chat.process_message import get_inference_chunks
-# from backend.onyx.document_index.vespa.index import VespaIndex
 
 logger = setup_logger()
 
@@ -62,7 +60,7 @@ def get_document_kg_info(
     return kg_doc_info
 
 
-@retry(tries=3, delay=1, backoff=2)
+@retry(tries=3, delay=0.1, backoff=3)
 def update_kg_chunks_vespa_info(
     kg_update_requests: list[KGUChunkUpdateRequest],
     index_name: str,
@@ -84,57 +82,68 @@ def update_kg_chunks_vespa_info(
     )
 
 
-def update_kg_chunks_vespa_info_for_entity(
-    entity: KGEntity,
+def update_kg_vespa_info_for_document(
+    document_id: str,
     index_name: str,
     tenant_id: str,
 ) -> None:
-    """Add the entity information to vespa for filtered search."""
-    if entity.document_id is None:
-        raise ValueError("Entity has no document_id")
-
-    # Add entity, and the generalized entity
-    kg_entities = {entity.id_name, f"{entity.entity_type_id_name}::*"}
-
-    # Add relationship and the generalized relationships in case
-    # an entity referenced already by a relationship gains a document_id
-    kg_relationships: set[str] = set()
+    """Update the vespa index with the new kg_info."""
+    # get all entities and relationships tied to the document
     with get_session_with_current_tenant() as db_session:
+        entities = (
+            db_session.query(KGEntity).filter(KGEntity.document_id == document_id).all()
+        )
+        if not entities:
+            return
+        entity_id_names = [entity.id_name for entity in entities]
+
         relationships = (
             db_session.query(KGRelationship)
             .filter(
                 or_(
-                    KGRelationship.source_node == entity.id_name,
-                    KGRelationship.target_node == entity.id_name,
+                    KGRelationship.source_node.in_(entity_id_names),
+                    KGRelationship.target_node.in_(entity_id_names),
+                    KGRelationship.source_document == document_id,
                 )
             )
             .all()
         )
-        for relationship in relationships:
-            kg_relationships.update(
-                {
-                    relationship.id_name,
-                    f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node}",
-                    f"{relationship.source_node}__{relationship.type}__{relationship.target_node_type}::*",
-                    f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node_type}::*",
-                }
-            )
 
-    # get chunks in the entity document
+    # create the kg vespa info
+    kg_entities: set[str] = set()
+    kg_relationships: set[str] = set()
+
+    for entity in entities:
+        kg_entities.add(entity.id_name)
+        kg_entities.add(f"{entity.entity_type_id_name}::*")
+
+    for relationship in relationships:
+        kg_relationships.add(relationship.id_name)
+        kg_relationships.add(
+            f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node}"
+        )
+        kg_relationships.add(
+            f"{relationship.source_node}__{relationship.type}__{relationship.target_node_type}::*",
+        )
+        kg_relationships.add(
+            f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node_type}::*"
+        )
+
+    # get chunks in the document
     chunks = _get_chunks_via_visit_api(
-        chunk_request=VespaChunkRequest(document_id=entity.document_id),
+        chunk_request=VespaChunkRequest(document_id=document_id),
         index_name=index_name,
         filters=IndexFilters(access_control_list=None),
-        field_names=["chunk_id", "metadata"],
+        field_names=["chunk_id"],
         get_large_chunks=False,
     )
 
     # update vespa
     kg_update_requests = [
         KGUChunkUpdateRequest(
-            document_id=entity.document_id,
+            document_id=document_id,
             chunk_id=chunk["fields"]["chunk_id"],
-            core_entity=entity.id_name,
+            core_entity="unused",
             entities=kg_entities,
             relationships=kg_relationships or None,
         )
@@ -145,58 +154,3 @@ def update_kg_chunks_vespa_info_for_entity(
         index_name=index_name,
         tenant_id=tenant_id,
     )
-
-
-def update_kg_chunks_vespa_info_for_relationship(
-    relationship: KGRelationship,
-    index_name: str,
-    tenant_id: str,
-) -> None:
-    """Add the relationship information to vespa for filtered search."""
-    # Add relationship, and the generalized relationship
-    kg_relationships = {
-        relationship.id_name,
-        f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node}",
-        f"{relationship.source_node}__{relationship.type}__{relationship.target_node_type}::*",
-        f"{relationship.source_node_type}::*__{relationship.type}__{relationship.target_node_type}::*",
-    }
-
-    with get_session_with_current_tenant() as db_session:
-        entity_documents = (
-            db_session.query(KGEntity.id_name, KGEntity.document_id)
-            .filter(
-                KGEntity.id_name.in_(
-                    [relationship.source_node, relationship.target_node]
-                )
-            )
-            .all()
-        )
-
-    for entity_id_name, source_document_id in entity_documents:
-        if source_document_id is None:
-            continue
-
-        # get chunks in the entity document
-        chunks = _get_chunks_via_visit_api(
-            chunk_request=VespaChunkRequest(document_id=source_document_id),
-            index_name=index_name,
-            filters=IndexFilters(access_control_list=None),
-            field_names=["chunk_id"],
-            get_large_chunks=False,
-        )
-
-        # update vespa
-        kg_update_requests = [
-            KGUChunkUpdateRequest(
-                document_id=source_document_id,
-                chunk_id=chunk["fields"]["chunk_id"],
-                core_entity=entity_id_name,
-                relationships=kg_relationships,
-            )
-            for chunk in chunks
-        ]
-        update_kg_chunks_vespa_info(
-            kg_update_requests=kg_update_requests,
-            index_name=index_name,
-            tenant_id=tenant_id,
-        )

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -181,7 +181,7 @@ def kg_clustering(
     ]
     entity_translations: dict[str, str] = {
         entity.id_name: entity.transferred_id_name
-        for entity in untransferred_grounded_entities
+        for entity in grounded_entities
         if entity.transferred_id_name is not None
     }
     vespa_update_documents: set[str] = set()

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -355,8 +355,6 @@ def kg_extraction(
         kg_config_settings = get_kg_config_settings(db_session)
 
     execute_kg_setting_tests(kg_config_settings)
-    assert kg_config_settings.KG_VENDOR is not None
-    assert kg_config_settings.KG_VENDOR_DOMAINS is not None
 
     # get connector ids that are enabled for KG extraction
 
@@ -366,9 +364,6 @@ def kg_extraction(
     connector_extraction_stats: list[ConnectorExtractionStats] = []
 
     processing_chunk_doc_extractions: list[
-        tuple[KGChunkFormat, KGDocumentEntitiesRelationshipsAttributes]
-    ] = []
-    carryover_chunk_doc_extractions: list[
         tuple[KGChunkFormat, KGDocumentEntitiesRelationshipsAttributes]
     ] = []
     connector_aggregated_kg_extractions_list: list[KGAggregatedExtractions] = []
@@ -473,6 +468,7 @@ def kg_extraction(
                     )
 
                     if kg_stage == KGStage.EXTRACTING:
+                        # TODO: update vespa
                         delete_from_kg_relationships__no_commit(
                             db_session, [unprocessed_document.id]
                         )
@@ -496,7 +492,7 @@ def kg_extraction(
 
             # run this only for primary grounded sources that have a classification approach configured
 
-            # mark docs in unprocessed_document_batch as EXTRACTING
+            # get documents with classification enabled
             classification_batch_list = []
             for unprocessed_document in unprocessed_document_batch:
                 # generate document batch for classifications
@@ -584,7 +580,7 @@ def kg_extraction(
                     continue
 
                 # 1. perform (implicit) KG 'extractions' on the documents that should be processed
-                # This is really about assigning document meta-data to KG entities/relationships or KG entity attrbutes
+                # This is really about assigning document meta-data to KG entities/relationships or KG entity attributes
                 # General approach:
                 #    - vendor emails to Employee-type entities + relationship to current primary grounded entity
                 #    - external account emails to Account-type entities + relationship to current primary grounded entity
@@ -604,129 +600,28 @@ def kg_extraction(
                     )
                 )
 
-                # 2. perform KG extraction on the chunks that should be processed
-
-                # TODO: kg-id-refactor: just grab first chunk as we update vespa in clustering
+                # 2. process each chunk in the document
+                # TODO: revisit once deep extraction is implemented, or metadata is different per chunk
+                # for now, just grab the first chunk
                 formatted_chunk_batches = get_document_chunks_for_kg_processing(
                     document_id=unprocessed_document.id,
                     deep_extraction=batch_metadata[
                         unprocessed_document.id
                     ].deep_extraction,
                     index_name=index_name,
-                    batch_size=processing_chunk_batch_size,
+                    batch_size=1,
                 )
 
-                formatted_chunk_doc_batches_list = list(formatted_chunk_batches)
+                formatted_chunk_doc_batch = next(formatted_chunk_batches)
+                if not formatted_chunk_doc_batch:
+                    continue
 
-                for formatted_chunk_doc_batch in formatted_chunk_doc_batches_list:
-
-                    processing_chunk_doc_extractions.extend(
-                        [
-                            (chunk, kg_document_extractions)
-                            for chunk in formatted_chunk_doc_batch
-                        ]
-                    )
-
-                    if (
-                        len(processing_chunk_doc_extractions)
-                        >= processing_chunk_batch_size
-                    ):
-                        carryover_chunk_doc_extractions.extend(
-                            processing_chunk_doc_extractions[
-                                processing_chunk_batch_size:
-                            ]
-                        )
-                        processing_chunk_doc_extractions = (
-                            processing_chunk_doc_extractions[
-                                :processing_chunk_batch_size
-                            ]
-                        )
-
-                        chunk_processing_batch_results = _kg_chunk_batch_extraction(
-                            chunk_doc_extractions=processing_chunk_doc_extractions,
-                            index_name=index_name,
-                            tenant_id=tenant_id,
-                            kg_config_settings=kg_config_settings,
-                        )
-
-                        # Consider removing the stats expressions here and rather write to the db(?)
-                        connector_failed_chunk_extractions.extend(
-                            chunk_processing_batch_results.failed
-                        )
-                        connector_succeeded_chunk_extractions.extend(
-                            chunk_processing_batch_results.succeeded
-                        )
-
-                        aggregated_batch_extractions = (
-                            chunk_processing_batch_results.aggregated_kg_extractions
-                        )
-                        # Update grounded_entities_document_ids (replace values)
-                        connector_aggregated_kg_extractions.grounded_entities_document_ids.update(
-                            aggregated_batch_extractions.grounded_entities_document_ids
-                        )
-                        # Add to entity counts instead of replacing
-                        for (
-                            entity,
-                            count,
-                        ) in aggregated_batch_extractions.entities.items():
-                            if (
-                                entity
-                                not in connector_aggregated_kg_extractions.entities
-                            ):
-                                connector_aggregated_kg_extractions.entities[entity] = (
-                                    count
-                                )
-                            else:
-                                connector_aggregated_kg_extractions.entities[
-                                    entity
-                                ] += count
-                        # Add to relationship counts instead of replacing
-                        for (
-                            relationship,
-                            relationship_data,
-                        ) in aggregated_batch_extractions.relationships.items():
-                            for source_document_id, count in relationship_data.items():
-                                if (
-                                    relationship
-                                    not in connector_aggregated_kg_extractions.relationships
-                                ):
-                                    connector_aggregated_kg_extractions.relationships[
-                                        relationship
-                                    ] = defaultdict(int)
-                                connector_aggregated_kg_extractions.relationships[
-                                    relationship
-                                ][source_document_id] += count
-
-                        # Add to term counts instead of replacing
-                        for term, count in aggregated_batch_extractions.terms.items():
-                            if term not in connector_aggregated_kg_extractions.terms:
-                                connector_aggregated_kg_extractions.terms[term] = count
-                            else:
-                                connector_aggregated_kg_extractions.terms[term] += count
-
-                        for (
-                            document_id,
-                            attributes,
-                        ) in aggregated_batch_extractions.attributes.items():
-                            connector_aggregated_kg_extractions.attributes[
-                                document_id
-                            ] = attributes
-
-                        connector_extraction_stats.append(
-                            ConnectorExtractionStats(
-                                connector_id=connector_id,
-                                num_failed=len(connector_failed_chunk_extractions),
-                                num_succeeded=len(
-                                    connector_succeeded_chunk_extractions
-                                ),
-                                num_processed=len(processing_chunk_doc_extractions),
-                            )
-                        )
-
-                        processing_chunk_doc_extractions = (
-                            carryover_chunk_doc_extractions.copy()
-                        )
-                        carryover_chunk_doc_extractions = []
+                processing_chunk_doc_extractions.extend(
+                    [
+                        (chunk, kg_document_extractions)
+                        for chunk in formatted_chunk_doc_batch
+                    ]
+                )
 
             # processes remaining chunks
             chunk_processing_batch_results = _kg_chunk_batch_extraction(
@@ -797,7 +692,6 @@ def kg_extraction(
             )
 
             processing_chunk_doc_extractions = []
-            carryover_chunk_doc_extractions = []
 
             connector_aggregated_kg_extractions_list.append(
                 connector_aggregated_kg_extractions
@@ -934,12 +828,7 @@ def kg_extraction(
                         )
                         continue
 
-                    source_entity, _, target_entity = relationship.split("__")
-                    source_entity = relationship_split[0]
-                    relationship_type = " ".join(relationship_split[1:-1]).replace(
-                        "__", "_"
-                    )
-                    target_entity = relationship_split[-1]
+                    source_entity, relationship_type, target_entity = relationship_split
 
                     source_entity_type = source_entity.split("::")[0]
                     target_entity_type = target_entity.split("::")[0]

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -468,7 +468,6 @@ def kg_extraction(
                     )
 
                     if kg_stage == KGStage.EXTRACTING:
-                        # TODO: update vespa
                         delete_from_kg_relationships__no_commit(
                             db_session, [unprocessed_document.id]
                         )
@@ -602,7 +601,7 @@ def kg_extraction(
 
                 # 2. process each chunk in the document
                 # TODO: revisit once deep extraction is implemented, or metadata is different per chunk
-                # for now, just grab the first chunk
+                # for now, just grab a single chunk (could be any chunk, as metadata is the same) per document
                 formatted_chunk_batches = get_document_chunks_for_kg_processing(
                     document_id=unprocessed_document.id,
                     deep_extraction=batch_metadata[
@@ -626,8 +625,6 @@ def kg_extraction(
             # processes remaining chunks
             chunk_processing_batch_results = _kg_chunk_batch_extraction(
                 chunk_doc_extractions=processing_chunk_doc_extractions,
-                index_name=index_name,
-                tenant_id=tenant_id,
                 kg_config_settings=kg_config_settings,
             )
 
@@ -983,8 +980,6 @@ def _kg_chunk_batch_extraction(
     chunk_doc_extractions: list[
         tuple[KGChunkFormat, KGDocumentEntitiesRelationshipsAttributes]
     ],
-    index_name: str,
-    tenant_id: str,
     kg_config_settings: KGConfigSettings,
 ) -> KGBatchExtractionStats:
     _, fast_llm = get_default_llms()

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -9,6 +9,7 @@ from onyx.configs.kg_configs import KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH
 
 
 class KGConfigSettings(BaseModel):
+    KG_EXPOSED: bool = False
     KG_ENABLED: bool = False
     KG_VENDOR: str | None = None
     KG_VENDOR_DOMAINS: list[str] | None = None
@@ -21,6 +22,7 @@ class KGConfigSettings(BaseModel):
 
 
 class KGConfigVars(str, Enum):
+    KG_EXPOSED = "KG_EXPOSED"
     KG_ENABLED = "KG_ENABLED"
     KG_VENDOR = "KG_VENDOR"
     KG_VENDOR_DOMAINS = "KG_VENDOR_DOMAINS"

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -14,7 +14,8 @@ class KGConfigSettings(BaseModel):
     KG_EXTRACTION_IN_PROGRESS: bool = False
     KG_CLUSTERING_IN_PROGRESS: bool = False
     KG_COVERAGE_START: datetime = datetime(1970, 1, 1)
-    KG_MAX_COVERAGE_DAYS: int = 1000000
+    KG_MAX_COVERAGE_DAYS: int = 10000
+    KG_MAX_PARENT_RECURSION_DEPTH: int = 2
 
 
 class KGConfigVars(str, Enum):
@@ -26,6 +27,7 @@ class KGConfigVars(str, Enum):
     KG_CLUSTERING_IN_PROGRESS = "KG_CLUSTERING_IN_PROGRESS"
     KG_COVERAGE_START = "KG_COVERAGE_START"
     KG_MAX_COVERAGE_DAYS = "KG_MAX_COVERAGE_DAYS"
+    KG_MAX_PARENT_RECURSION_DEPTH = "KG_MAX_PARENT_RECURSION_DEPTH"
 
 
 class KGChunkFormat(BaseModel):

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -5,6 +5,8 @@ from typing import Dict
 
 from pydantic import BaseModel
 
+from onyx.configs.kg_configs import KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH
+
 
 class KGConfigSettings(BaseModel):
     KG_ENABLED: bool = False
@@ -15,7 +17,7 @@ class KGConfigSettings(BaseModel):
     KG_CLUSTERING_IN_PROGRESS: bool = False
     KG_COVERAGE_START: datetime = datetime(1970, 1, 1)
     KG_MAX_COVERAGE_DAYS: int = 10000
-    KG_MAX_PARENT_RECURSION_DEPTH: int = 2
+    KG_MAX_PARENT_RECURSION_DEPTH: int = KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH
 
 
 class KGConfigVars(str, Enum):

--- a/backend/onyx/kg/resets/reset_vespa.py
+++ b/backend/onyx/kg/resets/reset_vespa.py
@@ -20,7 +20,7 @@ from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 logger = setup_logger()
 
 
-@retry(tries=3, delay=0.1, backoff=2)
+@retry(tries=3, delay=0.1, backoff=3)
 def _reset_vespa_for_doc(document_id: str, tenant_id: str, index_name: str) -> None:
     vespa_index = VespaIndex(
         index_name=index_name,


### PR DESCRIPTION
## Description

- Removed unnecessary extraction from other chunks of a document in extraction processing (we only look at 1 chunk now) now that vespa update got moved to clustering
- Moved vespa update at the end of clustering to speed up clustering
- Made vespa replace the entire kg_entity and kg_relationships info on update to better handle deleted entities/relationships, and fix issues of leftover info from previous runs
- Fixed vespa update for created parent child relationships
- Made parent-child relationship extraction depth configurable

## How Has This Been Tested?

Locally, on jira, github, linear, account, and opportunity entity types

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
