### PR TITLE
errors have correct file id

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -463,6 +463,12 @@ def _convert_drive_item_to_document(
             ),
         )
     except Exception as e:
+        doc_id = "unknown"
+        try:
+            doc_id = onyx_document_id_from_drive_file(file)
+        except Exception as e2:
+            logger.warning(f"Error getting document id from file: {e2}")
+
         file_name = file.get("name")
         error_str = (
             f"Error converting file '{file_name}' to Document as {retriever_email}: {e}"


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2035/drive-connectorfailure-file-id-unknown
Recent minor regression; ConnectorFailures would have id "unknown" if the error occurred before the doc id was extracted

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
