### PR TITLE
Fixed indexing when no sites are specified

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -10,6 +10,7 @@ import msal  # type: ignore
 from office365.graph_client import GraphClient  # type: ignore
 from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore
 from office365.onedrive.sites.site import Site  # type: ignore
+from office365.onedrive.sites.sites_with_root import SitesWithRoot  # type: ignore
 from pydantic import BaseModel
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -229,7 +230,9 @@ class SharepointConnector(LoadConnector, PollConnector):
 
         return final_driveitems
 
-    def _handle_paginated_sites(self, sites) -> Generator[Site, None, None]:
+    def _handle_paginated_sites(
+        self, sites: SitesWithRoot
+    ) -> Generator[Site, None, None]:
         while sites:
             if sites.current_page:
                 yield from sites.current_page

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -229,13 +229,16 @@ class SharepointConnector(LoadConnector, PollConnector):
 
     def _fetch_sites(self) -> list[SiteDescriptor]:
         sites = self.graph_client.sites.get_all().execute_query()
-        site_descriptors = [
-            SiteDescriptor(
-                url=sites.resource_url,
-                drive_name=None,
-                folder_path=None,
+        site_descriptors = []
+        for site in sites.current_page:
+            site_descriptors.append(
+                SiteDescriptor(
+                    url=site.web_url,
+                    drive_name=None,
+                    folder_path=None,
+                )
             )
-        ]
+
         return site_descriptors
 
     def _fetch_from_sharepoint(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1,5 +1,6 @@
 import io
 import os
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -8,6 +9,7 @@ from urllib.parse import unquote
 import msal  # type: ignore
 from office365.graph_client import GraphClient  # type: ignore
 from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore
+from office365.onedrive.sites.site import Site  # type: ignore
 from pydantic import BaseModel
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -227,7 +229,7 @@ class SharepointConnector(LoadConnector, PollConnector):
 
         return final_driveitems
 
-    def _handle_paginated_sites(self, sites):
+    def _handle_paginated_sites(self, sites) -> Generator[Site, None, None]:
         while sites:
             if sites.current_page:
                 yield from sites.current_page

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -85,6 +85,26 @@ def sharepoint_credentials() -> dict[str, str]:
     }
 
 
+def test_sharepoint_connector_all_sites(
+    mock_get_unstructured_api_key: MagicMock,
+    sharepoint_credentials: dict[str, str],
+) -> None:
+    # Initialize connector with the base site URL
+    connector = SharepointConnector()
+
+    # Load credentials
+    connector.load_credentials(sharepoint_credentials)
+
+    # Get all documents
+    document_batches = list(connector.load_from_state())
+    found_documents: list[Document] = [
+        doc for batch in document_batches for doc in batch
+    ]
+    assert (
+        len(found_documents) > 0
+    ), "Should retrieve all sites and find at least one document"
+
+
 def test_sharepoint_connector_specific_folder(
     mock_get_unstructured_api_key: MagicMock,
     sharepoint_credentials: dict[str, str],

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -89,20 +89,16 @@ def test_sharepoint_connector_all_sites(
     mock_get_unstructured_api_key: MagicMock,
     sharepoint_credentials: dict[str, str],
 ) -> None:
-    # Initialize connector with the base site URL
+    # Initialize connector with no sites
     connector = SharepointConnector()
 
     # Load credentials
     connector.load_credentials(sharepoint_credentials)
 
-    # Get all documents
+    # Not asserting expected sites because that can change in test tenant at any time
+    # Finding any docs is good enough to verify that the connector is working
     document_batches = list(connector.load_from_state())
-    found_documents: list[Document] = [
-        doc for batch in document_batches for doc in batch
-    ]
-    assert (
-        len(found_documents) > 0
-    ), "Should retrieve all sites and find at least one document"
+    assert document_batches, "Should find documents from all sites"
 
 
 def test_sharepoint_connector_specific_folder(


### PR DESCRIPTION
## Description

Sharepoint connector didn't correctly list sites in organization

Fixes https://linear.app/danswer/issue/DAN-2044/sharepoint-indexing-bug

## How Has This Been Tested?

Created Sharepoint connector with no sites specified

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
