### PR TITLE
Add Helm chart resources for indexing-model and inference-model

### DIFF
--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx-stack.envSecrets" . | nindent 10}}
+        resources:
+          {{- toYaml .Values.indexCapability.resources | nindent 12 }}
         volumeMounts:
         {{- range .Values.indexCapability.volumeMounts }}
         - name: {{ .name }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -34,6 +34,8 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
+        resources:
+          {{- toYaml .Values.indexCapability.resources | nindent 12 }}
         volumeMounts:
         {{- range .Values.inferenceCapability.volumeMounts }}
         - name: {{ .name }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
         resources:
-          {{- toYaml .Values.indexCapability.resources | nindent 12 }}
+          {{- toYaml .Values.inferenceCapability.resources | nindent 12 }}
         volumeMounts:
         {{- range .Values.inferenceCapability.volumeMounts }}
         - name: {{ .name }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -95,7 +95,8 @@ inferenceCapability:
   podLabels:
     - key: app
       value: inference-model-server
-
+  resources: {}
+  
 indexCapability:
   service:
     portName: modelserver
@@ -129,6 +130,8 @@ indexCapability:
     tag: ""
     pullPolicy: IfNotPresent
   limitConcurrency: 10
+  resources: {}
+
 config:
   envConfigMapName: env-configmap
 


### PR DESCRIPTION
## Description

Add Helm chart resources for indexing-model and inference-model
Closes #4467

## How Has This Been Tested?

- helm lint
- helm template
- deploy (as a part of wider change)

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
