### PR TITLE
KG autofill metadata

### DIFF
--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -51,8 +51,8 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
 )
 
 
-KG_METADATA_TRACkING_THRESHOLD: int = int(
-    os.environ.get("KG_METADATA_TRACkING_THRESHOLD", "10")
+KG_METADATA_TRACKING_THRESHOLD: int = int(
+    os.environ.get("KG_METADATA_TRACKING_THRESHOLD", "10")
 )
 
 

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -51,6 +51,11 @@ KG_MAX_DEEP_SEARCH_RESULTS: int = int(
 )
 
 
+KG_METADATA_TRACkING_THRESHOLD: int = int(
+    os.environ.get("KG_METADATA_TRACkING_THRESHOLD", "10")
+)
+
+
 KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH: int = int(
     os.environ.get("KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH", "2")
 )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -647,7 +647,7 @@ class KGEntityType(Base):
         NullFilteredString, nullable=False, index=False
     )
 
-    attributes: Mapped[str] = mapped_column(
+    attributes: Mapped[dict] = mapped_column(
         postgresql.JSONB,
         nullable=True,
         default=dict,

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -221,3 +221,13 @@ class KGDefaultEntityDefinition(BaseModel):
     grounded_source_name: str | None
     attributes: dict = {}
     entity_values: dict = {}
+
+
+class MetadataTrackType(str, Enum):
+    VALUE = "value"
+    LIST = "list"
+
+
+class MetadataTrackInfo(BaseModel):
+    type: MetadataTrackType
+    values: set[str] | None

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -446,6 +446,7 @@ def is_email(email: str) -> bool:
 
 
 def trackinfo_to_str(trackinfo: MetadataTrackInfo | None) -> str:
+    """Convert trackinfo to an LLM friendly string"""
     if trackinfo is None:
         return ""
 
@@ -460,6 +461,7 @@ def trackinfo_to_str(trackinfo: MetadataTrackInfo | None) -> str:
 
 
 def trackinfo_from_str(trackinfo_str: str) -> MetadataTrackInfo | None:
+    """Convert back from LLM friendly string to trackinfo"""
     if trackinfo_str == "any suitable value":
         return MetadataTrackInfo(type=MetadataTrackType.VALUE, values=None)
     elif trackinfo_str == "a list of any suitable values":

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -6,7 +6,7 @@ from typing import Literal
 from pydantic import BaseModel
 
 from onyx.configs.constants import OnyxCallTypes
-from onyx.configs.kg_configs import KG_METADATA_TRACkING_THRESHOLD
+from onyx.configs.kg_configs import KG_METADATA_TRACKING_THRESHOLD
 from onyx.db.engine import get_session_with_current_tenant
 from onyx.db.entities import get_kg_entity_by_document
 from onyx.db.kg_config import KGConfigSettings
@@ -552,7 +552,7 @@ class EntityTypeMetadataTracker:
             # if we see to many different values, we stop tracking
             if (
                 trackinfo.values is None
-                or len(trackinfo.values) > KG_METADATA_TRACkING_THRESHOLD
+                or len(trackinfo.values) > KG_METADATA_TRACKING_THRESHOLD
             ):
                 trackinfo.values = None
                 continue


### PR DESCRIPTION
## Description

Autofills metadata possible values
Can be either a list or a single value.
If there are too many possible options, it is replaced with "any suitable value" or "list of any suitable values"

E.g.,
- "status": "one of: To Do, In Progress, Done"
- "created_at": "a suitable value"
- "labels": "a list with possible values: good first issue, enhancements"
- "assignees": "a list of any suitable values"

## How Has This Been Tested?

Locally, both incrementally and all at once

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
