### PR TITLE
Order sub-questions for chat message

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2036,6 +2036,7 @@ class ChatMessage(Base):
     sub_questions: Mapped[list["AgentSubQuestion"]] = relationship(
         "AgentSubQuestion",
         back_populates="primary_message",
+        order_by="(AgentSubQuestion.level, AgentSubQuestion.level_question_num)",
     )
 
     standard_answers: Mapped[list["StandardAnswer"]] = relationship(


### PR DESCRIPTION
## Description

One-line PR that sorts the subquestions for a chat message.

here is the issue: https://linear.app/danswer/issue/DAN-2061/wrong-step-ordering-in-kg-ui-prototype

This is now addressed by ordering the sub-questions (level first, then level_question_num).

## How Has This Been Tested?

Locally in multi-tenant environment. Used standard Search, Agent Search, and KG Search.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
