### PR TITLE
fix(discourse): Remove early break that was limiting topics to indexing batch size

### DIFF
--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -182,8 +182,6 @@ class DiscourseConnector(PollConnector):
                 continue
 
             topic_ids.append(topic["id"])
-            if len(topic_ids) >= self.batch_size:
-                break
 
         return topic_ids
 


### PR DESCRIPTION
## Description

The Discourse connector was incorrectly `break`ing after processing the first batch of topics (16) even though the API returns 30 topics per page. This caused the connector to miss processing the remaining topics from each page.

## How Has This Been Tested?

Noticed a discrepancy in the document count indexed when trying to sync my own discourse setup. I tested by making the changes and building the `background` service locally and running the sync again. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
