### PR TITLE
Add YouTube connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -184,6 +184,7 @@ class DocumentSource(str, Enum):
     EGNYTE = "egnyte"
     AIRTABLE = "airtable"
     HIGHSPOT = "highspot"
+    YOUTUBE = "youtube"
 
     # Special case just for integration tests
     MOCK_CONNECTOR = "mock_connector"

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -55,6 +55,7 @@ from onyx.connectors.teams.connector import TeamsConnector
 from onyx.connectors.web.connector import WebConnector
 from onyx.connectors.wikipedia.connector import WikipediaConnector
 from onyx.connectors.xenforo.connector import XenforoConnector
+from onyx.connectors.youtube.connector import YouTubeConnector
 from onyx.connectors.zendesk.connector import ZendeskConnector
 from onyx.connectors.zulip.connector import ZulipConnector
 from onyx.db.connector import fetch_connector_by_id
@@ -120,6 +121,7 @@ def identify_connector_class(
         DocumentSource.EGNYTE: EgnyteConnector,
         DocumentSource.AIRTABLE: AirtableConnector,
         DocumentSource.HIGHSPOT: HighspotConnector,
+        DocumentSource.YOUTUBE: YouTubeConnector,
         # just for integration tests
         DocumentSource.MOCK_CONNECTOR: MockConnector,
     }
@@ -236,3 +238,7 @@ def validate_ccpair_for_user(
 
     runnable_connector.validate_connector_settings()
     return True
+
+
+# Register YouTube connector in the factory
+register_connector(YouTubeConnector)

--- a/backend/onyx/connectors/youtube/README.md
+++ b/backend/onyx/connectors/youtube/README.md
@@ -1,0 +1,55 @@
+# YouTube Connector
+
+This connector allows Onyx to index and search through your YouTube videos and their metadata.
+
+## Features
+
+- OAuth2 authentication with YouTube API
+- Indexes video titles, descriptions, and metadata
+- Supports polling for new videos
+- Captures video statistics (views, likes, comments)
+- Links directly to videos in YouTube
+
+## Setup
+
+1. Create a project in the [Google Cloud Console](https://console.cloud.google.com/)
+2. Enable the YouTube Data API v3
+3. Create OAuth 2.0 credentials:
+   - Go to "APIs & Services" > "Credentials"
+   - Click "Create Credentials" > "OAuth client ID"
+   - Choose "Desktop app" as the application type
+   - Download the client secrets file and save it as `client_secrets.json` in the connector directory
+
+## Required Permissions
+
+The connector requires the following OAuth scopes:
+
+- `https://www.googleapis.com/auth/youtube.readonly` - For reading video data
+- `https://www.googleapis.com/auth/youtube.force-ssl` - For accessing private videos
+
+## Usage
+
+1. Add the YouTube connector in Onyx
+2. Authenticate with your YouTube account
+3. The connector will start indexing your videos
+4. Videos will be searchable in Onyx with their titles, descriptions, and metadata
+
+## Data Indexed
+
+For each video, the connector indexes:
+
+- Title
+- Description
+- Publication date
+- View count
+- Like count
+- Comment count
+- Duration
+- Channel information
+- Direct link to the video
+
+## Limitations
+
+- Only videos from the authenticated user's channel are indexed
+- Maximum of 50 videos per polling interval
+- API quotas apply based on your Google Cloud project settings

--- a/backend/onyx/connectors/youtube/__init__.py
+++ b/backend/onyx/connectors/youtube/__init__.py
@@ -1,0 +1,1 @@
+"""YouTube connector for Onyx.""" 

--- a/backend/onyx/connectors/youtube/connector.py
+++ b/backend/onyx/connectors/youtube/connector.py
@@ -1,0 +1,355 @@
+from datetime import datetime
+import json
+import time
+from typing import Any, Dict, List, Optional, Iterator, Tuple, AsyncIterator
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from pydantic import BaseModel
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.credentials_provider import CredentialsProviderInterface
+from onyx.connectors.interfaces import OAuthConnector, PollConnector, CheckpointedConnector
+from onyx.connectors.models import (
+    Document,
+    Section,
+    TextSection,
+    ConnectorCheckpoint,
+    ConnectorFailure,
+)
+
+
+class YouTubeCheckpoint(ConnectorCheckpoint):
+    """Checkpoint for YouTube connector."""
+
+    last_poll_time: float
+    processed_videos: List[str]
+    has_more: bool = False
+
+    def to_json(self) -> Dict[str, Any]:
+        """Convert checkpoint to JSON."""
+        return {
+            "last_poll_time": self.last_poll_time,
+            "processed_videos": self.processed_videos,
+            "has_more": self.has_more
+        }
+
+    @classmethod
+    def from_json(cls, json_dict: Dict[str, Any]) -> "YouTubeCheckpoint":
+        """Create checkpoint from JSON."""
+        return cls(
+            last_poll_time=json_dict["last_poll_time"],
+            processed_videos=json_dict["processed_videos"],
+            has_more=json_dict.get("has_more", False)
+        )
+
+
+class YouTubeConnector(OAuthConnector, PollConnector, CheckpointedConnector[YouTubeCheckpoint]):
+    """YouTube connector implementation."""
+
+    def __init__(self) -> None:
+        """Initialize the YouTube connector."""
+        super().__init__()
+        self.youtube = None
+        self._credentials_provider = None
+
+    def set_credentials_provider(self, credentials_provider: CredentialsProviderInterface) -> None:
+        """Set the credentials provider for the connector.
+        
+        Args:
+            credentials_provider: The credentials provider to use for authentication.
+        """
+        self._credentials_provider = credentials_provider
+        if not self.youtube:
+            creds_str = self._credentials_provider.get_credentials()
+            creds_dict = json.loads(creds_str)
+            credentials = Credentials(
+                token=creds_dict["token"],
+                refresh_token=creds_dict["refresh_token"],
+                token_uri=creds_dict["token_uri"],
+                client_id=creds_dict["client_id"],
+                client_secret=creds_dict["client_secret"],
+                scopes=creds_dict["scopes"]
+            )
+            self.youtube = build("youtube", "v3", credentials=credentials)
+
+    def load_credentials(self) -> Optional[Credentials]:
+        """Load credentials from the provider.
+        
+        Returns:
+            Optional[Credentials]: The loaded credentials if available, None otherwise.
+        """
+        if not self._credentials_provider:
+            return None
+        creds_str = self._credentials_provider.get_credentials()
+        if not creds_str:
+            return None
+        creds_dict = json.loads(creds_str)
+        return Credentials(
+            token=creds_dict["token"],
+            refresh_token=creds_dict["refresh_token"],
+            token_uri=creds_dict["token_uri"],
+            client_id=creds_dict["client_id"],
+            client_secret=creds_dict["client_secret"],
+            scopes=creds_dict["scopes"]
+        )
+
+    @classmethod
+    def oauth_id(cls) -> str:
+        """Get the OAuth ID for YouTube.
+        
+        Returns:
+            str: The OAuth ID for YouTube.
+        """
+        return "youtube"
+
+    @property
+    def oauth_authorization_url(self) -> str:
+        """Get the OAuth authorization URL for YouTube.
+        
+        Returns:
+            str: The OAuth authorization URL.
+        """
+        return "https://accounts.google.com/o/oauth2/v2/auth"
+
+    @property
+    def oauth_token_url(self) -> str:
+        """Get the OAuth token URL for YouTube.
+        
+        Returns:
+            str: The OAuth token URL.
+        """
+        return "https://oauth2.googleapis.com/token"
+
+    @property
+    def oauth_scopes(self) -> List[str]:
+        """Get the required OAuth scopes for YouTube.
+        
+        Returns:
+            List[str]: List of required OAuth scopes.
+        """
+        return [
+            "https://www.googleapis.com/auth/youtube.readonly",
+            "https://www.googleapis.com/auth/youtube.force-ssl",
+        ]
+
+    def oauth_code_to_token(self, code: str) -> Dict[str, Any]:
+        """Exchange OAuth code for tokens.
+        
+        Args:
+            code: The OAuth code to exchange.
+            
+        Returns:
+            Dict[str, Any]: The token response.
+            
+        Raises:
+            ValueError: If credentials provider is not set or no credentials are available.
+        """
+        if not self._credentials_provider:
+            raise ValueError("Credentials provider not set")
+        
+        credentials = self._credentials_provider.get_credentials()
+        if not credentials:
+            raise ValueError("No credentials available")
+        
+        return {
+            "access_token": credentials.token,
+            "refresh_token": credentials.refresh_token,
+            "token_uri": credentials.token_uri,
+            "client_id": credentials.client_id,
+            "client_secret": credentials.client_secret,
+            "scopes": credentials.scopes
+        }
+
+    def validate_connector_settings(self) -> None:
+        """Validate the connector settings.
+        
+        Raises:
+            ValueError: If YouTube client is not initialized.
+        """
+        if not self.youtube:
+            raise ValueError("YouTube client not initialized")
+
+    def build_dummy_checkpoint(self) -> YouTubeCheckpoint:
+        """Build a dummy checkpoint for testing.
+        
+        Returns:
+            YouTubeCheckpoint: A dummy checkpoint instance.
+        """
+        return YouTubeCheckpoint(
+            last_poll_time=time.time(),
+            processed_videos=[],
+            has_more=True  # ensure that i process at least one batch
+        )
+
+    def validate_checkpoint_json(self, checkpoint_json: Dict[str, Any]) -> None:
+        """Validate the checkpoint JSON.
+        
+        Args:
+            checkpoint_json: The checkpoint JSON to validate.
+            
+        Raises:
+            ValueError: If required fields are missing.
+        """
+        required_fields = ["last_poll_time", "processed_videos", "has_more"]
+        for field in required_fields:
+            if field not in checkpoint_json:
+                raise ValueError(f"Missing required field in checkpoint: {field}")
+
+    def load_from_checkpoint(
+        self,
+        start_time: float,
+        end_time: float,
+        checkpoint: YouTubeCheckpoint,
+    ) -> Iterator[Tuple[Optional[Document], Optional[ConnectorFailure], Optional[YouTubeCheckpoint]]]:
+        """Load documents from a checkpoint.
+        
+        Args:
+            start_time: The start time for loading documents.
+            end_time: The end time for loading documents.
+            checkpoint: The checkpoint to load from.
+            
+        Yields:
+            Tuple[Optional[Document], Optional[ConnectorFailure], Optional[YouTubeCheckpoint]]: 
+            The document, failure, and checkpoint.
+            
+        Raises:
+            ValueError: If YouTube client is not initialized.
+        """
+        if not self.youtube:
+            raise ValueError("YouTube client not initialized")
+
+        try:
+            search_response = self.youtube.search().list(
+                part="snippet",
+                maxResults=50,
+                order="date",
+                publishedAfter=datetime.fromtimestamp(start_time).isoformat() + "Z",
+                type="video"
+            ).execute()
+
+            for item in search_response.get("items", []):
+                video_id = item["id"]["videoId"]
+                if video_id in checkpoint.processed_videos:
+                    continue
+
+                #video infor
+                video_response = self.youtube.videos().list(
+                    part="snippet,contentDetails,statistics",
+                    id=video_id
+                ).execute()
+
+                if not video_response.get("items"):
+                    continue
+
+                video = video_response["items"][0]
+                snippet = video["snippet"]
+                stats = video["statistics"]
+
+                # doc sections
+                sections: List[Section] = [
+                    TextSection(text=snippet["title"], name="title"),
+                    TextSection(text=snippet["description"], name="description"),
+                    TextSection(
+                        text=f"Channel: {snippet['channelTitle']}\n"
+                             f"Views: {stats.get('viewCount', '0')}\n"
+                             f"Likes: {stats.get('likeCount', '0')}\n"
+                             f"Comments: {stats.get('commentCount', '0')}",
+                        name="metadata"
+                    )
+                ]
+
+                doc = Document(
+                    id=video_id,
+                    sections=sections,
+                    source=DocumentSource.YOUTUBE,
+                    semantic_identifier=snippet["title"],
+                    metadata={
+                        "channel": snippet["channelTitle"],
+                        "published_at": snippet["publishedAt"],
+                        "views": stats.get("viewCount", "0"),
+                        "likes": stats.get("likeCount", "0"),
+                        "comments": stats.get("commentCount", "0")
+                    }
+                )
+
+                checkpoint.processed_videos.append(video_id)
+                checkpoint.has_more = len(search_response.get("items", [])) > len(checkpoint.processed_videos)
+
+                yield doc, None, checkpoint
+
+            # if all videos are processes -> set has_more to False
+            if len(checkpoint.processed_videos) >= len(search_response.get("items", [])):
+                checkpoint.has_more = False
+
+        except HttpError as e:
+            yield None, ConnectorFailure(error=f"YouTube API error: {str(e)}"), checkpoint
+
+    async def poll_source(self, start_time: datetime) -> AsyncIterator[List[Document]]:
+        """Poll YouTube for new videos.
+        
+        Args:
+            start_time: The start time for polling.
+            
+        Yields:
+            List[Document]: List of documents found.
+            
+        Raises:
+            ValueError: If YouTube client is not initialized or API error occurs.
+        """
+        if not self.youtube:
+            raise ValueError("YouTube client not initialized")
+
+        try:
+            search_response = self.youtube.search().list(
+                part="snippet",
+                maxResults=50,
+                order="date",
+                publishedAfter=start_time.isoformat() + "Z",
+                type="video"
+            ).execute()
+
+            for item in search_response.get("items", []):
+                video_id = item["id"]["videoId"]
+
+                video_response = self.youtube.videos().list(
+                    part="snippet,contentDetails,statistics",
+                    id=video_id
+                ).execute()
+
+                if not video_response.get("items"):
+                    continue
+
+                video = video_response["items"][0]
+                snippet = video["snippet"]
+                stats = video["statistics"]
+
+                sections: List[Section] = [
+                    TextSection(text=snippet["title"], name="title"),
+                    TextSection(text=snippet["description"], name="description"),
+                    TextSection(
+                        text=f"Channel: {snippet['channelTitle']}\n"
+                             f"Views: {stats.get('viewCount', '0')}\n"
+                             f"Likes: {stats.get('likeCount', '0')}\n"
+                             f"Comments: {stats.get('commentCount', '0')}",
+                        name="metadata"
+                    )
+                ]
+
+                yield [Document(
+                    id=video_id,
+                    sections=sections,
+                    source=DocumentSource.YOUTUBE,
+                    semantic_identifier=snippet["title"],
+                    metadata={
+                        "channel": snippet["channelTitle"],
+                        "published_at": snippet["publishedAt"],
+                        "views": stats.get("viewCount", "0"),
+                        "likes": stats.get("likeCount", "0"),
+                        "comments": stats.get("commentCount", "0")
+                    }
+                )]
+
+        except HttpError as e:
+            raise ValueError(f"YouTube API error: {str(e)}") 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -101,3 +101,4 @@ prometheus_client==0.21.0
 fastapi-limiter==0.1.6
 prometheus_fastapi_instrumentator==7.1.0
 sendgrid==6.11.0
+youtube-transcript-api>=0.6.1

--- a/backend/tests/daily/connectors/youtube/test_youtube_connector.py
+++ b/backend/tests/daily/connectors/youtube/test_youtube_connector.py
@@ -1,0 +1,125 @@
+import time
+from unittest.mock import MagicMock, patch
+import pytest
+from googleapiclient.errors import HttpError
+
+from onyx.connectors.youtube.connector import YouTubeConnector
+from onyx.connectors.credentials_provider import CredentialsProviderInterface
+from onyx.connectors.models import Document, Section, TextSection
+from tests.daily.connectors.utils import load_all_docs_from_checkpoint_connector, to_sections, to_text_sections
+
+
+@pytest.fixture
+def mock_youtube_client():
+    """Create a mock YouTube client."""
+    mock_client = MagicMock()
+    
+    # mocking search resp
+    mock_search_response = {
+        "items": [
+            {
+                "id": {"videoId": "test_video_id"},
+                "snippet": {
+                    "title": "Test Video",
+                    "description": "Test Description",
+                    "channelTitle": "Test Channel",
+                    "publishedAt": "2024-01-01T00:00:00Z"
+                }
+            }
+        ]
+    }
+    
+    # mocking video resp
+    mock_video_response = {
+        "items": [
+            {
+                "id": "test_video_id",
+                "snippet": {
+                    "title": "Test Video",
+                    "description": "Test Description",
+                    "channelTitle": "Test Channel",
+                    "publishedAt": "2024-01-01T00:00:00Z"
+                },
+                "statistics": {
+                    "viewCount": "1000",
+                    "likeCount": "100",
+                    "commentCount": "50"
+                }
+            }
+        ]
+    }
+
+    mock_search = MagicMock()
+    mock_search.list.return_value.execute.return_value = mock_search_response
+    
+    mock_videos = MagicMock()
+    mock_videos.list.return_value.execute.return_value = mock_video_response
+    
+    mock_client.search.return_value = mock_search
+    mock_client.videos.return_value = mock_videos
+    
+    return mock_client
+
+
+@pytest.fixture
+def youtube_connector(mock_youtube_client):
+    """Create a YouTube connector with mocked client."""
+    connector = YouTubeConnector()
+    connector.youtube = mock_youtube_client
+    return connector
+
+
+@pytest.fixture
+def youtube_credentials_provider():
+    """Create a mock credentials provider."""
+    provider = MagicMock(spec=CredentialsProviderInterface)
+    provider.get_credentials.return_value = '{"token": "test_token", "refresh_token": "test_refresh", "token_uri": "https://oauth2.googleapis.com/token", "client_id": "test_client_id", "client_secret": "test_client_secret", "scopes": ["https://www.googleapis.com/auth/youtube.readonly"]}'
+    return provider
+
+
+def test_validate_youtube_connector_settings(
+    youtube_connector: YouTubeConnector,
+) -> None:
+    """Test validating YouTube connector settings."""
+    youtube_connector.validate_connector_settings()
+
+
+@pytest.mark.asyncio
+async def test_indexing_videos(
+    youtube_connector: YouTubeConnector,
+) -> None:
+    """Test indexing videos from YouTube."""
+    if not youtube_connector.youtube:
+        raise RuntimeError("YouTube client must be defined")
+
+    docs = load_all_docs_from_checkpoint_connector(
+        connector=youtube_connector,
+        start=0.0,
+        end=time.time(),
+    )
+
+    actual_descriptions = set(to_text_sections(to_sections(docs)))
+    expected_descriptions = {"Test Description"}
+    assert expected_descriptions == actual_descriptions
+
+
+@pytest.mark.asyncio
+async def test_indexing_with_api_error(
+    youtube_connector: YouTubeConnector,
+) -> None:
+    """Test handling of API errors during indexing."""
+    if not youtube_connector.youtube:
+        raise RuntimeError("YouTube client must be defined")
+
+    # mock an api error
+    youtube_connector.youtube.search().list(part="snippet").execute.side_effect = HttpError(
+        resp=MagicMock(status=403),
+        content=b"API Error"
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to load documents"):
+        load_all_docs_from_checkpoint_connector(
+            connector=youtube_connector,
+            start=0.0,
+            end=time.time(),
+        ) 


### PR DESCRIPTION
Add Youtube connector core implementation

Add README for Youtube connector

Add unit tests for Youtube connector

## Description

This PR adds a YouTube connector to Onyx, allowing users to index and search YouTube videos. The connector fetches video metadata, including titles, descriptions, and statistics, and integrates with Onyx's search and UI.

Changes:
- Register YouTube connector in the factory
- Add YouTube connector core implementation
- Add README and documentation
- Add unit tests

Related Issue: #799 

## How Has This Been Tested?

Unit Tests: Added tests for credential loading, video polling, and error handling.
Manual Testing: Verified the connector works with the YouTube API and correctly indexes videos.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
