### PR TITLE
Feat: Better subtype support for Knowledge Graph

### DIFF
--- a/backend/onyx/agents/agent_search/kb_search/models.py
+++ b/backend/onyx/agents/agent_search/kb_search/models.py
@@ -8,7 +8,6 @@ from onyx.agents.agent_search.kb_search.states import YesNoEnum
 
 class KGQuestionEntityExtractionResult(BaseModel):
     entities: list[str]
-    terms: list[str]
     time_filter: str | None
 
 

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
@@ -140,16 +140,12 @@ def extract_ert(
                 "Failed to parse LLM response as JSON in Entity-Term Extraction"
             )
             entity_extraction_result = KGQuestionEntityExtractionResult(
-                entities=[],
-                terms=[],
-                time_filter="",
+                entities=[], time_filter=""
             )
     except Exception as e:
         logger.error(f"Error in extract_ert: {e}")
         entity_extraction_result = KGQuestionEntityExtractionResult(
-            entities=[],
-            terms=[],
-            time_filter="",
+            entities=[], time_filter=""
         )
 
     # remove the attribute filters from the entities to for the purpose of the relationship
@@ -253,7 +249,7 @@ Entities: {extracted_entity_string} - \n Relationships: {extracted_relationship_
         extracted_entities_w_attributes=entity_extraction_result.entities,
         extracted_entities_no_attributes=entities_no_attributes,
         extracted_relationships=relationship_extraction_result.relationships,
-        extracted_terms=entity_extraction_result.terms,
+        extracted_terms=[],  # TODO: fully remove eventually
         time_filter=entity_extraction_result.time_filter,
         kg_doc_temp_view_name=allowed_docs_view_name,
         kg_rel_temp_view_name=kg_relationships_view_name,

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a2_analyze.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a2_analyze.py
@@ -31,7 +31,6 @@ from onyx.db.entities import get_document_id_for_entity
 from onyx.kg.clustering.normalizations import normalize_entities
 from onyx.kg.clustering.normalizations import normalize_entities_w_attributes_from_map
 from onyx.kg.clustering.normalizations import normalize_relationships
-from onyx.kg.clustering.normalizations import normalize_terms
 from onyx.kg.utils.formatting_utils import split_relationship_id
 from onyx.prompts.kg_prompts import STRATEGY_GENERATION_PROMPT
 from onyx.utils.logger import setup_logger
@@ -147,7 +146,7 @@ def analyze(
         state.extracted_entities_no_attributes
     )  # attribute knowledge is not required for this step
     relationships = state.extracted_relationships
-    terms = state.extracted_terms
+    state.extracted_terms
     time_filter = state.time_filter
 
     ## STEP 2 - stream out goals
@@ -168,7 +167,7 @@ def analyze(
     normalized_relationships = normalize_relationships(
         relationships, normalized_entities.entity_normalization_map
     )
-    normalized_terms = normalize_terms(terms)
+
     normalized_time_filter = time_filter
 
     # If single-doc inquiry, send to single-doc processing directly
@@ -280,7 +279,7 @@ Format: {output_format.value}, Broken down question: {broken_down_question}"
         query_graph_entities_no_attributes=query_graph_entities,
         query_graph_entities_w_attributes=query_graph_entities_w_attributes,
         query_graph_relationships=query_graph_relationships,
-        normalized_terms=normalized_terms.terms,
+        normalized_terms=[],  # TODO: remove completely later
         normalized_time_filter=normalized_time_filter,
         strategy=search_strategy,
         broken_down_question=broken_down_question,

--- a/backend/onyx/agents/agent_search/kb_search/states.py
+++ b/backend/onyx/agents/agent_search/kb_search/states.py
@@ -67,7 +67,7 @@ class AnalysisUpdate(LoggerUpdate):
     normalized_core_entities: list[str] = []
     normalized_core_relationships: list[str] = []
     entity_normalization_map: dict[str, str] = {}
-    relationship_normalization_map: dict[str, str] = {}
+    relationship_normalization_map: dict[str, list[str]] = {}
     query_graph_entities_no_attributes: list[str] = []
     query_graph_entities_w_attributes: list[str] = []
     query_graph_relationships: list[str] = []

--- a/backend/onyx/agents/agent_search/kb_search/states.py
+++ b/backend/onyx/agents/agent_search/kb_search/states.py
@@ -67,7 +67,7 @@ class AnalysisUpdate(LoggerUpdate):
     normalized_core_entities: list[str] = []
     normalized_core_relationships: list[str] = []
     entity_normalization_map: dict[str, str] = {}
-    relationship_normalization_map: dict[str, list[str]] = {}
+    relationship_normalization_map: dict[str, str] = {}
     query_graph_entities_no_attributes: list[str] = []
     query_graph_entities_w_attributes: list[str] = []
     query_graph_relationships: list[str] = []

--- a/backend/onyx/db/kg_temp_view.py
+++ b/backend/onyx/db/kg_temp_view.py
@@ -113,7 +113,9 @@ def create_views(
            kgr.source_document as source_document,
            d.doc_updated_at as source_date,
            se.attributes as source_entity_attributes,
-           te.attributes as target_entity_attributes
+           te.attributes as target_entity_attributes,
+           se.entity_class as source_entity_class,
+           te.entity_class as target_entity_class
     FROM kg_relationship kgr
     INNER JOIN {allowed_docs_view_name} AD on AD.allowed_doc_id = kgr.source_document
     JOIN document d on d.id = kgr.source_document

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -456,9 +456,9 @@ def delete_relationship_types_by_id_names(
     return deleted_count
 
 
-def get_relationships_for_entity_type_pairs(
-    db_session: Session, entity_type_pairs: list[tuple[str, str]]
-) -> list["KGRelationshipType"]:
+def get_relationship_for_entity_type_pair(
+    db_session: Session, entity_type_pair: tuple[str, str]
+) -> list[KGRelationshipType]:
     """
     Get relationship types from the database based on a list of entity type pairs.
 
@@ -469,16 +469,7 @@ def get_relationships_for_entity_type_pairs(
     Returns:
         List of KGRelationshipType objects where source and target types match the provided pairs
     """
-
-    conditions = [
-        (
-            (KGRelationshipType.source_entity_type_id_name == source_type)
-            & (KGRelationshipType.target_entity_type_id_name == target_type)
-        )
-        for source_type, target_type in entity_type_pairs
-    ]
-
-    return db_session.query(KGRelationshipType).filter(or_(*conditions)).all()
+    return None  # TODO: rei
 
 
 def get_allowed_relationship_type_pairs(

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -251,11 +251,6 @@ def normalize_relationships(
 ) -> NormalizedRelationships:
     """
     Normalize relationships using entity mappings and relationship string matching.
-    A single raw relationship could get expanded into multiple normalized relationships,
-    e.g., JIRA-EPIC::A1B2__has_subcomponent__JIRA::* could be turn into
-    JIRA-EPIC::A1B2__has_subcomponent__JIRA-TASK::*,
-    JIRA-EPIC::A1B2__has_subcomponent__JIRA-STORY::*, etc.
-    depending on the available relationship types in the KG.
 
     Args:
         relationships: list of relationships in format "source__relation__target"

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -141,10 +141,9 @@ def get_entity_types_str(active: bool | None = None) -> str:
         entity_types_list: list[str] = []
         for entity_type in active_entity_types:
             # add entity class as valid entity type whenever we get a subtype
-            entity_type_split = split_entity_type(entity_type.id_name)
-            entity_class = entity_type_split[0]
+            entity_class, entity_subtype = split_entity_type(entity_type.id_name)
 
-            if len(entity_type_split) == 2 and entity_class not in entity_classes:
+            if entity_subtype is not None and entity_class not in entity_classes:
                 entity_classes.add(entity_class)
                 entity_types_list.append(
                     entity_class

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -113,7 +113,7 @@ class NormalizedEntities(BaseModel):
 
 class NormalizedRelationships(BaseModel):
     relationships: list[str]
-    relationship_normalization_map: dict[str, str]
+    relationship_normalization_map: dict[str, list[str]]
 
 
 class NormalizedTerms(BaseModel):

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -113,12 +113,7 @@ class NormalizedEntities(BaseModel):
 
 class NormalizedRelationships(BaseModel):
     relationships: list[str]
-    relationship_normalization_map: dict[str, list[str]]
-
-
-class NormalizedTerms(BaseModel):
-    terms: list[str]
-    term_normalization_map: dict[str, str | None]
+    relationship_normalization_map: dict[str, str]
 
 
 class KGClassificationContent(BaseModel):

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -21,6 +21,10 @@ def get_entity_type(entity_id_name: str) -> str:
     return entity_id_name.split("::", 1)[0].upper()
 
 
+def split_entity_type(entity_type: str) -> list[str]:
+    return entity_type.split("-")
+
+
 def format_entity_id_for_models(entity_id_name: str) -> str:
     entity_split = entity_id_name.split("::")
     if len(entity_split) == 2:

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -22,6 +22,10 @@ def get_entity_type(entity_id_name: str) -> str:
 
 
 def split_entity_type(entity_type: str) -> tuple[str, str | None]:
+    """
+    Splits an entity type into its class and subclass.
+    If the entity type is not a subtype, the subclass will be None and entity_class = entity_type.
+    """
     entity_type_split = entity_type.split("-", 1)
     if len(entity_type_split) == 1:
         return entity_type_split[0], None

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -21,12 +21,12 @@ def get_entity_type(entity_id_name: str) -> str:
     return entity_id_name.split("::", 1)[0].upper()
 
 
-def split_entity_type(entity_type: str) -> list[str]:
-    return entity_type.split("-")
-
-
-def replace_entity_type(entity_id_name: str, new_entity_type: str) -> str:
-    return make_entity_id(new_entity_type, split_entity_id(entity_id_name)[1])
+def split_entity_type(entity_type: str) -> tuple[str, str | None]:
+    entity_type_split = entity_type.split("-", 1)
+    if len(entity_type_split) == 1:
+        return entity_type_split[0], None
+    else:
+        return entity_type_split[0], entity_type_split[1]
 
 
 def format_entity_id_for_models(entity_id_name: str) -> str:

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -25,6 +25,10 @@ def split_entity_type(entity_type: str) -> list[str]:
     return entity_type.split("-")
 
 
+def replace_entity_type(entity_id_name: str, new_entity_type: str) -> str:
+    return make_entity_id(new_entity_type, split_entity_id(entity_id_name)[1])
+
+
 def format_entity_id_for_models(entity_id_name: str) -> str:
     entity_split = entity_id_name.split("::")
     if len(entity_split) == 2:

--- a/backend/onyx/prompts/kg_prompts.py
+++ b/backend/onyx/prompts/kg_prompts.py
@@ -286,6 +286,10 @@ You can ONLY extract entities of these types:
 
 The list above here is the exclusive, only list of entities you can choose from!
 
+Note that some entity types may have a dash in them, indicating that they are a subtype of an entity class. \
+For example, the types PERSON-EMPLOYEE and PERSON-CUSTOMER are subtypes of the PERSON entity class. \
+The entity class is an implied entity type and are valid entity types to use in the extraction.
+
 Also, note that there are fixed relationship types between these entities. Please consider those \
 as well so to make sure that you are not missing implicit entities! Implicit entities are often \
 in verbs ('emailed to', 'talked to', ...). Also, they may be used to connect entities that are \
@@ -330,6 +334,8 @@ Example 3:
    -  you should only extract entities belonging to the entity types above - but do extract all that you \
 can reliably identify in the text
    - if you refer to all/any/an unspecified entity of an entity type listed above, use '*' as the entity name
+   - if the specific entity subtype is unclear, or you would like to refer to all subtypes, you can use the entity class \
+in place of the entity type (e.g., PERSON::John or PERSON::*)
    - keep the terms high-level
    - similarly, if a specific entity type is referred to in general, you should use '*' as the entity name
    - you MUST only use the initial list of entities provided! Ignore the entities in the examples unless \
@@ -370,6 +376,9 @@ First off as background, here are the entity types that are known to the system:
 ---entity_types---
 {SEPARATOR_LINE}
 
+Note that some entity types may have a dash in them, indicating that they are a subtype of an entity class. \
+For example, the types PERSON-EMPLOYEE and PERSON-CUSTOMER are subtypes of the PERSON entity class. \
+The entity class is an implied entity type and are valid entity types to use in the extraction.
 
 Here are the entities you have identified earlier:
 {SEPARATOR_LINE}
@@ -407,6 +416,8 @@ is just assumed for these examples, but you MUST use only the entities above for
 
 - You can either extract specific entities if a specific entity is referred to, or you can refer to the entity type.
 * if the entity type is referred to in general, you would use '*' as the entity name in the extraction.
+* if the specific entity subtype is unclear, or you would like to refer to all subtypes, you can use the entity class \
+in place of the entity type (e.g., PERSON::John or PERSON::*)
 
 As an example, if the question would say:
 
@@ -435,6 +446,7 @@ relationships.
    - you can only extract the relationships that match the listed relationship types
    - if in doubt and there are multiple relationships between the same two entities, you can extract \
 all of those that may fit with the question.
+   - use the entity class as the entity type where appropriate.
    - be really thinking through the question which type of relationships should be extracted and which should not.
 
 {SEPARATOR_LINE}

--- a/backend/onyx/prompts/kg_prompts.py
+++ b/backend/onyx/prompts/kg_prompts.py
@@ -745,18 +745,27 @@ It is of the form \
 <source_entity_type>::<source_entity_name>__<relationship_description>__<target_entity_type>::<target_entity_name> \
 [example: ACCOUNT::Nike__has__CONCERN::performance]. Note that this is NOT UNIQUE!
    - source_entity (str): the id of the source ENTITY/NODE in the relationship [example: ACCOUNT::Nike]
+   - source_entity_class (str): the type class of the source entity/node [example: ACCOUNT]. Only the entity \
+classes (entity types without a dash) provided below are valid. Entity-type-based filtering should mostly be done \
+using this column, unless you are interested in a specific subtype.
+   - source_entity_type (str): the specific subtype of the source entity/node [example: TASK-SALES]. Only the \
+entity types provided below are valid.
    - source_entity_attributes (json): the attributes of the source entity/node [example: {{"account_type": "customer"}}]
    - target_entity (str): the id of the target ENTITY/NODE in the relationship [example: CONCERN::performance]
+   - target_entity_class (str): the type class of the target entity/node [example: CONCERN]. Only the entity \
+classes (entity types without a dash) provided below are valid.
+   - target_entity_type (str): the specific subtype of the target entity/node [example: GITHUB-ISSUE]. Only the \
+entity types provided below are valid. Entity-type-based filtering should mostly be done \
+using this column, unless you are interested in a specific subtype.
    - target_entity_attributes (json): the attributes of the target entity/node [example: {{"degree": "severe"}}]
-   - source_entity_type (str): the type of the source entity/node [example: ACCOUNT]. Only the entity types provided \
-   below are valid.
-   - target_entity_type (str): the type of the target entity/node [example: CONCERN]. Only the entity types provided \
-   below are valid.
-   - relationship_type (str): the type of the relationship, formatted as  \
-<source_entity_type>__<relationship_description>__<target_entity_type>.   So the explicit entity_names have \
-been removed. [example: ACCOUNT__has__CONCERN]
-   - source_document (str): the id of the document that contains the relationship. Note that the combination of \
-id_name and source_document IS UNIQUE!
+   - relationship_type (str): the type of the relationship, formatted as \
+<source_entity_type>__<relationship_description>__<target_entity_type>. So the explicit entity_names have \
+been removed. [example: ACCOUNT__has__CONCERN]. Note that the source and target entity types are specific \
+down to the subtype. For example, EMPLOYEE__worked_on__TASK will not match EMPLOYEE__worked_on__TASK-SALES.
+   - relationship_description (str): the description of the relationship, e.g., 'has', 'worked_on', etc. \
+In general, use this column when filtering relationships.
+   - source_document (str): the id of the document that contains the relationship. Note that it is the combination \
+of the relationship and the source_document that is unique!
    - source_date (timestamp): the 'event' date of the source document [example: 2025-04-25 21:43:31.054741+00]
 
 {SEPARATOR_LINE}
@@ -764,6 +773,10 @@ id_name and source_document IS UNIQUE!
 Importantly, here are the entity (node) types that you can use, with a short description of what they mean. You may need to \
 identify the proper entity type through its description. Also notice the allowed attributes for each entity type and \
 their values, if provided.
+Note that some entity types may have a dash in them, indicating that they are a subtype of another entity type \
+(we will refer to them as entity classes). The entity class of a subtype is the entity type before the dash. \
+For example, the types TASK-ENGINEERING and TASK-SALES are subtypes of the TASK entity class. Some entity classes \
+may not have any subtypes, in which case they are the same as the entity type.
 {SEPARATOR_LINE}
 ---entity_types---
 {SEPARATOR_LINE}

--- a/backend/onyx/prompts/kg_prompts.py
+++ b/backend/onyx/prompts/kg_prompts.py
@@ -191,6 +191,19 @@ ENTITY_EXAMPLE_4 = r"""
 {{"entities": ["ACCOUNT::*--[]", "CONCERN::performance--[degree: severe]"], "terms": ["performance issue"]}}
 """.strip()
 
+ENTITY_EXAMPLE_5 = r"""
+{{"entities": ["TASK::*--[]"], "terms": []}}
+""".strip()
+
+ENTITY_EXAMPLE_6 = r"""
+{{"entities": ["TASK::T15--[]"], "terms": []}}
+""".strip()
+
+ENTITY_EXAMPLE_7 = r"""
+{{"entities": ["TASK-ENGINEERING::T15--[]"], "terms": []}}
+""".strip()
+
+
 MASTER_EXTRACTION_PROMPT = f"""
 You are an expert in the area of knowledge extraction in order to construct a knowledge graph. You are given a text \
 and asked to extract entities, relationships, and terms from it that you can reliably identify.
@@ -300,7 +313,7 @@ clearly in the question.
 {SEPARATOR_LINE}
 
 Here are some important additional instructions. (For the purpose of illustration, assume that \
- "ACCOUNT", "CONCERN", "EMAIL", and "FEATURE" are all in the list of entity types above, and the \
+"ACCOUNT", "CONCERN", "TASK-ENGINEERING", and "TASK-SALES" are all in the list of entity types above, and the \
 attribute options for "CONCERN" include 'degree' with possible values that include 'severe'. Note that this \
 is just assumed for these examples, but you MUST use only the entities above for the actual extraction!)
 
@@ -327,8 +340,26 @@ Example 3:
 * Then, if we inquire about an entity with a specific attribute :
 'Who reported severe performance issues?'
 then a suitable entity and term extraction could be:
-Example 3:
+Example 4:
 {ENTITY_EXAMPLE_4}
+
+* If the question refers to an entity class in general, like:
+'What tasks are there?'
+then a suitable extraction could be:
+Example 5:
+{ENTITY_EXAMPLE_5}
+
+* If the specific subtype is unclear:
+'Summarize task T15'
+then a suitable extraction could be:
+Example 6:
+{ENTITY_EXAMPLE_6}
+
+* If the subtask is clear, however, such as in the question:
+'Summarize the engineering task T15',
+then a more suitable extraction would be:
+Example 7:
+{ENTITY_EXAMPLE_7}
 
 - Again,
    -  you should only extract entities belonging to the entity types above - but do extract all that you \


### PR DESCRIPTION
## Description

- Partially removed kg_terms as it messes up the entity extraction. Will get fully removed in following PR
- Added source & target entity class columns to kg temp relationship view so `a3_sgenerate_simple_sql` works with subtypes
- Made changes to `get_allowed_relationship_type` and `get_allowed_relationship_type_pairs` to work with subtypes
- Made changes to `normalize_entities` and `normalize_relationships` to work with subtypes
- dropped `normalize_terms` and `NormalizedTerms` model for same reason
- added the entity class in the entity type list string that gets inserted into prompts so the entity class can get extracted as a valid entity type
- added utility tool to get entity class and subclass from an entity type (if any)
- modified entity and relationship extraction prompt to be aware of subtypes. Entity extraction prompt remains unchanged as we know exactly what the subtype is
- TODO: modify sql generation prompt to be aware of subtypes

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
