### PR TITLE
Dual search pipeline for non-tool-calling LLMs

### DIFF
--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -186,6 +186,20 @@ def choose_tool(
             is_keyword, keywords = wait_on_background(keyword_thread)
             override_kwargs.precomputed_is_keyword = is_keyword
             override_kwargs.precomputed_keywords = keywords
+            
+        # dual keyword expansion needs to be added here for non-tool calling LLM case
+        if (USE_SEMANTIC_KEYWORD_EXPANSIONS_BASIC_SEARCH
+            and expanded_keyword_thread
+            and expanded_semantic_thread
+            and tool.name == SearchTool._NAME
+        ):
+            keyword_expansion = wait_on_background(expanded_keyword_thread)
+            semantic_expansion = wait_on_background(expanded_semantic_thread)
+            override_kwargs.expanded_queries = QueryExpansions(
+                keywords_expansions=[keyword_expansion],
+                semantic_expansions=[semantic_expansion],
+            )
+
         return ToolChoiceUpdate(
             tool_choice=ToolChoice(
                 tool=tool,
@@ -289,12 +303,6 @@ def choose_tool(
             keywords_expansions=[keyword_expansion],
             semantic_expansions=[semantic_expansion],
         )
-
-        logger.info(
-            f"Original query: {agent_config.inputs.prompt_builder.raw_user_query}"
-        )
-        logger.info(f"Expanded keyword queries: {keyword_expansion}")
-        logger.info(f"Expanded semantic queries: {semantic_expansion}")
 
     return ToolChoiceUpdate(
         tool_choice=ToolChoice(


### PR DESCRIPTION
## Description

The dual search pipeline was not activated for non-tool-calling LLMs. It has now been added for the non-tool-calling Tool Choice Update. 

Here is the linear ticket: https://linear.app/danswer/issue/DAN-2075/dual-search-pipeline-broken-for-non-tool-calling-models

## How Has This Been Tested?

Locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
