### PR TITLE
Prep KG on-demand indexing through celery

### DIFF
--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -81,7 +81,7 @@ def _expand_query(
     rephrased_query: str = cast(str, response.content)
 
     return rephrased_query
-
+    
 
 def _expand_query_non_tool_calling_llm(
     expanded_keyword_thread: TimeoutThread[str],

--- a/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
+++ b/backend/onyx/agents/agent_search/orchestration/nodes/choose_tool.py
@@ -81,7 +81,7 @@ def _expand_query(
     rephrased_query: str = cast(str, response.content)
 
     return rephrased_query
-    
+
 
 def _expand_query_non_tool_calling_llm(
     expanded_keyword_thread: TimeoutThread[str],

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -1,11 +1,18 @@
-from onyx.background.celery.tasks.kg_processing.utils import check_kg_processing_requirements, check_kg_processing_unblocked
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.apps.client import celery_app
-from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask
+from onyx.background.celery.tasks.kg_processing.utils import (
+    check_kg_processing_requirements,
+)
+from onyx.background.celery.tasks.kg_processing.utils import (
+    check_kg_processing_unblocked,
+)
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
 
 
 def try_creating_kg_processing_task(
-        tenant_id: str,
+    tenant_id: str,
 ) -> None:
     """Checks for any conditions that should block the KG processing task from being
     created, then creates the task.
@@ -37,13 +44,13 @@ def try_creating_kg_processing_task(
             f"try_creating_kg_processing_task - Unexpected exception for tenant={tenant_id}"
         )
 
-    return None
+    return
 
 
 def try_creating_kg_source_reset_task(
-        tenant_id: str,
-        source_name: str | None,
-        index_name: str,
+    tenant_id: str,
+    source_name: str | None,
+    index_name: str,
 ) -> str | None:
     """Checks for any conditions that should block the KG source reset task from being
     created, then creates the task.

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -1,0 +1,83 @@
+from onyx.background.celery.tasks.kg_processing.utils import check_kg_processing_requirements, check_kg_processing_unblocked
+from onyx.background.celery.apps.app_base import task_logger
+from onyx.background.celery.apps.kg_processing import celery_app as kg_processing_celery_app
+from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask
+
+
+def try_creating_kg_processing_task(
+        tenant_id: str,
+) -> str | None:
+    """Checks for any conditions that should block the KG processing task from being
+    created, then creates the task.
+
+    Does not check for scheduling related conditions as this function
+    is used to trigger processing immediately.
+    """
+
+    try:
+
+        if not check_kg_processing_requirements(tenant_id):
+            return None
+
+        # Send the KG processing task
+        result = kg_processing_celery_app.send_task(
+            OnyxCeleryTask.KG_PROCESSING,
+            kwargs=dict(
+                tenant_id=tenant_id,
+            ),
+            queue=OnyxCeleryQueues.KG_PROCESSING,
+            priority=OnyxCeleryPriority.MEDIUM,
+        )
+
+        if not result:
+            raise RuntimeError("send_task for kg processing failed.")
+
+        task_id = result.id
+
+    except Exception:
+        task_logger.exception(
+            f"try_creating_kg_processing_task - Unexpected exception for tenant={tenant_id}"
+        )
+
+    return None
+
+
+def try_creating_kg_source_reset_task(
+        tenant_id: str,
+        source_name: str | None,
+        index_name: str,
+) -> str | None:
+    """Checks for any conditions that should block the KG source reset task from being
+    created, then creates the task.
+
+    """
+
+    try:
+
+        # if blocked - return None
+        if not check_kg_processing_unblocked(tenant_id):
+            return None
+
+        # Send the KG source reset task
+        result = kg_processing_celery_app.send_task(
+            OnyxCeleryTask.KG_RESET_SOURCE_INDEX,
+            kwargs=dict(
+                tenant_id=tenant_id,
+                source_name=source_name,
+                index_name=index_name,
+            ),
+            queue=OnyxCeleryQueues.KG_PROCESSING,
+            priority=OnyxCeleryPriority.MEDIUM,
+        )
+
+        if not result:
+            raise RuntimeError("send_task for kg source reset failed.")
+
+        task_id = result.id
+
+    except Exception:
+        task_logger.exception(
+            f"try_creating_kg_processing_task - Unexpected exception for tenant={tenant_id}"
+        )
+
+    return None

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -1,6 +1,6 @@
 from onyx.background.celery.tasks.kg_processing.utils import check_kg_processing_requirements, check_kg_processing_unblocked
 from onyx.background.celery.apps.app_base import task_logger
-from onyx.background.celery.apps.kg_processing import celery_app as kg_processing_celery_app
+from onyx.background.celery.apps.client import celery_app
 from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask
 
 
@@ -20,7 +20,7 @@ def try_creating_kg_processing_task(
             return None
 
         # Send the KG processing task
-        result = kg_processing_celery_app.send_task(
+        result = celery_app.send_task(
             OnyxCeleryTask.KG_PROCESSING,
             kwargs=dict(
                 tenant_id=tenant_id,
@@ -59,7 +59,7 @@ def try_creating_kg_source_reset_task(
             return None
 
         # Send the KG source reset task
-        result = kg_processing_celery_app.send_task(
+        result = celery_app.send_task(
             OnyxCeleryTask.KG_RESET_SOURCE_INDEX,
             kwargs=dict(
                 tenant_id=tenant_id,

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -1,10 +1,10 @@
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.apps.client import celery_app
 from onyx.background.celery.tasks.kg_processing.utils import (
-    check_kg_processing_requirements,
+    is_kg_processing_requirements_met,
 )
 from onyx.background.celery.tasks.kg_processing.utils import (
-    check_kg_processing_unblocked,
+    is_kg_processing_unblocked,
 )
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -25,7 +25,7 @@ def try_creating_kg_processing_task(
     try:
 
         with get_session_with_current_tenant() as db_session:
-            if not check_kg_processing_requirements(db_session):
+            if not is_kg_processing_requirements_met(db_session):
                 return None
 
         # Send the KG processing task
@@ -63,7 +63,7 @@ def try_creating_kg_source_reset_task(
 
         # if blocked - return None
         with get_session_with_current_tenant() as db_session:
-            if not check_kg_processing_unblocked(db_session):
+            if not is_kg_processing_unblocked(db_session):
                 return None
 
         # Send the KG source reset task

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -9,6 +9,7 @@ from onyx.background.celery.tasks.kg_processing.utils import (
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.engine import get_session_with_current_tenant
 
 
 def try_creating_kg_processing_task(
@@ -23,8 +24,9 @@ def try_creating_kg_processing_task(
 
     try:
 
-        if not check_kg_processing_requirements(tenant_id):
-            return None
+        with get_session_with_current_tenant() as db_session:
+            if not check_kg_processing_requirements(db_session):
+                return None
 
         # Send the KG processing task
         result = celery_app.send_task(
@@ -60,8 +62,9 @@ def try_creating_kg_source_reset_task(
     try:
 
         # if blocked - return None
-        if not check_kg_processing_unblocked(tenant_id):
-            return None
+        with get_session_with_current_tenant() as db_session:
+            if not check_kg_processing_unblocked(db_session):
+                return None
 
         # Send the KG source reset task
         result = celery_app.send_task(

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -6,7 +6,7 @@ from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCel
 
 def try_creating_kg_processing_task(
         tenant_id: str,
-) -> str | None:
+) -> None:
     """Checks for any conditions that should block the KG processing task from being
     created, then creates the task.
 
@@ -31,8 +31,6 @@ def try_creating_kg_processing_task(
 
         if not result:
             raise RuntimeError("send_task for kg processing failed.")
-
-        task_id = result.id
 
     except Exception:
         task_logger.exception(
@@ -73,11 +71,9 @@ def try_creating_kg_source_reset_task(
         if not result:
             raise RuntimeError("send_task for kg source reset failed.")
 
-        task_id = result.id
-
     except Exception:
         task_logger.exception(
-            f"try_creating_kg_processing_task - Unexpected exception for tenant={tenant_id}"
+            f"try_creating_kg_source_reset_task - Unexpected exception for tenant={tenant_id}"
         )
 
     return None

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -266,8 +266,6 @@ def kg_reset_source_index(
 ) -> int | None:
     """a task for KG reset of a source."""
 
-    time.monotonic()
-
     with get_session_with_current_tenant() as db_session:
         block_kg_processing_current_tenant(db_session)
         db_session.commit()

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -21,6 +21,10 @@ from onyx.db.kg_config import set_kg_processing_in_progress_status
 from onyx.db.search_settings import get_current_search_settings
 from onyx.kg.clustering.clustering import kg_clustering
 from onyx.kg.extractions.extraction_processing import kg_extraction
+from onyx.kg.resets.reset_source import reset_source_kg_index
+from onyx.background.celery.tasks.kg_processing.utils import check_kg_processing_requirements
+from onyx.background.celery.tasks.kg_processing.utils import block_kg_processing_current_tenant
+from onyx.background.celery.tasks.kg_processing.utils import unblock_kg_processing_current_tenant
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import get_redis_replica_client
 from onyx.redis.redis_pool import redis_lock_dump
@@ -57,35 +61,9 @@ def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
     try:
         locked = True
 
-        with get_session_with_current_tenant() as db_session:
+        kg_processing_requirements_met = check_kg_processing_requirements(tenant_id)
 
-            kg_config = get_kg_config_settings(db_session)
-
-            if not kg_config.KG_ENABLED:
-
-                return None
-
-            kg_coverage_start = kg_config.KG_COVERAGE_START
-            kg_max_coverage_days = kg_config.KG_MAX_COVERAGE_DAYS
-
-            kg_extraction_in_progress = kg_config.KG_EXTRACTION_IN_PROGRESS
-            kg_clustering_in_progress = kg_config.KG_CLUSTERING_IN_PROGRESS
-
-        if kg_extraction_in_progress or kg_clustering_in_progress:
-            task_logger.info(
-                f"KG processing already in progress for tenant {tenant_id}, skipping"
-            )
-            return None
-
-        with get_session_with_current_tenant() as db_session:
-            documents_needing_kg_processing = check_for_documents_needing_kg_processing(
-                db_session, kg_coverage_start, kg_max_coverage_days
-            )
-
-        if not documents_needing_kg_processing:
-            task_logger.info(
-                f"No documents needing KG processing for tenant {tenant_id}, skipping"
-            )
+        if not kg_processing_requirements_met:
             return None
 
         task_logger.info(
@@ -153,28 +131,13 @@ def check_for_kg_processing_clustering_only(
     try:
         locked = True
 
-        with get_session_with_current_tenant() as db_session:
-            kg_clustering_in_progress = get_kg_processing_in_progress_status(
-                db_session, processing_type=KGProcessingType.CLUSTERING
-            )
-            documents_needing_kg_clustering = check_for_documents_needing_kg_clustering(
-                db_session
-            )
+        kg_processing_requirements_met = check_kg_processing_requirements(tenant_id)
 
-        if kg_clustering_in_progress:
-            task_logger.info(
-                f"KG clustering already in progress for tenant {tenant_id}, skipping"
-            )
-            return None
-        elif not documents_needing_kg_clustering:
-            task_logger.info(
-                f"No documents needing KG clustering for tenant {tenant_id}, skipping"
-            )
-            return None
+        if not kg_processing_requirements_met:
 
-        task_logger.info(
-            f"Found documents needing KG processing for tenant {tenant_id}"
-        )
+            task_logger.info(
+                f"Found documents needing KG processing for tenant {tenant_id}"
+            )
 
         self.app.send_task(
             OnyxCeleryTask.KG_CLUSTERING_ONLY,
@@ -226,12 +189,7 @@ def kg_processing(self: Task, *, tenant_id: str) -> int | None:
         search_settings = get_current_search_settings(db_session)
         index_str = search_settings.index_name
 
-        set_kg_processing_in_progress_status(
-            db_session, processing_type=KGProcessingType.EXTRACTION, in_progress=True
-        )
-        set_kg_processing_in_progress_status(
-            db_session, processing_type=KGProcessingType.CLUSTERING, in_progress=True
-        )
+        block_kg_processing_current_tenant()
 
         db_session.commit()
         task_logger.info(f"KG processing set to in progress for tenant {tenant_id}")
@@ -240,37 +198,17 @@ def kg_processing(self: Task, *, tenant_id: str) -> int | None:
         kg_extraction(
             tenant_id=tenant_id, index_name=index_str, processing_chunk_batch_size=8
         )
-    except Exception as e:
-        task_logger.exception(f"Error during kg extraction: {e}")
-    finally:
-        with get_session_with_current_tenant() as db_session:
-            set_kg_processing_in_progress_status(
-                db_session,
-                processing_type=KGProcessingType.EXTRACTION,
-                in_progress=False,
-            )
-            db_session.commit()
 
-        task_logger.debug("Completed kg extraction task. Moving to clustering")
-
-    try:
         kg_clustering(
             tenant_id=tenant_id, index_name=index_str, processing_chunk_batch_size=8
         )
     except Exception as e:
-        task_logger.exception(f"Error during kg clustering: {e}")
+        task_logger.exception(f"Error during kg processing: {e}")
+
     finally:
-        with get_session_with_current_tenant() as db_session:
-            set_kg_processing_in_progress_status(
-                db_session,
-                processing_type=KGProcessingType.CLUSTERING,
-                in_progress=False,
-            )
-            db_session.commit()
+        unblock_kg_processing_current_tenant()
 
-        task_logger.debug("Completed kg clustering task!")
-
-    task_logger.debug("Completed kg clustering task!")
+    task_logger.debug("Completed kg processing task!")
 
     return None
 
@@ -288,9 +226,7 @@ def kg_clustering_only(self: Task, *, tenant_id: str) -> int | None:
         search_settings = get_current_search_settings(db_session)
         index_str = search_settings.index_name
 
-        set_kg_processing_in_progress_status(
-            db_session, processing_type=KGProcessingType.CLUSTERING, in_progress=True
-        )
+        block_kg_processing_current_tenant()
 
         db_session.commit()
         task_logger.info(f"KG processing set to in progress for tenant {tenant_id}")
@@ -304,16 +240,47 @@ def kg_clustering_only(self: Task, *, tenant_id: str) -> int | None:
     except Exception as e:
         task_logger.exception(f"Error during kg clustering: {e}")
     finally:
-        with get_session_with_current_tenant() as db_session:
-            set_kg_processing_in_progress_status(
-                db_session,
-                processing_type=KGProcessingType.CLUSTERING,
-                in_progress=False,
-            )
-            db_session.commit()
+        unblock_kg_processing_current_tenant()
 
         task_logger.debug("Completed kg clustering task!")
 
     task_logger.debug("Completed kg clustering task!")
 
     return None
+
+
+@shared_task(
+    name=OnyxCeleryTask.KG_RESET_SOURCE_INDEX,
+    soft_time_limit=1000,
+    bind=True,
+)
+def kg_reset_source_index(self: Task, *, 
+                          tenant_id: str, 
+                          source_name: str,
+                          index_name: str) -> int | None:
+    """a task for KG reset of a source."""
+
+    time.monotonic()
+    
+    block_kg_processing_current_tenant()
+
+    task_logger.debug("Starting source reset task!")
+
+    try:
+        reset_source_kg_index(source_name=source_name, 
+                              tenant_id=tenant_id,
+                              index_name=index_name)
+
+    except Exception as e:
+        task_logger.exception(f"Error during kg clustering: {e}")
+    finally:
+        unblock_kg_processing_current_tenant()
+
+        task_logger.debug("Completed kg clustering task!")
+
+    task_logger.debug("Completed kg clustering task!")
+
+    return None
+
+
+

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -10,10 +10,10 @@ from onyx.background.celery.tasks.kg_processing.utils import (
     block_kg_processing_current_tenant,
 )
 from onyx.background.celery.tasks.kg_processing.utils import (
-    check_kg_processing_requirements,
+    is_kg_clustering_only_requirements_met,
 )
 from onyx.background.celery.tasks.kg_processing.utils import (
-    check_kg_unclustered_extraction_requirements,
+    is_kg_processing_requirements_met,
 )
 from onyx.background.celery.tasks.kg_processing.utils import (
     unblock_kg_processing_current_tenant,
@@ -65,7 +65,7 @@ def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
         locked = True
 
         with get_session_with_current_tenant() as db_session:
-            kg_processing_requirements_met = check_kg_processing_requirements(
+            kg_processing_requirements_met = is_kg_processing_requirements_met(
                 db_session
             )
 
@@ -138,16 +138,16 @@ def check_for_kg_processing_clustering_only(
         locked = True
 
         with get_session_with_current_tenant() as db_session:
-            kg_processing_requirements_met = (
-                check_kg_unclustered_extraction_requirements(db_session)
+            kg_processing_requirements_met = is_kg_clustering_only_requirements_met(
+                db_session
             )
 
         if not kg_processing_requirements_met:
-
-            task_logger.info(
-                f"Found documents needing KG processing for tenant {tenant_id}"
-            )
             return None
+
+        task_logger.info(
+            f"Found documents needing KG processing for tenant {tenant_id}"
+        )
 
         self.app.send_task(
             OnyxCeleryTask.KG_CLUSTERING_ONLY,

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -38,7 +38,7 @@ logger = setup_logger()
 
 @shared_task(
     name=OnyxCeleryTask.CHECK_KG_PROCESSING,
-    soft_time_limit=300,
+    soft_time_limit=30000,
     bind=True,
 )
 def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
@@ -64,7 +64,10 @@ def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
     try:
         locked = True
 
-        kg_processing_requirements_met = check_kg_processing_requirements(tenant_id)
+        with get_session_with_current_tenant() as db_session:
+            kg_processing_requirements_met = check_kg_processing_requirements(
+                db_session
+            )
 
         if not kg_processing_requirements_met:
             return None
@@ -134,9 +137,10 @@ def check_for_kg_processing_clustering_only(
     try:
         locked = True
 
-        kg_processing_requirements_met = check_kg_unclustered_extraction_requirements(
-            tenant_id
-        )
+        with get_session_with_current_tenant() as db_session:
+            kg_processing_requirements_met = (
+                check_kg_unclustered_extraction_requirements(db_session)
+            )
 
         if not kg_processing_requirements_met:
 

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -1,0 +1,89 @@
+
+from onyx.background.celery.apps.app_base import task_logger
+
+from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.kg_config import get_kg_config_settings
+from onyx.db.document import check_for_documents_needing_kg_processing
+from onyx.db.kg_config import set_kg_processing_in_progress_status
+from onyx.db.kg_config import KGProcessingType
+
+
+def _update_kg_processing_status(status_update: bool) -> None:
+    """Updates KG processing status for a tenant. (tenant implied by db_session)"""
+    with get_session_with_current_tenant() as db_session:
+        set_kg_processing_in_progress_status(
+            db_session,
+            processing_type=KGProcessingType.EXTRACTION,
+            in_progress=status_update,
+        )
+
+        set_kg_processing_in_progress_status(
+            db_session,
+            processing_type=KGProcessingType.CLUSTERING,
+            in_progress=status_update,
+        )
+        db_session.commit()
+
+
+def check_kg_processing_unblocked(tenant_id: str
+) -> bool:
+    """Checks for any conditions that should block the KG processing task from being
+    created.
+    """
+    with get_session_with_current_tenant() as db_session:
+
+        kg_config = get_kg_config_settings(db_session)
+
+        if not kg_config.KG_ENABLED:
+            return False
+
+        kg_extraction_in_progress = kg_config.KG_EXTRACTION_IN_PROGRESS
+        kg_clustering_in_progress = kg_config.KG_CLUSTERING_IN_PROGRESS
+
+    if kg_extraction_in_progress or kg_clustering_in_progress:
+        task_logger.info(
+            f"KG processing already in progress for tenant {tenant_id}, skipping"
+        )
+        return False
+
+    return True 
+
+def check_kg_processing_requirements(tenant_id: str
+) -> bool:
+    """Checks for any conditions that should block the KG processing task from being
+    created, and then looks for documents that should be indexed.
+    """
+    if not check_kg_processing_unblocked(tenant_id):
+        return False
+
+    with get_session_with_current_tenant() as db_session:
+
+        kg_config = get_kg_config_settings(db_session)
+
+        kg_coverage_start = kg_config.KG_COVERAGE_START
+        kg_max_coverage_days = kg_config.KG_MAX_COVERAGE_DAYS
+
+        documents_needing_kg_processing = check_for_documents_needing_kg_processing(
+            db_session, kg_coverage_start, kg_max_coverage_days
+        )
+        
+
+    if not documents_needing_kg_processing:
+        task_logger.info(
+            f"No documents needing KG processing for tenant {tenant_id}, skipping"
+        )
+        return False
+
+    return True 
+
+def block_kg_processing_current_tenant() -> None:
+    """Blocks KG processing for a tenant."""
+    _update_kg_processing_status(True)
+
+    return None
+
+def unblock_kg_processing_current_tenant() -> None:
+    """Blocks KG processing for a tenant."""
+    _update_kg_processing_status(False)
+
+    return None

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -41,9 +41,6 @@ def check_kg_processing_unblocked(tenant_id: str
         kg_clustering_in_progress = kg_config.KG_CLUSTERING_IN_PROGRESS
 
     if kg_extraction_in_progress or kg_clustering_in_progress:
-        task_logger.info(
-            f"KG processing already in progress for tenant {tenant_id}, skipping"
-        )
         return False
 
     return True 
@@ -69,9 +66,6 @@ def check_kg_processing_requirements(tenant_id: str
         
 
     if not documents_needing_kg_processing:
-        task_logger.info(
-            f"No documents needing KG processing for tenant {tenant_id}, skipping"
-        )
         return False
 
     return True 

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -1,99 +1,98 @@
-from onyx.background.celery.apps.app_base import task_logger
-
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.document import check_for_documents_needing_kg_processing
-from onyx.db.kg_config import set_kg_processing_in_progress_status
+from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import KGProcessingType
+from onyx.db.kg_config import set_kg_processing_in_progress_status
 from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationshipExtractionStaging
 
 
-def _update_kg_processing_status(status_update: bool) -> None:
+def _update_kg_processing_status(db_session, status_update: bool) -> None:
     """Updates KG processing status for a tenant. (tenant implied by db_session)"""
-    with get_session_with_current_tenant() as db_session:
-        set_kg_processing_in_progress_status(
-            db_session,
-            processing_type=KGProcessingType.EXTRACTION,
-            in_progress=status_update,
-        )
 
-        set_kg_processing_in_progress_status(
-            db_session,
-            processing_type=KGProcessingType.CLUSTERING,
-            in_progress=status_update,
-        )
-        db_session.commit()
+    set_kg_processing_in_progress_status(
+        db_session,
+        processing_type=KGProcessingType.EXTRACTION,
+        in_progress=status_update,
+    )
+
+    set_kg_processing_in_progress_status(
+        db_session,
+        processing_type=KGProcessingType.CLUSTERING,
+        in_progress=status_update,
+    )
 
 
-def check_kg_processing_unblocked() -> bool:
+def check_kg_processing_unblocked(db_session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created.
     """
-    with get_session_with_current_tenant() as db_session:
 
-        kg_config = get_kg_config_settings(db_session)
+    kg_config = get_kg_config_settings(db_session)
 
-        if not kg_config.KG_ENABLED:
-            return False
+    if not kg_config.KG_ENABLED:
+        return False
 
-        kg_extraction_in_progress = kg_config.KG_EXTRACTION_IN_PROGRESS
-        kg_clustering_in_progress = kg_config.KG_CLUSTERING_IN_PROGRESS
+    kg_extraction_in_progress = kg_config.KG_EXTRACTION_IN_PROGRESS
+    kg_clustering_in_progress = kg_config.KG_CLUSTERING_IN_PROGRESS
 
     if kg_extraction_in_progress or kg_clustering_in_progress:
         return False
 
-    return True 
+    return True
 
-def check_kg_processing_requirements() -> bool:
+
+def check_kg_processing_requirements(db_session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
-    if not check_kg_processing_unblocked():
+    if not check_kg_processing_unblocked(db_session):
         return False
 
-    with get_session_with_current_tenant() as db_session:
+    kg_config = get_kg_config_settings(db_session)
 
-        kg_config = get_kg_config_settings(db_session)
+    kg_coverage_start = kg_config.KG_COVERAGE_START
+    kg_max_coverage_days = kg_config.KG_MAX_COVERAGE_DAYS
 
-        kg_coverage_start = kg_config.KG_COVERAGE_START
-        kg_max_coverage_days = kg_config.KG_MAX_COVERAGE_DAYS
-
-        documents_needing_kg_processing = check_for_documents_needing_kg_processing(
-            db_session, kg_coverage_start, kg_max_coverage_days
-        )
-        
+    documents_needing_kg_processing = check_for_documents_needing_kg_processing(
+        db_session, kg_coverage_start, kg_max_coverage_days
+    )
 
     if not documents_needing_kg_processing:
         return False
 
-    return True 
+    return True
 
-def check_kg_unclustered_extraction_requirements() -> bool:
+
+def check_kg_unclustered_extraction_requirements(db_session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
-    if not check_kg_processing_unblocked():
+    if not check_kg_processing_unblocked(db_session):
         return False
 
-    with get_session_with_current_tenant() as db_session:
-        # Check if there are any entries in the staging tables
-        has_staging_entities = db_session.query(KGEntityExtractionStaging).first() is not None
-        has_staging_relationships = db_session.query(KGRelationshipExtractionStaging).first() is not None
-        
-        if not has_staging_entities and not has_staging_relationships:
-            return False
+    # Check if there are any entries in the staging tables
+    has_staging_entities = (
+        db_session.query(KGEntityExtractionStaging).first() is not None
+    )
+    has_staging_relationships = (
+        db_session.query(KGRelationshipExtractionStaging).first() is not None
+    )
+
+    if not has_staging_entities and not has_staging_relationships:
+        return False
 
     return True
 
-def block_kg_processing_current_tenant() -> None:
+
+def block_kg_processing_current_tenant(db_session) -> None:
     """Blocks KG processing for a tenant."""
-    _update_kg_processing_status(True)
+    _update_kg_processing_status(db_session, True)
 
     return None
 
-def unblock_kg_processing_current_tenant() -> None:
+
+def unblock_kg_processing_current_tenant(db_session) -> None:
     """Blocks KG processing for a tenant."""
-    _update_kg_processing_status(False)
+    _update_kg_processing_status(db_session, False)
 
     return None

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import Session
+
 from onyx.db.document import check_for_documents_needing_kg_processing
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import KGProcessingType
@@ -6,7 +8,7 @@ from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationshipExtractionStaging
 
 
-def _update_kg_processing_status(db_session, status_update: bool) -> None:
+def _update_kg_processing_status(db_session: Session, status_update: bool) -> None:
     """Updates KG processing status for a tenant. (tenant implied by db_session)"""
 
     set_kg_processing_in_progress_status(
@@ -22,7 +24,7 @@ def _update_kg_processing_status(db_session, status_update: bool) -> None:
     )
 
 
-def check_kg_processing_unblocked(db_session) -> bool:
+def check_kg_processing_unblocked(db_session: Session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created.
     """
@@ -41,7 +43,7 @@ def check_kg_processing_unblocked(db_session) -> bool:
     return True
 
 
-def check_kg_processing_requirements(db_session) -> bool:
+def check_kg_processing_requirements(db_session: Session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
@@ -63,7 +65,7 @@ def check_kg_processing_requirements(db_session) -> bool:
     return True
 
 
-def check_kg_unclustered_extraction_requirements(db_session) -> bool:
+def check_kg_unclustered_extraction_requirements(db_session: Session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
@@ -84,14 +86,14 @@ def check_kg_unclustered_extraction_requirements(db_session) -> bool:
     return True
 
 
-def block_kg_processing_current_tenant(db_session) -> None:
+def block_kg_processing_current_tenant(db_session: Session) -> None:
     """Blocks KG processing for a tenant."""
     _update_kg_processing_status(db_session, True)
 
     return None
 
 
-def unblock_kg_processing_current_tenant(db_session) -> None:
+def unblock_kg_processing_current_tenant(db_session: Session) -> None:
     """Blocks KG processing for a tenant."""
     _update_kg_processing_status(db_session, False)
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -583,7 +583,7 @@ def stream_chat_message_objects(
             raise Exception("Extractions done")
 
         elif new_msg_req.message.startswith("kg_rs_source"):
-            msg_split = [x.strip() for x in new_msg_req.message.split(":")]
+            msg_split = [x for x in new_msg_req.message.split(":")]
             if len(msg_split) > 2:
                 raise Exception("Invalid format for a source reset command")
             elif len(msg_split) == 2:

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -471,6 +471,7 @@ class OnyxCeleryTask:
     KG_PROCESSING = "kg_processing"
     KG_CLUSTERING_ONLY = "kg_clustering_only"
     CHECK_KG_PROCESSING_CLUSTERING_ONLY = "check_kg_processing_clustering_only"
+    KG_RESET_SOURCE_INDEX = "kg_reset_source_index"
 
 
 # this needs to correspond to the matching entry in supervisord

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -47,6 +47,7 @@ from onyx.document_index.vespa_constants import SECTION_CONTINUATION
 from onyx.document_index.vespa_constants import SEMANTIC_IDENTIFIER
 from onyx.document_index.vespa_constants import SOURCE_LINKS
 from onyx.document_index.vespa_constants import SOURCE_TYPE
+from onyx.document_index.vespa_constants import TENANT_ID
 from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import YQL_BASE
 from onyx.utils.logger import setup_logger
@@ -176,6 +177,12 @@ def get_chunks_via_visit_api(
         and acl_fieldset_entry not in field_set_list
     ):
         field_set_list.append(acl_fieldset_entry)
+
+    if MULTI_TENANT:
+        tenant_id_fieldset_entry = f"{TENANT_ID}"
+        if tenant_id_fieldset_entry not in field_set_list:
+            field_set_list.append(tenant_id_fieldset_entry)
+
     if field_set_list:
         field_set = f"{index_name}:" + ",".join(field_set_list)
     else:
@@ -237,6 +244,15 @@ def get_chunks_via_visit_api(
                         for user_acl_entry in filters.access_control_list
                     ):
                         continue
+
+                if MULTI_TENANT:
+                    if filters.tenant_id:
+                        document_tenant_id = document["fields"].get(TENANT_ID)
+                        if document_tenant_id != filters.tenant_id:
+                            continue
+                    else:
+                        raise ValueError("Tenant ID is required for multi-tenant")
+
                 document_chunks.append(document)
 
         # Check for continuation token to handle pagination

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -49,7 +49,6 @@ from onyx.document_index.vespa_constants import SOURCE_LINKS
 from onyx.document_index.vespa_constants import SOURCE_TYPE
 from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import YQL_BASE
-from shared_configs.configs import MULTI_TENANT
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from shared_configs.configs import MULTI_TENANT

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -249,6 +249,11 @@ def get_chunks_via_visit_api(
                     if filters.tenant_id:
                         document_tenant_id = document["fields"].get(TENANT_ID)
                         if document_tenant_id != filters.tenant_id:
+                            logger.error(
+                                f"Skipping document {document['document_id']} because "
+                                f"it does not belong to tenant {filters.tenant_id}. "
+                                "This should never happen."
+                            )
                             continue
                     else:
                         raise ValueError("Tenant ID is required for multi-tenant")

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -246,17 +246,16 @@ def get_chunks_via_visit_api(
                         continue
 
                 if MULTI_TENANT:
-                    if filters.tenant_id:
-                        document_tenant_id = document["fields"].get(TENANT_ID)
-                        if document_tenant_id != filters.tenant_id:
-                            logger.error(
-                                f"Skipping document {document['document_id']} because "
-                                f"it does not belong to tenant {filters.tenant_id}. "
-                                "This should never happen."
-                            )
-                            continue
-                    else:
+                    if not filters.tenant_id:
                         raise ValueError("Tenant ID is required for multi-tenant")
+                    document_tenant_id = document["fields"].get(TENANT_ID)
+                    if document_tenant_id != filters.tenant_id:
+                        logger.error(
+                            f"Skipping document {document['document_id']} because "
+                            f"it does not belong to tenant {filters.tenant_id}. "
+                            "This should never happen."
+                        )
+                        continue
 
                 document_chunks.append(document)
 

--- a/backend/onyx/document_index/vespa/chunk_retrieval.py
+++ b/backend/onyx/document_index/vespa/chunk_retrieval.py
@@ -49,6 +49,7 @@ from onyx.document_index.vespa_constants import SOURCE_LINKS
 from onyx.document_index.vespa_constants import SOURCE_TYPE
 from onyx.document_index.vespa_constants import TITLE
 from onyx.document_index.vespa_constants import YQL_BASE
+from shared_configs.configs import MULTI_TENANT
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from shared_configs.configs import MULTI_TENANT

--- a/backend/onyx/document_index/vespa/kg_interactions.py
+++ b/backend/onyx/document_index/vespa/kg_interactions.py
@@ -60,7 +60,8 @@ def get_kg_vespa_info_update_requests_for_document(
     chunks = get_chunks_via_visit_api(
         chunk_request=VespaChunkRequest(document_id=document_id),
         index_name=index_name,
-        filters=IndexFilters(access_control_list=None, tenant_id=tenant_id),
+        filters=IndexFilters(access_control_list=None, 
+                             tenant_id=tenant_id),
         field_names=["chunk_id"],
         get_large_chunks=False,
     )

--- a/backend/onyx/document_index/vespa/kg_interactions.py
+++ b/backend/onyx/document_index/vespa/kg_interactions.py
@@ -1,10 +1,8 @@
 from retry import retry
 
 from onyx.db.document import get_document_kg_entities_and_relationships
+from onyx.db.document import get_num_chunks_for_document
 from onyx.db.engine import get_session_with_current_tenant
-from onyx.document_index.vespa.chunk_retrieval import get_chunks_via_visit_api
-from onyx.document_index.vespa.chunk_retrieval import VespaChunkRequest
-from onyx.document_index.vespa.index import IndexFilters
 from onyx.document_index.vespa.index import KGUChunkUpdateRequest
 from onyx.document_index.vespa.index import VespaIndex
 from onyx.kg.utils.formatting_utils import generalize_entities
@@ -57,23 +55,17 @@ def get_kg_vespa_info_update_requests_for_document(
     )
 
     # get chunks in the document
-    chunks = get_chunks_via_visit_api(
-        chunk_request=VespaChunkRequest(document_id=document_id),
-        index_name=index_name,
-        filters=IndexFilters(access_control_list=None, 
-                             tenant_id=tenant_id),
-        field_names=["chunk_id"],
-        get_large_chunks=False,
-    )
+    with get_session_with_current_tenant() as db_session:
+        num_chunks = get_num_chunks_for_document(db_session, document_id)
 
     # get vespa update requests
     return [
         KGUChunkUpdateRequest(
             document_id=document_id,
-            chunk_id=chunk["fields"]["chunk_id"],
+            chunk_id=chunk_id,
             core_entity="unused",
             entities=kg_entities,
             relationships=kg_relationships or None,
         )
-        for chunk in chunks
+        for chunk_id in range(num_chunks)
     ]

--- a/backend/onyx/kg/resets/reset_source.py
+++ b/backend/onyx/kg/resets/reset_source.py
@@ -24,82 +24,76 @@ def reset_source_kg_index(source_name: str| None, tenant_id: str, index_name: st
     # reset vespa for the source
     reset_vespa_kg_index(tenant_id, index_name, source_name)
 
-    # reset the kg stage for the documents
-    with get_session_with_current_tenant() as db_session:
-        db_session.query(Document).update(
-            {"kg_stage": KGStage.NOT_STARTED}
-        )
-        db_session.commit()
+    
 
     if source_name is None:
         reset_full_kg_index()
 
-        return None
+    else:
+        with get_session_with_current_tenant() as db_session:
+            # get all the entity types for the given source
+            entity_types = [
+                et.id_name
+                for et in db_session.query(KGEntityType)
+                .filter(KGEntityType.grounded_source_name == source_name)
+                .all()
+            ]
+            if not entity_types:
+                raise ValueError(f"There are no entity types for the source {source_name}")
 
-    with get_session_with_current_tenant() as db_session:
-        # get all the entity types for the given source
-        entity_types = [
-            et.id_name
-            for et in db_session.query(KGEntityType)
-            .filter(KGEntityType.grounded_source_name == source_name)
-            .all()
-        ]
-        if not entity_types:
-            raise ValueError(f"There are no entity types for the source {source_name}")
+            # delete the entity type from the knowledge graph
+            for entity_type in entity_types:
+                db_session.query(KGRelationship).filter(
+                    or_(
+                        KGRelationship.source_node_type == entity_type,
+                        KGRelationship.target_node_type == entity_type,
+                    )
+                ).delete()
+                db_session.query(KGRelationshipType).filter(
+                    or_(
+                        KGRelationshipType.source_entity_type_id_name == entity_type,
+                        KGRelationshipType.target_entity_type_id_name == entity_type,
+                    )
+                ).delete()
+                db_session.query(KGEntity).filter(
+                    KGEntity.entity_type_id_name == entity_type
+                ).delete()
+                db_session.query(KGRelationshipExtractionStaging).filter(
+                    or_(
+                        KGRelationshipExtractionStaging.source_node_type == entity_type,
+                        KGRelationshipExtractionStaging.target_node_type == entity_type,
+                    )
+                ).delete()
+                db_session.query(KGEntityExtractionStaging).filter(
+                    KGEntityExtractionStaging.entity_type_id_name == entity_type
+                ).delete()
+                db_session.query(KGRelationshipTypeExtractionStaging).filter(
+                    or_(
+                        KGRelationshipTypeExtractionStaging.source_entity_type_id_name
+                        == entity_type,
+                        KGRelationshipTypeExtractionStaging.target_entity_type_id_name
+                        == entity_type,
+                    )
+                ).delete()
+            db_session.commit()
 
-        # delete the entity type from the knowledge graph
-        for entity_type in entity_types:
-            db_session.query(KGRelationship).filter(
-                or_(
-                    KGRelationship.source_node_type == entity_type,
-                    KGRelationship.target_node_type == entity_type,
-                )
-            ).delete()
-            db_session.query(KGRelationshipType).filter(
-                or_(
-                    KGRelationshipType.source_entity_type_id_name == entity_type,
-                    KGRelationshipType.target_entity_type_id_name == entity_type,
-                )
-            ).delete()
-            db_session.query(KGEntity).filter(
-                KGEntity.entity_type_id_name == entity_type
-            ).delete()
-            db_session.query(KGRelationshipExtractionStaging).filter(
-                or_(
-                    KGRelationshipExtractionStaging.source_node_type == entity_type,
-                    KGRelationshipExtractionStaging.target_node_type == entity_type,
-                )
-            ).delete()
-            db_session.query(KGEntityExtractionStaging).filter(
-                KGEntityExtractionStaging.entity_type_id_name == entity_type
-            ).delete()
-            db_session.query(KGRelationshipTypeExtractionStaging).filter(
-                or_(
-                    KGRelationshipTypeExtractionStaging.source_entity_type_id_name
-                    == entity_type,
-                    KGRelationshipTypeExtractionStaging.target_entity_type_id_name
-                    == entity_type,
-                )
-            ).delete()
-        db_session.commit()
+        with get_session_with_current_tenant() as db_session:
+            # get all the documents for the given source
+            kg_connectors = [
+                connector.id
+                for connector in db_session.query(Connector)
+                .filter(Connector.source == DocumentSource(source_name))
+                .all()
+            ]
+            document_ids = [
+                cc_pair.id
+                for cc_pair in db_session.query(DocumentByConnectorCredentialPair)
+                .filter(DocumentByConnectorCredentialPair.connector_id.in_(kg_connectors))
+                .all()
+            ]
 
-    with get_session_with_current_tenant() as db_session:
-        # get all the documents for the given source
-        kg_connectors = [
-            connector.id
-            for connector in db_session.query(Connector)
-            .filter(Connector.source == DocumentSource(source_name))
-            .all()
-        ]
-        document_ids = [
-            cc_pair.id
-            for cc_pair in db_session.query(DocumentByConnectorCredentialPair)
-            .filter(DocumentByConnectorCredentialPair.connector_id.in_(kg_connectors))
-            .all()
-        ]
-
-        # reset the kg stage for the documents
-        db_session.query(Document).filter(Document.id.in_(document_ids)).update(
-            {"kg_stage": KGStage.NOT_STARTED}
-        )
-        db_session.commit()
+            # reset the kg stage for the documents
+            db_session.query(Document).filter(Document.id.in_(document_ids)).update(
+                {"kg_stage": KGStage.NOT_STARTED}
+            )
+            db_session.commit()

--- a/backend/onyx/kg/resets/reset_source.py
+++ b/backend/onyx/kg/resets/reset_source.py
@@ -13,18 +13,18 @@ from onyx.db.models import KGRelationshipExtractionStaging
 from onyx.db.models import KGRelationshipType
 from onyx.db.models import KGRelationshipTypeExtractionStaging
 from onyx.db.models import KGStage
-from onyx.kg.resets.reset_vespa import reset_vespa_kg_index
 from onyx.kg.resets.reset_index import reset_full_kg_index
+from onyx.kg.resets.reset_vespa import reset_vespa_kg_index
 
 
-def reset_source_kg_index(source_name: str| None, tenant_id: str, index_name: str) -> None:
+def reset_source_kg_index(
+    source_name: str | None, tenant_id: str, index_name: str
+) -> None:
     """
     Resets the knowledge graph index and vespa for a source.
     """
     # reset vespa for the source
     reset_vespa_kg_index(tenant_id, index_name, source_name)
-
-    
 
     if source_name is None:
         reset_full_kg_index()
@@ -39,7 +39,9 @@ def reset_source_kg_index(source_name: str| None, tenant_id: str, index_name: st
                 .all()
             ]
             if not entity_types:
-                raise ValueError(f"There are no entity types for the source {source_name}")
+                raise ValueError(
+                    f"There are no entity types for the source {source_name}"
+                )
 
             # delete the entity type from the knowledge graph
             for entity_type in entity_types:
@@ -88,7 +90,9 @@ def reset_source_kg_index(source_name: str| None, tenant_id: str, index_name: st
             document_ids = [
                 cc_pair.id
                 for cc_pair in db_session.query(DocumentByConnectorCredentialPair)
-                .filter(DocumentByConnectorCredentialPair.connector_id.in_(kg_connectors))
+                .filter(
+                    DocumentByConnectorCredentialPair.connector_id.in_(kg_connectors)
+                )
                 .all()
             ]
 

--- a/backend/onyx/kg/resets/reset_vespa.py
+++ b/backend/onyx/kg/resets/reset_vespa.py
@@ -113,3 +113,8 @@ def reset_vespa_kg_index(
     # Reset the kg fields
     for document_id in document_ids:
         _reset_vespa_for_doc(document_id, tenant_id, index_name)
+
+    logger.info(
+        f"Finished resetting kg vespa index {index_name} for tenant {tenant_id}, "
+        f"source: {source_name if source_name else 'all'}"
+    )

--- a/backend/onyx/kg/resets/reset_vespa.py
+++ b/backend/onyx/kg/resets/reset_vespa.py
@@ -11,7 +11,6 @@ from onyx.db.models import KGEntityType
 from onyx.document_index.document_index_utils import get_uuid_from_chunk_info
 from onyx.document_index.vespa.index import KGVespaChunkUpdateRequest
 from onyx.document_index.vespa.index import VespaIndex
-from onyx.db.document import get_num_chunks_for_document
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT

--- a/backend/onyx/kg/resets/reset_vespa.py
+++ b/backend/onyx/kg/resets/reset_vespa.py
@@ -11,6 +11,7 @@ from onyx.db.models import KGEntityType
 from onyx.document_index.document_index_utils import get_uuid_from_chunk_info
 from onyx.document_index.vespa.index import KGVespaChunkUpdateRequest
 from onyx.document_index.vespa.index import VespaIndex
+from onyx.db.document import get_num_chunks_for_document
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT


### PR DESCRIPTION
## Description

Use a function to invoke celery tasks to reset the Knowledge graph or re-index. This is in preparation for the Admin UI.

Here is the Linear ticket: https://linear.app/danswer/issue/DAN-2076/move-on-demand-kg-re-index-functions-to-celery-tasks

## How Has This Been Tested?

Locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
