### PR TITLE
skip large empty excel files

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1129,12 +1129,19 @@ class GoogleDriveConnector(
                     list[Document | ConnectorFailure | None],
                     run_functions_tuples_in_parallel(func_with_args, max_workers=8),
                 )
+                logger.debug(
+                    f"finished processing batch {batches_complete} with {len(results)} results"
+                )
 
                 docs_and_failures = [result for result in results if result is not None]
+                logger.debug(
+                    f"batch {batches_complete} has {len(docs_and_failures)} docs or failures"
+                )
 
                 if docs_and_failures:
                     yield from docs_and_failures
                     batches_complete += 1
+                logger.debug(f"finished yielding batch {batches_complete}")
 
             for retrieved_file in self._fetch_drive_items(
                 field_type=field_type,

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -439,6 +439,7 @@ def _convert_drive_item_to_document(
         # If it's a Google Doc, we might do advanced parsing
         if file.get("mimeType") == GDriveMimeType.DOC.value:
             try:
+                logger.debug(f"starting advanced parsing for {file.get('name')}")
                 # get_document_sections is the advanced approach for Google Docs
                 doc_sections = get_document_sections(
                     docs_service=_get_docs_service(),
@@ -447,6 +448,10 @@ def _convert_drive_item_to_document(
                 if doc_sections:
                     sections = cast(list[TextSection | ImageSection], doc_sections)
                     if any(SMART_CHIP_CHAR in section.text for section in doc_sections):
+                        logger.debug(
+                            f"found smart chips in {file.get('name')},"
+                            " aligning with basic sections"
+                        )
                         basic_sections = _download_and_extract_sections_basic(
                             file, _get_drive_service(), allow_images
                         )

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -375,22 +375,22 @@ def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
     text_content = []
     for sheet in workbook.worksheets:
         rows = []
-        num_empty_rows = 0
+        num_empty_consecutive_rows = 0
         for row in sheet.iter_rows(min_row=1, values_only=True):
             row_str = ",".join(str(cell or "") for cell in row)
 
             # Only add the row if there are any values in the cells
             if len(row_str) >= len(row):
                 rows.append(row_str)
-                num_empty_rows = 0
+                num_empty_consecutive_rows = 0
             else:
                 logger.debug(f"skipping empty row in {file_name}")
-                num_empty_rows += 1
+                num_empty_consecutive_rows += 1
 
-            if num_empty_rows > 100:
+            if num_empty_consecutive_rows > 100:
                 # handle massive excel sheets with mostly empty cells
                 logger.warning(
-                    f"Found {num_empty_rows} empty rows in {file_name},"
+                    f"Found {num_empty_consecutive_rows} empty rows in {file_name},"
                     " skipping rest of file"
                 )
                 break


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2081/drive-large-excel-files

When a spreadsheet is uploaded to drive, sometimes it can have an enormous number of empty cells which we were previously converting into an endless sea of commas as a csv. Now we skip the rest of the file after seeing enough rows in sequence with this property.

## How Has This Been Tested?

tested in UI, huge speedup with a local deployment on massive (100,000+ rows with 16384 columns) excel files

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
