### PR TITLE
new script for hard deleting sessions

### DIFF
--- a/backend/scripts/hard_delete_chats.py
+++ b/backend/scripts/hard_delete_chats.py
@@ -1,0 +1,52 @@
+import os
+import sys
+
+
+# Ensure PYTHONPATH is set up for direct script execution
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+print(parent_dir)
+sys.path.append(parent_dir)
+
+from onyx.db.engine import get_session_context_manager, SqlEngine  # noqa: E402
+from onyx.db.models import ChatSession  # noqa: E402
+from onyx.db.chat import delete_chat_session  # noqa: E402
+
+
+def main() -> None:
+    SqlEngine.init_engine(pool_size=20, max_overflow=5)
+
+    with get_session_context_manager() as db_session:
+        deleted_sessions = (
+            db_session.query(ChatSession).filter(ChatSession.deleted.is_(True)).all()
+        )
+        if not deleted_sessions:
+            print("No deleted chat sessions found.")
+            return
+        print(f"Found {len(deleted_sessions)} deleted chat sessions:")
+        for session in deleted_sessions:
+            print(f"  - ID: {session.id} | deleted: {session.deleted}")
+        confirm = input(
+            "\nAre you sure you want to hard delete these sessions? Type 'yes' to confirm: "
+        )
+        if confirm.strip().lower() != "yes":
+            print("Aborted by user.")
+            return
+        total = 0
+        for session in deleted_sessions:
+            print(f"Deleting {session.id}")
+            try:
+                delete_chat_session(
+                    user_id=None,
+                    chat_session_id=session.id,
+                    db_session=db_session,
+                    include_deleted=True,
+                    hard_delete=True,
+                )
+                total += 1
+            except Exception as e:
+                print(f"Error deleting session {session.id}: {e}")
+        print(f"Deleted {total}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2087/script-for-hard-deleting-old-chats

For hard deleting chats that were deleted prior to HARD_DELETE_CHATS was enabled.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
