### PR TITLE
Kg config refactor

### DIFF
--- a/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
+++ b/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
@@ -12,7 +12,7 @@ import json
 from datetime import datetime
 from datetime import timedelta
 from sqlalchemy.dialects import postgresql
-
+from sqlalchemy import text
 from alembic import op
 import sqlalchemy as sa
 
@@ -25,20 +25,42 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # get current config
+    current_configs = (
+        op.get_bind()
+        .execute(text("SELECT kg_variable_name, kg_variable_values FROM kg_config"))
+        .all()
+    )
+    current_config_dict = {
+        config.kg_variable_name: (
+            config.kg_variable_values[0]
+            if config.kg_variable_name
+            not in ("KG_VENDOR_DOMAINS", "KG_IGNORE_EMAIL_DOMAINS")
+            else config.kg_variable_values
+        )
+        for config in current_configs
+        if config.kg_variable_values
+    }
+
     # not using the KGConfigSettings model here in case it changes in the future
+    default_coverage_start = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d")
     kg_config_settings = json.dumps(
         {
-            "KG_EXPOSED": False,
-            "KG_ENABLED": False,
-            "KG_VENDOR": None,
-            "KG_VENDOR_DOMAINS": [],
-            "KG_IGNORE_EMAIL_DOMAINS": [],
-            "KG_COVERAGE_START": (datetime.now() - timedelta(days=90)).strftime(
-                "%Y-%m-%d"
+            "KG_EXPOSED": current_config_dict.get("KG_EXPOSED", False),
+            "KG_ENABLED": current_config_dict.get("KG_ENABLED", False),
+            "KG_VENDOR": current_config_dict.get("KG_VENDOR", None),
+            "KG_VENDOR_DOMAINS": current_config_dict.get("KG_VENDOR_DOMAINS", []),
+            "KG_IGNORE_EMAIL_DOMAINS": current_config_dict.get(
+                "KG_IGNORE_EMAIL_DOMAINS", []
             ),
-            "KG_MAX_COVERAGE_DAYS": 90,
-            "KG_MAX_PARENT_RECURSION_DEPTH": 2,
-            "KG_BETA_PERSONA_ID": None,
+            "KG_COVERAGE_START": current_config_dict.get(
+                "KG_COVERAGE_START", default_coverage_start
+            ),
+            "KG_MAX_COVERAGE_DAYS": current_config_dict.get("KG_MAX_COVERAGE_DAYS", 90),
+            "KG_MAX_PARENT_RECURSION_DEPTH": current_config_dict.get(
+                "KG_MAX_PARENT_RECURSION_DEPTH", 2
+            ),
+            "KG_BETA_PERSONA_ID": current_config_dict.get("KG_BETA_PERSONA_ID", None),
         }
     )
     op.execute(
@@ -63,8 +85,6 @@ def downgrade() -> None:
         sa.Column("kg_variable_values", postgresql.ARRAY(sa.String()), nullable=False),
         sa.UniqueConstraint("kg_variable_name", name="uq_kg_config_variable_name"),
     )
-
-    # Insert initial data into kg_config table
     op.bulk_insert(
         sa.table(
             "kg_config",

--- a/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
+++ b/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
@@ -67,12 +67,6 @@ def upgrade() -> None:
         f"INSERT INTO key_value_store (key, value) VALUES ('kg_config', '{kg_config_settings}')"
     )
 
-    # same here
-    kg_processing_status = json.dumps({"in_progress": False})
-    op.execute(
-        f"INSERT INTO key_value_store (key, value) VALUES ('kg_processing_status', '{kg_processing_status}')"
-    )
-
     # drop kg config table
     op.drop_table("kg_config")
 
@@ -119,5 +113,4 @@ def downgrade() -> None:
         ],
     )
 
-    op.execute("DELETE FROM key_value_store WHERE key = 'kg_processing_status'")
     op.execute("DELETE FROM key_value_store WHERE key = 'kg_config'")

--- a/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
+++ b/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
@@ -1,0 +1,103 @@
+"""rework-kg-config
+
+Revision ID: 03bf8be6b53a
+Revises: cec7ec36c505
+Create Date: 2025-06-16 10:52:34.815335
+
+"""
+
+import json
+
+
+from datetime import datetime
+from datetime import timedelta
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "03bf8be6b53a"
+down_revision = "cec7ec36c505"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # not using the KGConfigSettings model here in case it changes in the future
+    kg_config_settings = json.dumps(
+        {
+            "KG_EXPOSED": False,
+            "KG_ENABLED": False,
+            "KG_VENDOR": None,
+            "KG_VENDOR_DOMAINS": [],
+            "KG_IGNORE_EMAIL_DOMAINS": [],
+            "KG_COVERAGE_START": (datetime.now() - timedelta(days=90)).strftime(
+                "%Y-%m-%d"
+            ),
+            "KG_MAX_COVERAGE_DAYS": 90,
+            "KG_MAX_PARENT_RECURSION_DEPTH": 2,
+            "KG_BETA_PERSONA_ID": None,
+        }
+    )
+    op.execute(
+        f"INSERT INTO key_value_store (key, value) VALUES ('kg_config', '{kg_config_settings}')"
+    )
+
+    # same here
+    kg_processing_status = json.dumps({"in_progress": False})
+    op.execute(
+        f"INSERT INTO key_value_store (key, value) VALUES ('kg_processing_status', '{kg_processing_status}')"
+    )
+
+    # drop kg config table
+    op.drop_table("kg_config")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "kg_config",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False, index=True),
+        sa.Column("kg_variable_name", sa.String(), nullable=False, index=True),
+        sa.Column("kg_variable_values", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.UniqueConstraint("kg_variable_name", name="uq_kg_config_variable_name"),
+    )
+
+    # Insert initial data into kg_config table
+    op.bulk_insert(
+        sa.table(
+            "kg_config",
+            sa.column("kg_variable_name", sa.String),
+            sa.column("kg_variable_values", postgresql.ARRAY(sa.String)),
+        ),
+        [
+            {"kg_variable_name": "KG_EXPOSED", "kg_variable_values": ["false"]},
+            {"kg_variable_name": "KG_ENABLED", "kg_variable_values": ["false"]},
+            {"kg_variable_name": "KG_VENDOR", "kg_variable_values": []},
+            {"kg_variable_name": "KG_VENDOR_DOMAINS", "kg_variable_values": []},
+            {"kg_variable_name": "KG_IGNORE_EMAIL_DOMAINS", "kg_variable_values": []},
+            {
+                "kg_variable_name": "KG_EXTRACTION_IN_PROGRESS",
+                "kg_variable_values": ["false"],
+            },
+            {
+                "kg_variable_name": "KG_CLUSTERING_IN_PROGRESS",
+                "kg_variable_values": ["false"],
+            },
+            {
+                "kg_variable_name": "KG_COVERAGE_START",
+                "kg_variable_values": [
+                    (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d")
+                ],
+            },
+            {"kg_variable_name": "KG_MAX_COVERAGE_DAYS", "kg_variable_values": ["90"]},
+            {
+                "kg_variable_name": "KG_MAX_PARENT_RECURSION_DEPTH",
+                "kg_variable_values": ["2"],
+            },
+        ],
+    )
+
+    op.execute("DELETE FROM key_value_store WHERE key = 'kg_processing_status'")
+    op.execute("DELETE FROM key_value_store WHERE key = 'kg_config'")

--- a/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
+++ b/backend/alembic/versions/03bf8be6b53a_rework_kg_config.py
@@ -1,7 +1,7 @@
 """rework-kg-config
 
 Revision ID: 03bf8be6b53a
-Revises: cec7ec36c505
+Revises: 65bc6e0f8500
 Create Date: 2025-06-16 10:52:34.815335
 
 """
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "03bf8be6b53a"
-down_revision = "cec7ec36c505"
+down_revision = "65bc6e0f8500"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -3,13 +3,11 @@ from onyx.background.celery.apps.client import celery_app
 from onyx.background.celery.tasks.kg_processing.utils import (
     is_kg_processing_requirements_met,
 )
-from onyx.background.celery.tasks.kg_processing.utils import (
-    is_kg_processing_unblocked,
-)
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.kg_config import is_kg_processing_in_progress
 
 
 def try_creating_kg_processing_task(
@@ -62,9 +60,8 @@ def try_creating_kg_source_reset_task(
     try:
 
         # if blocked - return None
-        with get_session_with_current_tenant() as db_session:
-            if not is_kg_processing_unblocked(db_session):
-                return None
+        if is_kg_processing_in_progress():
+            return None
 
         # Send the KG source reset task
         result = celery_app.send_task(

--- a/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/kg_indexing.py
@@ -32,14 +32,13 @@ def try_creating_kg_processing_task(
 
         if not result:
             task_logger.error("send_task for kg processing failed.")
-            return False
+        return bool(result)
+
     except Exception:
         task_logger.exception(
             f"try_creating_kg_processing_task - Unexpected exception for tenant={tenant_id}"
         )
         return False
-
-    return True
 
 
 def try_creating_kg_source_reset_task(
@@ -69,12 +68,10 @@ def try_creating_kg_source_reset_task(
 
         if not result:
             task_logger.error("send_task for kg source reset failed.")
-            return False
+        return bool(result)
 
     except Exception:
         task_logger.exception(
             f"try_creating_kg_source_reset_task - Unexpected exception for tenant={tenant_id}"
         )
         return False
-
-    return True

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -7,16 +7,10 @@ from redis.lock import Lock as RedisLock
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.tasks.kg_processing.utils import (
-    block_kg_processing_current_tenant,
-)
-from onyx.background.celery.tasks.kg_processing.utils import (
     is_kg_clustering_only_requirements_met,
 )
 from onyx.background.celery.tasks.kg_processing.utils import (
     is_kg_processing_requirements_met,
-)
-from onyx.background.celery.tasks.kg_processing.utils import (
-    unblock_kg_processing_current_tenant,
 )
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
@@ -29,7 +23,6 @@ from onyx.kg.clustering.clustering import kg_clustering
 from onyx.kg.extractions.extraction_processing import kg_extraction
 from onyx.kg.resets.reset_source import reset_source_kg_index
 from onyx.redis.redis_pool import get_redis_client
-from onyx.redis.redis_pool import get_redis_replica_client
 from onyx.redis.redis_pool import redis_lock_dump
 from onyx.utils.logger import setup_logger
 
@@ -38,39 +31,17 @@ logger = setup_logger()
 
 @shared_task(
     name=OnyxCeleryTask.CHECK_KG_PROCESSING,
-    soft_time_limit=30000,
+    soft_time_limit=300,
     bind=True,
 )
-def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
+def check_for_kg_processing(self: Task, *, tenant_id: str) -> None:
     """a lightweight task used to kick off kg processing tasks."""
 
     time_start = time.monotonic()
     task_logger.warning("check_for_kg_processing - Starting")
-
-    tasks_created = 0
-    locked = False
-    redis_client = get_redis_client()
-    get_redis_replica_client()
-
-    lock_beat: RedisLock = redis_client.lock(
-        OnyxRedisLocks.KG_PROCESSING_LOCK,
-        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
-    )
-
-    # these tasks should never overlap
-    if not lock_beat.acquire(blocking=False):
-        return None
-
     try:
-        locked = True
-
-        with get_session_with_current_tenant() as db_session:
-            kg_processing_requirements_met = is_kg_processing_requirements_met(
-                db_session
-            )
-
-        if not kg_processing_requirements_met:
-            return None
+        if not is_kg_processing_requirements_met():
+            return
 
         task_logger.info(
             f"Found documents needing KG processing for tenant {tenant_id}"
@@ -91,20 +62,9 @@ def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
         )
     except Exception:
         task_logger.exception("Unexpected exception during kg processing check")
-    finally:
-        if locked:
-            if lock_beat.owned():
-                lock_beat.release()
-            else:
-                task_logger.error(
-                    "check_for_kg_processing - Lock not owned on completion: "
-                    f"tenant={tenant_id}"
-                )
-                redis_lock_dump(lock_beat, redis_client)
 
     time_elapsed = time.monotonic() - time_start
     task_logger.info(f"check_for_kg_processing finished: elapsed={time_elapsed:.2f}")
-    return tasks_created
 
 
 @shared_task(
@@ -112,41 +72,18 @@ def check_for_kg_processing(self: Task, *, tenant_id: str) -> int | None:
     soft_time_limit=300,
     bind=True,
 )
-def check_for_kg_processing_clustering_only(
-    self: Task, *, tenant_id: str
-) -> int | None:
+def check_for_kg_processing_clustering_only(self: Task, *, tenant_id: str) -> None:
     """a lightweight task used to kick off kg clustering tasks."""
 
     time_start = time.monotonic()
     task_logger.warning("check_for_kg_processing_clustering_only - Starting")
 
-    tasks_created = 0
-    locked = False
-    redis_client = get_redis_client()
-    get_redis_replica_client()
-
-    lock_beat: RedisLock = redis_client.lock(
-        OnyxRedisLocks.KG_PROCESSING_LOCK,
-        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
-    )
-
-    # these tasks should never overlap
-    if not lock_beat.acquire(blocking=False):
-        return None
-
     try:
-        locked = True
-
-        with get_session_with_current_tenant() as db_session:
-            kg_processing_requirements_met = is_kg_clustering_only_requirements_met(
-                db_session
-            )
-
-        if not kg_processing_requirements_met:
-            return None
+        if not is_kg_clustering_only_requirements_met():
+            return
 
         task_logger.info(
-            f"Found documents needing KG processing for tenant {tenant_id}"
+            f"Found documents needing KG clustering for tenant {tenant_id}"
         )
 
         self.app.send_task(
@@ -164,116 +101,153 @@ def check_for_kg_processing_clustering_only(
         )
     except Exception:
         task_logger.exception("Unexpected exception during kg clustering-only check")
-    finally:
-        if locked:
-            if lock_beat.owned():
-                lock_beat.release()
-            else:
-                task_logger.error(
-                    "check_for_kg_processing - Lock not owned on completion: "
-                    f"tenant={tenant_id}"
-                )
-                redis_lock_dump(lock_beat, redis_client)
 
     time_elapsed = time.monotonic() - time_start
     task_logger.info(
         f"check_for_kg_processing_clustering_only finished: elapsed={time_elapsed:.2f}"
     )
-    return tasks_created
 
 
 @shared_task(
     name=OnyxCeleryTask.KG_PROCESSING,
-    soft_time_limit=1000,
     bind=True,
 )
-def kg_processing(self: Task, *, tenant_id: str) -> int | None:
+def kg_processing(self: Task, *, tenant_id: str) -> None:
     """a task for doing kg extraction and clustering."""
 
-    time.monotonic()
     task_logger.warning(f"kg_processing - Starting for tenant {tenant_id}")
 
-    task_logger.debug("Starting kg processing task!")
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(
+        OnyxRedisLocks.KG_PROCESSING_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
 
-    with get_session_with_current_tenant() as db_session:
-        search_settings = get_current_search_settings(db_session)
-        index_str = search_settings.index_name
-
-    # prevent other tasks from running
-    block_kg_processing_current_tenant()
-    task_logger.info(f"KG processing set to in progress for tenant {tenant_id}")
+    # these tasks should never overlap
+    if not lock_beat.acquire(blocking=False):
+        return
 
     try:
+        with get_session_with_current_tenant() as db_session:
+            search_settings = get_current_search_settings(db_session)
+            index_str = search_settings.index_name
+
+        task_logger.info(f"KG processing set to in progress for tenant {tenant_id}")
+
         kg_extraction(
-            tenant_id=tenant_id, index_name=index_str, processing_chunk_batch_size=8
+            tenant_id=tenant_id,
+            index_name=index_str,
+            lock=lock_beat,
+            processing_chunk_batch_size=8,
         )
 
         kg_clustering(
-            tenant_id=tenant_id, index_name=index_str, processing_chunk_batch_size=8
+            tenant_id=tenant_id,
+            index_name=index_str,
+            lock=lock_beat,
+            processing_chunk_batch_size=8,
         )
     except Exception:
         task_logger.exception("Error during kg processing")
-
     finally:
-        unblock_kg_processing_current_tenant()
+        if lock_beat.owned():
+            lock_beat.release()
+        else:
+            task_logger.error(
+                "kg_processing - Lock not owned on completion: " f"tenant={tenant_id}"
+            )
+            redis_lock_dump(lock_beat, redis_client)
 
     task_logger.debug("Completed kg processing task!")
-
-    return None
 
 
 @shared_task(
     name=OnyxCeleryTask.KG_CLUSTERING_ONLY,
-    soft_time_limit=1000,
     bind=True,
 )
-def kg_clustering_only(self: Task, *, tenant_id: str) -> int | None:
+def kg_clustering_only(self: Task, *, tenant_id: str) -> None:
     """a task for doing kg clustering only."""
 
-    with get_session_with_current_tenant() as db_session:
-        search_settings = get_current_search_settings(db_session)
-        index_str = search_settings.index_name
+    task_logger.warning(f"kg_clustering_only - Starting for tenant {tenant_id}")
 
-    block_kg_processing_current_tenant()
-    task_logger.debug("Starting kg clustering-only task!")
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(
+        OnyxRedisLocks.KG_PROCESSING_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+
+    # these tasks should never overlap
+    if not lock_beat.acquire(blocking=False):
+        return
 
     try:
-        kg_clustering(
-            tenant_id=tenant_id, index_name=index_str, processing_chunk_batch_size=8
+        with get_session_with_current_tenant() as db_session:
+            search_settings = get_current_search_settings(db_session)
+            index_str = search_settings.index_name
+
+        task_logger.info(
+            f"KG clustering-only set to in progress for tenant {tenant_id}"
         )
-    except Exception as e:
-        task_logger.exception(f"Error during kg clustering: {e}")
+
+        kg_clustering(
+            tenant_id=tenant_id,
+            index_name=index_str,
+            lock=lock_beat,
+            processing_chunk_batch_size=8,
+        )
+    except Exception:
+        task_logger.exception("Error during kg clustering-only")
     finally:
-        unblock_kg_processing_current_tenant()
+        if lock_beat.owned():
+            lock_beat.release()
+        else:
+            task_logger.error(
+                "kg_clustering_only - Lock not owned on completion: "
+                f"tenant={tenant_id}"
+            )
+            redis_lock_dump(lock_beat, redis_client)
 
-    task_logger.debug("Completed kg clustering task!")
-
-    return None
+    task_logger.debug("Completed kg clustering-only task!")
 
 
 @shared_task(
     name=OnyxCeleryTask.KG_RESET_SOURCE_INDEX,
-    soft_time_limit=1000,
     bind=True,
 )
 def kg_reset_source_index(
     self: Task, *, tenant_id: str, source_name: str, index_name: str
-) -> int | None:
+) -> None:
     """a task for KG reset of a source."""
 
-    block_kg_processing_current_tenant()
-    task_logger.debug("Starting source reset task!")
+    task_logger.warning(f"kg_reset_source_index - Starting for tenant {tenant_id}")
+
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(
+        OnyxRedisLocks.KG_PROCESSING_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+
+    # these tasks should never overlap
+    if not lock_beat.acquire(blocking=False):
+        return
 
     try:
         reset_source_kg_index(
-            source_name=source_name, tenant_id=tenant_id, index_name=index_name
+            source_name=source_name,
+            tenant_id=tenant_id,
+            index_name=index_name,
+            lock=lock_beat,
         )
-
-    except Exception as e:
-        task_logger.exception(f"Error during kg reset: {e}")
+    except Exception:
+        task_logger.exception("Error during kg reset")
     finally:
-        unblock_kg_processing_current_tenant()
+        if lock_beat.owned():
+            lock_beat.release()
+        else:
+            task_logger.error(
+                "kg_reset_source_index - Lock not owned on completion: "
+                f"tenant={tenant_id}"
+            )
+            redis_lock_dump(lock_beat, redis_client)
 
-        task_logger.debug("Completed kg reset task!")
-
-    return None
+    task_logger.debug("Completed kg reset task!")

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -1,35 +1,44 @@
-from sqlalchemy.orm import Session
+import time
 
+from redis.lock import Lock as RedisLock
+
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.document import check_for_documents_needing_kg_processing
+from onyx.db.engine import get_session_with_current_tenant
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import is_kg_config_settings_enabled_valid
-from onyx.db.kg_config import is_kg_processing_in_progress
-from onyx.db.kg_config import set_kg_processing_in_progress
 from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationshipExtractionStaging
+from onyx.redis.redis_pool import get_redis_client
 
 
-def is_kg_processing_requirements_met(db_session: Session) -> bool:
-    """Checks for any conditions that should block the KG processing task from being
-    created, and then looks for documents that should be indexed.
-    """
-    if is_kg_processing_in_progress():
+def is_kg_processing_blocked() -> bool:
+    """Checks if there are any KG tasks in progress."""
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(OnyxRedisLocks.KG_PROCESSING_LOCK)
+    return lock_beat.locked()
+
+
+def is_kg_processing_requirements_met() -> bool:
+    """Checks that there is no other KG tasks in progress, KG is enabled, valid,
+    and there are documents that need KG processing."""
+    if is_kg_processing_blocked():
         return False
 
     kg_config = get_kg_config_settings()
     if not is_kg_config_settings_enabled_valid(kg_config):
         return False
 
-    return check_for_documents_needing_kg_processing(
-        db_session, kg_config.KG_COVERAGE_START_DATE, kg_config.KG_MAX_COVERAGE_DAYS
-    )
+    with get_session_with_current_tenant() as db_session:
+        return check_for_documents_needing_kg_processing(
+            db_session, kg_config.KG_COVERAGE_START_DATE, kg_config.KG_MAX_COVERAGE_DAYS
+        )
 
 
-def is_kg_clustering_only_requirements_met(db_session: Session) -> bool:
-    """Checks for any conditions that should block the KG processing task from being
-    created, and then looks for documents that should be indexed.
-    """
-    if is_kg_processing_in_progress():
+def is_kg_clustering_only_requirements_met() -> bool:
+    """Checks that there is no other KG tasks in progress, KG is enabled, valid,
+    and there are documents that need KG clustering."""
+    if is_kg_processing_blocked():
         return False
 
     kg_config = get_kg_config_settings()
@@ -37,21 +46,21 @@ def is_kg_clustering_only_requirements_met(db_session: Session) -> bool:
         return False
 
     # Check if there are any entries in the staging tables
-    has_staging_entities = (
-        db_session.query(KGEntityExtractionStaging).first() is not None
-    )
-    has_staging_relationships = (
-        db_session.query(KGRelationshipExtractionStaging).first() is not None
-    )
+    with get_session_with_current_tenant() as db_session:
+        has_staging_entities = (
+            db_session.query(KGEntityExtractionStaging).first() is not None
+        )
+        has_staging_relationships = (
+            db_session.query(KGRelationshipExtractionStaging).first() is not None
+        )
 
     return has_staging_entities or has_staging_relationships
 
 
-def block_kg_processing_current_tenant() -> None:
-    """Blocks KG processing for a tenant."""
-    set_kg_processing_in_progress(in_progress=True)
+def extend_lock(lock: RedisLock, timeout: int, last_lock_time: float) -> float:
+    current_time = time.monotonic()
+    if current_time - last_lock_time >= (timeout / 4):
+        lock.reacquire()
+        last_lock_time = current_time
 
-
-def unblock_kg_processing_current_tenant() -> None:
-    """Blocks KG processing for a tenant."""
-    set_kg_processing_in_progress(in_progress=False)
+    return last_lock_time

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -20,7 +20,7 @@ def is_kg_processing_blocked() -> bool:
 
 
 def is_kg_processing_requirements_met() -> bool:
-    """Checks that there is no other KG tasks in progress, KG is enabled, valid,
+    """Checks that there are no other KG tasks in progress, KG is enabled, valid,
     and there are documents that need KG processing."""
     if is_kg_processing_blocked():
         return False
@@ -36,7 +36,7 @@ def is_kg_processing_requirements_met() -> bool:
 
 
 def is_kg_clustering_only_requirements_met() -> bool:
-    """Checks that there is no other KG tasks in progress, KG is enabled, valid,
+    """Checks that there are no other KG tasks in progress, KG is enabled, valid,
     and there are documents that need KG clustering."""
     if is_kg_processing_blocked():
         return False

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -2,49 +2,22 @@ from sqlalchemy.orm import Session
 
 from onyx.db.document import check_for_documents_needing_kg_processing
 from onyx.db.kg_config import get_kg_config_settings
-from onyx.db.kg_config import KGProcessingType
-from onyx.db.kg_config import set_kg_processing_in_progress_status
+from onyx.db.kg_config import is_kg_processing_in_progress
+from onyx.db.kg_config import set_kg_processing_in_progress
 from onyx.db.models import KGEntityExtractionStaging
 from onyx.db.models import KGRelationshipExtractionStaging
-
-
-def _update_kg_processing_status(db_session: Session, status_update: bool) -> None:
-    """Updates KG processing status for a tenant. (tenant implied by db_session)"""
-
-    set_kg_processing_in_progress_status(
-        db_session,
-        processing_type=KGProcessingType.EXTRACTION,
-        in_progress=status_update,
-    )
-
-    set_kg_processing_in_progress_status(
-        db_session,
-        processing_type=KGProcessingType.CLUSTERING,
-        in_progress=status_update,
-    )
-
-
-def is_kg_processing_unblocked(db_session: Session) -> bool:
-    """Checks for any conditions that should block the KG processing task from being
-    created.
-    """
-
-    kg_config = get_kg_config_settings(db_session)
-    return kg_config.KG_ENABLED and not (
-        kg_config.KG_EXTRACTION_IN_PROGRESS or kg_config.KG_CLUSTERING_IN_PROGRESS
-    )
 
 
 def is_kg_processing_requirements_met(db_session: Session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
-    if not is_kg_processing_unblocked(db_session):
+    if is_kg_processing_in_progress():
         return False
 
-    kg_config = get_kg_config_settings(db_session)
+    kg_config = get_kg_config_settings()
     return check_for_documents_needing_kg_processing(
-        db_session, kg_config.KG_COVERAGE_START, kg_config.KG_MAX_COVERAGE_DAYS
+        db_session, kg_config.KG_COVERAGE_START_DATE, kg_config.KG_MAX_COVERAGE_DAYS
     )
 
 
@@ -52,7 +25,7 @@ def is_kg_clustering_only_requirements_met(db_session: Session) -> bool:
     """Checks for any conditions that should block the KG processing task from being
     created, and then looks for documents that should be indexed.
     """
-    if not is_kg_processing_unblocked(db_session):
+    if is_kg_processing_in_progress():
         return False
 
     # Check if there are any entries in the staging tables
@@ -66,11 +39,11 @@ def is_kg_clustering_only_requirements_met(db_session: Session) -> bool:
     return has_staging_entities or has_staging_relationships
 
 
-def block_kg_processing_current_tenant(db_session: Session) -> None:
+def block_kg_processing_current_tenant() -> None:
     """Blocks KG processing for a tenant."""
-    _update_kg_processing_status(db_session, True)
+    set_kg_processing_in_progress(in_progress=True)
 
 
-def unblock_kg_processing_current_tenant(db_session: Session) -> None:
+def unblock_kg_processing_current_tenant() -> None:
     """Blocks KG processing for a tenant."""
-    _update_kg_processing_status(db_session, False)
+    set_kg_processing_in_progress(in_progress=False)

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.document import check_for_documents_needing_kg_processing
 from onyx.db.kg_config import get_kg_config_settings
+from onyx.db.kg_config import is_kg_config_settings_enabled_valid
 from onyx.db.kg_config import is_kg_processing_in_progress
 from onyx.db.kg_config import set_kg_processing_in_progress
 from onyx.db.models import KGEntityExtractionStaging
@@ -16,6 +17,9 @@ def is_kg_processing_requirements_met(db_session: Session) -> bool:
         return False
 
     kg_config = get_kg_config_settings()
+    if not is_kg_config_settings_enabled_valid(kg_config):
+        return False
+
     return check_for_documents_needing_kg_processing(
         db_session, kg_config.KG_COVERAGE_START_DATE, kg_config.KG_MAX_COVERAGE_DAYS
     )
@@ -26,6 +30,10 @@ def is_kg_clustering_only_requirements_met(db_session: Session) -> bool:
     created, and then looks for documents that should be indexed.
     """
     if is_kg_processing_in_progress():
+        return False
+
+    kg_config = get_kg_config_settings()
+    if not is_kg_config_settings_enabled_valid(kg_config):
         return False
 
     # Check if there are any entries in the staging tables

--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -123,7 +123,7 @@ class Answer:
             allow_refinement=AGENT_ALLOW_REFINEMENT,
             allow_agent_reranking=allow_agent_reranking,
             perform_initial_search_decomposition=INITIAL_SEARCH_DECOMPOSITION_ENABLED,
-            kg_config_settings=get_kg_config_settings(db_session),
+            kg_config_settings=get_kg_config_settings(),
         )
         self.graph_config = GraphConfig(
             inputs=self.graph_inputs,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -86,6 +86,7 @@ from onyx.db.chat import translate_db_search_doc_to_server_search_doc
 from onyx.db.chat import update_chat_session_updated_at_timestamp
 from onyx.db.engine import get_session_context_manager
 from onyx.db.kg_config import get_kg_config_settings
+from onyx.db.kg_config import is_kg_config_settings_enabled_valid
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
 from onyx.db.milestone import update_user_assistant_milestone
@@ -572,7 +573,7 @@ def stream_chat_message_objects(
 
     kg_config_settings = get_kg_config_settings()
 
-    if kg_config_settings.KG_ENABLED:
+    if is_kg_config_settings_enabled_valid(kg_config_settings):
 
         # Temporarily, until we have a draft UI for the KG Operations/Management
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -570,7 +570,7 @@ def stream_chat_message_objects(
 
     llm: LLM
 
-    kg_config_settings = get_kg_config_settings(db_session)
+    kg_config_settings = get_kg_config_settings()
 
     if kg_config_settings.KG_ENABLED:
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -98,7 +98,6 @@ KV_ENTERPRISE_SETTINGS_KEY = "onyx_enterprise_settings"
 KV_CUSTOM_ANALYTICS_SCRIPT_KEY = "__custom_analytics_script__"
 KV_DOCUMENTS_SEEDED_KEY = "documents_seeded"
 KV_KG_CONFIG_KEY = "kg_config"
-KV_KG_PROCESSING_STATUS_KEY = "kg_processing_status"
 
 # NOTE: we use this timeout / 4 in various places to refresh a lock
 # might be worth separating this timeout into separate timeouts for each situation

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -97,6 +97,8 @@ KV_INSTANCE_DOMAIN_KEY = "instance_domain"
 KV_ENTERPRISE_SETTINGS_KEY = "onyx_enterprise_settings"
 KV_CUSTOM_ANALYTICS_SCRIPT_KEY = "__custom_analytics_script__"
 KV_DOCUMENTS_SEEDED_KEY = "documents_seeded"
+KV_KG_CONFIG_KEY = "kg_config"
+KV_KG_PROCESSING_STATUS_KEY = "kg_processing_status"
 
 # NOTE: we use this timeout / 4 in various places to refresh a lock
 # might be worth separating this timeout into separate timeouts for each situation

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -19,11 +19,7 @@ def get_kg_config_settings() -> KGConfigSettings:
     kv_store = get_kv_store()
     try:
         stored_config = kv_store.load(KV_KG_CONFIG_KEY)
-        return (
-            KGConfigSettings.model_validate(stored_config)
-            if stored_config
-            else KGConfigSettings()
-        )
+        return KGConfigSettings.model_validate(stored_config or {})
     except KvKeyNotFoundError:
         # Default to empty kg config if no config have been set yet
         logger.debug(f"No kg config found in KV store for key: {KV_KG_CONFIG_KEY}")

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -18,7 +18,8 @@ def set_kg_config_settings(kg_config_settings: KGConfigSettings) -> None:
 def get_kg_config_settings() -> KGConfigSettings:
     kv_store = get_kv_store()
     try:
-        stored_config = kv_store.load(KV_KG_CONFIG_KEY)
+        # refresh cache True until beta is over as we may manually update the config in the db
+        stored_config = kv_store.load(KV_KG_CONFIG_KEY, refresh_cache=True)
         return KGConfigSettings.model_validate(stored_config or {})
     except KvKeyNotFoundError:
         # Default to empty kg config if no config have been set yet

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -39,6 +39,14 @@ def validate_kg_settings(kg_config_settings: KGConfigSettings) -> None:
         raise ValueError("KG_VENDOR_DOMAINS is not set")
 
 
+def is_kg_config_settings_enabled_valid(kg_config_settings: KGConfigSettings) -> bool:
+    try:
+        validate_kg_settings(kg_config_settings)
+        return True
+    except Exception:
+        return False
+
+
 def set_kg_processing_in_progress(in_progress: bool) -> None:
     """
     Set the KV_KG_PROCESSING_STATUS_KEY in_progress value in the kv store.
@@ -62,7 +70,7 @@ def is_kg_processing_in_progress() -> bool:
     """
     kv_store = get_kv_store()
     try:
-        stored_value = kv_store.load(KV_KG_PROCESSING_STATUS_KEY)
+        stored_value = kv_store.load(KV_KG_PROCESSING_STATUS_KEY, refresh_cache=True)
         return (
             KGProcessingStatus.model_validate(stored_value).in_progress
             if stored_value

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -12,7 +12,7 @@ logger = setup_logger()
 
 def set_kg_config_settings(kg_config_settings: KGConfigSettings) -> None:
     kv_store = get_kv_store()
-    kv_store.store(KV_KG_CONFIG_KEY, kg_config_settings.model_dump_json())
+    kv_store.store(KV_KG_CONFIG_KEY, kg_config_settings.model_dump())
 
 
 def get_kg_config_settings() -> KGConfigSettings:

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -1,9 +1,7 @@
 from onyx.configs.constants import KV_KG_CONFIG_KEY
-from onyx.configs.constants import KV_KG_PROCESSING_STATUS_KEY
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.kg.models import KGConfigSettings
-from onyx.kg.models import KGProcessingStatus
 from onyx.server.kg.models import EnableKGConfigRequest
 from onyx.utils.logger import setup_logger
 
@@ -44,46 +42,6 @@ def is_kg_config_settings_enabled_valid(kg_config_settings: KGConfigSettings) ->
         validate_kg_settings(kg_config_settings)
         return True
     except Exception:
-        return False
-
-
-def set_kg_processing_in_progress(in_progress: bool) -> None:
-    """
-    Set the KV_KG_PROCESSING_STATUS_KEY in_progress value in the kv store.
-
-    Args:
-        in_progress: Whether KG processing is in progress (True) or not (False)
-    """
-    store = get_kv_store()
-    store.store(
-        KV_KG_PROCESSING_STATUS_KEY,
-        KGProcessingStatus(in_progress=in_progress).model_dump(),
-    )
-
-
-def is_kg_processing_in_progress() -> bool:
-    """
-    Get the current KV_KG_PROCESSING_STATUS_KEY in_progress value.
-
-    Returns:
-        bool: True if KG processing is in progress, False otherwise
-    """
-    kv_store = get_kv_store()
-    try:
-        stored_value = kv_store.load(KV_KG_PROCESSING_STATUS_KEY, refresh_cache=True)
-        return (
-            KGProcessingStatus.model_validate(stored_value).in_progress
-            if stored_value
-            else False
-        )
-    except KvKeyNotFoundError:
-        # Default to False if no status has been set yet
-        logger.debug(
-            f"No kg processing status found in KV store for key: {KV_KG_PROCESSING_STATUS_KEY}"
-        )
-        return False
-    except Exception as e:
-        logger.error(f"Error loading kg processing status from KV store: {str(e)}")
         return False
 
 

--- a/backend/onyx/db/kg_config.py
+++ b/backend/onyx/db/kg_config.py
@@ -1,131 +1,36 @@
-from datetime import datetime
-from enum import Enum
-
-from sqlalchemy import exists
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import Session
-
-from onyx.db.models import KGConfig
+from onyx.configs.constants import KV_KG_CONFIG_KEY
+from onyx.configs.constants import KV_KG_PROCESSING_STATUS_KEY
+from onyx.key_value_store.factory import get_kv_store
+from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.kg.models import KGConfigSettings
-from onyx.kg.models import KGConfigVars
+from onyx.kg.models import KGProcessingStatus
 from onyx.server.kg.models import EnableKGConfigRequest
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
-class KGProcessingType(Enum):
-    EXTRACTION = "extraction"
-    CLUSTERING = "clustering"
+def set_kg_config_settings(kg_config_settings: KGConfigSettings) -> None:
+    kv_store = get_kv_store()
+    kv_store.store(KV_KG_CONFIG_KEY, kg_config_settings.model_dump_json())
 
 
-def get_kg_exposed(db_session: Session) -> bool:
-    return db_session.query(
-        exists().where(
-            KGConfig.kg_variable_name == KGConfigVars.KG_EXPOSED,
-            KGConfig.kg_variable_values == ["true"],
-        )
-    ).scalar()
-
-
-def get_kg_beta_persona_id(db_session: Session) -> int | None:
-    """Get the ID of the KG Beta persona."""
-    config = (
-        db_session.query(KGConfig)
-        .filter(KGConfig.kg_variable_name == KGConfigVars.KG_BETA_PERSONA_ID)
-        .first()
-    )
-
-    if not config or not config.kg_variable_values:
-        return None
-
+def get_kg_config_settings() -> KGConfigSettings:
+    kv_store = get_kv_store()
     try:
-        return int(config.kg_variable_values[0])
-    except (ValueError, IndexError):
-        return None
-
-
-def set_kg_beta_persona_id(db_session: Session, persona_id: int | None) -> None:
-    """Set the ID of the KG Beta persona."""
-    value = [str(persona_id)] if persona_id is not None else []
-
-    stmt = (
-        pg_insert(KGConfig)
-        .values(
-            kg_variable_name=KGConfigVars.KG_BETA_PERSONA_ID,
-            kg_variable_values=value,
+        stored_config = kv_store.load(KV_KG_CONFIG_KEY)
+        return (
+            KGConfigSettings.model_validate(stored_config)
+            if stored_config
+            else KGConfigSettings()
         )
-        .on_conflict_do_update(
-            index_elements=["kg_variable_name"],
-            set_=dict(kg_variable_values=value),
-        )
-    )
-
-    db_session.execute(stmt)
-    db_session.commit()
-
-
-def get_kg_config_settings(db_session: Session) -> KGConfigSettings:
-    # TODO (raunakab):
-    # Cleanup.
-
-    # TODO (joachim-danswer): restructure together with KGConfig redesign
-
-    results = db_session.query(KGConfig).all()
-
-    kg_config_settings = KGConfigSettings()
-    for result in results:
-        if result.kg_variable_name == KGConfigVars.KG_ENABLED:
-            kg_config_settings.KG_ENABLED = result.kg_variable_values[0] == "true"
-        elif result.kg_variable_name == KGConfigVars.KG_VENDOR:
-            if len(result.kg_variable_values) > 0:
-                kg_config_settings.KG_VENDOR = result.kg_variable_values[0]
-            else:
-                kg_config_settings.KG_VENDOR = None
-        elif result.kg_variable_name == KGConfigVars.KG_VENDOR_DOMAINS:
-            kg_config_settings.KG_VENDOR_DOMAINS = result.kg_variable_values
-        elif result.kg_variable_name == KGConfigVars.KG_IGNORE_EMAIL_DOMAINS:
-            kg_config_settings.KG_IGNORE_EMAIL_DOMAINS = result.kg_variable_values
-        elif result.kg_variable_name == KGConfigVars.KG_COVERAGE_START:
-            kg_coverage_start_str = result.kg_variable_values[0] or "1970-01-01"
-
-            kg_config_settings.KG_COVERAGE_START = datetime.strptime(
-                kg_coverage_start_str, "%Y-%m-%d"
-            )
-
-        elif result.kg_variable_name == KGConfigVars.KG_MAX_COVERAGE_DAYS:
-            kg_max_coverage_days_str = result.kg_variable_values[0]
-            if not kg_max_coverage_days_str.isdigit():
-                raise ValueError(
-                    f"KG_MAX_COVERAGE_DAYS is not a number: {kg_max_coverage_days_str}"
-                )
-            kg_config_settings.KG_MAX_COVERAGE_DAYS = max(
-                0, int(kg_max_coverage_days_str)
-            )
-
-        elif result.kg_variable_name == KGConfigVars.KG_EXTRACTION_IN_PROGRESS:
-            kg_config_settings.KG_EXTRACTION_IN_PROGRESS = (
-                result.kg_variable_values[0] == "true"
-            )
-        elif result.kg_variable_name == KGConfigVars.KG_CLUSTERING_IN_PROGRESS:
-            kg_config_settings.KG_CLUSTERING_IN_PROGRESS = (
-                result.kg_variable_values[0] == "true"
-            )
-        elif result.kg_variable_name == KGConfigVars.KG_MAX_PARENT_RECURSION_DEPTH:
-            kg_max_parent_recursion_depth_str = result.kg_variable_values[0]
-            if not kg_max_parent_recursion_depth_str.isdigit():
-                raise ValueError(
-                    f"KG_MAX_PARENT_RECURSION_DEPTH is not a number: {kg_max_parent_recursion_depth_str}"
-                )
-            kg_config_settings.KG_MAX_PARENT_RECURSION_DEPTH = max(
-                0, int(kg_max_parent_recursion_depth_str)
-            )
-        elif result.kg_variable_name == KGConfigVars.KG_EXPOSED:
-            kg_config_settings.KG_EXPOSED = result.kg_variable_values[0] == "true"
-        elif result.kg_variable_name == KGConfigVars.KG_BETA_PERSONA_ID:
-            value = result.kg_variable_values[0] if result.kg_variable_values else None
-            kg_config_settings.KG_BETA_PERSONA_ID = (
-                int(value) if value and str(value).isdigit() else None
-            )
-
-    return kg_config_settings
+    except KvKeyNotFoundError:
+        # Default to empty kg config if no config have been set yet
+        logger.debug(f"No kg config found in KV store for key: {KV_KG_CONFIG_KEY}")
+        return KGConfigSettings()
+    except Exception as e:
+        logger.error(f"Error loading kg config from KV store: {str(e)}")
+        return KGConfigSettings()
 
 
 def validate_kg_settings(kg_config_settings: KGConfigSettings) -> None:
@@ -137,148 +42,62 @@ def validate_kg_settings(kg_config_settings: KGConfigSettings) -> None:
         raise ValueError("KG_VENDOR_DOMAINS is not set")
 
 
-def set_kg_processing_in_progress_status(
-    db_session: Session, processing_type: KGProcessingType, in_progress: bool
-) -> None:
+def set_kg_processing_in_progress(in_progress: bool) -> None:
     """
-    Set the KG_EXTRACTION_IN_PROGRESS or KG_CLUSTERING_IN_PROGRESS configuration values.
+    Set the KV_KG_PROCESSING_STATUS_KEY in_progress value in the kv store.
 
     Args:
-        db_session: The database session to use
         in_progress: Whether KG processing is in progress (True) or not (False)
     """
-    # Convert boolean to string and wrap in list as required by the model
-    value = [str(in_progress).lower()]
-
-    kg_variable_name = KGConfigVars.KG_EXTRACTION_IN_PROGRESS.value  # Default value
-
-    if processing_type == KGProcessingType.CLUSTERING:
-        kg_variable_name = KGConfigVars.KG_CLUSTERING_IN_PROGRESS.value
-
-    # Use PostgreSQL's upsert functionality
-    stmt = (
-        pg_insert(KGConfig)
-        .values(kg_variable_name=str(kg_variable_name), kg_variable_values=value)
-        .on_conflict_do_update(
-            index_elements=["kg_variable_name"], set_=dict(kg_variable_values=value)
-        )
+    store = get_kv_store()
+    store.store(
+        KV_KG_PROCESSING_STATUS_KEY,
+        KGProcessingStatus(in_progress=in_progress).model_dump(),
     )
 
-    db_session.execute(stmt)
 
-
-def get_kg_processing_in_progress_status(
-    db_session: Session, processing_type: KGProcessingType
-) -> bool:
+def is_kg_processing_in_progress() -> bool:
     """
-    Get the current KG_EXTRACTION_IN_PROGRESS or KG_CLUSTERING_IN_PROGRESS configuration value.
-
-    Args:
-        db_session: The database session to use
+    Get the current KV_KG_PROCESSING_STATUS_KEY in_progress value.
 
     Returns:
         bool: True if KG processing is in progress, False otherwise
     """
-
-    kg_variable_name = KGConfigVars.KG_EXTRACTION_IN_PROGRESS.value  # Default value
-    if processing_type == KGProcessingType.CLUSTERING:
-        kg_variable_name = KGConfigVars.KG_CLUSTERING_IN_PROGRESS.value
-
-    config = (
-        db_session.query(KGConfig)
-        .filter(KGConfig.kg_variable_name == kg_variable_name)
-        .first()
-    )
-
-    if not config:
+    kv_store = get_kv_store()
+    try:
+        stored_value = kv_store.load(KV_KG_PROCESSING_STATUS_KEY)
+        return (
+            KGProcessingStatus.model_validate(stored_value).in_progress
+            if stored_value
+            else False
+        )
+    except KvKeyNotFoundError:
+        # Default to False if no status has been set yet
+        logger.debug(
+            f"No kg processing status found in KV store for key: {KV_KG_PROCESSING_STATUS_KEY}"
+        )
+        return False
+    except Exception as e:
+        logger.error(f"Error loading kg processing status from KV store: {str(e)}")
         return False
 
-    return config.kg_variable_values[0] == "true"
 
-
-def enable_kg__commit(
-    db_session: Session,
-    enable_req: EnableKGConfigRequest,
-) -> None:
-    validate_kg_settings(
-        KGConfigSettings(
-            KG_ENABLED=True,
-            KG_VENDOR=enable_req.vendor,
-            KG_VENDOR_DOMAINS=enable_req.vendor_domains,
-            KG_IGNORE_EMAIL_DOMAINS=enable_req.ignore_domains,
-            KG_COVERAGE_START=enable_req.coverage_start,
-        )
+def enable_kg(enable_req: EnableKGConfigRequest) -> None:
+    kg_config_settings = get_kg_config_settings()
+    kg_config_settings.KG_ENABLED = True
+    kg_config_settings.KG_VENDOR = enable_req.vendor
+    kg_config_settings.KG_VENDOR_DOMAINS = enable_req.vendor_domains
+    kg_config_settings.KG_IGNORE_EMAIL_DOMAINS = enable_req.ignore_domains
+    kg_config_settings.KG_COVERAGE_START = enable_req.coverage_start.strftime(
+        "%Y-%m-%d"
     )
+    kg_config_settings.KG_MAX_COVERAGE_DAYS = 10000  # TODO: revisit after public beta
 
-    vars = [
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_ENABLED,
-            kg_variable_values=["true"],
-        ),
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_VENDOR,
-            kg_variable_values=[enable_req.vendor],
-        ),
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_VENDOR_DOMAINS,
-            kg_variable_values=enable_req.vendor_domains,
-        ),
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_IGNORE_EMAIL_DOMAINS,
-            kg_variable_values=enable_req.ignore_domains,
-        ),
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_COVERAGE_START,
-            kg_variable_values=[enable_req.coverage_start.strftime("%Y-%m-%d")],
-        ),
-        KGConfig(
-            kg_variable_name=KGConfigVars.KG_MAX_COVERAGE_DAYS,
-            kg_variable_values=["10000"],  # TODO: revisit coverage days
-        ),
-    ]
-
-    for var in vars:
-        existing_var = (
-            db_session.query(KGConfig)
-            .filter(KGConfig.kg_variable_name == var.kg_variable_name)
-            .first()
-        )
-        if not existing_var:
-            db_session.add(var)
-            continue
-
-        db_session.query(KGConfig).filter(
-            KGConfig.kg_variable_name == var.kg_variable_name
-        ).update(
-            {"kg_variable_values": var.kg_variable_values},
-            synchronize_session=False,
-        )
-
-    db_session.commit()
+    validate_kg_settings(kg_config_settings)
+    set_kg_config_settings(kg_config_settings)
 
 
-def disable_kg__commit(db_session: Session) -> None:
-    var = (
-        db_session.query(KGConfig)
-        .filter(KGConfig.kg_variable_name == KGConfigVars.KG_ENABLED)
-        .first()
-    )
-
-    values = ["false"]
-
-    if var:
-        db_session.query(KGConfig).where(
-            KGConfig.kg_variable_name == KGConfigVars.KG_ENABLED
-        ).update(
-            {"kg_variable_values": values},
-            synchronize_session=False,
-        )
-    else:
-        db_session.add(
-            KGConfig(
-                kg_variable_name=KGConfigVars.KG_ENABLED,
-                kg_variable_values=values,
-            )
-        )
-
-    db_session.commit()
+def disable_kg() -> None:
+    kg_config_settings = get_kg_config_settings()
+    kg_config_settings.KG_ENABLED = False
+    set_kg_config_settings(kg_config_settings)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -619,22 +619,6 @@ class Document(Base):
     )
 
 
-# TODO: restructure config management
-class KGConfig(Base):
-    __tablename__ = "kg_config"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-
-    kg_variable_name: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
-    kg_variable_values: Mapped[list[str]] = mapped_column(
-        postgresql.ARRAY(String), nullable=False, default=list
-    )
-
-    __table_args__ = (
-        UniqueConstraint("kg_variable_name", name="uq_kg_config_variable_name"),
-    )
-
-
 class KGEntityType(Base):
     __tablename__ = "kg_entity_type"
 

--- a/backend/onyx/key_value_store/interface.py
+++ b/backend/onyx/key_value_store/interface.py
@@ -15,7 +15,7 @@ class KeyValueStore:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def load(self, key: str) -> JSON_ro:
+    def load(self, key: str, refresh_cache: bool = False) -> JSON_ro:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -52,14 +52,17 @@ class PgRedisKVStore(KeyValueStore):
                 db_session.add(obj)
             db_session.commit()
 
-    def load(self, key: str) -> JSON_ro:
-        try:
-            redis_value = self.redis_client.get(REDIS_KEY_PREFIX + key)
-            if redis_value:
-                assert isinstance(redis_value, bytes)
-                return json.loads(redis_value.decode("utf-8"))
-        except Exception as e:
-            logger.error(f"Failed to get value from Redis for key '{key}': {str(e)}")
+    def load(self, key: str, refresh_cache: bool = False) -> JSON_ro:
+        if not refresh_cache:
+            try:
+                redis_value = self.redis_client.get(REDIS_KEY_PREFIX + key)
+                if redis_value:
+                    assert isinstance(redis_value, bytes)
+                    return json.loads(redis_value.decode("utf-8"))
+            except Exception as e:
+                logger.error(
+                    f"Failed to get value from Redis for key '{key}': {str(e)}"
+                )
 
         with get_session_context_manager() as db_session:
             obj = db_session.query(KVStore).filter_by(key=key).first()

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -57,7 +57,10 @@ class PgRedisKVStore(KeyValueStore):
             try:
                 redis_value = self.redis_client.get(REDIS_KEY_PREFIX + key)
                 if redis_value:
-                    assert isinstance(redis_value, bytes)
+                    if not isinstance(redis_value, bytes):
+                        raise ValueError(
+                            f"Redis value for key '{key}' is not a bytes object"
+                        )
                     return json.loads(redis_value.decode("utf-8"))
             except Exception as e:
                 logger.error(

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -306,8 +306,7 @@ def kg_clustering(
     """
     logger.info(f"Starting kg clustering for tenant {tenant_id}")
 
-    with get_session_with_current_tenant() as db_session:
-        kg_config_settings = get_kg_config_settings(db_session)
+    kg_config_settings = get_kg_config_settings()
     validate_kg_settings(kg_config_settings)
 
     # Cluster and transfer grounded entities sequentially

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -1,10 +1,14 @@
+import time
 from collections.abc import Generator
 from typing import cast
 
 from rapidfuzz.fuzz import ratio
+from redis.lock import Lock as RedisLock
 from sqlalchemy import func
 from sqlalchemy import text
 
+from onyx.background.celery.tasks.kg_processing.utils import extend_lock
+from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.kg_configs import KG_CLUSTERING_RETRIEVE_THRESHOLD
 from onyx.configs.kg_configs import KG_CLUSTERING_THRESHOLD
 from onyx.db.engine import get_session_with_current_tenant
@@ -290,7 +294,10 @@ def _transfer_batch_relationship_and_update_vespa(
 
 
 def kg_clustering(
-    tenant_id: str, index_name: str, processing_chunk_batch_size: int = 16
+    tenant_id: str,
+    index_name: str,
+    lock: RedisLock,
+    processing_chunk_batch_size: int = 16,
 ) -> None:
     """
     Here we will cluster the extractions based on their cluster frameworks.
@@ -309,12 +316,17 @@ def kg_clustering(
     kg_config_settings = get_kg_config_settings()
     validate_kg_settings(kg_config_settings)
 
+    last_lock_time = time.monotonic()
+
     # Cluster and transfer grounded entities sequentially
     for untransferred_grounded_entities in _get_batch_untransferred_grounded_entities(
         batch_size=processing_chunk_batch_size
     ):
         for entity in untransferred_grounded_entities:
             _cluster_one_grounded_entity(entity)
+        last_lock_time = extend_lock(
+            lock, CELERY_GENERIC_BEAT_LOCK_TIMEOUT, last_lock_time
+        )
     # NOTE: we assume every entity is transferred, as we currently only have grounded entities
     logger.info("Finished transferring all entities")
 
@@ -329,6 +341,9 @@ def kg_clustering(
                     for root_entity in root_entities
                 ]
             )
+            last_lock_time = extend_lock(
+                lock, CELERY_GENERIC_BEAT_LOCK_TIMEOUT, last_lock_time
+            )
     logger.info("Finished creating all parent-child relationships")
 
     # Transfer the relationship types (no need to do in parallel as there's only a few)
@@ -339,6 +354,9 @@ def kg_clustering(
             for relationship_type in relationship_types:
                 transfer_relationship_type(db_session, relationship_type)
             db_session.commit()
+        last_lock_time = extend_lock(
+            lock, CELERY_GENERIC_BEAT_LOCK_TIMEOUT, last_lock_time
+        )
     logger.info("Finished transferring all relationship types")
 
     # Transfer the relationships and update vespa in parallel
@@ -350,6 +368,9 @@ def kg_clustering(
             relationships=untransferred_relationships,
             index_name=index_name,
             tenant_id=tenant_id,
+        )
+        last_lock_time = extend_lock(
+            lock, CELERY_GENERIC_BEAT_LOCK_TIMEOUT, last_lock_time
         )
     logger.info("Finished transferring all relationships")
 

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -347,9 +347,7 @@ def kg_extraction(
 
     logger.info(f"Starting kg extraction for tenant {tenant_id}")
 
-    with get_session_with_current_tenant() as db_session:
-        kg_config_settings = get_kg_config_settings(db_session)
-
+    kg_config_settings = get_kg_config_settings()
     validate_kg_settings(kg_config_settings)
 
     # get connector ids that are enabled for KG extraction
@@ -405,7 +403,7 @@ def kg_extraction(
                     get_unprocessed_kg_document_batch_for_connector(
                         db_session,
                         connector_id,
-                        kg_coverage_start=kg_config_settings.KG_COVERAGE_START,
+                        kg_coverage_start=kg_config_settings.KG_COVERAGE_START_DATE,
                         kg_max_coverage_days=connector_coverage_days
                         or kg_config_settings.KG_MAX_COVERAGE_DAYS,
                         batch_size=8,

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -256,3 +256,7 @@ class KGDocumentEntitiesRelationshipsAttributes(BaseModel):
     account_participant_emails: set[str]
     converted_attributes_to_relationships: set[str]
     document_attributes: dict[str, Any] | None
+
+
+class KGException(Exception):
+    pass

--- a/backend/onyx/kg/models.py
+++ b/backend/onyx/kg/models.py
@@ -8,32 +8,25 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH
 
 
+# Note: make sure to write a migration if adding a non-nullable field or removing a field
 class KGConfigSettings(BaseModel):
     KG_EXPOSED: bool = False
     KG_ENABLED: bool = False
     KG_VENDOR: str | None = None
-    KG_VENDOR_DOMAINS: list[str] | None = None
-    KG_IGNORE_EMAIL_DOMAINS: list[str] | None = None
-    KG_EXTRACTION_IN_PROGRESS: bool = False
-    KG_CLUSTERING_IN_PROGRESS: bool = False
-    KG_COVERAGE_START: datetime = datetime(1970, 1, 1)
+    KG_VENDOR_DOMAINS: list[str] = []
+    KG_IGNORE_EMAIL_DOMAINS: list[str] = []
+    KG_COVERAGE_START: str = datetime(1970, 1, 1).strftime("%Y-%m-%d")
     KG_MAX_COVERAGE_DAYS: int = 10000
     KG_MAX_PARENT_RECURSION_DEPTH: int = KG_DEFAULT_MAX_PARENT_RECURSION_DEPTH
     KG_BETA_PERSONA_ID: int | None = None
 
+    @property
+    def KG_COVERAGE_START_DATE(self) -> datetime:
+        return datetime.strptime(self.KG_COVERAGE_START, "%Y-%m-%d")
 
-class KGConfigVars(str, Enum):
-    KG_EXPOSED = "KG_EXPOSED"
-    KG_ENABLED = "KG_ENABLED"
-    KG_VENDOR = "KG_VENDOR"
-    KG_VENDOR_DOMAINS = "KG_VENDOR_DOMAINS"
-    KG_IGNORE_EMAIL_DOMAINS = "KG_IGNORE_EMAIL_DOMAINS"
-    KG_EXTRACTION_IN_PROGRESS = "KG_EXTRACTION_IN_PROGRESS"
-    KG_CLUSTERING_IN_PROGRESS = "KG_CLUSTERING_IN_PROGRESS"
-    KG_COVERAGE_START = "KG_COVERAGE_START"
-    KG_MAX_COVERAGE_DAYS = "KG_MAX_COVERAGE_DAYS"
-    KG_MAX_PARENT_RECURSION_DEPTH = "KG_MAX_PARENT_RECURSION_DEPTH"
-    KG_BETA_PERSONA_ID = "KG_BETA_PERSONA_ID"
+
+class KGProcessingStatus(BaseModel):
+    in_progress: bool = False
 
 
 class KGGroundingType(str, Enum):

--- a/backend/onyx/kg/resets/reset_source.py
+++ b/backend/onyx/kg/resets/reset_source.py
@@ -1,3 +1,4 @@
+from redis.lock import Lock as RedisLock
 from sqlalchemy import or_
 
 from onyx.configs.constants import DocumentSource
@@ -18,13 +19,13 @@ from onyx.kg.resets.reset_vespa import reset_vespa_kg_index
 
 
 def reset_source_kg_index(
-    source_name: str | None, tenant_id: str, index_name: str
+    source_name: str | None, tenant_id: str, index_name: str, lock: RedisLock
 ) -> None:
     """
     Resets the knowledge graph index and vespa for a source.
     """
     # reset vespa for the source
-    reset_vespa_kg_index(tenant_id, index_name, source_name)
+    reset_vespa_kg_index(tenant_id, index_name, lock, source_name)
 
     with get_session_with_current_tenant() as db_session:
         if source_name is None:

--- a/backend/onyx/kg/setup/kg_default_entity_definitions.py
+++ b/backend/onyx/kg/setup/kg_default_entity_definitions.py
@@ -169,12 +169,6 @@ def get_default_entity_types(vendor_name: str) -> dict[str, KGEntityTypeDefiniti
             grounding=KGGroundingType.GROUNDED,
             grounded_source_name=DocumentSource.SALESFORCE,
         ),
-        "SLACK": KGEntityTypeDefinition(
-            description="A Slack conversation.",
-            attributes=KGEntityTypeAttributes(),
-            grounding=KGGroundingType.GROUNDED,
-            grounded_source_name=DocumentSource.SLACK,
-        ),
         "VENDOR": KGEntityTypeDefinition(
             description=f"The Vendor {vendor_name}, 'us'",
             grounding=KGGroundingType.GROUNDED,

--- a/backend/onyx/kg/setup/kg_default_entity_definitions.py
+++ b/backend/onyx/kg/setup/kg_default_entity_definitions.py
@@ -198,7 +198,7 @@ def populate_missing_default_entity_types__commit(db_session: Session) -> None:
     """
     Populates the database with the missing default entity types.
     """
-    kg_config_settings = get_kg_config_settings(db_session=db_session)
+    kg_config_settings = get_kg_config_settings()
     validate_kg_settings(kg_config_settings)
 
     vendor_name = cast(str, kg_config_settings.KG_VENDOR)

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -295,12 +295,6 @@ def kg_process_person(
     Returns:
         tuple containing (implied_entities, implied_relationships, company_participant_emails, account_participant_emails)
     """
-
-    if not kg_config_settings.KG_ENABLED:
-        raise ValueError("KG is not enabled")
-
-    assert isinstance(kg_config_settings.KG_IGNORE_EMAIL_DOMAINS, list)
-
     kg_person = kg_email_processing(person, kg_config_settings)
     if any(
         domain.lower() in kg_person.company.lower()

--- a/backend/onyx/server/kg/models.py
+++ b/backend/onyx/server/kg/models.py
@@ -24,7 +24,7 @@ class KGConfig(BaseModel):
             vendor=kg_config_settings.KG_VENDOR,
             vendor_domains=kg_config_settings.KG_VENDOR_DOMAINS,
             ignore_domains=kg_config_settings.KG_IGNORE_EMAIL_DOMAINS,
-            coverage_start=kg_config_settings.KG_COVERAGE_START,
+            coverage_start=kg_config_settings.KG_COVERAGE_START_DATE,
         )
 
 


### PR DESCRIPTION
## Description

- Replaced kg config with key value store
- Used locks for managing mutual exclusion of kg processing/reset tasks on a per-tenant basis. Fixes issues where if a process dies in the middle of processing, the lock stays locked forever
- kg_p and other commands now only runs from the KG Beta assistant

Benefits
- faster access because cached
- considerably simpler code for accessing and modifying the config

Downsides-ish
- may need to migrate if we add/remove stuff to the kg config unless we're fine with filling missing values with null (which technically doesn't make it any different from the current setup, so not really a downside)

## How Has This Been Tested?

Single tenant:
- [x] Processing starts if there are docs to be processed every minute or so
- [x] kg_p while processing/resetting is ongoing will not do anything
- [x] kg_rs_source while processing/resetting is ongoing will not do anything
- [x] the periodic processing does not start while kg_p or kg_rs_source is running
- [x] Killing the kg processing instance while processing is ongoing should not leave the lock locked

Multi tenant:
- [x] Processing starts if there are docs to be processed every minute or so, for that tenant
- [x] kg_p while processing/resetting is ongoing for that tenant will not do anything
- [x] kg_rs_source while processing/resetting is ongoing for that tenant will not do anything
- [x] the periodic processing does not start while kg_p or kg_rs_source is running for that tenant
- [x] multiple processing can occur simultaneously if they are for different tenants

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
