### PR TITLE
fail loudly when error should be propagated

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -224,9 +224,17 @@ class SharepointConnector(LoadConnector, PollConnector):
                     logger.warning(f"Failed to process drive: {str(e)}")
 
         except Exception as e:
+            err_str = str(e)
+            if (
+                "403 Client Error" in err_str
+                or "404 Client Error" in err_str
+                or "invalid_client" in err_str
+            ):
+                raise e
+
             # Sites include things that do not contain drives so this fails
             # but this is fine, as there are no actual documents in those
-            logger.warning(f"Failed to process site: {str(e)}")
+            logger.warning(f"Failed to process site: {err_str}")
 
         return final_driveitems
 


### PR DESCRIPTION
## Description

Several sharepoint connectors "succeed" with 0 docs when they fail for misconfiguration reasons. long term we should do connector validation on connector creation; this is a short term patch to make these failures evident

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
