### PR TITLE
feat: Add support for Assume Role authentication in S3

### DIFF
--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -64,7 +64,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         """Checks for boto3 credentials based on the bucket type.
         (1) R2: Access Key ID, Secret Access Key, Account ID
-        (2) S3: AWS Access Key ID, AWS Secret Access Key or IAM role
+        (2) S3: AWS Access Key ID, AWS Secret Access Key or IAM role or Assume Role
         (3) GOOGLE_CLOUD_STORAGE: Access Key ID, Secret Access Key, Project ID
         (4) OCI_STORAGE: Namespace, Region, Access Key ID, Secret Access Key
 
@@ -151,6 +151,10 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                 botocore_session._credentials = refreshable  # type: ignore[attr-defined]
                 session = boto3.Session(botocore_session=botocore_session)
                 self.s3_client = session.client("s3")
+            elif authentication_method == "assume_role":
+                # We will assume the instance role to access S3.
+                logger.debug("Using instance role authentication for S3 bucket.")
+                self.s3_client = boto3.client("s3")
             else:
                 raise ConnectorValidationError("Invalid authentication method for S3. ")
 

--- a/web/src/components/credentials/actions/CredentialFieldsRenderer.tsx
+++ b/web/src/components/credentials/actions/CredentialFieldsRenderer.tsx
@@ -79,6 +79,16 @@ export function CredentialFieldsRenderer({
               value={method.value}
               className="space-y-4"
             >
+              {/* Show description if method has no fields but has a description */}
+              {Object.keys(method.fields).length === 0 &&
+                method.description && (
+                  <div className="p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-md">
+                    <p className="text-sm text-blue-800 dark:text-blue-200">
+                      {method.description}
+                    </p>
+                  </div>
+                )}
+
               {Object.entries(method.fields).map(([key, val]) => {
                 if (typeof val === "boolean") {
                   return (

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -14,6 +14,7 @@ export interface AuthMethodOption<TFields> {
   value: string;
   label: string;
   fields: TFields;
+  description?: string;
 }
 export interface CredentialTemplateWithAuth<TFields> {
   authentication_method?: string;
@@ -337,6 +338,13 @@ export const credentialTemplates: Record<ValidSources, any> = {
         fields: {
           aws_role_arn: "",
         },
+      },
+      {
+        value: "assume_role",
+        label: "Assume Role",
+        fields: {},
+        description:
+          "If you select this mode, the Amazon EC2 instance will assume its existing role to access S3. No additional credentials are required.",
       },
     ],
   } as CredentialTemplateWithAuth<S3CredentialJson>,


### PR DESCRIPTION
## Description
This pull request introduces support for an "Assume Role" authentication method for S3 buckets and enhances the user interface to display descriptions for credential methods without fields.

## How Has This Been Tested?
By running the script that establishes a connection to S3 from the EC2 instance.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
