### PR TITLE
Add psql to backend containers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && \
         pkg-config \
         gcc \
         nano \
-        vim && \
+        vim \
+        postgresql-client && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
## Description

Add `psql` to backend containers for debugging.

## How Has This Been Tested?

Built backend container locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
