### PR TITLE
Fix no subject gmail docs

### DIFF
--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -195,6 +195,11 @@ def thread_to_document(
     primary_owners = _get_owners_from_emails(from_emails)
     secondary_owners = _get_owners_from_emails(other_emails)
 
+    # If emails have no subject, match Gmail's default "no subject"
+    # Search will break without a semantic identifier
+    if not semantic_identifier:
+        semantic_identifier = "(no subject)"
+
     return Document(
         id=id,
         semantic_identifier=semantic_identifier,


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2108/gmail-no-subject-docs-caues-crash

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
