### PR TITLE
Update container scripts for new S3 changes

### DIFF
--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -371,6 +371,22 @@
         "request": "launch",
         "runtimeExecutable": "bash",
         "runtimeArgs": [
+          "-c",
+          "${workspaceFolder}/backend/scripts/clear_containers.sh && ${workspaceFolder}/backend/scripts/restart_containers.sh"
+        ],
+        "cwd": "${workspaceFolder}",
+        "console": "integratedTerminal",
+        "stopOnEntry": true,
+        "presentation": {
+          "group": "3"
+        }
+      },
+      {
+        "name": "Restart External Volumes and Containers",
+        "type": "node",
+        "request": "launch",
+        "runtimeExecutable": "bash",
+        "runtimeArgs": [
           "${workspaceFolder}/backend/scripts/restart_containers.sh"
         ],
         "cwd": "${workspaceFolder}",
@@ -461,4 +477,3 @@
       }
     ]
   }
-  

--- a/.vscode/launch.template.jsonc
+++ b/.vscode/launch.template.jsonc
@@ -377,6 +377,12 @@
         "cwd": "${workspaceFolder}",
         "console": "integratedTerminal",
         "stopOnEntry": true,
+        "env": {
+          "S3_ENDPOINT_URL": "http://localhost:9004",
+          "S3_FILE_STORE_BUCKET_NAME": "onyx-file-store-bucket",
+          "S3_AWS_ACCESS_KEY_ID": "minioadmin",
+          "S3_AWS_SECRET_ACCESS_KEY": "minioadmin"
+        },
         "presentation": {
           "group": "3"
         }
@@ -392,6 +398,12 @@
         "cwd": "${workspaceFolder}",
         "console": "integratedTerminal",
         "stopOnEntry": true,
+        "env": {
+          "S3_ENDPOINT_URL": "http://localhost:9004",
+          "S3_FILE_STORE_BUCKET_NAME": "onyx-file-store-bucket",
+          "S3_AWS_ACCESS_KEY_ID": "minioadmin",
+          "S3_AWS_SECRET_ACCESS_KEY": "minioadmin"
+        },
         "presentation": {
           "group": "3"
         }

--- a/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
+++ b/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
@@ -160,6 +160,7 @@ def _migrate_files_to_postgres() -> None:
     # only create external store if we have files to migrate. This line
     # makes it so we need to have S3/MinIO configured to run this migration.
     external_store = get_s3_file_store(db_session=session)
+    external_store.initialize()
 
     for i, file_id in enumerate(files_to_migrate, 1):
         print(f"Migrating file {i}/{total_files}: {file_id}")

--- a/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
+++ b/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
@@ -240,6 +240,7 @@ def _migrate_files_to_external_storage() -> None:
 
     _set_tenant_contextvar(session)
     migrated_count = 0
+    external_store.initialize()
 
     for i, file_id in enumerate(files_to_migrate, 1):
         print(f"Migrating file {i}/{total_files}: {file_id}")

--- a/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
+++ b/backend/alembic/versions/c9e2cd766c29_add_s3_file_store_table.py
@@ -220,6 +220,7 @@ def _migrate_files_to_external_storage() -> None:
     bind = op.get_bind()
     session = Session(bind=bind)
     external_store = get_s3_file_store(db_session=session)
+    external_store.initialize()
 
     # Find all files currently stored in PostgreSQL (lobj_oid is not null)
     result = session.execute(
@@ -240,7 +241,6 @@ def _migrate_files_to_external_storage() -> None:
 
     _set_tenant_contextvar(session)
     migrated_count = 0
-    external_store.initialize()
 
     for i, file_id in enumerate(files_to_migrate, 1):
         print(f"Migrating file {i}/{total_files}: {file_id}")

--- a/backend/scripts/clear_containers.sh
+++ b/backend/scripts/clear_containers.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Usage of the script
+# ./clear_containers.sh
+
+# Stop and remove the existing containers
+echo "Stopping and removing existing containers..."
+docker stop onyx_postgres onyx_vespa onyx_redis onyx_minio 2>/dev/null || true
+docker rm onyx_postgres onyx_vespa onyx_redis onyx_minio 2>/dev/null || true
+
+echo "Containers stopped and removed."

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -3,47 +3,78 @@ set -e
 
 cleanup() {
   echo "Error occurred. Cleaning up..."
-  docker stop onyx_postgres onyx_vespa onyx_redis 2>/dev/null || true
-  docker rm onyx_postgres onyx_vespa onyx_redis 2>/dev/null || true
+  docker stop onyx_postgres onyx_vespa onyx_redis onyx_minio 2>/dev/null || true
 }
 
 # Trap errors and output a message, then cleanup
 trap 'echo "Error occurred on line $LINENO. Exiting script." >&2; cleanup' ERR
 
 # Usage of the script with optional volume arguments
-# ./restart_containers.sh [vespa_volume] [postgres_volume] [redis_volume]
+# ./restart_containers.sh [vespa_volume] [postgres_volume] [redis_volume] [minio_volume]
 
 VESPA_VOLUME=${1:-""}  # Default is empty if not provided
 POSTGRES_VOLUME=${2:-""}  # Default is empty if not provided
 REDIS_VOLUME=${3:-""}  # Default is empty if not provided
+MINIO_VOLUME=${4:-""}  # Default is empty if not provided
 
-# Stop and remove the existing containers
-echo "Stopping and removing existing containers..."
-docker stop onyx_postgres onyx_vespa onyx_redis 2>/dev/null || true
-docker rm onyx_postgres onyx_vespa onyx_redis 2>/dev/null || true
+# Stop the existing containers
+echo "Stopping existing containers..."
+docker stop onyx_postgres onyx_vespa onyx_redis onyx_minio 2>/dev/null || true
 
-# Start the PostgreSQL container with optional volume
+# Function to start or create PostgreSQL container
 echo "Starting PostgreSQL container..."
-if [[ -n "$POSTGRES_VOLUME" ]]; then
-    docker run -p 5432:5432 --name onyx_postgres -e POSTGRES_PASSWORD=password -d -v $POSTGRES_VOLUME:/var/lib/postgresql/data postgres -c max_connections=250
+if docker ps -a --format '{{.Names}}' | grep -q "^onyx_postgres$"; then
+    echo "PostgreSQL container exists, starting it..."
+    docker start onyx_postgres
 else
-    docker run -p 5432:5432 --name onyx_postgres -e POSTGRES_PASSWORD=password -d postgres -c max_connections=250
+    echo "Creating new PostgreSQL container..."
+    if [[ -n "$POSTGRES_VOLUME" ]]; then
+        docker run -p 5432:5432 --name onyx_postgres -e POSTGRES_PASSWORD=password -d -v $POSTGRES_VOLUME:/var/lib/postgresql/data postgres -c max_connections=250
+    else
+        docker run -p 5432:5432 --name onyx_postgres -e POSTGRES_PASSWORD=password -d postgres -c max_connections=250
+    fi
 fi
 
-# Start the Vespa container with optional volume
+# Function to start or create Vespa container
 echo "Starting Vespa container..."
-if [[ -n "$VESPA_VOLUME" ]]; then
-    docker run --detach --name onyx_vespa --hostname vespa-container --publish 8081:8081 --publish 19071:19071 -v $VESPA_VOLUME:/opt/vespa/var vespaengine/vespa:8
+if docker ps -a --format '{{.Names}}' | grep -q "^onyx_vespa$"; then
+    echo "Vespa container exists, starting it..."
+    docker start onyx_vespa
 else
-    docker run --detach --name onyx_vespa --hostname vespa-container --publish 8081:8081 --publish 19071:19071 vespaengine/vespa:8
+    echo "Creating new Vespa container..."
+    if [[ -n "$VESPA_VOLUME" ]]; then
+        docker run --detach --name onyx_vespa --hostname vespa-container --publish 8081:8081 --publish 19071:19071 -v $VESPA_VOLUME:/opt/vespa/var vespaengine/vespa:8
+    else
+        docker run --detach --name onyx_vespa --hostname vespa-container --publish 8081:8081 --publish 19071:19071 vespaengine/vespa:8
+    fi
 fi
 
-# Start the Redis container with optional volume
+# Function to start or create Redis container
 echo "Starting Redis container..."
-if [[ -n "$REDIS_VOLUME" ]]; then
-    docker run --detach --name onyx_redis --publish 6379:6379 -v $REDIS_VOLUME:/data redis
+if docker ps -a --format '{{.Names}}' | grep -q "^onyx_redis$"; then
+    echo "Redis container exists, starting it..."
+    docker start onyx_redis
 else
-    docker run --detach --name onyx_redis --publish 6379:6379 redis
+    echo "Creating new Redis container..."
+    if [[ -n "$REDIS_VOLUME" ]]; then
+        docker run --detach --name onyx_redis --publish 6379:6379 -v $REDIS_VOLUME:/data redis
+    else
+        docker run --detach --name onyx_redis --publish 6379:6379 redis
+    fi
+fi
+
+# Function to start or create MinIO container
+echo "Starting MinIO container..."
+if docker ps -a --format '{{.Names}}' | grep -q "^onyx_minio$"; then
+    echo "MinIO container exists, starting it..."
+    docker start onyx_minio
+else
+    echo "Creating new MinIO container..."
+    if [[ -n "$MINIO_VOLUME" ]]; then
+        docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin -e MINIO_DEFAULT_BUCKETS=onyx-file-store-bucket -v $MINIO_VOLUME:/data minio/minio:latest server /data --console-address ":9001"
+    else
+        docker run --detach --name onyx_minio --publish 9004:9000 --publish 9005:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin -e MINIO_DEFAULT_BUCKETS=onyx-file-store-bucket minio/minio:latest server /data --console-address ":9001"
+    fi
 fi
 
 # Ensure alembic runs in the correct directory

--- a/backend/scripts/restart_containers.sh
+++ b/backend/scripts/restart_containers.sh
@@ -21,7 +21,7 @@ MINIO_VOLUME=${4:-""}  # Default is empty if not provided
 echo "Stopping existing containers..."
 docker stop onyx_postgres onyx_vespa onyx_redis onyx_minio 2>/dev/null || true
 
-# Function to start or create PostgreSQL container
+# Start or create PostgreSQL container
 echo "Starting PostgreSQL container..."
 if docker ps -a --format '{{.Names}}' | grep -q "^onyx_postgres$"; then
     echo "PostgreSQL container exists, starting it..."
@@ -35,7 +35,7 @@ else
     fi
 fi
 
-# Function to start or create Vespa container
+# Start or create Vespa container
 echo "Starting Vespa container..."
 if docker ps -a --format '{{.Names}}' | grep -q "^onyx_vespa$"; then
     echo "Vespa container exists, starting it..."
@@ -49,7 +49,7 @@ else
     fi
 fi
 
-# Function to start or create Redis container
+# Start or create Redis container
 echo "Starting Redis container..."
 if docker ps -a --format '{{.Names}}' | grep -q "^onyx_redis$"; then
     echo "Redis container exists, starting it..."
@@ -63,7 +63,7 @@ else
     fi
 fi
 
-# Function to start or create MinIO container
+# Start or create MinIO container
 echo "Starting MinIO container..."
 if docker ps -a --format '{{.Names}}' | grep -q "^onyx_minio$"; then
     echo "MinIO container exists, starting it..."


### PR DESCRIPTION
## Description

Updated migrations and the container scripts. Now, there is an option to restart the containers without clearing them.

Here is what you need to do to properly do the S3 migrations, if you are using the launch.json to start up Onyx.
1. Copy the new `launch.template.jsonc` into `launch.json`.
In particular, replace the old `Clear and Restart External Volumes and Containers` with the new `Clear and Restart External Volumes and Containers` and `Restart External Volumes and Containers`.
2. Run `Restart External Volumes and Containers`. This will add the new MinIO container and run the migration, without clearing the containers.

## How Has This Been Tested?

Locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
