### PR TITLE
KG process email fix

### DIFF
--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -45,7 +45,6 @@ from onyx.kg.models import KGEnhancedDocumentMetadata
 from onyx.kg.models import KGEntityTypeInstructions
 from onyx.kg.models import KGExtractionInstructions
 from onyx.kg.utils.extraction_utils import EntityTypeMetadataTracker
-from onyx.kg.utils.extraction_utils import is_email
 from onyx.kg.utils.extraction_utils import (
     kg_document_entities_relationships_attribute_generation,
 )
@@ -54,6 +53,7 @@ from onyx.kg.utils.extraction_utils import prepare_llm_content_extraction
 from onyx.kg.utils.extraction_utils import prepare_llm_document_content
 from onyx.kg.utils.extraction_utils import trackinfo_to_str
 from onyx.kg.utils.formatting_utils import aggregate_kg_extractions
+from onyx.kg.utils.formatting_utils import extract_email
 from onyx.kg.utils.formatting_utils import extract_relationship_type_id
 from onyx.kg.utils.formatting_utils import generalize_entities
 from onyx.kg.utils.formatting_utils import get_entity_type
@@ -1045,14 +1045,14 @@ def _kg_chunk_batch_extraction(
         if chunk.metadata:
             for attribute, value in chunk.metadata.items():
                 if isinstance(value, str):
-                    if is_email(value):
+                    if email := extract_email(value):
                         (
                             implied_attribute_entities,
                             implied_attribute_relationships,
                             attribute_company_participant_emails,
                             attribute_account_participant_emails,
                         ) = kg_process_person(
-                            person=value,
+                            person=email,
                             core_document_id_name=kg_document_extractions.kg_core_document_id_name,
                             implied_entities=implied_attribute_entities,
                             implied_relationships=implied_attribute_relationships,
@@ -1069,14 +1069,14 @@ def _kg_chunk_batch_extraction(
                 elif isinstance(value, list):
                     email_attribute = False
                     for item in value:
-                        if is_email(item):
+                        if email := extract_email(item):
                             (
                                 implied_attribute_entities,
                                 implied_attribute_relationships,
                                 attribute_company_participant_emails,
                                 attribute_account_participant_emails,
                             ) = kg_process_person(
-                                person=item,
+                                person=email,
                                 core_document_id_name=kg_document_extractions.kg_core_document_id_name,
                                 implied_entities=implied_attribute_entities,
                                 implied_relationships=implied_attribute_relationships,

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -1,4 +1,3 @@
-import re
 from collections import defaultdict
 
 from onyx.configs.constants import OnyxCallTypes
@@ -18,6 +17,7 @@ from onyx.kg.models import (
 from onyx.kg.models import KGDocumentEntitiesRelationshipsAttributes
 from onyx.kg.models import KGEnhancedDocumentMetadata
 from onyx.kg.models import KGEntityTypeClassificationInfo
+from onyx.kg.utils.formatting_utils import extract_email
 from onyx.kg.utils.formatting_utils import generalize_entities
 from onyx.kg.utils.formatting_utils import kg_email_processing
 from onyx.kg.utils.formatting_utils import make_entity_id
@@ -41,7 +41,7 @@ def _update_implied_entities_relationships(
 
     for owner in owner_list or []:
 
-        if not is_email(owner):
+        if extract_email(owner) is None:
             converted_relationships_to_attributes[relationship_type].append(owner)
             continue
 
@@ -431,13 +431,6 @@ def prepare_llm_document_content(
         return KGDocumentClassificationPrompt(
             llm_prompt=None,
         )
-
-
-def is_email(email: str) -> bool:
-    """
-    Check if a string is a valid email address.
-    """
-    return re.match(r"[^@]+@[^@]+\.[^@]+", email) is not None
 
 
 def trackinfo_to_str(trackinfo: KGAttributeTrackInfo | None) -> str:

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -184,7 +184,7 @@ def kg_email_processing(email: str, kg_config_settings: KGConfigSettings) -> KGP
     else:
         # TODO: maybe store a list of domains for each account and use that to match
         # right now, gmail and other random domains are being converted into accounts
-        company = company_domain.capitalize()
+        company = company_domain.title()
 
     return KGPerson(name=name, company=company, employee=employee)
 

--- a/backend/onyx/kg/utils/formatting_utils.py
+++ b/backend/onyx/kg/utils/formatting_utils.py
@@ -158,6 +158,15 @@ def aggregate_kg_extractions(
     return aggregated_kg_extractions
 
 
+def extract_email(email: str) -> str | None:
+    """
+    Extract an email from an arbitrary string (if any).
+    Only the first email is returned.
+    """
+    match = re.search(r"([A-Za-z0-9._+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+)", email)
+    return match.group(0) if match else None
+
+
 def kg_email_processing(email: str, kg_config_settings: KGConfigSettings) -> KGPerson:
     """
     Process the email.
@@ -173,6 +182,8 @@ def kg_email_processing(email: str, kg_config_settings: KGConfigSettings) -> KGP
     if employee:
         company = kg_config_settings.KG_VENDOR
     else:
+        # TODO: maybe store a list of domains for each account and use that to match
+        # right now, gmail and other random domains are being converted into accounts
         company = company_domain.capitalize()
 
     return KGPerson(name=name, company=company, employee=employee)


### PR DESCRIPTION
## Description

Accounts extracted from GitHub attributes were showing up weird because of the way emails are shown in the metadata. This now extracts the email portion before passing it into the process_email function, rather than passing the whole string and treating everything before the @ as the name and after as the domain. 

Now, even if the attribute looks like {'name' John, 'email': johndoe@gmail.com}, the correct name and domain will be extracted. Same goes with any arbitrary string that contains an email. 

## How Has This Been Tested?

Without this PR:
Accounts extracted from GitHub have a weird } at the end. You'd have to test this on a repo with users that display their email. 

With this PR:
The name and account should look correct.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
