### PR TITLE
fix(gitbook): nested pages in page groups ignored due to missing updatedAt parameter

### DIFF
--- a/backend/onyx/connectors/gitbook/connector.py
+++ b/backend/onyx/connectors/gitbook/connector.py
@@ -239,6 +239,7 @@ class GitbookConnector(LoadConnector, PollConnector):
 
             while pages:
                 page = pages.pop(0)
+                pages.extend(page.get("pages", []))
 
                 updated_at_raw = page.get("updatedAt")
                 if updated_at_raw is None:
@@ -258,8 +259,6 @@ class GitbookConnector(LoadConnector, PollConnector):
                 if len(current_batch) >= self.batch_size:
                     yield current_batch
                     current_batch = []
-
-                pages.extend(page.get("pages", []))
 
             if current_batch:
                 yield current_batch


### PR DESCRIPTION
## Description

Page groups in GitBook often have missing `updatedAt` timestamps, which caused the connector to skip processing their child pages entirely. By moving the logic before the `updatedAt` check, we ensure all child pages are added to the processing queue regardless of their parent's timestamp status.

## How Has This Been Tested?

Noticed a discrepancy in the document count indexed when trying to sync a personal GitBook setup. Tested by making the changes and building the background service locally and running the sync again. The connector properly processed all child pages that were previously being skipped.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
