### PR TITLE
KG Vespa Rate Limit Fix

### DIFF
--- a/backend/onyx/document_index/vespa/index.py
+++ b/backend/onyx/document_index/vespa/index.py
@@ -569,6 +569,7 @@ class VespaIndex(DocumentIndex):
     ) -> None:
         """Runs a batch of updates in parallel via the ThreadPoolExecutor."""
 
+        @retry(tries=3, delay=1, backoff=2)
         def _kg_update_chunk(
             update: KGVespaChunkUpdateRequest, http_client: httpx.Client
         ) -> httpx.Response:

--- a/backend/onyx/document_index/vespa/kg_interactions.py
+++ b/backend/onyx/document_index/vespa/kg_interactions.py
@@ -1,5 +1,3 @@
-from retry import retry
-
 from onyx.db.document import get_document_kg_entities_and_relationships
 from onyx.db.document import get_num_chunks_for_document
 from onyx.db.engine import get_session_with_current_tenant
@@ -11,7 +9,6 @@ from shared_configs.configs import MULTI_TENANT
 logger = setup_logger()
 
 
-@retry(tries=3, delay=1, backoff=2)
 def update_kg_chunks_vespa_info(
     kg_update_requests: list[KGUChunkUpdateRequest],
     index_name: str,
@@ -34,7 +31,7 @@ def update_kg_chunks_vespa_info(
 
 
 def get_kg_vespa_info_update_requests_for_document(
-    document_id: str, index_name: str, tenant_id: str
+    document_id: str,
 ) -> list[KGUChunkUpdateRequest]:
     """Get the kg_info update requests for a document."""
     # get all entities and relationships tied to the document

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -282,10 +282,7 @@ def _transfer_batch_relationship_and_update_vespa(
     # update vespa in parallel
     batch_update_requests = run_functions_tuples_in_parallel(
         [
-            (
-                get_kg_vespa_info_update_requests_for_document,
-                (document_id, index_name, tenant_id),
-            )
+            (get_kg_vespa_info_update_requests_for_document, (document_id,))
             for document_id in docs_to_update
         ]
     )


### PR DESCRIPTION
## Description

Made retry on a per chunk basis to be in line with how the other vespa updates are done (rather than a per document basis). If hypothesis that rate limit is happening due to too many chunks per document is correct, this should fix it. Either way, it is a step in the right direction.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
