### PR TITLE
Add support for db proxy

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,12 +1,12 @@
 from typing import Any, Literal
-from onyx.db.engine import get_iam_auth_token
+from onyx.db.engine.iam_auth import get_iam_auth_token
 from onyx.configs.app_configs import USE_IAM_AUTH
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.app_configs import AWS_REGION_NAME
-from onyx.db.engine import build_connection_string
-from onyx.db.engine import get_all_tenant_ids
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from sqlalchemy import event
 from sqlalchemy import pool
 from sqlalchemy import text
@@ -24,7 +24,7 @@ from onyx.configs.constants import SSL_CERT_FILE
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA
 from onyx.db.models import Base
 from celery.backends.database.session import ResultModelBase  # type: ignore
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 
 # Make sure in alembic.ini [logger_root] level=INFO is set or most logging will be
 # hidden! (defaults to level=WARN)

--- a/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
+++ b/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
@@ -19,7 +19,7 @@ depends_on = None
 
 
 def _get_tenant_contextvar(session: Session) -> str:
-    """Set the tenant contextvar to the default schema"""
+    """Get the current schema for the migration"""
     current_tenant = session.execute(text("SELECT current_schema()")).scalar()
     if isinstance(current_tenant, str):
         return current_tenant

--- a/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
+++ b/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
@@ -1,0 +1,136 @@
+"""update_kg_trigger_functions
+
+Revision ID: 36e9220ab794
+Revises: c9e2cd766c29
+Create Date: 2025-06-22 17:33:25.833733
+
+"""
+
+from alembic import op
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+# revision identifiers, used by Alembic.
+revision = "36e9220ab794"
+down_revision = "c9e2cd766c29"
+branch_labels = None
+depends_on = None
+
+
+def _get_tenant_contextvar(session: Session) -> str:
+    """Set the tenant contextvar to the default schema"""
+    current_tenant = session.execute(text("SELECT current_schema()")).scalar()
+    if isinstance(current_tenant, str):
+        return current_tenant
+    else:
+        raise ValueError("Current tenant is not a string")
+
+
+def upgrade() -> None:
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Create kg_entity trigger to update kg_entity.name and its trigrams
+    tenant_id = _get_tenant_contextvar(session)
+    alphanum_pattern = r"[^a-z0-9]+"
+    truncate_length = 1000
+    function = "update_kg_entity_name"
+    op.execute(
+        text(
+            f"""
+            CREATE OR REPLACE FUNCTION "{tenant_id}".{function}()
+            RETURNS TRIGGER AS $$
+            DECLARE
+                name text;
+                cleaned_name text;
+            BEGIN
+                -- Set name to semantic_id if document_id is not NULL
+                IF NEW.document_id IS NOT NULL THEN
+                    SELECT lower(semantic_id) INTO name
+                    FROM "{tenant_id}".document
+                    WHERE id = NEW.document_id;
+                ELSE
+                    name = lower(NEW.name);
+                END IF;
+
+                -- Clean name and truncate if too long
+                cleaned_name = regexp_replace(
+                    name,
+                    '{alphanum_pattern}', '', 'g'
+                );
+                IF length(cleaned_name) > {truncate_length} THEN
+                    cleaned_name = left(cleaned_name, {truncate_length});
+                END IF;
+
+                -- Set name and name trigrams
+                NEW.name = name;
+                NEW.name_trigrams = {POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}.show_trgm(cleaned_name);
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+    trigger = f"{function}_trigger"
+    op.execute(f'DROP TRIGGER IF EXISTS {trigger} ON "{tenant_id}".kg_entity')
+    op.execute(
+        f"""
+        CREATE TRIGGER {trigger}
+            BEFORE INSERT OR UPDATE OF name
+            ON "{tenant_id}".kg_entity
+            FOR EACH ROW
+            EXECUTE FUNCTION "{tenant_id}".{function}();
+        """
+    )
+
+    # Create kg_entity trigger to update kg_entity.name and its trigrams
+    function = "update_kg_entity_name_from_doc"
+    op.execute(
+        text(
+            f"""
+            CREATE OR REPLACE FUNCTION "{tenant_id}".{function}()
+            RETURNS TRIGGER AS $$
+            DECLARE
+                doc_name text;
+                cleaned_name text;
+            BEGIN
+                doc_name = lower(NEW.semantic_id);
+
+                -- Clean name and truncate if too long
+                cleaned_name = regexp_replace(
+                    doc_name,
+                    '{alphanum_pattern}', '', 'g'
+                );
+                IF length(cleaned_name) > {truncate_length} THEN
+                    cleaned_name = left(cleaned_name, {truncate_length});
+                END IF;
+
+                -- Set name and name trigrams for all entities referencing this document
+                UPDATE "{tenant_id}".kg_entity
+                SET
+                    name = doc_name,
+                    name_trigrams = {POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE}.show_trgm(cleaned_name)
+                WHERE document_id = NEW.id;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+    trigger = f"{function}_trigger"
+    op.execute(f'DROP TRIGGER IF EXISTS {trigger} ON "{tenant_id}".document')
+    op.execute(
+        f"""
+        CREATE TRIGGER {trigger}
+            AFTER UPDATE OF semantic_id
+            ON "{tenant_id}".document
+            FOR EACH ROW
+            EXECUTE FUNCTION "{tenant_id}".{function}();
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic_tenants/env.py
+++ b/backend/alembic_tenants/env.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.schema import SchemaItem
 
 from alembic import context
-from onyx.db.engine import build_connection_string
+from onyx.db.engine.sql_engine import build_connection_string
 from onyx.db.models import PublicBase
 
 # this is the Alembic Config object, which provides

--- a/backend/ee/onyx/background/celery/apps/heavy.py
+++ b/backend/ee/onyx/background/celery/apps/heavy.py
@@ -16,7 +16,7 @@ from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import QueryHistoryType
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.tasks import delete_task_with_id
 from onyx.db.tasks import mark_task_as_finished_with_id
 from onyx.db.tasks import mark_task_as_started_with_id

--- a/backend/ee/onyx/background/celery/apps/primary.py
+++ b/backend/ee/onyx/background/celery/apps/primary.py
@@ -13,7 +13,7 @@ from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import TaskStatus
 from onyx.db.tasks import mark_task_as_finished_with_id
 from onyx.db.tasks import register_task

--- a/backend/ee/onyx/background/celery/tasks/cleanup/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/cleanup/tasks.py
@@ -6,7 +6,7 @@ from celery import shared_task
 from ee.onyx.db.query_history import get_all_query_history_export_tasks
 from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import OnyxCeleryTask
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import TaskStatus
 from onyx.db.tasks import delete_task_with_id
 from onyx.utils.logger import setup_logger

--- a/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
@@ -13,7 +13,7 @@ from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
-from onyx.db.engine import get_all_tenant_ids
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
 from shared_configs.configs import IGNORED_SYNCING_TENANT_LIST

--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -47,8 +47,8 @@ from onyx.db.connector import mark_cc_pair_as_permissions_synced
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.document import get_document_ids_for_connector_credential_pair
 from onyx.db.document import upsert_document_by_connector_credential_pair
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SyncStatus

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -41,7 +41,7 @@ from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import OnyxRedisSignals
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SyncStatus

--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -19,7 +19,7 @@ from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
-from onyx.db.engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import AvailableTenant
 from onyx.redis.redis_pool import get_redis_client
 from shared_configs.configs import MULTI_TENANT

--- a/backend/ee/onyx/external_permissions/post_query_censoring.py
+++ b/backend/ee/onyx/external_permissions/post_query_censoring.py
@@ -3,7 +3,7 @@ from ee.onyx.external_permissions.sync_params import get_all_censoring_enabled_s
 from ee.onyx.external_permissions.sync_params import get_source_perm_sync_config
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.pipeline import InferenceChunk
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 

--- a/backend/ee/onyx/external_permissions/post_query_censoring.py
+++ b/backend/ee/onyx/external_permissions/post_query_censoring.py
@@ -3,7 +3,7 @@ from ee.onyx.external_permissions.sync_params import get_all_censoring_enabled_s
 from ee.onyx.external_permissions.sync_params import get_source_perm_sync_config
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.pipeline import InferenceChunk
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 
@@ -22,7 +22,7 @@ def _get_all_censoring_enabled_sources() -> set[DocumentSource]:
     for every single chunk.
     """
     all_censoring_enabled_sources = get_all_censoring_enabled_sources()
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         enabled_sync_connectors = get_all_auto_sync_cc_pairs(db_session)
         return {
             cc_pair.connector.source

--- a/backend/ee/onyx/external_permissions/post_query_censoring.py
+++ b/backend/ee/onyx/external_permissions/post_query_censoring.py
@@ -3,7 +3,7 @@ from ee.onyx.external_permissions.sync_params import get_all_censoring_enabled_s
 from ee.onyx.external_permissions.sync_params import get_source_perm_sync_config
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.pipeline import InferenceChunk
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 
@@ -22,7 +22,7 @@ def _get_all_censoring_enabled_sources() -> set[DocumentSource]:
     for every single chunk.
     """
     all_censoring_enabled_sources = get_all_censoring_enabled_sources()
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         enabled_sync_connectors = get_all_auto_sync_cc_pairs(db_session)
         return {
             cc_pair.connector.source

--- a/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
+++ b/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
@@ -10,7 +10,7 @@ from ee.onyx.external_permissions.salesforce.utils import (
 )
 from onyx.configs.app_configs import BLURB_SIZE
 from onyx.context.search.models import InferenceChunk
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
+++ b/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
@@ -10,7 +10,7 @@ from ee.onyx.external_permissions.salesforce.utils import (
 )
 from onyx.configs.app_configs import BLURB_SIZE
 from onyx.context.search.models import InferenceChunk
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -44,7 +44,7 @@ def _get_objects_access_for_user_email_from_salesforce(
     # This is cached in the function so the first query takes an extra 0.1-0.3 seconds
     # but subsequent queries for this source are essentially instant
     first_doc_id = chunks[0].document_id
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         salesforce_client = get_any_salesforce_client_for_doc_id(
             db_session, first_doc_id
         )
@@ -217,7 +217,7 @@ def censor_salesforce_chunks(
 def _get_objects_access_for_user_email(
     object_ids: set[str], user_email: str
 ) -> dict[str, bool]:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         external_groups = fetch_external_groups_for_user_email_and_group_ids(
             db_session=db_session,
             user_email=user_email,

--- a/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
+++ b/backend/ee/onyx/external_permissions/salesforce/postprocessing.py
@@ -10,7 +10,7 @@ from ee.onyx.external_permissions.salesforce.utils import (
 )
 from onyx.configs.app_configs import BLURB_SIZE
 from onyx.context.search.models import InferenceChunk
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -44,7 +44,7 @@ def _get_objects_access_for_user_email_from_salesforce(
     # This is cached in the function so the first query takes an extra 0.1-0.3 seconds
     # but subsequent queries for this source are essentially instant
     first_doc_id = chunks[0].document_id
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         salesforce_client = get_any_salesforce_client_for_doc_id(
             db_session, first_doc_id
         )
@@ -217,7 +217,7 @@ def censor_salesforce_chunks(
 def _get_objects_access_for_user_email(
     object_ids: set[str], user_email: str
 ) -> dict[str, bool]:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         external_groups = fetch_external_groups_for_user_email_and_group_ids(
             db_session=db_session,
             user_email=user_email,

--- a/backend/ee/onyx/server/analytics/api.py
+++ b/backend/ee/onyx/server/analytics/api.py
@@ -19,7 +19,7 @@ from ee.onyx.db.analytics import fetch_query_analytics
 from ee.onyx.db.analytics import user_can_view_assistant_stats
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 
 router = APIRouter(prefix="/analytics")

--- a/backend/ee/onyx/server/documents/cc_pair.py
+++ b/backend/ee/onyx/server/documents/cc_pair.py
@@ -17,7 +17,7 @@ from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id_for_user,
 )
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_pool import get_redis_client

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -26,7 +26,7 @@ from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_user_with_expired_token
 from onyx.auth.users import get_user_manager
 from onyx.auth.users import UserManager
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.utils import BasicAuthenticationError

--- a/backend/ee/onyx/server/manage/standard_answer.py
+++ b/backend/ee/onyx/server/manage/standard_answer.py
@@ -13,7 +13,7 @@ from ee.onyx.db.standard_answer import remove_standard_answer
 from ee.onyx.db.standard_answer import update_standard_answer
 from ee.onyx.db.standard_answer import update_standard_answer_category
 from onyx.auth.users import current_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.server.manage.models import StandardAnswer
 from onyx.server.manage.models import StandardAnswerCategory

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -11,7 +11,7 @@ from ee.onyx.auth.users import decode_anonymous_user_jwt_token
 from onyx.auth.api_key import extract_tenant_from_api_key_header
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import TENANT_ID_COOKIE_NAME
-from onyx.db.engine import is_valid_schema_name
+from onyx.db.engine.sql_engine import is_valid_schema_name
 from onyx.redis.redis_pool import retrieve_auth_token_data_from_redis
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA

--- a/backend/ee/onyx/server/oauth/api.py
+++ b/backend/ee/onyx/server/oauth/api.py
@@ -12,10 +12,10 @@ from ee.onyx.server.oauth.slack import SlackOAuth
 from onyx.auth.users import current_admin_user
 from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.constants import DocumentSource
-from onyx.db.engine import get_current_tenant_id
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 

--- a/backend/ee/onyx/server/oauth/confluence_cloud.py
+++ b/backend/ee/onyx/server/oauth/confluence_cloud.py
@@ -25,12 +25,12 @@ from onyx.connectors.confluence.utils import CONFLUENCE_OAUTH_TOKEN_URL
 from onyx.db.credentials import create_credential
 from onyx.db.credentials import fetch_credential_by_id_for_user
 from onyx.db.credentials import update_credential_json
-from onyx.db.engine import get_current_tenant_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 

--- a/backend/ee/onyx/server/oauth/google_drive.py
+++ b/backend/ee/onyx/server/oauth/google_drive.py
@@ -33,11 +33,11 @@ from onyx.connectors.google_utils.shared_constants import (
     GoogleOAuthAuthenticationMethod,
 )
 from onyx.db.credentials import create_credential
-from onyx.db.engine import get_current_tenant_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase
+from shared_configs.contextvars import get_current_tenant_id
 
 
 class GoogleDriveOAuth:

--- a/backend/ee/onyx/server/oauth/slack.py
+++ b/backend/ee/onyx/server/oauth/slack.py
@@ -17,11 +17,11 @@ from onyx.configs.app_configs import OAUTH_SLACK_CLIENT_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import DocumentSource
 from onyx.db.credentials import create_credential
-from onyx.db.engine import get_current_tenant_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase
+from shared_configs.contextvars import get_current_tenant_id
 
 
 class SlackOAuth:

--- a/backend/ee/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/chat_backend.py
@@ -40,7 +40,7 @@ from onyx.context.search.models import SavedSearchDoc
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_or_create_root_message
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.llm.factory import get_llms_for_persona
 from onyx.natural_language_processing.utils import get_tokenizer

--- a/backend/ee/onyx/server/query_and_chat/query_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/query_backend.py
@@ -31,7 +31,7 @@ from onyx.context.search.utils import dedupe_documents
 from onyx.context.search.utils import drop_llm_indices
 from onyx.context.search.utils import relevant_sections_to_indices
 from onyx.db.chat import get_prompt_by_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -13,7 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.api_key import is_api_key_email_address
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -37,7 +37,7 @@ from onyx.configs.constants import QueryHistoryType
 from onyx.configs.constants import SessionType
 from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_chat_sessions_by_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import TaskStatus
 from onyx.db.file_record import get_query_history_export_files
 from onyx.db.models import ChatSession

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -14,7 +14,7 @@ from ee.onyx.db.usage_export import get_usage_report_data
 from ee.onyx.db.usage_export import UsageReportMetadata
 from ee.onyx.server.reporting.usage_export_generation import create_new_usage_report
 from onyx.auth.users import current_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.file_store.constants import STANDARD_CHUNK_SIZE
 

--- a/backend/ee/onyx/server/saml.py
+++ b/backend/ee/onyx/server/saml.py
@@ -27,9 +27,9 @@ from onyx.auth.users import get_user_manager
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
 from onyx.db.auth import get_user_count
 from onyx.db.auth import get_user_db
-from onyx.db.engine import get_async_session
-from onyx.db.engine import get_async_session_context_manager
-from onyx.db.engine import get_session
+from onyx.db.engine.async_sql_engine import get_async_session
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 

--- a/backend/ee/onyx/server/seeding.py
+++ b/backend/ee/onyx/server/seeding.py
@@ -19,7 +19,7 @@ from ee.onyx.server.enterprise_settings.store import (
 )
 from ee.onyx.server.enterprise_settings.store import upload_logo
 from onyx.context.search.enums import RecencyBiasSetting
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.llm import update_default_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import Tool
@@ -235,7 +235,7 @@ def seed_db() -> None:
         logger.debug("No seeding configuration file passed")
         return
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         if seed_config.llms is not None:
             _seed_llms(db_session, seed_config.llms)
         if seed_config.personas is not None:

--- a/backend/ee/onyx/server/seeding.py
+++ b/backend/ee/onyx/server/seeding.py
@@ -19,7 +19,7 @@ from ee.onyx.server.enterprise_settings.store import (
 )
 from ee.onyx.server.enterprise_settings.store import upload_logo
 from onyx.context.search.enums import RecencyBiasSetting
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.llm import update_default_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import Tool
@@ -235,7 +235,7 @@ def seed_db() -> None:
         logger.debug("No seeding configuration file passed")
         return
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         if seed_config.llms is not None:
             _seed_llms(db_session, seed_config.llms)
         if seed_config.personas is not None:

--- a/backend/ee/onyx/server/seeding.py
+++ b/backend/ee/onyx/server/seeding.py
@@ -19,7 +19,7 @@ from ee.onyx.server.enterprise_settings.store import (
 )
 from ee.onyx.server.enterprise_settings.store import upload_logo
 from onyx.context.search.enums import RecencyBiasSetting
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.llm import update_default_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import Tool

--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -10,7 +10,7 @@ from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from onyx.auth.users import auth_backend
 from onyx.auth.users import get_redis_strategy
 from onyx.auth.users import User
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email
 from onyx.utils.logger import setup_logger
 

--- a/backend/ee/onyx/server/tenants/anonymous_users_api.py
+++ b/backend/ee/onyx/server/tenants/anonymous_users_api.py
@@ -18,7 +18,7 @@ from onyx.auth.users import optional_user
 from onyx.auth.users import User
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
-from onyx.db.engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -28,8 +28,8 @@ from onyx.auth.users import exceptions
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.constants import MilestoneRecordType
-from onyx.db.engine import get_session_with_shared_schema
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.llm import update_default_provider
 from onyx.db.llm import upsert_cloud_embedding_provider
 from onyx.db.llm import upsert_llm_provider

--- a/backend/ee/onyx/server/tenants/schema_management.py
+++ b/backend/ee/onyx/server/tenants/schema_management.py
@@ -8,8 +8,8 @@ from sqlalchemy.schema import CreateSchema
 
 from alembic import command
 from alembic.config import Config
-from onyx.db.engine import build_connection_string
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 
 logger = logging.getLogger(__name__)
 

--- a/backend/ee/onyx/server/tenants/team_membership_api.py
+++ b/backend/ee/onyx/server/tenants/team_membership_api.py
@@ -9,7 +9,7 @@ from ee.onyx.server.tenants.user_mapping import remove_users_from_tenant
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import User
 from onyx.db.auth import get_user_count
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.users import delete_user_from_db
 from onyx.db.users import get_user_by_email
 from onyx.server.manage.models import UserByEmail

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -5,8 +5,8 @@ from onyx.auth.invited_users import get_invited_users
 from onyx.auth.invited_users import get_pending_users
 from onyx.auth.invited_users import write_invited_users
 from onyx.auth.invited_users import write_pending_users
-from onyx.db.engine import get_session_with_shared_schema
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import UserTenantMapping
 from onyx.server.manage.models import TenantSnapshot
 from onyx.utils.logger import setup_logger

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -9,7 +9,7 @@ from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_user
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_curator_or_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
 from onyx.db.token_limit import insert_user_token_rate_limit

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -16,7 +16,7 @@ from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupUpdate
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_curator_or_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/agents/agent_search/basic/graph_builder.py
+++ b/backend/onyx/agents/agent_search/basic/graph_builder.py
@@ -78,7 +78,7 @@ def should_continue(state: BasicState) -> str:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_with_shared_schema
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
     from onyx.context.search.models import SearchRequest
     from onyx.llm.factory import get_default_llms
     from onyx.agents.agent_search.shared_graph_utils.utils import get_test_config
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     compiled_graph = graph.compile()
     input = BasicInput(unused=True)
     primary_llm, fast_llm = get_default_llms()
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         config, _ = get_test_config(
             db_session=db_session,
             primary_llm=primary_llm,

--- a/backend/onyx/agents/agent_search/basic/graph_builder.py
+++ b/backend/onyx/agents/agent_search/basic/graph_builder.py
@@ -78,7 +78,7 @@ def should_continue(state: BasicState) -> str:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_with_shared_schema
     from onyx.context.search.models import SearchRequest
     from onyx.llm.factory import get_default_llms
     from onyx.agents.agent_search.shared_graph_utils.utils import get_test_config
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     compiled_graph = graph.compile()
     input = BasicInput(unused=True)
     primary_llm, fast_llm = get_default_llms()
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         config, _ = get_test_config(
             db_session=db_session,
             primary_llm=primary_llm,

--- a/backend/onyx/agents/agent_search/basic/graph_builder.py
+++ b/backend/onyx/agents/agent_search/basic/graph_builder.py
@@ -78,7 +78,7 @@ def should_continue(state: BasicState) -> str:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_context_manager
     from onyx.context.search.models import SearchRequest
     from onyx.llm.factory import get_default_llms
     from onyx.agents.agent_search.shared_graph_utils.utils import get_test_config

--- a/backend/onyx/agents/agent_search/dc_search_analysis/ops.py
+++ b/backend/onyx/agents/agent_search/dc_search_analysis/ops.py
@@ -4,7 +4,7 @@ from typing import cast
 from onyx.chat.models import LlmDoc
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (
     FINAL_CONTEXT_DOCUMENTS_ID,

--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
@@ -111,7 +111,7 @@ def answer_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_with_shared_schema
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     search_request = SearchRequest(
         query="what can you do with onyx or danswer?",
     )
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         graph_config, search_tool = get_test_config(
             db_session, primary_llm, fast_llm, search_request
         )

--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
@@ -111,7 +111,7 @@ def answer_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_with_shared_schema
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     search_request = SearchRequest(
         query="what can you do with onyx or danswer?",
     )
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         graph_config, search_tool = get_test_config(
             db_session, primary_llm, fast_llm, search_request
         )

--- a/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/initial/generate_individual_sub_answer/graph_builder.py
@@ -111,7 +111,7 @@ def answer_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_context_manager
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 

--- a/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
@@ -238,7 +238,7 @@ def agent_search_graph_builder() -> StateGraph:
 if __name__ == "__main__":
     pass
 
-    from onyx.db.engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_context_manager
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 

--- a/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
@@ -238,7 +238,7 @@ def agent_search_graph_builder() -> StateGraph:
 if __name__ == "__main__":
     pass
 
-    from onyx.db.engine.sql_engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_with_shared_schema
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -246,7 +246,7 @@ if __name__ == "__main__":
     compiled_graph = graph.compile()
     primary_llm, fast_llm = get_default_llms()
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         search_request = SearchRequest(query="Who created Excel?")
         graph_config = get_test_config(
             db_session, primary_llm, fast_llm, search_request

--- a/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/main/graph_builder.py
@@ -238,7 +238,7 @@ def agent_search_graph_builder() -> StateGraph:
 if __name__ == "__main__":
     pass
 
-    from onyx.db.engine.sql_engine import get_session_with_shared_schema
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -246,7 +246,7 @@ if __name__ == "__main__":
     compiled_graph = graph.compile()
     primary_llm, fast_llm = get_default_llms()
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         search_request = SearchRequest(query="Who created Excel?")
         graph_config = get_test_config(
             db_session, primary_llm, fast_llm, search_request

--- a/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
@@ -109,7 +109,7 @@ def answer_refined_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_with_shared_schema
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     search_request = SearchRequest(
         query="what can you do with onyx or danswer?",
     )
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         inputs = SubQuestionAnsweringInput(
             question="what can you do with onyx?",
             question_id="0_0",

--- a/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
@@ -109,7 +109,7 @@ def answer_refined_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_with_shared_schema
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     search_request = SearchRequest(
         query="what can you do with onyx or danswer?",
     )
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         inputs = SubQuestionAnsweringInput(
             question="what can you do with onyx?",
             question_id="0_0",

--- a/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/refinement/consolidate_sub_answers/graph_builder.py
@@ -109,7 +109,7 @@ def answer_refined_query_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_context_manager
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
@@ -131,7 +131,7 @@ def expanded_retrieval_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_context_manager
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
@@ -131,7 +131,7 @@ def expanded_retrieval_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_with_shared_schema
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         query="what can you do with onyx or danswer?",
     )
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         graph_config, search_tool = get_test_config(
             db_session, primary_llm, fast_llm, search_request
         )

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/graph_builder.py
@@ -131,7 +131,7 @@ def expanded_retrieval_graph_builder() -> StateGraph:
 
 
 if __name__ == "__main__":
-    from onyx.db.engine.sql_engine import get_session_context_manager
+    from onyx.db.engine.sql_engine import get_session_with_shared_schema
     from onyx.llm.factory import get_default_llms
     from onyx.context.search.models import SearchRequest
 
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         query="what can you do with onyx or danswer?",
     )
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         graph_config, search_tool = get_test_config(
             db_session, primary_llm, fast_llm, search_request
         )

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
@@ -24,7 +24,7 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.postprocessing.postprocessing import rerank_sections
 from onyx.context.search.postprocessing.postprocessing import should_rerank
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.search_settings import get_current_search_settings
 from onyx.utils.timing import log_function_time
 
@@ -60,7 +60,7 @@ def rerank_documents(
     allow_agent_reranking = graph_config.behavior.allow_agent_reranking
 
     if rerank_settings is None:
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             search_settings = get_current_search_settings(db_session)
             if not search_settings.disable_rerank_for_streaming:
                 rerank_settings = RerankingDetails.from_db_model(search_settings)

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
@@ -24,7 +24,7 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.postprocessing.postprocessing import rerank_sections
 from onyx.context.search.postprocessing.postprocessing import should_rerank
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.search_settings import get_current_search_settings
 from onyx.utils.timing import log_function_time
 

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/rerank_documents.py
@@ -24,7 +24,7 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.postprocessing.postprocessing import rerank_sections
 from onyx.context.search.postprocessing.postprocessing import should_rerank
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.utils.timing import log_function_time
 
@@ -60,7 +60,7 @@ def rerank_documents(
     allow_agent_reranking = graph_config.behavior.allow_agent_reranking
 
     if rerank_settings is None:
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             search_settings = get_current_search_settings(db_session)
             if not search_settings.disable_rerank_for_streaming:
                 rerank_settings = RerankingDetails.from_db_model(search_settings)

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
@@ -21,7 +21,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
 from onyx.configs.agent_configs import AGENT_MAX_QUERY_RETRIEVAL_RESULTS
 from onyx.configs.agent_configs import AGENT_RETRIEVAL_STATS
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.tools.models import SearchQueryInfo
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (
@@ -67,7 +67,7 @@ def retrieve_documents(
     callback_container: list[list[InferenceSection]] = []
 
     # new db session to avoid concurrency issues
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         for tool_response in search_tool.run(
             query=query_to_retrieve,
             override_kwargs=SearchToolOverrideKwargs(

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
@@ -21,7 +21,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
 from onyx.configs.agent_configs import AGENT_MAX_QUERY_RETRIEVAL_RESULTS
 from onyx.configs.agent_configs import AGENT_RETRIEVAL_STATS
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.tools.models import SearchQueryInfo
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (

--- a/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
+++ b/backend/onyx/agents/agent_search/deep_search/shared/expanded_retrieval/nodes/retrieve_documents.py
@@ -21,7 +21,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
 from onyx.configs.agent_configs import AGENT_MAX_QUERY_RETRIEVAL_RESULTS
 from onyx.configs.agent_configs import AGENT_RETRIEVAL_STATS
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.tools.models import SearchQueryInfo
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (
@@ -67,7 +67,7 @@ def retrieve_documents(
     callback_container: list[list[InferenceSection]] = []
 
     # new db session to avoid concurrency issues
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         for tool_response in search_tool.run(
             query=query_to_retrieve,
             override_kwargs=SearchToolOverrideKwargs(

--- a/backend/onyx/agents/agent_search/kb_search/graph_utils.py
+++ b/backend/onyx/agents/agent_search/kb_search/graph_utils.py
@@ -19,7 +19,7 @@ from onyx.chat.models import SubQuestionPiece
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
 from onyx.db.document import get_kg_doc_info_for_entity_name
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import get_document_id_for_entity
 from onyx.db.entities import get_entity_name
 from onyx.db.entity_type import get_entity_types

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
@@ -35,6 +35,7 @@ from onyx.prompts.kg_prompts import QUERY_ENTITY_EXTRACTION_PROMPT
 from onyx.prompts.kg_prompts import QUERY_RELATIONSHIP_EXTRACTION_PROMPT
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_with_timeout
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -80,10 +81,12 @@ def extract_ert(
     stream_write_step_activities(writer, _KG_STEP_NR)
 
     # Create temporary views. TODO: move into parallel step, if ultimately materialized
-    kg_views = get_user_view_names(user_email)
+    tenant_id = get_current_tenant_id()
+    kg_views = get_user_view_names(user_email, tenant_id)
     with get_session_with_current_tenant() as db_session:
         create_views(
             db_session,
+            tenant_id=tenant_id,
             user_email=user_email,
             allowed_docs_view_name=kg_views.allowed_docs_view_name,
             kg_relationships_view_name=kg_views.kg_relationships_view_name,

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a1_extract_ert.py
@@ -25,7 +25,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
 )
 from onyx.configs.kg_configs import KG_ENTITY_EXTRACTION_TIMEOUT
 from onyx.configs.kg_configs import KG_RELATIONSHIP_EXTRACTION_TIMEOUT
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.kg_temp_view import create_views
 from onyx.db.kg_temp_view import get_user_view_names
 from onyx.db.relationships import get_allowed_relationship_type_pairs

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a2_analyze.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a2_analyze.py
@@ -27,7 +27,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
     get_langgraph_node_log_string,
 )
 from onyx.configs.kg_configs import KG_STRATEGY_GENERATION_TIMEOUT
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import get_document_id_for_entity
 from onyx.kg.clustering.normalizations import normalize_entities
 from onyx.kg.clustering.normalizations import normalize_relationships

--- a/backend/onyx/agents/agent_search/kb_search/nodes/a3_generate_simple_sql.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/a3_generate_simple_sql.py
@@ -29,7 +29,7 @@ from onyx.configs.kg_configs import KG_SQL_GENERATION_TIMEOUT_OVERRIDE
 from onyx.configs.kg_configs import KG_TEMP_ALLOWED_DOCS_VIEW_NAME_PREFIX
 from onyx.configs.kg_configs import KG_TEMP_KG_ENTITIES_VIEW_NAME_PREFIX
 from onyx.configs.kg_configs import KG_TEMP_KG_RELATIONSHIPS_VIEW_NAME_PREFIX
-from onyx.db.engine import get_db_readonly_user_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_db_readonly_user_session_with_current_tenant
 from onyx.db.kg_temp_view import drop_views
 from onyx.llm.interfaces import LLM
 from onyx.prompts.kg_prompts import ENTITY_SOURCE_DETECTION_PROMPT

--- a/backend/onyx/agents/agent_search/kb_search/nodes/b1_construct_deep_search_filters.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/b1_construct_deep_search_filters.py
@@ -13,7 +13,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
     get_langgraph_node_log_string,
 )
 from onyx.configs.kg_configs import KG_FILTER_CONSTRUCTION_TIMEOUT
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entity_type import get_entity_types_with_grounded_source_name
 from onyx.kg.utils.formatting_utils import make_entity_id
 from onyx.prompts.kg_prompts import SEARCH_FILTER_CONSTRUCTION_PROMPT

--- a/backend/onyx/agents/agent_search/kb_search/nodes/c1_process_kg_only_answers.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/c1_process_kg_only_answers.py
@@ -16,7 +16,7 @@ from onyx.agents.agent_search.shared_graph_utils.utils import (
 from onyx.agents.agent_search.shared_graph_utils.utils import write_custom_event
 from onyx.chat.models import SubQueryPiece
 from onyx.db.document import get_base_llm_doc_information
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.utils.logger import setup_logger
 
 

--- a/backend/onyx/agents/agent_search/kb_search/nodes/d1_generate_answer.py
+++ b/backend/onyx/agents/agent_search/kb_search/nodes/d1_generate_answer.py
@@ -28,7 +28,7 @@ from onyx.configs.kg_configs import KG_TIMEOUT_CONNECT_LLM_INITIAL_ANSWER_GENERA
 from onyx.configs.kg_configs import KG_TIMEOUT_LLM_INITIAL_ANSWER_GENERATION
 from onyx.context.search.enums import SearchType
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.prompts.kg_prompts import OUTPUT_FORMAT_NO_EXAMPLES_PROMPT
 from onyx.prompts.kg_prompts import OUTPUT_FORMAT_NO_OVERALL_ANSWER_PROMPT
 from onyx.tools.tool_implementations.search.search_tool import IndexFilters

--- a/backend/onyx/agents/agent_search/kb_search/ops.py
+++ b/backend/onyx/agents/agent_search/kb_search/ops.py
@@ -5,7 +5,7 @@ from onyx.chat.models import LlmDoc
 from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_RESEARCH_NUM_RETRIEVED_DOCS
 from onyx.context.search.models import InferenceSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import (
     FINAL_CONTEXT_DOCUMENTS_ID,

--- a/backend/onyx/agents/agent_search/run_graph.py
+++ b/backend/onyx/agents/agent_search/run_graph.py
@@ -33,7 +33,7 @@ from onyx.chat.models import SubQueryPiece
 from onyx.chat.models import SubQuestionPiece
 from onyx.chat.models import ToolResponse
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.llm.factory import get_default_llms
 from onyx.tools.tool_runner import ToolCallKickoff
 from onyx.utils.logger import setup_logger
@@ -195,7 +195,7 @@ if __name__ == "__main__":
             query="Do a search to tell me what is the difference between astronomy and astrology?",
         )
 
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             config = get_test_config(db_session, primary_llm, fast_llm, search_request)
             assert (
                 config.persistence is not None

--- a/backend/onyx/agents/agent_search/run_graph.py
+++ b/backend/onyx/agents/agent_search/run_graph.py
@@ -33,7 +33,7 @@ from onyx.chat.models import SubQueryPiece
 from onyx.chat.models import SubQuestionPiece
 from onyx.chat.models import ToolResponse
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.llm.factory import get_default_llms
 from onyx.tools.tool_runner import ToolCallKickoff
 from onyx.utils.logger import setup_logger
@@ -195,7 +195,7 @@ if __name__ == "__main__":
             query="Do a search to tell me what is the difference between astronomy and astrology?",
         )
 
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             config = get_test_config(db_session, primary_llm, fast_llm, search_request)
             assert (
                 config.persistence is not None

--- a/backend/onyx/agents/agent_search/run_graph.py
+++ b/backend/onyx/agents/agent_search/run_graph.py
@@ -33,7 +33,7 @@ from onyx.chat.models import SubQueryPiece
 from onyx.chat.models import SubQuestionPiece
 from onyx.chat.models import ToolResponse
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.llm.factory import get_default_llms
 from onyx.tools.tool_runner import ToolCallKickoff
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
@@ -56,7 +56,7 @@ from onyx.context.search.enums import LLMEvaluationType
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RetrievalDetails
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import Persona
 from onyx.llm.chat_llm import LLMRateLimitError
@@ -363,7 +363,7 @@ def retrieve_search_docs(
     retrieved_docs: list[InferenceSection] = []
 
     # new db session to avoid concurrency issues
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         for tool_response in search_tool.run(
             query=question,
             override_kwargs=SearchToolOverrideKwargs(

--- a/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
@@ -56,7 +56,7 @@ from onyx.context.search.enums import LLMEvaluationType
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RetrievalDetails
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import Persona
 from onyx.llm.chat_llm import LLMRateLimitError
@@ -363,7 +363,7 @@ def retrieve_search_docs(
     retrieved_docs: list[InferenceSection] = []
 
     # new db session to avoid concurrency issues
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         for tool_response in search_tool.run(
             query=question,
             override_kwargs=SearchToolOverrideKwargs(

--- a/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
+++ b/backend/onyx/agents/agent_search/shared_graph_utils/utils.py
@@ -56,7 +56,7 @@ from onyx.context.search.enums import LLMEvaluationType
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RetrievalDetails
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import Persona
 from onyx.llm.chat_llm import LLMRateLimitError

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -97,9 +97,9 @@ from onyx.db.auth import get_default_admin_user_emails
 from onyx.db.auth import get_user_count
 from onyx.db.auth import get_user_db
 from onyx.db.auth import SQLAlchemyUserAdminDB
-from onyx.db.engine import get_async_session
-from onyx.db.engine import get_async_session_context_manager
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.async_sql_engine import get_async_session
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import User

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -26,7 +26,7 @@ from onyx.background.celery.celery_utils import celery_is_worker_primary
 from onyx.background.celery.celery_utils import make_probe_path
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxRedisLocks
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.document_index.vespa.shared_utils.utils import wait_for_vespa_with_timeout
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_connector import RedisConnector

--- a/backend/onyx/background/celery/apps/beat.py
+++ b/backend/onyx/background/celery/apps/beat.py
@@ -11,8 +11,8 @@ import onyx.background.celery.apps.app_base as app_base
 from onyx.background.celery.celery_utils import make_probe_path
 from onyx.background.celery.tasks.beat_schedule import CLOUD_BEAT_MULTIPLIER_DEFAULT
 from onyx.configs.constants import POSTGRES_CELERY_BEAT_APP_NAME
-from onyx.db.engine import get_all_tenant_ids
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from shared_configs.configs import IGNORED_SYNCING_TENANT_LIST

--- a/backend/onyx/background/celery/apps/heavy.py
+++ b/backend/onyx/background/celery/apps/heavy.py
@@ -12,7 +12,7 @@ from celery.signals import worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_HEAVY_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 

--- a/backend/onyx/background/celery/apps/indexing.py
+++ b/backend/onyx/background/celery/apps/indexing.py
@@ -13,7 +13,7 @@ from celery.signals import worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 

--- a/backend/onyx/background/celery/apps/kg_processing.py
+++ b/backend/onyx/background/celery/apps/kg_processing.py
@@ -13,7 +13,7 @@ from celery.signals import worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_KG_PROCESSING_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -15,7 +15,7 @@ from onyx.configs.app_configs import MANAGED_VESPA
 from onyx.configs.app_configs import VESPA_CLOUD_CERT_PATH
 from onyx.configs.app_configs import VESPA_CLOUD_KEY_PATH
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_LIGHT_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 

--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -11,7 +11,7 @@ from celery.signals import worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_MONITORING_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -25,8 +25,8 @@ from onyx.configs.constants import CELERY_PRIMARY_WORKER_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxRedisConstants
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_PRIMARY_APP_NAME
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.redis.redis_connector_credential_pair import (

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -38,7 +38,7 @@ from onyx.db.document import (
 )
 from onyx.db.document import get_document_ids_for_connector_credential_pair
 from onyx.db.document_set import delete_document_set_cc_pair_relationship__no_commit
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType

--- a/backend/onyx/background/celery/tasks/indexing/tasks.py
+++ b/backend/onyx/background/celery/tasks/indexing/tasks.py
@@ -56,7 +56,7 @@ from onyx.db.connector import mark_ccpair_with_indexing_trigger
 from onyx.db.connector_credential_pair import fetch_connector_credential_pairs
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.connector_credential_pair import set_cc_pair_repeated_error_state
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingMode
 from onyx.db.enums import IndexingStatus

--- a/backend/onyx/background/celery/tasks/indexing/utils.py
+++ b/backend/onyx/background/celery/tasks/indexing/utils.py
@@ -23,8 +23,8 @@ from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisConstants
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine import get_db_current_time
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus

--- a/backend/onyx/background/celery/tasks/kg_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/tasks.py
@@ -17,7 +17,7 @@ from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.kg.clustering.clustering import kg_clustering
 from onyx.kg.extractions.extraction_processing import kg_extraction

--- a/backend/onyx/background/celery/tasks/kg_processing/utils.py
+++ b/backend/onyx/background/celery/tasks/kg_processing/utils.py
@@ -4,7 +4,7 @@ from redis.lock import Lock as RedisLock
 
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.document import check_for_documents_needing_kg_processing
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import is_kg_config_settings_enabled_valid
 from onyx.db.models import KGEntityExtractionStaging

--- a/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
@@ -8,7 +8,7 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.app_configs import LLM_MODEL_UPDATE_API_URL
 from onyx.configs.constants import OnyxCeleryTask
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import LLMProvider
 from onyx.db.models import ModelConfiguration
 

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -27,10 +27,10 @@ from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
-from onyx.db.engine import get_all_tenant_ids
-from onyx.db.engine import get_db_current_time
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
+from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType

--- a/backend/onyx/background/celery/tasks/periodic/tasks.py
+++ b/backend/onyx/background/celery/tasks/periodic/tasks.py
@@ -15,7 +15,7 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import PostgresAdvisoryLocks
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 
 
 @shared_task(

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -41,7 +41,7 @@ from onyx.db.connector_credential_pair import get_connector_credential_pair
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
 from onyx.db.document import get_documents_for_connector_credential_pair
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -22,7 +22,7 @@ from onyx.db.document import get_document_connector_count
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
 from onyx.db.document_set import fetch_document_sets_for_document
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.relationships import delete_document_references_from_kg
 from onyx.db.search_settings import get_active_search_settings
 from onyx.document_index.factory import get_default_document_index

--- a/backend/onyx/background/celery/tasks/user_file_folder_sync/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_folder_sync/tasks.py
@@ -21,7 +21,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pairs_with_user_files,
 )
 from onyx.db.document import get_document
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
 from onyx.db.models import DocumentByConnectorCredentialPair

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -35,7 +35,7 @@ from onyx.db.document_set import fetch_document_sets
 from onyx.db.document_set import fetch_document_sets_for_document
 from onyx.db.document_set import get_document_set_by_id
 from onyx.db.document_set import mark_document_set_as_synced
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SyncStatus
 from onyx.db.enums import SyncType
 from onyx.db.models import DocumentSet

--- a/backend/onyx/background/error_logging.py
+++ b/backend/onyx/background/error_logging.py
@@ -1,7 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 
 from onyx.db.background_error import create_background_error
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 
 
 def emit_background_error(

--- a/backend/onyx/background/indexing/checkpointing_utils.py
+++ b/backend/onyx/background/indexing/checkpointing_utils.py
@@ -9,7 +9,7 @@ from onyx.configs.constants import FileOrigin
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.models import ConnectorCheckpoint
-from onyx.db.engine import get_db_current_time
+from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_recent_completed_attempts_for_cc_pair
 from onyx.db.models import IndexAttempt

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -16,7 +16,7 @@ from typing import Literal
 from typing import Optional
 
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import TENANT_ID_PREFIX

--- a/backend/onyx/background/indexing/run_indexing.py
+++ b/backend/onyx/background/indexing/run_indexing.py
@@ -34,7 +34,7 @@ from onyx.db.connector_credential_pair import get_connector_credential_pair_from
 from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.connector_credential_pair import update_connector_credential_pair
 from onyx.db.constants import CONNECTOR_VALIDATION_ERROR_MESSAGE_PREFIX
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -79,7 +79,7 @@ from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
 from onyx.db.chat import update_chat_session_updated_at_timestamp
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
 from onyx.db.milestone import update_user_assistant_milestone
@@ -1240,7 +1240,7 @@ def stream_chat_message(
     is_connected: Callable[[], bool] | None = None,
 ) -> Iterator[str]:
     start_time = time.time()
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         objects = stream_chat_message_objects(
             new_msg_req=new_msg_req,
             user=user,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -79,7 +79,7 @@ from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
 from onyx.db.chat import update_chat_session_updated_at_timestamp
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
 from onyx.db.milestone import update_user_assistant_milestone

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -79,7 +79,7 @@ from onyx.db.chat import reserve_message_id
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
 from onyx.db.chat import update_chat_session_updated_at_timestamp
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.milestone import check_multi_assistant_milestone
 from onyx.db.milestone import create_milestone_if_not_exists
 from onyx.db.milestone import update_user_assistant_milestone
@@ -1240,7 +1240,7 @@ def stream_chat_message(
     is_connected: Callable[[], bool] | None = None,
 ) -> Iterator[str]:
     start_time = time.time()
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         objects = stream_chat_message_objects(
             new_msg_req=new_msg_req,
             user=user,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -222,17 +222,6 @@ try:
 except ValueError:
     POSTGRES_POOL_RECYCLE = POSTGRES_POOL_RECYCLE_DEFAULT
 
-# Experimental setting to control idle transactions
-POSTGRES_IDLE_SESSIONS_TIMEOUT_DEFAULT = 0  # milliseconds
-try:
-    POSTGRES_IDLE_SESSIONS_TIMEOUT = int(
-        os.environ.get(
-            "POSTGRES_IDLE_SESSIONS_TIMEOUT", POSTGRES_IDLE_SESSIONS_TIMEOUT_DEFAULT
-        )
-    )
-except ValueError:
-    POSTGRES_IDLE_SESSIONS_TIMEOUT = POSTGRES_IDLE_SESSIONS_TIMEOUT_DEFAULT
-
 USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
 
 

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -34,7 +34,7 @@ from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.extract_file_text import is_accepted_file_ext

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -23,7 +23,7 @@ from onyx.configs.app_configs import (
 )
 from onyx.configs.app_configs import CONFLUENCE_CONNECTOR_ATTACHMENT_SIZE_THRESHOLD
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import is_accepted_file_ext
 from onyx.file_processing.extract_file_text import OnyxExtensionType

--- a/backend/onyx/connectors/credentials_provider.py
+++ b/backend/onyx/connectors/credentials_provider.py
@@ -6,7 +6,7 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy import select
 
 from onyx.connectors.interfaces import CredentialsProviderInterface
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import Credential
 from onyx.redis.redis_pool import get_redis_client
 

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -18,7 +18,7 @@ from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.extract_file_text import is_accepted_file_ext

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -27,7 +27,7 @@ from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_processing.extract_file_text import ALL_ACCEPTED_FILE_EXTENSIONS
 from onyx.file_processing.extract_file_text import docx_to_text_and_images
 from onyx.file_processing.extract_file_text import extract_file_text

--- a/backend/onyx/connectors/google_site/connector.py
+++ b/backend/onyx/connectors/google_site/connector.py
@@ -12,7 +12,7 @@ from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import TextSection
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_processing.extract_file_text import load_files_from_zip
 from onyx.file_processing.extract_file_text import read_text_file
 from onyx.file_processing.html_utils import web_html_cleanup
@@ -68,7 +68,7 @@ class GoogleSitesConnector(LoadConnector):
     def load_from_state(self) -> GenerateDocumentsOutput:
         documents: list[Document] = []
 
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             file_content_io = get_default_file_store(db_session).read_file(
                 self.zip_path, mode="b"
             )

--- a/backend/onyx/connectors/google_site/connector.py
+++ b/backend/onyx/connectors/google_site/connector.py
@@ -12,7 +12,7 @@ from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import TextSection
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.file_processing.extract_file_text import load_files_from_zip
 from onyx.file_processing.extract_file_text import read_text_file
 from onyx.file_processing.html_utils import web_html_cleanup
@@ -68,7 +68,7 @@ class GoogleSitesConnector(LoadConnector):
     def load_from_state(self) -> GenerateDocumentsOutput:
         documents: list[Document] = []
 
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             file_content_io = get_default_file_store(db_session).read_file(
                 self.zip_path, mode="b"
             )

--- a/backend/onyx/connectors/google_site/connector.py
+++ b/backend/onyx/connectors/google_site/connector.py
@@ -12,7 +12,7 @@ from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import TextSection
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.file_processing.extract_file_text import load_files_from_zip
 from onyx.file_processing.extract_file_text import read_text_file
 from onyx.file_processing.html_utils import web_html_cleanup

--- a/backend/onyx/context/search/postprocessing/postprocessing.py
+++ b/backend/onyx/context/search/postprocessing/postprocessing.py
@@ -25,7 +25,7 @@ from onyx.context.search.models import MAX_METRICS_CONTENT
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.models import RerankMetricsContainer
 from onyx.context.search.models import SearchQuery
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.document_index.document_index_utils import (
     translate_boost_count_to_multiplier,
 )

--- a/backend/onyx/db/auth.py
+++ b/backend/onyx/db/auth.py
@@ -17,8 +17,8 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
 from onyx.db.api_key import get_api_key_email_pattern
-from onyx.db.engine import get_async_session
-from onyx.db.engine import get_async_session_context_manager
+from onyx.db.engine.async_sql_engine import get_async_session
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import User

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -18,7 +18,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.credentials import fetch_credential_by_id_for_user
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import Connector

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -18,7 +18,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.credentials import fetch_credential_by_id_for_user
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import Connector
@@ -148,7 +148,7 @@ def get_connector_credential_pairs_for_user_parallel(
     eager_load_credential: bool = False,
     eager_load_user: bool = False,
 ) -> list[ConnectorCredentialPair]:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         return get_connector_credential_pairs_for_user(
             db_session,
             user,
@@ -208,7 +208,7 @@ def get_cc_pair_groups_for_ids(
 def get_cc_pair_groups_for_ids_parallel(
     cc_pair_ids: list[int],
 ) -> list[UserGroup__ConnectorCredentialPair]:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         return get_cc_pair_groups_for_ids(db_session, cc_pair_ids)
 
 

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -18,7 +18,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.credentials import fetch_credential_by_id_for_user
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import Connector
@@ -148,7 +148,7 @@ def get_connector_credential_pairs_for_user_parallel(
     eager_load_credential: bool = False,
     eager_load_user: bool = False,
 ) -> list[ConnectorCredentialPair]:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         return get_connector_credential_pairs_for_user(
             db_session,
             user,
@@ -208,7 +208,7 @@ def get_cc_pair_groups_for_ids(
 def get_cc_pair_groups_for_ids_parallel(
     cc_pair_ids: list[int],
 ) -> list[UserGroup__ConnectorCredentialPair]:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         return get_cc_pair_groups_for_ids(db_session, cc_pair_ids)
 
 

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -28,7 +28,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_SIMPLE_ANSWER_MAX_DISPLAYED_SOURCES
 from onyx.db.chunk import delete_chunk_stats_by_connector_credential_pair__no_commit
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import delete_from_kg_entities__no_commit
 from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_commit
 from onyx.db.enums import AccessType
@@ -299,7 +299,7 @@ def get_document_counts_for_cc_pairs(
 def get_document_counts_for_cc_pairs_parallel(
     cc_pairs: list[ConnectorCredentialPairIdentifier],
 ) -> Sequence[tuple[int, int, int]]:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         return get_document_counts_for_cc_pairs(db_session, cc_pairs)
 
 

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -28,7 +28,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_SIMPLE_ANSWER_MAX_DISPLAYED_SOURCES
 from onyx.db.chunk import delete_chunk_stats_by_connector_credential_pair__no_commit
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.entities import delete_from_kg_entities__no_commit
 from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_commit
 from onyx.db.enums import AccessType

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -28,7 +28,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.kg_configs import KG_SIMPLE_ANSWER_MAX_DISPLAYED_SOURCES
 from onyx.db.chunk import delete_chunk_stats_by_connector_credential_pair__no_commit
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.entities import delete_from_kg_entities__no_commit
 from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_commit
 from onyx.db.enums import AccessType
@@ -299,7 +299,7 @@ def get_document_counts_for_cc_pairs(
 def get_document_counts_for_cc_pairs_parallel(
     cc_pairs: list[ConnectorCredentialPairIdentifier],
 ) -> Sequence[tuple[int, int, int]]:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         return get_document_counts_for_cc_pairs(db_session, cc_pairs)
 
 

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -10,7 +10,6 @@ from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.orm import sessionmaker
 
 from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
@@ -100,14 +99,6 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
                 cparams["ssl"] = ssl_context
 
     return _ASYNC_ENGINE
-
-
-engine = get_sqlalchemy_async_engine()
-AsyncSessionLocal = sessionmaker(  # type: ignore
-    bind=engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
 
 
 async def get_async_session(

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -125,9 +125,10 @@ async def get_async_session(
 
     # Create connection with schema translation to handle querying the right schema
     schema_translate_map = {None: tenant_id}
-    async with engine.connect().execution_options(
-        schema_translate_map=schema_translate_map
-    ) as connection:
+    async with engine.connect() as connection:
+        connection = await connection.execution_options(
+            schema_translate_map=schema_translate_map
+        )
         async with AsyncSession(
             bind=connection, expire_on_commit=False
         ) as async_session:

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -1,0 +1,144 @@
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from typing import AsyncContextManager
+
+import asyncpg  # type: ignore
+from fastapi import HTTPException
+from sqlalchemy import event
+from sqlalchemy import pool
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from onyx.configs.app_configs import AWS_REGION_NAME
+from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
+from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
+from onyx.configs.app_configs import POSTGRES_DB
+from onyx.configs.app_configs import POSTGRES_HOST
+from onyx.configs.app_configs import POSTGRES_IDLE_SESSIONS_TIMEOUT
+from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
+from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
+from onyx.configs.app_configs import POSTGRES_PORT
+from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
+from onyx.configs.app_configs import POSTGRES_USER
+from onyx.db.engine.iam_auth import get_iam_auth_token
+from onyx.db.engine.iam_auth import ssl_context
+from onyx.db.engine.sql_engine import ASYNC_DB_API
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.engine.sql_engine import is_valid_schema_name
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.engine.sql_engine import USE_IAM_AUTH
+from shared_configs.contextvars import get_current_tenant_id
+
+
+# Global so we don't create more than one engine per process
+_ASYNC_ENGINE: AsyncEngine | None = None
+
+
+async def get_async_connection() -> Any:
+    """
+    Custom connection function for async engine when using IAM auth.
+    """
+    host = POSTGRES_HOST
+    port = POSTGRES_PORT
+    user = POSTGRES_USER
+    db = POSTGRES_DB
+    token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
+
+    # asyncpg requires 'ssl="require"' if SSL needed
+    return await asyncpg.connect(
+        user=user, password=token, host=host, port=int(port), database=db, ssl="require"
+    )
+
+
+def get_sqlalchemy_async_engine() -> AsyncEngine:
+    global _ASYNC_ENGINE
+    if _ASYNC_ENGINE is None:
+        app_name = SqlEngine.get_app_name() + "_async"
+        connection_string = build_connection_string(
+            db_api=ASYNC_DB_API,
+            use_iam_auth=USE_IAM_AUTH,
+        )
+
+        connect_args: dict[str, Any] = {}
+        if app_name:
+            connect_args["server_settings"] = {"application_name": app_name}
+
+        connect_args["ssl"] = ssl_context
+
+        engine_kwargs = {
+            "connect_args": connect_args,
+            "pool_pre_ping": POSTGRES_POOL_PRE_PING,
+            "pool_recycle": POSTGRES_POOL_RECYCLE,
+        }
+
+        if POSTGRES_USE_NULL_POOL:
+            engine_kwargs["poolclass"] = pool.NullPool
+        else:
+            engine_kwargs["pool_size"] = POSTGRES_API_SERVER_POOL_SIZE
+            engine_kwargs["max_overflow"] = POSTGRES_API_SERVER_POOL_OVERFLOW
+
+        _ASYNC_ENGINE = create_async_engine(
+            connection_string,
+            **engine_kwargs,
+        )
+
+        if USE_IAM_AUTH:
+
+            @event.listens_for(_ASYNC_ENGINE.sync_engine, "do_connect")
+            def provide_iam_token_async(
+                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
+            ) -> None:
+                # For async engine using asyncpg, we still need to set the IAM token here.
+                host = POSTGRES_HOST
+                port = POSTGRES_PORT
+                user = POSTGRES_USER
+                token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
+                cparams["password"] = token
+                cparams["ssl"] = ssl_context
+
+    return _ASYNC_ENGINE
+
+
+engine = get_sqlalchemy_async_engine()
+AsyncSessionLocal = sessionmaker(  # type: ignore
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+async def get_async_session(
+    tenant_id: str | None = None,
+) -> AsyncGenerator[AsyncSession, None]:
+    """For use w/ Depends for *async* FastAPI endpoints.
+
+    For standard `async with ... as ...` use, use get_async_session_context_manager.
+    """
+
+    if tenant_id is None:
+        tenant_id = get_current_tenant_id()
+
+    engine = get_sqlalchemy_async_engine()
+
+    async with AsyncSession(engine, expire_on_commit=False) as async_session:
+        if POSTGRES_IDLE_SESSIONS_TIMEOUT:
+            await async_session.execute(
+                text(
+                    f"SET idle_in_transaction_session_timeout = {POSTGRES_IDLE_SESSIONS_TIMEOUT}"
+                )
+            )
+
+        if not is_valid_schema_name(tenant_id):
+            raise HTTPException(status_code=400, detail="Invalid tenant ID")
+
+        yield async_session
+
+
+def get_async_session_context_manager(
+    tenant_id: str | None = None,
+) -> AsyncContextManager[AsyncSession]:
+    return asynccontextmanager(get_async_session)(tenant_id)

--- a/backend/onyx/db/engine/connection_warmup.py
+++ b/backend/onyx/db/engine/connection_warmup.py
@@ -1,0 +1,27 @@
+from sqlalchemy import text
+
+from onyx.db.engine.async_sql_engine import get_sqlalchemy_async_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
+
+
+async def warm_up_connections(
+    sync_connections_to_warm_up: int = 20, async_connections_to_warm_up: int = 20
+) -> None:
+    sync_postgres_engine = get_sqlalchemy_engine()
+    connections = [
+        sync_postgres_engine.connect() for _ in range(sync_connections_to_warm_up)
+    ]
+    for conn in connections:
+        conn.execute(text("SELECT 1"))
+    for conn in connections:
+        conn.close()
+
+    async_postgres_engine = get_sqlalchemy_async_engine()
+    async_connections = [
+        await async_postgres_engine.connect()
+        for _ in range(async_connections_to_warm_up)
+    ]
+    for async_conn in async_connections:
+        await async_conn.execute(text("SELECT 1"))
+    for async_conn in async_connections:
+        await async_conn.close()

--- a/backend/onyx/db/engine/iam_auth.py
+++ b/backend/onyx/db/engine/iam_auth.py
@@ -1,0 +1,56 @@
+import os
+import ssl
+from typing import Any
+
+import boto3
+
+from onyx.configs.app_configs import POSTGRES_HOST
+from onyx.configs.app_configs import POSTGRES_PORT
+from onyx.configs.app_configs import POSTGRES_USER
+from onyx.configs.app_configs import USE_IAM_AUTH
+from onyx.configs.constants import SSL_CERT_FILE
+
+
+def get_iam_auth_token(
+    host: str, port: str, user: str, region: str = "us-east-2"
+) -> str:
+    """
+    Generate an IAM authentication token using boto3.
+    """
+    client = boto3.client("rds", region_name=region)
+    token = client.generate_db_auth_token(
+        DBHostname=host, Port=int(port), DBUsername=user
+    )
+    return token
+
+
+def configure_psycopg2_iam_auth(
+    cparams: dict[str, Any], host: str, port: str, user: str, region: str
+) -> None:
+    """
+    Configure cparams for psycopg2 with IAM token and SSL.
+    """
+    token = get_iam_auth_token(host, port, user, region)
+    cparams["password"] = token
+    cparams["sslmode"] = "require"
+    cparams["sslrootcert"] = SSL_CERT_FILE
+
+
+def provide_iam_token(dialect: Any, conn_rec: Any, cargs: Any, cparams: Any) -> None:
+    if USE_IAM_AUTH:
+        host = POSTGRES_HOST
+        port = POSTGRES_PORT
+        user = POSTGRES_USER
+        region = os.getenv("AWS_REGION_NAME", "us-east-2")
+        # Configure for psycopg2 with IAM token
+        configure_psycopg2_iam_auth(cparams, host, port, user, region)
+
+
+def create_ssl_context_if_iam() -> ssl.SSLContext | None:
+    """Create an SSL context if IAM authentication is enabled, else return None."""
+    if USE_IAM_AUTH:
+        return ssl.create_default_context(cafile=SSL_CERT_FILE)
+    return None
+
+
+ssl_context = create_ssl_context_if_iam()

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -1,38 +1,24 @@
 import contextlib
 import os
 import re
-import ssl
 import threading
 import time
-from collections.abc import AsyncGenerator
 from collections.abc import Generator
-from contextlib import asynccontextmanager
 from contextlib import contextmanager
-from datetime import datetime
 from typing import Any
-from typing import AsyncContextManager
 
-import asyncpg  # type: ignore
-import boto3
 from fastapi import HTTPException
 from sqlalchemy import event
 from sqlalchemy import pool
 from sqlalchemy import text
 from sqlalchemy.engine import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext.asyncio import AsyncEngine
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import Session
-from sqlalchemy.orm import sessionmaker
 
-from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.configs.app_configs import DB_READONLY_PASSWORD
 from onyx.configs.app_configs import DB_READONLY_USER
 from onyx.configs.app_configs import LOG_POSTGRES_CONN_COUNTS
 from onyx.configs.app_configs import LOG_POSTGRES_LATENCY
-from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
-from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
 from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_IDLE_SESSIONS_TIMEOUT
@@ -43,65 +29,33 @@ from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.constants import POSTGRES_UNKNOWN_APP_NAME
-from onyx.configs.constants import SSL_CERT_FILE
+from onyx.db.engine.iam_auth import provide_iam_token
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
-from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
-from shared_configs.configs import TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import get_current_tenant_id
 
+# Moved is_valid_schema_name here to avoid circular import
+
+
 logger = setup_logger()
+
+
+# Schema name validation (moved here to avoid circular import)
+SCHEMA_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def is_valid_schema_name(name: str) -> bool:
+    return SCHEMA_NAME_REGEX.match(name) is not None
+
 
 SYNC_DB_API = "psycopg2"
 ASYNC_DB_API = "asyncpg"
 
 # why isn't this in configs?
 USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
-
-SCHEMA_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_-]+$")
-
-
-# Global so we don't create more than one engine per process
-_ASYNC_ENGINE: AsyncEngine | None = None
-SessionFactory: sessionmaker[Session] | None = None
-
-
-def create_ssl_context_if_iam() -> ssl.SSLContext | None:
-    """Create an SSL context if IAM authentication is enabled, else return None."""
-    if USE_IAM_AUTH:
-        return ssl.create_default_context(cafile=SSL_CERT_FILE)
-    return None
-
-
-ssl_context = create_ssl_context_if_iam()
-
-
-def get_iam_auth_token(
-    host: str, port: str, user: str, region: str = "us-east-2"
-) -> str:
-    """
-    Generate an IAM authentication token using boto3.
-    """
-    client = boto3.client("rds", region_name=region)
-    token = client.generate_db_auth_token(
-        DBHostname=host, Port=int(port), DBUsername=user
-    )
-    return token
-
-
-def configure_psycopg2_iam_auth(
-    cparams: dict[str, Any], host: str, port: str, user: str, region: str
-) -> None:
-    """
-    Configure cparams for psycopg2 with IAM token and SSL.
-    """
-    token = get_iam_auth_token(host, port, user, region)
-    cparams["password"] = token
-    cparams["sslmode"] = "require"
-    cparams["sslrootcert"] = SSL_CERT_FILE
 
 
 def build_connection_string(
@@ -174,17 +128,6 @@ if LOG_POSTGRES_CONN_COUNTS:
         global checkin_count
         checkin_count += 1
         logger.debug(f"Total connection checkins: {checkin_count}")
-
-
-def get_db_current_time(db_session: Session) -> datetime:
-    result = db_session.execute(text("SELECT NOW()")).scalar()
-    if result is None:
-        raise ValueError("Database did not return a time")
-    return result
-
-
-def is_valid_schema_name(name: str) -> bool:
-    return SCHEMA_NAME_REGEX.match(name) is not None
 
 
 class SqlEngine:
@@ -348,112 +291,12 @@ class SqlEngine:
                 cls._engine = None
 
 
-def get_all_tenant_ids() -> list[str]:
-    """Returning [None] means the only tenant is the 'public' or self hosted tenant."""
-
-    tenant_ids: list[str]
-
-    if not MULTI_TENANT:
-        return [POSTGRES_DEFAULT_SCHEMA]
-
-    with get_session_with_shared_schema() as session:
-        result = session.execute(
-            text(
-                f"""
-                SELECT schema_name
-                FROM information_schema.schemata
-                WHERE schema_name NOT IN ('pg_catalog', 'information_schema', '{POSTGRES_DEFAULT_SCHEMA}')"""
-            )
-        )
-        tenant_ids = [row[0] for row in result]
-
-    valid_tenants = [
-        tenant
-        for tenant in tenant_ids
-        if tenant is None or tenant.startswith(TENANT_ID_PREFIX)
-    ]
-    return valid_tenants
-
-
 def get_sqlalchemy_engine() -> Engine:
     return SqlEngine.get_engine()
 
 
 def get_readonly_sqlalchemy_engine() -> Engine:
     return SqlEngine.get_readonly_engine()
-
-
-async def get_async_connection() -> Any:
-    """
-    Custom connection function for async engine when using IAM auth.
-    """
-    host = POSTGRES_HOST
-    port = POSTGRES_PORT
-    user = POSTGRES_USER
-    db = POSTGRES_DB
-    token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
-
-    # asyncpg requires 'ssl="require"' if SSL needed
-    return await asyncpg.connect(
-        user=user, password=token, host=host, port=int(port), database=db, ssl="require"
-    )
-
-
-def get_sqlalchemy_async_engine() -> AsyncEngine:
-    global _ASYNC_ENGINE
-    if _ASYNC_ENGINE is None:
-        app_name = SqlEngine.get_app_name() + "_async"
-        connection_string = build_connection_string(
-            db_api=ASYNC_DB_API,
-            use_iam_auth=USE_IAM_AUTH,
-        )
-
-        connect_args: dict[str, Any] = {}
-        if app_name:
-            connect_args["server_settings"] = {"application_name": app_name}
-
-        connect_args["ssl"] = ssl_context
-
-        engine_kwargs = {
-            "connect_args": connect_args,
-            "pool_pre_ping": POSTGRES_POOL_PRE_PING,
-            "pool_recycle": POSTGRES_POOL_RECYCLE,
-        }
-
-        if POSTGRES_USE_NULL_POOL:
-            engine_kwargs["poolclass"] = pool.NullPool
-        else:
-            engine_kwargs["pool_size"] = POSTGRES_API_SERVER_POOL_SIZE
-            engine_kwargs["max_overflow"] = POSTGRES_API_SERVER_POOL_OVERFLOW
-
-        _ASYNC_ENGINE = create_async_engine(
-            connection_string,
-            **engine_kwargs,
-        )
-
-        if USE_IAM_AUTH:
-
-            @event.listens_for(_ASYNC_ENGINE.sync_engine, "do_connect")
-            def provide_iam_token_async(
-                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
-            ) -> None:
-                # For async engine using asyncpg, we still need to set the IAM token here.
-                host = POSTGRES_HOST
-                port = POSTGRES_PORT
-                user = POSTGRES_USER
-                token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
-                cparams["password"] = token
-                cparams["ssl"] = ssl_context
-
-    return _ASYNC_ENGINE
-
-
-engine = get_sqlalchemy_async_engine()
-AsyncSessionLocal = sessionmaker(  # type: ignore
-    bind=engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-)
 
 
 @contextmanager
@@ -473,24 +316,12 @@ def get_session_with_shared_schema() -> Generator[Session, None, None]:
     CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
-def _set_search_path_on_checkout__listener(
-    dbapi_conn: Any, connection_record: Any, connection_proxy: Any
-) -> None:
-    """Listener to make sure we ALWAYS set the search path on checkout."""
-    tenant_id = get_current_tenant_id()
-    if tenant_id and is_valid_schema_name(tenant_id):
-        with dbapi_conn.cursor() as cursor:
-            cursor.execute(f'SET search_path TO "{tenant_id}"')
-
-
 @contextmanager
 def get_session_with_tenant(*, tenant_id: str) -> Generator[Session, None, None]:
     """
     Generate a database session for a specific tenant.
     """
     engine = get_sqlalchemy_engine()
-
-    event.listen(engine, "checkout", _set_search_path_on_checkout__listener)
 
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")
@@ -557,97 +388,6 @@ def get_session_context_manager() -> Generator[Session, None, None]:
         yield session
 
 
-def _set_search_path_on_transaction__listener(
-    session: Session, transaction: Any, connection: Any, *args: Any, **kwargs: Any
-) -> None:
-    """Every time a new transaction is started,
-    set the search_path from the session's info."""
-    tenant_id = session.info.get("tenant_id")
-    if tenant_id:
-        connection.exec_driver_sql(f'SET search_path = "{tenant_id}"')
-
-
-async def get_async_session(
-    tenant_id: str | None = None,
-) -> AsyncGenerator[AsyncSession, None]:
-    """For use w/ Depends for *async* FastAPI endpoints.
-
-    For standard `async with ... as ...` use, use get_async_session_context_manager.
-    """
-
-    if tenant_id is None:
-        tenant_id = get_current_tenant_id()
-
-    engine = get_sqlalchemy_async_engine()
-
-    async with AsyncSession(engine, expire_on_commit=False) as async_session:
-        # IMPORTANT: do NOT remove. The search_path seems to get reset on every `.commit()`
-        # without this. Do not fully understand why atm
-        async_session.info["tenant_id"] = tenant_id
-        event.listen(
-            async_session.sync_session,
-            "after_begin",
-            _set_search_path_on_transaction__listener,
-        )
-
-        if POSTGRES_IDLE_SESSIONS_TIMEOUT:
-            await async_session.execute(
-                text(
-                    f"SET idle_in_transaction_session_timeout = {POSTGRES_IDLE_SESSIONS_TIMEOUT}"
-                )
-            )
-
-        if not is_valid_schema_name(tenant_id):
-            raise HTTPException(status_code=400, detail="Invalid tenant ID")
-
-        # don't need to set the search path for self-hosted + default schema
-        # this is also true for sync sessions, but just not adding it there for
-        # now to simplify / not change too much
-        if MULTI_TENANT or tenant_id != POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE:
-            await async_session.execute(text(f'SET search_path = "{tenant_id}"'))
-
-        yield async_session
-
-
-def get_async_session_context_manager(
-    tenant_id: str | None = None,
-) -> AsyncContextManager[AsyncSession]:
-    return asynccontextmanager(get_async_session)(tenant_id)
-
-
-async def warm_up_connections(
-    sync_connections_to_warm_up: int = 20, async_connections_to_warm_up: int = 20
-) -> None:
-    sync_postgres_engine = get_sqlalchemy_engine()
-    connections = [
-        sync_postgres_engine.connect() for _ in range(sync_connections_to_warm_up)
-    ]
-    for conn in connections:
-        conn.execute(text("SELECT 1"))
-    for conn in connections:
-        conn.close()
-
-    async_postgres_engine = get_sqlalchemy_async_engine()
-    async_connections = [
-        await async_postgres_engine.connect()
-        for _ in range(async_connections_to_warm_up)
-    ]
-    for async_conn in async_connections:
-        await async_conn.execute(text("SELECT 1"))
-    for async_conn in async_connections:
-        await async_conn.close()
-
-
-def provide_iam_token(dialect: Any, conn_rec: Any, cargs: Any, cparams: Any) -> None:
-    if USE_IAM_AUTH:
-        host = POSTGRES_HOST
-        port = POSTGRES_PORT
-        user = POSTGRES_USER
-        region = os.getenv("AWS_REGION_NAME", "us-east-2")
-        # Configure for psycopg2 with IAM token
-        configure_psycopg2_iam_auth(cparams, host, port, user, region)
-
-
 @contextmanager
 def get_db_readonly_user_session_with_current_tenant() -> (
     Generator[Session, None, None]
@@ -659,8 +399,6 @@ def get_db_readonly_user_session_with_current_tenant() -> (
     tenant_id = get_current_tenant_id()
 
     readonly_engine = get_readonly_sqlalchemy_engine()
-
-    event.listen(readonly_engine, "checkout", _set_search_path_on_checkout__listener)
 
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -342,7 +342,7 @@ def get_session() -> Generator[Session, None, None]:
     """For use w/ Depends for FastAPI endpoints.
 
     Has some additional validation, and likely should be merged
-    with get_session_with_shared_schema in the future."""
+    with get_session_with_current_tenant in the future."""
     tenant_id = get_current_tenant_id()
     if tenant_id == POSTGRES_DEFAULT_SCHEMA and MULTI_TENANT:
         raise BasicAuthenticationError(detail="User must authenticate")
@@ -350,7 +350,7 @@ def get_session() -> Generator[Session, None, None]:
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         yield db_session
 
 

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,0 +1,33 @@
+from sqlalchemy import text
+
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.configs import TENANT_ID_PREFIX
+
+
+def get_all_tenant_ids() -> list[str]:
+    """Returning [None] means the only tenant is the 'public' or self hosted tenant."""
+
+    tenant_ids: list[str]
+
+    if not MULTI_TENANT:
+        return [POSTGRES_DEFAULT_SCHEMA]
+
+    with get_session_with_shared_schema() as session:
+        result = session.execute(
+            text(
+                f"""
+                SELECT schema_name
+                FROM information_schema.schemata
+                WHERE schema_name NOT IN ('pg_catalog', 'information_schema', '{POSTGRES_DEFAULT_SCHEMA}')"""
+            )
+        )
+        tenant_ids = [row[0] for row in result]
+
+    valid_tenants = [
+        tenant
+        for tenant in tenant_ids
+        if tenant is None or tenant.startswith(TENANT_ID_PREFIX)
+    ]
+    return valid_tenants

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import TENANT_ID_PREFIX
@@ -14,7 +14,7 @@ def get_all_tenant_ids() -> list[str]:
     if not MULTI_TENANT:
         return [POSTGRES_DEFAULT_SCHEMA]
 
-    with get_session_with_shared_schema() as session:
+    with get_session_with_current_tenant() as session:
         result = session.execute(
             text(
                 f"""

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import TENANT_ID_PREFIX
@@ -14,7 +14,7 @@ def get_all_tenant_ids() -> list[str]:
     if not MULTI_TENANT:
         return [POSTGRES_DEFAULT_SCHEMA]
 
-    with get_session_with_current_tenant() as session:
+    with get_session_with_shared_schema() as session:
         result = session.execute(
             text(
                 f"""

--- a/backend/onyx/db/engine/time_utils.py
+++ b/backend/onyx/db/engine/time_utils.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def get_db_current_time(db_session: Session) -> datetime:
+    result = db_session.execute(text("SELECT NOW()")).scalar()
+    if result is None:
+        raise ValueError("Database did not return a time")
+    return result

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from onyx.connectors.models import ConnectorFailure
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
 from onyx.db.models import ConnectorCredentialPair

--- a/backend/onyx/db/kg_temp_view.py
+++ b/backend/onyx/db/kg_temp_view.py
@@ -7,7 +7,7 @@ from onyx.configs.app_configs import DB_READONLY_USER
 from onyx.configs.kg_configs import KG_TEMP_ALLOWED_DOCS_VIEW_NAME_PREFIX
 from onyx.configs.kg_configs import KG_TEMP_KG_ENTITIES_VIEW_NAME_PREFIX
 from onyx.configs.kg_configs import KG_TEMP_KG_RELATIONSHIPS_VIEW_NAME_PREFIX
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 
 
 Base = declarative_base()

--- a/backend/onyx/db/kg_temp_view.py
+++ b/backend/onyx/db/kg_temp_view.py
@@ -13,18 +13,21 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 Base = declarative_base()
 
 
-def get_user_view_names(user_email: str) -> KGViewNames:
-    user_email_cleaned = user_email.replace("@", "_").replace(".", "_")
+def get_user_view_names(user_email: str, tenant_id: str) -> KGViewNames:
+    user_email_cleaned = (
+        user_email.replace("@", "__").replace(".", "_").replace("+", "_")
+    )
     return KGViewNames(
-        allowed_docs_view_name=f"{KG_TEMP_ALLOWED_DOCS_VIEW_NAME_PREFIX}_{user_email_cleaned}",
-        kg_relationships_view_name=f"{KG_TEMP_KG_RELATIONSHIPS_VIEW_NAME_PREFIX}_{user_email_cleaned}",
-        kg_entity_view_name=f"{KG_TEMP_KG_ENTITIES_VIEW_NAME_PREFIX}_{user_email_cleaned}",
+        allowed_docs_view_name=f'"{tenant_id}".{KG_TEMP_ALLOWED_DOCS_VIEW_NAME_PREFIX}_{user_email_cleaned}',
+        kg_relationships_view_name=f'"{tenant_id}".{KG_TEMP_KG_RELATIONSHIPS_VIEW_NAME_PREFIX}_{user_email_cleaned}',
+        kg_entity_view_name=f'"{tenant_id}".{KG_TEMP_KG_ENTITIES_VIEW_NAME_PREFIX}_{user_email_cleaned}',
     )
 
 
 # First, create the view definition
 def create_views(
     db_session: Session,
+    tenant_id: str,
     user_email: str,
     allowed_docs_view_name: str,
     kg_relationships_view_name: str,
@@ -37,24 +40,24 @@ def create_views(
     CREATE OR REPLACE VIEW {allowed_docs_view_name} AS
     WITH kg_used_docs AS (
         SELECT document_id as kg_used_doc_id
-        FROM kg_entity d
+        FROM "{tenant_id}".kg_entity d
         WHERE document_id IS NOT NULL
     ),
 
     public_docs AS (
         SELECT d.id as allowed_doc_id
-        FROM document d
+        FROM "{tenant_id}".document d
         INNER JOIN kg_used_docs kud ON kud.kg_used_doc_id = d.id
         WHERE d.is_public
     ),
     user_owned_docs AS (
         SELECT d.id as allowed_doc_id
-        FROM document_by_connector_credential_pair d
-        JOIN credential c ON d.credential_id = c.id
-        JOIN connector_credential_pair ccp ON
+        FROM "{tenant_id}".document_by_connector_credential_pair d
+        JOIN "{tenant_id}".credential c ON d.credential_id = c.id
+        JOIN "{tenant_id}".connector_credential_pair ccp ON
             d.connector_id = ccp.connector_id AND
             d.credential_id = ccp.credential_id
-        JOIN "user" u ON c.user_id = u.id
+        JOIN "{tenant_id}".user u ON c.user_id = u.id
         INNER JOIN kg_used_docs kud ON kud.kg_used_doc_id = d.id
         WHERE ccp.status != 'DELETING'
         AND ccp.access_type != 'SYNC'
@@ -62,15 +65,15 @@ def create_views(
     ),
     user_group_accessible_docs AS (
         SELECT d.id as allowed_doc_id
-        FROM document_by_connector_credential_pair d
-        JOIN connector_credential_pair ccp ON
+        FROM "{tenant_id}".document_by_connector_credential_pair d
+        JOIN "{tenant_id}".connector_credential_pair ccp ON
             d.connector_id = ccp.connector_id AND
             d.credential_id = ccp.credential_id
-        JOIN user_group__connector_credential_pair ugccp ON
+        JOIN "{tenant_id}".user_group__connector_credential_pair ugccp ON
             ccp.id = ugccp.cc_pair_id
-        JOIN user__user_group uug ON
+        JOIN "{tenant_id}".user__user_group uug ON
             uug.user_group_id = ugccp.user_group_id
-        JOIN "user" u ON uug.user_id = u.id
+        JOIN "{tenant_id}".user u ON uug.user_id = u.id
         INNER JOIN kg_used_docs kud ON kud.kg_used_doc_id = d.id
         WHERE kud.kg_used_doc_id IS NOT NULL
         AND ccp.status != 'DELETING'
@@ -79,17 +82,17 @@ def create_views(
     ),
     external_user_docs AS (
         SELECT d.id as allowed_doc_id
-        FROM document d
+        FROM "{tenant_id}".document d
         INNER JOIN kg_used_docs kud ON kud.kg_used_doc_id = d.id
         WHERE kud.kg_used_doc_id IS NOT NULL
         AND :user_email = ANY(external_user_emails)
     ),
     external_group_docs AS (
         SELECT d.id as allowed_doc_id
-        FROM document d
+        FROM "{tenant_id}".document d
         INNER JOIN kg_used_docs kud ON kud.kg_used_doc_id = d.id
-        JOIN user__external_user_group_id ueg ON ueg.external_user_group_id = ANY(d.external_user_group_ids)
-        JOIN "user" u ON ueg.user_id = u.id
+        JOIN "{tenant_id}".user__external_user_group_id ueg ON ueg.external_user_group_id = ANY(d.external_user_group_ids)
+        JOIN "{tenant_id}".user u ON ueg.user_id = u.id
         WHERE kud.kg_used_doc_id IS NOT NULL
         AND u.email = :user_email
     )
@@ -122,11 +125,11 @@ def create_views(
            d.doc_updated_at as source_date,
            se.attributes as source_entity_attributes,
            te.attributes as target_entity_attributes
-    FROM kg_relationship kgr
+    FROM "{tenant_id}".kg_relationship kgr
     INNER JOIN {allowed_docs_view_name} AD on AD.allowed_doc_id = kgr.source_document
-    JOIN document d on d.id = kgr.source_document
-    JOIN kg_entity se on se.id_name = kgr.source_node
-    JOIN kg_entity te on te.id_name = kgr.target_node
+    JOIN "{tenant_id}".document d on d.id = kgr.source_document
+    JOIN "{tenant_id}".kg_entity se on se.id_name = kgr.source_node
+    JOIN "{tenant_id}".kg_entity te on te.id_name = kgr.target_node
     """
     )
 
@@ -139,9 +142,9 @@ def create_views(
            kge.attributes as entity_attributes,
            kge.document_id as source_document,
            d.doc_updated_at as source_date
-    FROM kg_entity kge
+    FROM "{tenant_id}".kg_entity kge
     INNER JOIN {allowed_docs_view_name} AD on AD.allowed_doc_id = kge.document_id
-    JOIN document d on d.id = kge.document_id
+    JOIN "{tenant_id}".document d on d.id = kge.document_id
     """
     )
 

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.model_configs import DEFAULT_DOCUMENT_ENCODER_MODEL
 from onyx.configs.model_configs import DOCUMENT_ENCODER_MODEL
 from onyx.context.search.models import SavedSearchSettings
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.llm import fetch_embedding_provider
 from onyx.db.models import CloudEmbeddingProvider
 from onyx.db.models import IndexAttempt

--- a/backend/onyx/db/seeding/chat_history_seeding.py
+++ b/backend/onyx/db/seeding/chat_history_seeding.py
@@ -7,7 +7,7 @@ from onyx.configs.constants import MessageType
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_or_create_root_message
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatSession
 
 logger = getLogger(__name__)

--- a/backend/onyx/db/tasks.py
+++ b/backend/onyx/db/tasks.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import delete
 
 from onyx.configs.app_configs import JOB_TIMEOUT
-from onyx.db.engine import get_db_current_time
+from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.models import TaskQueueState
 from onyx.db.models import TaskStatus
 

--- a/backend/onyx/document_index/vespa/kg_interactions.py
+++ b/backend/onyx/document_index/vespa/kg_interactions.py
@@ -2,7 +2,7 @@ from retry import retry
 
 from onyx.db.document import get_document_kg_entities_and_relationships
 from onyx.db.document import get_num_chunks_for_document
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.document_index.vespa.index import KGUChunkUpdateRequest
 from onyx.document_index.vespa.index import VespaIndex
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/file_store/utils.py
+++ b/backend/onyx/file_store/utils.py
@@ -8,7 +8,7 @@ import requests
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import UserFile
 from onyx.db.models import UserFolder

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -41,7 +41,7 @@ from onyx.db.document import update_docs_updated_at__no_commit
 from onyx.db.document import upsert_document_by_connector_credential_pair
 from onyx.db.document import upsert_documents
 from onyx.db.document_set import fetch_document_sets_for_documents
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import Document as DBDocument
 from onyx.db.models import IndexModelStatus
 from onyx.db.search_settings import get_active_search_settings

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -3,7 +3,7 @@ from typing import cast
 
 from redis.client import Redis
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import KVStore
 from onyx.key_value_store.interface import KeyValueStore
 from onyx.key_value_store.interface import KvKeyNotFoundError
@@ -39,7 +39,7 @@ class PgRedisKVStore(KeyValueStore):
 
         encrypted_val = val if encrypt else None
         plain_val = val if not encrypt else None
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             obj = db_session.query(KVStore).filter_by(key=key).first()
             if obj:
                 obj.value = plain_val
@@ -67,7 +67,7 @@ class PgRedisKVStore(KeyValueStore):
                     f"Failed to get value from Redis for key '{key}': {str(e)}"
                 )
 
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             obj = db_session.query(KVStore).filter_by(key=key).first()
             if not obj:
                 raise KvKeyNotFoundError
@@ -92,7 +92,7 @@ class PgRedisKVStore(KeyValueStore):
         except Exception as e:
             logger.error(f"Failed to delete value from Redis for key '{key}': {str(e)}")
 
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             result = db_session.query(KVStore).filter_by(key=key).delete()  # type: ignore
             if result == 0:
                 raise KvKeyNotFoundError

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -3,7 +3,7 @@ from typing import cast
 
 from redis.client import Redis
 
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import KVStore
 from onyx.key_value_store.interface import KeyValueStore
 from onyx.key_value_store.interface import KvKeyNotFoundError
@@ -39,7 +39,7 @@ class PgRedisKVStore(KeyValueStore):
 
         encrypted_val = val if encrypt else None
         plain_val = val if not encrypt else None
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             obj = db_session.query(KVStore).filter_by(key=key).first()
             if obj:
                 obj.value = plain_val
@@ -67,7 +67,7 @@ class PgRedisKVStore(KeyValueStore):
                     f"Failed to get value from Redis for key '{key}': {str(e)}"
                 )
 
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             obj = db_session.query(KVStore).filter_by(key=key).first()
             if not obj:
                 raise KvKeyNotFoundError
@@ -92,7 +92,7 @@ class PgRedisKVStore(KeyValueStore):
         except Exception as e:
             logger.error(f"Failed to delete value from Redis for key '{key}': {str(e)}")
 
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             result = db_session.query(KVStore).filter_by(key=key).delete()  # type: ignore
             if result == 0:
                 raise KvKeyNotFoundError

--- a/backend/onyx/key_value_store/store.py
+++ b/backend/onyx/key_value_store/store.py
@@ -3,7 +3,7 @@ from typing import cast
 
 from redis.client import Redis
 
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.models import KVStore
 from onyx.key_value_store.interface import KeyValueStore
 from onyx.key_value_store.interface import KvKeyNotFoundError

--- a/backend/onyx/kg/clustering/clustering.py
+++ b/backend/onyx/kg/clustering/clustering.py
@@ -11,7 +11,7 @@ from onyx.background.celery.tasks.kg_processing.utils import extend_lock
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.kg_configs import KG_CLUSTERING_RETRIEVE_THRESHOLD
 from onyx.configs.kg_configs import KG_CLUSTERING_THRESHOLD
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import KGEntity
 from onyx.db.entities import KGEntityExtractionStaging
 from onyx.db.entities import merge_entities

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -82,8 +82,14 @@ def _normalize_one_entity(
         metadata = MetaData()
         if allowed_docs_temp_view_name is None:
             raise ValueError("allowed_docs_temp_view_name is not available")
+        if allowed_docs_temp_view_name.startswith('"tenant'):
+            effective_schema_allowed_docs_temp_view_name = (
+                allowed_docs_temp_view_name.split(".")[1]
+            )
+        else:
+            effective_schema_allowed_docs_temp_view_name = allowed_docs_temp_view_name
         allowed_docs_temp_view = Table(
-            allowed_docs_temp_view_name,
+            effective_schema_allowed_docs_temp_view_name,
             metadata,
             autoload_with=db_session.get_bind(),
         )

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -33,6 +33,7 @@ from onyx.kg.utils.formatting_utils import split_entity_id
 from onyx.kg.utils.formatting_utils import split_relationship_id
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 logger = setup_logger()
@@ -82,12 +83,13 @@ def _normalize_one_entity(
         metadata = MetaData()
         if allowed_docs_temp_view_name is None:
             raise ValueError("allowed_docs_temp_view_name is not available")
-        if allowed_docs_temp_view_name.startswith('"tenant'):
+        if MULTI_TENANT:
             effective_schema_allowed_docs_temp_view_name = (
-                allowed_docs_temp_view_name.split(".")[1]
+                allowed_docs_temp_view_name.split(".")[-1]
             )
         else:
             effective_schema_allowed_docs_temp_view_name = allowed_docs_temp_view_name
+
         allowed_docs_temp_view = Table(
             effective_schema_allowed_docs_temp_view_name,
             metadata,

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -18,7 +18,7 @@ from onyx.configs.kg_configs import KG_NORMALIZATION_RERANK_LEVENSHTEIN_WEIGHT
 from onyx.configs.kg_configs import KG_NORMALIZATION_RERANK_NGRAM_WEIGHTS
 from onyx.configs.kg_configs import KG_NORMALIZATION_RERANK_THRESHOLD
 from onyx.configs.kg_configs import KG_NORMALIZATION_RETRIEVE_ENTITIES_LIMIT
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import KGEntity
 from onyx.db.relationships import get_relationships_for_entity_type_pairs
 from onyx.kg.models import NormalizedEntities

--- a/backend/onyx/kg/extractions/extraction_processing.py
+++ b/backend/onyx/kg/extractions/extraction_processing.py
@@ -16,7 +16,7 @@ from onyx.db.document import get_skipped_kg_documents
 from onyx.db.document import get_unprocessed_kg_document_batch_for_connector
 from onyx.db.document import update_document_kg_info
 from onyx.db.document import update_document_kg_stage
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import delete_from_kg_entities__no_commit
 from onyx.db.entities import upsert_staging_entity
 from onyx.db.entity_type import get_entity_types

--- a/backend/onyx/kg/resets/reset_source.py
+++ b/backend/onyx/kg/resets/reset_source.py
@@ -2,7 +2,7 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy import or_
 
 from onyx.configs.constants import DocumentSource
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import Connector
 from onyx.db.models import Document
 from onyx.db.models import DocumentByConnectorCredentialPair

--- a/backend/onyx/kg/resets/reset_vespa.py
+++ b/backend/onyx/kg/resets/reset_vespa.py
@@ -8,7 +8,7 @@ from onyx.background.celery.tasks.kg_processing.utils import extend_lock
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import DocumentSource
 from onyx.db.document import get_num_chunks_for_document
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import Connector
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import KGEntityType

--- a/backend/onyx/kg/utils/embeddings.py
+++ b/backend/onyx/kg/utils/embeddings.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.natural_language_processing.search_nlp_models import EmbedTextType

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from onyx.configs.constants import OnyxCallTypes
 from onyx.configs.kg_configs import KG_METADATA_TRACKING_THRESHOLD
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.entities import get_kg_entity_by_document
 from onyx.db.kg_config import KGConfigSettings
 from onyx.db.models import Document

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -5,7 +5,6 @@ from onyx.configs.app_configs import DISABLE_GENERATIVE_AI
 from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.llm import fetch_default_provider
 from onyx.db.llm import fetch_default_vision_provider
 from onyx.db.llm import fetch_existing_llm_providers
@@ -62,7 +61,7 @@ def get_llms_for_persona(
             long_term_logger=long_term_logger,
         )
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         llm_provider = fetch_llm_provider_view(db_session, provider_name)
 
     if not llm_provider:
@@ -210,7 +209,7 @@ def llm_from_provider(
 
 
 def get_llm_for_contextual_rag(model_name: str, model_provider: str) -> LLM:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         llm_provider = fetch_llm_provider_view(db_session, model_provider)
     if not llm_provider:
         raise ValueError("No LLM provider with name {} found".format(model_provider))
@@ -229,7 +228,7 @@ def get_default_llms(
     if DISABLE_GENERATIVE_AI:
         raise GenAIDisabledException()
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         llm_provider = fetch_default_provider(db_session)
 
     if not llm_provider:

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -4,8 +4,8 @@ from onyx.chat.models import PersonaOverrideConfig
 from onyx.configs.app_configs import DISABLE_GENERATIVE_AI
 from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
-from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.llm import fetch_default_provider
 from onyx.db.llm import fetch_default_vision_provider
 from onyx.db.llm import fetch_existing_llm_providers
@@ -62,7 +62,7 @@ def get_llms_for_persona(
             long_term_logger=long_term_logger,
         )
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         llm_provider = fetch_llm_provider_view(db_session, provider_name)
 
     if not llm_provider:
@@ -210,7 +210,7 @@ def llm_from_provider(
 
 
 def get_llm_for_contextual_rag(model_name: str, model_provider: str) -> LLM:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         llm_provider = fetch_llm_provider_view(db_session, model_provider)
     if not llm_provider:
         raise ValueError("No LLM provider with name {} found".format(model_provider))
@@ -229,7 +229,7 @@ def get_default_llms(
     if DISABLE_GENERATIVE_AI:
         raise GenAIDisabledException()
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         llm_provider = fetch_default_provider(db_session)
 
     if not llm_provider:

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -4,8 +4,8 @@ from onyx.chat.models import PersonaOverrideConfig
 from onyx.configs.app_configs import DISABLE_GENERATIVE_AI
 from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
-from onyx.db.engine import get_session_context_manager
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.llm import fetch_default_provider
 from onyx.db.llm import fetch_default_vision_provider
 from onyx.db.llm import fetch_existing_llm_providers

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -48,9 +48,9 @@ from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
-from onyx.db.engine import get_session_context_manager
-from onyx.db.engine import SqlEngine
-from onyx.db.engine import warm_up_connections
+from onyx.db.engine.connection_warmup import warm_up_connections
+from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.api_key.api import router as api_key_router
 from onyx.server.auth_check import check_router_auth

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -49,7 +49,7 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
 from onyx.db.engine.connection_warmup import warm_up_connections
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.api_key.api import router as api_key_router
@@ -254,7 +254,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         get_or_generate_uuid()
 
         # If we are multi-tenant, we need to only set up initial public tables
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             setup_onyx(db_session, POSTGRES_DEFAULT_SCHEMA)
             # set up the file store (e.g. create bucket if needed). On multi-tenant,
             # this is done via IaC

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -49,7 +49,7 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
 from onyx.db.engine.connection_warmup import warm_up_connections
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.api_key.api import router as api_key_router
@@ -254,7 +254,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         get_or_generate_uuid()
 
         # If we are multi-tenant, we need to only set up initial public tables
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             setup_onyx(db_session, POSTGRES_DEFAULT_SCHEMA)
             # set up the file store (e.g. create bucket if needed). On multi-tenant,
             # this is done via IaC

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -23,7 +23,7 @@ from onyx.configs.constants import SearchFeedbackType
 from onyx.configs.onyxbot_configs import DANSWER_BOT_NUM_DOCS_TO_DISPLAY
 from onyx.context.search.models import SavedSearchDoc
 from onyx.db.chat import get_chat_session_by_message_id
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChannelConfig
 from onyx.onyxbot.slack.constants import CONTINUE_IN_WEB_UI_ACTION_ID
 from onyx.onyxbot.slack.constants import DISLIKE_BLOCK_ACTION_ID

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -18,7 +18,7 @@ from onyx.connectors.slack.utils import expert_info_from_slack_id
 from onyx.context.search.models import SavedSearchDoc
 from onyx.db.chat import get_chat_message
 from onyx.db.chat import translate_db_message_to_chat_message_detail
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.feedback import create_chat_message_feedback
 from onyx.db.feedback import create_doc_retrieval_feedback
 from onyx.db.users import get_user_by_email

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -5,7 +5,7 @@ from slack_sdk.errors import SlackApiError
 
 from onyx.configs.onyxbot_configs import DANSWER_BOT_FEEDBACK_REMINDER
 from onyx.configs.onyxbot_configs import DANSWER_REACT_EMOJI
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import SlackChannelConfig
 from onyx.db.users import add_slack_user_if_not_exists
 from onyx.onyxbot.slack.blocks import get_feedback_reminder_blocks

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -23,7 +23,7 @@ from onyx.configs.onyxbot_configs import MAX_THREAD_CONTEXT_PERCENTAGE
 from onyx.context.search.enums import OptionalSearchSetting
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import RetrievalDetails
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import SlackChannelConfig
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -38,10 +38,10 @@ from onyx.connectors.slack.utils import expert_info_from_slack_id
 from onyx.context.search.retrieval.search_runner import (
     download_nltk_data,
 )
-from onyx.db.engine import get_all_tenant_ids
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import get_session_with_tenant
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.db.models import SlackBot
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.slack_bot import fetch_slack_bot

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -32,7 +32,7 @@ from onyx.configs.onyxbot_configs import (
     DANSWER_BOT_RESPONSE_LIMIT_TIME_PERIOD_SECONDS,
 )
 from onyx.connectors.slack.utils import SlackTextCleaner
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.users import get_user_by_email
 from onyx.llm.exceptions import GenAIDisabledException
 from onyx.llm.factory import get_default_llms

--- a/backend/onyx/secondary_llm_flows/source_filter.py
+++ b/backend/onyx/secondary_llm_flows/source_filter.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.chat_configs import ENABLE_CONNECTOR_CLASSIFIER
 from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_unique_document_sources
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.llm.interfaces import LLM
 from onyx.llm.utils import dict_based_prompt_to_langchain_prompt
 from onyx.llm.utils import message_to_string

--- a/backend/onyx/server/api_key/api.py
+++ b/backend/onyx/server/api_key/api.py
@@ -9,7 +9,7 @@ from onyx.db.api_key import insert_api_key
 from onyx.db.api_key import regenerate_api_key
 from onyx.db.api_key import remove_api_key
 from onyx.db.api_key import update_api_key
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.server.api_key.models import APIKeyArgs
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -31,7 +31,7 @@ from onyx.db.connector_credential_pair import (
 )
 from onyx.db.document import get_document_counts_for_cc_pairs
 from onyx.db.document import get_documents_for_cc_pair
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.index_attempt import count_index_attempt_errors_for_cc_pair

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -87,8 +87,7 @@ from onyx.db.credentials import delete_service_account_credentials
 from onyx.db.credentials import fetch_credential_by_id_for_user
 from onyx.db.deletion_attempt import check_deletion_attempt_is_allowed
 from onyx.db.document import get_document_counts_for_cc_pairs_parallel
-from onyx.db.engine import get_current_tenant_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingMode
 from onyx.db.index_attempt import get_index_attempts_for_cc_pair
@@ -129,6 +128,7 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import create_milestone_and_report
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -19,7 +19,7 @@ from onyx.db.credentials import fetch_credentials_by_source_for_user
 from onyx.db.credentials import fetch_credentials_for_user
 from onyx.db.credentials import swap_credentials_connector
 from onyx.db.credentials import update_credential
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import DocumentSource
 from onyx.db.models import User
 from onyx.server.documents.models import CredentialBase

--- a/backend/onyx/server/documents/document.py
+++ b/backend/onyx/server/documents/document.py
@@ -9,7 +9,7 @@ from onyx.context.search.models import IndexFilters
 from onyx.context.search.preprocessing.access_filters import (
     build_access_filters_for_user,
 )
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.factory import get_default_document_index

--- a/backend/onyx/server/documents/standard_oauth.py
+++ b/backend/onyx/server/documents/standard_oauth.py
@@ -17,7 +17,7 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import OAuthConnector
 from onyx.db.credentials import create_credential
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -14,8 +14,7 @@ from onyx.db.document_set import fetch_all_document_sets_for_user
 from onyx.db.document_set import insert_document_set
 from onyx.db.document_set import mark_document_set_as_to_be_deleted
 from onyx.db.document_set import update_document_set
-from onyx.db.engine import get_current_tenant_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.server.features.document_set.models import CheckDocSetPublicRequest
 from onyx.server.features.document_set.models import CheckDocSetPublicResponse
@@ -23,6 +22,7 @@ from onyx.server.features.document_set.models import DocumentSet
 from onyx.server.features.document_set.models import DocumentSetCreationRequest
 from onyx.server.features.document_set.models import DocumentSetUpdateRequest
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.contextvars import get_current_tenant_id
 
 
 router = APIRouter(prefix="/manage")

--- a/backend/onyx/server/features/folder/api.py
+++ b/backend/onyx/server/features/folder/api.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_user
 from onyx.db.chat import get_chat_session_by_id
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.folder import add_chat_to_folder
 from onyx.db.folder import create_folder
 from onyx.db.folder import delete_folder

--- a/backend/onyx/server/features/input_prompt/api.py
+++ b/backend/onyx/server/features/input_prompt/api.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.input_prompt import disable_input_prompt_for_user
 from onyx.db.input_prompt import fetch_input_prompt_by_id
 from onyx.db.input_prompt import fetch_input_prompts_by_user

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.notification import dismiss_notification
 from onyx.db.notification import get_notification_by_id

--- a/backend/onyx/server/features/password/api.py
+++ b/backend/onyx/server/features/password/api.py
@@ -9,7 +9,7 @@ from onyx.auth.users import current_user
 from onyx.auth.users import get_user_manager
 from onyx.auth.users import User
 from onyx.auth.users import UserManager
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.users import get_user_by_email
 from onyx.server.features.password.models import ChangePasswordRequest
 from onyx.server.features.password.models import UserResetRequest

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -17,7 +17,7 @@ from onyx.auth.users import current_user
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import NotificationType
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import StarterMessageModel as StarterMessage
 from onyx.db.models import User
 from onyx.db.notification import create_notification

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.tools import create_tool
 from onyx.db.tools import delete_tool

--- a/backend/onyx/server/gpts/api.py
+++ b/backend/onyx/server/gpts/api.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from onyx.context.search.models import SearchRequest
 from onyx.context.search.pipeline import SearchPipeline
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.llm.factory import get_default_llms
 from onyx.server.onyx_api.ingestion import api_key_dep

--- a/backend/onyx/server/kg/api.py
+++ b/backend/onyx/server/kg/api.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
 from onyx.context.search.enums import RecencyBiasSetting
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.entity_type import get_configured_entity_types
 from onyx.db.entity_type import update_entity_types_and_related_connectors__commit
 from onyx.db.kg_config import disable_kg

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -20,7 +20,7 @@ from onyx.db.connector_credential_pair import get_connector_credential_pair_for_
 from onyx.db.connector_credential_pair import (
     update_connector_credential_pair_from_id,
 )
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.feedback import fetch_docs_ranked_by_boost_for_user
 from onyx.db.feedback import update_document_boost_for_user

--- a/backend/onyx/server/manage/embedding/api.py
+++ b/backend/onyx/server/manage/embedding/api.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.llm import fetch_existing_embedding_providers
 from onyx.db.llm import remove_embedding_provider
 from onyx.db.llm import upsert_cloud_embedding_provider

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
 from onyx.auth.users import current_chat_accessible_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.llm import fetch_existing_llm_provider
 from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.llm import fetch_existing_llm_providers_for_user

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -11,7 +11,7 @@ from onyx.context.search.models import SavedSearchSettings
 from onyx.context.search.models import SearchSettingsCreationRequest
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
 from onyx.db.connector_credential_pair import resync_cc_pair
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.index_attempt import expire_index_attempts
 from onyx.db.models import IndexModelStatus
 from onyx.db.models import User

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.users import current_admin_user
 from onyx.configs.constants import MilestoneRecordType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import ChannelConfig
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -44,7 +44,7 @@ from onyx.configs.constants import AuthType
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.auth import get_live_users_count
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import AccessToken
 from onyx.db.models import User
 from onyx.db.users import delete_user_from_db

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -11,7 +11,7 @@ from onyx.connectors.models import IndexAttemptMetadata
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.document import get_documents_by_cc_pair
 from onyx.db.document import get_ingestion_documents
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.search_settings import get_active_search_settings
 from onyx.db.search_settings import get_current_search_settings

--- a/backend/onyx/server/openai_assistants_api/asssistants_api.py
+++ b/backend/onyx/server/openai_assistants_api/asssistants_api.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_user
 from onyx.context.search.enums import RecencyBiasSetting
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id

--- a/backend/onyx/server/openai_assistants_api/messages_api.py
+++ b/backend/onyx/server/openai_assistants_api/messages_api.py
@@ -18,7 +18,7 @@ from onyx.db.chat import get_chat_message
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_or_create_root_message
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.llm.utils import check_number_of_tokens
 

--- a/backend/onyx/server/openai_assistants_api/runs_api.py
+++ b/backend/onyx/server/openai_assistants_api/runs_api.py
@@ -18,7 +18,7 @@ from onyx.db.chat import get_chat_message
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_or_create_root_message
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import ChatMessage
 from onyx.db.models import User
 from onyx.server.query_and_chat.models import ChatMessageDetail

--- a/backend/onyx/server/openai_assistants_api/threads_api.py
+++ b/backend/onyx/server/openai_assistants_api/threads_api.py
@@ -13,7 +13,7 @@ from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_chat_sessions_by_user
 from onyx.db.chat import update_chat_session
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.server.query_and_chat.models import ChatSessionDetails
 from onyx.server.query_and_chat.models import ChatSessionsResponse

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -54,8 +54,8 @@ from onyx.db.chat_search import search_chat_sessions
 from onyx.db.connector import create_connector
 from onyx.db.connector_credential_pair import add_credential_to_connector
 from onyx.db.credentials import create_credential
-from onyx.db.engine import get_session
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import AccessType
 from onyx.db.feedback import create_chat_message_feedback
 from onyx.db.feedback import create_doc_retrieval_feedback

--- a/backend/onyx/server/query_and_chat/query_backend.py
+++ b/backend/onyx/server/query_and_chat/query_backend.py
@@ -22,7 +22,7 @@ from onyx.db.chat import get_search_docs_for_chat_message
 from onyx.db.chat import get_valid_messages_from_query_sessions
 from onyx.db.chat import translate_db_message_to_chat_message_detail
 from onyx.db.chat import translate_db_search_doc_to_server_search_doc
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.tag import find_tags

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_chat_accessible_user
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_chat_accessible_user
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit
@@ -52,7 +52,7 @@ Global rate limits
 
 
 def _user_is_rate_limited_by_global() -> None:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         global_rate_limits = fetch_all_global_token_rate_limits(
             db_session=db_session, enabled_only=True, ordered=False
         )
@@ -124,7 +124,7 @@ def any_rate_limit_exists() -> bool:
     """Checks if any rate limit exists in the database. Is cached, so that if no rate limits
     are setup, we don't have any effect on average query latency."""
     logger.debug("Checking for any rate limits...")
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         return (
             db_session.scalar(
                 select(TokenRateLimit.id).where(

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_chat_accessible_user
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import TokenRateLimit
@@ -52,7 +52,7 @@ Global rate limits
 
 
 def _user_is_rate_limited_by_global() -> None:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         global_rate_limits = fetch_all_global_token_rate_limits(
             db_session=db_session, enabled_only=True, ordered=False
         )
@@ -124,7 +124,7 @@ def any_rate_limit_exists() -> bool:
     """Checks if any rate limit exists in the database. Is cached, so that if no rate limits
     are setup, we don't have any effect on average query latency."""
     logger.debug("Checking for any rate limits...")
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         return (
             db_session.scalar(
                 select(TokenRateLimit.id).where(

--- a/backend/onyx/server/runtime/onyx_runtime.py
+++ b/backend/onyx/server/runtime/onyx_runtime.py
@@ -11,7 +11,7 @@ from onyx.configs.constants import CLOUD_BUILD_FENCE_LOOKUP_TABLE_INTERVAL_DEFAU
 from onyx.configs.constants import ONYX_CLOUD_REDIS_RUNTIME
 from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.configs.constants import ONYX_EMAILABLE_LOGO_MAX_DIM
-from onyx.db.engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.file_store.file_store import get_default_file_store
 from onyx.redis.redis_pool import get_redis_replica_client
 from onyx.utils.file import FileWithMimeType

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -10,7 +10,7 @@ from onyx.auth.users import current_user
 from onyx.auth.users import is_user_admin
 from onyx.configs.constants import KV_REINDEX_KEY
 from onyx.configs.constants import NotificationType
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.notification import create_notification
 from onyx.db.notification import dismiss_all_notifications

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -3,7 +3,7 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_admin_user
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
 from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_global_token_rate_limits

--- a/backend/onyx/server/user_documents/api.py
+++ b/backend/onyx/server/user_documents/api.py
@@ -23,7 +23,7 @@ from onyx.connectors.models import InputType
 from onyx.db.connector import create_connector
 from onyx.db.connector_credential_pair import add_credential_to_connector
 from onyx.db.credentials import create_credential
-from onyx.db.engine import get_session
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import ConnectorCredentialPair

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -17,7 +17,7 @@ from requests import JSONDecodeError
 
 from onyx.chat.prompt_builder.answer_prompt_builder import AnswerPromptBuilder
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -12,7 +12,7 @@ from onyx.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from onyx.configs.constants import KV_CUSTOMER_UUID_KEY
 from onyx.configs.constants import KV_INSTANCE_DOMAIN_KEY
 from onyx.configs.constants import MilestoneRecordType
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.milestone import create_milestone_if_not_exists
 from onyx.db.models import User
 from onyx.key_value_store.factory import get_kv_store

--- a/backend/scripts/debugging/onyx_db.py
+++ b/backend/scripts/debugging/onyx_db.py
@@ -12,14 +12,14 @@ if True:  # noqa: E402
     from pydantic import BaseModel
     from sqlalchemy import func
 
-    from onyx.db.engine import (
+    from onyx.db.engine.sql_engine import (
         SYNC_DB_API,
         USE_IAM_AUTH,
         build_connection_string,
-        get_all_tenant_ids,
     )
-    from onyx.db.engine import get_session_with_tenant
-    from onyx.db.engine import SqlEngine
+    from onyx.db.engine.tenant_utils import get_all_tenant_ids
+    from onyx.db.engine.sql_engine import get_session_with_tenant
+    from onyx.db.engine.sql_engine import SqlEngine
     from onyx.db.models import Document
     from onyx.db.models import User
     from onyx.utils.logger import setup_logger

--- a/backend/scripts/debugging/onyx_redis.py
+++ b/backend/scripts/debugging/onyx_redis.py
@@ -19,7 +19,7 @@ from onyx.configs.app_configs import REDIS_HOST
 from onyx.configs.app_configs import REDIS_PASSWORD
 from onyx.configs.app_configs import REDIS_PORT
 from onyx.configs.app_configs import REDIS_SSL
-from onyx.db.engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_index import RedisConnectorIndex

--- a/backend/scripts/debugging/onyx_vespa.py
+++ b/backend/scripts/debugging/onyx_vespa.py
@@ -45,9 +45,9 @@ from sqlalchemy import and_
 from onyx.configs.constants import INDEX_SEPARATOR
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import get_session_with_tenant
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document
 from onyx.db.models import DocumentByConnectorCredentialPair

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -38,7 +38,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id,
     get_connector_credential_pair,
 )
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.document_index.factory import get_default_document_index
 from onyx.file_store.file_store import get_default_file_store
 
@@ -228,5 +228,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         _delete_connector(args.connector_id, db_session)

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -38,7 +38,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id,
     get_connector_credential_pair,
 )
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.document_index.factory import get_default_document_index
 from onyx.file_store.file_store import get_default_file_store
 

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -38,7 +38,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_from_id,
     get_connector_credential_pair,
 )
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.document_index.factory import get_default_document_index
 from onyx.file_store.file_store import get_default_file_store
 
@@ -228,5 +228,5 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         _delete_connector(args.connector_id, db_session)

--- a/backend/scripts/hard_delete_chats.py
+++ b/backend/scripts/hard_delete_chats.py
@@ -7,7 +7,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 print(parent_dir)
 sys.path.append(parent_dir)
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
 from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
 from onyx.db.models import ChatSession  # noqa: E402
 from onyx.db.chat import delete_chat_session  # noqa: E402
@@ -16,7 +16,7 @@ from onyx.db.chat import delete_chat_session  # noqa: E402
 def main() -> None:
     SqlEngine.init_engine(pool_size=20, max_overflow=5)
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         deleted_sessions = (
             db_session.query(ChatSession).filter(ChatSession.deleted.is_(True)).all()
         )

--- a/backend/scripts/hard_delete_chats.py
+++ b/backend/scripts/hard_delete_chats.py
@@ -7,7 +7,8 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 print(parent_dir)
 sys.path.append(parent_dir)
 
-from onyx.db.engine import get_session_context_manager, SqlEngine  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_context_manager  # noqa: E402
+from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
 from onyx.db.models import ChatSession  # noqa: E402
 from onyx.db.chat import delete_chat_session  # noqa: E402
 

--- a/backend/scripts/hard_delete_chats.py
+++ b/backend/scripts/hard_delete_chats.py
@@ -7,7 +7,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 print(parent_dir)
 sys.path.append(parent_dir)
 
-from onyx.db.engine.sql_engine import get_session_context_manager  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_shared_schema  # noqa: E402
 from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
 from onyx.db.models import ChatSession  # noqa: E402
 from onyx.db.chat import delete_chat_session  # noqa: E402
@@ -16,7 +16,7 @@ from onyx.db.chat import delete_chat_session  # noqa: E402
 def main() -> None:
     SqlEngine.init_engine(pool_size=20, max_overflow=5)
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         deleted_sessions = (
             db_session.query(ChatSession).filter(ChatSession.deleted.is_(True)).all()
         )

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -14,7 +14,7 @@ sys.path.append(parent_dir)
 
 from onyx.context.search.models import IndexFilters  # noqa: E402
 from onyx.document_index.interfaces import VespaChunkRequest  # noqa: E402
-from onyx.db.engine.sql_engine import get_session_context_manager  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_shared_schema  # noqa: E402
 from onyx.db.document import delete_documents_complete__no_commit  # noqa: E402
 from onyx.db.tag import delete_orphan_tags__no_commit  # noqa: E402
 from onyx.db.search_settings import get_current_search_settings  # noqa: E402
@@ -41,7 +41,7 @@ def _get_orphaned_document_ids(db_session: Session, limit: int) -> list[str]:
 
 
 def main() -> None:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         total_processed = 0
         while True:
             # Get orphaned document IDs in batches

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -14,7 +14,7 @@ sys.path.append(parent_dir)
 
 from onyx.context.search.models import IndexFilters  # noqa: E402
 from onyx.document_index.interfaces import VespaChunkRequest  # noqa: E402
-from onyx.db.engine import get_session_context_manager  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_context_manager  # noqa: E402
 from onyx.db.document import delete_documents_complete__no_commit  # noqa: E402
 from onyx.db.tag import delete_orphan_tags__no_commit  # noqa: E402
 from onyx.db.search_settings import get_current_search_settings  # noqa: E402

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -14,7 +14,7 @@ sys.path.append(parent_dir)
 
 from onyx.context.search.models import IndexFilters  # noqa: E402
 from onyx.document_index.interfaces import VespaChunkRequest  # noqa: E402
-from onyx.db.engine.sql_engine import get_session_with_shared_schema  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
 from onyx.db.document import delete_documents_complete__no_commit  # noqa: E402
 from onyx.db.tag import delete_orphan_tags__no_commit  # noqa: E402
 from onyx.db.search_settings import get_current_search_settings  # noqa: E402
@@ -41,7 +41,7 @@ def _get_orphaned_document_ids(db_session: Session, limit: int) -> list[str]:
 
 
 def main() -> None:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         total_processed = 0
         while True:
             # Get orphaned document IDs in batches

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from onyx.access.models import DocumentAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import Document
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex
@@ -140,7 +140,7 @@ def seed_dummy_docs(
     chunks_per_doc: int = 5,
     batch_size: int = 100,
 ) -> None:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         search_settings = get_current_search_settings(db_session)
         multipass_config = get_multipass_config(search_settings)
         index_name = search_settings.index_name

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from onyx.access.models import DocumentAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import Document
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex

--- a/backend/scripts/query_time_check/seed_dummy_docs.py
+++ b/backend/scripts/query_time_check/seed_dummy_docs.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from onyx.access.models import DocumentAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import Document
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex
@@ -140,7 +140,7 @@ def seed_dummy_docs(
     chunks_per_doc: int = 5,
     batch_size: int = 100,
 ) -> None:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         search_settings = get_current_search_settings(db_session)
         multipass_config = get_multipass_config(search_settings)
         index_name = search_settings.index_name

--- a/backend/scripts/query_time_check/test_query_times.py
+++ b/backend/scripts/query_time_check/test_query_times.py
@@ -9,7 +9,7 @@ from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionTyp
 from onyx.configs.constants import DocumentSource
 from onyx.configs.model_configs import DOC_EMBEDDING_DIM
 from onyx.context.search.models import IndexFilters
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex
@@ -63,7 +63,7 @@ def _random_filters() -> IndexFilters:
 def test_hybrid_retrieval_times(
     number_of_queries: int,
 ) -> None:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         search_settings = get_current_search_settings(db_session)
         multipass_config = get_multipass_config(search_settings)
         index_name = search_settings.index_name

--- a/backend/scripts/query_time_check/test_query_times.py
+++ b/backend/scripts/query_time_check/test_query_times.py
@@ -9,7 +9,7 @@ from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionTyp
 from onyx.configs.constants import DocumentSource
 from onyx.configs.model_configs import DOC_EMBEDDING_DIM
 from onyx.context.search.models import IndexFilters
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex

--- a/backend/scripts/query_time_check/test_query_times.py
+++ b/backend/scripts/query_time_check/test_query_times.py
@@ -9,7 +9,7 @@ from onyx.agents.agent_search.shared_graph_utils.models import QueryExpansionTyp
 from onyx.configs.constants import DocumentSource
 from onyx.configs.model_configs import DOC_EMBEDDING_DIM
 from onyx.context.search.models import IndexFilters
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.document_index_utils import get_multipass_config
 from onyx.document_index.vespa.index import VespaIndex
@@ -63,7 +63,7 @@ def _random_filters() -> IndexFilters:
 def test_hybrid_retrieval_times(
     number_of_queries: int,
 ) -> None:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         search_settings = get_current_search_settings(db_session)
         multipass_config = get_multipass_config(search_settings)
         index_name = search_settings.index_name

--- a/backend/scripts/reset_postgres.py
+++ b/backend/scripts/reset_postgres.py
@@ -4,7 +4,7 @@ import sys
 import psycopg2
 from sqlalchemy.orm import Session
 
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 
 # makes it so `PYTHONPATH=.` is not required when running this script
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/backend/tests/daily/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/daily/file_store/test_file_store_non_mocked.py
@@ -18,7 +18,7 @@ from botocore.exceptions import ClientError
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import S3BackedFileStore
 from onyx.utils.logger import setup_logger
@@ -112,7 +112,7 @@ def db_session() -> Generator[Session, None, None]:
         pool_size=10,
         max_overflow=5,
     )
-    with get_session_context_manager() as session:
+    with get_session_with_shared_schema() as session:
         yield session
 
 
@@ -850,7 +850,7 @@ class TestS3BackedFileStore:
                 token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
                 try:
                     # Create a new database session for each worker to avoid conflicts
-                    with get_session_context_manager() as worker_session:
+                    with get_session_with_shared_schema() as worker_session:
                         worker_file_store = S3BackedFileStore(
                             db_session=worker_session,
                             bucket_name=current_bucket_name,

--- a/backend/tests/daily/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/daily/file_store/test_file_store_non_mocked.py
@@ -18,7 +18,7 @@ from botocore.exceptions import ClientError
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import S3BackedFileStore
 from onyx.utils.logger import setup_logger
@@ -112,7 +112,7 @@ def db_session() -> Generator[Session, None, None]:
         pool_size=10,
         max_overflow=5,
     )
-    with get_session_with_shared_schema() as session:
+    with get_session_with_current_tenant() as session:
         yield session
 
 
@@ -850,7 +850,7 @@ class TestS3BackedFileStore:
                 token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
                 try:
                     # Create a new database session for each worker to avoid conflicts
-                    with get_session_with_shared_schema() as worker_session:
+                    with get_session_with_current_tenant() as worker_session:
                         worker_file_store = S3BackedFileStore(
                             db_session=worker_session,
                             bucket_name=current_bucket_name,

--- a/backend/tests/daily/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/daily/file_store/test_file_store_non_mocked.py
@@ -18,8 +18,8 @@ from botocore.exceptions import ClientError
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine import get_session_context_manager
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.file_store.file_store import S3BackedFileStore
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR

--- a/backend/tests/integration/common_utils/chat.py
+++ b/backend/tests/integration/common_utils/chat.py
@@ -1,6 +1,6 @@
 import requests
 
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.models import User
 
 

--- a/backend/tests/integration/common_utils/chat.py
+++ b/backend/tests/integration/common_utils/chat.py
@@ -1,12 +1,12 @@
 import requests
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import User
 
 
 def test_create_chat_session_and_send_messages() -> None:
     # Create a test user
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         test_user = User(email="test@example.com", hashed_password="dummy_hash")
         db_session.add(test_user)
         db_session.commit()

--- a/backend/tests/integration/common_utils/chat.py
+++ b/backend/tests/integration/common_utils/chat.py
@@ -1,12 +1,12 @@
 import requests
 
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.models import User
 
 
 def test_create_chat_session_and_send_messages() -> None:
     # Create a test user
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         test_user = User(email="test@example.com", hashed_password="dummy_hash")
         db_session.add(test_user)
         db_session.commit()

--- a/backend/tests/integration/common_utils/managers/index_attempt.py
+++ b/backend/tests/integration/common_utils/managers/index_attempt.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 import requests
 
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import IndexModelStatus
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexingStatus

--- a/backend/tests/integration/common_utils/managers/index_attempt.py
+++ b/backend/tests/integration/common_utils/managers/index_attempt.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 import requests
 
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexModelStatus
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexingStatus
@@ -37,7 +37,7 @@ class IndexAttemptManager:
             base_time = datetime.now()
 
         attempts = []
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             # Get the current search settings
             search_settings = get_current_search_settings(db_session)
             if (

--- a/backend/tests/integration/common_utils/managers/index_attempt.py
+++ b/backend/tests/integration/common_utils/managers/index_attempt.py
@@ -6,7 +6,7 @@ from urllib.parse import urlencode
 import requests
 
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import IndexModelStatus
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexingStatus
@@ -37,7 +37,7 @@ class IndexAttemptManager:
             base_time = datetime.now()
 
         attempts = []
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             # Get the current search settings
             search_settings = get_current_search_settings(db_session)
             if (

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -12,7 +12,7 @@ from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.engine.sql_engine import SYNC_DB_API
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
@@ -285,14 +285,14 @@ def reset_postgres(
     upgrade_postgres(database=database, config_name=config_name, revision="head")
     if setup_onyx:
         logger.info("Setting up Postgres...")
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             setup_postgres(db_session)
 
 
 def reset_vespa() -> None:
     """Wipe all data from the Vespa index."""
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         # swap to the correct default model
         check_and_perform_index_swap(db_session)
 

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -12,7 +12,7 @@ from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.engine.sql_engine import SYNC_DB_API
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
@@ -285,14 +285,14 @@ def reset_postgres(
     upgrade_postgres(database=database, config_name=config_name, revision="head")
     if setup_onyx:
         logger.info("Setting up Postgres...")
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             setup_postgres(db_session)
 
 
 def reset_vespa() -> None:
     """Wipe all data from the Vespa index."""
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         # swap to the correct default model
         check_and_perform_index_swap(db_session)
 

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -11,11 +11,11 @@ from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
-from onyx.db.engine import build_connection_string
-from onyx.db.engine import get_all_tenant_ids
-from onyx.db.engine import get_session_context_manager
-from onyx.db.engine import get_session_with_tenant
-from onyx.db.engine import SYNC_DB_API
+from onyx.db.engine.sql_engine import build_connection_string
+from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.engine.sql_engine import SYNC_DB_API
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.document_index.document_index_utils import get_multipass_config

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -3,8 +3,8 @@ import os
 import pytest
 
 from onyx.auth.schemas import UserRole
-from onyx.db.engine import get_session_context_manager
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.search_settings import get_current_search_settings
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
 from tests.integration.common_utils.constants import GENERAL_HEADERS

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from onyx.auth.schemas import UserRole
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.search_settings import get_current_search_settings
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
@@ -47,7 +47,7 @@ instantiate the session directly within the test.
 """
 # @pytest.fixture
 # def db_session() -> Generator[Session, None, None]:
-#     with get_session_with_shared_schema() as session:
+#     with get_session_with_current_tenant() as session:
 #         yield session
 
 
@@ -62,7 +62,7 @@ def initialize_db() -> None:
 
 @pytest.fixture
 def vespa_client() -> vespa_fixture:
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         search_settings = get_current_search_settings(db_session)
         return vespa_fixture(index_name=search_settings.index_name)
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from onyx.auth.schemas import UserRole
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.search_settings import get_current_search_settings
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
@@ -47,7 +47,7 @@ instantiate the session directly within the test.
 """
 # @pytest.fixture
 # def db_session() -> Generator[Session, None, None]:
-#     with get_session_context_manager() as session:
+#     with get_session_with_shared_schema() as session:
 #         yield session
 
 
@@ -62,7 +62,7 @@ def initialize_db() -> None:
 
 @pytest.fixture
 def vespa_client() -> vespa_fixture:
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         search_settings = get_current_search_settings(db_session)
         return vespa_fixture(index_name=search_settings.index_name)
 

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import DocumentFailure
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.db.enums import IndexingStatus
 from onyx.db.index_attempt import create_index_attempt
 from onyx.db.index_attempt import create_index_attempt_error

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -5,7 +5,7 @@ from datetime import timezone
 import pytest
 
 from onyx.connectors.models import InputType
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -94,7 +94,7 @@ def test_image_indexing(
         user_performing_action=admin_user,
     )
 
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         # really gets the chunks from Vespa, which is why there are two;
         # one for the raw text and one for the summarized image.
         documents = DocumentManager.fetch_documents_for_cc_pair(

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -5,7 +5,7 @@ from datetime import timezone
 import pytest
 
 from onyx.connectors.models import InputType
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -5,7 +5,7 @@ from datetime import timezone
 import pytest
 
 from onyx.connectors.models import InputType
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -94,7 +94,7 @@ def test_image_indexing(
         user_performing_action=admin_user,
     )
 
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         # really gets the chunks from Vespa, which is why there are two;
         # one for the raw text and one for the summarized image.
         documents = DocumentManager.fetch_documents_for_cc_pair(

--- a/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
+++ b/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
@@ -7,7 +7,7 @@ import pytest
 
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_for_cc_pair
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -100,7 +100,7 @@ def test_zip_metadata_handling(
     )
 
     # Get the indexed documents
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = get_documents_for_cc_pair(db_session, cc_pair.id)
 
     # Expected metadata from the .onyx_metadata.json file

--- a/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
+++ b/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
@@ -7,7 +7,7 @@ import pytest
 
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_for_cc_pair
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager

--- a/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
+++ b/backend/tests/integration/tests/indexing/file_connector/test_file_connector_zip_metadata.py
@@ -7,7 +7,7 @@ import pytest
 
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_for_cc_pair
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
@@ -100,7 +100,7 @@ def test_zip_metadata_handling(
     )
 
     # Get the indexed documents
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = get_documents_for_cc_pair(db_session, cc_pair.id)
 
     # Expected metadata from the .onyx_metadata.json file

--- a/backend/tests/integration/tests/indexing/test_checkpointing.py
+++ b/backend/tests/integration/tests/indexing/test_checkpointing.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import InputType
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
@@ -83,7 +83,7 @@ def test_mock_connector_basic_flow(
     assert finished_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify results
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         chunks = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -156,7 +156,7 @@ def test_mock_connector_with_failures(
     assert finished_index_attempt.status == IndexingStatus.COMPLETED_WITH_ERRORS
 
     # Verify results: doc1 should be indexed and doc2 should have an error entry
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -247,7 +247,7 @@ def test_mock_connector_failure_recovery(
     assert finished_index_attempt.status == IndexingStatus.COMPLETED_WITH_ERRORS
 
     # Verify initial state: doc1 indexed, doc2 failed
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -311,7 +311,7 @@ def test_mock_connector_failure_recovery(
     assert finished_second_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify both documents are now indexed
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -415,7 +415,7 @@ def test_mock_connector_checkpoint_recovery(
     assert finished_index_attempt.status == IndexingStatus.FAILED
 
     # Verify initial state: both docs should be indexed
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -486,7 +486,7 @@ def test_mock_connector_checkpoint_recovery(
     assert finished_recovery_attempt.status == IndexingStatus.SUCCESS
 
     # Verify results
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,

--- a/backend/tests/integration/tests/indexing/test_checkpointing.py
+++ b/backend/tests/integration/tests/indexing/test_checkpointing.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import InputType
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
@@ -83,7 +83,7 @@ def test_mock_connector_basic_flow(
     assert finished_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify results
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         chunks = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -156,7 +156,7 @@ def test_mock_connector_with_failures(
     assert finished_index_attempt.status == IndexingStatus.COMPLETED_WITH_ERRORS
 
     # Verify results: doc1 should be indexed and doc2 should have an error entry
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -247,7 +247,7 @@ def test_mock_connector_failure_recovery(
     assert finished_index_attempt.status == IndexingStatus.COMPLETED_WITH_ERRORS
 
     # Verify initial state: doc1 indexed, doc2 failed
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -311,7 +311,7 @@ def test_mock_connector_failure_recovery(
     assert finished_second_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify both documents are now indexed
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -415,7 +415,7 @@ def test_mock_connector_checkpoint_recovery(
     assert finished_index_attempt.status == IndexingStatus.FAILED
 
     # Verify initial state: both docs should be indexed
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -486,7 +486,7 @@ def test_mock_connector_checkpoint_recovery(
     assert finished_recovery_attempt.status == IndexingStatus.SUCCESS
 
     # Verify results
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,

--- a/backend/tests/integration/tests/indexing/test_checkpointing.py
+++ b/backend/tests/integration/tests/indexing/test_checkpointing.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import InputType
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import EXTERNAL_USER_GROUP_IDS
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_by_ids
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
@@ -87,7 +87,7 @@ def test_mock_connector_initial_permission_sync(
     assert finished_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify document was indexed
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -104,7 +104,7 @@ def test_mock_connector_initial_permission_sync(
     assert len(errors) == 0
 
     # Verify permissions were set during indexing by checking the document in the database
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         db_docs = get_documents_by_ids(
             db_session=db_session,
             document_ids=[test_doc.id],

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import EXTERNAL_USER_GROUP_IDS
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_by_ids
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -10,7 +10,7 @@ from onyx.connectors.mock_connector.connector import EXTERNAL_USER_GROUP_IDS
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.document import get_documents_by_ids
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
@@ -87,7 +87,7 @@ def test_mock_connector_initial_permission_sync(
     assert finished_index_attempt.status == IndexingStatus.SUCCESS
 
     # Verify document was indexed
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -104,7 +104,7 @@ def test_mock_connector_initial_permission_sync(
     assert len(errors) == 0
 
     # Verify permissions were set during indexing by checking the document in the database
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         db_docs = get_documents_by_ids(
             db_session=db_session,
             document_ids=[test_doc.id],

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -10,7 +10,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
@@ -96,7 +96,7 @@ def test_repeated_error_state_detection_and_recovery(
 
         # make sure that we don't mark the connector as in repeated error state
         # before we have the required number of failed attempts
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,
@@ -114,7 +114,7 @@ def test_repeated_error_state_detection_and_recovery(
     # Check if the connector is in a repeated error state
     start_time = time.monotonic()
     while True:
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,
@@ -171,7 +171,7 @@ def test_repeated_error_state_detection_and_recovery(
     assert finished_recovery_attempt.status == IndexingStatus.SUCCESS
 
     # Verify the document was indexed
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -183,7 +183,7 @@ def test_repeated_error_state_detection_and_recovery(
     # Verify the CC pair is no longer in a repeated error state
     start = time.monotonic()
     while True:
-        with get_session_with_shared_schema() as db_session:
+        with get_session_with_current_tenant() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -10,7 +10,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -10,7 +10,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.mock_connector.connector import MockConnectorCheckpoint
 from onyx.connectors.models import InputType
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
@@ -96,7 +96,7 @@ def test_repeated_error_state_detection_and_recovery(
 
         # make sure that we don't mark the connector as in repeated error state
         # before we have the required number of failed attempts
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,
@@ -114,7 +114,7 @@ def test_repeated_error_state_detection_and_recovery(
     # Check if the connector is in a repeated error state
     start_time = time.monotonic()
     while True:
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,
@@ -171,7 +171,7 @@ def test_repeated_error_state_detection_and_recovery(
     assert finished_recovery_attempt.status == IndexingStatus.SUCCESS
 
     # Verify the document was indexed
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         documents = DocumentManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
@@ -183,7 +183,7 @@ def test_repeated_error_state_detection_and_recovery(
     # Verify the CC pair is no longer in a repeated error state
     start = time.monotonic()
     while True:
-        with get_session_context_manager() as db_session:
+        with get_session_with_shared_schema() as db_session:
             cc_pair_obj = get_connector_credential_pair_from_id(
                 db_session=db_session,
                 cc_pair_id=cc_pair.id,

--- a/backend/tests/integration/tests/kg/test_kg.py
+++ b/backend/tests/integration/tests/kg/test_kg.py
@@ -8,7 +8,7 @@ import requests
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.connector import create_connector
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import set_kg_config_settings
 from onyx.db.models import Connector
@@ -35,7 +35,7 @@ def reset_for_test() -> None:
 @pytest.fixture()
 def connectors() -> None:
     """Set up connectors for tests."""
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         # Create Salesforce connector
         connector_data = ConnectorBase(
             name="Salesforce Test",
@@ -194,7 +194,7 @@ def test_update_kg_entity_types(connectors: None) -> None:
     ), f"Error response: {res3.status_code} - {res3.text}"
 
     # Check connector kg_processing is enabled
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         connector = (
             db_session.query(Connector)
             .filter(Connector.name == "Salesforce Test")

--- a/backend/tests/integration/tests/kg/test_kg.py
+++ b/backend/tests/integration/tests/kg/test_kg.py
@@ -8,7 +8,7 @@ import requests
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.connector import create_connector
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import set_kg_config_settings
 from onyx.db.models import Connector

--- a/backend/tests/integration/tests/kg/test_kg.py
+++ b/backend/tests/integration/tests/kg/test_kg.py
@@ -8,7 +8,7 @@ import requests
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.connector import create_connector
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import set_kg_config_settings
 from onyx.db.models import Connector
@@ -35,7 +35,7 @@ def reset_for_test() -> None:
 @pytest.fixture()
 def connectors() -> None:
     """Set up connectors for tests."""
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         # Create Salesforce connector
         connector_data = ConnectorBase(
             name="Salesforce Test",
@@ -194,7 +194,7 @@ def test_update_kg_entity_types(connectors: None) -> None:
     ), f"Error response: {res3.status_code} - {res3.text}"
 
     # Check connector kg_processing is enabled
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         connector = (
             db_session.query(Connector)
             .filter(Connector.name == "Salesforce Test")

--- a/backend/tests/integration/tests/migrations/test_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_migrations.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 
 from onyx.configs.constants import DEFAULT_BOOST
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from tests.integration.common_utils.reset import downgrade_postgres
 from tests.integration.common_utils.reset import upgrade_postgres
 
@@ -52,7 +52,7 @@ def test_fix_capitalization_migration() -> None:
     ]
 
     # Insert the test data
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         for doc in test_data:
             db_session.execute(
                 text(
@@ -90,7 +90,7 @@ def test_fix_capitalization_migration() -> None:
         db_session.commit()
 
     # Verify the data was inserted correctly
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -113,7 +113,7 @@ def test_fix_capitalization_migration() -> None:
     )
 
     # Verify the fix was applied
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -177,7 +177,7 @@ def test_jira_connector_migration() -> None:
     ]
 
     # Insert the test data
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         for connector in test_data:
             db_session.execute(
                 text(
@@ -206,7 +206,7 @@ def test_jira_connector_migration() -> None:
         db_session.commit()
 
     # Verify the data was inserted correctly
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -239,7 +239,7 @@ def test_jira_connector_migration() -> None:
     )
 
     # Verify the upgrade was applied correctly
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -284,7 +284,7 @@ def test_jira_connector_migration() -> None:
     )
 
     # Verify the downgrade was applied correctly
-    with get_session_with_shared_schema() as db_session:
+    with get_session_with_current_tenant() as db_session:
         results = db_session.execute(
             text(
                 """

--- a/backend/tests/integration/tests/migrations/test_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_migrations.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 
 from onyx.configs.constants import DEFAULT_BOOST
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from tests.integration.common_utils.reset import downgrade_postgres
 from tests.integration.common_utils.reset import upgrade_postgres
 

--- a/backend/tests/integration/tests/migrations/test_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_migrations.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy import text
 
 from onyx.configs.constants import DEFAULT_BOOST
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from tests.integration.common_utils.reset import downgrade_postgres
 from tests.integration.common_utils.reset import upgrade_postgres
 
@@ -52,7 +52,7 @@ def test_fix_capitalization_migration() -> None:
     ]
 
     # Insert the test data
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         for doc in test_data:
             db_session.execute(
                 text(
@@ -90,7 +90,7 @@ def test_fix_capitalization_migration() -> None:
         db_session.commit()
 
     # Verify the data was inserted correctly
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -113,7 +113,7 @@ def test_fix_capitalization_migration() -> None:
     )
 
     # Verify the fix was applied
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -177,7 +177,7 @@ def test_jira_connector_migration() -> None:
     ]
 
     # Insert the test data
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         for connector in test_data:
             db_session.execute(
                 text(
@@ -206,7 +206,7 @@ def test_jira_connector_migration() -> None:
         db_session.commit()
 
     # Verify the data was inserted correctly
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -239,7 +239,7 @@ def test_jira_connector_migration() -> None:
     )
 
     # Verify the upgrade was applied correctly
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         results = db_session.execute(
             text(
                 """
@@ -284,7 +284,7 @@ def test_jira_connector_migration() -> None:
     )
 
     # Verify the downgrade was applied correctly
-    with get_session_context_manager() as db_session:
+    with get_session_with_shared_schema() as db_session:
         results = db_session.execute(
             text(
                 """

--- a/backend/tests/integration/tests/query_history/test_usage_reports.py
+++ b/backend/tests/integration/tests/query_history/test_usage_reports.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from datetime import timezone
 
 from ee.onyx.db.usage_export import get_all_empty_chat_message_entries
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.seeding.chat_history_seeding import seed_chat_history
 
 

--- a/backend/tests/regression/answer_quality/agent_test_script.py
+++ b/backend/tests/regression/answer_quality/agent_test_script.py
@@ -24,7 +24,7 @@ from onyx.chat.models import StreamStopInfo
 from onyx.chat.models import StreamType
 from onyx.chat.models import SubQuestionPiece
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.llm.factory import get_default_llms
 from onyx.tools.force import ForceUseTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
@@ -61,7 +61,7 @@ example_ids = test_data["example_ids"]
 
 failed_example_ids: list[int] = []
 
-with get_session_with_shared_schema() as db_session:
+with get_session_with_current_tenant() as db_session:
     output_data: dict[str, Any] = {}
 
     primary_llm, fast_llm = get_default_llms()
@@ -105,7 +105,7 @@ with get_session_with_shared_schema() as db_session:
 
             answer_tokens: dict[str, list[str]] = defaultdict(list)
 
-            with get_session_with_shared_schema() as db_session:
+            with get_session_with_current_tenant() as db_session:
                 config = get_test_config(
                     db_session, primary_llm, fast_llm, search_request
                 )

--- a/backend/tests/regression/answer_quality/agent_test_script.py
+++ b/backend/tests/regression/answer_quality/agent_test_script.py
@@ -24,7 +24,7 @@ from onyx.chat.models import StreamStopInfo
 from onyx.chat.models import StreamType
 from onyx.chat.models import SubQuestionPiece
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_context_manager
 from onyx.llm.factory import get_default_llms
 from onyx.tools.force import ForceUseTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool

--- a/backend/tests/regression/answer_quality/agent_test_script.py
+++ b/backend/tests/regression/answer_quality/agent_test_script.py
@@ -24,7 +24,7 @@ from onyx.chat.models import StreamStopInfo
 from onyx.chat.models import StreamType
 from onyx.chat.models import SubQuestionPiece
 from onyx.context.search.models import SearchRequest
-from onyx.db.engine.sql_engine import get_session_context_manager
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.llm.factory import get_default_llms
 from onyx.tools.force import ForceUseTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
@@ -61,7 +61,7 @@ example_ids = test_data["example_ids"]
 
 failed_example_ids: list[int] = []
 
-with get_session_context_manager() as db_session:
+with get_session_with_shared_schema() as db_session:
     output_data: dict[str, Any] = {}
 
     primary_llm, fast_llm = get_default_llms()
@@ -105,7 +105,7 @@ with get_session_context_manager() as db_session:
 
             answer_tokens: dict[str, list[str]] = defaultdict(list)
 
-            with get_session_context_manager() as db_session:
+            with get_session_with_shared_schema() as db_session:
                 config = get_test_config(
                     db_session, primary_llm, fast_llm, search_request
                 )

--- a/backend/tests/regression/search_quality/run_search_eval.py
+++ b/backend/tests/regression/search_quality/run_search_eval.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
 from onyx.context.search.models import RerankingDetails
-from onyx.db.engine import get_session_with_current_tenant
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_multilingual_expansion
 from onyx.document_index.factory import get_default_document_index

--- a/backend/tests/regression/search_quality/util_data.py
+++ b/backend/tests/regression/search_quality/util_data.py
@@ -13,7 +13,7 @@ from onyx.chat.prompt_builder.answer_prompt_builder import AnswerPromptBuilder
 from onyx.chat.prompt_builder.answer_prompt_builder import default_build_system_message
 from onyx.chat.prompt_builder.answer_prompt_builder import default_build_user_message
 from onyx.configs.constants import DEFAULT_PERSONA_ID
-from onyx.db.engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.persona import get_persona_by_id
 from onyx.llm.factory import get_llms_for_persona
 from onyx.llm.interfaces import LLM

--- a/backend/tests/unit/onyx/auth/test_email.py
+++ b/backend/tests/unit/onyx/auth/test_email.py
@@ -4,7 +4,7 @@ from onyx.auth.email_utils import build_user_email_invite
 from onyx.auth.email_utils import send_email
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
-from onyx.db.engine import SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 
 

--- a/backend/tests/unit/onyx/indexing/test_vespa.py
+++ b/backend/tests/unit/onyx/indexing/test_vespa.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.document_index.document_index_utils import get_both_index_properties
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2112/switch-to-schema-translate-map-to-add-support-for-transaction-level

Also includes a refactor of the `engine.py` file to split it up into a few different files + removing a duplicate function.

Also removes `POSTGRES_IDLE_SESSIONS_TIMEOUT`, I don't think anyone is using it.

## How Has This Been Tested?

Tested locally w/ single-tenant + multi-tenant mode.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
