### PR TITLE
fix: Fix sidebar logic to hit kg-endpoint for admins only

### DIFF
--- a/web/src/app/admin/kg/page.tsx
+++ b/web/src/app/admin/kg/page.tsx
@@ -39,6 +39,7 @@ import { PopupSpec, usePopup } from "@/components/admin/connectors/Popup";
 import Title from "@/components/ui/title";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { useIsKGExposed } from "./utils";
 
 function createDomainField(
   name: string,
@@ -516,10 +517,7 @@ function Main() {
 }
 
 export default function Page() {
-  const { data: kgExposed, isLoading } = useSWR<boolean>(
-    "/api/admin/kg/exposed",
-    errorHandlingFetcher
-  );
+  const { kgExposed, isLoading } = useIsKGExposed();
 
   if (isLoading) {
     return <></>;

--- a/web/src/app/admin/kg/utils.ts
+++ b/web/src/app/admin/kg/utils.ts
@@ -1,0 +1,19 @@
+import { useUser } from "@/components/user/UserProvider";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import useSWR from "swr";
+
+export type KgExposedStatus = { kgExposed: boolean; isLoading: boolean };
+
+export function useIsKGExposed(): KgExposedStatus {
+  const { isAdmin } = useUser();
+  const { data: kgExposedRaw, isLoading } = useSWR<boolean>(
+    isAdmin ? "/api/admin/kg/exposed" : null,
+    errorHandlingFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      revalidateOnReconnect: false,
+    }
+  );
+  return { kgExposed: kgExposedRaw ?? false, isLoading };
+}

--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -42,6 +42,7 @@ import Link from "next/link";
 import { Button } from "../ui/button";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
+import { useIsKGExposed } from "@/app/admin/kg/utils";
 
 const connectors_items = () => [
   {
@@ -153,7 +154,7 @@ const collections = (
   enableCloud: boolean,
   enableEnterprise: boolean,
   settings: CombinedSettings | null,
-  kgExposed?: boolean | null
+  kgExposed: boolean
 ) => [
   {
     name: "Connectors",
@@ -392,13 +393,11 @@ export function ClientLayout({
   enableEnterprise: boolean;
   enableCloud: boolean;
 }) {
-  const { data: kgExposed, isLoading } = useSWR<boolean>(
-    "/api/admin/kg/exposed",
-    errorHandlingFetcher
-  );
+  const { kgExposed, isLoading } = useIsKGExposed();
 
   const isCurator =
     user?.role === UserRole.CURATOR || user?.role === UserRole.GLOBAL_CURATOR;
+
   const pathname = usePathname();
   const settings = useContext(SettingsContext);
   const [userSettingsOpen, setUserSettingsOpen] = useState(false);


### PR DESCRIPTION
## Description

This PR removes the constant refresh of the KG-exposed endpoint.

Addresses: https://linear.app/danswer/issue/DAN-2114/fix-fetching-of-kg-exposed-endpoint.

## How Has This Been Tested?

Not tested.