### PR TITLE
Update Docker Compose restart policy to unless-stopped

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:
@@ -165,7 +165,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     environment:
       - ENCRYPTION_KEY_SECRET=${ENCRYPTION_KEY_SECRET:-}
       - JWT_PUBLIC_KEY_URL=${JWT_PUBLIC_KEY_URL:-} # used for JWT authentication of users via API
@@ -317,7 +317,7 @@ services:
         - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     environment:
       - INTERNAL_URL=http://api_server:8080
       - WEB_DOMAIN=${WEB_DOMAIN:-}
@@ -340,7 +340,7 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
-    restart: always
+    restart: unless-stopped
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
       # Set to debug to get more fine-grained logs
@@ -371,7 +371,7 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
-    restart: always
+    restart: unless-stopped
     environment:
       - INDEX_BATCH_SIZE=${INDEX_BATCH_SIZE:-}
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -397,7 +397,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
@@ -411,7 +411,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -427,7 +427,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -456,7 +456,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables
@@ -465,7 +465,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - "9004:9000"
       - "9005:9001"

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -13,7 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:
@@ -131,7 +131,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     environment:
       - ENCRYPTION_KEY_SECRET=${ENCRYPTION_KEY_SECRET:-}
       # Gen AI Settings (Needed by OnyxBot)
@@ -251,7 +251,7 @@ services:
         - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     environment:
       - INTERNAL_URL=http://api_server:8080
       - WEB_DOMAIN=${WEB_DOMAIN:-}
@@ -342,7 +342,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
@@ -356,7 +356,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -372,7 +372,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -401,7 +401,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - "9004:9000"
       - "9005:9001"
@@ -420,7 +420,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -14,7 +14,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:
@@ -140,7 +140,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     environment:
       - ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
       - MULTI_TENANT=true
@@ -293,7 +293,7 @@ services:
         - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     environment:
       - INTERNAL_URL=http://api_server:8080
       - WEB_DOMAIN=${WEB_DOMAIN:-}
@@ -369,7 +369,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
@@ -383,7 +383,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -399,7 +399,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -428,7 +428,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - "9004:9000"
       - "9005:9001"
@@ -447,7 +447,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -13,7 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -46,7 +46,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -83,7 +83,7 @@ services:
         - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -98,7 +98,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
       - .env
@@ -167,7 +167,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -183,7 +183,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -218,7 +218,7 @@ services:
   # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
   certbot:
     image: certbot/certbot
-    restart: always
+    restart: unless-stopped
     volumes:
       - ../data/certbot/conf:/etc/letsencrypt
       - ../data/certbot/www:/var/www/certbot
@@ -231,7 +231,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -247,7 +247,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -13,7 +13,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -57,7 +57,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -103,7 +103,7 @@ services:
         - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -176,7 +176,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
       - .env
@@ -191,7 +191,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -207,7 +207,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -237,7 +237,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -253,7 +253,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -14,7 +14,7 @@ services:
       - index
       - cache
       - inference_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -61,7 +61,7 @@ services:
       - cache
       - inference_model_server
       - indexing_model_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -115,7 +115,7 @@ services:
         - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env
     environment:
@@ -130,7 +130,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
       - .env
@@ -154,7 +154,7 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
-    restart: always
+    restart: unless-stopped
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
       # Set to debug to get more fine-grained logs
@@ -182,7 +182,7 @@ services:
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
-    restart: always
+    restart: unless-stopped
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
       - INDEXING_ONLY=True
@@ -203,7 +203,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -219,7 +219,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -254,7 +254,7 @@ services:
   # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
   certbot:
     image: certbot/certbot
-    restart: always
+    restart: unless-stopped
     volumes:
       - ../data/certbot/conf:/etc/letsencrypt
       - ../data/certbot/www:/var/www/certbot
@@ -267,7 +267,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -283,7 +283,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -12,7 +12,7 @@ services:
       - relational_db
       - index
       - cache
-    restart: always
+    restart: unless-stopped
     ports:
       - "8080"
     env_file:
@@ -52,7 +52,7 @@ services:
       - relational_db
       - index
       - cache
-    restart: always
+    restart: unless-stopped
     env_file:
       - .env_eval
     environment:
@@ -99,7 +99,7 @@ services:
         - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
     depends_on:
       - api_server
-    restart: always
+    restart: unless-stopped
     environment:
       - INTERNAL_URL=http://api_server:8080
       - WEB_DOMAIN=${WEB_DOMAIN:-}
@@ -160,7 +160,7 @@ services:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    restart: always
+    restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
@@ -174,7 +174,7 @@ services:
   # This container name cannot have an underscore in it due to Vespa expectations of the URL
   index:
     image: vespaengine/vespa:8.526.15
-    restart: always
+    restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=true
     ports:
@@ -190,7 +190,7 @@ services:
 
   nginx:
     image: nginx:1.23.4-alpine
-    restart: always
+    restart: unless-stopped
     # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
     # if api_server / web_server are not up
     depends_on:
@@ -218,7 +218,7 @@ services:
 
   minio:
     image: minio/minio:latest
-    restart: always
+    restart: unless-stopped
     ports:
       - "9004:9000"
       - "9005:9001"
@@ -237,7 +237,7 @@ services:
 
   cache:
     image: redis:7.4-alpine
-    restart: always
+    restart: unless-stopped
     ports:
       - "6379:6379"
     # docker silently mounts /data even without an explicit volume mount, which enables


### PR DESCRIPTION
## Description

Changed the restart policy to `unless-stopped` to ensure containers automatically restart after failures or reboots but allow manual stop without immediate restart.

This is preferable over `always` because it prevents containers from restarting automatically after a manual stop, enabling controlled shutdowns and maintenance without unintended restarts.

## How Has This Been Tested?

### Case 1:

1. start docker containers
2. stop docker containers
3. restart docker engine
4. see that it doesnt automatically restart

### Case 2:

1. start docker containers
3. restart docker engine
4. see that it automatically restarts (like before)

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
