### PR TITLE
perm sync validation framework

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -425,6 +425,7 @@ def connector_permission_sync_generator_task(
                 created = validate_ccpair_for_user(
                     cc_pair.connector.id,
                     cc_pair.credential.id,
+                    cc_pair.access_type,
                     db_session,
                     enforce_creation=False,
                 )

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -60,6 +60,7 @@ from onyx.connectors.zulip.connector import ZulipConnector
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import backend_update_credential_json
 from onyx.db.credentials import fetch_credential_by_id
+from onyx.db.enums import AccessType
 from onyx.db.models import Credential
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -193,6 +194,7 @@ def instantiate_connector(
 def validate_ccpair_for_user(
     connector_id: int,
     credential_id: int,
+    access_type: AccessType,
     db_session: Session,
     enforce_creation: bool = True,
 ) -> bool:

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -59,6 +59,14 @@ class BaseConnector(abc.ABC, Generic[CT]):
         Default is a no-op (always successful).
         """
 
+    def validate_perm_sync(self) -> None:
+        """
+        Override this if your connector needs to validate permissions syncing.
+        Raise an exception if invalid, otherwise do nothing.
+
+        Default is a no-op (always successful).
+        """
+
     def set_allow_images(self, value: bool) -> None:
         """Implement if the underlying connector wants to skip/allow image downloading
         based on the application level image analysis setting."""

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -466,7 +466,9 @@ def associate_credential_to_connector(
     )
 
     try:
-        validate_ccpair_for_user(connector_id, credential_id, db_session)
+        validate_ccpair_for_user(
+            connector_id, credential_id, metadata.access_type, db_session
+        )
 
         response = add_credential_to_connector(
             db_session=db_session,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -953,6 +953,7 @@ def create_connector_with_mock_credential(
         validate_ccpair_for_user(
             connector_id=connector_id,
             credential_id=credential_id,
+            access_type=connector_data.access_type,
             db_session=db_session,
         )
         response = add_credential_to_connector(

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -104,6 +104,7 @@ def swap_credentials_for_connector(
     validate_ccpair_for_user(
         credential_swap_req.connector_id,
         credential_swap_req.new_credential_id,
+        credential_swap_req.access_type,
         db_session,
     )
 

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -106,6 +106,7 @@ class ConnectorSnapshot(ConnectorBase):
 class CredentialSwapRequest(BaseModel):
     new_credential_id: int
     connector_id: int
+    access_type: AccessType
 
 
 class CredentialDataUpdateRequest(BaseModel):

--- a/web/src/components/credentials/CredentialSection.tsx
+++ b/web/src/components/credentials/CredentialSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ValidSources } from "@/lib/types";
+import { AccessType, ValidSources } from "@/lib/types";
 import useSWR, { mutate } from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { FaKey } from "react-icons/fa";
@@ -79,9 +79,14 @@ export default function CredentialSection({
 
   const onSwap = async (
     selectedCredential: Credential<any>,
-    connectorId: number
+    connectorId: number,
+    accessType: AccessType
   ) => {
-    const response = await swapCredential(selectedCredential.id, connectorId);
+    const response = await swapCredential(
+      selectedCredential.id,
+      connectorId,
+      accessType
+    );
     if (response.ok) {
       mutate(buildSimilarCredentialInfoURL(sourceType));
       refresh();
@@ -224,7 +229,7 @@ export default function CredentialSection({
         >
           <ModifyCredential
             close={closeModifyCredential}
-            source={sourceType}
+            accessType={ccPair.access_type}
             attachedConnector={ccPair.connector}
             defaultedCredential={defaultedCredential}
             credentials={credentials}
@@ -272,6 +277,7 @@ export default function CredentialSection({
               ) : (
                 <CreateCredential
                   sourceType={sourceType}
+                  accessType={ccPair.access_type}
                   swapConnector={ccPair.connector}
                   setPopup={setPopup}
                   onSwap={onSwap}

--- a/web/src/components/credentials/actions/CreateCredential.tsx
+++ b/web/src/components/credentials/actions/CreateCredential.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { ValidSources } from "@/lib/types";
+import { ValidSources, AccessType } from "@/lib/types";
 import { FaAccusoft } from "react-icons/fa";
 import { submitCredential } from "@/components/admin/connectors/CredentialForm";
 import { BooleanFormField, TextFormField } from "@/components/Field";
@@ -59,6 +59,7 @@ type formType = IsPublicGroupSelectorFormType & {
 export default function CreateCredential({
   hideSource,
   sourceType,
+  accessType,
   setPopup,
   close,
   onClose = () => null,
@@ -70,7 +71,7 @@ export default function CreateCredential({
   // Source information
   hideSource?: boolean; // hides docs link
   sourceType: ValidSources;
-
+  accessType: AccessType;
   setPopup: (popupSpec: PopupSpec | null) => void;
 
   // Optional toggle- close section after selection?
@@ -81,7 +82,11 @@ export default function CreateCredential({
   // Switch currently selected credential
   onSwitch?: (selectedCredential: Credential<any>) => Promise<void>;
   // Switch currently selected credential + link with connector
-  onSwap?: (selectedCredential: Credential<any>, connectorId: number) => void;
+  onSwap?: (
+    selectedCredential: Credential<any>,
+    connectorId: number,
+    accessType: AccessType
+  ) => void;
 
   // For swapping credentials on selection
   swapConnector?: Connector<any>;
@@ -137,7 +142,7 @@ export default function CreateCredential({
 
       if (isSuccess && swapConnector) {
         if (action === "createAndSwap") {
-          onSwap(credential, swapConnector.id);
+          onSwap(credential, swapConnector.id, accessType);
         } else {
           setPopup({ type: "success", message: "Created new credential!" });
           setTimeout(() => setPopup(null), 4000);

--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -3,7 +3,7 @@ import { Modal } from "@/components/Modal";
 import { Button } from "@/components/ui/button";
 import Text from "@/components/ui/text";
 import { Badge } from "@/components/ui/badge";
-import { ValidSources } from "@/lib/types";
+import { AccessType } from "@/lib/types";
 import {
   EditIcon,
   NewChatIcon,
@@ -157,6 +157,7 @@ export default function ModifyCredential({
   credentials,
   editableCredentials,
   defaultedCredential,
+  accessType,
   onSwap,
   onSwitch,
   onEditCredential,
@@ -166,15 +167,19 @@ export default function ModifyCredential({
   close?: () => void;
   showIfEmpty?: boolean;
   attachedConnector?: Connector<any>;
-  defaultedCredential?: Credential<any>;
   credentials: Credential<any>[];
   editableCredentials: Credential<any>[];
-  source: ValidSources;
+  defaultedCredential?: Credential<any>;
+  accessType: AccessType;
+  onSwap?: (
+    newCredential: Credential<any>,
+    connectorId: number,
+    accessType: AccessType
+  ) => void;
   onSwitch?: (newCredential: Credential<any>) => void;
-  onSwap?: (newCredential: Credential<any>, connectorId: number) => void;
-  onCreateNew?: () => void;
-  onDeleteCredential: (credential: Credential<any | null>) => void;
   onEditCredential?: (credential: Credential<ConfluenceCredentialJson>) => void;
+  onDeleteCredential: (credential: Credential<any | null>) => void;
+  onCreateNew?: () => void;
 }) {
   const [selectedCredential, setSelectedCredential] =
     useState<Credential<any> | null>(null);
@@ -271,7 +276,7 @@ export default function ModifyCredential({
               disabled={selectedCredential == null}
               onClick={() => {
                 if (onSwap && attachedConnector) {
-                  onSwap(selectedCredential!, attachedConnector.id);
+                  onSwap(selectedCredential!, attachedConnector.id, accessType);
                   if (close) {
                     close();
                   }

--- a/web/src/lib/credential.ts
+++ b/web/src/lib/credential.ts
@@ -85,7 +85,11 @@ export function updateCredential(credentialId: number, newDetails: any) {
   });
 }
 
-export function swapCredential(newCredentialId: number, connectorId: number) {
+export function swapCredential(
+  newCredentialId: number,
+  connectorId: number,
+  accessType: AccessType
+) {
   return fetch(`/api/manage/admin/credential/swap`, {
     method: "PUT",
     headers: {
@@ -94,6 +98,7 @@ export function swapCredential(newCredentialId: number, connectorId: number) {
     body: JSON.stringify({
       new_credential_id: newCredentialId,
       connector_id: connectorId,
+      access_type: accessType,
     }),
   });
 }


### PR DESCRIPTION
## Description

Adds a new validation function to connectors that connector implementers can implement. The validation function is called for all CC pairs set up to use perm sync

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
