### PR TITLE
Fix test_gdrive_perm_sync_with_real_data patching

### DIFF
--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -74,16 +74,17 @@ def test_gdrive_perm_sync_with_real_data(
         doc_access_generator = gdrive_doc_sync(mock_cc_pair, lambda: [], mock_heartbeat)
         doc_access_list = list(doc_access_generator)
 
+    # Verify we got some results
+    assert len(doc_access_list) > 0
+    print(f"Found {len(doc_access_list)} documents with permissions")
+
     # create new connector
     with patch(
         "ee.onyx.external_permissions.google_drive.group_sync.GoogleDriveConnector",
         return_value=_build_connector(google_drive_service_acct_connector_factory),
     ):
-        external_user_groups = gdrive_group_sync("test_tenant", mock_cc_pair)
-
-    # Verify we got some results
-    assert len(doc_access_list) > 0
-    print(f"Found {len(doc_access_list)} documents with permissions")
+        external_user_group_generator = gdrive_group_sync("test_tenant", mock_cc_pair)
+        external_user_groups = list(external_user_group_generator)
 
     # map group ids to emails
     group_id_to_email_mapping: dict[str, set[str]] = defaultdict(set)


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
