### PR TITLE
Onyx Metadata Header for File Connector

### DIFF
--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -114,6 +114,7 @@ def process_onyx_metadata(
             primary_owners=p_owners,
             secondary_owners=s_owners,
             doc_updated_at=doc_updated_at,
+            title=metadata.get("title"),
         ),
         {
             k: v

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -171,10 +171,13 @@ def _process_file(
         custom_tags.update(more_custom_tags)
 
         # File-specific metadata overrides metadata processed so far
+        doc_id = onyx_metadata.doc_id or doc_id
+        source_type = onyx_metadata.source_type or source_type
         primary_owners = onyx_metadata.primary_owners or primary_owners
         secondary_owners = onyx_metadata.secondary_owners or secondary_owners
         time_updated = onyx_metadata.doc_updated_at or time_updated
         file_display_name = onyx_metadata.file_display_name or file_display_name
+        title = onyx_metadata.title or onyx_metadata.file_display_name or title
         link = onyx_metadata.link or link
 
     # Build sections: first the text as a single Section

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -364,8 +364,11 @@ class ConnectorFailure(BaseModel):
 
 
 class OnyxMetadata(BaseModel):
+    doc_id: str | None = None
+    source_type: DocumentSource | None = None
     link: str | None = None
     file_display_name: str | None = None
     primary_owners: list[BasicExpertInfo] | None = None
     secondary_owners: list[BasicExpertInfo] | None = None
     doc_updated_at: datetime | None = None
+    title: str | None = None


### PR DESCRIPTION
## Description
Now supports additional override fields such as title, source_type, doc_id

## How Has This Been Tested?
Locally with file connector

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
