### PR TITLE
account for category prefix added by user

### DIFF
--- a/backend/onyx/connectors/mediawiki/wiki.py
+++ b/backend/onyx/connectors/mediawiki/wiki.py
@@ -129,7 +129,14 @@ class MediaWikiConnector(LoadConnector, PollConnector):
         self.family = family_class_dispatch(hostname, "WikipediaConnector")()
         self.site = pywikibot.Site(fam=self.family, code=language_code)
         self.categories = [
-            pywikibot.Category(self.site, f"Category:{category.replace(' ', '_')}")
+            pywikibot.Category(
+                self.site,
+                (
+                    f"{category.replace(' ', '_')}"
+                    if category.startswith("Category:")
+                    else f"Category:{category.replace(' ', '_')}"
+                ),
+            )
             for category in categories
         ]
 


### PR DESCRIPTION
## Description

- Wikipedia connector now normalizes user input for categories

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
