### PR TITLE
Fix broken Drag&Drop file upload

### DIFF
--- a/web/src/app/chat/input/ChatInputBar.tsx
+++ b/web/src/app/chat/input/ChatInputBar.tsx
@@ -743,12 +743,16 @@ export function ChatInputBar({
                       <SourceChip
                         key={`${file.source}-${file.id}-${index}`}
                         icon={
-                          <FileIcon
-                            className={
-                              file.source === "current" ? "text-red-500" : ""
-                            }
-                            size={16}
-                          />
+                          file.isUploading ? (
+                            <FiLoader className="animate-spin" />
+                          ) : (
+                            <FileIcon
+                              className={
+                                file.source === "current" ? "text-red-500" : ""
+                              }
+                              size={16}
+                            />
+                          )
                         }
                         title={file.name}
                         onRemove={() => {


### PR DESCRIPTION
## Description

* Fixes the broken Drag&Drop file upload feature due to inconsistent/mixed up usage of both `/api/user/file/upload` and `/api/chat/file`, unifying uploads mechanism to use Chat API.
* Add a spinning loader for when file upload is ongoing

## How Has This Been Tested?

* Drag and drop a file directly in the chat box (Not the `+ File` feature)
* Check that a spinning wheel displays while file uploads, and blocks user interaction until upload completes;