### PR TITLE
Re-adding .epub file support

### DIFF
--- a/web/src/app/chat/my-documents/[id]/UserFolderContent.tsx
+++ b/web/src/app/chat/my-documents/[id]/UserFolderContent.tsx
@@ -30,6 +30,7 @@ const ALLOWED_FILE_TYPES = [
   ".pdf",
   ".doc",
   ".docx",
+  ".epub",
   ".txt",
   ".rtf",
   ".odt",


### PR DESCRIPTION
## Description
.epub files apparently were forgotten and were not allowed for upload in the frontend, even though the backend can process them.

## How Has This Been Tested?
Upload a .epub file
