### PR TITLE
fireflies metadata update

### DIFF
--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -35,6 +35,7 @@ _FIREFLIES_API_QUERY = """
             organizer_email
             participants
             date
+            duration
             transcript_url
             sentences {
                 text
@@ -101,7 +102,14 @@ def _create_doc_from_transcript(transcript: dict) -> Document | None:
         sections=cast(list[TextSection | ImageSection], sections),
         source=DocumentSource.FIREFLIES,
         semantic_identifier=meeting_title,
-        metadata={},
+        metadata={
+            k: v
+            for k, v in {
+                "meeting_date": meeting_date,
+                "duration_min": transcript.get("duration"),
+            }.items()
+            if v is not None
+        },
         doc_updated_at=meeting_date,
         primary_owners=organizer_email_user_info,
         secondary_owners=meeting_participants_email_list,

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -103,7 +103,7 @@ def _create_doc_from_transcript(transcript: dict) -> Document | None:
         source=DocumentSource.FIREFLIES,
         semantic_identifier=meeting_title,
         metadata={
-            k: v
+            k: str(v)
             for k, v in {
                 "meeting_date": meeting_date,
                 "duration_min": transcript.get("duration"),

--- a/backend/tests/daily/connectors/fireflies/test_fireflies_connector.py
+++ b/backend/tests/daily/connectors/fireflies/test_fireflies_connector.py
@@ -46,11 +46,12 @@ def test_fireflies_connector_basic(fireflies_connector: FirefliesConnector) -> N
     assert target_doc.semantic_identifier == test_data["semantic_identifier"]
     assert target_doc.primary_owners[0].email == test_data["primary_owners"]
     assert target_doc.secondary_owners == test_data["secondary_owners"]
+    assert str(target_doc.doc_updated_at) == test_data["doc_updated_at"]
 
     assert (
         target_doc.source == DocumentSource.FIREFLIES
     ), "Document source is not fireflies"
-    assert target_doc.metadata == {}
+    assert target_doc.metadata == test_data["metadata"]
 
     # Check that the test data and the connector data contain the same section data
     assert {section.text for section in target_doc.sections} == {

--- a/backend/tests/daily/connectors/fireflies/test_fireflies_data.json
+++ b/backend/tests/daily/connectors/fireflies/test_fireflies_data.json
@@ -3,6 +3,11 @@
   "semantic_identifier": "Lead Generation Efforts",
   "primary_owners": "admin@onyx-test.com",
   "secondary_owners": [],
+  "doc_updated_at": "2025-01-10 19:10:00+00:00",
+  "metadata": {
+    "meeting_date": "2025-01-10 19:10:00+00:00",
+    "duration_min": "10"
+  },
   "sections": [
     {
       "link": "https://app.fireflies.ai/view/VcBdZpuV82rImQCA?t=153.1",


### PR DESCRIPTION
## Description

Added date + duration

Date is part of the context string (doc_updated_at) already, but it seems like the model doesn't make the connection that updated_at = time of the meeting. Also, duration is the length of the meeting in minutes, floored to the nearest integer. Even if the last half of the meeting is silent, it will still count towards the duration. I think this is fine in most cases though.

## How Has This Been Tested?

Before:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/c77498d8-4ec4-4da1-a3fe-5689ab206f03" />

After:
<img width="239" alt="image" src="https://github.com/user-attachments/assets/74d843be-c70a-469f-b482-33ea25d319aa" />
<img width="275" alt="image" src="https://github.com/user-attachments/assets/43a24cf4-2ba7-4afa-acfe-0aefe5116809" />


## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
