### PR TITLE
Feature/GitHub permission sync

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -505,7 +505,7 @@ def connector_permission_sync_generator_task(
                 where_clause: ColumnElement[bool] | None = None,
                 limit: int | None = None,
             ) -> list[dict[str, Any]]:
-                return get_documents_for_connector_credential_pair_filtered(
+                result = get_documents_for_connector_credential_pair_filtered(
                     db_session=db_session,
                     connector_id=cc_pair.connector.id,
                     credential_id=cc_pair.credential.id,
@@ -513,6 +513,7 @@ def connector_permission_sync_generator_task(
                     limit=limit,
                     columns=columns,
                 )
+                return list(result)
 
             doc_sync_func = sync_config.doc_sync_config.doc_sync_func
             document_external_accesses = doc_sync_func(

--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -72,6 +72,19 @@ GOOGLE_DRIVE_PERMISSION_GROUP_SYNC_FREQUENCY = int(
 
 
 #####
+# GitHub
+#####
+# In seconds, default is 30 minutes
+GITHUB_PERMISSION_DOC_SYNC_FREQUENCY = int(
+    os.environ.get("GITHUB_PERMISSION_DOC_SYNC_FREQUENCY") or 30 * 60
+)
+# In seconds, default is 5 minutes
+GITHUB_PERMISSION_GROUP_SYNC_FREQUENCY = int(
+    os.environ.get("GITHUB_PERMISSION_GROUP_SYNC_FREQUENCY") or 5 * 60
+)
+
+
+#####
 # Slack
 #####
 SLACK_PERMISSION_DOC_SYNC_FREQUENCY = int(

--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -74,9 +74,9 @@ GOOGLE_DRIVE_PERMISSION_GROUP_SYNC_FREQUENCY = int(
 #####
 # GitHub
 #####
-# In seconds, default is 30 minutes
+# In seconds, default is 5 minutes
 GITHUB_PERMISSION_DOC_SYNC_FREQUENCY = int(
-    os.environ.get("GITHUB_PERMISSION_DOC_SYNC_FREQUENCY") or 30 * 60
+    os.environ.get("GITHUB_PERMISSION_DOC_SYNC_FREQUENCY") or 5 * 60
 )
 # In seconds, default is 5 minutes
 GITHUB_PERMISSION_GROUP_SYNC_FREQUENCY = int(

--- a/backend/ee/onyx/external_permissions/github/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/github/doc_sync.py
@@ -16,7 +16,7 @@ from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFuncti
 from onyx.access.models import DocExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.connector_runner import SlimCheckpointOutputWrapper
 from onyx.connectors.github.connector import GithubConnector
 from onyx.connectors.github.connector import GithubConnectorCheckpoint
 from onyx.connectors.github.models import SerializedRepository
@@ -86,7 +86,7 @@ def github_doc_sync(
             checkpoint=checkpoint,
         )
 
-        for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+        for slim_doc, failure, new_checkpoint in SlimCheckpointOutputWrapper[
             GithubConnectorCheckpoint
         ]()(slim_doc_generator):
             # New checkpoint means we've moved to a different repository
@@ -309,7 +309,6 @@ def is_repo_visibility_changed(
                 [onyx_organization_group_id]
             ),
         )
-        logger.info(f"Organization group ID: {onyx_organization_group_id}  ")
         logger.info(f"Found {len(existing_docs)} existing docs with organization group")
 
         if existing_docs:

--- a/backend/ee/onyx/external_permissions/github/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/github/doc_sync.py
@@ -1,19 +1,30 @@
-import os
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
 
 from github import Github
+from github.Repository import Repository
 
+from ee.onyx.external_permissions.github.utils import fetch_repository_team_slugs
+from ee.onyx.external_permissions.github.utils import form_collaborators_group_id
+from ee.onyx.external_permissions.github.utils import form_organization_group_id
+from ee.onyx.external_permissions.github.utils import (
+    form_outside_collaborators_group_id,
+)
+from ee.onyx.external_permissions.github.utils import get_repository_visibility
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
 from onyx.access.models import DocExternalAccess
+from onyx.access.utils import build_ext_group_name_for_onyx
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.connector_runner import CheckpointOutputWrapper
 from onyx.connectors.github.connector import GithubConnector
 from onyx.connectors.github.connector import GithubConnectorCheckpoint
-from onyx.connectors.github.connector import SerializedRepository
+from onyx.connectors.github.models import SerializedRepository
+from onyx.connectors.github.utils import deserialize_repository
 from onyx.connectors.interfaces import CheckpointedSlimConnector
 from onyx.connectors.models import SlimDocument
 from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 
@@ -21,35 +32,54 @@ logger = setup_logger()
 
 
 def github_doc_sync(
-    cc_pair: ConnectorCredentialPair | None = None,
-    fetch_all_existing_docs_fn: FetchAllDocumentsFunction | None = None,
+    cc_pair: ConnectorCredentialPair,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
     callback: IndexingHeartbeatInterface | None = None,
 ) -> Generator[DocExternalAccess, None, None]:
-    # github_connector = GithubConnector(
-    #     **cc_pair.connector.connector_specific_config
-    # )
-    # github_connector.load_credentials(cc_pair.credential.credential_json)
-    logger.info("Starting GitHub document sync...")
-    github_connector = GithubConnector(
-        repo_owner=os.environ["REPO_OWNER"],
-        repositories=os.environ.get("REPOSITORIES"),
-        include_issues=True,  # Enable issues processing
-    )
-    github_connector.load_credentials(
-        {"github_access_token": os.environ["ACCESS_TOKEN_GITHUB"]}
+    """
+    Sync GitHub documents with external access permissions.
+
+    Args:
+        cc_pair: Connector credential pair for GitHub authentication
+        fetch_all_existing_docs_fn: Function to fetch existing documents
+        callback: Indexing heartbeat interface for progress tracking
+
+    Yields:
+        DocExternalAccess: Document external access records
+    """
+
+    # Initialize GitHub connector with credentials
+    logger.info(f"Initializing GitHub connector for credential pair ID: {cc_pair.id}")
+    github_connector: GithubConnector = GithubConnector(
+        **cc_pair.connector.connector_specific_config
     )
 
+    github_connector.load_credentials(cc_pair.credential.credential_json)
+    logger.info("GitHub connector credentials loaded successfully")
+
+    if not github_connector.github_client:
+        logger.error("GitHub client initialization failed")
+        raise ValueError("github_client is required")
+
     if not isinstance(github_connector, CheckpointedSlimConnector):
+        logger.error(f"Invalid connector type: {type(github_connector)}")
         raise TypeError(
             f"Expected CheckpointedSlimConnector, got {type(github_connector)}"
         )
-    logger.info("GitHub connector initialized successfully.")
+
+    logger.info("Starting GitHub document sync with checkpointed retrieval")
+
+    # Initialize checkpoint and time boundaries for document retrieval
     checkpoint = github_connector.build_dummy_checkpoint()
     current_time = datetime.now(timezone.utc)
-    start_time = 0.0
-    logger.info(f"Checkpoint initialized: {checkpoint}")
+    start_time = 0.0  # Start from epoch time to get all documents
+    logger.info(
+        f"Checkpoint initialized: {checkpoint}, time range: {start_time} to {current_time.timestamp()}"
+    )
 
+    # Process documents in batches using checkpointing
     while checkpoint.has_more:
+        logger.info(f"Processing checkpoint batch, has_more: {checkpoint.has_more}")
         slim_doc_generator = github_connector.checkpointed_retrieve_all_slim_documents(
             start=start_time,
             end=current_time.timestamp(),
@@ -59,12 +89,33 @@ def github_doc_sync(
         for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
             GithubConnectorCheckpoint
         ]()(slim_doc_generator):
+            # New checkpoint means we've moved to a different repository
             if new_checkpoint:
-                logger.info(f"New checkpoint received: {new_checkpoint}")
+                logger.info(f"Received new checkpoint: {new_checkpoint}")
                 checkpoint = new_checkpoint
-                continue
 
-            if slim_doc:
+                # Process repository visibility and team changes if checkpoint has cached repo
+                if checkpoint.has_more and checkpoint.cached_repo:
+                    repo: Repository = deserialize_repository(
+                        checkpoint.cached_repo, github_connector.github_client
+                    )
+                    logger.info(
+                        f"Processing cached repository: {repo.id} (name: {repo.name})"
+                    )
+
+                    checkpoint = _check_repo_permission_changes(
+                        repo=repo,
+                        github_client=github_connector.github_client,
+                        fetch_all_existing_docs_fn=fetch_all_existing_docs_fn,
+                        checkpoint=checkpoint,
+                    )
+                    continue
+                else:
+                    logger.info("No cached repository or no more data, continuing")
+                    continue
+
+            # Yield document external access records
+            if slim_doc and slim_doc.external_access:
                 if isinstance(slim_doc, SlimDocument):
                     yield DocExternalAccess(
                         doc_id=slim_doc.id,
@@ -72,33 +123,214 @@ def github_doc_sync(
                     )
 
 
-def _get_repo_with_updated_teams(
-    github_client: Github, checkpoint: GithubConnectorCheckpoint
+def _check_repo_permission_changes(
+    repo: Repository,
+    github_client: Github,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+    checkpoint: GithubConnectorCheckpoint,
 ) -> GithubConnectorCheckpoint:
+    """
+    Check if repository has any permission changes (visibility or team updates).
 
-    if not _teams_updated(checkpoint.cached_repo, github_client):
+    Returns:
+        Updated checkpoint with next repository to process
+    """
+    # Check for repository visibility changes, if it's changed,
+    # we need to re-sync the repository permissions for all documents in the repository
+    if is_repo_visibility_changed(
+        repo=repo,
+        github_client=github_client,
+        fetch_all_existing_docs_fn=fetch_all_existing_docs_fn,
+    ):
+        logger.info(
+            f"Repository {repo.id} (name: {repo.name}) visibility has changed, continuing to next batch"
+        )
         return checkpoint
 
+    # Check for team membership changes, if it's changed,
+    # we need to re-sync the repository permissions for all documents in the repository
+    if get_repository_visibility(repo) == "private" and _teams_updated(
+        repo, github_client, fetch_all_existing_docs_fn
+    ):
+        logger.info(
+            f"Teams updated for repository {repo.id} (name: {repo.name}), returning checkpoint"
+        )
+        return checkpoint
+
+    # If no changes, move to next repository in the checkpoint and do the same check
     if checkpoint.cached_repo_ids:
         next_id = checkpoint.cached_repo_ids.pop()
+        logger.info(f"Moving to next cached repository: {next_id}")
         next_repo = github_client.get_repo(next_id)
+        logger.info(f"Next repository: {next_id} (name: {next_repo.name})")
+        repo = next_repo
         checkpoint.cached_repo = SerializedRepository(
             id=next_id,
             headers=next_repo.raw_headers,
             raw_data=next_repo.raw_data,
         )
+        return _check_repo_permission_changes(
+            repo=repo,
+            github_client=github_client,
+            fetch_all_existing_docs_fn=fetch_all_existing_docs_fn,
+            checkpoint=checkpoint,
+        )
 
-    return _get_repo_with_updated_teams(
-        github_client=github_client, checkpoint=checkpoint
+    # If no more repositories to process, return the checkpoint
+    logger.info("No more repositories to process, marking checkpoint as complete")
+    checkpoint.has_more = False
+    checkpoint.cached_repo = None
+    return checkpoint
+
+
+def _teams_updated(
+    repo: Repository,
+    github_client: Github,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+) -> bool:
+    """
+    Check if repository team memberships have changed.
+
+    Returns:
+        True if team count differs from existing documents
+    """
+    # Fetch current team slugs for the repository
+    current_teams = fetch_repository_team_slugs(repo=repo, github_client=github_client)
+    logger.info(
+        f"Current teams for repository {repo.id} (name: {repo.name}): {current_teams}"
     )
 
+    # Build collaborators group ID for comparison
+    collaborators_group_id = form_collaborators_group_id(repo.id)
+    onyx_collaborators_group_id = build_ext_group_name_for_onyx(
+        source=DocumentSource.GITHUB, ext_group_name=collaborators_group_id
+    )
 
-def _teams_updated(repo: SerializedRepository, github_client: Github) -> bool:
-    return False
+    # Fetch existing documents with collaborators group
+    existing_docs = fetch_all_existing_docs_fn(
+        columns=[Document.id, Document.external_user_group_ids],
+        where_clause=Document.external_user_group_ids.contains(
+            [onyx_collaborators_group_id]
+        ),
+        limit=1,
+    )
+    logger.info(f"Found {len(existing_docs)} existing docs with collaborators group")
+
+    # Extract existing team IDs from documents
+    existing_team_ids = set()
+    for doc in existing_docs:
+        if doc.get("external_user_group_ids"):
+            for group_id in doc["external_user_group_ids"]:
+                # Skip collaborators and outside collaborators groups, focus on team groups
+                if group_id not in [
+                    onyx_collaborators_group_id,
+                    build_ext_group_name_for_onyx(
+                        source=DocumentSource.GITHUB,
+                        ext_group_name=form_outside_collaborators_group_id(repo.id),
+                    ),
+                ]:
+                    existing_team_ids.add(group_id)
+
+    logger.info(
+        f"Existing team IDs: {existing_team_ids}, Current teams: {current_teams}"
+    )
+
+    # Compare team counts to detect changes
+    teams_changed = len(current_teams) != len(existing_team_ids)
+    if teams_changed:
+        logger.info(
+            f"Team count changed for repo {repo.id} (name: {repo.name}): {len(existing_team_ids)} -> {len(current_teams)}"
+        )
+
+    return teams_changed
 
 
-if __name__ == "__main__":
-    # Consume the generator to actually execute the sync
-    for doc_access in github_doc_sync():
-        logger.info(f"Processed document: {doc_access.doc_id}")
-    logger.info("GitHub document sync completed.")
+def is_repo_visibility_changed(
+    repo: Repository,
+    github_client: Github,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction,
+) -> bool:
+    """
+    Check if repository visibility has changed by comparing current visibility
+    with inferred previous visibility from existing document permissions.
+
+    Returns:
+        True if visibility has changed
+    """
+    logger.info(
+        f"Checking visibility change for repository {repo.id} (name: {repo.name})"
+    )
+
+    # Get current repository visibility
+    current_repo_visibility = get_repository_visibility(repo)
+    logger.info(f"Current repository visibility: {current_repo_visibility}")
+
+    # Default to public visibility
+    existing_repo_visibility: str = "public"
+
+    # Check for collaborators group (indicates private repo)
+    onyx_collaborators_group_id = build_ext_group_name_for_onyx(
+        source=DocumentSource.GITHUB,
+        ext_group_name=form_collaborators_group_id(repo.id),
+    )
+    existing_docs = fetch_all_existing_docs_fn(
+        columns=[Document.id, Document.external_user_group_ids],
+        limit=1,
+        where_clause=Document.external_user_group_ids.contains(
+            [onyx_collaborators_group_id]
+        ),
+    )
+
+    if existing_docs:
+        existing_repo_visibility = "private"
+        logger.info(
+            "Found documents with collaborators group, inferring private visibility"
+        )
+        visibility_changed = existing_repo_visibility != current_repo_visibility
+        if visibility_changed:
+            logger.info(
+                f"Visibility changed for repo {repo.id} (name: {repo.name}): "
+                f"{existing_repo_visibility} -> {current_repo_visibility}"
+            )
+        return visibility_changed
+
+    # Check for organization group (indicates internal repo)
+    org = repo.organization
+    logger.info(f"Organization for repository {repo.id} (name: {repo.name}): {org}")
+    if org:
+        onyx_organization_group_id = build_ext_group_name_for_onyx(
+            source=DocumentSource.GITHUB,
+            ext_group_name=form_organization_group_id(org.id),
+        )
+        existing_docs = fetch_all_existing_docs_fn(
+            columns=[Document.id, Document.external_user_group_ids],
+            limit=1,
+            where_clause=Document.external_user_group_ids.contains(
+                [onyx_organization_group_id]
+            ),
+        )
+        logger.info(f"Organization group ID: {onyx_organization_group_id}  ")
+        logger.info(f"Found {len(existing_docs)} existing docs with organization group")
+
+        if existing_docs:
+            existing_repo_visibility = "internal"
+            logger.info(
+                "Found documents with organization group, inferring internal visibility"
+            )
+            visibility_changed = existing_repo_visibility != current_repo_visibility
+            if visibility_changed:
+                logger.info(
+                    f"Visibility changed for repo {repo.id} (name: {repo.name}): "
+                    f"{existing_repo_visibility} -> {current_repo_visibility}"
+                )
+            return visibility_changed
+
+    # No specific groups found, assume public visibility
+    logger.info("No specific groups found, assuming public visibility")
+    visibility_changed = existing_repo_visibility != current_repo_visibility
+    if visibility_changed:
+        logger.info(
+            f"Visibility changed for repo {repo.id} (name: {repo.name}): "
+            f"{existing_repo_visibility} -> {current_repo_visibility}"
+        )
+    return visibility_changed

--- a/backend/ee/onyx/external_permissions/github/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/github/doc_sync.py
@@ -1,0 +1,104 @@
+import os
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+
+from github import Github
+
+from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
+from onyx.access.models import DocExternalAccess
+from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.github.connector import GithubConnector
+from onyx.connectors.github.connector import GithubConnectorCheckpoint
+from onyx.connectors.github.connector import SerializedRepository
+from onyx.connectors.interfaces import CheckpointedSlimConnector
+from onyx.connectors.models import SlimDocument
+from onyx.db.models import ConnectorCredentialPair
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def github_doc_sync(
+    cc_pair: ConnectorCredentialPair | None = None,
+    fetch_all_existing_docs_fn: FetchAllDocumentsFunction | None = None,
+    callback: IndexingHeartbeatInterface | None = None,
+) -> Generator[DocExternalAccess, None, None]:
+    # github_connector = GithubConnector(
+    #     **cc_pair.connector.connector_specific_config
+    # )
+    # github_connector.load_credentials(cc_pair.credential.credential_json)
+    logger.info("Starting GitHub document sync...")
+    github_connector = GithubConnector(
+        repo_owner=os.environ["REPO_OWNER"],
+        repositories=os.environ.get("REPOSITORIES"),
+        include_issues=True,  # Enable issues processing
+    )
+    github_connector.load_credentials(
+        {"github_access_token": os.environ["ACCESS_TOKEN_GITHUB"]}
+    )
+
+    if not isinstance(github_connector, CheckpointedSlimConnector):
+        raise TypeError(
+            f"Expected CheckpointedSlimConnector, got {type(github_connector)}"
+        )
+    logger.info("GitHub connector initialized successfully.")
+    checkpoint = github_connector.build_dummy_checkpoint()
+    current_time = datetime.now(timezone.utc)
+    start_time = 0.0
+    logger.info(f"Checkpoint initialized: {checkpoint}")
+
+    while checkpoint.has_more:
+        slim_doc_generator = github_connector.checkpointed_retrieve_all_slim_documents(
+            start=start_time,
+            end=current_time.timestamp(),
+            checkpoint=checkpoint,
+        )
+
+        for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+            GithubConnectorCheckpoint
+        ]()(slim_doc_generator):
+            if new_checkpoint:
+                logger.info(f"New checkpoint received: {new_checkpoint}")
+                checkpoint = new_checkpoint
+                continue
+
+            if slim_doc:
+                if isinstance(slim_doc, SlimDocument):
+                    yield DocExternalAccess(
+                        doc_id=slim_doc.id,
+                        external_access=slim_doc.external_access,
+                    )
+
+
+def _get_repo_with_updated_teams(
+    github_client: Github, checkpoint: GithubConnectorCheckpoint
+) -> GithubConnectorCheckpoint:
+
+    if not _teams_updated(checkpoint.cached_repo, github_client):
+        return checkpoint
+
+    if checkpoint.cached_repo_ids:
+        next_id = checkpoint.cached_repo_ids.pop()
+        next_repo = github_client.get_repo(next_id)
+        checkpoint.cached_repo = SerializedRepository(
+            id=next_id,
+            headers=next_repo.raw_headers,
+            raw_data=next_repo.raw_data,
+        )
+
+    return _get_repo_with_updated_teams(
+        github_client=github_client, checkpoint=checkpoint
+    )
+
+
+def _teams_updated(repo: SerializedRepository, github_client: Github) -> bool:
+    return False
+
+
+if __name__ == "__main__":
+    # Consume the generator to actually execute the sync
+    for doc_access in github_doc_sync():
+        logger.info(f"Processed document: {doc_access.doc_id}")
+    logger.info("GitHub document sync completed.")

--- a/backend/ee/onyx/external_permissions/github/group_sync.py
+++ b/backend/ee/onyx/external_permissions/github/group_sync.py
@@ -1,0 +1,43 @@
+from collections.abc import Generator
+
+from github import Repository
+
+from ee.onyx.db.external_perm import ExternalUserGroup
+from ee.onyx.external_permissions.github.utils import get_external_user_group
+from onyx.connectors.github.connector import GithubConnector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def github_group_sync(
+    tenant_id: str,
+    cc_pair: ConnectorCredentialPair,
+) -> Generator[ExternalUserGroup, None, None]:
+    github_connector: GithubConnector = GithubConnector(
+        **cc_pair.connector.connector_specific_config
+    )
+    github_connector.load_credentials(cc_pair.credential.credential_json)
+    if not github_connector.github_client:
+        raise ValueError("github_client is required")
+    github_connector.load_credentials(cc_pair.credential.credential_json)
+    logger.info("Starting GitHub group sync...")
+    repos: list[Repository.Repository] = []
+    if github_connector.repositories:
+        if "," in github_connector.repositories:
+            # Multiple repositories specified
+            repos = github_connector.get_github_repos(github_connector.github_client)
+        else:
+            # Single repository (backward compatibility)
+            repos = [github_connector.get_github_repo(github_connector.github_client)]
+    else:
+        # All repositories
+        repos = github_connector.get_all_repos(github_connector.github_client)
+
+    for repo in repos:
+        for external_group in get_external_user_group(
+            repo, github_connector.github_client
+        ):
+            logger.warning(f"External group: {external_group}")
+            yield external_group

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -1,19 +1,62 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import List
 from typing import Optional
+from typing import Tuple
+from typing import TypeVar
 
 from github import Github
 from github import RateLimitExceededException
 from github.GithubException import GithubException
+from github.Organization import Organization
 from github.Repository import Repository
 
+from ee.onyx.db.external_perm import ExternalUserGroup
+from onyx.access.models import ExternalAccess
 from onyx.connectors.github.rate_limit_utils import sleep_after_rate_limit_exception
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Maximum number of retries for rate limit handling
 MAX_RETRY_COUNT = 3
+
+T = TypeVar("T")
+
+# Higher-order function to wrap GitHub operations with retry and exception handling
+
+
+def _run_with_retry(
+    operation: Callable[[], T],
+    description: str,
+    github_client: Github,
+    retry_count: int = 0,
+) -> Optional[T]:
+    """Execute a GitHub operation with retry on rate limit and exception handling."""
+    logger.debug(f"Starting operation '{description}', attempt {retry_count + 1}")
+    try:
+        result = operation()
+        logger.debug(f"Operation '{description}' completed successfully")
+        return result
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while {description}. Retrying... "
+                f"(attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _run_with_retry(
+                operation, description, github_client, retry_count + 1
+            )
+        else:
+            error_msg = f"Max retries exceeded for {description}"
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"GitHub API error during {description}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Unexpected error during {description}: {e}")
+        return None
 
 
 @dataclass
@@ -34,622 +77,366 @@ class TeamInfo:
     members: List[UserInfo]
 
 
-@dataclass
-class RepositoryPermissionsBase:
-    """Base class for repository permissions with common fields and methods."""
-
-    repository_name: str
-    repository_id: int
-    repository_owner: str
-    repository_owner_type: str  # "Organization" or "User"
-    is_public: bool = False
-    organization_name: Optional[str] = None
-
-    @property
-    def collaborators_group_id(self) -> str:
-        """Generate group ID for repository collaborators."""
-        if not self.repository_owner or not self.repository_id:
-            raise ValueError(
-                "Repository owner and ID must be set to generate group ID."
-            )
-        return f"{self.repository_owner}_{self.repository_id}_collaborators"
-
-    @property
-    def owners_group_id(self) -> str:
-        """Generate group ID for repository owners."""
-        if not self.repository_owner or not self.repository_id:
-            raise ValueError(
-                "Repository owner and ID must be set to generate group ID."
-            )
-        return f"{self.repository_owner}_{self.repository_id}_owners"
-
-    @property
-    def outside_collaborators_group_id(self) -> str:
-        """Generate group ID for repository outside collaborators."""
-        if not self.repository_owner or not self.repository_id:
-            raise ValueError(
-                "Repository owner and ID must be set to generate group ID."
-            )
-        return f"{self.repository_owner}_{self.repository_id}_outside_collaborators"
-
-
-@dataclass
-class RepositoryPermissions(RepositoryPermissionsBase):
-    """Comprehensive repository permissions data structure."""
-
-    org_members: List[UserInfo] = None
-    teams: List[TeamInfo] = None
-    collaborators: List[UserInfo] = None
-    outside_collaborators: List[UserInfo] = None
-
-    def __post_init__(self):
-        """Initialize empty lists if None."""
-        if self.org_members is None:
-            self.org_members = []
-        if self.teams is None:
-            self.teams = []
-        if self.collaborators is None:
-            self.collaborators = []
-        if self.outside_collaborators is None:
-            self.outside_collaborators = []
-
-
-@dataclass
-class RepositoryPermissionsSummary(RepositoryPermissionsBase):
-    """Lightweight repository permissions summary with boolean flags for member presence."""
-
-    has_org_members: bool = False
-    has_teams: bool = False
-    has_collaborators: bool = False
-    has_outside_collaborators: bool = False
-    team_count: int = 0
-    teams: List[TeamInfo] = None
-
-    def __post_init__(self):
-        """Initialize empty lists if None."""
-        if self.teams is None:
-            self.teams = []
-
-
 def _fetch_organization_members(
     github_client: Github, org_name: str, retry_count: int = 0
 ) -> List[UserInfo]:
     """Fetch all organization members including owners and regular members."""
-    org_members = []
-    try:
-        logger.info(f"Fetching organization members for {org_name}")
-        org = github_client.get_organization(org_name)
+    org_members: List[UserInfo] = []
+    logger.info(f"Fetching organization members for {org_name}")
 
-        # Get all members (both public and private)
-        all_members = org.get_members(filter_="all")
-        for member in all_members:
-            member_info = UserInfo(
-                login=member.login, name=member.name, email=member.email
-            )
-            org_members.append(member_info)
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while fetching organization members for "
-                f"{org_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-            )
-            return _fetch_organization_members(github_client, org_name, retry_count + 1)
-        else:
-            error_msg = (
-                f"Max retries exceeded for fetching organization members for {org_name}"
-            )
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except GithubException as e:
-        logger.warning(f"Could not fetch organization members for {org_name}: {e}")
+    org = _run_with_retry(
+        lambda: github_client.get_organization(org_name),
+        f"get organization {org_name}",
+        github_client,
+    )
+    if not org:
+        logger.warning(f"Failed to fetch organization {org_name}")
+        return org_members
+
+    member_objs = (
+        _run_with_retry(
+            lambda: org.get_members(filter_="all"),
+            f"get members for organization {org_name}",
+            github_client,
+        )
+        or []
+    )
+
+    for member in member_objs:
+        user_info = UserInfo(login=member.login, name=member.name, email=member.email)
+        org_members.append(user_info)
+
+    logger.info(f"Fetched {len(org_members)} members for organization {org_name}")
     return org_members
 
 
-def _fetch_repository_teams(
+def _fetch_repository_teams_detailed(
     repo: Repository, github_client: Github, retry_count: int = 0
 ) -> List[TeamInfo]:
     """Fetch teams with access to the repository and their members."""
-    teams_data = []
-    try:
-        logger.info(f"Fetching teams for repository {repo.full_name}")
-        teams = repo.get_teams()
-        for team in teams:
-            team_members = []
-            try:
-                team_member_objects = team.get_members()
-                logger.info(f"Fetching members for team {team_member_objects}")
-                for member in team_member_objects:
-                    logger.info(
-                        f"Processing member {member.login} for team {team.name}"
-                    )
-                    user_info = UserInfo(
-                        login=member.login, name=member.name, email=member.email
-                    )
-                    team_members.append(user_info)
-            except RateLimitExceededException:
-                if retry_count < MAX_RETRY_COUNT:
-                    sleep_after_rate_limit_exception(github_client)
-                    logger.warning(
-                        f"Rate limit exceeded while fetching team members for "
-                        f"{team.name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-                    )
-                    return _fetch_repository_teams(repo, github_client, retry_count + 1)
-                else:
-                    error_msg = f"Max retries exceeded for fetching team members for {team.name}"
-                    logger.exception(error_msg)
-                    raise RuntimeError(error_msg)
-            except GithubException as e:
-                logger.warning(f"Could not fetch team members for {team.name}: {e}")
+    teams_data: List[TeamInfo] = []
+    logger.info(f"Fetching teams for repository {repo.full_name}")
 
-            team_info = TeamInfo(name=team.name, slug=team.slug, members=team_members)
-            teams_data.append(team_info)
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while fetching teams for "
-                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+    team_objs = (
+        _run_with_retry(
+            lambda: repo.get_teams(),
+            f"get teams for repository {repo.full_name}",
+            github_client,
+        )
+        or []
+    )
+
+    for team in team_objs:
+        logger.info(
+            f"Processing team {team.name} (slug: {team.slug}) for repository {repo.full_name}"
+        )
+
+        members = (
+            _run_with_retry(
+                lambda: team.get_members(),
+                f"get members for team {team.name}",
+                github_client,
             )
-            return _fetch_repository_teams(repo, github_client, retry_count + 1)
-        else:
-            error_msg = f"Max retries exceeded for fetching teams for {repo.full_name}"
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except GithubException as e:
-        logger.warning(f"Could not fetch teams: {e}")
+            or []
+        )
+
+        team_members = []
+        for m in members:
+            user_info = UserInfo(login=m.login, name=m.name, email=m.email)
+            team_members.append(user_info)
+
+        team_info = TeamInfo(name=team.name, slug=team.slug, members=team_members)
+        teams_data.append(team_info)
+        logger.debug(f"Team {team.name} has {len(team_members)} members")
+
+    logger.info(f"Fetched {len(teams_data)} teams for repository {repo.full_name}")
     return teams_data
 
 
-def _categorize_collaborators(
+def fetch_repository_team_slugs(
+    repo: Repository, github_client: Github, retry_count: int = 0
+) -> List[str]:
+    """Fetch team slugs with access to the repository."""
+    logger.info(f"Fetching team slugs for repository {repo.full_name}")
+    teams_data: List[str] = []
+
+    team_objs = (
+        _run_with_retry(
+            lambda: repo.get_teams(),
+            f"get teams for repository {repo.full_name}",
+            github_client,
+        )
+        or []
+    )
+
+    for team in team_objs:
+        teams_data.append(team.slug)
+
+    logger.info(f"Fetched {len(teams_data)} team slugs for repository {repo.full_name}")
+    return teams_data
+
+
+def _get_collaborators_and_outside_collaborators(
     github_client: Github,
     repo: Repository,
-    org_members: List[UserInfo],
-    retry_count: int = 0,
-) -> tuple[List[UserInfo], List[UserInfo]]:
-    """Fetch and categorize collaborators into regular collaborators and outside collaborators."""
-    collaborators = []
-    outside_collaborators = []
+) -> Tuple[List[UserInfo], List[UserInfo]]:
+    """Fetch and categorize collaborators into regular and outside collaborators."""
+    collaborators: List[UserInfo] = []
+    outside_collaborators: List[UserInfo] = []
+    logger.info(f"Fetching collaborators for repository {repo.full_name}")
 
-    try:
-        logger.info(f"Fetching collaborators for repository {repo.full_name}")
-        repo_collaborators = repo.get_collaborators()
+    repo_collaborators = (
+        _run_with_retry(
+            lambda: repo.get_collaborators(),
+            f"get collaborators for repository {repo.full_name}",
+            github_client,
+        )
+        or []
+    )
 
-        for collaborator in repo_collaborators:
-            # For organization repos, check if this is an outside collaborator
-            is_outside = False
+    for collaborator in repo_collaborators:
+        is_outside = False
 
-            if repo.organization:
-                try:
-                    org = github_client.get_organization(repo.organization.login)
-                    is_outside = not org.has_in_members(collaborator)
-                except RateLimitExceededException:
-                    if retry_count < MAX_RETRY_COUNT:
-                        sleep_after_rate_limit_exception(github_client)
-                        logger.warning(
-                            f"Rate limit exceeded while checking collaborator "
-                            f"{collaborator.login}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-                        )
-                        return _categorize_collaborators(
-                            github_client, repo, org_members, retry_count + 1
-                        )
-                    else:
-                        error_msg = f"Max retries exceeded for checking collaborator {collaborator.login}"
-                        logger.exception(error_msg)
-                        raise RuntimeError(error_msg)
-                except GithubException:
-                    # If we can't check membership, assume it's a regular collaborator
-                    is_outside = False
-
-            collaborator_info = UserInfo(
-                login=collaborator.login,
-                name=collaborator.name,
-                email=collaborator.email,
+        # Check if collaborator is outside the organization
+        if repo.organization:
+            org: Organization | None = _run_with_retry(
+                lambda: github_client.get_organization(repo.organization.login),
+                f"get organization {repo.organization.login}",
+                github_client,
             )
 
-            # Categorize based on organization membership
-            if repo.organization and is_outside:
-                outside_collaborators.append(collaborator_info)
-            else:
-                collaborators.append(collaborator_info)
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while fetching collaborators for "
-                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-            )
-            return _categorize_collaborators(
-                github_client, repo, org_members, retry_count + 1
-            )
+            if org is not None:
+                org_obj = org  # type: ignore
+                membership = _run_with_retry(
+                    lambda: org_obj.has_in_members(collaborator),
+                    f"check membership for {collaborator.login} in org {org_obj.login}",
+                    github_client,
+                )
+                is_outside = membership is not None and not membership
+
+        info = UserInfo(
+            login=collaborator.login, name=collaborator.name, email=collaborator.email
+        )
+        if repo.organization and is_outside:
+            outside_collaborators.append(info)
         else:
-            error_msg = (
-                f"Max retries exceeded for fetching collaborators for {repo.full_name}"
-            )
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
+            collaborators.append(info)
 
-    except GithubException as e:
-        logger.warning(f"Could not fetch collaborators: {e}")
-
+    logger.info(
+        f"Categorized {len(collaborators)} regular and {len(outside_collaborators)} outside collaborators for {repo.full_name}"
+    )
     return collaborators, outside_collaborators
 
 
-def _log_permissions_summary(permissions_data: RepositoryPermissions, repo: Repository):
-    """Log a summary of the repository permissions."""
-    repo_type = "organization" if repo.organization else "personal"
-    logger.info(
-        f"Repository permissions summary for {repo.full_name} ({repo_type} repository):"
-    )
-    logger.info(
-        f"  Repository owner: {permissions_data.repository_owner} ({permissions_data.repository_owner_type})"
-    )
-    if repo.organization:
-        logger.info(f"  Organization: {permissions_data.organization_name}")
-        logger.info(f"  Organization members: {len(permissions_data.org_members)}")
-        logger.info(f"  Teams: {len(permissions_data.teams)}")
-        logger.info(
-            f"  Outside collaborators: {len(permissions_data.outside_collaborators)}"
+def form_collaborators_group_id(repository_id: int) -> str:
+    """Generate group ID for repository collaborators."""
+    if not repository_id:
+        logger.error("Repository ID is required to generate collaborators group ID")
+        raise ValueError("Repository ID must be set to generate group ID.")
+    group_id = f"{repository_id}_collaborators"
+    return group_id
+
+
+def form_organization_group_id(organization_id: int) -> str:
+    """Generate group ID for organization using organization ID."""
+    if not organization_id:
+        logger.error("Organization ID is required to generate organization group ID")
+        raise ValueError("Organization ID must be set to generate group ID.")
+    group_id = f"{organization_id}_organization"
+    return group_id
+
+
+def form_outside_collaborators_group_id(repository_id: int) -> str:
+    """Generate group ID for outside collaborators."""
+    if not repository_id:
+        logger.error(
+            "Repository ID is required to generate outside collaborators group ID"
         )
-    logger.info(f"  Collaborators: {len(permissions_data.collaborators)}")
+        raise ValueError("Repository ID must be set to generate group ID.")
+    group_id = f"{repository_id}_outside_collaborators"
+    return group_id
 
 
-def _check_repository_visibility(repo: Repository, retry_count: int = 0) -> bool:
-    """Check if the repository is public."""
-    try:
-        return not repo.private
-    except RateLimitExceededException as e:
-        if retry_count < MAX_RETRY_COUNT:
-            logger.warning(
-                f"Rate limit exceeded while checking visibility for {repo.full_name}: {e}"
-            )
-            sleep_after_rate_limit_exception(repo._github)
-            return _check_repository_visibility(repo, retry_count + 1)
-        else:
-            error_msg = (
-                f"Max retries exceeded for checking visibility of {repo.full_name}"
-            )
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except Exception as e:
-        logger.warning(
-            f"Could not determine repository visibility for {repo.full_name}: {e}"
-        )
-        return False
-
-
-def get_repository_permissions(
-    github_client: Github, repo: Repository
-) -> RepositoryPermissions:
+def get_repository_visibility(repo: Repository) -> str:
     """
-    Get comprehensive repository permissions including organization members, teams,
-    collaborators, and outside collaborators with their email addresses.
-    Handles both organization and personal repositories.
-
-    Args:
-        github_client: Authenticated GitHub client
-        repo: Repository object
-
-    Returns:
-        RepositoryPermissions object containing permission information
+    Get the visibility of a repository.
+    Returns "public", "private", or "internal".
     """
-    logger.info(f"Fetching permissions for repository: {repo} {type(repo)}")
-    permissions_data = RepositoryPermissions(
-        repository_name=repo.full_name,
-        repository_id=repo.id,
-        repository_owner=repo.owner.login,
-        repository_owner_type=repo.owner.type,
-        is_public=_check_repository_visibility(repo),
-    )
-    # If the repository is public, we can skip fetching detailed permissions
-    if permissions_data.is_public:
-        logger.info(
-            f"Repository {repo.full_name} is public, skipping permissions fetch."
+    if hasattr(repo, "visibility"):
+        visibility = repo.visibility
+        logger.debug(
+            f"Repository {repo.full_name} visibility from attribute: {visibility}"
         )
-        return permissions_data
+        return visibility
 
-    try:
-        # Check if the repository belongs to an organization
-        if repo.organization:
-            org_name = repo.organization.login
-            permissions_data.organization_name = org_name
+    # Fallback to private field for older GitHub API versions
+    if not repo.private:
+        logger.debug(f"Repository {repo.full_name} is public")
+        return "public"
 
-            try:
-                # Get organization members (including owners)
-                permissions_data.org_members = _fetch_organization_members(
-                    github_client, org_name
-                )
-
-                # Get teams with access to this repository
-                permissions_data.teams = _fetch_repository_teams(repo, github_client)
-
-            except GithubException as e:
-                logger.warning(f"Could not access organization {org_name}: {e}")
-        else:
-            # Handle personal repositories by adding owner information
-            permissions_data.collaborators = _handle_personal_repository(
-                repo, github_client
-            )
-
-        # Get direct collaborators (works for both org and personal repos)
-        collaborators, outside_collaborators = _categorize_collaborators(
-            github_client, repo, permissions_data.org_members
-        )
-
-        if repo.organization:
-            permissions_data.outside_collaborators.extend(outside_collaborators)
-
-        permissions_data.collaborators.extend(collaborators)
-
-    except Exception as e:
-        logger.exception(f"Unexpected error while fetching repository permissions: {e}")
-
-    # Log summary
-    _log_permissions_summary(permissions_data, repo)
-
-    return permissions_data
+    logger.debug(f"Repository {repo.full_name} is private")
+    return "private"
 
 
-def get_repository_permissions_summary(
-    github_client: Github, repo: Repository
-) -> RepositoryPermissionsSummary:
-    """
-    Get a lightweight summary of repository permissions with boolean flags
-    indicating presence of members without fetching detailed member information.
-    This is more efficient when you only need to know if groups have members.
-
-    Args:
-        github_client: Authenticated GitHub client
-        repo: Repository object
-
-    Returns:
-        RepositoryPermissionsSummary object containing permission flags
-    """
-    logger.info(f"Fetching permissions summary for repository: {repo.full_name}")
-    permissions_summary = RepositoryPermissionsSummary(
-        repository_name=repo.full_name,
-        repository_id=repo.id,
-        repository_owner=repo.owner.login,
-        repository_owner_type=repo.owner.type,
-        is_public=_check_repository_visibility(repo),
-    )
-
-    # If the repository is public, we can skip fetching detailed permissions
-    if permissions_summary.is_public:
-        logger.info(
-            f"Repository {repo.full_name} is public, skipping permissions check."
-        )
-        return permissions_summary
-
-    try:
-        # Check if the repository belongs to an organization
-        if repo.organization:
-            org_name = repo.organization.login
-            permissions_summary.organization_name = org_name
-
-            try:
-                # Check if organization has members
-                permissions_summary.has_org_members = _check_organization_members_exist(
-                    github_client, org_name
-                )
-
-                # Check if repository has teams
-                (
-                    permissions_summary.has_teams,
-                    permissions_summary.team_count,
-                    permissions_summary.teams,
-                ) = _check_repository_teams_exist(repo, github_client)
-
-            except GithubException as e:
-                logger.warning(f"Could not access organization {org_name}: {e}")
-        else:
-            # For personal repositories, there's always at least the owner as collaborator
-            permissions_summary.has_collaborators = True
-
-        # Check for direct collaborators (works for both org and personal repos)
-        has_collaborators, has_outside_collaborators = _check_collaborators_exist(
-            github_client, repo
-        )
-        logger.info(
-            f"Repository {repo.full_name} has collaborators: {has_collaborators}, "
-            f"outside collaborators: {has_outside_collaborators}"
-        )
-        permissions_summary.has_collaborators = (
-            permissions_summary.has_collaborators or has_collaborators
-        )
-        if repo.organization:
-            permissions_summary.has_outside_collaborators = has_outside_collaborators
-
-    except Exception as e:
-        logger.exception(
-            f"Unexpected error while fetching repository permissions summary: {e}"
-        )
-
-    # Log summary
-    repo_type = "organization" if repo.organization else "personal"
-    logger.info(
-        f"Repository permissions summary for {repo.full_name} ({repo_type} repository):"
-    )
-    logger.info(
-        f"  Repository owner: {permissions_summary.repository_owner} ({permissions_summary.repository_owner_type})"
-    )
-    if repo.organization:
-        logger.info(f"  Organization: {permissions_summary.organization_name}")
-        logger.info(
-            f"  Has organization members: {permissions_summary.has_org_members}"
-        )
-        logger.info(
-            f"  Has teams: {permissions_summary.has_teams} (count: {permissions_summary.team_count})"
-        )
-        if permissions_summary.teams:
-            team_names = [
-                f"{team.name} ({team.slug})" for team in permissions_summary.teams
-            ]
-            logger.info(f"  Team details: {', '.join(team_names)}")
-        logger.info(
-            f"  Has outside collaborators: {permissions_summary.has_outside_collaborators}"
-        )
-    logger.info(f"  Has collaborators: {permissions_summary.has_collaborators}")
-
-    return permissions_summary
-
-
-def _check_organization_members_exist(
-    github_client: Github, org_name: str, retry_count: int = 0
-) -> bool:
-    """Check if organization has members without fetching all member details."""
-    try:
-        logger.info(f"Checking if organization {org_name} has members")
-        org = github_client.get_organization(org_name)
-        members = org.get_members(filter_="all")
-        # Just check if there's at least one member
-        try:
-            next(iter(members))
-            return True
-        except StopIteration:
-            return False
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while checking organization members for "
-                f"{org_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-            )
-            return _check_organization_members_exist(
-                github_client, org_name, retry_count + 1
-            )
-        else:
-            error_msg = (
-                f"Max retries exceeded for checking organization members for {org_name}"
-            )
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except GithubException as e:
-        logger.warning(f"Could not check organization members for {org_name}: {e}")
-        return False
-
-
-def _check_repository_teams_exist(
-    repo: Repository, github_client: Github, retry_count: int = 0
-) -> tuple[bool, int, List[TeamInfo]]:
-    """Check if repository has teams and return team names/slugs without fetching team member details."""
-    try:
-        logger.info(f"Checking teams for repository {repo.full_name}")
-        teams = repo.get_teams()
-        team_count = 0
-        has_teams = False
-        team_infos = []
-
-        try:
-            # Get team info without fetching members
-            for team in teams:
-                team_count += 1
-                has_teams = True
-                team_info = TeamInfo(
-                    name=team.name,
-                    slug=team.slug,
-                    members=[],  # Empty list since we're not fetching members for summary
-                )
-                team_infos.append(team_info)
-        except StopIteration:
-            pass
-
-        return has_teams, team_count, team_infos
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while checking teams for "
-                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-            )
-            return _check_repository_teams_exist(repo, github_client, retry_count + 1)
-        else:
-            error_msg = f"Max retries exceeded for checking teams for {repo.full_name}"
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except GithubException as e:
-        logger.warning(f"Could not check teams: {e}")
-        return False, 0, []
-
-
-def _check_collaborators_exist(
-    github_client: Github, repo: Repository, retry_count: int = 0
-) -> tuple[bool, bool]:
-    """Check if repository has collaborators and outside collaborators without fetching details."""
-    has_collaborators = False
-    has_outside_collaborators = False
-
-    try:
-        logger.info(f"Checking collaborators for repository {repo.full_name}")
-        repo_collaborators = repo.get_collaborators()
-        logger.info(
-            f"Found {repo_collaborators.totalCount} collaborators for {repo.full_name}"
-        )
-        for collaborator in repo_collaborators:
-            has_collaborators = True
-
-            # For organization repos, check if this is an outside collaborator
-            if repo.organization:
-                try:
-                    org = github_client.get_organization(repo.organization.login)
-                    is_outside = not org.has_in_members(collaborator)
-                    if is_outside:
-                        has_outside_collaborators = True
-                        # If we found both types, we can break early
-                        if has_collaborators and has_outside_collaborators:
-                            break
-                except RateLimitExceededException:
-                    if retry_count < MAX_RETRY_COUNT:
-                        sleep_after_rate_limit_exception(github_client)
-                        logger.warning(
-                            f"Rate limit exceeded while checking collaborator "
-                            f"{collaborator.login}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-                        )
-                        return _check_collaborators_exist(
-                            github_client, repo, retry_count + 1
-                        )
-                    else:
-                        error_msg = f"Max retries exceeded for checking collaborator {collaborator.login}"
-                        logger.exception(error_msg)
-                        raise RuntimeError(error_msg)
-                except GithubException:
-                    # If we can't check membership, assume it's a regular collaborator
-                    pass
-            else:
-                # For personal repos, break after finding first collaborator
-                break
-
-    except RateLimitExceededException:
-        if retry_count < MAX_RETRY_COUNT:
-            sleep_after_rate_limit_exception(github_client)
-            logger.warning(
-                f"Rate limit exceeded while checking collaborators for "
-                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
-            )
-            return _check_collaborators_exist(github_client, repo, retry_count + 1)
-        else:
-            error_msg = (
-                f"Max retries exceeded for checking collaborators for {repo.full_name}"
-            )
-            logger.exception(error_msg)
-            raise RuntimeError(error_msg)
-    except GithubException as e:
-        logger.warning(f"Could not check collaborators: {e}")
-
-    return has_collaborators, has_outside_collaborators
-
-
-def _handle_personal_repository(
+def get_external_access_permission(
     repo: Repository, github_client: Github
-) -> List[UserInfo]:
-    """Handle personal repositories by adding owner information."""
-    try:
-        owner_info = UserInfo(
-            login=repo.owner.login,
-            name=repo.owner.name,
-            email=repo.owner.email,
+) -> ExternalAccess:
+    """
+    Get the external access permission for a repository.
+    Uses group-based permissions for efficiency and scalability.
+    """
+    # We maintain collaborators, and outside collaborators as two separate groups
+    # instead of adding individual user emails to ExternalAccess.external_user_emails for two reasons:
+    # 1. Changes in repo collaborators (additions/removals) would require updating all documents.
+    # 2. Repo permissions can change without updating the repo's updated_at timestamp,
+    #    forcing full permission syncs for all documents every time, which is inefficient.
+
+    user_emails: set[str] = set()
+    group_ids: set[str] = set()
+
+    repo_visibility = get_repository_visibility(repo)
+    logger.info(
+        f"Generating ExternalAccess for {repo.full_name}: visibility={repo_visibility}"
+    )
+
+    if repo_visibility == "public":
+        logger.info(
+            f"Repository {repo.full_name} is public - allowing access to all users"
         )
-        return [owner_info]
-    except Exception as e:
-        logger.warning(f"Could not fetch owner information for {repo.full_name}: {e}")
-        return []
+        return ExternalAccess(
+            external_user_emails=user_emails,
+            external_user_group_ids=group_ids,
+            is_public=True,
+        )
+    elif repo_visibility == "private":
+        logger.info(
+            f"Repository {repo.full_name} is private - setting up restricted access"
+        )
+
+        collaborators_group_id = form_collaborators_group_id(repo.id)
+        outside_collaborators_group_id = form_outside_collaborators_group_id(repo.id)
+
+        group_ids.add(collaborators_group_id)
+        group_ids.add(outside_collaborators_group_id)
+
+        team_slugs = fetch_repository_team_slugs(repo, github_client)
+        group_ids.update(team_slugs)
+
+        logger.debug(f"ExternalAccess groups for {repo.full_name}: {group_ids}")
+        return ExternalAccess(
+            external_user_emails=user_emails,
+            external_user_group_ids=group_ids,
+            is_public=False,
+        )
+    else:
+        # Internal repositories - accessible to organization members
+        logger.info(
+            f"Repository {repo.full_name} is internal - accessible to org members"
+        )
+        org_group_id = form_organization_group_id(repo.organization.id)
+        group_ids.add(org_group_id)
+
+        logger.debug(f"ExternalAccess groups for {repo.full_name}: {group_ids}")
+        return ExternalAccess(
+            external_user_emails=user_emails,
+            external_user_group_ids=group_ids,
+            is_public=False,
+        )
+
+
+def get_external_user_group(
+    repo: Repository, github_client: Github
+) -> list[ExternalUserGroup]:
+    """
+    Get the external user group for a repository.
+    Creates ExternalUserGroup objects with actual user emails for each permission group.
+    """
+    repo_visibility = get_repository_visibility(repo)
+    logger.info(
+        f"Generating ExternalUserGroups for {repo.full_name}: visibility={repo_visibility}"
+    )
+
+    if repo_visibility == "private":
+        logger.info(f"Processing private repository {repo.full_name}")
+
+        collaborators, outside_collaborators = (
+            _get_collaborators_and_outside_collaborators(github_client, repo)
+        )
+        teams = _fetch_repository_teams_detailed(repo, github_client)
+        external_user_groups = []
+
+        user_emails = set()
+        for collab in collaborators:
+            if collab.email:
+                user_emails.add(collab.email)
+
+        if user_emails:
+            collaborators_group = ExternalUserGroup(
+                id=form_collaborators_group_id(repo.id),
+                user_emails=list(user_emails),
+            )
+            external_user_groups.append(collaborators_group)
+            logger.info(f"Created collaborators group with {len(user_emails)} emails")
+
+        # Create group for outside collaborators
+        user_emails = set()
+        for collab in outside_collaborators:
+            if collab.email:
+                user_emails.add(collab.email)
+
+        if user_emails:
+            outside_collaborators_group = ExternalUserGroup(
+                id=form_outside_collaborators_group_id(repo.id),
+                user_emails=list(user_emails),
+            )
+            external_user_groups.append(outside_collaborators_group)
+            logger.info(
+                f"Created outside collaborators group with {len(user_emails)} emails"
+            )
+
+        # Create groups for teams
+        for team in teams:
+            user_emails = set()
+            for member in team.members:
+                if member.email:
+                    user_emails.add(member.email)
+
+            if user_emails:
+                team_group = ExternalUserGroup(
+                    id=team.slug,
+                    user_emails=list(user_emails),
+                )
+                external_user_groups.append(team_group)
+                logger.info(
+                    f"Created team group {team.name} with {len(user_emails)} emails"
+                )
+
+        logger.info(
+            f"Created {len(external_user_groups)} ExternalUserGroups for private repository {repo.full_name}"
+        )
+        return external_user_groups
+
+    if repo_visibility == "internal":
+        logger.info(f"Processing internal repository {repo.full_name}")
+
+        org_group_id = form_organization_group_id(repo.organization.id)
+        org_members = _fetch_organization_members(
+            github_client, repo.organization.login
+        )
+
+        user_emails = set()
+        for member in org_members:
+            if member.email:
+                user_emails.add(member.email)
+
+        org_group = ExternalUserGroup(
+            id=org_group_id,
+            user_emails=list(user_emails),
+        )
+        logger.info(
+            f"Created organization group with {len(user_emails)} emails for internal repository {repo.full_name}"
+        )
+        return [org_group]
+
+    logger.info(f"Repository {repo.full_name} is public - no user groups needed")
+    return []

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -1,0 +1,655 @@
+from dataclasses import dataclass
+from typing import List
+from typing import Optional
+
+from github import Github
+from github import RateLimitExceededException
+from github.GithubException import GithubException
+from github.Repository import Repository
+
+from onyx.connectors.github.rate_limit_utils import sleep_after_rate_limit_exception
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Maximum number of retries for rate limit handling
+MAX_RETRY_COUNT = 3
+
+
+@dataclass
+class UserInfo:
+    """Represents a GitHub user with their basic information."""
+
+    login: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+
+@dataclass
+class TeamInfo:
+    """Represents a GitHub team with its members."""
+
+    name: str
+    slug: str
+    members: List[UserInfo]
+
+
+@dataclass
+class RepositoryPermissionsBase:
+    """Base class for repository permissions with common fields and methods."""
+
+    repository_name: str
+    repository_id: int
+    repository_owner: str
+    repository_owner_type: str  # "Organization" or "User"
+    is_public: bool = False
+    organization_name: Optional[str] = None
+
+    @property
+    def collaborators_group_id(self) -> str:
+        """Generate group ID for repository collaborators."""
+        if not self.repository_owner or not self.repository_id:
+            raise ValueError(
+                "Repository owner and ID must be set to generate group ID."
+            )
+        return f"{self.repository_owner}_{self.repository_id}_collaborators"
+
+    @property
+    def owners_group_id(self) -> str:
+        """Generate group ID for repository owners."""
+        if not self.repository_owner or not self.repository_id:
+            raise ValueError(
+                "Repository owner and ID must be set to generate group ID."
+            )
+        return f"{self.repository_owner}_{self.repository_id}_owners"
+
+    @property
+    def outside_collaborators_group_id(self) -> str:
+        """Generate group ID for repository outside collaborators."""
+        if not self.repository_owner or not self.repository_id:
+            raise ValueError(
+                "Repository owner and ID must be set to generate group ID."
+            )
+        return f"{self.repository_owner}_{self.repository_id}_outside_collaborators"
+
+
+@dataclass
+class RepositoryPermissions(RepositoryPermissionsBase):
+    """Comprehensive repository permissions data structure."""
+
+    org_members: List[UserInfo] = None
+    teams: List[TeamInfo] = None
+    collaborators: List[UserInfo] = None
+    outside_collaborators: List[UserInfo] = None
+
+    def __post_init__(self):
+        """Initialize empty lists if None."""
+        if self.org_members is None:
+            self.org_members = []
+        if self.teams is None:
+            self.teams = []
+        if self.collaborators is None:
+            self.collaborators = []
+        if self.outside_collaborators is None:
+            self.outside_collaborators = []
+
+
+@dataclass
+class RepositoryPermissionsSummary(RepositoryPermissionsBase):
+    """Lightweight repository permissions summary with boolean flags for member presence."""
+
+    has_org_members: bool = False
+    has_teams: bool = False
+    has_collaborators: bool = False
+    has_outside_collaborators: bool = False
+    team_count: int = 0
+    teams: List[TeamInfo] = None
+
+    def __post_init__(self):
+        """Initialize empty lists if None."""
+        if self.teams is None:
+            self.teams = []
+
+
+def _fetch_organization_members(
+    github_client: Github, org_name: str, retry_count: int = 0
+) -> List[UserInfo]:
+    """Fetch all organization members including owners and regular members."""
+    org_members = []
+    try:
+        logger.info(f"Fetching organization members for {org_name}")
+        org = github_client.get_organization(org_name)
+
+        # Get all members (both public and private)
+        all_members = org.get_members(filter_="all")
+        for member in all_members:
+            member_info = UserInfo(
+                login=member.login, name=member.name, email=member.email
+            )
+            org_members.append(member_info)
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while fetching organization members for "
+                f"{org_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _fetch_organization_members(github_client, org_name, retry_count + 1)
+        else:
+            error_msg = (
+                f"Max retries exceeded for fetching organization members for {org_name}"
+            )
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"Could not fetch organization members for {org_name}: {e}")
+    return org_members
+
+
+def _fetch_repository_teams(
+    repo: Repository, github_client: Github, retry_count: int = 0
+) -> List[TeamInfo]:
+    """Fetch teams with access to the repository and their members."""
+    teams_data = []
+    try:
+        logger.info(f"Fetching teams for repository {repo.full_name}")
+        teams = repo.get_teams()
+        for team in teams:
+            team_members = []
+            try:
+                team_member_objects = team.get_members()
+                logger.info(f"Fetching members for team {team_member_objects}")
+                for member in team_member_objects:
+                    logger.info(
+                        f"Processing member {member.login} for team {team.name}"
+                    )
+                    user_info = UserInfo(
+                        login=member.login, name=member.name, email=member.email
+                    )
+                    team_members.append(user_info)
+            except RateLimitExceededException:
+                if retry_count < MAX_RETRY_COUNT:
+                    sleep_after_rate_limit_exception(github_client)
+                    logger.warning(
+                        f"Rate limit exceeded while fetching team members for "
+                        f"{team.name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+                    )
+                    return _fetch_repository_teams(repo, github_client, retry_count + 1)
+                else:
+                    error_msg = f"Max retries exceeded for fetching team members for {team.name}"
+                    logger.exception(error_msg)
+                    raise RuntimeError(error_msg)
+            except GithubException as e:
+                logger.warning(f"Could not fetch team members for {team.name}: {e}")
+
+            team_info = TeamInfo(name=team.name, slug=team.slug, members=team_members)
+            teams_data.append(team_info)
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while fetching teams for "
+                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _fetch_repository_teams(repo, github_client, retry_count + 1)
+        else:
+            error_msg = f"Max retries exceeded for fetching teams for {repo.full_name}"
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"Could not fetch teams: {e}")
+    return teams_data
+
+
+def _categorize_collaborators(
+    github_client: Github,
+    repo: Repository,
+    org_members: List[UserInfo],
+    retry_count: int = 0,
+) -> tuple[List[UserInfo], List[UserInfo]]:
+    """Fetch and categorize collaborators into regular collaborators and outside collaborators."""
+    collaborators = []
+    outside_collaborators = []
+
+    try:
+        logger.info(f"Fetching collaborators for repository {repo.full_name}")
+        repo_collaborators = repo.get_collaborators()
+
+        for collaborator in repo_collaborators:
+            # For organization repos, check if this is an outside collaborator
+            is_outside = False
+
+            if repo.organization:
+                try:
+                    org = github_client.get_organization(repo.organization.login)
+                    is_outside = not org.has_in_members(collaborator)
+                except RateLimitExceededException:
+                    if retry_count < MAX_RETRY_COUNT:
+                        sleep_after_rate_limit_exception(github_client)
+                        logger.warning(
+                            f"Rate limit exceeded while checking collaborator "
+                            f"{collaborator.login}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+                        )
+                        return _categorize_collaborators(
+                            github_client, repo, org_members, retry_count + 1
+                        )
+                    else:
+                        error_msg = f"Max retries exceeded for checking collaborator {collaborator.login}"
+                        logger.exception(error_msg)
+                        raise RuntimeError(error_msg)
+                except GithubException:
+                    # If we can't check membership, assume it's a regular collaborator
+                    is_outside = False
+
+            collaborator_info = UserInfo(
+                login=collaborator.login,
+                name=collaborator.name,
+                email=collaborator.email,
+            )
+
+            # Categorize based on organization membership
+            if repo.organization and is_outside:
+                outside_collaborators.append(collaborator_info)
+            else:
+                collaborators.append(collaborator_info)
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while fetching collaborators for "
+                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _categorize_collaborators(
+                github_client, repo, org_members, retry_count + 1
+            )
+        else:
+            error_msg = (
+                f"Max retries exceeded for fetching collaborators for {repo.full_name}"
+            )
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+
+    except GithubException as e:
+        logger.warning(f"Could not fetch collaborators: {e}")
+
+    return collaborators, outside_collaborators
+
+
+def _log_permissions_summary(permissions_data: RepositoryPermissions, repo: Repository):
+    """Log a summary of the repository permissions."""
+    repo_type = "organization" if repo.organization else "personal"
+    logger.info(
+        f"Repository permissions summary for {repo.full_name} ({repo_type} repository):"
+    )
+    logger.info(
+        f"  Repository owner: {permissions_data.repository_owner} ({permissions_data.repository_owner_type})"
+    )
+    if repo.organization:
+        logger.info(f"  Organization: {permissions_data.organization_name}")
+        logger.info(f"  Organization members: {len(permissions_data.org_members)}")
+        logger.info(f"  Teams: {len(permissions_data.teams)}")
+        logger.info(
+            f"  Outside collaborators: {len(permissions_data.outside_collaborators)}"
+        )
+    logger.info(f"  Collaborators: {len(permissions_data.collaborators)}")
+
+
+def _check_repository_visibility(repo: Repository, retry_count: int = 0) -> bool:
+    """Check if the repository is public."""
+    try:
+        return not repo.private
+    except RateLimitExceededException as e:
+        if retry_count < MAX_RETRY_COUNT:
+            logger.warning(
+                f"Rate limit exceeded while checking visibility for {repo.full_name}: {e}"
+            )
+            sleep_after_rate_limit_exception(repo._github)
+            return _check_repository_visibility(repo, retry_count + 1)
+        else:
+            error_msg = (
+                f"Max retries exceeded for checking visibility of {repo.full_name}"
+            )
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except Exception as e:
+        logger.warning(
+            f"Could not determine repository visibility for {repo.full_name}: {e}"
+        )
+        return False
+
+
+def get_repository_permissions(
+    github_client: Github, repo: Repository
+) -> RepositoryPermissions:
+    """
+    Get comprehensive repository permissions including organization members, teams,
+    collaborators, and outside collaborators with their email addresses.
+    Handles both organization and personal repositories.
+
+    Args:
+        github_client: Authenticated GitHub client
+        repo: Repository object
+
+    Returns:
+        RepositoryPermissions object containing permission information
+    """
+    logger.info(f"Fetching permissions for repository: {repo} {type(repo)}")
+    permissions_data = RepositoryPermissions(
+        repository_name=repo.full_name,
+        repository_id=repo.id,
+        repository_owner=repo.owner.login,
+        repository_owner_type=repo.owner.type,
+        is_public=_check_repository_visibility(repo),
+    )
+    # If the repository is public, we can skip fetching detailed permissions
+    if permissions_data.is_public:
+        logger.info(
+            f"Repository {repo.full_name} is public, skipping permissions fetch."
+        )
+        return permissions_data
+
+    try:
+        # Check if the repository belongs to an organization
+        if repo.organization:
+            org_name = repo.organization.login
+            permissions_data.organization_name = org_name
+
+            try:
+                # Get organization members (including owners)
+                permissions_data.org_members = _fetch_organization_members(
+                    github_client, org_name
+                )
+
+                # Get teams with access to this repository
+                permissions_data.teams = _fetch_repository_teams(repo, github_client)
+
+            except GithubException as e:
+                logger.warning(f"Could not access organization {org_name}: {e}")
+        else:
+            # Handle personal repositories by adding owner information
+            permissions_data.collaborators = _handle_personal_repository(
+                repo, github_client
+            )
+
+        # Get direct collaborators (works for both org and personal repos)
+        collaborators, outside_collaborators = _categorize_collaborators(
+            github_client, repo, permissions_data.org_members
+        )
+
+        if repo.organization:
+            permissions_data.outside_collaborators.extend(outside_collaborators)
+
+        permissions_data.collaborators.extend(collaborators)
+
+    except Exception as e:
+        logger.exception(f"Unexpected error while fetching repository permissions: {e}")
+
+    # Log summary
+    _log_permissions_summary(permissions_data, repo)
+
+    return permissions_data
+
+
+def get_repository_permissions_summary(
+    github_client: Github, repo: Repository
+) -> RepositoryPermissionsSummary:
+    """
+    Get a lightweight summary of repository permissions with boolean flags
+    indicating presence of members without fetching detailed member information.
+    This is more efficient when you only need to know if groups have members.
+
+    Args:
+        github_client: Authenticated GitHub client
+        repo: Repository object
+
+    Returns:
+        RepositoryPermissionsSummary object containing permission flags
+    """
+    logger.info(f"Fetching permissions summary for repository: {repo.full_name}")
+    permissions_summary = RepositoryPermissionsSummary(
+        repository_name=repo.full_name,
+        repository_id=repo.id,
+        repository_owner=repo.owner.login,
+        repository_owner_type=repo.owner.type,
+        is_public=_check_repository_visibility(repo),
+    )
+
+    # If the repository is public, we can skip fetching detailed permissions
+    if permissions_summary.is_public:
+        logger.info(
+            f"Repository {repo.full_name} is public, skipping permissions check."
+        )
+        return permissions_summary
+
+    try:
+        # Check if the repository belongs to an organization
+        if repo.organization:
+            org_name = repo.organization.login
+            permissions_summary.organization_name = org_name
+
+            try:
+                # Check if organization has members
+                permissions_summary.has_org_members = _check_organization_members_exist(
+                    github_client, org_name
+                )
+
+                # Check if repository has teams
+                (
+                    permissions_summary.has_teams,
+                    permissions_summary.team_count,
+                    permissions_summary.teams,
+                ) = _check_repository_teams_exist(repo, github_client)
+
+            except GithubException as e:
+                logger.warning(f"Could not access organization {org_name}: {e}")
+        else:
+            # For personal repositories, there's always at least the owner as collaborator
+            permissions_summary.has_collaborators = True
+
+        # Check for direct collaborators (works for both org and personal repos)
+        has_collaborators, has_outside_collaborators = _check_collaborators_exist(
+            github_client, repo
+        )
+        logger.info(
+            f"Repository {repo.full_name} has collaborators: {has_collaborators}, "
+            f"outside collaborators: {has_outside_collaborators}"
+        )
+        permissions_summary.has_collaborators = (
+            permissions_summary.has_collaborators or has_collaborators
+        )
+        if repo.organization:
+            permissions_summary.has_outside_collaborators = has_outside_collaborators
+
+    except Exception as e:
+        logger.exception(
+            f"Unexpected error while fetching repository permissions summary: {e}"
+        )
+
+    # Log summary
+    repo_type = "organization" if repo.organization else "personal"
+    logger.info(
+        f"Repository permissions summary for {repo.full_name} ({repo_type} repository):"
+    )
+    logger.info(
+        f"  Repository owner: {permissions_summary.repository_owner} ({permissions_summary.repository_owner_type})"
+    )
+    if repo.organization:
+        logger.info(f"  Organization: {permissions_summary.organization_name}")
+        logger.info(
+            f"  Has organization members: {permissions_summary.has_org_members}"
+        )
+        logger.info(
+            f"  Has teams: {permissions_summary.has_teams} (count: {permissions_summary.team_count})"
+        )
+        if permissions_summary.teams:
+            team_names = [
+                f"{team.name} ({team.slug})" for team in permissions_summary.teams
+            ]
+            logger.info(f"  Team details: {', '.join(team_names)}")
+        logger.info(
+            f"  Has outside collaborators: {permissions_summary.has_outside_collaborators}"
+        )
+    logger.info(f"  Has collaborators: {permissions_summary.has_collaborators}")
+
+    return permissions_summary
+
+
+def _check_organization_members_exist(
+    github_client: Github, org_name: str, retry_count: int = 0
+) -> bool:
+    """Check if organization has members without fetching all member details."""
+    try:
+        logger.info(f"Checking if organization {org_name} has members")
+        org = github_client.get_organization(org_name)
+        members = org.get_members(filter_="all")
+        # Just check if there's at least one member
+        try:
+            next(iter(members))
+            return True
+        except StopIteration:
+            return False
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while checking organization members for "
+                f"{org_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _check_organization_members_exist(
+                github_client, org_name, retry_count + 1
+            )
+        else:
+            error_msg = (
+                f"Max retries exceeded for checking organization members for {org_name}"
+            )
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"Could not check organization members for {org_name}: {e}")
+        return False
+
+
+def _check_repository_teams_exist(
+    repo: Repository, github_client: Github, retry_count: int = 0
+) -> tuple[bool, int, List[TeamInfo]]:
+    """Check if repository has teams and return team names/slugs without fetching team member details."""
+    try:
+        logger.info(f"Checking teams for repository {repo.full_name}")
+        teams = repo.get_teams()
+        team_count = 0
+        has_teams = False
+        team_infos = []
+
+        try:
+            # Get team info without fetching members
+            for team in teams:
+                team_count += 1
+                has_teams = True
+                team_info = TeamInfo(
+                    name=team.name,
+                    slug=team.slug,
+                    members=[],  # Empty list since we're not fetching members for summary
+                )
+                team_infos.append(team_info)
+        except StopIteration:
+            pass
+
+        return has_teams, team_count, team_infos
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while checking teams for "
+                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _check_repository_teams_exist(repo, github_client, retry_count + 1)
+        else:
+            error_msg = f"Max retries exceeded for checking teams for {repo.full_name}"
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"Could not check teams: {e}")
+        return False, 0, []
+
+
+def _check_collaborators_exist(
+    github_client: Github, repo: Repository, retry_count: int = 0
+) -> tuple[bool, bool]:
+    """Check if repository has collaborators and outside collaborators without fetching details."""
+    has_collaborators = False
+    has_outside_collaborators = False
+
+    try:
+        logger.info(f"Checking collaborators for repository {repo.full_name}")
+        repo_collaborators = repo.get_collaborators()
+        logger.info(
+            f"Found {repo_collaborators.totalCount} collaborators for {repo.full_name}"
+        )
+        for collaborator in repo_collaborators:
+            has_collaborators = True
+
+            # For organization repos, check if this is an outside collaborator
+            if repo.organization:
+                try:
+                    org = github_client.get_organization(repo.organization.login)
+                    is_outside = not org.has_in_members(collaborator)
+                    if is_outside:
+                        has_outside_collaborators = True
+                        # If we found both types, we can break early
+                        if has_collaborators and has_outside_collaborators:
+                            break
+                except RateLimitExceededException:
+                    if retry_count < MAX_RETRY_COUNT:
+                        sleep_after_rate_limit_exception(github_client)
+                        logger.warning(
+                            f"Rate limit exceeded while checking collaborator "
+                            f"{collaborator.login}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+                        )
+                        return _check_collaborators_exist(
+                            github_client, repo, retry_count + 1
+                        )
+                    else:
+                        error_msg = f"Max retries exceeded for checking collaborator {collaborator.login}"
+                        logger.exception(error_msg)
+                        raise RuntimeError(error_msg)
+                except GithubException:
+                    # If we can't check membership, assume it's a regular collaborator
+                    pass
+            else:
+                # For personal repos, break after finding first collaborator
+                break
+
+    except RateLimitExceededException:
+        if retry_count < MAX_RETRY_COUNT:
+            sleep_after_rate_limit_exception(github_client)
+            logger.warning(
+                f"Rate limit exceeded while checking collaborators for "
+                f"{repo.full_name}. Retrying... (attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+            )
+            return _check_collaborators_exist(github_client, repo, retry_count + 1)
+        else:
+            error_msg = (
+                f"Max retries exceeded for checking collaborators for {repo.full_name}"
+            )
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
+    except GithubException as e:
+        logger.warning(f"Could not check collaborators: {e}")
+
+    return has_collaborators, has_outside_collaborators
+
+
+def _handle_personal_repository(
+    repo: Repository, github_client: Github
+) -> List[UserInfo]:
+    """Handle personal repositories by adding owner information."""
+    try:
+        owner_info = UserInfo(
+            login=repo.owner.login,
+            name=repo.owner.name,
+            email=repo.owner.email,
+        )
+        return [owner_info]
+    except Exception as e:
+        logger.warning(f"Could not fetch owner information for {repo.full_name}: {e}")
+        return []

--- a/backend/ee/onyx/external_permissions/perm_sync_types.py
+++ b/backend/ee/onyx/external_permissions/perm_sync_types.py
@@ -1,8 +1,12 @@
 from collections.abc import Callable
 from collections.abc import Generator
+from typing import Any
 from typing import Optional
 from typing import Protocol
 from typing import TYPE_CHECKING
+
+from sqlalchemy import ColumnElement
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 
 from onyx.context.search.models import InferenceChunk
 
@@ -15,14 +19,31 @@ if TYPE_CHECKING:
 
 
 class FetchAllDocumentsFunction(Protocol):
-    """Protocol for a function that fetches all document IDs for a connector credential pair."""
+    """Protocol for a function that fetches documents for a connector credential pair.
 
-    def __call__(self) -> list[str]:
+    This protocol defines the interface for functions that retrieve documents
+    from the database, typically used in permission synchronization workflows.
+    """
+
+    def __call__(
+        self,
+        columns: list[InstrumentedAttribute] | None = None,
+        where_clause: ColumnElement[bool] | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         """
-        Returns a list of document IDs for a connector credential pair.
+        Fetches documents for a connector credential pair with optional filtering.
 
-        This is typically used to determine which documents should no longer be
-        accessible during the document sync process.
+        Args:
+            columns: List of column attributes to select.
+                    If None, implementation should default to all columns.
+            where_clause: Optional SQLAlchemy where clause for filtering documents.
+                         If None, no additional filtering is applied.
+            limit: Optional limit on the number of documents to return.
+                  If None, all matching documents are returned.
+
+        Returns:
+            List of dicts matching the specified criteria.
         """
         ...
 

--- a/backend/ee/onyx/external_permissions/sync_params.py
+++ b/backend/ee/onyx/external_permissions/sync_params.py
@@ -13,6 +13,7 @@ from ee.onyx.configs.app_configs import SLACK_PERMISSION_DOC_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import TEAMS_PERMISSION_DOC_SYNC_FREQUENCY
 from ee.onyx.external_permissions.confluence.doc_sync import confluence_doc_sync
 from ee.onyx.external_permissions.confluence.group_sync import confluence_group_sync
+from ee.onyx.external_permissions.github.doc_sync import github_doc_sync
 from ee.onyx.external_permissions.gmail.doc_sync import gmail_doc_sync
 from ee.onyx.external_permissions.google_drive.doc_sync import gdrive_doc_sync
 from ee.onyx.external_permissions.google_drive.group_sync import gdrive_group_sync
@@ -116,6 +117,18 @@ _SOURCE_TO_SYNC_CONFIG: dict[DocumentSource, SyncConfig] = {
             doc_sync_func=gmail_doc_sync,
             initial_index_should_sync=False,
         ),
+    ),
+    DocumentSource.GITHUB: SyncConfig(
+        doc_sync_config=DocSyncConfig(
+            doc_sync_frequency=2 * 60,
+            doc_sync_func=github_doc_sync,
+            initial_index_should_sync=True,
+        ),
+        # group_sync_config=GroupSyncConfig(
+        #     group_sync_frequency= 2 * 60,
+        #     group_sync_func=github_group_sync,
+        #     group_sync_is_cc_pair_agnostic=False,
+        # ),
     ),
     DocumentSource.SALESFORCE: SyncConfig(
         censoring_config=CensoringConfig(

--- a/backend/ee/onyx/external_permissions/sync_params.py
+++ b/backend/ee/onyx/external_permissions/sync_params.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel
 from ee.onyx.configs.app_configs import CONFLUENCE_PERMISSION_DOC_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import CONFLUENCE_PERMISSION_GROUP_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import DEFAULT_PERMISSION_DOC_SYNC_FREQUENCY
+from ee.onyx.configs.app_configs import GITHUB_PERMISSION_DOC_SYNC_FREQUENCY
+from ee.onyx.configs.app_configs import GITHUB_PERMISSION_GROUP_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import GOOGLE_DRIVE_PERMISSION_GROUP_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import JIRA_PERMISSION_DOC_SYNC_FREQUENCY
 from ee.onyx.configs.app_configs import SLACK_PERMISSION_DOC_SYNC_FREQUENCY
@@ -14,6 +16,7 @@ from ee.onyx.configs.app_configs import TEAMS_PERMISSION_DOC_SYNC_FREQUENCY
 from ee.onyx.external_permissions.confluence.doc_sync import confluence_doc_sync
 from ee.onyx.external_permissions.confluence.group_sync import confluence_group_sync
 from ee.onyx.external_permissions.github.doc_sync import github_doc_sync
+from ee.onyx.external_permissions.github.group_sync import github_group_sync
 from ee.onyx.external_permissions.gmail.doc_sync import gmail_doc_sync
 from ee.onyx.external_permissions.google_drive.doc_sync import gdrive_doc_sync
 from ee.onyx.external_permissions.google_drive.group_sync import gdrive_group_sync
@@ -120,15 +123,15 @@ _SOURCE_TO_SYNC_CONFIG: dict[DocumentSource, SyncConfig] = {
     ),
     DocumentSource.GITHUB: SyncConfig(
         doc_sync_config=DocSyncConfig(
-            doc_sync_frequency=2 * 60,
+            doc_sync_frequency=GITHUB_PERMISSION_DOC_SYNC_FREQUENCY,
             doc_sync_func=github_doc_sync,
             initial_index_should_sync=True,
         ),
-        # group_sync_config=GroupSyncConfig(
-        #     group_sync_frequency= 2 * 60,
-        #     group_sync_func=github_group_sync,
-        #     group_sync_is_cc_pair_agnostic=False,
-        # ),
+        group_sync_config=GroupSyncConfig(
+            group_sync_frequency=GITHUB_PERMISSION_GROUP_SYNC_FREQUENCY,
+            group_sync_func=github_group_sync,
+            group_sync_is_cc_pair_agnostic=False,
+        ),
     ),
     DocumentSource.SALESFORCE: SyncConfig(
         censoring_config=CensoringConfig(

--- a/backend/ee/onyx/external_permissions/utils.py
+++ b/backend/ee/onyx/external_permissions/utils.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from typing import Any
 
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
 from onyx.access.models import DocExternalAccess
@@ -6,6 +7,7 @@ from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import SlimConnector
 from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 
@@ -62,7 +64,10 @@ def generic_doc_sync(
             )
 
     logger.info(f"Querying existing document IDs for CC Pair ID: {cc_pair.id=}")
-    existing_doc_ids = set(fetch_all_existing_docs_fn())
+    existing_docs: list[dict[str, Any]] = fetch_all_existing_docs_fn(
+        columns=[Document.id],
+    )
+    existing_doc_ids = set(doc["id"] for doc in existing_docs)
 
     missing_doc_ids = existing_doc_ids - newly_fetched_doc_ids
 

--- a/backend/onyx/connectors/connector_runner.py
+++ b/backend/onyx/connectors/connector_runner.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from typing import Generic
 from typing import TypeVar
 
+from onyx.access.models import ExternalAccess
+from onyx.access.utils import build_ext_group_name_for_onyx
+from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
@@ -135,7 +138,26 @@ class ConnectorRunner(Generic[CT]):
                 for document, failure, next_checkpoint in CheckpointOutputWrapper[CT]()(
                     checkpoint_connector_generator
                 ):
-                    if document is not None:
+                    if document is not None and isinstance(document, Document):
+                        # We need to prefix the group IDs with the source to match the format in the database for github
+                        if document.source == DocumentSource.GITHUB:
+                            prefixed_group_ids: set[str] = set()
+                            document_external_access = document.external_access
+                            if document_external_access:
+                                for (
+                                    group_id
+                                ) in document_external_access.external_user_group_ids:
+                                    group_id = build_ext_group_name_for_onyx(
+                                        source=DocumentSource.GITHUB,
+                                        ext_group_name=group_id,
+                                    )
+                                    prefixed_group_ids.add(group_id)
+                                document_external_access = ExternalAccess(
+                                    external_user_emails=document_external_access.external_user_emails,
+                                    external_user_group_ids=prefixed_group_ids,
+                                    is_public=document_external_access.is_public,
+                                )
+                                document.external_access = document_external_access
                         self.doc_batch.append(document)
 
                     if failure is not None:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -760,9 +760,9 @@ class GithubConnector(
     @override
     def checkpointed_retrieve_all_slim_documents(
         self,
-        start: SecondsSinceUnixEpoch,
-        end: SecondsSinceUnixEpoch,
-        checkpoint: GithubConnectorCheckpoint,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        checkpoint: GithubConnectorCheckpoint | None = None,
     ) -> SlimCheckpointOutput[GithubConnectorCheckpoint]:
         """
         Retrieve slim documents from GitHub with checkpointing support.
@@ -781,6 +781,16 @@ class GithubConnector(
         Returns:
             GithubConnectorCheckpoint: Updated checkpoint for next iteration
         """
+        # Set default values for optional parameters
+        if checkpoint is None:
+            checkpoint = self.build_dummy_checkpoint()
+
+        if start is None:
+            start = 0.0
+
+        if end is None:
+            end = datetime.now(timezone.utc).timestamp()
+
         logger.info(
             f"Starting slim document retrieval for GitHub connector. "
             f"Repo owner: {self.repo_owner}, "

--- a/backend/onyx/connectors/github/models.py
+++ b/backend/onyx/connectors/github/models.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from github import Repository
+from github.Requester import Requester
+from pydantic import BaseModel
+
+
+class SerializedRepository(BaseModel):
+    # id is part of the raw_data as well, just pulled out for convenience
+    id: int
+    headers: dict[str, str | int]
+    raw_data: dict[str, Any]
+
+    def to_Repository(self, requester: Requester) -> Repository.Repository:
+        return Repository.Repository(
+            requester, self.headers, self.raw_data, completed=True
+        )

--- a/backend/onyx/connectors/github/rate_limit_utils.py
+++ b/backend/onyx/connectors/github/rate_limit_utils.py
@@ -1,0 +1,25 @@
+import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from github import Github
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def sleep_after_rate_limit_exception(github_client: Github) -> None:
+    """
+    Sleep until the GitHub rate limit resets.
+
+    Args:
+        github_client: The GitHub client that hit the rate limit
+    """
+    sleep_time = github_client.get_rate_limit().core.reset.replace(
+        tzinfo=timezone.utc
+    ) - datetime.now(tz=timezone.utc)
+    sleep_time += timedelta(minutes=1)  # add an extra minute just to be safe
+    logger.notice(f"Ran into Github rate-limit. Sleeping {sleep_time.seconds} seconds.")
+    time.sleep(sleep_time.seconds)

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -1,10 +1,14 @@
+from collections.abc import Callable
+from typing import cast
+
 from github import Github
 from github.Repository import Repository
 
-from ee.onyx.external_permissions.github.utils import get_repository_permissions_summary
-from ee.onyx.external_permissions.github.utils import RepositoryPermissionsSummary
 from onyx.access.models import ExternalAccess
+from onyx.connectors.github.models import SerializedRepository
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import fetch_versioned_implementation
+from onyx.utils.variable_functionality import global_version
 
 logger = setup_logger()
 
@@ -14,39 +18,46 @@ def get_external_access_permission(
 ) -> ExternalAccess:
     """
     Get the external access permission for a repository.
+    This functionality requires Enterprise Edition.
     """
-    user_emails: list[str] = []
-    group_ids: list[str] = []
+    # Check if EE is enabled
+    if not global_version.is_ee_version():
+        # For the MIT version, return an empty ExternalAccess (private document)
+        return ExternalAccess.empty()
 
-    repo_permissions: RepositoryPermissionsSummary = get_repository_permissions_summary(
-        github_client, repo
+    # Fetch the EE implementation
+    ee_get_external_access_permission = cast(
+        Callable[[Repository, Github], ExternalAccess],
+        fetch_versioned_implementation(
+            "onyx.external_permissions.github.utils",
+            "get_external_access_permission",
+        ),
     )
 
-    if repo_permissions.is_public:
-        return ExternalAccess(
-            external_user_emails=user_emails,
-            external_user_group_ids=group_ids,
-            is_public=True,
+    return ee_get_external_access_permission(repo, github_client)
+
+
+def deserialize_repository(
+    cached_repo: SerializedRepository, github_client: Github
+) -> Repository:
+    """
+    Deserialize a SerializedRepository back into a Repository object.
+    """
+    # Try to access the requester - different PyGithub versions may use different attribute names
+    try:
+        # Try to get the requester using getattr to avoid linter errors
+        requester = getattr(github_client, "_requester", None)
+        if requester is None:
+            requester = getattr(github_client, "_Github__requester", None)
+        if requester is None:
+            # If we can't find the requester attribute, we need to fall back to recreating the repo
+            raise AttributeError("Could not find requester attribute")
+
+        return cached_repo.to_Repository(requester)
+    except Exception as e:
+        # If all else fails, re-fetch the repo directly
+        logger.warning(
+            f"Failed to deserialize repository: {e}. Attempting to re-fetch."
         )
-
-    # We maintain collaborators, owners, and outside collaborators as three separate groups
-    # instead of adding individual user emails to ExternalAccess.external_user_emails for two reasons:
-    # 1. Changes in repo collaborators (additions/removals) would require updating all documents.
-    # 2. Repo permissions can change without updating the repo's updated_at timestamp,
-    #    forcing full permission syncs for all documents every time, which is inefficient.
-    group_ids.extend(
-        [repo_permissions.collaborators_group_id, repo_permissions.owners_group_id]
-    )
-
-    if repo_permissions.has_outside_collaborators:
-        group_ids.append(repo_permissions.outside_collaborators_group_id)
-
-    if repo_permissions.has_teams:
-        group_ids.extend(team.slug for team in repo_permissions.teams if team.slug)
-
-    logger.info(group_ids)
-    return ExternalAccess(
-        external_user_emails=user_emails,
-        external_user_group_ids=group_ids,
-        is_public=False,
-    )
+        repo_id = cached_repo.id
+        return github_client.get_repo(repo_id)

--- a/backend/onyx/connectors/github/utils.py
+++ b/backend/onyx/connectors/github/utils.py
@@ -1,0 +1,52 @@
+from github import Github
+from github.Repository import Repository
+
+from ee.onyx.external_permissions.github.utils import get_repository_permissions_summary
+from ee.onyx.external_permissions.github.utils import RepositoryPermissionsSummary
+from onyx.access.models import ExternalAccess
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def get_external_access_permission(
+    repo: Repository, github_client: Github
+) -> ExternalAccess:
+    """
+    Get the external access permission for a repository.
+    """
+    user_emails: list[str] = []
+    group_ids: list[str] = []
+
+    repo_permissions: RepositoryPermissionsSummary = get_repository_permissions_summary(
+        github_client, repo
+    )
+
+    if repo_permissions.is_public:
+        return ExternalAccess(
+            external_user_emails=user_emails,
+            external_user_group_ids=group_ids,
+            is_public=True,
+        )
+
+    # We maintain collaborators, owners, and outside collaborators as three separate groups
+    # instead of adding individual user emails to ExternalAccess.external_user_emails for two reasons:
+    # 1. Changes in repo collaborators (additions/removals) would require updating all documents.
+    # 2. Repo permissions can change without updating the repo's updated_at timestamp,
+    #    forcing full permission syncs for all documents every time, which is inefficient.
+    group_ids.extend(
+        [repo_permissions.collaborators_group_id, repo_permissions.owners_group_id]
+    )
+
+    if repo_permissions.has_outside_collaborators:
+        group_ids.append(repo_permissions.outside_collaborators_group_id)
+
+    if repo_permissions.has_teams:
+        group_ids.extend(team.slug for team in repo_permissions.teams if team.slug)
+
+    logger.info(group_ids)
+    return ExternalAccess(
+        external_user_emails=user_emails,
+        external_user_group_ids=group_ids,
+        is_public=False,
+    )

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -212,6 +212,7 @@ class EventConnector(BaseConnector):
 
 
 CheckpointOutput: TypeAlias = Generator[Document | ConnectorFailure, None, CT]
+SlimCheckpointOutput: TypeAlias = Generator[SlimDocument | ConnectorFailure, None, CT]
 
 
 class CheckpointedConnector(BaseConnector[CT]):
@@ -261,4 +262,17 @@ class CheckpointedConnectorWithPermSync(CheckpointedConnector[CT]):
         end: SecondsSinceUnixEpoch,
         checkpoint: CT,
     ) -> CheckpointOutput[CT]:
+        raise NotImplementedError
+
+
+# Slim connector with checkpointing support
+class CheckpointedSlimConnector(CheckpointedConnector[CT]):
+    @abc.abstractmethod
+    def checkpointed_retrieve_all_slim_documents(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        checkpoint: CT | None = None,
+    ) -> CheckpointOutput[CT]:
+        """Retrieve all slim documents with checkpointing support."""
         raise NotImplementedError

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -273,6 +273,6 @@ class CheckpointedSlimConnector(CheckpointedConnector[CT]):
         start: SecondsSinceUnixEpoch | None = None,
         end: SecondsSinceUnixEpoch | None = None,
         checkpoint: CT | None = None,
-    ) -> CheckpointOutput[CT]:
+    ) -> SlimCheckpointOutput[CT]:
         """Retrieve all slim documents with checkpointing support."""
         raise NotImplementedError

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -6,8 +6,10 @@ from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from typing import Any
 
 from sqlalchemy import and_
+from sqlalchemy import ColumnElement
 from sqlalchemy import delete
 from sqlalchemy import exists
 from sqlalchemy import func
@@ -20,6 +22,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine.util import TransactionalContext
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.sql.expression import null
 
 from onyx.agents.agent_search.kb_search.models import KGEntityDocInfo
@@ -208,6 +211,74 @@ def get_document_ids_for_connector_credential_pair(
         )
     )
     return list(db_session.execute(doc_ids_stmt).scalars().all())
+
+
+def get_documents_for_connector_credential_pair_filtered(
+    db_session: Session,
+    connector_id: int,
+    credential_id: int,
+    where_clause: ColumnElement[bool] | None = None,
+    limit: int | None = None,
+    columns: list[InstrumentedAttribute] | None = None,
+) -> Sequence[dict[str, Any]]:
+    """Get documents for a connector credential pair with optional filtering and column selection.
+
+    Args:
+        db_session: Database session
+        connector_id: ID of the connector
+        credential_id: ID of the credential
+        where_clause: Optional SQLAlchemy where clause for additional filtering
+        limit: Optional limit on number of results
+        columns: Optional list of specific columns to select (if None, selects all document columns)
+
+    Returns:
+        Sequence of Document objects matching the criteria
+    """
+    # First, get the document IDs for the connector credential pair
+    initial_doc_ids_stmt = select(DocumentByConnectorCredentialPair.id).where(
+        and_(
+            DocumentByConnectorCredentialPair.connector_id == connector_id,
+            DocumentByConnectorCredentialPair.credential_id == credential_id,
+        )
+    )
+
+    # If limit is 1, order by last_modified ASC to get the oldest record
+    if limit and limit == 1 and where_clause is not None:
+        # Join with Document table to get access to last_modified for ordering
+        initial_doc_ids_stmt = (
+            select(DocumentByConnectorCredentialPair.id)
+            .join(DbDocument, DocumentByConnectorCredentialPair.id == DbDocument.id)
+            .where(
+                and_(
+                    DocumentByConnectorCredentialPair.connector_id == connector_id,
+                    DocumentByConnectorCredentialPair.credential_id == credential_id,
+                )
+            )
+            .order_by(DbDocument.last_modified.asc())
+            .limit(limit)
+            .where(where_clause)
+        )
+    elif limit:
+        # Apply limit to the first query for better performance
+        initial_doc_ids_stmt = initial_doc_ids_stmt.limit(limit)
+    # Build the main query based on columns requested
+    if columns:
+        stmt = select(*columns)
+    else:
+        stmt = select(DbDocument)
+
+    # Filter documents by the IDs from the first query
+    stmt = stmt.where(DbDocument.id.in_(initial_doc_ids_stmt))
+
+    # Apply additional filtering if provided
+    if where_clause is not None:
+        logger.info(f"Where clause: {where_clause}")
+        stmt = stmt.where(where_clause)
+
+    # Make results distinct
+    stmt = stmt.distinct()
+
+    return [dict(row) for row in db_session.execute(stmt).mappings().all()]
 
 
 def get_documents_for_connector_credential_pair(

--- a/backend/tests/daily/connectors/utils.py
+++ b/backend/tests/daily/connectors/utils.py
@@ -33,7 +33,7 @@ def load_all_docs_from_checkpoint_connector(
         for document, failure, next_checkpoint in doc_batch_generator:
             if failure is not None:
                 raise RuntimeError(f"Failed to load documents: {failure}")
-            if document is not None:
+            if document is not None and isinstance(document, Document):
                 documents.append(document)
             if next_checkpoint is not None:
                 checkpoint = next_checkpoint
@@ -74,7 +74,7 @@ def load_everything_from_checkpoint_connector(
         for document, failure, next_checkpoint in doc_batch_generator:
             if failure is not None:
                 outputs.append(failure)
-            if document is not None:
+            if document is not None and isinstance(document, Document):
                 outputs.append(document)
             if next_checkpoint is not None:
                 checkpoint = next_checkpoint

--- a/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
@@ -19,7 +19,7 @@ from github.Repository import Repository
 from github.Requester import Requester
 
 from onyx.access.models import ExternalAccess
-from onyx.connectors.connector_runner import CheckpointOutputWrapper
+from onyx.connectors.connector_runner import SlimCheckpointOutputWrapper
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
@@ -956,9 +956,9 @@ def test_checkpointed_retrieve_all_slim_documents_single_repo(
     with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
         end_time = time.time()
         checkpoint = github_connector.build_dummy_checkpoint()
-        slim_docs = []
+        slim_docs: list[SlimDocument] = []
 
-        # Process documents using CheckpointOutputWrapper like in doc_sync
+        # Process documents using SlimCheckpointOutputWrapper like in doc_sync
         while checkpoint.has_more:
             slim_doc_generator = (
                 github_connector.checkpointed_retrieve_all_slim_documents(
@@ -966,7 +966,7 @@ def test_checkpointed_retrieve_all_slim_documents_single_repo(
                 )
             )
 
-            for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+            for slim_doc, failure, new_checkpoint in SlimCheckpointOutputWrapper[
                 GithubConnectorCheckpoint
             ]()(slim_doc_generator):
                 # New checkpoint means we've moved to a different repository
@@ -1082,9 +1082,9 @@ def test_checkpointed_retrieve_all_slim_documents_multiple_repos(
         # Call checkpointed_retrieve_all_slim_documents
         end_time = time.time()
         checkpoint = github_connector.build_dummy_checkpoint()
-        slim_docs = []
+        slim_docs: list[SlimDocument] = []
 
-        # Process documents using CheckpointOutputWrapper like in doc_sync
+        # Process documents using SlimCheckpointOutputWrapper like in doc_sync
         while checkpoint.has_more:
             slim_doc_generator = (
                 github_connector.checkpointed_retrieve_all_slim_documents(
@@ -1092,7 +1092,7 @@ def test_checkpointed_retrieve_all_slim_documents_multiple_repos(
                 )
             )
 
-            for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+            for slim_doc, failure, new_checkpoint in SlimCheckpointOutputWrapper[
                 GithubConnectorCheckpoint
             ]()(slim_doc_generator):
                 # New checkpoint means we've moved to a different repository or stage
@@ -1155,9 +1155,9 @@ def test_checkpointed_retrieve_all_slim_documents_empty_repo(
         # Call checkpointed_retrieve_all_slim_documents
         end_time = time.time()
         checkpoint = github_connector.build_dummy_checkpoint()
-        slim_docs = []
+        slim_docs: list[SlimDocument] = []
 
-        # Process documents using CheckpointOutputWrapper like in doc_sync
+        # Process documents using SlimCheckpointOutputWrapper like in doc_sync
         while checkpoint.has_more:
             slim_doc_generator = (
                 github_connector.checkpointed_retrieve_all_slim_documents(
@@ -1165,7 +1165,7 @@ def test_checkpointed_retrieve_all_slim_documents_empty_repo(
                 )
             )
 
-            for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+            for slim_doc, failure, new_checkpoint in SlimCheckpointOutputWrapper[
                 GithubConnectorCheckpoint
             ]()(slim_doc_generator):
                 # New checkpoint means we've moved to a different repository or stage
@@ -1229,9 +1229,9 @@ def test_checkpointed_retrieve_all_slim_documents_with_external_access(
         # Call checkpointed_retrieve_all_slim_documents
         end_time = time.time()
         checkpoint = github_connector.build_dummy_checkpoint()
-        slim_docs = []
+        slim_docs: list[SlimDocument] = []
 
-        # Process documents using CheckpointOutputWrapper like in doc_sync
+        # Process documents using SlimCheckpointOutputWrapper like in doc_sync
         while checkpoint.has_more:
             slim_doc_generator = (
                 github_connector.checkpointed_retrieve_all_slim_documents(
@@ -1239,7 +1239,7 @@ def test_checkpointed_retrieve_all_slim_documents_with_external_access(
                 )
             )
 
-            for slim_doc, failure, new_checkpoint in CheckpointOutputWrapper[
+            for slim_doc, failure, new_checkpoint in SlimCheckpointOutputWrapper[
                 GithubConnectorCheckpoint
             ]()(slim_doc_generator):
                 # New checkpoint means we've moved to a different repository or stage

--- a/web/src/lib/connectors/AutoSyncOptionFields.tsx
+++ b/web/src/lib/connectors/AutoSyncOptionFields.tsx
@@ -14,6 +14,7 @@ export const autoSyncConfigBySource: Record<
   confluence: {},
   google_drive: {},
   gmail: {},
+  github: {},
   slack: {},
   salesforce: {},
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -400,6 +400,7 @@ export const validAutoSyncSources = [
   ValidSources.Gmail,
   ValidSources.Slack,
   ValidSources.Salesforce,
+  ValidSources.GitHub,
 ] as const;
 
 // Create a type from the array elements


### PR DESCRIPTION
## Description
This pull request consists of GitHub doc sync, group sync and unit tests.
Added new connector type **CheckpointedSlimConnector** which helps in handling connectors with multiple repositories. The GithubConnector implements this interface and provides the `checkpointed_retrieve_all_slim_documents() `method that allows me to individually check whether each repository has any permission changes one by one. I also created SlimCheckpointOutputWrapper to handle the output of the new connector type's method, which yields tuples of `(SlimDocument | None, ConnectorFailure | None, GithubConnectorCheckpoint | None) `to make the checkpointed output more digestible for the calling code.

This architecture enables efficient processing of multiple repositories by allowing the system to pause and resume at repository boundaries, making it possible to check permission changes for each repository individually without losing progress.

## How Has This Been Tested?
By creating connector and syncing it

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
