### PR TITLE
skip id migration based on env var

### DIFF
--- a/backend/alembic/versions/12635f6655b7_drive_canonical_ids.py
+++ b/backend/alembic/versions/12635f6655b7_drive_canonical_ids.py
@@ -19,6 +19,7 @@ from onyx.document_index.vespa.shared_utils.utils import (
 )
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.utils.logger import setup_logger
+import os
 
 logger = setup_logger()
 
@@ -27,6 +28,8 @@ revision = "12635f6655b7"
 down_revision = "58c50ef19f08"
 branch_labels = None
 depends_on = None
+
+SKIP_CANON_DRIVE_IDS = os.environ.get("SKIP_CANON_DRIVE_IDS", "true").lower() == "true"
 
 
 def active_search_settings() -> tuple[SearchSettings, SearchSettings | None]:
@@ -514,6 +517,8 @@ def delete_document_from_db(current_doc_id: str, index_name: str) -> None:
 
 
 def upgrade() -> None:
+    if SKIP_CANON_DRIVE_IDS:
+        return
     current_search_settings, future_search_settings = active_search_settings()
     document_index = get_default_document_index(
         current_search_settings,


### PR DESCRIPTION
## Description

the migration takes forever for currently unknown reasons, skipping it for the time being. Downside is until it is run, everyone will see duplicate drive docs being indexed

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
