### PR TITLE
fix: More small IMAP backend fixes

### DIFF
--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -33,6 +33,7 @@ from onyx.connectors.google_site.connector import GoogleSitesConnector
 from onyx.connectors.guru.connector import GuruConnector
 from onyx.connectors.highspot.connector import HighspotConnector
 from onyx.connectors.hubspot.connector import HubSpotConnector
+from onyx.connectors.imap.connector import ImapConnector
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CredentialsConnector
@@ -121,6 +122,7 @@ def identify_connector_class(
         DocumentSource.EGNYTE: EgnyteConnector,
         DocumentSource.AIRTABLE: AirtableConnector,
         DocumentSource.HIGHSPOT: HighspotConnector,
+        DocumentSource.IMAP: ImapConnector,
         # just for integration tests
         DocumentSource.MOCK_CONNECTOR: MockConnector,
     }

--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -333,14 +333,19 @@ def _convert_email_headers_and_body_into_document(
     email_headers: EmailHeaders,
     include_perm_sync: bool,
 ) -> Document:
-    _sender_name, sender_addr = _parse_singular_addr(raw_header=email_headers.sender)
-    parsed_recipients = _parse_addrs(raw_header=email_headers.recipients)
+    sender_name, sender_addr = _parse_singular_addr(raw_header=email_headers.sender)
+    parsed_recipients = (
+        _parse_addrs(raw_header=email_headers.recipients)
+        if email_headers.recipients
+        else []
+    )
 
     email_body = _parse_email_body(email_msg=email_msg, email_headers=email_headers)
     primary_owners = [
         BasicExpertInfo(display_name=recipient_name, email=recipient_addr)
         for recipient_name, recipient_addr in parsed_recipients
     ]
+    primary_owners.append(BasicExpertInfo(display_name=sender_name, email=sender_addr))
     external_access = (
         ExternalAccess(
             external_user_emails=set(addr for _name, addr in parsed_recipients),

--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -340,15 +340,22 @@ def _convert_email_headers_and_body_into_document(
         else []
     )
 
-    email_body = _parse_email_body(email_msg=email_msg, email_headers=email_headers)
-    primary_owners = [
-        BasicExpertInfo(display_name=recipient_name, email=recipient_addr)
+    expert_info_map = {
+        recipient_addr: BasicExpertInfo(
+            display_name=recipient_name, email=recipient_addr
+        )
         for recipient_name, recipient_addr in parsed_recipients
-    ]
-    primary_owners.append(BasicExpertInfo(display_name=sender_name, email=sender_addr))
+    }
+    if sender_addr not in expert_info_map:
+        expert_info_map[sender_addr] = BasicExpertInfo(
+            display_name=sender_name, email=sender_addr
+        )
+
+    email_body = _parse_email_body(email_msg=email_msg, email_headers=email_headers)
+    primary_owners = list(expert_info_map.values())
     external_access = (
         ExternalAccess(
-            external_user_emails=set(addr for _name, addr in parsed_recipients),
+            external_user_emails=set(expert_info_map.keys()),
             external_user_group_ids=set(),
             is_public=False,
         )

--- a/backend/onyx/connectors/imap/models.py
+++ b/backend/onyx/connectors/imap/models.py
@@ -25,7 +25,7 @@ class EmailHeaders(BaseModel):
     id: str
     subject: str
     sender: str
-    recipients: str
+    recipients: str | None
     date: datetime
 
     @classmethod


### PR DESCRIPTION
## Description

This PR makes the `recipients` field optional. It also adds the `ImapConnector` to the list of identified connectors.

Addresses: https://linear.app/danswer/issue/DAN-2168/fix-imap-backend-connector-failures.

## How Has This Been Tested?

Existing IMAP connector tests still pass.