### PR TITLE
personas no longer overwrite when same name

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -466,6 +466,13 @@ def upsert_persona(
             persona_name=name, user=user, db_session=db_session
         )
 
+        # Check for duplicate names when creating new personas
+        # Deleted personas are allowed to be overwritten
+        if existing_persona and not existing_persona.deleted:
+            raise ValueError(
+                f"Assistant with name '{name}' already exists. Please rename your assistant."
+            )
+
     if existing_persona:
         # this checks if the user has permission to edit the persona
         # will raise an Exception if the user does not have permission


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-98/fix-creating-assistant-with-same-name-as-before

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
