### PR TITLE
Add suggested helm resource limits

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -35,7 +35,6 @@
     * k -n onyx delete pvc vespa-storage-da-vespa-0
   * If you didn't disable Postgres persistence earlier, you may want to delete that PVC too.
 
-
 ## Resourcing
 In the helm charts, we have resource suggestions for all Onyx-owned components. 
 These are simply initial suggestions, and may need to be tuned for your specific use case.

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -34,3 +34,10 @@
     * k -n onyx get pvc
     * k -n onyx delete pvc vespa-storage-da-vespa-0
   * If you didn't disable Postgres persistence earlier, you may want to delete that PVC too.
+
+
+## Resourcing
+In the helm charts, we have resource suggestions for all Onyx-owned components. 
+These are simply initial suggestions, and may need to be tuned for your specific use case.
+
+Please talk to us in Slack if you have any questions!

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -40,3 +40,7 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx-stack.envSecrets" . | nindent 10}}
+        {{- if .Values.indexCapability.resources }}
+        resources:
+          {{- toYaml .Values.indexCapability.resources | nindent 10 }}
+        {{- end }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -34,4 +34,8 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
+        {{- if .Values.inferenceCapability.resources }}
+        resources:
+          {{- toYaml .Values.inferenceCapability.resources | nindent 10 }}
+        {{- end }}
 

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -54,6 +54,7 @@ vespa:
     # The Vespa Helm chart specifies default resources, which are quite modest. We override
     # them here to increase chances of the chart running successfully. If you plan to index at
     # scale, you will likely need to increase these limits further.
+    # At large scale, it is recommended to use a dedicated Vespa cluster / Vespa cloud.
     requests:
       cpu: 4000m
       memory: 8000Mi
@@ -88,6 +89,13 @@ inferenceCapability:
   podLabels:
     - key: app
       value: inference-model-server
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 6Gi
+    limits:
+      cpu: 4000m
+      memory: 10Gi
 
 indexCapability:
   service:
@@ -110,6 +118,13 @@ indexCapability:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
   limitConcurrency: 10
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 6Gi
+    limits:
+      cpu: 4000m
+      memory: 10Gi
 config:
   envConfigMapName: env-configmap
 
@@ -174,17 +189,13 @@ webserver:
     servicePort: 3000
     targetPort: http
 
-  resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources: 
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
 
   autoscaling:
     enabled: false
@@ -245,17 +256,13 @@ api:
     targetPort: api-server-port
     portName: api-server-port
 
-  resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  #  requests:
-  #    cpu: 1000m  # Requests 1 CPU core
-  #    memory: 1Gi  # Requests 1 GiB of memory
-  #  limits:
-  #    cpu: 2000m  # Limits to 2 CPU cores
-  #    memory: 2Gi  # Limits to 2 GiB of memory
+  resources: 
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
 
   autoscaling:
     enabled: false
@@ -281,62 +288,11 @@ api:
   tolerations: []
 
 
-# background:
-#   replicaCount: 1
-#   autoscaling:
-#     enabled: false
-# #     minReplicas: 1
-# #     maxReplicas: 100
-# #     targetCPUUtilizationPercentage: 80
-# #     targetMemoryUtilizationPercentage: 80
+######################################################################
 #
-#   image:
-#     repository: onyxdotapp/onyx-backend
-#     pullPolicy: IfNotPresent
-#     # Overrides the image tag whose default is the chart appVersion.
-#     tag: ""
-#   podAnnotations: {}
-#   podLabels:
-#     scope: onyx-backend
-#     app: background
-#   deploymentLabels:
-#     app: background
-#   podSecurityContext:
-#     {}
-#     # fsGroup: 2000
-#   securityContext:
-#     privileged: true
-#     runAsUser: 0
-#   enableMiniChunk: "true"
-#   resources: {}
-#   # We usually recommend not to specify default resources and to leave this as a conscious
-#   # choice for the user. This also increases chances charts run on environments with little
-#   # resources, such as Minikube. If you do want to specify resources, uncomment the following
-#   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-#   #  requests:
-#   #    cpu: 1000m  # Requests 1 CPU core
-#   #    memory: 1Gi  # Requests 1 GiB of memory
-#   #  limits:
-#   #    cpu: 2000m  # Limits to 2 CPU cores
-#   #    memory: 2Gi  # Limits to 2 GiB of memory
+# Background workers
 #
-#
-#   # Additional volumes on the output Deployment definition.
-#   volumes: []
-#   # - name: foo
-#   #   secret:
-#   #     secretName: mysecret
-#   #     optional: false
-#
-#   # Additional volumeMounts on the output Deployment definition.
-#   volumeMounts: []
-#   # - name: foo
-#   #   mountPath: "/etc/foo"
-#   #   readOnly: true
-#
-#   nodeSelector: {}
-#   tolerations: []
-#   affinity: {}
+######################################################################
 
 celery_shared:
   image:
@@ -376,7 +332,13 @@ celery_beat:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -398,7 +360,13 @@ celery_worker_heavy:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 2Gi
+    limits:
+      cpu: 2500m
+      memory: 5Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -420,7 +388,13 @@ celery_worker_indexing:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 2000m
+      memory: 8Gi
+    limits:
+      cpu: 2000m
+      memory: 16Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -442,7 +416,13 @@ celery_worker_light:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -464,7 +444,13 @@ celery_worker_monitoring:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -486,7 +472,13 @@ celery_worker_primary:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources:
+    requests:
+      cpu: 1000m
+      memory: 8Gi
+    limits:
+      cpu: 2000m
+      memory: 16Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -508,7 +500,13 @@ celery_worker_user_files_indexing:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: {}
+  resources: 
+    requests: 
+      cpu: 2000m
+      memory: 6Gi
+    limits:
+      cpu: 4000m
+      memory: 12Gi
   volumes: []  # Additional volumes on the output Deployment definition.
   volumeMounts: []  # Additional volumeMounts on the output Deployment definition.
   nodeSelector: {}
@@ -538,6 +536,12 @@ slackbot:
     limits:
       cpu: "1000m"
       memory: "2000Mi"
+
+######################################################################
+#
+# End background workers section
+#
+######################################################################
 
 redis:
   enabled: true

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -189,7 +189,7 @@ webserver:
     servicePort: 3000
     targetPort: http
 
-  resources: 
+  resources:
     requests:
       cpu: 200m
       memory: 512Mi
@@ -256,7 +256,7 @@ api:
     targetPort: api-server-port
     portName: api-server-port
 
-  resources: 
+  resources:
     requests:
       cpu: 1000m
       memory: 1Gi
@@ -500,8 +500,8 @@ celery_worker_user_files_indexing:
   securityContext:
     privileged: true
     runAsUser: 0
-  resources: 
-    requests: 
+  resources:
+    requests:
       cpu: 2000m
       memory: 6Gi
     limits:


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2185/add-default-resource-suggestions-to-helm-charts

## How Has This Been Tested?

Ran on `helm-test`

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added suggested resource requests and limits for all Onyx Helm chart components to help users configure deployments more easily.

- **New Features**
  - Set default CPU and memory values for API, webserver, model deployments, and all background workers.
  - Updated Helm README with guidance on resource tuning.

<!-- End of auto-generated description by cubic. -->

