### PR TITLE
fix: Fix Confluence pagination

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -1,3 +1,17 @@
+"""
+# README (notes on Confluence pagination):
+
+We've noticed that the `search/users` and `users/memberof` endpoints for Confluence Cloud use offset-based pagination as
+opposed to cursor-based. We also know that page-retrieval uses cursor-based pagination.
+
+Our default pagination strategy right now for cloud is to assume cursor-based.
+However, if you notice that a cloud API is not being properly paginated (i.e., if the `_links.next` is not appearing in the
+returned payload), then you can force offset-based pagination.
+
+# TODO (@raunakab)
+We haven't explored all of the cloud APIs' pagination strategies. @raunakab take time to go through this and figure them out.
+"""
+
 import json
 import time
 from collections.abc import Callable

--- a/backend/tests/daily/connectors/confluence/conftest.py
+++ b/backend/tests/daily/connectors/confluence/conftest.py
@@ -1,0 +1,35 @@
+import os
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def confluence_connector_config() -> dict[str, Any]:
+    url_base = os.environ.get("CONFLUENCE_URL")
+    space_key = os.environ.get("CONFLUENCE_SPACE_KEY")
+    page_id = os.environ.get("CONFLUENCE_PAGE_ID")
+    is_cloud = os.environ.get("CONFLUENCE_IS_CLOUD", "").lower() == "true"
+
+    assert url_base, "CONFLUENCE_URL environment variable is required"
+
+    return {
+        "wiki_base": url_base,
+        "is_cloud": is_cloud,
+        "space": space_key or "",
+        "page_id": page_id or "",
+    }
+
+
+@pytest.fixture
+def confluence_credential_json() -> dict[str, Any]:
+    username = os.environ.get("CONFLUENCE_USERNAME")
+    access_token = os.environ.get("CONFLUENCE_ACCESS_TOKEN")
+
+    assert username, "CONFLUENCE_USERNAME environment variable is required"
+    assert access_token, "CONFLUENCE_ACCESS_TOKEN environment variable is required"
+
+    return {
+        "confluence_username": username,
+        "confluence_access_token": access_token,
+    }

--- a/backend/tests/daily/connectors/confluence/test_confluence_group_sync.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_group_sync.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+from ee.onyx.db.external_perm import ExternalUserGroup
+from ee.onyx.external_permissions.confluence.group_sync import confluence_group_sync
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from shared_configs.contextvars import get_current_tenant_id
+
+
+_EXPECTED_CONFLUENCE_GROUPS = [
+    ExternalUserGroup(
+        id="confluence-admins-onyx-test",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="org-admins",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="confluence-users-onyx-test",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="jira-servicemanagement-users-onyx-test",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="jira-users-onyx-test",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="jira-product-discovery-users-onyx-test",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+    ExternalUserGroup(
+        id="All_Confluence_Users_Found_By_Onyx",
+        user_emails=["admin@onyx-test.com"],
+        gives_anyone_access=False,
+    ),
+]
+
+
+def test_confluence_group_sync(
+    confluence_connector_config: dict[str, Any],
+    confluence_credential_json: dict[str, Any],
+) -> None:
+    SqlEngine.init_engine(pool_size=10, max_overflow=10)
+
+    with get_session_with_current_tenant() as db_session:
+        connector = Connector(
+            name="Test Connector",
+            source=DocumentSource.CONFLUENCE,
+            input_type=InputType.POLL,
+            connector_specific_config=confluence_connector_config,
+            refresh_freq=None,
+            prune_freq=None,
+            indexing_start=None,
+        )
+        db_session.add(connector)
+        db_session.flush()
+
+        credential = Credential(
+            source=DocumentSource.CONFLUENCE,
+            credential_json=confluence_credential_json,
+        )
+        db_session.add(credential)
+        db_session.flush()
+
+        cc_pair = ConnectorCredentialPair(
+            connector_id=connector.id,
+            credential_id=credential.id,
+            name="Test CC Pair",
+            status=ConnectorCredentialPairStatus.ACTIVE,
+            access_type=AccessType.SYNC,
+            auto_sync_options=None,
+        )
+        db_session.add(cc_pair)
+        db_session.commit()
+        db_session.refresh(cc_pair)
+
+        tenant_id = get_current_tenant_id()
+        group_sync_iter = confluence_group_sync(
+            tenant_id=tenant_id,
+            cc_pair=cc_pair,
+        )
+
+        expected_groups = {group.id: group for group in _EXPECTED_CONFLUENCE_GROUPS}
+        actual_groups = {group.id: group for group in group_sync_iter}
+        assert expected_groups == actual_groups

--- a/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_user_email_overrides.py
@@ -117,5 +117,7 @@ def test_paginated_cql_user_retrieval_no_overrides_cloud() -> None:
 
         # Check that the cloud-specific user search URL is called
         mock_paginate.assert_called_once_with(
-            "rest/api/search/user?cql=type=user", None
+            "rest/api/search/user?cql=type=user",
+            None,
+            force_offset_pagination=True,
         )

--- a/backend/tests/integration/tests/connector/test_connector_creation.py
+++ b/backend/tests/integration/tests/connector/test_connector_creation.py
@@ -37,9 +37,8 @@ def test_overlapping_connector_creation(reset: None) -> None:
 
     config = {
         "wiki_base": os.environ["CONFLUENCE_TEST_SPACE_URL"],
-        "space": "DailyConne",
+        "space": "DailyConnectorTestSpace",
         "is_cloud": True,
-        "page_id": "",
     }
 
     credential = {
@@ -98,9 +97,7 @@ def test_connector_pause_while_indexing(reset: None) -> None:
 
     config = {
         "wiki_base": os.environ["CONFLUENCE_TEST_SPACE_URL"],
-        "space": "",
         "is_cloud": True,
-        "page_id": "",
     }
 
     credential = {


### PR DESCRIPTION
## Description

This PR uses index-based pagination to retrieve all the paginated queries that are available. https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-search/#api-wiki-rest-api-search-user-get.

Addresses: https://linear.app/danswer/issue/DAN-2170/investigate-confluence-user-pagination.

## How Has This Been Tested?

Wrote a test for group-sync. All existing Confluence tests continue to pass.