### PR TITLE
gemini embedding model support

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -229,8 +229,13 @@ class CloudEmbedding:
 
         inputs = [TextEmbeddingInput(text, embedding_type) for text in texts]
 
-        # Split into batches of 25 texts
-        max_texts_per_batch = VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
+        # gemini-embedding-001 max batch size is 1. otherwise use default
+        max_texts_per_batch = (
+            1
+            if model == "gemini-embedding-001"
+            else VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
+        )
+
         batches = [
             inputs[i : i + max_texts_per_batch]
             for i in range(0, len(inputs), max_texts_per_batch)

--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -62,6 +62,11 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_text_embedding_3_small",
     ),
     _BaseEmbeddingModel(
+        name="google/gemini-embedding-001",
+        dim=3072,
+        index_name="danswer_chunk_google_gemini_embedding_001",
+    ),
+    _BaseEmbeddingModel(
         name="google/text-embedding-005",
         dim=768,
         index_name="danswer_chunk_google_text_embedding_005",

--- a/web/src/components/embedding/interfaces.tsx
+++ b/web/src/components/embedding/interfaces.tsx
@@ -267,8 +267,21 @@ export const AVAILABLE_CLOUD_PROVIDERS: CloudEmbeddingProvider[] = [
     embedding_models: [
       {
         provider_type: EmbeddingProvider.GOOGLE,
+        model_name: "gemini-embedding-001",
+        description: "Google's latest text embedding model.",
+        pricePerMillion: 0.15,
+        model_dim: 3072,
+        normalize: false,
+        query_prefix: "",
+        passage_prefix: "",
+        index_name: "",
+        api_key: null,
+        api_url: null,
+      },
+      {
+        provider_type: EmbeddingProvider.GOOGLE,
         model_name: "text-embedding-005",
-        description: "Google's most recent text embedding model.",
+        description: "Google's previous generation text embedding model.",
         pricePerMillion: 0.025,
         model_dim: 768,
         normalize: false,


### PR DESCRIPTION
## Description

- Adds gemini-embedding-001 3072 as supported embedding model

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
