### PR TITLE
fix: Fix Teams connector failing when `from_.user` is not specified

### DIFF
--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -286,9 +286,14 @@ class TeamsConnector(
 
 
 def _construct_semantic_identifier(channel: Channel, top_message: Message) -> str:
-    top_message_user_name = (
-        top_message.from_.user.display_name if top_message.from_ else "Unknown User"
-    )
+    top_message_user_name: str
+
+    if top_message.from_ and top_message.from_.user:
+        top_message_user_name = top_message.from_.user.display_name
+    else:
+        logger.warn(f"Message {top_message=} has no `from.user` field")
+        top_message_user_name = "Unknown User"
+
     top_message_content = top_message.body.content or ""
     top_message_subject = top_message.subject or "Unknown Subject"
     channel_name = channel.properties.get("displayName", "Unknown")

--- a/backend/onyx/connectors/teams/models.py
+++ b/backend/onyx/connectors/teams/models.py
@@ -27,7 +27,7 @@ class User(BaseModel):
 
 
 class From(BaseModel):
-    user: User
+    user: User | None
 
     model_config = ConfigDict(
         alias_generator=to_camel,


### PR DESCRIPTION
## Description

The `Teams` connector expects that `from_.user` is defined. It can be that the `user` field is missing.

This PR makes that field optional (thus allowing validation to pass), and updates usages of `from_.user` to be optional now.

Addresses: https://linear.app/danswer/issue/DAN-2221/fix-teams-issue-in-which-from-user-was-not-in-message-causing.

## How Has This Been Tested?

No new tests written. All existing tests pass.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed Teams connector error when the from_.user field is missing by making it optional and defaulting to "Unknown User" if not present. This addresses Linear issue DAN-2221.

<!-- End of auto-generated description by cubic. -->

