### PR TITLE
Reducto Integration

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -81,7 +81,6 @@ UNNAMED_KEY_PLACEHOLDER = "Unnamed"
 # Key-Value store keys
 KV_REINDEX_KEY = "needs_reindexing"
 KV_SEARCH_SETTINGS = "search_settings"
-KV_UNSTRUCTURED_API_KEY = "unstructured_api_key"
 KV_USER_STORE_KEY = "INVITED_USERS"
 KV_PENDING_USERS_KEY = "PENDING_USERS"
 KV_NO_AUTH_USER_PREFERENCES_KEY = "no_auth_user_preferences"
@@ -98,6 +97,8 @@ KV_ENTERPRISE_SETTINGS_KEY = "onyx_enterprise_settings"
 KV_CUSTOM_ANALYTICS_SCRIPT_KEY = "__custom_analytics_script__"
 KV_DOCUMENTS_SEEDED_KEY = "documents_seeded"
 KV_KG_CONFIG_KEY = "kg_config"
+DOC_PROCESSING_TYPE = "docprocessing_type"
+DOC_PROCESSING_API_KEY = "docprocessing_api_key"
 
 # NOTE: we use this timeout / 4 in various places to refresh a lock
 # might be worth separating this timeout into separate timeouts for each situation

--- a/backend/onyx/file_processing/unstructured.py
+++ b/backend/onyx/file_processing/unstructured.py
@@ -1,37 +1,50 @@
+from enum import Enum
 from typing import Any
-from typing import cast
 from typing import IO
 
+import requests
+from reducto import Reducto
 from unstructured.staging.base import dict_to_elements
 from unstructured_client import UnstructuredClient  # type: ignore
 from unstructured_client.models import operations  # type: ignore
 from unstructured_client.models import shared
 
-from onyx.configs.constants import KV_UNSTRUCTURED_API_KEY
+from onyx.configs.constants import DOC_PROCESSING_API_KEY
+from onyx.configs.constants import DOC_PROCESSING_TYPE
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.utils.logger import setup_logger
 
-
 logger = setup_logger()
 
 
-def get_unstructured_api_key() -> str | None:
+class DocumentProcessor(Enum):
+    UNSTRUCTURED = "unstructured"
+    REDUCTO = "reducto"
+
+
+def get_api_key() -> str | None:
     kv_store = get_kv_store()
     try:
-        return cast(str, kv_store.load(KV_UNSTRUCTURED_API_KEY))
+        docprocessing_type = kv_store.load(DOC_PROCESSING_TYPE)
+        if docprocessing_type:
+            return (docprocessing_type, kv_store.load(DOC_PROCESSING_API_KEY))
+        else:
+            return None
     except KvKeyNotFoundError:
         return None
 
 
-def update_unstructured_api_key(api_key: str) -> None:
+def update_api_key(documentProcessor: DocumentProcessor, api_key: str) -> None:
     kv_store = get_kv_store()
-    kv_store.store(KV_UNSTRUCTURED_API_KEY, api_key)
+    kv_store.store(DOC_PROCESSING_TYPE, documentProcessor.value)
+    kv_store.store(DOC_PROCESSING_API_KEY, api_key)
 
 
-def delete_unstructured_api_key() -> None:
+def delete_api_key(documentProcessor: DocumentProcessor) -> None:
     kv_store = get_kv_store()
-    kv_store.delete(KV_UNSTRUCTURED_API_KEY)
+    kv_store.delete(DOC_PROCESSING_TYPE)
+    kv_store.delete(DOC_PROCESSING_API_KEY)
 
 
 def _sdk_partition_request(
@@ -51,11 +64,11 @@ def _sdk_partition_request(
         raise
 
 
-def unstructured_to_text(file: IO[Any], file_name: str) -> str:
+def unstructured_to_text(file: IO[Any], file_name: str, api_key: str) -> str:
     logger.debug(f"Starting to read file: {file_name}")
     req = _sdk_partition_request(file, file_name, strategy="fast")
 
-    unstructured_client = UnstructuredClient(api_key_auth=get_unstructured_api_key())
+    unstructured_client = UnstructuredClient(api_key_auth=api_key)
 
     response = unstructured_client.general.partition(req)  # type: ignore
     elements = dict_to_elements(response.elements)
@@ -66,3 +79,45 @@ def unstructured_to_text(file: IO[Any], file_name: str) -> str:
         raise ValueError(err)
 
     return "\n\n".join(str(el) for el in elements)
+
+
+def reducto_to_text(file: IO[Any], file_name: str, api_key: str) -> str:
+    logger.debug(f"Starting to read file with reducto: {file_name}")
+    client = Reducto(api_key=api_key)
+
+    # get file size
+    current_pos = file.tell()
+    file.seek(0, 2)
+    file_size_bytes = file.tell()
+    file.seek(current_pos)
+    file_size_mb = file_size_bytes / (1024 * 1024)
+
+    if file_size_mb < 95:
+        # Use direct upload for smaller files
+        upload = client.upload(file=file)
+        response = client.parse.run(document_url=upload)
+        logger.debug(response)
+
+    else:
+        # untested presigned URL upload method for larger files
+        logger.debug(
+            f"File {file_name} is {file_size_mb:.2f}MB, using presigned URL upload"
+        )
+
+        presigned_response = client.upload.presigned_url(file_name=file_name)
+        presigned_url = presigned_response["presigned_url"]
+        document_id = presigned_response["document_id"]
+
+        file.seek(0)  # reset file pointer
+        files = {"file": (file_name, file, "application/octet-stream")}
+        upload_response = requests.post(presigned_url, files=files)
+        upload_response.raise_for_status()
+
+        response = client.parse.run(document_id=document_id)
+    chunks = response.result.chunks
+    content_parts = []
+    for chunk in chunks:
+        if hasattr(chunk, "content") and chunk.content:
+            content_parts.append(chunk.content)
+
+    return "\n\n".join(content_parts)

--- a/web/src/app/admin/configuration/document-processing/page.tsx
+++ b/web/src/app/admin/configuration/document-processing/page.tsx
@@ -9,69 +9,106 @@ import { ThreeDotsLoader } from "@/components/Loading";
 import { AdminPageTitle } from "@/components/admin/Title";
 import { Lock } from "@phosphor-icons/react";
 
-function Main() {
-  const {
-    data: isApiKeySet,
-    error,
-    mutate,
-    isLoading,
-  } = useSWR<{
-    unstructured_api_key: string | null;
-  }>("/api/search-settings/unstructured-api-key-set", (url: string) =>
-    fetch(url).then((res) => res.json())
-  );
+type DocumentProcessor = "unstructured" | "reducto";
 
-  const [apiKey, setApiKey] = useState("");
+interface ProcessorConfig {
+  title: string;
+  description: string;
+  learnMoreText: string;
+  learnMoreUrl: string;
+  note: string;
+  checkUrl: string;
+  upsertUrl: string;
+  deleteUrl: string;
+}
+
+const API_CONFIGS: Record<DocumentProcessor, ProcessorConfig> = {
+  unstructured: {
+    title: "Process with Unstructured API",
+    description:
+      "Unstructured extracts and transforms complex data from formats like .pdf, .docx, .png, .pptx, etc. into clean text for Onyx to ingest. Provide an API key to enable Unstructured document processing.",
+    learnMoreText: "Learn more about Unstructured",
+    learnMoreUrl: "https://docs.unstructured.io/welcome",
+    note: "this will send documents to Unstructured servers for processing.",
+    checkUrl: "/api/search-settings/unstructured-api-key-set",
+    upsertUrl: "/api/search-settings/upsert-unstructured-api-key",
+    deleteUrl: "/api/search-settings/delete-unstructured-api-key",
+  },
+  reducto: {
+    title: "Process with Reducto API",
+    description:
+      "Reducto provides advanced document parsing and extraction capabilities for complex documents. Provide an API key to enable Reducto document processing.",
+    learnMoreText: "Learn more about Reducto",
+    learnMoreUrl: "https://docs.reducto.ai/overview",
+    note: "this will send documents to Reducto servers for processing.",
+    checkUrl: "/api/search-settings/reducto-api-key-set",
+    upsertUrl: "/api/search-settings/upsert-reducto-api-key",
+    deleteUrl: "/api/search-settings/delete-reducto-api-key",
+  },
+};
+
+function Main({
+  documentProcessor,
+  activeProcessor,
+  onMutate,
+}: {
+  documentProcessor: DocumentProcessor;
+  activeProcessor: DocumentProcessor | null;
+  onMutate: () => void;
+}) {
+  const config = API_CONFIGS[documentProcessor];
+  const [apiKey, setApiKey] = useState<string>("");
+
+  const isApiKeySet = activeProcessor === documentProcessor;
+  const isDisabled =
+    activeProcessor !== null && activeProcessor !== documentProcessor;
 
   const handleSave = async () => {
     try {
-      await fetch(
-        `/api/search-settings/upsert-unstructured-api-key?unstructured_api_key=${apiKey}`,
-        {
-          method: "PUT",
-        }
-      );
+      const paramName =
+        documentProcessor === "unstructured"
+          ? "unstructured_api_key"
+          : "reducto_api_key";
+      await fetch(`${config.upsertUrl}?${paramName}=${apiKey}`, {
+        method: "PUT",
+      });
     } catch (error) {
       console.error("Failed to save API key:", error);
     }
-    mutate();
+    onMutate();
   };
 
   const handleDelete = async () => {
     try {
-      await fetch("/api/search-settings/delete-unstructured-api-key", {
+      await fetch(config.deleteUrl, {
         method: "DELETE",
       });
       setApiKey("");
     } catch (error) {
       console.error("Failed to delete API key:", error);
     }
-    mutate();
+    onMutate();
   };
 
-  if (isLoading) {
-    return <ThreeDotsLoader />;
-  }
   return (
     <div className="container mx-auto p-4">
-      <CardSection className="mb-8 max-w-2xl bg-white text-text shadow-lg rounded-lg">
+      <CardSection
+        className={`mb-8 max-w-2xl bg-white text-text shadow-lg rounded-lg h-3/4 flex flex-col ${isDisabled ? "opacity-60" : ""}`}
+      >
         <h3 className="text-2xl text-text-800 font-bold mb-4 text-text border-b border-b-border pb-2">
-          Process with Unstructured API
+          {config.title}
         </h3>
 
         <div className="space-y-4">
           <p className="text-text-600">
-            Unstructured extracts and transforms complex data from formats like
-            .pdf, .docx, .png, .pptx, etc. into clean text for Onyx to ingest.
-            Provide an API key to enable Unstructured document processing.
+            {config.description}
             <br />
-            <br /> <strong>Note:</strong> this will send documents to
-            Unstructured servers for processing.
+            <br /> <strong>Note:</strong> {config.note}
           </p>
           <p className="text-text-600">
-            Learn more about Unstructured{" "}
+            {config.learnMoreText}{" "}
             <a
-              href="https://docs.unstructured.io/welcome"
+              href={config.learnMoreUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-500 hover:underline font-medium"
@@ -89,10 +126,15 @@ function Main() {
             ) : (
               <input
                 type="text"
-                placeholder="Enter API Key"
+                placeholder={
+                  isDisabled ? "Delete other API key first" : "Enter API Key"
+                }
                 value={apiKey}
                 onChange={(e) => setApiKey(e.target.value)}
-                className="w-full p-3 border rounded-md bg-background text-text focus:ring-2 focus:ring-blue-500 transition duration-200"
+                disabled={isDisabled}
+                className={`w-full p-3 border rounded-md bg-background text-text focus:ring-2 focus:ring-blue-500 transition duration-200 ${
+                  isDisabled ? "cursor-not-allowed opacity-50" : ""
+                }`}
               />
             )}
           </div>
@@ -107,12 +149,23 @@ function Main() {
                 </p>
               </>
             ) : (
-              <Button
-                onClick={handleSave}
-                className="bg-blue-500 text-white hover:bg-blue-600 transition duration-200"
-              >
-                Save API Key
-              </Button>
+              <>
+                <Button
+                  onClick={handleSave}
+                  disabled={isDisabled || !apiKey.trim()}
+                  className={`bg-blue-500 text-white hover:bg-blue-600 transition duration-200 ${
+                    isDisabled ? "cursor-not-allowed opacity-50" : ""
+                  }`}
+                >
+                  Save API Key
+                </Button>
+                {isDisabled && (
+                  <p className="text-amber-300 my-auto text-sm">
+                    Only one document processor can be active at a time. Delete
+                    the other API key first.
+                  </p>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -122,13 +175,38 @@ function Main() {
 }
 
 export default function Page() {
+  const {
+    data: activeProcessor,
+    error,
+    mutate,
+    isLoading,
+  } = useSWR<DocumentProcessor | null>(
+    "/api/search-settings/active-document-processor",
+    (url: string) => fetch(url).then((res) => res.json())
+  );
+
+  if (isLoading) {
+    return <ThreeDotsLoader />;
+  }
+
   return (
     <div className="mx-auto container">
       <AdminPageTitle
         title="Document Processing"
         icon={<DocumentIcon2 size={32} className="my-auto" />}
       />
-      <Main />
+      <div className="flex flex-row gap-4 items-stretch h-full">
+        <Main
+          documentProcessor="unstructured"
+          activeProcessor={activeProcessor ?? null}
+          onMutate={mutate}
+        />
+        <Main
+          documentProcessor="reducto"
+          activeProcessor={activeProcessor ?? null}
+          onMutate={mutate}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Add option for users to use Reducto to parse pdfs. Users can only enable Unstructured or Reducto, not both.

## How Has This Been Tested?

If one document processor has been configured, the other one will be disabled. 
<img width="1465" height="837" alt="Screenshot 2025-07-21 at 6 43 54 PM" src="https://github.com/user-attachments/assets/f2460800-998e-4aee-83ee-a1274e46b1e5" />

A pdf successfully indexed by Reducto. 
<img width="851" height="684" alt="Screenshot 2025-07-21 at 6 44 06 PM" src="https://github.com/user-attachments/assets/c3b19ab2-8960-4d48-9ab5-e17efcb713f4" />

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for Reducto as a document processor, allowing users to choose between Reducto and Unstructured for PDF parsing. Only one processor can be enabled at a time, and the UI now lets admins manage both API keys with clear selection and disabling logic.

- **New Features**
  - Integrated Reducto API for PDF parsing and indexing.
  - Updated admin UI to configure and switch between Reducto and Unstructured, ensuring only one is active at a time.

<!-- End of auto-generated description by cubic. -->

