### PR TITLE
adding support for markdown files for github

### DIFF
--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -242,6 +242,14 @@ export const connectorConfigs: Record<
         description: "Index issues from repositories",
         optional: true,
       },
+      {
+        type: "checkbox",
+        query: "Include Markdown files?",
+        label: "Include Markdown files?",
+        name: "include_files_md",
+        description: "Index Markdown files from repositories",
+        optional: true,
+      },
     ],
     advanced_values: [],
   },
@@ -1492,6 +1500,7 @@ export interface GithubConfig {
   repositories: string; // Comma-separated list of repository names
   include_prs: boolean;
   include_issues: boolean;
+  include_files_md: boolean;
 }
 
 export interface GitlabConfig {


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The PR adds support to index markdown files for the Github connector

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
- manual testing
- working on adding the unit tests

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
