### PR TITLE
feat: avoid full rerun

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -110,15 +110,6 @@ beat_task_templates: list[dict] = [
         },
     },
     {
-        "name": "check-for-external-group-sync",
-        "task": OnyxCeleryTask.CHECK_FOR_EXTERNAL_GROUP_SYNC,
-        "schedule": timedelta(seconds=20),
-        "options": {
-            "priority": OnyxCeleryPriority.MEDIUM,
-            "expires": BEAT_EXPIRES_DEFAULT,
-        },
-    },
-    {
         "name": "monitor-background-processes",
         "task": OnyxCeleryTask.MONITOR_BACKGROUND_PROCESSES,
         "schedule": timedelta(minutes=5),

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -101,15 +101,6 @@ beat_task_templates: list[dict] = [
         },
     },
     {
-        "name": "check-for-doc-permissions-sync",
-        "task": OnyxCeleryTask.CHECK_FOR_DOC_PERMISSIONS_SYNC,
-        "schedule": timedelta(seconds=30),
-        "options": {
-            "priority": OnyxCeleryPriority.MEDIUM,
-            "expires": BEAT_EXPIRES_DEFAULT,
-        },
-    },
-    {
         "name": "monitor-background-processes",
         "task": OnyxCeleryTask.MONITOR_BACKGROUND_PROCESSES,
         "schedule": timedelta(minutes=5),

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -1060,9 +1060,14 @@ def connector_document_extraction(
                 connector=connector_runner.connector,
             )
 
+            # checkpoint resumption OR the connector already finished.
             if (
                 isinstance(connector_runner.connector, CheckpointedConnector)
                 and resuming_from_checkpoint
+            ) or (
+                most_recent_attempt
+                and most_recent_attempt.total_batches is not None
+                and not checkpoint.has_more
             ):
                 reissued_batch_count, completed_batches = reissue_old_batches(
                     batch_storage,


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2238/avoid-full-rerun-edge-case

Addresses an edge case in indexing; in deployments with large resource intensive indexing workloads, the docfetching worker might schedule a bunch of docprocessing tasks on the queue that don't get run until much later because the queue has grown very large. We don't want to enter this state in the first place, but we REALLY don't want to re-run docfetching after it has already completed once and the attempt gets marked as failed due to inactivity. This PR causes the batches to get re-issued to docprocessing if docfetching completed, avoiding duplicating work.

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents unnecessary full reruns of document fetching by reissuing processing batches only if fetching has completed, reducing duplicate work in large indexing jobs. Also removes unused scheduled tasks for group and permissions sync.

<!-- End of auto-generated description by cubic. -->

