### PR TITLE
fix: regen api key

### DIFF
--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -148,7 +148,10 @@ def regenerate_api_key(db_session: Session, api_key_id: int) -> ApiKeyDescriptor
     if api_key_user is None:
         raise RuntimeError("API Key does not have associated user.")
 
-    new_api_key = generate_api_key()
+    # Get tenant_id from context var (will be default schema for single tenant)
+    tenant_id = get_current_tenant_id()
+
+    new_api_key = generate_api_key(tenant_id)
     existing_api_key.hashed_api_key = hash_api_key(new_api_key)
     existing_api_key.api_key_display = build_displayable_api_key(new_api_key)
     db_session.commit()


### PR DESCRIPTION
## Description

API keys were being regenerated without tenant information (these keys were unable to access anything, so this is a functionality fix, not a security issue).

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed API key regeneration to include tenant information, so new keys work as expected.

<!-- End of auto-generated description by cubic. -->

