### PR TITLE
fix: sharepoint lg files issue

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -468,6 +468,11 @@ GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD = int(
     os.environ.get("GOOGLE_DRIVE_CONNECTOR_SIZE_THRESHOLD", 10 * 1024 * 1024)
 )
 
+# Default size threshold for SharePoint files (20MB)
+SHAREPOINT_CONNECTOR_SIZE_THRESHOLD = int(
+    os.environ.get("SHAREPOINT_CONNECTOR_SIZE_THRESHOLD", 20 * 1024 * 1024)
+)
+
 JIRA_CONNECTOR_LABELS_TO_SKIP = [
     ignored_tag
     for ignored_tag in os.environ.get("JIRA_CONNECTOR_LABELS_TO_SKIP", "").split(",")

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -112,6 +112,10 @@ def _convert_driveitem_to_document(
 
     # Proceed with download if size is acceptable or not available
     content = _sleep_and_retry(driveitem.get_content(), "get_content")
+    if content is None:
+        logger.warning(f"Could not access content for '{driveitem.name}'")
+        return None
+
     file_text = extract_file_text(
         file=io.BytesIO(content.value),
         file_name=driveitem.name,

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -82,9 +82,6 @@ def _sleep_and_retry(query_obj: Any, method_name: str, max_retries: int = 3) -> 
                     )
                 raise e
 
-    # This should never be reached, but included for completeness
-    raise RuntimeError(f"Unexpected end of retry loop for {method_name}")
-
 
 def _convert_driveitem_to_document(
     driveitem: DriveItem,

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -12,7 +12,7 @@ from office365.graph_client import GraphClient  # type: ignore
 from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore
 from office365.onedrive.sites.site import Site  # type: ignore
 from office365.onedrive.sites.sites_with_root import SitesWithRoot  # type: ignore
-from office365.runtime.client_request import ClientRequestException
+from office365.runtime.client_request import ClientRequestException  # type: ignore
 from pydantic import BaseModel
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the SharePoint connector in the `backend/onyx` package, focusing on rate-limiting handling, file size threshold enforcement, and retry logic for SharePoint queries. 
Linear link -> https://linear.app/danswer/issue/DAN-2245/sharepoint-connector-failing

## How Has This Been Tested?
By creating connector

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the SharePoint connector by adding file size checks, rate limit handling, and retry logic to prevent errors and skip large files.

- **Bug Fixes**
  - Skips SharePoint files larger than 20MB.
  - Retries SharePoint queries on rate limit or server errors, with exponential backoff.

<!-- End of auto-generated description by cubic. -->

