### PR TITLE
fix: adjust template variable to match versioning pattern

### DIFF
--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -37,7 +37,7 @@ spec:
         - name: celery-worker-docfetching
           securityContext:
             {{- toYaml .Values.celery_worker_docfetching.securityContext | nindent 12 }}
-          image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
             [


### PR DESCRIPTION
## Description

This PR is a bugfix for the celery-worker-docfetching.yaml template.

Expected Behavior:

- When using global version in values yaml file, all version references should match the defined global version.

Actual Behavior:

- When using global version in values yaml file, the celery_worker_docfetching image is still referencing the "latest" version.

## How Has This Been Tested?

Used `helm template` command to test the render, confirmed that after the variable is switched all the versions match correctly.

This pattern was applied to the other celery workers, but it seems this template was missed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the celery-worker-docfetching Helm template to use the global version variable instead of defaulting to "latest" for the image tag. This ensures all worker images follow the same versioning pattern.

<!-- End of auto-generated description by cubic. -->

