### PR TITLE
fix: remove locks from indexing callback

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -1113,15 +1113,8 @@ def connector_document_extraction(
                 # index being built. We want to populate it even for paused connectors
                 # Often paused connectors are sources that aren't updated frequently but the
                 # contents still need to be initially pulled.
-                if callback:
-                    if callback.should_stop():
-                        raise ConnectorStopSignal("Connector stop signal detected")
-
-                    # NOTE: this progress callback runs on every loop. We've seen cases
-                    # where we loop many times with no new documents and eventually time
-                    # out, so only doing the callback after indexing isn't sufficient.
-                    # TODO: change to doc extraction if it doesnt break things
-                    callback.progress("_run_indexing", 0)
+                if callback and callback.should_stop():
+                    raise ConnectorStopSignal("Connector stop signal detected")
 
                 # will exception if the connector/index attempt is marked as paused/failed
                 with get_session_with_current_tenant() as db_session_tmp:

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -258,8 +258,6 @@ class EmbeddingModel:
                     try:
                         result = future.result()
                         batch_results.append(result)
-                        if self.callback:
-                            self.callback.progress("_batch_encode_texts", 1)
                     except Exception as e:
                         logger.exception("Embedding model failed to process batch")
                         raise e
@@ -279,8 +277,6 @@ class EmbeddingModel:
                     request_id=request_id,
                 )
                 embeddings.extend(batch_embeddings)
-                if self.callback:
-                    self.callback.progress("_batch_encode_texts", 1)
 
         return embeddings
 

--- a/backend/onyx/redis/redis_connector_index.py
+++ b/backend/onyx/redis/redis_connector_index.py
@@ -79,9 +79,6 @@ class RedisConnectorIndex:
             f"{self.TERMINATE_PREFIX}_{cc_pair_id}/{search_settings_id}"
         )
 
-    def lock_key_by_batch(self, batch_n: int) -> str:
-        return f"{self.per_worker_lock_key}/{batch_n}"
-
     def set_generator_complete(self, payload: int | None) -> None:
         if not payload:
             self.redis.delete(self.generator_complete_key)


### PR DESCRIPTION
## Description

Remove everything from IndexingCallback except connector pausing logic, because that is all the IndexingCallback is currently used for. In particular we're removing the logic that prevents duplicate docfetching processes from running (deduping is handled in check_for_indexing as cc_pairs that already have a non-terminal status are skipped). We're also removing the logic that avoids duplicate docprocessing tasks per batch. We never *should* have duplicate processes per batch anyways (each process is tied to an active index attempt and only one task is emitted per batch), but even if we do, worst case is having some extra total docs show up.

## How Has This Been Tested?

tested basic indexing behavior in the UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
