### PR TITLE
fix: attempt fix for broken excel files

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -83,6 +83,11 @@ IMAGE_MEDIA_TYPES = [
     "image/webp",
 ]
 
+KNOWN_OPENPYXL_BUGS = [
+    "Value must be either numerical or a string containing a wildcard",
+    "File contains no valid workbook part",
+]
+
 
 class OnyxExtensionType(IntFlag):
     Plain = auto()
@@ -374,7 +379,7 @@ def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
             logger.warning(error_str)
         return ""
     except Exception as e:
-        if "File contains no valid workbook part" in str(e):
+        if any(s in str(e) for s in KNOWN_OPENPYXL_BUGS):
             logger.error(
                 f"Failed to extract text from {file_name or 'xlsx file'}. This happens due to a bug in openpyxl. {e}"
             )

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -49,7 +49,7 @@ nltk==3.9.1
 Office365-REST-Python-Client==2.5.9
 oauthlib==3.2.2
 openai==1.75.0
-openpyxl==3.1.2
+openpyxl==3.0.10
 passlib==1.7.4
 playwright==1.41.2
 psutil==5.9.5


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2244/excel-file-parsing-for-files-with-weird-filters

Context in linear, but basically openpyxl added a strict check in 3.1.0 that breaks parsing for fancy excel files

## How Has This Been Tested?

can't reproduce, but the changes should a) use a openpyxl version that doesn't contain the issue and b) allow indexing to at least skip these docs if the issue persists.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed Excel file parsing errors by downgrading openpyxl and improving error handling for known issues.

- **Bug Fixes**
  - Rolled back openpyxl to 3.0.10 to avoid strict checks that break parsing.
  - Added handling for specific openpyxl errors so problematic files are skipped instead of causing failures.

<!-- End of auto-generated description by cubic. -->

