### PR TITLE
fix: drive external links

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -341,8 +341,18 @@ def docx_to_text_and_images(
 
     for rel_id, rel in doc.part.rels.items():
         if "image" in rel.reltype:
-            # image is typically in rel.target_part.blob
-            image_bytes = rel.target_part.blob
+            # Skip images that are linked rather than embedded (TargetMode="External")
+            if getattr(rel, "is_external", False):
+                continue
+
+            try:
+                # image is typically in rel.target_part.blob
+                image_bytes = rel.target_part.blob
+            except ValueError:
+                # Safeguard against relationships that lack an internal target_part
+                # (e.g., external relationships or other anomalies)
+                continue
+
             image_name = rel.target_part.partname
             # store
             embedded_images.append((image_bytes, os.path.basename(str(image_name))))


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2250/docx-external-links

We were previously erroring out on docx files with external links; we're temporarily going to skip them to allow indexing. In the future we should add some best-effort fetching of external links.

## How Has This Been Tested?

n/a, should be totally benign

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Docx files with external image links are now skipped during processing to prevent errors and allow successful indexing.

- **Bug Fixes**
 - Ignores external image relationships in docx files instead of raising errors.

<!-- End of auto-generated description by cubic. -->

