### PR TITLE
fix: attempt to fix parsing of tricky template files

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -317,7 +317,7 @@ def docx_to_text_and_images(
 
     try:
         doc = docx.Document(file)
-    except BadZipFile as e:
+    except (BadZipFile, ValueError) as e:
         logger.warning(
             f"Failed to extract docx {file_name or 'docx file'}: {e}. Attempting to read as text file."
         )


### PR DESCRIPTION
## Description

There are exceedingly rare cases where certain template files in drive have a mimetype provided by google drive that differs from the mimetype extracted from within the file that causes a ValueError to be raised when they are processed by python-docx. Now we catch these errors and attempt to parse as raw text.

## How Has This Been Tested?

n/a, worst case is we get a different error

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an error when parsing rare template files with mismatched mimetypes by catching ValueError and falling back to reading as raw text.

<!-- End of auto-generated description by cubic. -->

