### PR TITLE
fix: sidebar ranges

### DIFF
--- a/web/src/app/chat/lib.tsx
+++ b/web/src/app/chat/lib.tsx
@@ -36,6 +36,14 @@ import { INTERNET_SEARCH_TOOL_ID } from "./tools/constants";
 import { SEARCH_TOOL_ID } from "./tools/constants";
 import { IIMAGE_GENERATION_TOOL_ID } from "./tools/constants";
 
+// Date range group constants
+export const DATE_RANGE_GROUPS = {
+  TODAY: "Today",
+  PREVIOUS_7_DAYS: "Previous 7 Days",
+  PREVIOUS_30_DAYS: "Previous 30 Days",
+  OVER_30_DAYS: "Over 30 Days",
+} as const;
+
 interface ChatRetentionInfo {
   chatRetentionDays: number;
   daysFromCreation: number;
@@ -421,10 +429,10 @@ export function groupSessionsByDateRange(chatSessions: ChatSession[]) {
   today.setHours(0, 0, 0, 0); // Set to start of today for accurate comparison
 
   const groups: Record<string, ChatSession[]> = {
-    Today: [],
-    "Previous 7 Days": [],
-    "Previous 30 days": [],
-    "Over 30 days": [],
+    [DATE_RANGE_GROUPS.TODAY]: [],
+    [DATE_RANGE_GROUPS.PREVIOUS_7_DAYS]: [],
+    [DATE_RANGE_GROUPS.PREVIOUS_30_DAYS]: [],
+    [DATE_RANGE_GROUPS.OVER_30_DAYS]: [],
   };
 
   chatSessions.forEach((chatSession) => {
@@ -434,22 +442,22 @@ export function groupSessionsByDateRange(chatSessions: ChatSession[]) {
     const diffDays = diffTime / (1000 * 3600 * 24); // Convert time difference to days
 
     if (diffDays < 1) {
-      const groups_today = groups["Today"];
+      const groups_today = groups[DATE_RANGE_GROUPS.TODAY];
       if (groups_today) {
         groups_today.push(chatSession);
       }
     } else if (diffDays <= 7) {
-      const groups_7 = groups["Previous 7 Days"];
+      const groups_7 = groups[DATE_RANGE_GROUPS.PREVIOUS_7_DAYS];
       if (groups_7) {
         groups_7.push(chatSession);
       }
     } else if (diffDays <= 30) {
-      const groups_30 = groups["Previous 30 Days"];
+      const groups_30 = groups[DATE_RANGE_GROUPS.PREVIOUS_30_DAYS];
       if (groups_30) {
         groups_30.push(chatSession);
       }
     } else {
-      const groups_over_30 = groups["Over 30 days"];
+      const groups_over_30 = groups[DATE_RANGE_GROUPS.OVER_30_DAYS];
       if (groups_over_30) {
         groups_over_30.push(chatSession);
       }


### PR DESCRIPTION
## Description

There was a discrepancy is "Previous 30 days" that is now fixed; refactored this so a similar thing won't happen in the future

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the "Previous 30 Days" sidebar grouping so sessions are now sorted into the correct date ranges.

- **Refactors**
 - Centralized date range group labels to prevent future mismatches.

<!-- End of auto-generated description by cubic. -->

