### PR TITLE
feat: pruning freq

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -277,6 +277,9 @@ def try_creating_prune_generator_task(
     if not ALLOW_SIMULTANEOUS_PRUNING:
         count = redis_connector.prune.get_active_task_count()
         if count > 0:
+            logger.info(
+                f"try_creating_prune_generator_task: cc_pair={cc_pair.id} no simultaneous pruning allowed"
+            )
             return None
 
     LOCK_TIMEOUT = 30
@@ -288,9 +291,11 @@ def try_creating_prune_generator_task(
         timeout=LOCK_TIMEOUT,
     )
 
-    # TODO: allow multiple prunings to run in parallel
     acquired = lock.acquire(blocking_timeout=LOCK_TIMEOUT / 2)
     if not acquired:
+        logger.info(
+            f"try_creating_prune_generator_task: cc_pair={cc_pair.id} lock not acquired"
+        )
         return None
 
     try:

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -70,9 +70,9 @@ logger = setup_logger()
 def _get_pruning_block_expiration() -> int:
     """
     Compute the expiration time for the pruning block signal.
-    Base expiration is 3600 seconds (1 hour), multiplied by the beat multiplier only in MULTI_TENANT mode.
+    Base expiration is 60 seconds (1 minute), multiplied by the beat multiplier only in MULTI_TENANT mode.
     """
-    base_expiration = 3600  # seconds
+    base_expiration = 60  # seconds
 
     if not MULTI_TENANT:
         return base_expiration
@@ -145,10 +145,7 @@ def _is_pruning_due(cc_pair: ConnectorCredentialPair) -> bool:
         last_pruned = cc_pair.connector.time_created
 
     next_prune = last_pruned + timedelta(seconds=cc_pair.connector.prune_freq)
-    if datetime.now(timezone.utc) < next_prune:
-        return False
-
-    return True
+    return datetime.now(timezone.utc) >= next_prune
 
 
 @shared_task(
@@ -291,6 +288,7 @@ def try_creating_prune_generator_task(
         timeout=LOCK_TIMEOUT,
     )
 
+    # TODO: allow multiple prunings to run in parallel
     acquired = lock.acquire(blocking_timeout=LOCK_TIMEOUT / 2)
     if not acquired:
         return None

--- a/backend/onyx/redis/redis_document_set.py
+++ b/backend/onyx/redis/redis_document_set.py
@@ -28,10 +28,7 @@ class RedisDocumentSet(RedisObjectHelper):
 
     @property
     def fenced(self) -> bool:
-        if self.redis.exists(self.fence_key):
-            return True
-
-        return False
+        return bool(self.redis.exists(self.fence_key))
 
     def set_fence(self, payload: int | None) -> None:
         if payload is None:


### PR DESCRIPTION
## Description

There are two ways of setting pruning frequency: the TTL of the BLOCK_PRUNING signal and individual connector pruning frequencies. With the previous TTL, pruning was only checked about once a day. We're greatly increasing the frequency of the check (to about once per 25 minutes on cloud, once per minute on self deploy) as it should be quite lightweight. We're also going to start allowing simultaneous pruning on cloud.

## How Has This Been Tested?

n/a, timing and logging only

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increased the frequency of pruning checks to run every 25 minutes on cloud and every minute on self-deployed setups, and enabled simultaneous pruning on cloud.

- **Improvements**
  - Reduced pruning block signal TTL for more frequent checks.
  - Added logging for lock acquisition and simultaneous pruning attempts.
  - Simplified fenced property logic in redis_document_set.

<!-- End of auto-generated description by cubic. -->

