### PR TITLE
feat: Add Outline knowledge base connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -152,6 +152,7 @@ class DocumentSource(str, Enum):
     GITLAB = "gitlab"
     GURU = "guru"
     BOOKSTACK = "bookstack"
+    OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
     SLAB = "slab"

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -11,6 +11,7 @@ from onyx.connectors.asana.connector import AsanaConnector
 from onyx.connectors.axero.connector import AxeroConnector
 from onyx.connectors.blob.connector import BlobStorageConnector
 from onyx.connectors.bookstack.connector import BookstackConnector
+from onyx.connectors.outline.connector import OutlineConnector
 from onyx.connectors.clickup.connector import ClickupConnector
 from onyx.connectors.confluence.connector import ConfluenceConnector
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
@@ -87,6 +88,7 @@ def identify_connector_class(
         DocumentSource.GITBOOK: GitbookConnector,
         DocumentSource.GOOGLE_DRIVE: GoogleDriveConnector,
         DocumentSource.BOOKSTACK: BookstackConnector,
+        DocumentSource.OUTLINE: OutlineConnector,
         DocumentSource.CONFLUENCE: ConfluenceConnector,
         DocumentSource.JIRA: JiraConnector,
         DocumentSource.PRODUCTBOARD: ProductboardConnector,

--- a/backend/onyx/connectors/outline/__init__.py
+++ b/backend/onyx/connectors/outline/__init__.py
@@ -1,0 +1,1 @@
+# Outline connector package

--- a/backend/onyx/connectors/outline/client.py
+++ b/backend/onyx/connectors/outline/client.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import requests
+
+
+class OutlineClientRequestFailedError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f"Outline API request failed with status {status_code}: {message}")
+
+
+class OutlineApiClient:
+    def __init__(
+        self,
+        base_url: str,
+        api_token: str,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_token = api_token
+
+    def post(self, endpoint: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Make a POST request to the Outline API"""
+        url = self._build_url(endpoint)
+        headers = self._build_headers()
+        
+        response = requests.post(url, headers=headers, json=data or {})
+
+        try:
+            json_response = response.json()
+        except Exception:
+            json_response = {}
+
+        if response.status_code >= 300:
+            error_message = response.reason
+            if json_response.get("error"):
+                error_message = json_response["error"]
+            elif json_response.get("message"):
+                error_message = json_response["message"]
+            raise OutlineClientRequestFailedError(response.status_code, error_message)
+
+        return json_response
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build headers for API requests"""
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _build_url(self, endpoint: str) -> str:
+        """Build the full URL for an API endpoint"""
+        return f"{self.base_url}/api/{endpoint.lstrip('/')}"
+
+    def build_app_url(self, path: str) -> str:
+        """Build a URL for the Outline application (for document links)"""
+        return f"{self.base_url}/{path.lstrip('/')}"

--- a/backend/onyx/connectors/outline/connector.py
+++ b/backend/onyx/connectors/outline/connector.py
@@ -1,0 +1,217 @@
+import time
+from datetime import datetime
+from typing import Any
+from typing import Callable
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.connectors.outline.client import OutlineApiClient
+from onyx.connectors.outline.client import OutlineClientRequestFailedError
+from onyx.file_processing.html_utils import parse_html_page_basic
+
+
+class OutlineConnector(LoadConnector, PollConnector):
+    def __init__(
+        self,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.batch_size = batch_size
+        self.outline_client: OutlineApiClient | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self.outline_client = OutlineApiClient(
+            base_url=credentials["outline_base_url"],
+            api_token=credentials["outline_api_token"],
+        )
+        return None
+
+    @staticmethod
+    def _get_doc_batch(
+        batch_size: int,
+        outline_client: OutlineApiClient,
+        endpoint: str,
+        transformer: Callable[[OutlineApiClient, dict], Document],
+        start_ind: int,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> tuple[list[Document], int]:
+        data = {
+            "limit": batch_size,
+            "offset": start_ind,
+        }
+
+        # Add date filters if provided
+        if start:
+            # Outline uses ISO format for date filtering
+            data["updatedAt"] = {
+                "gte": datetime.utcfromtimestamp(start).isoformat() + "Z"
+            }
+        if end:
+            if "updatedAt" not in data:
+                data["updatedAt"] = {}
+            data["updatedAt"]["lte"] = datetime.utcfromtimestamp(end).isoformat() + "Z"
+
+        response = outline_client.post(endpoint, data)
+        batch = response.get("data", [])
+        doc_batch = [transformer(outline_client, item) for item in batch]
+
+        return doc_batch, len(batch)
+
+    @staticmethod
+    def _collection_to_document(
+        outline_client: OutlineApiClient, collection: dict[str, Any]
+    ) -> Document:
+        collection_id = str(collection.get("id", ""))
+        url = outline_client.build_app_url(f"/collection/{collection.get('urlId', collection_id)}")
+        title = str(collection.get("name", ""))
+        description = collection.get("description", "")
+        text = f"{title}\n{description}" if description else title
+        
+        updated_at_str = collection.get("updatedAt")
+        
+        return Document(
+            id=f"collection__{collection_id}",
+            sections=[TextSection(link=url, text=text)],
+            source=DocumentSource.OUTLINE,
+            semantic_identifier=f"Collection: {title}",
+            title=title,
+            doc_updated_at=(
+                time_str_to_utc(updated_at_str) if updated_at_str else None
+            ),
+            metadata={"type": "collection"},
+        )
+
+    @staticmethod
+    def _document_to_document(
+        outline_client: OutlineApiClient, document: dict[str, Any]
+    ) -> Document:
+        document_id = str(document.get("id", ""))
+        url_id = document.get("urlId", document_id)
+        url = outline_client.build_app_url(f"/doc/{url_id}")
+        title = str(document.get("title", ""))
+        
+        # Get the document content - Outline stores content in 'text' field as markdown
+        text_content = document.get("text", "")
+        if not text_content and document.get("id"):
+            # If text is not included, we might need to fetch it separately
+            try:
+                doc_detail = outline_client.post("documents.info", {"id": document_id})
+                text_content = doc_detail.get("data", {}).get("text", "")
+            except Exception:
+                # If we can't fetch the content, use title as fallback
+                text_content = title
+        
+        # Parse HTML content if needed (Outline can contain HTML in markdown)
+        if text_content:
+            try:
+                parsed_text = parse_html_page_basic(text_content)
+                if parsed_text.strip():
+                    text_content = parsed_text
+            except Exception:
+                # If parsing fails, use original content
+                pass
+        
+        updated_at_str = document.get("updatedAt")
+        
+        # Add a small delay to avoid rate limiting
+        time.sleep(0.1)
+        
+        return Document(
+            id=f"document__{document_id}",
+            sections=[TextSection(link=url, text=text_content or title)],
+            source=DocumentSource.OUTLINE,
+            semantic_identifier=f"Document: {title}",
+            title=title,
+            doc_updated_at=(
+                time_str_to_utc(updated_at_str) if updated_at_str else None
+            ),
+            metadata={
+                "type": "document",
+                "collection_id": document.get("collectionId", ""),
+            },
+        )
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        if self.outline_client is None:
+            raise ConnectorMissingCredentialError("Outline")
+
+        return self.poll_source(None, None)
+
+    def poll_source(
+        self, start: SecondsSinceUnixEpoch | None, end: SecondsSinceUnixEpoch | None
+    ) -> GenerateDocumentsOutput:
+        if self.outline_client is None:
+            raise ConnectorMissingCredentialError("Outline")
+
+        transform_by_endpoint: dict[
+            str, Callable[[OutlineApiClient, dict], Document]
+        ] = {
+            "collections.list": self._collection_to_document,
+            "documents.list": self._document_to_document,
+        }
+
+        for endpoint, transformer in transform_by_endpoint.items():
+            start_ind = 0
+            while True:
+                doc_batch, batch_size = self._get_doc_batch(
+                    self.batch_size,
+                    self.outline_client,
+                    endpoint,
+                    transformer,
+                    start_ind,
+                    start,
+                    end,
+                )
+
+                if doc_batch:
+                    yield doc_batch
+
+                if batch_size < self.batch_size:
+                    break
+
+                start_ind += batch_size
+
+    def validate_connector_settings(self) -> None:
+        """
+        Validate that the Outline credentials and connector settings are correct.
+        Specifically checks that we can make an authenticated request to Outline.
+        """
+        if not self.outline_client:
+            raise ConnectorMissingCredentialError(
+                "Outline credentials have not been loaded."
+            )
+
+        try:
+            # Attempt to fetch auth info to verify credentials
+            _ = self.outline_client.post("auth.info")
+
+        except OutlineClientRequestFailedError as e:
+            # Check for HTTP status codes
+            if e.status_code == 401:
+                raise CredentialExpiredError(
+                    "Your Outline credentials appear to be invalid or expired (HTTP 401)."
+                ) from e
+            elif e.status_code == 403:
+                raise InsufficientPermissionsError(
+                    "The configured Outline token does not have sufficient permissions (HTTP 403)."
+                ) from e
+            else:
+                raise ConnectorValidationError(
+                    f"Unexpected Outline error (status={e.status_code}): {e}"
+                ) from e
+
+        except Exception as exc:
+            raise ConnectorValidationError(
+                f"Unexpected error while validating Outline connector settings: {exc}"
+            ) from exc

--- a/backend/tests/unit/onyx/connectors/outline/__init__.py
+++ b/backend/tests/unit/onyx/connectors/outline/__init__.py
@@ -1,0 +1,1 @@
+# Outline connector tests

--- a/backend/tests/unit/onyx/connectors/outline/test_outline_connector.py
+++ b/backend/tests/unit/onyx/connectors/outline/test_outline_connector.py
@@ -1,0 +1,265 @@
+import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.outline.client import OutlineApiClient
+from onyx.connectors.outline.client import OutlineClientRequestFailedError
+from onyx.connectors.outline.connector import OutlineConnector
+
+
+@pytest.fixture
+def outline_connector():
+    """Create an OutlineConnector instance for testing."""
+    return OutlineConnector(batch_size=10)
+
+
+@pytest.fixture
+def mock_outline_client():
+    """Create a mock OutlineApiClient."""
+    return Mock(spec=OutlineApiClient)
+
+
+@pytest.fixture
+def sample_collection():
+    """Sample collection data from Outline API."""
+    return {
+        "id": "collection-123",
+        "urlId": "test-collection",
+        "name": "Test Collection",
+        "description": "A test collection for unit tests",
+        "updatedAt": "2024-01-15T10:30:00Z",
+    }
+
+
+@pytest.fixture
+def sample_document():
+    """Sample document data from Outline API."""
+    return {
+        "id": "document-456",
+        "urlId": "test-document",
+        "title": "Test Document",
+        "text": "# Test Document\n\nThis is a test document with some content.",
+        "collectionId": "collection-123",
+        "updatedAt": "2024-01-15T11:00:00Z",
+    }
+
+
+class TestOutlineConnector:
+    def test_load_credentials(self, outline_connector):
+        """Test loading credentials."""
+        credentials = {
+            "outline_base_url": "https://test.getoutline.com",
+            "outline_api_token": "test-token-123",
+        }
+        
+        result = outline_connector.load_credentials(credentials)
+        
+        assert result is None
+        assert outline_connector.outline_client is not None
+        assert outline_connector.outline_client.base_url == "https://test.getoutline.com"
+        assert outline_connector.outline_client.api_token == "test-token-123"
+
+    def test_collection_to_document(self, sample_collection):
+        """Test converting a collection to a Document."""
+        mock_client = Mock()
+        mock_client.build_app_url.return_value = "https://test.getoutline.com/collection/test-collection"
+        
+        document = OutlineConnector._collection_to_document(mock_client, sample_collection)
+        
+        assert isinstance(document, Document)
+        assert document.id == "collection__collection-123"
+        assert document.source == DocumentSource.OUTLINE
+        assert document.semantic_identifier == "Collection: Test Collection"
+        assert document.title == "Test Collection"
+        assert len(document.sections) == 1
+        assert document.sections[0].link == "https://test.getoutline.com/collection/test-collection"
+        assert "Test Collection" in document.sections[0].text
+        assert "A test collection for unit tests" in document.sections[0].text
+        assert document.metadata == {"type": "collection"}
+        assert document.doc_updated_at is not None
+
+    def test_document_to_document(self, sample_document):
+        """Test converting a document to a Document."""
+        mock_client = Mock()
+        mock_client.build_app_url.return_value = "https://test.getoutline.com/doc/test-document"
+        
+        document = OutlineConnector._document_to_document(mock_client, sample_document)
+        
+        assert isinstance(document, Document)
+        assert document.id == "document__document-456"
+        assert document.source == DocumentSource.OUTLINE
+        assert document.semantic_identifier == "Document: Test Document"
+        assert document.title == "Test Document"
+        assert len(document.sections) == 1
+        assert document.sections[0].link == "https://test.getoutline.com/doc/test-document"
+        assert "Test Document" in document.sections[0].text
+        assert document.metadata == {"type": "document", "collection_id": "collection-123"}
+        assert document.doc_updated_at is not None
+
+    def test_load_from_state_missing_credentials(self, outline_connector):
+        """Test load_from_state raises error when credentials are missing."""
+        with pytest.raises(ConnectorMissingCredentialError):
+            list(outline_connector.load_from_state())
+
+    def test_poll_source_missing_credentials(self, outline_connector):
+        """Test poll_source raises error when credentials are missing."""
+        with pytest.raises(ConnectorMissingCredentialError):
+            list(outline_connector.poll_source(None, None))
+
+    @patch('onyx.connectors.outline.connector.time.sleep')
+    def test_poll_source_success(self, mock_sleep, outline_connector, mock_outline_client, 
+                                 sample_collection, sample_document):
+        """Test successful polling of source."""
+        outline_connector.outline_client = mock_outline_client
+        
+        # Mock API responses
+        mock_outline_client.post.side_effect = [
+            {"data": [sample_collection]},  # collections.list response
+            {"data": []},  # collections.list empty response (end of pagination)
+            {"data": [sample_document]},  # documents.list response
+            {"data": []},  # documents.list empty response (end of pagination)
+        ]
+        mock_outline_client.build_app_url.side_effect = [
+            "https://test.getoutline.com/collection/test-collection",
+            "https://test.getoutline.com/doc/test-document",
+        ]
+        
+        documents = list(outline_connector.poll_source(None, None))
+        
+        assert len(documents) == 2  # Two batches: collections and documents
+        assert len(documents[0]) == 1  # One collection
+        assert len(documents[1]) == 1  # One document
+        
+        # Verify collection document
+        collection_doc = documents[0][0]
+        assert collection_doc.id == "collection__collection-123"
+        assert collection_doc.semantic_identifier == "Collection: Test Collection"
+        
+        # Verify document
+        document_doc = documents[1][0]
+        assert document_doc.id == "document__document-456"
+        assert document_doc.semantic_identifier == "Document: Test Document"
+
+    def test_validate_connector_settings_missing_client(self, outline_connector):
+        """Test validation fails when client is missing."""
+        with pytest.raises(ConnectorMissingCredentialError):
+            outline_connector.validate_connector_settings()
+
+    def test_validate_connector_settings_success(self, outline_connector, mock_outline_client):
+        """Test successful validation."""
+        outline_connector.outline_client = mock_outline_client
+        mock_outline_client.post.return_value = {"data": {"user": {"id": "user-123"}}}
+        
+        # Should not raise any exception
+        outline_connector.validate_connector_settings()
+        
+        mock_outline_client.post.assert_called_once_with("auth.info")
+
+    def test_validate_connector_settings_401_error(self, outline_connector, mock_outline_client):
+        """Test validation handles 401 error."""
+        outline_connector.outline_client = mock_outline_client
+        mock_outline_client.post.side_effect = OutlineClientRequestFailedError(401, "Unauthorized")
+        
+        with pytest.raises(CredentialExpiredError):
+            outline_connector.validate_connector_settings()
+
+    def test_validate_connector_settings_403_error(self, outline_connector, mock_outline_client):
+        """Test validation handles 403 error."""
+        outline_connector.outline_client = mock_outline_client
+        mock_outline_client.post.side_effect = OutlineClientRequestFailedError(403, "Forbidden")
+        
+        with pytest.raises(InsufficientPermissionsError):
+            outline_connector.validate_connector_settings()
+
+    def test_validate_connector_settings_other_error(self, outline_connector, mock_outline_client):
+        """Test validation handles other HTTP errors."""
+        outline_connector.outline_client = mock_outline_client
+        mock_outline_client.post.side_effect = OutlineClientRequestFailedError(500, "Server Error")
+        
+        with pytest.raises(ConnectorValidationError):
+            outline_connector.validate_connector_settings()
+
+    def test_validate_connector_settings_unexpected_error(self, outline_connector, mock_outline_client):
+        """Test validation handles unexpected errors."""
+        outline_connector.outline_client = mock_outline_client
+        mock_outline_client.post.side_effect = Exception("Unexpected error")
+        
+        with pytest.raises(ConnectorValidationError):
+            outline_connector.validate_connector_settings()
+
+
+class TestOutlineApiClient:
+    def test_init(self):
+        """Test OutlineApiClient initialization."""
+        client = OutlineApiClient("https://test.getoutline.com", "test-token")
+        
+        assert client.base_url == "https://test.getoutline.com"
+        assert client.api_token == "test-token"
+
+    def test_build_url(self):
+        """Test URL building."""
+        client = OutlineApiClient("https://test.getoutline.com/", "test-token")
+        
+        url = client._build_url("/collections.list")
+        assert url == "https://test.getoutline.com/api/collections.list"
+        
+        url = client._build_url("documents.info")
+        assert url == "https://test.getoutline.com/api/documents.info"
+
+    def test_build_app_url(self):
+        """Test app URL building."""
+        client = OutlineApiClient("https://test.getoutline.com", "test-token")
+        
+        url = client.build_app_url("/collection/test")
+        assert url == "https://test.getoutline.com/collection/test"
+        
+        url = client.build_app_url("doc/test-doc")
+        assert url == "https://test.getoutline.com/doc/test-doc"
+
+    def test_build_headers(self):
+        """Test header building."""
+        client = OutlineApiClient("https://test.getoutline.com", "test-token")
+        
+        headers = client._build_headers()
+        
+        assert headers["Authorization"] == "Bearer test-token"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Accept"] == "application/json"
+
+    @patch('onyx.connectors.outline.client.requests.post')
+    def test_post_success(self, mock_post):
+        """Test successful POST request."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": {"test": "value"}}
+        mock_post.return_value = mock_response
+        
+        client = OutlineApiClient("https://test.getoutline.com", "test-token")
+        result = client.post("collections.list", {"limit": 10})
+        
+        assert result == {"data": {"test": "value"}}
+        mock_post.assert_called_once()
+
+    @patch('onyx.connectors.outline.client.requests.post')
+    def test_post_error(self, mock_post):
+        """Test POST request with error."""
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.reason = "Bad Request"
+        mock_response.json.return_value = {"error": "Invalid request"}
+        mock_post.return_value = mock_response
+        
+        client = OutlineApiClient("https://test.getoutline.com", "test-token")
+        
+        with pytest.raises(OutlineClientRequestFailedError) as exc_info:
+            client.post("collections.list")
+        
+        assert exc_info.value.status_code == 400
+        assert "Invalid request" in str(exc_info.value)

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -205,6 +205,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Wiki,
     docs: "https://docs.onyx.app/connectors/bookstack",
   },
+  outline: {
+    icon: FileIcon2,
+    displayName: "Outline",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/outline",
+  },
   google_sites: {
     icon: GoogleSitesIcon,
     displayName: "Google Sites",


### PR DESCRIPTION
## Overview

Implements Outline (getoutline.com) connector as requested in issue #3256.

## Features

- **OutlineApiClient** for RPC-style API communication with Bearer token authentication
- **OutlineConnector** implementing LoadConnector and PollConnector interfaces
- Support for Collections and Documents with proper metadata
- Incremental updates with time-based filtering
- Comprehensive error handling (401, 403, validation errors)
- Rate limiting protection and HTML content parsing
- Frontend integration with Wiki category display

## Files Added

- `backend/onyx/connectors/outline/client.py` - API client for Outline
- `backend/onyx/connectors/outline/connector.py` - Main connector implementation
- `backend/tests/unit/onyx/connectors/outline/test_outline_connector.py` - Comprehensive unit tests

## Files Modified

- `backend/onyx/configs/constants.py` - Added OUTLINE DocumentSource
- `backend/onyx/connectors/factory.py` - Registered OutlineConnector
- `web/src/lib/sources.ts` - Added Outline source metadata

## Implementation Details

### Architecture
- Follows the same pattern as existing BookStack connector
- Uses Outline's RPC-style POST API endpoints
- Converts Collections and Documents to Onyx Document format
- Supports both full indexing and incremental updates

### Error Handling
- `ConnectorMissingCredentialError` for missing credentials
- `CredentialExpiredError` for 401 authentication failures
- `InsufficientPermissionsError` for 403 permission issues
- `ConnectorValidationError` for other API errors

### Testing
- Comprehensive unit tests covering all functionality
- Mock-based testing for API interactions
- Error scenario coverage

## Configuration

Users will need to provide:
- `outline_base_url` - Base URL of their Outline instance
- `outline_api_token` - API token from Outline Settings > API & Apps

## Value Proposition

- Expands Onyx's ecosystem to include Outline's 28k+ GitHub stars user base
- Enables unified search across popular knowledge platform
- Follows established patterns for easy maintenance

Closes #3256

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author