### PR TITLE
feat: run with non-root users

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -116,6 +116,16 @@ COPY ./assets /app/assets
 
 ENV PYTHONPATH=/app
 
+# Create non-root user for security best practices
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
+    chown -R onyx:onyx /app && \
+    chmod 775 /var/log && \
+    chown onyx:onyx /var/log
+
+# Switch to non-root user
+USER onyx
+
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD
 CMD ["tail", "-f", "/dev/null"]

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -59,4 +59,14 @@ COPY ./model_server /app/model_server
 
 ENV PYTHONPATH=/app
 
+# Create non-root user for security best practices
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
+    chown -R onyx:onyx /app && \
+    chmod 775 /var/log && \
+    chown onyx:onyx /var/log
+
+# Switch to non-root user
+USER onyx
+
 CMD ["uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -30,11 +30,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_beat.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_beat.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-beat
           securityContext:
-            {{- toYaml .Values.celery_beat.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_beat.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_docfetching.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docfetching.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-docfetching
           securityContext:
-            {{- toYaml .Values.celery_worker_docfetching.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docfetching.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_docprocessing.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docprocessing.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-docprocessing
           securityContext:
-            {{- toYaml .Values.celery_worker_docprocessing.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docprocessing.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_heavy.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_heavy.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-heavy
           securityContext:
-            {{- toYaml .Values.celery_worker_heavy.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_heavy.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_light.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_light.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-light
           securityContext:
-            {{- toYaml .Values.celery_worker_light.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_light.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_monitoring.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_monitoring.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-monitoring
           securityContext:
-            {{- toYaml .Values.celery_worker_monitoring.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_monitoring.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_primary.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_primary.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-primary
           securityContext:
-            {{- toYaml .Values.celery_worker_primary.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_primary.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_user_files_indexing.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_user_files_indexing.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-user-files-indexing
           securityContext:
-            {{- toYaml .Values.celery_worker_user_files_indexing.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_user_files_indexing.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -24,8 +24,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.indexCapability.podSecurityContext | nindent 8 }}
       containers:
       - name: {{ .Values.indexCapability.name }}
+        securityContext:
+          {{- toYaml .Values.indexCapability.securityContext | nindent 10 }}
         image: "{{ .Values.indexCapability.image.repository }}:{{ .Values.indexCapability.image.tag | default .Values.global.version }}"
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.indexCapability.containerPorts.server }}", "--limit-concurrency", "{{ .Values.indexCapability.limitConcurrency }}" ]

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -20,8 +20,12 @@ spec:
         {{ .key }}: {{ .value }}
         {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.inferenceCapability.podSecurityContext | nindent 8 }}
       containers:
       - name: model-server-inference
+        securityContext:
+          {{- toYaml .Values.inferenceCapability.securityContext | nindent 10 }}
         image: "{{ .Values.inferenceCapability.image.repository }}:{{ .Values.inferenceCapability.image.tag | default .Values.global.version }}"
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         command: [ "uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "{{ .Values.inferenceCapability.containerPorts.server }}" ]

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -318,6 +318,11 @@ celery_shared:
     periodSeconds: 60
     failureThreshold: 5
     timeoutSeconds: 3
+  podSecurityContext:
+    {}
+  securityContext:
+    privileged: false
+    runAsUser: 1001
 
 celery_beat:
   replicaCount: 1
@@ -327,11 +332,6 @@ celery_beat:
     app: celery-beat
   deploymentLabels:
     app: celery-beat
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -355,11 +355,6 @@ celery_worker_heavy:
     app: celery-worker-heavy
   deploymentLabels:
     app: celery-worker-heavy
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -383,11 +378,6 @@ celery_worker_docprocessing:
     app: celery-worker-docprocessing
   deploymentLabels:
     app: celery-worker-docprocessing
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m
@@ -411,11 +401,6 @@ celery_worker_light:
     app: celery-worker-light
   deploymentLabels:
     app: celery-worker-light
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -439,11 +424,6 @@ celery_worker_monitoring:
     app: celery-worker-monitoring
   deploymentLabels:
     app: celery-worker-monitoring
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m
@@ -467,11 +447,6 @@ celery_worker_primary:
     app: celery-worker-primary
   deploymentLabels:
     app: celery-worker-primary
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -495,11 +470,6 @@ celery_worker_user_files_indexing:
     app: celery-worker-user-files-indexing
   deploymentLabels:
     app: celery-worker-user-files-indexing
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 2000m
@@ -546,11 +516,6 @@ celery_worker_docfetching:
     app: celery-worker-docfetching
   deploymentLabels:
     app: celery-worker-docfetching
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -89,6 +89,11 @@ inferenceCapability:
   podLabels:
     - key: app
       value: inference-model-server
+  podSecurityContext:
+    {}
+  securityContext:
+    privileged: false
+    runAsUser: 1001
   resources:
     requests:
       cpu: 2000m
@@ -118,6 +123,11 @@ indexCapability:
     # Overrides the image tag whose default is the chart appVersion.
     tag: ""
   limitConcurrency: 10
+  podSecurityContext:
+    {}
+  securityContext:
+    privileged: false
+    runAsUser: 1001
   resources:
     requests:
       cpu: 2000m
@@ -173,13 +183,13 @@ webserver:
     # fsGroup: 2000
 
   securityContext:
-    {}
+    privileged: false
+    runAsUser: 1001
     # capabilities:
     #   drop:
     #   - ALL
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
-    # runAsUser: 1000
 
   containerPorts:
     server: 3000


### PR DESCRIPTION
## Description
We are attempting to deploy using the helm chart provided in this repository. Our kubernetes cluster has policies in place that prohibit any pods running as root. We noticed that the values file for the celery workers and the model-servers support adding "runAsUser" attributes, but the images do not have any non-root users created.

This change introduces a non-root USER to both the onyx-backend and the onyx-model-server images to follow pod security best practices. We updated the values for "celery_shared" to apply the 'podSecurityContext' and 'securityContext' to all celery workloads in one spot. We made sure to add support in the templates to ensure that any edits made to a specific celery worker would be applied. Lastly, we added security context for the web server to explicitly declare the non-root user.

## How Has This Been Tested?
We built all docker images locally and ran with `docker run --user 1001 <image> <respective app command>` to ensure that the applications started successfully.

## Backporting (check the box to trigger backport action)
Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.
- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check