### PR TITLE
feat(infra): Update helm version after new feature

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: latest
 annotations:
   category: Productivity


### PR DESCRIPTION
## Description
We should have bumped the helm version when making the changes below and retroactively making the helm update now.

PR with helm update: https://github.com/onyx-dot-app/onyx/pull/4893
[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Version bump which should have been tied to the above PR.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the Helm chart version to 0.2.3 to reflect recent Vespa resource configuration changes. Reduced Vespa node count and increased memory allocation per node.

<!-- End of auto-generated description by cubic. -->

