### PR TITLE
feat: add non-root user to backend and model-server images

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -116,6 +116,13 @@ COPY ./assets /app/assets
 
 ENV PYTHONPATH=/app
 
+# Create non-root user for security best practices
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
+    chown -R onyx:onyx /app && \
+    chmod 775 /var/log && \
+    chown onyx:onyx /var/log
+    
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD
 CMD ["tail", "-f", "/dev/null"]

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -9,8 +9,8 @@ visit https://github.com/onyx-dot-app/onyx."
 # Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION} \
-    DANSWER_RUNNING_IN_DOCKER="true"
-
+    DANSWER_RUNNING_IN_DOCKER="true" \
+    HF_HOME=/app/cache/huggingface
 
 RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 
@@ -39,8 +39,16 @@ from sentence_transformers import SentenceTransformer; \
 SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);"
 
 # In case the user has volumes mounted to /root/.cache/huggingface that they've downloaded while
-# running Onyx, don't overwrite it with the built in cache folder
-RUN mv /root/.cache/huggingface /root/.cache/temp_huggingface
+# running Onyx, don't overwrite it with the built-in cache folder (ensure it's readable by the non-root user)
+RUN mkdir -p $HF_HOME && \
+    mv /root/.cache/huggingface/* $HF_HOME
+
+# Create non-root user for security best practices
+RUN groupadd -g 1001 onyx && \
+    useradd -u 1001 -g onyx -m -s /bin/bash onyx && \
+    chown -R onyx:onyx /app && \
+    chmod 775 /var/log && \
+    chown onyx:onyx /var/log
 
 WORKDIR /app
 

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -10,7 +10,7 @@ visit https://github.com/onyx-dot-app/onyx."
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION} \
     DANSWER_RUNNING_IN_DOCKER="true" \
-    HF_HOME=/app/cache/huggingface
+    HF_HOME=/app/.cache/huggingface
 
 RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 
@@ -38,10 +38,10 @@ snapshot_download('mixedbread-ai/mxbai-rerank-xsmall-v1'); \
 from sentence_transformers import SentenceTransformer; \
 SentenceTransformer(model_name_or_path='nomic-ai/nomic-embed-text-v1', trust_remote_code=True);"
 
-# In case the user has volumes mounted to /root/.cache/huggingface that they've downloaded while
-# running Onyx, don't overwrite it with the built-in cache folder (ensure it's readable by the non-root user)
-RUN mkdir -p $HF_HOME && \
-    mv /root/.cache/huggingface/* $HF_HOME
+# In case the user has volumes mounted to /.cache/huggingface that they've downloaded while
+# running Onyx, move the current contents of the cache folder to a temporary location to ensure 
+# it's preserved in order to combine with the user's cache contents
+RUN mv /app/.cache/huggingface /app/.cache/temp_huggingface
 
 # Create non-root user for security best practices
 RUN groupadd -g 1001 onyx && \

--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -34,8 +34,8 @@ from shared_configs.configs import SENTRY_DSN
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
 
-HF_CACHE_PATH = Path(os.path.expanduser("~")) / ".cache/huggingface"
-TEMP_HF_CACHE_PATH = Path(os.path.expanduser("~")) / ".cache/temp_huggingface"
+HF_CACHE_PATH = Path(".cache/huggingface")
+TEMP_HF_CACHE_PATH = Path(".cache/temp_huggingface")
 
 transformer_logging.set_verbosity_error()
 

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
@@ -141,7 +141,7 @@ Resources:
               Value: "1"
           MountPoints:
             - SourceVolume: efs-volume
-              ContainerPath: /root/.cache/huggingface/
+              ContainerPath: /app/.cache/huggingface/
               ReadOnly: false
           VolumesFrom: []
           LogConfiguration:

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
@@ -137,7 +137,7 @@ Resources:
               Value: info
           MountPoints:
             - SourceVolume: efs-volume
-              ContainerPath: /root/.cache/huggingface/
+              ContainerPath: /app/.cache/huggingface/
               ReadOnly: false
           VolumesFrom: []
           LogConfiguration:

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -354,7 +354,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - inference_model_server_logs:/var/log
     logging:
@@ -388,7 +388,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - indexing_model_server_logs:/var/log
     logging:

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -293,7 +293,7 @@ services:
       - CLIENT_EMBEDDING_TIMEOUT=${CLIENT_EMBEDDING_TIMEOUT:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - inference_model_server_logs:/var/log
     logging:
@@ -332,7 +332,7 @@ services:
       - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - indexing_model_server_logs:/var/log
     logging:

--- a/deployment/docker_compose/docker-compose.model-server-test.yml
+++ b/deployment/docker_compose/docker-compose.model-server-test.yml
@@ -24,7 +24,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -330,7 +330,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:
@@ -362,7 +362,7 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -130,7 +130,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:
@@ -158,7 +158,7 @@ services:
       - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -134,7 +134,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - inference_model_server_logs:/var/log
     logging:
@@ -164,7 +164,7 @@ services:
       - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - indexing_model_server_logs:/var/log
     logging:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -162,7 +162,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/root/.cache/huggingface/
+      - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - inference_model_server_logs:/var/log
     logging:
@@ -192,7 +192,7 @@ services:
       - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
     volumes:
       # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/root/.cache/huggingface/
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
       - indexing_model_server_logs:/var/log
     logging:

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -125,7 +125,7 @@ services:
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
       - LOG_LEVEL=${LOG_LEVEL:-debug}
-      - inference_model_cache_huggingface:/root/.cache/huggingface/
+      - inference_model_cache_huggingface:/app/.cache/huggingface/
     logging:
       driver: json-file
       options:
@@ -149,7 +149,7 @@ services:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
       - INDEXING_ONLY=True
       - LOG_LEVEL=${LOG_LEVEL:-debug}
-      - index_model_cache_huggingface:/root/.cache/huggingface/
+      - index_model_cache_huggingface:/app/.cache/huggingface/
       - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
     logging:
       driver: json-file

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -30,11 +30,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_beat.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_beat.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-beat
           securityContext:
-            {{- toYaml .Values.celery_beat.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_beat.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_docfetching.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docfetching.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-docfetching
           securityContext:
-            {{- toYaml .Values.celery_worker_docfetching.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docfetching.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_docprocessing.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docprocessing.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-docprocessing
           securityContext:
-            {{- toYaml .Values.celery_worker_docprocessing.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docprocessing.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_heavy.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_heavy.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-heavy
           securityContext:
-            {{- toYaml .Values.celery_worker_heavy.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_heavy.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_light.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_light.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-light
           securityContext:
-            {{- toYaml .Values.celery_worker_light.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_light.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_monitoring.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_monitoring.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-monitoring
           securityContext:
-            {{- toYaml .Values.celery_worker_monitoring.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_monitoring.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_primary.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_primary.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-primary
           securityContext:
-            {{- toYaml .Values.celery_worker_primary.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_primary.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_worker_user_files_indexing.podSecurityContext | nindent 8 }}
+        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_user_files_indexing.podSecurityContext) | nindent 8 }}
       containers:
         - name: celery-worker-user-files-indexing
           securityContext:
-            {{- toYaml .Values.celery_worker_user_files_indexing.securityContext | nindent 12 }}
+            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_user_files_indexing.securityContext) | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.indexCapability.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.indexCapability.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.indexCapability.name }}
         image: "{{ .Values.indexCapability.image.repository }}:{{ .Values.indexCapability.image.tag | default .Values.global.version }}"
@@ -40,6 +44,10 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx-stack.envSecrets" . | nindent 10}}
+        {{- if .Values.indexCapability.securityContext }}
+        securityContext:
+          {{- toYaml .Values.indexCapability.securityContext | nindent 10 }}
+        {{- end }}
         {{- if .Values.indexCapability.resources }}
         resources:
           {{- toYaml .Values.indexCapability.resources | nindent 10 }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -20,6 +20,10 @@ spec:
         {{ .key }}: {{ .value }}
         {{- end }}
     spec:
+      {{- if .Values.inferenceCapability.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.inferenceCapability.podSecurityContext | nindent 8 }}
+      {{- end }}
       containers:
       - name: model-server-inference
         image: "{{ .Values.inferenceCapability.image.repository }}:{{ .Values.inferenceCapability.image.tag | default .Values.global.version }}"
@@ -34,6 +38,10 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
+        {{- if .Values.inferenceCapability.securityContext }}
+        securityContext:
+          {{- toYaml .Values.inferenceCapability.securityContext | nindent 10 }}
+        {{- end }}
         {{- if .Values.inferenceCapability.resources }}
         resources:
           {{- toYaml .Values.inferenceCapability.resources | nindent 10 }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -96,6 +96,10 @@ inferenceCapability:
     limits:
       cpu: 4000m
       memory: 10Gi
+  podSecurityContext: {}
+  securityContext:
+    privileged: true
+    runAsUser: 0
 
 indexCapability:
   service:
@@ -125,6 +129,10 @@ indexCapability:
     limits:
       cpu: 4000m
       memory: 10Gi
+  podSecurityContext: {}
+  securityContext:
+    privileged: true
+    runAsUser: 0
 config:
   envConfigMapName: env-configmap
 
@@ -318,6 +326,10 @@ celery_shared:
     periodSeconds: 60
     failureThreshold: 5
     timeoutSeconds: 3
+  podSecurityContext: {}
+  securityContext:
+    privileged: true
+    runAsUser: 0
 
 celery_beat:
   replicaCount: 1


### PR DESCRIPTION
## Description

We are attempting to deploy using the helm chart provided in this repository. Our kubernetes cluster has [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) pod security policies in place that prohibit any containers running as root. We noticed that the values file for the celery workers support adding "runAsUser" attributes, but the images do not have any non-root users created.

This change introduces a non-root USER to both the `onyx-backend` and the `onyx-model-server` images to follow pod security best practices. We updated the values for "celery_shared" to apply the 'podSecurityContext' and 'securityContext' to all celery workloads in one spot, while ensuring that any edits made to a specific celery worker's 'securityContext' or 'podSecurityContext' would still be applied over the shared values. We also introduced the podSecurityContext' and 'securityContext' values to the indexing-model-server and the inference-model-server.

**NOTE**: This change creates the non-root user but **does not** run the containers as non-root by default. Users must specify in the security context. All containers using the `onyx-backend` and `onyx-model-server` images will continue to run as root by default.

See issue #5117 

## How Has This Been Tested?

We built all docker images locally and ran with `docker run --user 1001 <image> <respective app command>` to ensure that the applications started successfully.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a non-root user to the backend and model-server Docker images to support Kubernetes clusters with restricted pod security policies. Updated Helm chart values and templates to allow setting security contexts for all Celery workloads, indexing, and inference model servers.

- **Migration**
  - Containers still run as root by default; set `runAsUser` in the security context to use the non-root user.

<!-- End of auto-generated description by cubic. -->

