### PR TITLE
fix unsupported character error in minio migration

### DIFF
--- a/backend/onyx/file_store/s3_key_utils.py
+++ b/backend/onyx/file_store/s3_key_utils.py
@@ -49,11 +49,10 @@ def sanitize_s3_key_name(file_name: str) -> str:
 
     # Characters to avoid completely (replace with underscore)
     # These are characters that AWS recommends avoiding
-    avoid_chars = r'[\\{}^%`\[\]"<>#|~]'
+    avoid_chars = r'[\\{}^%`\[\]"<>#|~/]'
 
     # Replace avoided characters with underscore
     sanitized = re.sub(avoid_chars, "_", file_name)
-    sanitized = sanitized.replace("/", "-")
     # Characters that might require special handling but are allowed
     # We'll URL encode these to be safe
     special_chars = r"[&$@=;:+,?\s]"

--- a/backend/onyx/file_store/s3_key_utils.py
+++ b/backend/onyx/file_store/s3_key_utils.py
@@ -53,7 +53,7 @@ def sanitize_s3_key_name(file_name: str) -> str:
 
     # Replace avoided characters with underscore
     sanitized = re.sub(avoid_chars, "_", file_name)
-
+    sanitized = sanitized.replace("/", "-")
     # Characters that might require special handling but are allowed
     # We'll URL encode these to be safe
     special_chars = r"[&$@=;:+,?\s]"
@@ -80,6 +80,9 @@ def sanitize_s3_key_name(file_name: str) -> str:
 
     # Remove any trailing periods to avoid download issues
     sanitized = sanitized.rstrip(".")
+
+    # Remove multiple separators
+    sanitized = re.sub(r"[-_]{2,}", "-", sanitized)
 
     # If sanitization resulted in empty string, use a default
     if not sanitized:


### PR DESCRIPTION
## Description
This pull request updates the `sanitize_s3_key_name` function in `backend/onyx/file_store/s3_key_utils.py` to improve the sanitization process for S3 key names. The changes aim to handle special characters more effectively and ensure consistent formatting of sanitized file names.

### Improvements to sanitization logic:

* Replaced forward slashes (`/`) in file names with hyphens (`-`) to avoid issues with S3 key paths. (`[backend/onyx/file_store/s3_key_utils.pyL56-R56](diffhunk://#diff-88c10e8801ae081482cd784617f79a3e9dae6648f297c5fc65aeee74a0a5957bL56-R56)`)
* Added logic to collapse multiple consecutive separators (`-` or `_`) into a single hyphen (`-`) for cleaner and more consistent key names. (`[backend/onyx/file_store/s3_key_utils.pyR84-R86](diffhunk://#diff-88c10e8801ae081482cd784617f79a3e9dae6648f297c5fc65aeee74a0a5957bR84-R86)`)

Linear link -> https://linear.app/danswer/issue/DAN-2252/invalid-char-in-minio-put

## How Has This Been Tested?
I wrote a script to insert files with problematic names, successfully reproduced the issues, and verified the changes using the script.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved S3 key name sanitization to handle unsupported characters in MinIO migrations. File names with slashes are now replaced with hyphens, and repeated separators are collapsed for cleaner keys.

- **Bug Fixes**
  - Replaces forward slashes with hyphens in file names.
  - Collapses multiple consecutive hyphens or underscores into a single hyphen.

<!-- End of auto-generated description by cubic. -->

