### PR TITLE
fix: removal of old tags + is_list differentiation 

### DIFF
--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -1,7 +1,7 @@
 """tag-fix
 
 Revision ID: 90e3b9af7da4
-Revises: 3fc5d75723b3
+Revises: 62c3a055a141
 Create Date: 2025-08-01 20:58:14.607624
 
 """
@@ -26,7 +26,7 @@ logger = setup_logger()
 
 # revision identifiers, used by Alembic.
 revision = "90e3b9af7da4"
-down_revision = "3fc5d75723b3"
+down_revision = "62c3a055a141"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -16,6 +16,8 @@ import json
 from onyx.document_index.factory import get_default_document_index
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.db.search_settings import SearchSettings
+from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.constants import AuthType
 from onyx.document_index.vespa.shared_utils.utils import get_vespa_http_client
 
 logger = setup_logger()
@@ -27,8 +29,11 @@ down_revision = "3fc5d75723b3"
 branch_labels = None
 depends_on = None
 
-# FIXME: set true before merge
-SKIP_TAG_FIX = os.environ.get("SKIP_TAG_FIX", "false").lower() == "true"
+SKIP_TAG_FIX = os.environ.get("SKIP_TAG_FIX", "true").lower() == "true"
+
+# override for cloud
+if AUTH_TYPE == AuthType.CLOUD:
+    SKIP_TAG_FIX = True
 
 
 def set_is_list_for_known_tags() -> None:

--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -1,0 +1,144 @@
+"""tag-fix
+
+Revision ID: 90e3b9af7da4
+Revises: 3fc5d75723b3
+Create Date: 2025-08-01 20:58:14.607624
+
+"""
+
+import os
+
+from alembic import op
+import sqlalchemy as sa
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# revision identifiers, used by Alembic.
+revision = "90e3b9af7da4"
+down_revision = "3fc5d75723b3"
+branch_labels = None
+depends_on = None
+
+# FIXME: set true before merge
+SKIP_TAG_FIX = os.environ.get("SKIP_TAG_FIX", "false").lower() == "true"
+
+
+def set_is_list_for_known_tags() -> None:
+    """
+    Sets is_list to true for all tags that are known to be lists.
+    """
+    LIST_METADATA: list[tuple[str, str]] = [
+        ("CLICKUP", "tags"),
+        ("CONFLUENCE", "labels"),
+        ("DISCOURSE", "tags"),
+        ("FRESHDESK", "emails"),
+        ("GITHUB", "assignees"),
+        ("GITHUB", "labels"),
+        ("GURU", "tags"),
+        ("GURU", "folders"),
+        ("HUBSPOT", "associated_contact_ids"),
+        ("HUBSPOT", "associated_company_ids"),
+        ("HUBSPOT", "associated_deal_ids"),
+        ("HUBSPOT", "associated_ticket_ids"),
+        ("JIRA", "labels"),
+        ("MEDIAWIKI", "categories"),
+        ("ZENDESK", "labels"),
+        ("ZENDESK", "content_tags"),
+    ]
+
+    bind = op.get_bind()
+    for source, key in LIST_METADATA:
+        bind.execute(
+            sa.text(
+                f"""
+                UPDATE document__tag AS dt
+                SET is_list = true
+                FROM tag
+                WHERE tag.id = dt.tag_id
+                AND tag.tag_key = '{key}'
+                AND tag.source = '{source}'
+                """
+            )
+        )
+
+
+def set_is_list_for_list_tags() -> None:
+    """
+    Sets is_list to true for all tags which have multiple values for a given
+    document, key, and source triplet. This only works if we remove old tags
+    from the database.
+    """
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            UPDATE document__tag AS dt
+            SET is_list = true
+            FROM (
+                SELECT DISTINCT tag.tag_key, tag.source
+                FROM tag
+                JOIN document__tag ON tag.id = document__tag.tag_id
+                GROUP BY tag.tag_key, tag.source, document__tag.document_id
+                HAVING count(*) > 1
+            ) AS list_tags
+            JOIN tag ON tag.tag_key = list_tags.tag_key AND tag.source = list_tags.source
+            WHERE dt.tag_id = tag.id
+            """
+        )
+    )
+
+
+def print_list_tags() -> None:
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            """
+            SELECT DISTINCT source, tag_key FROM document__tag
+            JOIN tag ON tag.id = document__tag.tag_id
+            WHERE is_list
+            ORDER BY source, tag_key
+            """
+        )
+    ).fetchall()
+    print("List tags:\n" + "\n".join(f"  {source}: {key}" for source, key in result))
+
+
+def remove_old_tags() -> None:
+    """
+    Removes old tags from the database.
+    Previously, there was a bug where if a document got indexed with a tag and then
+    the document got reindexed, the old tag would not be removed.
+    This function removes those old tags by comparing it against the tags in vespa.
+    """
+    # TODO:
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document__tag",
+        sa.Column("is_list", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    set_is_list_for_known_tags()
+
+    if SKIP_TAG_FIX:
+        logger.warning(
+            "Skipping removal of old tags. "
+            "This can cause issues when using the knowledge graph, or "
+            "when filtering for documents by tags."
+        )
+        print_list_tags()
+        return
+
+    remove_old_tags()
+    set_is_list_for_list_tags()
+
+    # debug
+    print_list_tags()
+
+
+def downgrade() -> None:
+    # the migration adds and populates the is_list column, and removes old bugged tags
+    # there isn't a point in adding back the bugged tags, so we just drop the column
+    op.drop_column("document__tag", "is_list")

--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -293,6 +293,16 @@ def upgrade() -> None:
         "tag",
         sa.Column("is_list", sa.Boolean(), nullable=False, server_default="false"),
     )
+    op.drop_constraint(
+        constraint_name="_tag_key_value_source_uc",
+        table_name="tag",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        constraint_name="_tag_key_value_source_list_uc",
+        table_name="tag",
+        columns=["tag_key", "tag_value", "source", "is_list"],
+    )
     set_is_list_for_known_tags()
 
     if SKIP_TAG_FIX:
@@ -314,4 +324,14 @@ def upgrade() -> None:
 def downgrade() -> None:
     # the migration adds and populates the is_list column, and removes old bugged tags
     # there isn't a point in adding back the bugged tags, so we just drop the column
+    op.drop_constraint(
+        constraint_name="_tag_key_value_source_list_uc",
+        table_name="tag",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        constraint_name="_tag_key_value_source_uc",
+        table_name="tag",
+        columns=["tag_key", "tag_value", "source"],
+    )
     op.drop_column("tag", "is_list")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -379,6 +379,8 @@ class Document__Tag(Base):
         ForeignKey("tag.id"), primary_key=True, index=True
     )
 
+    is_list: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
 
 class Persona__Tool(Base):
     __tablename__ = "persona__tool"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -379,8 +379,6 @@ class Document__Tag(Base):
         ForeignKey("tag.id"), primary_key=True, index=True
     )
 
-    is_list: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-
 
 class Persona__Tool(Base):
     __tablename__ = "persona__tool"
@@ -1295,6 +1293,7 @@ class Tag(Base):
     source: Mapped[DocumentSource] = mapped_column(
         Enum(DocumentSource, native_enum=False)
     )
+    is_list: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     documents = relationship(
         "Document",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1303,7 +1303,11 @@ class Tag(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "tag_key", "tag_value", "source", name="_tag_key_value_source_uc"
+            "tag_key",
+            "tag_value",
+            "source",
+            "is_list",
+            name="_tag_key_value_source_list_uc",
         ),
     )
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -44,8 +44,7 @@ from onyx.db.document_set import fetch_document_sets_for_documents
 from onyx.db.models import Document as DBDocument
 from onyx.db.models import IndexModelStatus
 from onyx.db.search_settings import get_active_search_settings
-from onyx.db.tag import create_or_add_document_tag
-from onyx.db.tag import create_or_add_document_tag_list
+from onyx.db.tag import upsert_document_tags
 from onyx.db.user_documents import fetch_user_files_for_documents
 from onyx.db.user_documents import fetch_user_folders_for_documents
 from onyx.db.user_documents import update_user_file_token_count__no_commit
@@ -150,24 +149,12 @@ def _upsert_documents_in_db(
 
     # Insert document content metadata
     for doc in documents:
-        for k, v in doc.metadata.items():
-            if isinstance(v, list):
-                create_or_add_document_tag_list(
-                    tag_key=k,
-                    tag_values=v,
-                    source=doc.source,
-                    document_id=doc.id,
-                    db_session=db_session,
-                )
-                continue
-
-            create_or_add_document_tag(
-                tag_key=k,
-                tag_value=v,
-                source=doc.source,
-                document_id=doc.id,
-                db_session=db_session,
-            )
+        upsert_document_tags(
+            document_id=doc.id,
+            source=doc.source,
+            metadata=doc.metadata,
+            db_session=db_session,
+        )
 
 
 def _get_aggregated_chunk_boost_factor(

--- a/backend/tests/integration/tests/tags/test_tags.py
+++ b/backend/tests/integration/tests/tags/test_tags.py
@@ -1,0 +1,220 @@
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Document
+from onyx.db.tag import get_structured_tags_for_document
+from tests.integration.common_utils.managers.api_key import APIKeyManager
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_tag_creation_and_update(reset: None) -> None:
+    # create admin user
+    admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
+
+    # create a minimal file connector
+    cc_pair = CCPairManager.create_from_scratch(
+        name="KG-Test-FileConnector",
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "file_locations": [],
+            "file_names": [],
+            "zip_metadata": {},
+        },
+        user_performing_action=admin_user,
+    )
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    api_key.headers.update(admin_user.headers)
+    LLMProviderManager.create(user_performing_action=admin_user)
+
+    # create document
+    doc1_expected_metadata: dict[str, str | list[str]] = {
+        "value": "val",
+        "multiple_list": ["a", "b", "c"],
+        "single_list": ["x"],
+    }
+    doc1_expected_tags: set[tuple[str, str, bool]] = {
+        ("value", "val", False),
+        ("multiple_list", "a", True),
+        ("multiple_list", "b", True),
+        ("multiple_list", "c", True),
+        ("single_list", "x", True),
+    }
+    doc1 = DocumentManager.seed_doc_with_content(
+        cc_pair=cc_pair,
+        content="Dummy content",
+        document_id="doc1",
+        metadata=doc1_expected_metadata,
+        api_key=api_key,
+    )
+
+    # these are added by the connector
+    doc1_expected_metadata["document_id"] = "doc1"
+    doc1_expected_tags.add(("document_id", "doc1", False))
+
+    # get document from db
+    with get_session_with_current_tenant() as db_session:
+        doc1_db = db_session.query(Document).filter(Document.id == doc1.id).first()
+        assert doc1_db is not None
+        assert doc1_db.id == doc1.id
+
+        doc1_tags = doc1_db.tags
+
+    # check tags
+    doc1_tags_data: set[tuple[str, str, bool]] = {
+        (tag.tag_key, tag.tag_value, tag.is_list) for tag in doc1_tags
+    }
+    assert doc1_tags_data == doc1_expected_tags
+
+    # check structured tags
+    with get_session_with_current_tenant() as db_session:
+        doc1_metadata = get_structured_tags_for_document(doc1.id, db_session)
+    assert doc1_metadata == doc1_expected_metadata
+
+    # update metadata
+    doc1_new_expected_metadata: dict[str, str | list[str]] = {
+        "value": "val2",
+        "multiple_list": ["a", "d"],
+        "new_value": "new_val",
+    }
+    doc1_new_expected_tags: set[tuple[str, str, bool]] = {
+        ("value", "val2", False),
+        ("multiple_list", "a", True),
+        ("multiple_list", "d", True),
+        ("new_value", "new_val", False),
+    }
+    doc1_new = DocumentManager.seed_doc_with_content(
+        cc_pair=cc_pair,
+        content="Dummy content",
+        document_id="doc1",
+        metadata=doc1_new_expected_metadata,
+        api_key=api_key,
+    )
+    assert doc1_new.id == doc1.id
+
+    # these are added by the connector
+    doc1_new_expected_metadata["document_id"] = "doc1"
+    doc1_new_expected_tags.add(("document_id", "doc1", False))
+
+    # get new document from db
+    with get_session_with_current_tenant() as db_session:
+        doc1_new_db = db_session.query(Document).filter(Document.id == doc1.id).first()
+        assert doc1_new_db is not None
+        assert doc1_new_db.id == doc1.id
+
+        doc1_new_tags = doc1_new_db.tags
+
+    # check tags
+    doc1_new_tags_data: set[tuple[str, str, bool]] = {
+        (tag.tag_key, tag.tag_value, tag.is_list) for tag in doc1_new_tags
+    }
+    assert doc1_new_tags_data == doc1_new_expected_tags
+
+    # check structured tags
+    with get_session_with_current_tenant() as db_session:
+        doc1_new_metadata = get_structured_tags_for_document(doc1.id, db_session)
+    assert doc1_new_metadata == doc1_new_expected_metadata
+
+
+def test_tag_sharing(reset: None) -> None:
+    # create admin user
+    admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
+
+    # create a minimal file connector
+    cc_pair = CCPairManager.create_from_scratch(
+        name="KG-Test-FileConnector",
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "file_locations": [],
+            "file_names": [],
+            "zip_metadata": {},
+        },
+        user_performing_action=admin_user,
+    )
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    api_key.headers.update(admin_user.headers)
+    LLMProviderManager.create(user_performing_action=admin_user)
+
+    # create documents
+    doc1_expected_metadata: dict[str, str | list[str]] = {
+        "value": "val",
+        "list": ["a", "b"],
+        "same_key": "x",
+    }
+    doc1_expected_tags: set[tuple[str, str, bool]] = {
+        ("value", "val", False),
+        ("list", "a", True),
+        ("list", "b", True),
+        ("same_key", "x", False),
+    }
+    doc1 = DocumentManager.seed_doc_with_content(
+        cc_pair=cc_pair,
+        content="Dummy content",
+        document_id="doc1",
+        metadata=doc1_expected_metadata,
+        api_key=api_key,
+    )
+
+    doc2_expected_metadata: dict[str, str | list[str]] = {
+        "value": "val",
+        "list": ["a", "c"],
+        "same_key": ["x"],
+    }
+    doc2_expected_tags: set[tuple[str, str, bool]] = {
+        ("value", "val", False),
+        ("list", "a", True),
+        ("list", "c", True),
+        ("same_key", "x", True),
+    }
+    doc2 = DocumentManager.seed_doc_with_content(
+        cc_pair=cc_pair,
+        content="Dummy content",
+        document_id="doc2",
+        metadata=doc2_expected_metadata,
+        api_key=api_key,
+    )
+
+    # these are added by the connector
+    doc1_expected_metadata["document_id"] = "doc1"
+    doc1_expected_tags.add(("document_id", "doc1", False))
+    doc2_expected_metadata["document_id"] = "doc2"
+    doc2_expected_tags.add(("document_id", "doc2", False))
+
+    # get documents from db
+    with get_session_with_current_tenant() as db_session:
+        doc1_db = db_session.query(Document).filter(Document.id == doc1.id).first()
+        doc2_db = db_session.query(Document).filter(Document.id == doc2.id).first()
+        assert doc1_db is not None
+        assert doc1_db.id == doc1.id
+        assert doc2_db is not None
+        assert doc2_db.id == doc2.id
+
+        doc1_tags = doc1_db.tags
+        doc2_tags = doc2_db.tags
+
+    # check tags
+    doc1_tags_data: set[tuple[str, str, bool]] = {
+        (tag.tag_key, tag.tag_value, tag.is_list) for tag in doc1_tags
+    }
+    assert doc1_tags_data == doc1_expected_tags
+
+    doc2_tags_data: set[tuple[str, str, bool]] = {
+        (tag.tag_key, tag.tag_value, tag.is_list) for tag in doc2_tags
+    }
+    assert doc2_tags_data == doc2_expected_tags
+
+    # check tag sharing
+    doc1_tagkv_id: dict[tuple[str, str], int] = {
+        (tag.tag_key, tag.tag_value): tag.id for tag in doc1_tags
+    }
+    doc2_tagkv_id: dict[tuple[str, str], int] = {
+        (tag.tag_key, tag.tag_value): tag.id for tag in doc2_tags
+    }
+    assert doc1_tagkv_id[("value", "val")] == doc2_tagkv_id[("value", "val")]
+    assert doc1_tagkv_id[("list", "a")] == doc2_tagkv_id[("list", "a")]
+    assert doc1_tagkv_id[("same_key", "x")] != doc2_tagkv_id[("same_key", "x")]


### PR DESCRIPTION
## Description

fixes: https://linear.app/danswer/issue/DAN-2138/reindexing-does-not-update-tag-table

- fixes issue where old tags were not deleted during reindexing
(e.g., if metadata changes from state: closed -> state: open, both of these would remain as a tag)
- added is_list column to differentiate list and value metadata (useful for single-element lists)
- made corresponding changes to set these values properly
- wrote migration to remove old tags and set the is_list value 
- wrote test cases for tags

## How Has This Been Tested?

Tested locally + with new integration tests

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where old tags were not removed during reindexing and added an is_list flag to accurately track list-type metadata on document tags.

- **Migration**
  - Removes outdated tags left over from previous reindexing runs.
  - Adds and populates the is_list column to distinguish between list and single-value tags.

<!-- End of auto-generated description by cubic. -->

