### PR TITLE
no more scheduled stalling

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -381,8 +381,9 @@ def check_indexing_completion(
             db_session, index_attempt_id, batches_processed
         )
 
-        # Check for stalls (3-6 hour timeout)
-        if timed_out:
+        # Check for stalls (3-6 hour timeout). Only applies to in-progress attempts.
+        attempt = get_index_attempt(db_session, index_attempt_id)
+        if timed_out and attempt and attempt.status == IndexingStatus.IN_PROGRESS:
             logger.error(
                 f"Indexing attempt {index_attempt_id} has been indexing for 3-6 hours without progress. "
                 f"Marking it as failed."


### PR DESCRIPTION
## Description

Only fail attempts and mark as stalled when the attempt has been In Progress for 3-6 hours with no progress. no longer fail attempts that are waiting to be picked up by docfetching.

## How Has This Been Tested?

n/a

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
