### PR TITLE
feat(infra): Release Charts on Github Pages

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: latest
 annotations:
   category: Productivity


### PR DESCRIPTION
## Description
The github action has been created but need to push a new version to force the creation of the charts.

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
This is a version bump and will not impact the infrastructure

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Bumped the Helm chart version to 0.2.4 to trigger chart release on GitHub Pages.

<!-- End of auto-generated description by cubic. -->

