### PR TITLE
fix: don't show full api key in logs

### DIFF
--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -313,13 +313,13 @@ class DefaultMultiLLM(LLM):
 
         self._model_kwargs = model_kwargs
 
-    def log_model_configs(self) -> None:
-        logger.debug(f"Config: {self.config}")
-
     def _safe_model_config(self) -> dict:
         dump = self.config.model_dump()
         dump["api_key"] = mask_string(dump.get("api_key", ""))
         return dump
+
+    def log_model_configs(self) -> None:
+        logger.debug(f"Config: {self._safe_model_config()}")
 
     def _record_call(self, prompt: LanguageModelInput) -> None:
         if self._long_term_logger:


### PR DESCRIPTION
## Description

title

## How Has This Been Tested?
locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
API keys are now masked in logs to prevent exposing full keys during model configuration logging.

<!-- End of auto-generated description by cubic. -->

