### PR TITLE
fix: make starter messages visible on smaller screens

### DIFF
--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -2834,7 +2834,7 @@ export function ChatPage({
                             currentSessionChatState == "input" &&
                             !loadingError &&
                             !submittedMessage && (
-                              <div className="h-full  w-[95%] mx-auto flex flex-col justify-center items-center">
+                              <div className="h-full w-[95%] mx-auto flex flex-col justify-center items-center">
                                 <ChatIntro selectedPersona={liveAssistant} />
 
                                 {currentPersona && (

--- a/web/src/components/assistants/StarterMessage.tsx
+++ b/web/src/components/assistants/StarterMessage.tsx
@@ -15,7 +15,7 @@ export function StarterMessages({
     <div
       key={-4}
       className={`
-        short:hidden
+        very-short:hidden
         mx-auto
         w-full
         ${


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2302/make-default-prompts-show-up-on-small-screens

## How Has This Been Tested?

Tested locally.

<img width="1024" height="749" alt="Screenshot 2025-08-07 at 2 58 18 PM" src="https://github.com/user-attachments/assets/191e9355-eb6b-4f90-b553-a40baba108a0" />

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Starter messages are now visible on smaller screens, fixing an issue where they were hidden on mobile devices. This addresses the requirements in Linear issue DAN-2302.

<!-- End of auto-generated description by cubic. -->

