### PR TITLE
fix(infra): Update github workflow to not tag latest

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -18,25 +18,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
+      - name: Install Helm CLI
         uses: azure/setup-helm@v4
         with:
           version: v3.12.1
 
-      - name: Add Required Helm Repositories
+      - name: Add required Helm repositories
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
           helm repo update
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+      - name: Build chart dependencies
+        run: |
+          set -euo pipefail
+          for chart_dir in deployment/helm/charts/*; do
+            if [ -f "$chart_dir/Chart.yaml" ]; then
+              echo "Building dependencies for $chart_dir"
+              helm dependency build "$chart_dir"
+            fi
+          done
+
+      - name: Publish Helm charts to gh-pages
+        uses: stefanprodan/helm-gh-pages@master
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          branch: gh-pages
+          helm_version: v3.12.1
+          commit_username: ${{ github.actor }}
+          commit_email: ${{ github.actor }}@users.noreply.github.com
+          dependencies: |
+            bitnami,https://charts.bitnami.com/bitnami;onyx-vespa,https://onyx-dot-app.github.io/vespa-helm-charts

--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -40,7 +40,7 @@ jobs:
           done
 
       - name: Publish Helm charts to gh-pages
-        uses: stefanprodan/helm-gh-pages@master
+        uses: stefanprodan/helm-gh-pages@v1.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts
@@ -48,5 +48,3 @@ jobs:
           helm_version: v3.12.1
           commit_username: ${{ github.actor }}
           commit_email: ${{ github.actor }}@users.noreply.github.com
-          dependencies: |
-            bitnami,https://charts.bitnami.com/bitnami;onyx-vespa,https://onyx-dot-app.github.io/vespa-helm-charts


### PR DESCRIPTION
## Description
Previously the chart-releaser was tagging latest as part of the workflow. I have since updated the repo that we are using to not do any git changes. This should now only push the charts and that should be it.

## How Has This Been Tested?
Ran example tests

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the Helm chart release workflow to stop tagging git releases and only publish charts to the gh-pages branch.

- **Workflow Changes**
 - Removed git tagging steps.
 - Switched to stefanprodan/helm-gh-pages for publishing charts.
 - Added chart dependency build before publishing.

<!-- End of auto-generated description by cubic. -->

