### PR TITLE
feat: make sharepoint documents and sharepoint pages optional

### DIFF
--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -90,7 +90,9 @@ def test_sharepoint_connector_all_sites__docs_only(
     sharepoint_credentials: dict[str, str],
 ) -> None:
     # Initialize connector with no sites
-    connector = SharepointConnector(include_site_pages=False)
+    connector = SharepointConnector(
+        include_site_pages=False, include_site_documents=True
+    )
 
     # Load credentials
     connector.load_credentials(sharepoint_credentials)
@@ -141,7 +143,9 @@ def test_sharepoint_connector_root_folder__docs_only(
 ) -> None:
     # Initialize connector with the base site URL
     connector = SharepointConnector(
-        sites=[os.environ["SHAREPOINT_SITE"]], include_site_pages=False
+        sites=[os.environ["SHAREPOINT_SITE"]],
+        include_site_pages=False,
+        include_site_documents=True,
     )
 
     # Load credentials

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -666,14 +666,31 @@ See our docs for more details.`,
         name: "sites",
         optional: true,
         description: `• If no sites are specified, all sites in your organization will be indexed (Sites.Read.All permission required).
-
-• Specifying 'https://onyxai.sharepoint.com/sites/support' for example will only index documents within this site.
-
-• Specifying 'https://onyxai.sharepoint.com/sites/support/subfolder' for example will only index documents within this folder.
+• Specifying 'https://onyxai.sharepoint.com/sites/support' for example only indexes this site.
+• Specifying 'https://onyxai.sharepoint.com/sites/support/subfolder' for example only indexes this folder.
 `,
       },
     ],
-    advanced_values: [],
+    advanced_values: [
+      {
+        type: "checkbox",
+        query: "Index Documents:",
+        label: "Index Documents",
+        name: "include_site_documents",
+        optional: true,
+        default: true,
+        description: "Index documents from SharePoint document libraries",
+      },
+      {
+        type: "checkbox",
+        query: "Index ASPX Sites:",
+        label: "Index ASPX Sites",
+        name: "include_site_pages",
+        optional: true,
+        default: true,
+        description: "Index SharePoint site pages (.aspx files)",
+      },
+    ],
   },
   teams: {
     description: "Configure Teams connector",
@@ -1579,6 +1596,8 @@ export interface SalesforceConfig {
 
 export interface SharepointConfig {
   sites?: string[];
+  include_site_pages?: boolean;
+  include_site_documents?: boolean;
 }
 
 export interface TeamsConfig {


### PR DESCRIPTION
## Description

The Feature allows users to choose whether they want to index only SharePoint pages, only SharePoint documents, or both.
The PR adds the backend logic to the sharepoint connector.py and the necessary UI elements to the connectors.tsx.

<img width="823" height="848" alt="image" src="https://github.com/user-attachments/assets/82d0deed-2e77-4859-8720-6b79d2b559c2" />

## How Has This Been Tested?

I tested the UI elements and its functionality manually by building the images locally and starting the application.
I created three Sharepoint connectors with permutation of all three options (see below) and tested them in an assistant.

- include_site_pages: bool = True, include_site_documents: bool = True
- include_site_pages: bool = True, include_site_documents: bool = False
- include_site_pages: bool = False, include_site_documents: bool = True


## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added options to let users choose whether to index SharePoint documents, SharePoint pages, or both when setting up a connector.

- **New Features**
  - Added checkboxes in the UI for selecting documents and/or pages.
  - Updated backend logic to support indexing based on user selection.

<!-- End of auto-generated description by cubic. -->

