### PR TITLE
fix(infra): Removing invalid helm version

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -45,6 +45,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           charts_dir: deployment/helm/charts
           branch: gh-pages
-          helm_version: v3.12.1
           commit_username: ${{ github.actor }}
           commit_email: ${{ github.actor }}@users.noreply.github.com


### PR DESCRIPTION
## Description
There seems to have been an issue with the helm release pipeline because we are adding in the helm_version to the run function. We already install helm at an earlier step so removing it given it's duplicated. 

Link to failing github action: https://github.com/onyx-dot-app/onyx/actions/runs/16843711808/job/47719611239#step:2:20

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
This is an update to a broken Github Action

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
