### PR TITLE
feat: make sharepoint documents and sharepoint pages optional

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -798,6 +798,10 @@ class SharepointConnector(
         end: datetime | None = None,
     ) -> list[dict[str, Any]]:
         """Fetch SharePoint site pages (.aspx files) using the SharePoint Pages API."""
+        # Exclude personal sites because GET personal site pages returns 404
+        if "-my.sharepoint" in site_descriptor.url:
+            return []
+
         # Get the site to extract the site ID
         site = self.graph_client.sites.get_by_url(site_descriptor.url)
         site.execute_query()  # Execute the query to actually fetch the data

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -110,7 +110,9 @@ def test_sharepoint_connector_all_sites__docs_only(
         mock_store_image,
     ):
         # Initialize connector with no sites
-        connector = SharepointConnector(include_site_pages=False)
+        connector = SharepointConnector(
+        include_site_pages=False, include_site_documents=True
+    )
 
         # Load credentials
         connector.load_credentials(sharepoint_credentials)
@@ -176,7 +178,9 @@ def test_sharepoint_connector_root_folder__docs_only(
     ):
         # Initialize connector with the base site URL
         connector = SharepointConnector(
-            sites=[os.environ["SHAREPOINT_SITE"]], include_site_pages=False
+            sites=[os.environ["SHAREPOINT_SITE"]],
+        include_site_pages=False,
+        include_site_documents=True,
         )
 
         # Load credentials

--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -111,8 +111,8 @@ def test_sharepoint_connector_all_sites__docs_only(
     ):
         # Initialize connector with no sites
         connector = SharepointConnector(
-        include_site_pages=False, include_site_documents=True
-    )
+            include_site_pages=False, include_site_documents=True
+        )
 
         # Load credentials
         connector.load_credentials(sharepoint_credentials)
@@ -179,8 +179,8 @@ def test_sharepoint_connector_root_folder__docs_only(
         # Initialize connector with the base site URL
         connector = SharepointConnector(
             sites=[os.environ["SHAREPOINT_SITE"]],
-        include_site_pages=False,
-        include_site_documents=True,
+            include_site_pages=False,
+            include_site_documents=True,
         )
 
         # Load credentials

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -663,14 +663,31 @@ Example:
         name: "sites",
         optional: true,
         description: `• If no sites are specified, all sites in your organization will be indexed (Sites.Read.All permission required).
-
-• Specifying 'https://onyxai.sharepoint.com/sites/support' for example will only index documents within this site.
-
-• Specifying 'https://onyxai.sharepoint.com/sites/support/subfolder' for example will only index documents within this folder.
+• Specifying 'https://onyxai.sharepoint.com/sites/support' for example only indexes this site.
+• Specifying 'https://onyxai.sharepoint.com/sites/support/subfolder' for example only indexes this folder.
 `,
       },
     ],
-    advanced_values: [],
+    advanced_values: [
+      {
+        type: "checkbox",
+        query: "Index Documents:",
+        label: "Index Documents",
+        name: "include_site_documents",
+        optional: true,
+        default: true,
+        description: "Index documents from SharePoint document libraries",
+      },
+      {
+        type: "checkbox",
+        query: "Index ASPX Sites:",
+        label: "Index ASPX Sites",
+        name: "include_site_pages",
+        optional: true,
+        default: true,
+        description: "Index SharePoint site pages (.aspx files)",
+      },
+    ],
   },
   teams: {
     description: "Configure Teams connector",
@@ -1576,6 +1593,8 @@ export interface SalesforceConfig {
 
 export interface SharepointConfig {
   sites?: string[];
+  include_site_pages?: boolean;
+  include_site_documents?: boolean;
 }
 
 export interface TeamsConfig {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -676,7 +676,8 @@ Example:
         name: "include_site_documents",
         optional: true,
         default: true,
-        description: "Index documents from SharePoint document libraries",
+        description:
+          "Index documents of all SharePoint libraries or folders defined above.",
       },
       {
         type: "checkbox",
@@ -685,7 +686,8 @@ Example:
         name: "include_site_pages",
         optional: true,
         default: true,
-        description: "Index SharePoint site pages (.aspx files)",
+        description:
+          "Index aspx-pages of all SharePoint sites defined above, even if a library or folder is specified.",
       },
     ],
   },


### PR DESCRIPTION
The Feature allows users to choose whether they want to index only SharePoint pages, only SharePoint documents, or both.
The PR adds the backend logic to the sharepoint connector.py and the necessary UI elements to the connectors.tsx.

<img width="823" height="848" alt="image" src="https://github.com/user-attachments/assets/9aef75f7-d75a-4da3-b9c7-6b51bb1e4e78" />

## How Has This Been Tested?

include_site_pages: bool = True, include_site_documents: bool = True
include_site_pages: bool = True, include_site_documents: bool = False
include_site_pages: bool = False, include_site_documents: bool = True## Description

I tested the UI elements and its functionality manually by building the images locally and starting the application.
I created three Sharepoint connectors with permutation of all three options (see below) and tested them in an assistant.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added options to let users choose whether to index SharePoint documents, SharePoint pages, or both when setting up a connector.

- **New Features**
 - Added checkboxes in the UI for selecting documents and/or pages.
 - Updated backend logic to support these options.

<!-- End of auto-generated description by cubic. -->

