### PR TITLE
feat: reorganize connectors pages

### DIFF
--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -65,3 +65,6 @@ S3_ENDPOINT_URL=http://localhost:9004
 S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin
+
+# Show extra/uncommon connectors
+SHOW_EXTRA_CONNECTORS=True

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -38,6 +38,9 @@ DISABLE_GENERATIVE_AI = os.environ.get("DISABLE_GENERATIVE_AI", "").lower() == "
 # Controls whether users can use User Knowledge (personal documents) in assistants
 DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() == "true"
 
+# If set to true, will show extra/uncommon connectors in the "Other" category
+SHOW_EXTRA_CONNECTORS = os.environ.get("SHOW_EXTRA_CONNECTORS", "").lower() == "true"
+
 # Controls whether to allow admin query history reports with:
 # 1. associated user emails
 # 2. anonymized user emails

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -219,9 +219,6 @@ class BlobType(str, Enum):
     GOOGLE_CLOUD_STORAGE = "google_cloud_storage"
     OCI_STORAGE = "oci_storage"
 
-    # Special case, for internet search
-    NOT_APPLICABLE = "not_applicable"
-
 
 class DocumentIndexType(str, Enum):
     COMBINED = "combined"  # Vespa

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -62,6 +62,9 @@ class Settings(BaseModel):
     # User Knowledge settings
     user_knowledge_enabled: bool | None = True
 
+    # Connector settings
+    show_extra_connectors: bool | None = True
+
 
 class UserSettings(Settings):
     notifications: list[Notification]

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -1,5 +1,6 @@
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
+from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
 from onyx.configs.constants import KV_SETTINGS_KEY
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.key_value_store.factory import get_kv_store
@@ -53,6 +54,7 @@ def load_settings() -> Settings:
     if DISABLE_USER_KNOWLEDGE:
         settings.user_knowledge_enabled = False
 
+    settings.show_extra_connectors = SHOW_EXTRA_CONNECTORS
     return settings
 
 

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -120,6 +120,9 @@ services:
       # Chat Configs
       - HARD_DELETE_CHATS=${HARD_DELETE_CHATS:-}
 
+      # Show extra/uncommon connectors
+      - SHOW_EXTRA_CONNECTORS=${SHOW_EXTRA_CONNECTORS:-true}
+
       # Enables the use of bedrock models or IAM Auth
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -97,6 +97,9 @@ services:
 
       # Chat Configs
       - HARD_DELETE_CHATS=${HARD_DELETE_CHATS:-}
+      
+      # Show extra/uncommon connectors
+      - SHOW_EXTRA_CONNECTORS=${SHOW_EXTRA_CONNECTORS:-true}
 
       # Vespa Language Forcing
       # See: https://docs.vespa.ai/en/linguistics.html 

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -106,6 +106,10 @@ services:
       - SENTRY_DSN=${SENTRY_DSN:-}
       # Chat Configs
       - HARD_DELETE_CHATS=${HARD_DELETE_CHATS:-}
+
+      # Show extra/uncommon connectors
+      - SHOW_EXTRA_CONNECTORS=${SHOW_EXTRA_CONNECTORS:-true}
+      
       # Enables the use of bedrock models or IAM Auth
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -65,3 +65,7 @@ DB_READONLY_PASSWORD=password
 # If setting the vespa language is required, set this ('en', 'de', etc.).
 # See: https://docs.vespa.ai/en/linguistics.html 
 #VESPA_LANGUAGE_OVERRIDE=
+
+# Show extra/uncommon connectors
+# See https://docs.onyx.app for a full list of connectors
+SHOW_EXTRA_CONNECTORS=False

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -270,7 +270,7 @@ export default function Page() {
         className="ml-1 w-96 h-9  flex-none rounded-md border border-border bg-background-50 px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
 
-      {popularSources.length > 0 && (
+      {popularSources.length > 0 && !searchTerm && (
         <div className="mb-8">
           <div className="flex mt-8">
             <Title>Popular</Title>
@@ -278,7 +278,7 @@ export default function Page() {
           <div className="flex flex-wrap gap-4 p-4">
             {popularSources.map((source, sourceInd) => (
               <SourceTileTooltipWrapper
-                preSelect={searchTerm.length > 0 && sourceInd == 0}
+                preSelect={false}
                 key={source.internalName}
                 sourceMetadata={source}
                 federatedConnectors={federatedConnectors}

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -6,8 +6,14 @@ import { listSourceMetadata } from "@/lib/sources";
 import Title from "@/components/ui/title";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -24,6 +30,7 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { buildSimilarCredentialInfoURL } from "@/app/admin/connector/[ccPairId]/lib";
 import { Credential } from "@/lib/connectors/credentials";
+import { SettingsContext } from "@/components/settings/SettingsProvider";
 import SourceTile from "@/components/SourceTile";
 
 function SourceTileTooltipWrapper({
@@ -140,6 +147,7 @@ export default function Page() {
 
   const [searchTerm, setSearchTerm] = useState("");
   const { data: federatedConnectors } = useFederatedConnectors();
+  const settings = useContext(SettingsContext);
 
   // Fetch Slack credentials to determine navigation behavior
   const { data: slackCredentials } = useSWR<Credential<any>[]>(
@@ -167,9 +175,19 @@ export default function Page() {
     [searchTerm]
   );
 
+  const popularSources = useMemo(() => {
+    const filtered = filterSources(sources);
+    return sources.filter(
+      (source) =>
+        source.isPopular &&
+        (filtered.includes(source) ||
+          source.displayName.toLowerCase().includes(searchTerm.toLowerCase()))
+    );
+  }, [sources, filterSources, searchTerm]);
+
   const categorizedSources = useMemo(() => {
     const filtered = filterSources(sources);
-    return Object.values(SourceCategory).reduce(
+    const categories = Object.values(SourceCategory).reduce(
       (acc, category) => {
         acc[category] = sources.filter(
           (source) =>
@@ -181,7 +199,23 @@ export default function Page() {
       },
       {} as Record<SourceCategory, SourceMetadata[]>
     );
-  }, [sources, filterSources, searchTerm]);
+    // Filter out the "Other" category if show_extra_connectors is false
+    if (settings?.settings?.show_extra_connectors === false) {
+      const filteredCategories = Object.entries(categories).filter(
+        ([category]) => category !== SourceCategory.Other
+      );
+      return Object.fromEntries(filteredCategories) as Record<
+        SourceCategory,
+        SourceMetadata[]
+      >;
+    }
+    return categories;
+  }, [
+    sources,
+    filterSources,
+    searchTerm,
+    settings?.settings?.show_extra_connectors,
+  ]);
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -236,6 +270,25 @@ export default function Page() {
         className="ml-1 w-96 h-9  flex-none rounded-md border border-border bg-background-50 px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
 
+      {popularSources.length > 0 && (
+        <div className="mb-8">
+          <div className="flex mt-8">
+            <Title>Popular</Title>
+          </div>
+          <div className="flex flex-wrap gap-4 p-4">
+            {popularSources.map((source, sourceInd) => (
+              <SourceTileTooltipWrapper
+                preSelect={searchTerm.length > 0 && sourceInd == 0}
+                key={source.internalName}
+                sourceMetadata={source}
+                federatedConnectors={federatedConnectors}
+                slackCredentials={slackCredentials}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       {Object.entries(categorizedSources)
         .filter(([_, sources]) => sources.length > 0)
         .map(([category, sources], categoryInd) => (
@@ -243,7 +296,6 @@ export default function Page() {
             <div className="flex mt-8">
               <Title>{category}</Title>
             </div>
-            <p>{getCategoryDescription(category as SourceCategory)}</p>
             <div className="flex flex-wrap gap-4 p-4">
               {sources.map((source, sourceInd) => (
                 <SourceTileTooltipWrapper
@@ -261,27 +313,4 @@ export default function Page() {
         ))}
     </div>
   );
-}
-
-function getCategoryDescription(category: SourceCategory): string {
-  switch (category) {
-    case SourceCategory.Messaging:
-      return "Integrate with messaging and communication platforms.";
-    case SourceCategory.ProjectManagement:
-      return "Link to project management and task tracking tools.";
-    case SourceCategory.CustomerSupport:
-      return "Connect to customer support and helpdesk systems.";
-    case SourceCategory.CustomerRelationshipManagement:
-      return "Integrate with customer relationship management platforms.";
-    case SourceCategory.CodeRepository:
-      return "Integrate with code repositories and version control systems.";
-    case SourceCategory.Storage:
-      return "Connect to cloud storage and file hosting services.";
-    case SourceCategory.Wiki:
-      return "Link to wiki and knowledge base platforms.";
-    case SourceCategory.Other:
-      return "Connect to other miscellaneous knowledge sources.";
-    default:
-      return "Connect to various knowledge sources.";
-  }
 }

--- a/web/src/app/admin/settings/interfaces.ts
+++ b/web/src/app/admin/settings/interfaces.ts
@@ -30,6 +30,9 @@ export interface Settings {
 
   // User Knowledge settings
   user_knowledge_enabled?: boolean;
+
+  // Connector settings
+  show_extra_connectors?: boolean;
 }
 
 export enum NotificationType {

--- a/web/src/lib/search/interfaces.ts
+++ b/web/src/lib/search/interfaces.ts
@@ -162,10 +162,10 @@ export interface SearchResponse {
 }
 
 export enum SourceCategory {
-  Storage = "Storage",
-  Wiki = "Wiki",
+  Storage = "Cloud Storage",
+  Wiki = "Knowledge Base & Wiki",
   CustomerSupport = "Customer Support",
-  CustomerRelationshipManagement = "Customer Relationship Management",
+  SalesAndMarketing = "Sales & Marketing",
   Messaging = "Messaging",
   ProjectManagement = "Project Management",
   CodeRepository = "Code Repository",
@@ -179,6 +179,7 @@ export interface SourceMetadata {
   shortDescription?: string;
   internalName: ValidSources;
   adminUrl: string;
+  isPopular?: boolean;
   oauthSupported?: boolean;
   federated?: boolean;
   federatedTooltip?: string;

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -54,6 +54,7 @@ interface PartialSourceMetadata {
   icon: React.FC<{ size?: number; className?: string }>;
   displayName: string;
   category: SourceCategory;
+  isPopular?: boolean;
   docs?: string;
   oauthSupported?: boolean;
   federated?: boolean;
@@ -71,6 +72,7 @@ const slackMetadata = {
   icon: ColorSlackIcon,
   displayName: "Slack",
   category: SourceCategory.Messaging,
+  isPopular: true,
   docs: "https://docs.onyx.app/connectors/slack",
   oauthSupported: true,
   federated: true,
@@ -81,31 +83,40 @@ const slackMetadata = {
 };
 
 export const SOURCE_METADATA_MAP: SourceMap = {
+  // Keep web and file at the top
   web: {
     icon: GlobeIcon2,
     displayName: "Web",
     category: SourceCategory.Other,
     docs: "https://docs.onyx.app/connectors/web",
+    isPopular: true,
   },
   file: {
     icon: FileIcon2,
     displayName: "File",
-    category: SourceCategory.Storage,
+    category: SourceCategory.Other,
     docs: "https://docs.onyx.app/connectors/file",
+    isPopular: true,
   },
-  slack: slackMetadata,
-  federated_slack: slackMetadata,
-  discord: {
-    icon: ColorDiscordIcon,
-    displayName: "Discord",
-    category: SourceCategory.Messaging,
-    docs: "https://docs.onyx.app/connectors/discord",
+
+  // Cloud Storage
+  dropbox: {
+    icon: DropboxIcon,
+    displayName: "Dropbox",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/dropbox",
   },
-  gmail: {
-    icon: GmailIcon,
-    displayName: "Gmail",
-    category: SourceCategory.Messaging,
-    docs: "https://docs.onyx.app/connectors/gmail/overview",
+  egnyte: {
+    icon: EgnyteIcon,
+    displayName: "Egnyte",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/egnyte",
+  },
+  google_cloud_storage: {
+    icon: GoogleStorageIcon,
+    displayName: "Google Storage",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/google_storage",
   },
   google_drive: {
     icon: GoogleDriveIcon,
@@ -113,12 +124,41 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Storage,
     docs: "https://docs.onyx.app/connectors/google_drive/overview",
     oauthSupported: true,
+    isPopular: true,
   },
+  oci_storage: {
+    icon: OCIStorageIcon,
+    displayName: "Oracle Storage",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/oci_storage",
+  },
+  r2: {
+    icon: R2Icon,
+    displayName: "R2",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/r2",
+  },
+  s3: {
+    icon: S3Icon,
+    displayName: "S3",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/s3",
+  },
+  sharepoint: {
+    icon: SharepointIcon,
+    displayName: "Sharepoint",
+    category: SourceCategory.Storage,
+    docs: "https://docs.onyx.app/connectors/sharepoint",
+    isPopular: true,
+  },
+
+  // Code Repository
   github: {
     icon: GithubIcon,
     displayName: "Github",
     category: SourceCategory.CodeRepository,
     docs: "https://docs.onyx.app/connectors/github",
+    isPopular: true,
   },
   gitlab: {
     icon: GitlabIcon,
@@ -126,18 +166,78 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.CodeRepository,
     docs: "https://docs.onyx.app/connectors/gitlab",
   },
+
+  // Customer Support
+  freshdesk: {
+    icon: FreshdeskIcon,
+    displayName: "Freshdesk",
+    category: SourceCategory.CustomerSupport,
+    docs: "https://docs.onyx.app/connectors/freshdesk",
+  },
+  zendesk: {
+    icon: ZendeskIcon,
+    displayName: "Zendesk",
+    category: SourceCategory.CustomerSupport,
+    docs: "https://docs.onyx.app/connectors/zendesk",
+    isPopular: true,
+  },
+
+  // Knowledge Base & Wiki
+  axero: {
+    icon: AxeroIcon,
+    displayName: "Axero",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/axero",
+  },
+  bookstack: {
+    icon: BookstackIcon,
+    displayName: "BookStack",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/bookstack",
+  },
   confluence: {
     icon: ConfluenceIcon,
     displayName: "Confluence",
     category: SourceCategory.Wiki,
     docs: "https://docs.onyx.app/connectors/confluence",
     oauthSupported: true,
+    isPopular: true,
   },
-  jira: {
-    icon: JiraIcon,
-    displayName: "Jira",
-    category: SourceCategory.ProjectManagement,
-    docs: "https://docs.onyx.app/connectors/jira",
+  document360: {
+    icon: Document360Icon,
+    displayName: "Document360",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/document360",
+  },
+  gitbook: {
+    icon: GitbookIcon,
+    displayName: "GitBook",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/gitbook",
+  },
+  google_sites: {
+    icon: GoogleSitesIcon,
+    displayName: "Google Sites",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/google_sites",
+  },
+  guru: {
+    icon: GuruIcon,
+    displayName: "Guru",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/guru",
+  },
+  highspot: {
+    icon: HighspotIcon,
+    displayName: "Highspot",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/highspot",
+  },
+  mediawiki: {
+    icon: MediaWikiIcon,
+    displayName: "MediaWiki",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/mediawiki",
   },
   notion: {
     icon: NotionIcon,
@@ -145,17 +245,88 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Wiki,
     docs: "https://docs.onyx.app/connectors/notion",
   },
-  zendesk: {
-    icon: ZendeskIcon,
-    displayName: "Zendesk",
-    category: SourceCategory.CustomerSupport,
-    docs: "https://docs.onyx.app/connectors/zendesk",
+  slab: {
+    icon: SlabIcon,
+    displayName: "Slab",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/slab",
   },
-  gong: {
-    icon: GongIcon,
-    displayName: "Gong",
-    category: SourceCategory.Other,
-    docs: "https://docs.onyx.app/connectors/gong",
+  wikipedia: {
+    icon: WikipediaIcon,
+    displayName: "Wikipedia",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/wikipedia",
+  },
+
+  // Messaging
+  discord: {
+    icon: ColorDiscordIcon,
+    displayName: "Discord",
+    category: SourceCategory.Messaging,
+    docs: "https://docs.onyx.app/connectors/discord",
+  },
+  discourse: {
+    icon: DiscourseIcon,
+    displayName: "Discourse",
+    category: SourceCategory.Messaging,
+    docs: "https://docs.onyx.app/connectors/discourse",
+  },
+  gmail: {
+    icon: GmailIcon,
+    displayName: "Gmail",
+    category: SourceCategory.Messaging,
+    docs: "https://docs.onyx.app/connectors/gmail/overview",
+  },
+  imap: {
+    icon: EmailIcon,
+    displayName: "Email",
+    category: SourceCategory.Messaging,
+  },
+  slack: slackMetadata,
+  federated_slack: slackMetadata,
+  teams: {
+    icon: TeamsIcon,
+    displayName: "Teams",
+    category: SourceCategory.Messaging,
+    docs: "https://docs.onyx.app/connectors/teams",
+  },
+  xenforo: {
+    icon: XenforoIcon,
+    displayName: "Xenforo",
+    category: SourceCategory.Messaging,
+  },
+  zulip: {
+    icon: ZulipIcon,
+    displayName: "Zulip",
+    category: SourceCategory.Messaging,
+    docs: "https://docs.onyx.app/connectors/zulip",
+  },
+
+  // Project Management
+  airtable: {
+    icon: AirtableIcon,
+    displayName: "Airtable",
+    category: SourceCategory.ProjectManagement,
+    docs: "https://docs.onyx.app/connectors/airtable",
+  },
+  asana: {
+    icon: AsanaIcon,
+    displayName: "Asana",
+    category: SourceCategory.ProjectManagement,
+    docs: "https://docs.onyx.app/connectors/asana",
+  },
+  clickup: {
+    icon: ClickupIcon,
+    displayName: "Clickup",
+    category: SourceCategory.ProjectManagement,
+    docs: "https://docs.onyx.app/connectors/clickup",
+  },
+  jira: {
+    icon: JiraIcon,
+    displayName: "Jira",
+    category: SourceCategory.ProjectManagement,
+    docs: "https://docs.onyx.app/connectors/jira",
+    isPopular: true,
   },
   linear: {
     icon: LinearIcon,
@@ -169,197 +340,53 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.ProjectManagement,
     docs: "https://docs.onyx.app/connectors/productboard",
   },
-  slab: {
-    icon: SlabIcon,
-    displayName: "Slab",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/slab",
+
+  // Sales & Marketing
+  fireflies: {
+    icon: FirefliesIcon,
+    displayName: "Fireflies",
+    category: SourceCategory.SalesAndMarketing,
+    docs: "https://docs.onyx.app/connectors/fireflies",
   },
-  zulip: {
-    icon: ZulipIcon,
-    displayName: "Zulip",
-    category: SourceCategory.Messaging,
-    docs: "https://docs.onyx.app/connectors/zulip",
-  },
-  guru: {
-    icon: GuruIcon,
-    displayName: "Guru",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/guru",
+  gong: {
+    icon: GongIcon,
+    displayName: "Gong",
+    category: SourceCategory.SalesAndMarketing,
+    docs: "https://docs.onyx.app/connectors/gong",
+    isPopular: true,
   },
   hubspot: {
     icon: HubSpotIcon,
     displayName: "HubSpot",
-    category: SourceCategory.CustomerRelationshipManagement,
+    category: SourceCategory.SalesAndMarketing,
     docs: "https://docs.onyx.app/connectors/hubspot",
-  },
-  document360: {
-    icon: Document360Icon,
-    displayName: "Document360",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/document360",
-  },
-  bookstack: {
-    icon: BookstackIcon,
-    displayName: "BookStack",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/bookstack",
-  },
-  google_sites: {
-    icon: GoogleSitesIcon,
-    displayName: "Google Sites",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/google_sites",
   },
   loopio: {
     icon: LoopioIcon,
     displayName: "Loopio",
-    category: SourceCategory.Other,
-  },
-  dropbox: {
-    icon: DropboxIcon,
-    displayName: "Dropbox",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/dropbox",
+    category: SourceCategory.SalesAndMarketing,
   },
   salesforce: {
     icon: SalesforceIcon,
     displayName: "Salesforce",
-    category: SourceCategory.CustomerRelationshipManagement,
+    category: SourceCategory.SalesAndMarketing,
     docs: "https://docs.onyx.app/connectors/salesforce",
+    isPopular: true,
   },
-  sharepoint: {
-    icon: SharepointIcon,
-    displayName: "Sharepoint",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/sharepoint",
-  },
-  teams: {
-    icon: TeamsIcon,
-    displayName: "Teams",
-    category: SourceCategory.Messaging,
-    docs: "https://docs.onyx.app/connectors/teams",
-  },
-  discourse: {
-    icon: DiscourseIcon,
-    displayName: "Discourse",
-    category: SourceCategory.Messaging,
-    docs: "https://docs.onyx.app/connectors/discourse",
-  },
-  axero: {
-    icon: AxeroIcon,
-    displayName: "Axero",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/axero",
-  },
-  wikipedia: {
-    icon: WikipediaIcon,
-    displayName: "Wikipedia",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/wikipedia",
-  },
-  asana: {
-    icon: AsanaIcon,
-    displayName: "Asana",
-    category: SourceCategory.ProjectManagement,
-    docs: "https://docs.onyx.app/connectors/asana",
-  },
-  mediawiki: {
-    icon: MediaWikiIcon,
-    displayName: "MediaWiki",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/mediawiki",
-  },
-  clickup: {
-    icon: ClickupIcon,
-    displayName: "Clickup",
-    category: SourceCategory.ProjectManagement,
-    docs: "https://docs.onyx.app/connectors/clickup",
-  },
-  s3: {
-    icon: S3Icon,
-    displayName: "S3",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/s3",
-  },
-  r2: {
-    icon: R2Icon,
-    displayName: "R2",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/r2",
-  },
-  oci_storage: {
-    icon: OCIStorageIcon,
-    displayName: "Oracle Storage",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/oci_storage",
-  },
-  google_cloud_storage: {
-    icon: GoogleStorageIcon,
-    displayName: "Google Storage",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/google_storage",
-  },
-  xenforo: {
-    icon: XenforoIcon,
-    displayName: "Xenforo",
-    category: SourceCategory.Messaging,
-  },
+
+  // Other
   ingestion_api: {
     icon: GlobeIcon,
     displayName: "Ingestion",
     category: SourceCategory.Other,
   },
-  freshdesk: {
-    icon: FreshdeskIcon,
-    displayName: "Freshdesk",
-    category: SourceCategory.CustomerSupport,
-    docs: "https://docs.onyx.app/connectors/freshdesk",
-  },
-  fireflies: {
-    icon: FirefliesIcon,
-    displayName: "Fireflies",
-    category: SourceCategory.Other,
-    docs: "https://docs.onyx.app/connectors/fireflies",
-  },
-  egnyte: {
-    icon: EgnyteIcon,
-    displayName: "Egnyte",
-    category: SourceCategory.Storage,
-    docs: "https://docs.onyx.app/connectors/egnyte",
-  },
-  airtable: {
-    icon: AirtableIcon,
-    displayName: "Airtable",
-    category: SourceCategory.Other,
-    docs: "https://docs.onyx.app/connectors/airtable",
-  },
-  gitbook: {
-    icon: GitbookIcon,
-    displayName: "GitBook",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/gitbook",
-  },
-  highspot: {
-    icon: HighspotIcon,
-    displayName: "Highspot",
-    category: SourceCategory.Wiki,
-    docs: "https://docs.onyx.app/connectors/highspot",
-  },
-  imap: {
-    icon: EmailIcon,
-    displayName: "Email",
-    category: SourceCategory.Messaging,
-  },
-  // currently used for the Internet Search tool docs, which is why
-  // a globe is used
+
+  // Placeholder (non-null default)
   not_applicable: {
     icon: GlobeIcon,
     displayName: "Not Applicable",
     category: SourceCategory.Other,
   },
-
-  // Just so integration tests don't crash the UI
   mock_connector: {
     icon: GlobeIcon,
     displayName: "Mock Connector",


### PR DESCRIPTION
## Description

- Added popular connectors section
- Re-purposed "Other" connectors category to hold uncommon/extra connectors
- Added env var to show/hide Other category
- Reorganized connectors (sources.ts) by type and alphabetical order

## How Has This Been Tested?

locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
