### PR TITLE
fix: seeded total doc count

### DIFF
--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -21,6 +21,7 @@ from onyx.db.connector import create_connector
 from onyx.db.connector_credential_pair import add_credential_to_connector
 from onyx.db.credentials import PUBLIC_CREDENTIAL_ID
 from onyx.db.document import check_docs_exist
+from onyx.db.document import mark_document_as_indexed_for_cc_pair__no_commit
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.index_attempt import mock_successful_index_attempt
@@ -246,6 +247,13 @@ def seed_initial_documents(
             large_chunks_enabled=False,
             tenant_id=tenant_id,
         ),
+    )
+
+    mark_document_as_indexed_for_cc_pair__no_commit(
+        connector_id=connector_id,
+        credential_id=PUBLIC_CREDENTIAL_ID,
+        document_ids=[doc.id for doc in docs],
+        db_session=db_session,
     )
 
     # Mock a run for the UI even though it did not actually call out to anything

--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -249,13 +249,6 @@ def seed_initial_documents(
         ),
     )
 
-    mark_document_as_indexed_for_cc_pair__no_commit(
-        connector_id=connector_id,
-        credential_id=PUBLIC_CREDENTIAL_ID,
-        document_ids=[doc.id for doc in docs],
-        db_session=db_session,
-    )
-
     # Mock a run for the UI even though it did not actually call out to anything
     mock_successful_index_attempt(
         connector_credential_pair_id=cc_pair_id,
@@ -271,6 +264,14 @@ def seed_initial_documents(
             .where(DbDocument.id == doc.id)
             .values(chunk_count=doc.chunk_count)
         )
+
+    # Since we bypass the indexing flow, we need to manually mark the document as indexed
+    mark_document_as_indexed_for_cc_pair__no_commit(
+        connector_id=connector_id,
+        credential_id=PUBLIC_CREDENTIAL_ID,
+        document_ids=[doc.id for doc in docs],
+        db_session=db_session,
+    )
 
     db_session.commit()
     kv_store.store(KV_DOCUMENTS_SEEDED_KEY, True)


### PR DESCRIPTION
## Description

- title
- 
## How Has This Been Tested?

-locally 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed seeded document count by marking documents as indexed during the seeding process to ensure accurate totals.

<!-- End of auto-generated description by cubic. -->

