### PR TITLE
ensure exception strings don't get swallowed

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -295,7 +295,11 @@ def process_job_result(
         if result.exit_code is not None:
             result.status = IndexingWatchdogTerminalStatus.from_code(result.exit_code)
 
-        result.exception_str = job.exception()
+        job_level_exception = job.exception()
+        result.exception_str = (
+            f"Internal docfetching error (if any): {result.exception_str}"
+            f">> Job level exception: {job_level_exception}"
+        )
 
     return result
 


### PR DESCRIPTION
## Description

We were throwing out some error messages in rare cases, now we ensure that both the info that has been displayed correctly in the past is still displayed but also we're adding in error messages set during docfetching execution

## How Has This Been Tested?

n/a pretty harmless logging change

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
