### PR TITLE
fix(connector): user file helm start cmd + legacy file connector incompatibility

### DIFF
--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -245,6 +245,9 @@ class LocalFileConnector(LoadConnector):
         # Resolve file_names: prefer explicit list, fall back to locations
         if file_names is None:
             file_names = self.file_locations
+        else:
+            # Ensure we have a concrete list of strings
+            file_names = [str(name) for name in file_names]
 
         self.batch_size = batch_size
         self.pdf_pass: Optional[str] = None

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -237,7 +237,7 @@ class LocalFileConnector(LoadConnector):
         self,
         file_locations: list[Path | str],
         file_names: Optional[list[str]] = None,  # Must accept this parameter as connector_specific_config is unpacked as args
-        zip_metadata: dict[str, Any] = None,
+        zip_metadata: Optional[dict[str, Any]] = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:
         self.file_locations = [str(loc) for loc in file_locations]

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -230,7 +230,6 @@ class LocalFileConnector(LoadConnector):
 
     # Note: file_names is a required parameter, but should not break backwards compatibility.
     # If add_file_names migration is not run, old file connector configs will not have file_names.
-    # This is fine because the configs are not re-used to instantiate the connector.
     # file_names is only used for display purposes in the UI and file_locations is used as a fallback.
     def __init__(
         self,

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -235,7 +235,7 @@ class LocalFileConnector(LoadConnector):
     def __init__(
         self,
         file_locations: list[Path | str],
-        file_names: list[str] | None = None,
+        file_names: list[str] | None = None, # Must accept this parameter as connector_specific_config is unpacked as args
         zip_metadata: dict[str, Any] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -245,9 +245,6 @@ class LocalFileConnector(LoadConnector):
         # Resolve file_names: prefer explicit list, fall back to locations
         if file_names is None:
             file_names = self.file_locations
-        else:
-            # Ensure we have a concrete list of strings
-            file_names = [str(name) for name in file_names]
 
         self.batch_size = batch_size
         self.pdf_pass: Optional[str] = None

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -235,7 +235,7 @@ class LocalFileConnector(LoadConnector):
     def __init__(
         self,
         file_locations: list[Path | str],
-        file_names: list[str] | None = None, # Must accept this parameter as connector_specific_config is unpacked as args
+        file_names: list[str] | None = None,
         zip_metadata: dict[str, Any] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -4,7 +4,6 @@ from datetime import timezone
 from pathlib import Path
 from typing import Any
 from typing import IO
-from typing import Optional
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
@@ -236,21 +235,13 @@ class LocalFileConnector(LoadConnector):
     def __init__(
         self,
         file_locations: list[Path | str],
-        file_names: Optional[list[str]] = None,  # Must accept this parameter as connector_specific_config is unpacked as args
-        zip_metadata: Optional[dict[str, Any]] = None,
+        file_names: list[str] | None = None,
+        zip_metadata: dict[str, Any] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:
         self.file_locations = [str(loc) for loc in file_locations]
-
-        # Resolve file_names: prefer explicit list, fall back to locations
-        if file_names is None:
-            file_names = self.file_locations
-        else:
-            # Ensure we have a concrete list of strings
-            file_names = [str(name) for name in file_names]
-
         self.batch_size = batch_size
-        self.pdf_pass: Optional[str] = None
+        self.pdf_pass: str | None = None
         self.zip_metadata = zip_metadata or {}
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -43,7 +43,7 @@ spec:
             [
               "celery",
               "-A",
-              "onyx.background.celery.versioned_apps.docprocessing",
+              "onyx.background.celery.versioned_apps.docfetching",
               "worker",
               "--loglevel=INFO",
               "--hostname=user-files-indexing@%n",


### PR DESCRIPTION
## Description

On the main branch/v1.3.1, we encounter two issues preventing us from ingesting user files. This PR fixes both of them.

1) The user-files-indexing helm template starts `onyx.background.celery.versioned_apps.docprocessing` by default instead of **docfetching**. This is in contrast to the values in `supervisord.conf,` and the pod complains about an unrecognized task until this is changed:

```
ERROR:    ERROR    08/13/2025 04:07:34 PM     consumer.py:591 : celery.worker.consumer.consumer Received unregistered task of type 'connector_doc_fetching_task'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you're using relative imports?

Please see
https://docs.celeryq.dev/en/latest/internals/protocol.html
for more information.

The full contents of the message body was:
b'[[], {"index_attempt_id": 342820, "cc_pair_id": 227, "search_settings_id": 4, "tenant_id": "public"}, {"callbacks": null, "errbacks": null, "chain": null, "chord": null}]' (170b)

The full contents of the message headers:
{'lang': 'py', 'task': 'connector_doc_fetching_task', 'id': 'docfetching_227_4_f5e49db6-3c57-4ce9-9730-a97388531741', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '4868351a-9242-4cdf-92c1-5a93220f523e', 'parent_id': '4868351a-9242-4cdf-92c1-5a93220f523e', 'argsrepr': '()', 'kwargsrepr': "{'index_attempt_id': 342820, 'cc_pair_id': 227, 'search_settings_id': 4, 'tenant_id': 'public'}", 'origin': 'gen1@onyx-helmchart-celery-worker-primary-c6dfdfd4b-bx5tp', 'ignore_result': False, 'replaced_task_nesting': 0, 'stamped_headers': None, 'stamps': {}}

The delivery info for this task is:
{'exchange': '', 'routing_key': 'user_files_indexing'}
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/celery/worker/consumer/consumer.py", line 662, in on_task_received
    strategy = strategies[type_]
               ~~~~~~~~~~^^^^^^^
KeyError: 'connector_doc_fetching_task'
INFO:     INFO     08/13/2025 06:24:35 PM       gossip.py:145 : celery.worker.consumer.gossip missed heartbeat from light@onyx-helmchart-celery-worker-light-5c9bd567cd-8w9nm
```

2) Once you fix that error, it looks like all of our legacy user file connectors encounter this next one, which this PR also resolves. Both parameters seem to be optional but not set to None by default, resulting in the below error.

```
TypeError: LocalFileConnector.__init__() missing 2 required positional arguments: 'file_names' and 'zip_metadata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/onyx/background/indexing/job_client.py", line 84, in _initializer
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/background/celery/tasks/docfetching/tasks.py", line 124, in docfetching_task
    _docfetching_task(
  File "/app/onyx/background/celery/tasks/docfetching/tasks.py", line 251, in _docfetching_task
    raise e
  File "/app/onyx/background/celery/tasks/docfetching/tasks.py", line 217, in _docfetching_task
    run_indexing_entrypoint(
  File "/app/onyx/background/indexing/run_docfetching.py", line 873, in run_indexing_entrypoint
    connector_document_extraction(
  File "/app/onyx/background/indexing/run_docfetching.py", line 1028, in connector_document_extraction
    connector_runner = _get_connector_runner(
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/background/indexing/run_docfetching.py", line 147, in _get_connector_runner
    raise e
  File "/app/onyx/background/indexing/run_docfetching.py", line 106, in _get_connector_runner
    runnable_connector = instantiate_connector(
                         ^^^^^^^^^^^^^^^^^^^^^^
  File "/app/onyx/connectors/factory.py", line 178, in instantiate_connector
    connector = connector_class(**connector_specific_config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: LocalFileConnector.__init__() missing 2 required positional arguments: 'file_names' and 'zip_metadata'
```

## How Has This Been Tested?

Locally, via our own deployment on k8s + helm.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed startup errors in the user files celery worker and improved legacy file connector support by updating the Helm command and setting default values for missing parameters.

- **Bug Fixes**
 - Changed the Helm template to run the correct docfetching worker for user files.
 - Updated LocalFileConnector to set default values for file_names and zip_metadata when missing.

<!-- End of auto-generated description by cubic. -->

