### PR TITLE
fix(connector): file connector failure fix

### DIFF
--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -72,6 +72,7 @@ def _process_file(
     file: IO[Any],
     metadata: dict[str, Any] | None,
     pdf_pass: str | None,
+    file_type: str | None,
 ) -> list[Document]:
     """
     Process a file and return a list of Documents.
@@ -148,6 +149,7 @@ def _process_file(
         file=file,
         file_name=file_name,
         pdf_pass=pdf_pass,
+        content_type=file_type,
     )
 
     # Each file may have file-specific ONYX_METADATA https://docs.onyx.app/connectors/file
@@ -278,6 +280,7 @@ class LocalFileConnector(LoadConnector):
                 file=file_io,
                 metadata=metadata,
                 pdf_pass=self.pdf_pass,
+                file_type=file_record.file_type,
             )
             documents.extend(new_docs)
 

--- a/backend/onyx/file_processing/file_validation.py
+++ b/backend/onyx/file_processing/file_validation.py
@@ -21,6 +21,9 @@ EXCLUDED_IMAGE_TYPES = [
     "image/avif",
 ]
 
+# Text MIME types
+TEXT_MIME_TYPE = "text/plain"
+
 
 def is_valid_image_type(mime_type: str) -> bool:
     """


### PR DESCRIPTION
## Description
This pull request enhances the file processing logic by improving how text files are detected and extracted, particularly when files may have content types that don't match their extensions. It introduces a dedicated function for extracting text from plain text files, makes the MIME type available throughout the processing pipeline, and refactors related code for clarity and maintainability.

Linear issue link - https://linear.app/danswer/issue/DAN-2323/indexing-fails-when-we-upload-files-from-connector-and-mydocuments

## How Has This Been Tested?
My uploading file form UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved file processing to fix indexing failures by correctly handling text file extraction based on MIME type, even when file extensions do not match. Addresses Linear issue DAN-2323 for files uploaded from connectors and MyDocuments.

- **Bug Fixes**
 - Added a dedicated function for extracting text from plain text files using MIME type detection.
 - Made MIME type available throughout the processing pipeline for accurate file handling.

<!-- End of auto-generated description by cubic. -->

