### PR TITLE
fix: bump timeout when docprocessing has not started

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1690,12 +1690,14 @@ class IndexAttempt(Base):
     # can be taken to the FileStore to grab the actual checkpoint value
     checkpoint_pointer: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    # NEW: Database-based coordination fields (replacing Redis fencing)
+    # Database-based coordination fields (replacing Redis fencing)
     celery_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
     cancellation_requested: Mapped[bool] = mapped_column(Boolean, default=False)
 
-    # NEW: Batch coordination fields (replacing FileStore state)
+    # Batch coordination fields
+    # Once this is set, docfetching has completed
     total_batches: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # batches that are fully indexed (i.e. have completed docfetching and docprocessing)
     completed_batches: Mapped[int] = mapped_column(Integer, default=0)
     # TODO: unused, remove this column
     total_failures_batch_level: Mapped[int] = mapped_column(Integer, default=0)
@@ -1707,7 +1709,7 @@ class IndexAttempt(Base):
     )
     last_batches_completed_count: Mapped[int] = mapped_column(Integer, default=0)
 
-    # NEW: Heartbeat tracking for worker liveness detection
+    # Heartbeat tracking for worker liveness detection
     heartbeat_counter: Mapped[int] = mapped_column(Integer, default=0)
     last_heartbeat_value: Mapped[int] = mapped_column(Integer, default=0)
     last_heartbeat_time: Mapped[datetime.datetime | None] = mapped_column(

--- a/web/src/components/RichTextSubtext.tsx
+++ b/web/src/components/RichTextSubtext.tsx
@@ -9,6 +9,9 @@ interface RichTextSubtextProps {
  * Component that renders text with clickable links.
  * Detects URLs in the text and converts them to clickable links.
  * Also supports markdown-style links like [text](url).
+ * NOTE: we should be careful not to use this component in a way that displays text from external sources
+ * because it could be used to create links to malicious sites. Right now it's just used to make links
+ * to our docs in connector setup pages
  */
 export function RichTextSubtext({
   text,


### PR DESCRIPTION
## Description

If docprocessing pods are underprovisioned relative to docfetching or the model server is taking a while, it can take a while for the batches/tasks emitted by docfetching to be picked up by docprocessing. We also use a heartbeat system where all docfetching/docprocessing tasks write to the db in a background thread to notify that "indexing is still happening". This is read by the primary worker periodically to ensure that dead indexing attempts get marked as failed.

So, there are cases where docfetching starts -> emits some batches -> docfetching finishes -> 30 minutes pass with all available docprocessing workers not starting on those batches

During those 30 minutes the docfetching tasks has stopped heartbeating because it finished, so the index attempt appears "dead". I'm bumping the heartbeat timeout in this specific case to 12 hours to allow docprocessing more time to work through the queue. If a docprocessing batch isn't picked up for 12 hours, the real solution is just to provision more docprocessing pods.

## How Has This Been Tested?

n/a, simple timeout bump

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increase the indexing heartbeat timeout when docfetching is done but docprocessing hasn’t started. This prevents healthy indexing attempts from being marked failed during long queues by allowing up to 12 hours before timing out.

- **Bug Fixes**
  - Use a longer heartbeat window (30m x 24) when total_batches is set and completed_batches is 0.
  - Centralized HEARTBEAT_TIMEOUT_SECONDS (30m) and added DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER (24).
  - Failure logs now show the actual timeout used.

- **Refactors**
  - Clarified comments on batch and heartbeat fields in IndexAttempt.
  - Added a safety note in RichTextSubtext about not rendering untrusted links.

<!-- End of auto-generated description by cubic. -->

