### PR TITLE
fix: unpause user files

### DIFF
--- a/backend/alembic/versions/b558f51620b4_pause_finished_user_file_connectors.py
+++ b/backend/alembic/versions/b558f51620b4_pause_finished_user_file_connectors.py
@@ -1,0 +1,33 @@
+"""Pause finished user file connectors
+
+Revision ID: b558f51620b4
+Revises: 90e3b9af7da4
+Create Date: 2025-08-15 17:17:02.456704
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b558f51620b4"
+down_revision = "90e3b9af7da4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Set all user file connector credential pairs with ACTIVE status to PAUSED
+    # This ensures user files don't continue to run indexing tasks after processing
+    op.execute(
+        """
+        UPDATE connector_credential_pair
+        SET status = 'PAUSED'
+        WHERE is_user_file = true
+        AND status = 'ACTIVE'
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -505,7 +505,14 @@ def check_indexing_completion(
                 ConnectorCredentialPairStatus.SCHEDULED,
                 ConnectorCredentialPairStatus.INITIAL_INDEXING,
             ]:
-                cc_pair.status = ConnectorCredentialPairStatus.ACTIVE
+                # User file connectors must be paused on success
+                # NOTE: _run_indexing doesn't update connectors if the index attempt is the future embedding model
+                # TODO: figure out why this doesn't pause connectors during swap
+                cc_pair.status = (
+                    ConnectorCredentialPairStatus.PAUSED
+                    if cc_pair.is_user_file
+                    else ConnectorCredentialPairStatus.ACTIVE
+                )
                 db_session.commit()
 
             # Clear repeated error state on success

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -271,7 +271,7 @@ def _check_failure_threshold(
 
 # NOTE: this is the old run_indexing function that the new decoupled approach
 # is based on. Leaving this for comparison purposes, but if you see this comment
-# has been here for >1 month, please delete this function.
+# has been here for >2 month, please delete this function.
 def _run_indexing(
     db_session: Session,
     index_attempt_id: int,

--- a/web/src/app/admin/configuration/search/UpgradingPage.tsx
+++ b/web/src/app/admin/configuration/search/UpgradingPage.tsx
@@ -154,6 +154,9 @@ export default function UpgradingPage({
                     re-indexed successfully, the new model will be used for all
                     search queries. Until then, we will use the old model so
                     that no downtime is necessary during this transition.
+                    <br />
+                    Note: User file re-indexing progress is not shown. You will
+                    see this page until all user files are re-indexed!
                   </Text>
 
                   {sortedReindexingProgress ? (


### PR DESCRIPTION
## Description

- user file connectors were not being paused on successful creation

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes unpaused user file connectors by pausing them after successful indexing. Also clarifies the Upgrading page that user file re-indexing progress isn’t shown.

- **Bug Fixes**
  - Pause user file connectors on successful indexing instead of activating them.
  - Add Upgrading page note explaining user file progress is hidden and the page stays until all user files re-index.

- **Migration**
  - Alembic migration sets existing user file connector pairs from ACTIVE to PAUSED.
  - No manual steps required.

<!-- End of auto-generated description by cubic. -->

