### PR TITLE
refactor(model): move api-based embeddings/reranking calls out of model server

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .mypy_cache
 .idea/
+venv/
 site_crawls/
 .ipynb_checkpoints/
 api_keys.py

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,7 +1,6 @@
 __pycache__/
 .mypy_cache
 .idea/
-venv/
 site_crawls/
 .ipynb_checkpoints/
 api_keys.py

--- a/backend/model_server/constants.py
+++ b/backend/model_server/constants.py
@@ -1,6 +1,7 @@
 MODEL_WARM_UP_STRING = "hi " * 512
 INFORMATION_CONTENT_MODEL_WARM_UP_STRING = "hi " * 16
 
+
 class GPUStatus:
     CUDA = "cuda"
     MAC_MPS = "mps"

--- a/backend/model_server/constants.py
+++ b/backend/model_server/constants.py
@@ -1,35 +1,5 @@
-from shared_configs.enums import EmbeddingProvider
-from shared_configs.enums import EmbedTextType
-
-
 MODEL_WARM_UP_STRING = "hi " * 512
 INFORMATION_CONTENT_MODEL_WARM_UP_STRING = "hi " * 16
-DEFAULT_OPENAI_MODEL = "text-embedding-3-small"
-DEFAULT_COHERE_MODEL = "embed-english-light-v3.0"
-DEFAULT_VOYAGE_MODEL = "voyage-large-2-instruct"
-DEFAULT_VERTEX_MODEL = "text-embedding-005"
-
-
-class EmbeddingModelTextType:
-    PROVIDER_TEXT_TYPE_MAP = {
-        EmbeddingProvider.COHERE: {
-            EmbedTextType.QUERY: "search_query",
-            EmbedTextType.PASSAGE: "search_document",
-        },
-        EmbeddingProvider.VOYAGE: {
-            EmbedTextType.QUERY: "query",
-            EmbedTextType.PASSAGE: "document",
-        },
-        EmbeddingProvider.GOOGLE: {
-            EmbedTextType.QUERY: "RETRIEVAL_QUERY",
-            EmbedTextType.PASSAGE: "RETRIEVAL_DOCUMENT",
-        },
-    }
-
-    @staticmethod
-    def get_type(provider: EmbeddingProvider, text_type: EmbedTextType) -> str:
-        return EmbeddingModelTextType.PROVIDER_TEXT_TYPE_MAP[provider][text_type]
-
 
 class GPUStatus:
     CUDA = "cuda"

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -1,116 +1,39 @@
 import asyncio
 import json
 import time
-from types import TracebackType
 from typing import Any
-from typing import cast
 from typing import Optional
 
 import aioboto3  # type: ignore
 import httpx
-import openai
-import vertexai  # type: ignore
-import voyageai  # type: ignore
 from cohere import AsyncClient as CohereAsyncClient
 from fastapi import APIRouter
 from fastapi import HTTPException
 from fastapi import Request
-from google.oauth2 import service_account  # type: ignore
-from litellm import aembedding
 from litellm.exceptions import RateLimitError
 from retry import retry
 from sentence_transformers import CrossEncoder  # type: ignore
 from sentence_transformers import SentenceTransformer  # type: ignore
-from vertexai.language_models import TextEmbeddingInput  # type: ignore
-from vertexai.language_models import TextEmbeddingModel  # type: ignore
 
-from model_server.constants import DEFAULT_COHERE_MODEL
-from model_server.constants import DEFAULT_OPENAI_MODEL
-from model_server.constants import DEFAULT_VERTEX_MODEL
-from model_server.constants import DEFAULT_VOYAGE_MODEL
-from model_server.constants import EmbeddingModelTextType
-from model_server.constants import EmbeddingProvider
 from model_server.utils import pass_aws_key
 from model_server.utils import simple_log_function_time
 from onyx.utils.logger import setup_logger
-from shared_configs.configs import API_BASED_EMBEDDING_TIMEOUT
 from shared_configs.configs import INDEXING_ONLY
-from shared_configs.configs import OPENAI_EMBEDDING_TIMEOUT
-from shared_configs.configs import VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
 from shared_configs.enums import EmbedTextType
+from shared_configs.enums import EmbeddingProvider
 from shared_configs.enums import RerankerProvider
 from shared_configs.model_server_models import Embedding
 from shared_configs.model_server_models import EmbedRequest
 from shared_configs.model_server_models import EmbedResponse
 from shared_configs.model_server_models import RerankRequest
 from shared_configs.model_server_models import RerankResponse
-from shared_configs.utils import batch_list
 
 
 logger = setup_logger()
 
 router = APIRouter(prefix="/encoder")
 
-_GLOBAL_MODELS_DICT: dict[str, "SentenceTransformer"] = {}
-_RERANK_MODEL: Optional["CrossEncoder"] = None
-
-# If we are not only indexing, dont want retry very long
-_RETRY_DELAY = 10 if INDEXING_ONLY else 0.1
-_RETRY_TRIES = 10 if INDEXING_ONLY else 2
-
-# OpenAI only allows 2048 embeddings to be computed at once
-_OPENAI_MAX_INPUT_LEN = 2048
-# Cohere allows up to 96 embeddings in a single embedding calling
-_COHERE_MAX_INPUT_LEN = 96
-
-# Authentication error string constants
-_AUTH_ERROR_401 = "401"
-_AUTH_ERROR_UNAUTHORIZED = "unauthorized"
-_AUTH_ERROR_INVALID_API_KEY = "invalid api key"
-_AUTH_ERROR_PERMISSION = "permission"
-
-
-def is_authentication_error(error: Exception) -> bool:
-    """Check if an exception is related to authentication issues.
-
-    Args:
-        error: The exception to check
-
-    Returns:
-        bool: True if the error appears to be authentication-related
-    """
-    error_str = str(error).lower()
-    return (
-        _AUTH_ERROR_401 in error_str
-        or _AUTH_ERROR_UNAUTHORIZED in error_str
-        or _AUTH_ERROR_INVALID_API_KEY in error_str
-        or _AUTH_ERROR_PERMISSION in error_str
-    )
-
-
-def format_embedding_error(
-    error: Exception,
-    service_name: str,
-    model: str | None,
-    provider: EmbeddingProvider,
-    sanitized_api_key: str | None = None,
-    status_code: int | None = None,
-) -> str:
-    """
-    Format a standardized error string for embedding errors.
-    """
-    detail = f"Status {status_code}" if status_code else f"{type(error)}"
-
-    return (
-        f"{'HTTP error' if status_code else 'Exception'} embedding text with {service_name} - {detail}: "
-        f"Model: {model} "
-        f"Provider: {provider} "
-        f"API Key: {sanitized_api_key} "
-        f"Exception: {error}"
-    )
-
-
-# Custom exception for authentication errors
+# Custom exception for authentication errors (needed for reranking functions)
 class AuthenticationError(Exception):
     """Raised when authentication fails with a provider."""
 
@@ -119,253 +42,17 @@ class AuthenticationError(Exception):
         self.message = message
         super().__init__(f"{provider} authentication failed: {message}")
 
+_GLOBAL_MODELS_DICT: dict[str, "SentenceTransformer"] = {}
+_RERANK_MODEL: Optional["CrossEncoder"] = None
 
-class CloudEmbedding:
-    def __init__(
-        self,
-        api_key: str,
-        provider: EmbeddingProvider,
-        api_url: str | None = None,
-        api_version: str | None = None,
-        timeout: int = API_BASED_EMBEDDING_TIMEOUT,
-    ) -> None:
-        self.provider = provider
-        self.api_key = api_key
-        self.api_url = api_url
-        self.api_version = api_version
-        self.timeout = timeout
-        self.http_client = httpx.AsyncClient(timeout=timeout)
-        self._closed = False
-        self.sanitized_api_key = api_key[:4] + "********" + api_key[-4:]
+# If we are not only indexing, dont want retry very long
+_RETRY_DELAY = 10 if INDEXING_ONLY else 0.1
+_RETRY_TRIES = 10 if INDEXING_ONLY else 2
 
-    async def _embed_openai(
-        self, texts: list[str], model: str | None, reduced_dimension: int | None
-    ) -> list[Embedding]:
-        if not model:
-            model = DEFAULT_OPENAI_MODEL
 
-        # Use the OpenAI specific timeout for this one
-        client = openai.AsyncOpenAI(
-            api_key=self.api_key, timeout=OPENAI_EMBEDDING_TIMEOUT
-        )
 
-        final_embeddings: list[Embedding] = []
 
-        for text_batch in batch_list(texts, _OPENAI_MAX_INPUT_LEN):
-            response = await client.embeddings.create(
-                input=text_batch,
-                model=model,
-                dimensions=reduced_dimension or openai.NOT_GIVEN,
-            )
-            final_embeddings.extend(
-                [embedding.embedding for embedding in response.data]
-            )
-        return final_embeddings
 
-    async def _embed_cohere(
-        self, texts: list[str], model: str | None, embedding_type: str
-    ) -> list[Embedding]:
-        if not model:
-            model = DEFAULT_COHERE_MODEL
-
-        client = CohereAsyncClient(api_key=self.api_key)
-
-        final_embeddings: list[Embedding] = []
-        for text_batch in batch_list(texts, _COHERE_MAX_INPUT_LEN):
-            # Does not use the same tokenizer as the Onyx API server but it's approximately the same
-            # empirically it's only off by a very few tokens so it's not a big deal
-            response = await client.embed(
-                texts=text_batch,
-                model=model,
-                input_type=embedding_type,
-                truncate="END",
-            )
-            final_embeddings.extend(cast(list[Embedding], response.embeddings))
-        return final_embeddings
-
-    async def _embed_voyage(
-        self, texts: list[str], model: str | None, embedding_type: str
-    ) -> list[Embedding]:
-        if not model:
-            model = DEFAULT_VOYAGE_MODEL
-
-        client = voyageai.AsyncClient(
-            api_key=self.api_key, timeout=API_BASED_EMBEDDING_TIMEOUT
-        )
-
-        response = await client.embed(
-            texts=texts,
-            model=model,
-            input_type=embedding_type,
-            truncation=True,
-        )
-        return response.embeddings
-
-    async def _embed_azure(
-        self, texts: list[str], model: str | None
-    ) -> list[Embedding]:
-        response = await aembedding(
-            model=model,
-            input=texts,
-            timeout=API_BASED_EMBEDDING_TIMEOUT,
-            api_key=self.api_key,
-            api_base=self.api_url,
-            api_version=self.api_version,
-        )
-        embeddings = [embedding["embedding"] for embedding in response.data]
-        return embeddings
-
-    async def _embed_vertex(
-        self, texts: list[str], model: str | None, embedding_type: str
-    ) -> list[Embedding]:
-        if not model:
-            model = DEFAULT_VERTEX_MODEL
-
-        credentials = service_account.Credentials.from_service_account_info(
-            json.loads(self.api_key)
-        )
-        project_id = json.loads(self.api_key)["project_id"]
-        vertexai.init(project=project_id, credentials=credentials)
-        client = TextEmbeddingModel.from_pretrained(model)
-
-        inputs = [TextEmbeddingInput(text, embedding_type) for text in texts]
-
-        # Split into batches of 25 texts
-        max_texts_per_batch = VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
-        batches = [
-            inputs[i : i + max_texts_per_batch]
-            for i in range(0, len(inputs), max_texts_per_batch)
-        ]
-
-        # Dispatch all embedding calls asynchronously at once
-        tasks = [
-            client.get_embeddings_async(batch, auto_truncate=True) for batch in batches
-        ]
-
-        # Wait for all tasks to complete in parallel
-        results = await asyncio.gather(*tasks)
-
-        return [embedding.values for batch in results for embedding in batch]
-
-    async def _embed_litellm_proxy(
-        self, texts: list[str], model_name: str | None
-    ) -> list[Embedding]:
-        if not model_name:
-            raise ValueError("Model name is required for LiteLLM proxy embedding.")
-
-        if not self.api_url:
-            raise ValueError("API URL is required for LiteLLM proxy embedding.")
-
-        headers = (
-            {} if not self.api_key else {"Authorization": f"Bearer {self.api_key}"}
-        )
-
-        response = await self.http_client.post(
-            self.api_url,
-            json={
-                "model": model_name,
-                "input": texts,
-            },
-            headers=headers,
-        )
-        response.raise_for_status()
-        result = response.json()
-        return [embedding["embedding"] for embedding in result["data"]]
-
-    @retry(tries=_RETRY_TRIES, delay=_RETRY_DELAY)
-    async def embed(
-        self,
-        *,
-        texts: list[str],
-        text_type: EmbedTextType,
-        model_name: str | None = None,
-        deployment_name: str | None = None,
-        reduced_dimension: int | None = None,
-    ) -> list[Embedding]:
-        try:
-            if self.provider == EmbeddingProvider.OPENAI:
-                return await self._embed_openai(texts, model_name, reduced_dimension)
-            elif self.provider == EmbeddingProvider.AZURE:
-                return await self._embed_azure(texts, f"azure/{deployment_name}")
-            elif self.provider == EmbeddingProvider.LITELLM:
-                return await self._embed_litellm_proxy(texts, model_name)
-
-            embedding_type = EmbeddingModelTextType.get_type(self.provider, text_type)
-            if self.provider == EmbeddingProvider.COHERE:
-                return await self._embed_cohere(texts, model_name, embedding_type)
-            elif self.provider == EmbeddingProvider.VOYAGE:
-                return await self._embed_voyage(texts, model_name, embedding_type)
-            elif self.provider == EmbeddingProvider.GOOGLE:
-                return await self._embed_vertex(texts, model_name, embedding_type)
-            else:
-                raise ValueError(f"Unsupported provider: {self.provider}")
-        except openai.AuthenticationError:
-            raise AuthenticationError(provider="OpenAI")
-        except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError(provider=str(self.provider))
-
-            error_string = format_embedding_error(
-                e,
-                str(self.provider),
-                model_name or deployment_name,
-                self.provider,
-                sanitized_api_key=self.sanitized_api_key,
-                status_code=e.response.status_code,
-            )
-            logger.error(error_string)
-            logger.debug(f"Exception texts: {texts}")
-
-            raise RuntimeError(error_string)
-        except Exception as e:
-            if is_authentication_error(e):
-                raise AuthenticationError(provider=str(self.provider))
-
-            error_string = format_embedding_error(
-                e,
-                str(self.provider),
-                model_name or deployment_name,
-                self.provider,
-                sanitized_api_key=self.sanitized_api_key,
-            )
-            logger.error(error_string)
-            logger.debug(f"Exception texts: {texts}")
-
-            raise RuntimeError(error_string)
-
-    @staticmethod
-    def create(
-        api_key: str,
-        provider: EmbeddingProvider,
-        api_url: str | None = None,
-        api_version: str | None = None,
-    ) -> "CloudEmbedding":
-        logger.debug(f"Creating Embedding instance for provider: {provider}")
-        return CloudEmbedding(api_key, provider, api_url, api_version)
-
-    async def aclose(self) -> None:
-        """Explicitly close the client."""
-        if not self._closed:
-            await self.http_client.aclose()
-            self._closed = True
-
-    async def __aenter__(self) -> "CloudEmbedding":
-        return self
-
-    async def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        await self.aclose()
-
-    def __del__(self) -> None:
-        """Finalizer to warn about unclosed clients."""
-        if not self._closed:
-            logger.warning(
-                "CloudEmbedding was not properly closed. Use 'async with' or call aclose()"
-            )
 
 
 def get_embedding_model(
@@ -429,17 +116,10 @@ def _concurrent_embedding(
 @simple_log_function_time()
 async def embed_text(
     texts: list[str],
-    text_type: EmbedTextType,
     model_name: str | None,
-    deployment_name: str | None,
     max_context_length: int,
     normalize_embeddings: bool,
-    api_key: str | None,
-    provider_type: EmbeddingProvider | None,
     prefix: str | None,
-    api_url: str | None,
-    api_version: str | None,
-    reduced_dimension: int | None,
     gpu_type: str = "UNKNOWN",
 ) -> list[Embedding]:
     if not all(texts):
@@ -456,52 +136,10 @@ async def embed_text(
     for text in texts:
         total_chars += len(text)
 
-    if provider_type is not None:
-        logger.info(
-            f"Embedding {len(texts)} texts with {total_chars} total characters with provider: {provider_type}"
-        )
+    # Only local models should call this function now
+    # API providers should go directly to API server
 
-        if api_key is None:
-            logger.error("API key not provided for cloud model")
-            raise RuntimeError("API key not provided for cloud model")
-
-        if prefix:
-            logger.warning("Prefix provided for cloud model, which is not supported")
-            raise ValueError(
-                "Prefix string is not valid for cloud models. "
-                "Cloud models take an explicit text type instead."
-            )
-
-        async with CloudEmbedding(
-            api_key=api_key,
-            provider=provider_type,
-            api_url=api_url,
-            api_version=api_version,
-        ) as cloud_model:
-            embeddings = await cloud_model.embed(
-                texts=texts,
-                model_name=model_name,
-                deployment_name=deployment_name,
-                text_type=text_type,
-                reduced_dimension=reduced_dimension,
-            )
-
-        if any(embedding is None for embedding in embeddings):
-            error_message = "Embeddings contain None values\n"
-            error_message += "Corresponding texts:\n"
-            error_message += "\n".join(texts)
-            logger.error(error_message)
-            raise ValueError(error_message)
-
-        elapsed = time.monotonic() - start
-        logger.info(
-            f"event=embedding_provider "
-            f"texts={len(texts)} "
-            f"chars={total_chars} "
-            f"provider={provider_type} "
-            f"elapsed={elapsed:.2f}"
-        )
-    elif model_name is not None:
+    if model_name is not None:
         logger.info(
             f"Embedding {len(texts)} texts with {total_chars} total characters with local model: {model_name}"
         )
@@ -555,75 +193,6 @@ async def local_rerank(query: str, docs: list[str], model_name: str) -> list[flo
     )
 
 
-async def cohere_rerank_api(
-    query: str, docs: list[str], model_name: str, api_key: str
-) -> list[float]:
-    cohere_client = CohereAsyncClient(api_key=api_key)
-    response = await cohere_client.rerank(query=query, documents=docs, model=model_name)
-    results = response.results
-    sorted_results = sorted(results, key=lambda item: item.index)
-    return [result.relevance_score for result in sorted_results]
-
-
-async def cohere_rerank_aws(
-    query: str,
-    docs: list[str],
-    model_name: str,
-    region_name: str,
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-) -> list[float]:
-    session = aioboto3.Session(
-        aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key
-    )
-    async with session.client(
-        "bedrock-runtime", region_name=region_name
-    ) as bedrock_client:
-        body = json.dumps(
-            {
-                "query": query,
-                "documents": docs,
-                "api_version": 2,
-            }
-        )
-        # Invoke the Bedrock model asynchronously
-        response = await bedrock_client.invoke_model(
-            modelId=model_name,
-            accept="application/json",
-            contentType="application/json",
-            body=body,
-        )
-
-        # Read the response asynchronously
-        response_body = json.loads(await response["body"].read())
-
-        # Extract and sort the results
-        results = response_body.get("results", [])
-        sorted_results = sorted(results, key=lambda item: item["index"])
-
-        return [result["relevance_score"] for result in sorted_results]
-
-
-async def litellm_rerank(
-    query: str, docs: list[str], api_url: str, model_name: str, api_key: str | None
-) -> list[float]:
-    headers = {} if not api_key else {"Authorization": f"Bearer {api_key}"}
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            api_url,
-            json={
-                "model": model_name,
-                "query": query,
-                "documents": docs,
-            },
-            headers=headers,
-        )
-        response.raise_for_status()
-        result = response.json()
-        return [
-            item["relevance_score"]
-            for item in sorted(result["results"], key=lambda x: x["index"])
-        ]
 
 
 @router.post("/bi-encoder-embed")
@@ -654,15 +223,8 @@ async def process_embed_request(
         embeddings = await embed_text(
             texts=embed_request.texts,
             model_name=embed_request.model_name,
-            deployment_name=embed_request.deployment_name,
             max_context_length=embed_request.max_context_length,
             normalize_embeddings=embed_request.normalize_embeddings,
-            api_key=embed_request.api_key,
-            provider_type=embed_request.provider_type,
-            text_type=embed_request.text_type,
-            api_url=embed_request.api_url,
-            api_version=embed_request.api_version,
-            reduced_dimension=embed_request.reduced_dimension,
             prefix=prefix,
             gpu_type=gpu_type,
         )
@@ -702,6 +264,11 @@ async def process_rerank_request(rerank_request: RerankRequest) -> RerankRespons
         raise ValueError("Empty documents cannot be reranked.")
 
     try:
+        # Reject API provider requests - they should go directly to API server now
+        if rerank_request.provider_type is not None:
+            logger.error(f"API provider {rerank_request.provider_type} should not call model server")
+            raise ValueError(f"API provider {rerank_request.provider_type} requests should be handled by API server directly")
+
         if rerank_request.provider_type is None:
             sim_scores = await local_rerank(
                 query=rerank_request.query,
@@ -709,48 +276,8 @@ async def process_rerank_request(rerank_request: RerankRequest) -> RerankRespons
                 model_name=rerank_request.model_name,
             )
             return RerankResponse(scores=sim_scores)
-        elif rerank_request.provider_type == RerankerProvider.LITELLM:
-            if rerank_request.api_url is None:
-                raise ValueError("API URL is required for LiteLLM reranking.")
-
-            sim_scores = await litellm_rerank(
-                query=rerank_request.query,
-                docs=rerank_request.documents,
-                api_url=rerank_request.api_url,
-                model_name=rerank_request.model_name,
-                api_key=rerank_request.api_key,
-            )
-
-            return RerankResponse(scores=sim_scores)
-
-        elif rerank_request.provider_type == RerankerProvider.COHERE:
-            if rerank_request.api_key is None:
-                raise RuntimeError("Cohere Rerank Requires an API Key")
-            sim_scores = await cohere_rerank_api(
-                query=rerank_request.query,
-                docs=rerank_request.documents,
-                model_name=rerank_request.model_name,
-                api_key=rerank_request.api_key,
-            )
-            return RerankResponse(scores=sim_scores)
-
-        elif rerank_request.provider_type == RerankerProvider.BEDROCK:
-            if rerank_request.api_key is None:
-                raise RuntimeError("Bedrock Rerank Requires an API Key")
-            aws_access_key_id, aws_secret_access_key, aws_region = pass_aws_key(
-                rerank_request.api_key
-            )
-            sim_scores = await cohere_rerank_aws(
-                query=rerank_request.query,
-                docs=rerank_request.documents,
-                model_name=rerank_request.model_name,
-                region_name=aws_region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            return RerankResponse(scores=sim_scores)
         else:
-            raise ValueError(f"Unsupported provider: {rerank_request.provider_type}")
+            raise ValueError("Neither model name nor provider specified for reranking")
 
     except Exception as e:
         logger.exception(f"Error during reranking process:\n{str(e)}")

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -70,6 +70,3 @@ def get_gpu_type() -> str:
         return GPUStatus.MAC_MPS
 
     return GPUStatus.NONE
-
-
-

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -72,30 +72,4 @@ def get_gpu_type() -> str:
     return GPUStatus.NONE
 
 
-def pass_aws_key(api_key: str) -> tuple[str, str, str]:
-    """Parse AWS API key string into components.
 
-    Args:
-        api_key: String in format 'aws_ACCESSKEY_SECRETKEY_REGION'
-
-    Returns:
-        Tuple of (access_key, secret_key, region)
-
-    Raises:
-        ValueError: If key format is invalid
-    """
-    if not api_key.startswith("aws"):
-        raise ValueError("API key must start with 'aws' prefix")
-
-    parts = api_key.split("_")
-    if len(parts) != 4:
-        raise ValueError(
-            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts"
-            "this is an onyx specific format for formatting the aws secrets for bedrock"
-        )
-
-    try:
-        _, aws_access_key_id, aws_secret_access_key, aws_region = parts
-        return aws_access_key_id, aws_secret_access_key, aws_region
-    except Exception as e:
-        raise ValueError(f"Failed to parse AWS key components: {str(e)}")

--- a/backend/onyx/natural_language_processing/constants.py
+++ b/backend/onyx/natural_language_processing/constants.py
@@ -18,7 +18,7 @@ DEFAULT_VERTEX_MODEL = "text-embedding-005"
 
 class EmbeddingModelTextType:
     """Mapping of Onyx text types to provider-specific text types."""
-    
+
     PROVIDER_TEXT_TYPE_MAP = {
         EmbeddingProvider.COHERE: {
             EmbedTextType.QUERY: "search_query",

--- a/backend/onyx/natural_language_processing/constants.py
+++ b/backend/onyx/natural_language_processing/constants.py
@@ -1,0 +1,40 @@
+"""
+Constants for natural language processing, including embedding and reranking models.
+
+This file contains constants moved from model_server to support the gradual migration
+of API-based calls to bypass the model server.
+"""
+
+from shared_configs.enums import EmbeddingProvider
+from shared_configs.enums import EmbedTextType
+
+
+# Default model names for different providers
+DEFAULT_OPENAI_MODEL = "text-embedding-3-small"
+DEFAULT_COHERE_MODEL = "embed-english-light-v3.0"
+DEFAULT_VOYAGE_MODEL = "voyage-large-2-instruct"
+DEFAULT_VERTEX_MODEL = "text-embedding-005"
+
+
+class EmbeddingModelTextType:
+    """Mapping of Onyx text types to provider-specific text types."""
+    
+    PROVIDER_TEXT_TYPE_MAP = {
+        EmbeddingProvider.COHERE: {
+            EmbedTextType.QUERY: "search_query",
+            EmbedTextType.PASSAGE: "search_document",
+        },
+        EmbeddingProvider.VOYAGE: {
+            EmbedTextType.QUERY: "query",
+            EmbedTextType.PASSAGE: "document",
+        },
+        EmbeddingProvider.GOOGLE: {
+            EmbedTextType.QUERY: "RETRIEVAL_QUERY",
+            EmbedTextType.PASSAGE: "RETRIEVAL_DOCUMENT",
+        },
+    }
+
+    @staticmethod
+    def get_type(provider: EmbeddingProvider, text_type: EmbedTextType) -> str:
+        """Get provider-specific text type string."""
+        return EmbeddingModelTextType.PROVIDER_TEXT_TYPE_MAP[provider][text_type]

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -28,7 +28,7 @@ from retry import retry
 from vertexai.language_models import TextEmbeddingInput  # type: ignore
 from vertexai.language_models import TextEmbeddingModel  # type: ignore
 
-from model_server.utils import pass_aws_key  # change from where this is imported
+from onyx.utils.search_nlp_models_utils import pass_aws_key
 from onyx.configs.app_configs import INDEXING_EMBEDDING_MODEL_NUM_THREADS
 from onyx.configs.app_configs import LARGE_CHUNK_RATIO
 from onyx.configs.app_configs import SKIP_WARM_UP

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -525,7 +525,7 @@ class EmbeddingModel:
         # Only build model server endpoint for local models
         if self.provider_type is None:
             model_server_url = build_model_server_url(server_host, server_port)
-            self.embed_server_endpoint = f"{model_server_url}/encoder/bi-encoder-embed"
+            self.embed_server_endpoint: str | None = f"{model_server_url}/encoder/bi-encoder-embed"
         else:
             # API providers don't need model server endpoint
             self.embed_server_endpoint = None
@@ -865,7 +865,7 @@ class RerankingModel:
             model_server_url = build_model_server_url(
                 model_server_host, model_server_port
             )
-            self.rerank_server_endpoint = (
+            self.rerank_server_endpoint: str | None = (
                 model_server_url + "/encoder/cross-encoder-scores"
             )
         else:

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -28,7 +28,6 @@ from retry import retry
 from vertexai.language_models import TextEmbeddingInput  # type: ignore
 from vertexai.language_models import TextEmbeddingModel  # type: ignore
 
-from onyx.utils.search_nlp_models_utils import pass_aws_key
 from onyx.configs.app_configs import INDEXING_EMBEDDING_MODEL_NUM_THREADS
 from onyx.configs.app_configs import LARGE_CHUNK_RATIO
 from onyx.configs.app_configs import SKIP_WARM_UP
@@ -51,6 +50,7 @@ from onyx.natural_language_processing.exceptions import (
 from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.natural_language_processing.utils import tokenizer_trim_content
 from onyx.utils.logger import setup_logger
+from onyx.utils.search_nlp_models_utils import pass_aws_key
 from shared_configs.configs import API_BASED_EMBEDDING_TIMEOUT
 from shared_configs.configs import INDEXING_MODEL_SERVER_HOST
 from shared_configs.configs import INDEXING_MODEL_SERVER_PORT

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 import threading
 import time
 from collections.abc import Callable
@@ -5,10 +7,23 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from functools import wraps
+from types import TracebackType
 from typing import Any
+from typing import cast
 
+import aioboto3  # type: ignore
+import httpx
+import openai
 import requests
+import vertexai  # type: ignore
+import voyageai  # type: ignore
+from cohere import AsyncClient as CohereAsyncClient
+from google.oauth2 import service_account  # type: ignore
+from vertexai.language_models import TextEmbeddingInput  # type: ignore
+from vertexai.language_models import TextEmbeddingModel  # type: ignore
 from httpx import HTTPError
+from litellm import aembedding
+from litellm.exceptions import RateLimitError
 from requests import JSONDecodeError
 from requests import RequestException
 from requests import Response
@@ -31,10 +46,20 @@ from onyx.natural_language_processing.exceptions import (
 from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.natural_language_processing.utils import tokenizer_trim_content
 from onyx.utils.logger import setup_logger
+from onyx.natural_language_processing.constants import DEFAULT_COHERE_MODEL
+from onyx.natural_language_processing.constants import DEFAULT_OPENAI_MODEL
+from onyx.natural_language_processing.constants import DEFAULT_VERTEX_MODEL
+from onyx.natural_language_processing.constants import DEFAULT_VOYAGE_MODEL
+from onyx.natural_language_processing.constants import EmbeddingModelTextType
+from model_server.utils import pass_aws_key # change from where this is imported
+from shared_configs.configs import API_BASED_EMBEDDING_TIMEOUT
 from shared_configs.configs import INDEXING_MODEL_SERVER_HOST
 from shared_configs.configs import INDEXING_MODEL_SERVER_PORT
+from shared_configs.configs import INDEXING_ONLY
 from shared_configs.configs import MODEL_SERVER_HOST
 from shared_configs.configs import MODEL_SERVER_PORT
+from shared_configs.configs import OPENAI_EMBEDDING_TIMEOUT
+from shared_configs.configs import VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
 from shared_configs.enums import EmbeddingProvider
 from shared_configs.enums import EmbedTextType
 from shared_configs.enums import RerankerProvider
@@ -52,6 +77,21 @@ from shared_configs.model_server_models import RerankResponse
 from shared_configs.utils import batch_list
 
 logger = setup_logger()
+
+# If we are not only indexing, dont want retry very long
+_RETRY_DELAY = 10 if INDEXING_ONLY else 0.1
+_RETRY_TRIES = 10 if INDEXING_ONLY else 2
+
+# OpenAI only allows 2048 embeddings to be computed at once
+_OPENAI_MAX_INPUT_LEN = 2048
+# Cohere allows up to 96 embeddings in a single embedding calling
+_COHERE_MAX_INPUT_LEN = 96
+
+# Authentication error string constants
+_AUTH_ERROR_401 = "401"
+_AUTH_ERROR_UNAUTHORIZED = "unauthorized"
+_AUTH_ERROR_INVALID_API_KEY = "invalid api key"
+_AUTH_ERROR_PERMISSION = "permission"
 
 
 WARM_UP_STRINGS = [
@@ -77,6 +117,376 @@ def build_model_server_url(
 
     # otherwise default to http
     return f"http://{model_server_url}"
+
+
+def is_authentication_error(error: Exception) -> bool:
+    """Check if an exception is related to authentication issues.
+
+    Args:
+        error: The exception to check
+
+    Returns:
+        bool: True if the error appears to be authentication-related
+    """
+    error_str = str(error).lower()
+    return (
+        _AUTH_ERROR_401 in error_str
+        or _AUTH_ERROR_UNAUTHORIZED in error_str
+        or _AUTH_ERROR_INVALID_API_KEY in error_str
+        or _AUTH_ERROR_PERMISSION in error_str
+    )
+
+
+def format_embedding_error(
+    error: Exception,
+    service_name: str,
+    model: str | None,
+    provider: EmbeddingProvider,
+    sanitized_api_key: str | None = None,
+    status_code: int | None = None,
+) -> str:
+    """
+    Format a standardized error string for embedding errors.
+    """
+    detail = f"Status {status_code}" if status_code else f"{type(error)}"
+
+    return (
+        f"{'HTTP error' if status_code else 'Exception'} embedding text with {service_name} - {detail}: "
+        f"Model: {model} "
+        f"Provider: {provider} "
+        f"API Key: {sanitized_api_key} "
+        f"Exception: {error}"
+    )
+
+
+# Custom exception for authentication errors
+class AuthenticationError(Exception):
+    """Raised when authentication fails with a provider."""
+
+    def __init__(self, provider: str, message: str = "API key is invalid or expired"):
+        self.provider = provider
+        self.message = message
+        super().__init__(f"{provider} authentication failed: {message}")
+
+
+class CloudEmbedding:
+    def __init__(
+        self,
+        api_key: str,
+        provider: EmbeddingProvider,
+        api_url: str | None = None,
+        api_version: str | None = None,
+        timeout: int = API_BASED_EMBEDDING_TIMEOUT,
+    ) -> None:
+        self.provider = provider
+        self.api_key = api_key
+        self.api_url = api_url
+        self.api_version = api_version
+        self.timeout = timeout
+        self.http_client = httpx.AsyncClient(timeout=timeout)
+        self._closed = False
+        self.sanitized_api_key = api_key[:4] + "********" + api_key[-4:]
+
+    async def _embed_openai(
+        self, texts: list[str], model: str | None, reduced_dimension: int | None
+    ) -> list[Embedding]:
+        if not model:
+            model = DEFAULT_OPENAI_MODEL
+
+        # Use the OpenAI specific timeout for this one
+        client = openai.AsyncOpenAI(
+            api_key=self.api_key, timeout=OPENAI_EMBEDDING_TIMEOUT
+        )
+
+        final_embeddings: list[Embedding] = []
+
+        for text_batch in batch_list(texts, _OPENAI_MAX_INPUT_LEN):
+            response = await client.embeddings.create(
+                input=text_batch,
+                model=model,
+                dimensions=reduced_dimension or openai.NOT_GIVEN,
+            )
+            final_embeddings.extend(
+                [embedding.embedding for embedding in response.data]
+            )
+        return final_embeddings
+
+    async def _embed_cohere(
+        self, texts: list[str], model: str | None, embedding_type: str
+    ) -> list[Embedding]:
+        if not model:
+            model = DEFAULT_COHERE_MODEL
+
+        client = CohereAsyncClient(api_key=self.api_key)
+
+        final_embeddings: list[Embedding] = []
+        for text_batch in batch_list(texts, _COHERE_MAX_INPUT_LEN):
+            # Does not use the same tokenizer as the Onyx API server but it's approximately the same
+            # empirically it's only off by a very few tokens so it's not a big deal
+            response = await client.embed(
+                texts=text_batch,
+                model=model,
+                input_type=embedding_type,
+                truncate="END",
+            )
+            final_embeddings.extend(cast(list[Embedding], response.embeddings))
+        return final_embeddings
+
+    async def _embed_voyage(
+        self, texts: list[str], model: str | None, embedding_type: str
+    ) -> list[Embedding]:
+        if not model:
+            model = DEFAULT_VOYAGE_MODEL
+
+        client = voyageai.AsyncClient(
+            api_key=self.api_key, timeout=API_BASED_EMBEDDING_TIMEOUT
+        )
+
+        response = await client.embed(
+            texts=texts,
+            model=model,
+            input_type=embedding_type,
+            truncation=True,
+        )
+        return response.embeddings
+
+    async def _embed_azure(
+        self, texts: list[str], model: str | None
+    ) -> list[Embedding]:
+        response = await aembedding(
+            model=model,
+            input=texts,
+            timeout=API_BASED_EMBEDDING_TIMEOUT,
+            api_key=self.api_key,
+            api_base=self.api_url,
+            api_version=self.api_version,
+        )
+        embeddings = [embedding["embedding"] for embedding in response.data]
+        return embeddings
+
+    async def _embed_vertex(
+        self, texts: list[str], model: str | None, embedding_type: str
+    ) -> list[Embedding]:
+        if not model:
+            model = DEFAULT_VERTEX_MODEL
+
+        credentials = service_account.Credentials.from_service_account_info(
+            json.loads(self.api_key)
+        )
+        project_id = json.loads(self.api_key)["project_id"]
+        vertexai.init(project=project_id, credentials=credentials)
+        client = TextEmbeddingModel.from_pretrained(model)
+
+        inputs = [TextEmbeddingInput(text, embedding_type) for text in texts]
+
+        # Split into batches of 25 texts
+        max_texts_per_batch = VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
+        batches = [
+            inputs[i : i + max_texts_per_batch]
+            for i in range(0, len(inputs), max_texts_per_batch)
+        ]
+
+        # Dispatch all embedding calls asynchronously at once
+        tasks = [
+            client.get_embeddings_async(batch, auto_truncate=True) for batch in batches
+        ]
+
+        # Wait for all tasks to complete in parallel
+        results = await asyncio.gather(*tasks)
+
+        return [embedding.values for batch in results for embedding in batch]
+
+    async def _embed_litellm_proxy(
+        self, texts: list[str], model_name: str | None
+    ) -> list[Embedding]:
+        if not model_name:
+            raise ValueError("Model name is required for LiteLLM proxy embedding.")
+
+        if not self.api_url:
+            raise ValueError("API URL is required for LiteLLM proxy embedding.")
+
+        headers = (
+            {} if not self.api_key else {"Authorization": f"Bearer {self.api_key}"}
+        )
+
+        response = await self.http_client.post(
+            self.api_url,
+            json={
+                "model": model_name,
+                "input": texts,
+            },
+            headers=headers,
+        )
+        response.raise_for_status()
+        result = response.json()
+        return [embedding["embedding"] for embedding in result["data"]]
+
+    @retry(tries=_RETRY_TRIES, delay=_RETRY_DELAY)
+    async def embed(
+        self,
+        *,
+        texts: list[str],
+        text_type: EmbedTextType,
+        model_name: str | None = None,
+        deployment_name: str | None = None,
+        reduced_dimension: int | None = None,
+    ) -> list[Embedding]:
+        try:
+            if self.provider == EmbeddingProvider.OPENAI:
+                return await self._embed_openai(texts, model_name, reduced_dimension)
+            elif self.provider == EmbeddingProvider.AZURE:
+                return await self._embed_azure(texts, f"azure/{deployment_name}")
+            elif self.provider == EmbeddingProvider.LITELLM:
+                return await self._embed_litellm_proxy(texts, model_name)
+
+            embedding_type = EmbeddingModelTextType.get_type(self.provider, text_type)
+            if self.provider == EmbeddingProvider.COHERE:
+                return await self._embed_cohere(texts, model_name, embedding_type)
+            elif self.provider == EmbeddingProvider.VOYAGE:
+                return await self._embed_voyage(texts, model_name, embedding_type)
+            elif self.provider == EmbeddingProvider.GOOGLE:
+                return await self._embed_vertex(texts, model_name, embedding_type)
+            else:
+                raise ValueError(f"Unsupported provider: {self.provider}")
+        except openai.AuthenticationError:
+            raise AuthenticationError(provider="OpenAI")
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise AuthenticationError(provider=str(self.provider))
+
+            error_string = format_embedding_error(
+                e,
+                str(self.provider),
+                model_name or deployment_name,
+                self.provider,
+                sanitized_api_key=self.sanitized_api_key,
+                status_code=e.response.status_code,
+            )
+            logger.error(error_string)
+            logger.debug(f"Exception texts: {texts}")
+
+            raise RuntimeError(error_string)
+        except Exception as e:
+            if is_authentication_error(e):
+                raise AuthenticationError(provider=str(self.provider))
+
+            error_string = format_embedding_error(
+                e,
+                str(self.provider),
+                model_name or deployment_name,
+                self.provider,
+                sanitized_api_key=self.sanitized_api_key,
+            )
+            logger.error(error_string)
+            logger.debug(f"Exception texts: {texts}")
+
+            raise RuntimeError(error_string)
+
+    @staticmethod
+    def create(
+        api_key: str,
+        provider: EmbeddingProvider,
+        api_url: str | None = None,
+        api_version: str | None = None,
+    ) -> "CloudEmbedding":
+        logger.debug(f"Creating Embedding instance for provider: {provider}")
+        return CloudEmbedding(api_key, provider, api_url, api_version)
+
+    async def aclose(self) -> None:
+        """Explicitly close the client."""
+        if not self._closed:
+            await self.http_client.aclose()
+            self._closed = True
+
+    async def __aenter__(self) -> "CloudEmbedding":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()
+
+    def __del__(self) -> None:
+        """Finalizer to warn about unclosed clients."""
+        if not self._closed:
+            logger.warning(
+                "CloudEmbedding was not properly closed. Use 'async with' or call aclose()"
+            )
+
+
+# API-based reranking functions (moved from model server)
+async def cohere_rerank_api(
+    query: str, docs: list[str], model_name: str, api_key: str
+) -> list[float]:
+    cohere_client = CohereAsyncClient(api_key=api_key)
+    response = await cohere_client.rerank(query=query, documents=docs, model=model_name)
+    results = response.results
+    sorted_results = sorted(results, key=lambda item: item.index)
+    return [result.relevance_score for result in sorted_results]
+
+
+async def cohere_rerank_aws(
+    query: str,
+    docs: list[str],
+    model_name: str,
+    region_name: str,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+) -> list[float]:
+    session = aioboto3.Session(
+        aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key
+    )
+    async with session.client(
+        "bedrock-runtime", region_name=region_name
+    ) as bedrock_client:
+        body = json.dumps(
+            {
+                "query": query,
+                "documents": docs,
+                "api_version": 2,
+            }
+        )
+        # Invoke the Bedrock model asynchronously
+        response = await bedrock_client.invoke_model(
+            modelId=model_name,
+            accept="application/json",
+            contentType="application/json",
+            body=body,
+        )
+
+        # Read the response asynchronously
+        response_body = json.loads(await response["body"].read())
+
+        # Extract and sort the results
+        results = response_body.get("results", [])
+        sorted_results = sorted(results, key=lambda item: item["index"])
+
+        return [result["relevance_score"] for result in sorted_results]
+
+
+async def litellm_rerank(
+    query: str, docs: list[str], api_url: str, model_name: str, api_key: str | None
+) -> list[float]:
+    headers = {} if not api_key else {"Authorization": f"Bearer {api_key}"}
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            api_url,
+            json={
+                "model": model_name,
+                "query": query,
+                "documents": docs,
+            },
+            headers=headers,
+        )
+        response.raise_for_status()
+        result = response.json()
+        return [
+            item["relevance_score"]
+            for item in sorted(result["results"], key=lambda x: x["index"])
+        ]
 
 
 class EmbeddingModel:
@@ -113,8 +523,82 @@ class EmbeddingModel:
         )
         self.callback = callback
 
-        model_server_url = build_model_server_url(server_host, server_port)
-        self.embed_server_endpoint = f"{model_server_url}/encoder/bi-encoder-embed"
+        # Only build model server endpoint for local models
+        if self.provider_type is None:
+            model_server_url = build_model_server_url(server_host, server_port)
+            self.embed_server_endpoint = f"{model_server_url}/encoder/bi-encoder-embed"
+        else:
+            # API providers don't need model server endpoint
+            self.embed_server_endpoint = None
+
+    async def _make_direct_api_call(
+        self,
+        embed_request: EmbedRequest,
+        tenant_id: str | None = None,
+        request_id: str | None = None,
+    ) -> EmbedResponse:
+        """Make direct API call to cloud provider, bypassing model server."""
+        if self.provider_type is None:
+            raise ValueError("Provider type is required for direct API calls")
+        
+        if self.api_key is None:
+            logger.error("API key not provided for cloud model")
+            raise RuntimeError("API key not provided for cloud model")
+
+        # Check for prefix usage with cloud models
+        if embed_request.manual_query_prefix or embed_request.manual_passage_prefix:
+            logger.warning("Prefix provided for cloud model, which is not supported")
+            raise ValueError(
+                "Prefix string is not valid for cloud models. "
+                "Cloud models take an explicit text type instead."
+            )
+
+        if not all(embed_request.texts):
+            logger.error("Empty strings provided for embedding")
+            raise ValueError("Empty strings are not allowed for embedding.")
+
+        if not embed_request.texts:
+            logger.error("No texts provided for embedding")
+            raise ValueError("No texts provided for embedding.")
+
+        start_time = time.monotonic()
+        total_chars = sum(len(text) for text in embed_request.texts)
+
+        logger.info(
+            f"Embedding {len(embed_request.texts)} texts with {total_chars} total characters with provider: {self.provider_type}"
+        )
+
+        async with CloudEmbedding(
+            api_key=self.api_key,
+            provider=self.provider_type,
+            api_url=self.api_url,
+            api_version=self.api_version,
+        ) as cloud_model:
+            embeddings = await cloud_model.embed(
+                texts=embed_request.texts,
+                model_name=embed_request.model_name,
+                deployment_name=embed_request.deployment_name,
+                text_type=embed_request.text_type,
+                reduced_dimension=embed_request.reduced_dimension,
+            )
+
+        if any(embedding is None for embedding in embeddings):
+            error_message = "Embeddings contain None values\n"
+            error_message += "Corresponding texts:\n"
+            error_message += "\n".join(embed_request.texts)
+            logger.error(error_message)
+            raise ValueError(error_message)
+
+        elapsed = time.monotonic() - start_time
+        logger.info(
+            f"event=embedding_provider "
+            f"texts={len(embed_request.texts)} "
+            f"chars={total_chars} "
+            f"provider={self.provider_type} "
+            f"elapsed={elapsed:.2f}"
+        )
+
+        return EmbedResponse(embeddings=embeddings)
 
     def _make_model_server_request(
         self,
@@ -219,11 +703,21 @@ class EmbeddingModel:
                 reduced_dimension=self.reduced_dimension,
             )
 
-            start_time = time.time()
-            response = self._make_model_server_request(
-                embed_request, tenant_id=tenant_id, request_id=request_id
-            )
-            end_time = time.time()
+            start_time = time.monotonic()
+            
+            # Route between direct API calls and model server calls
+            if self.provider_type is not None:
+                # For API providers, make direct API call
+                response = asyncio.run(self._make_direct_api_call(
+                    embed_request, tenant_id=tenant_id, request_id=request_id
+                ))
+            else:
+                # For local models, use model server
+                response = self._make_model_server_request(
+                    embed_request, tenant_id=tenant_id, request_id=request_id
+                )
+            
+            end_time = time.monotonic()
 
             processing_time = end_time - start_time
             logger.debug(
@@ -360,29 +854,67 @@ class RerankingModel:
         model_server_host: str = MODEL_SERVER_HOST,
         model_server_port: int = MODEL_SERVER_PORT,
     ) -> None:
-        model_server_url = build_model_server_url(model_server_host, model_server_port)
-        self.rerank_server_endpoint = model_server_url + "/encoder/cross-encoder-scores"
         self.model_name = model_name
         self.provider_type = provider_type
         self.api_key = api_key
         self.api_url = api_url
+        
+        # Only build model server endpoint for local models
+        if self.provider_type is None:
+            model_server_url = build_model_server_url(model_server_host, model_server_port)
+            self.rerank_server_endpoint = model_server_url + "/encoder/cross-encoder-scores"
+        else:
+            # API providers don't need model server endpoint
+            self.rerank_server_endpoint = None
+
+    async def _make_direct_rerank_call(
+        self, query: str, passages: list[str]
+    ) -> list[float]:
+        """Make direct API call to cloud provider, bypassing model server."""
+        if self.provider_type is None:
+            raise ValueError("Provider type is required for direct API calls")
+        
+        if self.api_key is None:
+            raise ValueError("API key is required for cloud provider")
+
+        if self.provider_type == RerankerProvider.COHERE:
+            return await cohere_rerank_api(query, passages, self.model_name, self.api_key)
+        elif self.provider_type == RerankerProvider.BEDROCK:
+            aws_access_key_id, aws_secret_access_key, aws_region = pass_aws_key(
+                self.api_key
+            )
+            return await cohere_rerank_aws(
+                query, passages, self.model_name, aws_region, aws_access_key_id, aws_secret_access_key
+            )
+        elif self.provider_type == RerankerProvider.LITELLM:
+            if self.api_url is None:
+                raise ValueError("API URL is required for LiteLLM reranking.")
+            return await litellm_rerank(query, passages, self.api_url, self.model_name, self.api_key)
+        else:
+            raise ValueError(f"Unsupported reranking provider: {self.provider_type}")
 
     def predict(self, query: str, passages: list[str]) -> list[float]:
-        rerank_request = RerankRequest(
-            query=query,
-            documents=passages,
-            model_name=self.model_name,
-            provider_type=self.provider_type,
-            api_key=self.api_key,
-            api_url=self.api_url,
-        )
+        # Route between direct API calls and model server calls
+        if self.provider_type is not None:
+            # For API providers, make direct API call
+            return asyncio.run(self._make_direct_rerank_call(query, passages))
+        else:
+            # For local models, use model server
+            rerank_request = RerankRequest(
+                query=query,
+                documents=passages,
+                model_name=self.model_name,
+                provider_type=self.provider_type,
+                api_key=self.api_key,
+                api_url=self.api_url,
+            )
 
-        response = requests.post(
-            self.rerank_server_endpoint, json=rerank_request.model_dump()
-        )
-        response.raise_for_status()
+            response = requests.post(
+                self.rerank_server_endpoint, json=rerank_request.model_dump()
+            )
+            response.raise_for_status()
 
-        return RerankResponse(**response.json()).scores
+            return RerankResponse(**response.json()).scores
 
 
 class QueryAnalysisModel:

--- a/backend/onyx/utils/search_nlp_models_utils.py
+++ b/backend/onyx/utils/search_nlp_models_utils.py
@@ -15,9 +15,8 @@ def pass_aws_key(api_key: str) -> tuple[str, str, str]:
     parts = api_key.split("_")
     if len(parts) != 4:
         raise ValueError(
-            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts"
+            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts "
             "this is an onyx specific format for formatting the aws secrets for bedrock"
-        )
 
     try:
         _, aws_access_key_id, aws_secret_access_key, aws_region = parts

--- a/backend/onyx/utils/search_nlp_models_utils.py
+++ b/backend/onyx/utils/search_nlp_models_utils.py
@@ -15,8 +15,9 @@ def pass_aws_key(api_key: str) -> tuple[str, str, str]:
     parts = api_key.split("_")
     if len(parts) != 4:
         raise ValueError(
-            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts "
-            "this is an onyx specific format for formatting the aws secrets for bedrock"
+            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts. "
+            "This is an onyx specific format for formatting the aws secrets for bedrock"
+        )
 
     try:
         _, aws_access_key_id, aws_secret_access_key, aws_region = parts

--- a/backend/onyx/utils/search_nlp_models_utils.py
+++ b/backend/onyx/utils/search_nlp_models_utils.py
@@ -1,0 +1,26 @@
+def pass_aws_key(api_key: str) -> tuple[str, str, str]:
+    """Parse AWS API key string into components.
+
+    Args:
+        api_key: String in format 'aws_ACCESSKEY_SECRETKEY_REGION'
+
+    Returns:
+        Tuple of (access_key, secret_key, region)
+
+    Raises:
+        ValueError: If key format is invalid
+    """
+    if not api_key.startswith("aws"):
+        raise ValueError("API key must start with 'aws' prefix")
+    parts = api_key.split("_")
+    if len(parts) != 4:
+        raise ValueError(
+            f"API key must be in format 'aws_ACCESSKEY_SECRETKEY_REGION', got {len(parts) - 1} parts"
+            "this is an onyx specific format for formatting the aws secrets for bedrock"
+        )
+
+    try:
+        _, aws_access_key_id, aws_secret_access_key, aws_region = parts
+        return aws_access_key_id, aws_secret_access_key, aws_region
+    except Exception as e:
+        raise ValueError(f"Failed to parse AWS key components: {str(e)}")

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -101,3 +101,5 @@ prometheus_client==0.21.0
 fastapi-limiter==0.1.6
 prometheus_fastapi_instrumentator==7.1.0
 sendgrid==6.11.0
+voyageai==0.2.3
+cohere==5.6.1

--- a/backend/tests/unit/model_server/test_embedding.py
+++ b/backend/tests/unit/model_server/test_embedding.py
@@ -19,7 +19,7 @@ async def test_embed_text_no_model_name() -> None:
     # Test that the function raises an error when no model name is provided
     with pytest.raises(
         ValueError,
-        match="Either model name or provider must be provided to run embeddings",
+        match="Model name must be provided to run embeddings",
     ):
         await embed_text(
             texts=["test1", "test2"],

--- a/backend/tests/unit/model_server/test_embedding.py
+++ b/backend/tests/unit/model_server/test_embedding.py
@@ -1,99 +1,30 @@
 import asyncio
 import time
-from collections.abc import AsyncGenerator
 from typing import Any
 from typing import List
-from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
-from httpx import AsyncClient
-from litellm.exceptions import RateLimitError
 
-from model_server.encoders import CloudEmbedding
 from model_server.encoders import embed_text
 from model_server.encoders import local_rerank
 from model_server.encoders import process_embed_request
-from shared_configs.enums import EmbeddingProvider
 from shared_configs.enums import EmbedTextType
 from shared_configs.model_server_models import EmbedRequest
 
 
-@pytest.fixture
-async def mock_http_client() -> AsyncGenerator[AsyncMock, None]:
-    with patch("httpx.AsyncClient") as mock:
-        client = AsyncMock(spec=AsyncClient)
-        mock.return_value = client
-        client.post = AsyncMock()
-        async with client as c:
-            yield c
-
-
-@pytest.fixture
-def sample_embeddings() -> List[List[float]]:
-    return [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
-
-
 @pytest.mark.asyncio
-async def test_cloud_embedding_context_manager() -> None:
-    async with CloudEmbedding("fake-key", EmbeddingProvider.OPENAI) as embedding:
-        assert not embedding._closed
-    assert embedding._closed
-
-
-@pytest.mark.asyncio
-async def test_cloud_embedding_explicit_close() -> None:
-    embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
-    assert not embedding._closed
-    await embedding.aclose()
-    assert embedding._closed
-
-
-@pytest.mark.asyncio
-async def test_openai_embedding(
-    mock_http_client: AsyncMock, sample_embeddings: List[List[float]]
-) -> None:
-    with patch("openai.AsyncOpenAI") as mock_openai:
-        mock_client = AsyncMock()
-        mock_openai.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.data = [MagicMock(embedding=emb) for emb in sample_embeddings]
-        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
-
-        embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
-        result = await embedding._embed_openai(
-            ["test1", "test2"], "text-embedding-ada-002", None
-        )
-
-        assert result == sample_embeddings
-        mock_client.embeddings.create.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_embed_text_cloud_provider() -> None:
-    with patch("model_server.encoders.CloudEmbedding.embed") as mock_embed:
-        mock_embed.return_value = [[0.1, 0.2], [0.3, 0.4]]
-        mock_embed.side_effect = AsyncMock(return_value=[[0.1, 0.2], [0.3, 0.4]])
-
-        result = await embed_text(
+async def test_embed_text_no_model_name() -> None:
+    # Test that the function raises an error when no model name is provided
+    with pytest.raises(ValueError, match="Either model name.*must be provided"):
+        await embed_text(
             texts=["test1", "test2"],
-            text_type=EmbedTextType.QUERY,
-            model_name="fake-model",
-            deployment_name=None,
+            model_name=None,
             max_context_length=512,
             normalize_embeddings=True,
-            api_key="fake-key",
-            provider_type=EmbeddingProvider.OPENAI,
             prefix=None,
-            api_url=None,
-            api_version=None,
-            reduced_dimension=None,
         )
-
-        assert result == [[0.1, 0.2], [0.3, 0.4]]
-        mock_embed.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -105,17 +36,10 @@ async def test_embed_text_local_model() -> None:
 
         result = await embed_text(
             texts=["test1", "test2"],
-            text_type=EmbedTextType.QUERY,
             model_name="fake-local-model",
-            deployment_name=None,
             max_context_length=512,
             normalize_embeddings=True,
-            api_key=None,
-            provider_type=None,
             prefix=None,
-            api_url=None,
-            api_version=None,
-            reduced_dimension=None,
         )
 
         assert result == [[0.1, 0.2], [0.3, 0.4]]
@@ -137,30 +61,6 @@ async def test_local_rerank() -> None:
 
         assert result == [0.8, 0.6]
         mock_model.predict.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_handling() -> None:
-    with patch("model_server.encoders.CloudEmbedding.embed") as mock_embed:
-        mock_embed.side_effect = RateLimitError(
-            "Rate limit exceeded", llm_provider="openai", model="fake-model"
-        )
-
-        with pytest.raises(RateLimitError):
-            await embed_text(
-                texts=["test"],
-                text_type=EmbedTextType.QUERY,
-                model_name="fake-model",
-                deployment_name=None,
-                max_context_length=512,
-                normalize_embeddings=True,
-                api_key="fake-key",
-                provider_type=EmbeddingProvider.OPENAI,
-                prefix=None,
-                api_url=None,
-                api_version=None,
-                reduced_dimension=None,
-            )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/model_server/test_embedding.py
+++ b/backend/tests/unit/model_server/test_embedding.py
@@ -17,7 +17,10 @@ from shared_configs.model_server_models import EmbedRequest
 @pytest.mark.asyncio
 async def test_embed_text_no_model_name() -> None:
     # Test that the function raises an error when no model name is provided
-    with pytest.raises(ValueError, match="Either model name.*must be provided"):
+    with pytest.raises(
+        ValueError,
+        match="Either model name or provider must be provided to run embeddings",
+    ):
         await embed_text(
             texts=["test1", "test2"],
             model_name=None,

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -10,6 +10,7 @@ from litellm.exceptions import RateLimitError
 
 from onyx.natural_language_processing.search_nlp_models import CloudEmbedding
 from shared_configs.enums import EmbeddingProvider
+from shared_configs.enums import EmbedTextType
 
 
 @pytest.fixture
@@ -78,5 +79,5 @@ async def test_rate_limit_handling() -> None:
             await embedding.embed(
                 texts=["test"],
                 model_name="fake-model",
-                text_type=None,
+                text_type=EmbedTextType.QUERY,
             )

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -1,0 +1,81 @@
+import time
+from collections.abc import AsyncGenerator
+from typing import List
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from litellm.exceptions import RateLimitError
+
+from onyx.natural_language_processing.search_nlp_models import CloudEmbedding
+from shared_configs.enums import EmbeddingProvider
+
+
+@pytest.fixture
+async def mock_http_client() -> AsyncGenerator[AsyncMock, None]:
+    with patch("httpx.AsyncClient") as mock:
+        client = AsyncMock(spec=AsyncClient)
+        mock.return_value = client
+        client.post = AsyncMock()
+        async with client as c:
+            yield c
+
+
+@pytest.fixture
+def sample_embeddings() -> List[List[float]]:
+    return [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+@pytest.mark.asyncio
+async def test_cloud_embedding_context_manager() -> None:
+    async with CloudEmbedding("fake-key", EmbeddingProvider.OPENAI) as embedding:
+        assert not embedding._closed
+    assert embedding._closed
+
+
+@pytest.mark.asyncio
+async def test_cloud_embedding_explicit_close() -> None:
+    embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
+    assert not embedding._closed
+    await embedding.aclose()
+    assert embedding._closed
+
+
+@pytest.mark.asyncio
+async def test_openai_embedding(
+    mock_http_client: AsyncMock, sample_embeddings: List[List[float]]
+) -> None:
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_client = AsyncMock()
+        mock_openai.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.data = [MagicMock(embedding=emb) for emb in sample_embeddings]
+        mock_client.embeddings.create = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
+        result = await embedding._embed_openai(
+            ["test1", "test2"], "text-embedding-ada-002", None
+        )
+
+        assert result == sample_embeddings
+        mock_client.embeddings.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_handling() -> None:
+    with patch("onyx.natural_language_processing.search_nlp_models.CloudEmbedding.embed") as mock_embed:
+        mock_embed.side_effect = RateLimitError(
+            "Rate limit exceeded", llm_provider="openai", model="fake-model"
+        )
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
+        
+        with pytest.raises(RateLimitError):
+            await embedding.embed(
+                texts=["test"],
+                model_name="fake-model",
+                text_type=None,
+            )

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -1,4 +1,3 @@
-import time
 from collections.abc import AsyncGenerator
 from typing import List
 from unittest.mock import AsyncMock
@@ -66,13 +65,15 @@ async def test_openai_embedding(
 
 @pytest.mark.asyncio
 async def test_rate_limit_handling() -> None:
-    with patch("onyx.natural_language_processing.search_nlp_models.CloudEmbedding.embed") as mock_embed:
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CloudEmbedding.embed"
+    ) as mock_embed:
         mock_embed.side_effect = RateLimitError(
             "Rate limit exceeded", llm_provider="openai", model="fake-model"
         )
 
         embedding = CloudEmbedding("fake-key", EmbeddingProvider.OPENAI)
-        
+
         with pytest.raises(RateLimitError):
             await embedding.embed(
                 texts=["test"],


### PR DESCRIPTION
[DAN-2326](https://linear.app/danswer/issue/DAN-2326/have-api-based-embeddingre-ranking-model-calls-not-go-through-the)

## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Route API-based embedding and reranking calls directly through the Onyx NLP layer, leaving the model server for local models only. This simplifies the path, reduces latency, and fulfills DAN-2326.

- **Refactors**
  - Removed cloud embedding/rerank logic from model_server; embed_text now supports only local models and reranking rejects provider_type requests.
  - Added CloudEmbedding and direct provider calls (OpenAI, Azure via LiteLLM, Cohere, Voyage, Vertex AI) to onyx/natural_language_processing/search_nlp_models.py.
  - Moved provider constants and text-type mappings to onyx/natural_language_processing/constants.py.
  - EmbeddingModel and RerankerModel now route: provider_type=None → model server; otherwise → direct API call.
  - Updated/relocated unit tests to match the new routing; removed obsolete model_server tests.
  - Minor: add venv/ to backend/.gitignore.

- **Migration**
  - For API providers, do not call model_server /encoder endpoints. Construct EmbeddingModel/RerankerModel with provider_type and api_key to use direct calls.
  - Do not set manual query/passage prefixes for cloud models; they use text_type instead.
  - No changes needed for local models.

<!-- End of auto-generated description by cubic. -->

