### PR TITLE
feat(auth): Fix OAuth Domain casing

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -241,7 +241,7 @@ def verify_email_domain(email: str) -> None:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Email is not valid",
             )
-        domain = email.split("@")[-1]
+        domain = email.split("@")[-1].lower()
         if domain not in VALID_EMAIL_DOMAINS:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -108,7 +108,11 @@ _VALID_EMAIL_DOMAINS_STR = (
     os.environ.get("VALID_EMAIL_DOMAINS", "") or _VALID_EMAIL_DOMAIN
 )
 VALID_EMAIL_DOMAINS = (
-    [domain.strip() for domain in _VALID_EMAIL_DOMAINS_STR.split(",")]
+    [
+        domain.strip().lower()
+        for domain in _VALID_EMAIL_DOMAINS_STR.split(",")
+        if domain.strip()
+    ]
     if _VALID_EMAIL_DOMAINS_STR
     else []
 )

--- a/backend/tests/unit/onyx/auth/test_verify_email_domain.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_domain.py
@@ -1,0 +1,37 @@
+import pytest
+from fastapi import HTTPException
+
+import onyx.auth.users as users
+from onyx.auth.users import verify_email_domain
+
+
+def test_verify_email_domain_allows_case_insensitive_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Configure whitelist to lowercase while email has uppercase domain
+    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
+
+    # Should not raise
+    verify_email_domain("User@EXAMPLE.COM")
+
+
+def test_verify_email_domain_rejects_non_whitelisted_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_email_domain("user@another.com")
+    assert exc.value.status_code == 400
+    assert "Email domain is not valid" in exc.value.detail
+
+
+def test_verify_email_domain_invalid_email_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(users, "VALID_EMAIL_DOMAINS", ["example.com"], raising=False)
+
+    with pytest.raises(HTTPException) as exc:
+        verify_email_domain("userexample.com")  # missing '@'
+    assert exc.value.status_code == 400
+    assert "Email is not valid" in exc.value.detail


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We had an issue with a customer domain returning a non lowercase domain thus failing the casing issues when there were uppercase domains being returned by the IdP. 

This PR aims to fix this to ensure that we can handle all types of domains that are returned by any IdP.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran the local unit tests by running: 
`pytest -s backend/tests/unit/onyx/auth/test_verify_email_domain.py`

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
