### PR TITLE
fix: PDF file upload

### DIFF
--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -19,6 +19,14 @@ class ChatFileType(str, Enum):
     # "user knowledge" is not a file type, it's a source or intent
     USER_KNOWLEDGE = "user_knowledge"
 
+    def is_text_file(self) -> bool:
+        return self in (
+            ChatFileType.PLAIN_TEXT,
+            ChatFileType.DOC,
+            ChatFileType.CSV,
+            ChatFileType.USER_KNOWLEDGE,
+        )
+
 
 class FileDescriptor(TypedDict):
     """NOTE: is a `TypedDict` so it can be used as a type hint for a JSONB column

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -136,16 +136,7 @@ def _build_content(
     if not files:
         return message
 
-    text_files = [
-        file
-        for file in files
-        if file.file_type
-        in (
-            ChatFileType.PLAIN_TEXT,
-            ChatFileType.CSV,
-            ChatFileType.USER_KNOWLEDGE,
-        )
-    ]
+    text_files = [file for file in files if file.file_type.is_text_file()]
 
     if not text_files:
         return message

--- a/web/src/app/chat/interfaces.ts
+++ b/web/src/app/chat/interfaces.ts
@@ -41,6 +41,14 @@ export enum ChatFileType {
   USER_KNOWLEDGE = "user_knowledge",
 }
 
+export const isTextFile = (fileType: ChatFileType) =>
+  [
+    ChatFileType.PLAIN_TEXT,
+    ChatFileType.CSV,
+    ChatFileType.USER_KNOWLEDGE,
+    ChatFileType.DOCUMENT,
+  ].includes(fileType);
+
 export interface FileDescriptor {
   id: string;
   type: ChatFileType;

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -26,7 +26,12 @@ import { SearchSummary, UserKnowledgeFiles } from "./SearchSummary";
 import { SkippedSearch } from "./SkippedSearch";
 import remarkGfm from "remark-gfm";
 import { CopyButton } from "@/components/CopyButton";
-import { ChatFileType, FileDescriptor, ToolCallMetadata } from "../interfaces";
+import {
+  ChatFileType,
+  FileDescriptor,
+  isTextFile,
+  ToolCallMetadata,
+} from "../interfaces";
 import {
   IMAGE_GENERATION_TOOL_NAME,
   SEARCH_TOOL_NAME,
@@ -99,12 +104,8 @@ function FileDisplay({
   setPresentingDocument: (document: MinimalOnyxDocument) => void;
 }) {
   const [close, setClose] = useState(true);
-  const [expandedKnowledge, setExpandedKnowledge] = useState(false);
   const imageFiles = files.filter((file) => file.type === ChatFileType.IMAGE);
-  const textFiles = files.filter(
-    (file) => file.type == ChatFileType.PLAIN_TEXT
-  );
-
+  const textFiles = files.filter((file) => isTextFile(file.type));
   const csvImgFiles = files.filter((file) => file.type == ChatFileType.CSV);
 
   return (

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -105,7 +105,9 @@ function FileDisplay({
 }) {
   const [close, setClose] = useState(true);
   const imageFiles = files.filter((file) => file.type === ChatFileType.IMAGE);
-  const textFiles = files.filter((file) => isTextFile(file.type));
+  const textFiles = files.filter(
+    (file) => isTextFile(file.type) && file.type !== ChatFileType.CSV
+  );
   const csvImgFiles = files.filter((file) => file.type == ChatFileType.CSV);
 
   return (


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2332/fix-pdf-file-upload-in-chat

## How Has This Been Tested?

tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix PDF uploads in chat by treating PDFs as text files for rendering and LLM input. Users can now attach PDFs and have them displayed and included in prompts as expected. Fixes DAN-2332.

- **Bug Fixes**
  - Added helpers to identify “text-like” files (backend: is_text_file; frontend: isTextFile).
  - Included PDF/doc files in the text file set used for message content and UI display.
  - Simplified content-building logic to rely on the new helper, ensuring PDFs are processed like text.

<!-- End of auto-generated description by cubic. -->

