### PR TITLE
Update date format used for fetching from Bookstack

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -57,11 +57,11 @@ class BookstackConnector(LoadConnector, PollConnector):
         if start:
             params["filter[updated_at:gte]"] = datetime.utcfromtimestamp(
                 start
-            ).strftime("%Y-%m-%d %H:%M:%S")
+            ).strftime("%Y-%m-%d")
 
         if end:
             params["filter[updated_at:lte]"] = datetime.utcfromtimestamp(end).strftime(
-                "%Y-%m-%d %H:%M:%S"
+                "%Y-%m-%d"
             )
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])


### PR DESCRIPTION
## Description

Updates the Bookstack syncing to use date only, instead of date and time.

Matches what Bookstack recommends in the [API Documentation](https://bookstack.bassopaolo.com/api/docs#listing-endpoints) and [Searching documentation](https://www.bookstackapp.com/docs/user/searching/#available-filters)

<img width="951" height="432" alt="image" src="https://github.com/user-attachments/assets/8d56a638-ee1c-48a3-9562-b2a4d62b7a3e" />

<img width="909" height="537" alt="image" src="https://github.com/user-attachments/assets/d5734509-61c4-4d1c-999e-a17ca693b3e5" />

May help to address #5220 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use date-only format (YYYY-MM-DD) for Bookstack updated_at filters to align with API guidance and improve sync reliability by avoiding time precision issues.

- **Bug Fixes**
  - Changed updated_at gte/lte params from "%Y-%m-%d %H:%M:%S" to "%Y-%m-%d".
  - Prevents missed or duplicate results caused by time-based filtering.

<!-- End of auto-generated description by cubic. -->

