### PR TITLE
docs: add non-root user info

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -35,6 +35,23 @@
     * k -n onyx delete pvc vespa-storage-da-vespa-0
   * If you didn't disable Postgres persistence earlier, you may want to delete that PVC too.
 
+## Run as non-root user
+By default, some onyx containers run as root. If you'd like to explicitly run the onyx containers as a non-root user, update the values.yaml file for the following components:
+  * `celery_shared`, `api`, `webserver`, `indexCapability`, `inferenceCapability`
+    ```yaml
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+    ```
+  * `vespa`
+    ```yaml
+    podSecurityContext:
+      fsGroup: 1000
+    securityContext:
+      privileged: false
+      runAsUser: 1000
+    ```
+
 ## Resourcing
 In the helm charts, we have resource suggestions for all Onyx-owned components. 
 These are simply initial suggestions, and may need to be tuned for your specific use case.


### PR DESCRIPTION
## Description

This PR adds a block of documentation to the Helm chart README explaining how to run containers as a non-root user.

## How Has This Been Tested?

N/A

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new section to the Helm chart README explaining how to run containers as a non-root user. Includes example securityContext/podSecurityContext values for app components (celery_shared, api, webserver, indexCapability, inferenceCapability) and for vespa.

<!-- End of auto-generated description by cubic. -->

