### PR TITLE
feat(infra): AWS IAM Terraform

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -173,9 +173,29 @@ resource "aws_iam_policy" "rds_iam_connect_policy" {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-resource "aws_iam_role_policy_attachment" "attach_rds_iam_connect" {
-  count      = var.enable_rds_iam_for_service_account && var.rds_dbi_resource_id != null && var.rds_db_username != null ? 1 : 0
-  role       = module.irsa-s3-access[0].iam_role_name
-  policy_arn = aws_iam_policy.rds_iam_connect_policy[0].arn
-  depends_on = [module.irsa-s3-access]
+module "irsa-rds-connect" {
+  count   = var.enable_rds_iam_for_service_account && var.rds_dbi_resource_id != null && var.rds_db_username != null ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "4.7.0"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFRDSConnectRole-${module.eks.cluster_name}"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [aws_iam_policy.rds_iam_connect_policy[0].arn]
+  oidc_fully_qualified_subjects = [
+    "system:serviceaccount:${var.irsa_service_account_namespace}:${var.rds_irsa_service_account_name}"
+  ]
+
+  depends_on = [module.eks]
+}
+
+resource "kubernetes_service_account" "rds_connect" {
+  count = var.enable_rds_iam_for_service_account && var.rds_dbi_resource_id != null && var.rds_db_username != null ? 1 : 0
+  metadata {
+    name      = var.rds_irsa_service_account_name
+    namespace = var.irsa_service_account_namespace
+    annotations = {
+      "eks.amazonaws.com/role-arn" = module.irsa-rds-connect[0].iam_role_arn
+    }
+  }
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -132,15 +132,15 @@ variable "enable_rds_iam_for_service_account" {
   default     = false
 }
 
-variable "rds_dbi_resource_id" {
-  type        = string
-  description = "DB instance resource ID used to build rds-db ARN for IAM authentication"
-  default     = null
-}
-
 variable "rds_db_username" {
   type        = string
   description = "Database username to allow via rds-db:connect"
+  default     = null
+}
+
+variable "rds_db_connect_arn" {
+  type        = string
+  description = "Full rds-db:connect ARN to allow (required when enable_rds_iam_for_service_account is true)"
   default     = null
 }
 

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -125,3 +125,21 @@ variable "irsa_service_account_name" {
   description = "Name of the IRSA-enabled Kubernetes service account for S3 access"
   default     = "onyx-s3-access"
 }
+
+variable "enable_rds_iam_for_service_account" {
+  type        = bool
+  description = "Whether to attach RDS IAM access to the IRSA service account (grants rds-db:connect)"
+  default     = false
+}
+
+variable "rds_dbi_resource_id" {
+  type        = string
+  description = "DB instance resource ID used to build rds-db ARN for IAM authentication"
+  default     = null
+}
+
+variable "rds_db_username" {
+  type        = string
+  description = "Database username to allow via rds-db:connect"
+  default     = null
+}

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -116,7 +116,7 @@ variable "s3_bucket_names" {
 
 variable "irsa_service_account_namespace" {
   type        = string
-  description = "Namespace where the IRSA-enabled Kubernetes service account for S3 access will be created"
+  description = "Namespace for IRSA-enabled Kubernetes service accounts (used by S3 and RDS)"
   default     = "onyx"
 }
 
@@ -128,7 +128,7 @@ variable "irsa_service_account_name" {
 
 variable "enable_rds_iam_for_service_account" {
   type        = bool
-  description = "Whether to attach RDS IAM access to the IRSA service account (grants rds-db:connect)"
+  description = "Whether to create a dedicated RDS IRSA role and service account (grants rds-db:connect)"
   default     = false
 }
 
@@ -142,4 +142,10 @@ variable "rds_db_username" {
   type        = string
   description = "Database username to allow via rds-db:connect"
   default     = null
+}
+
+variable "rds_irsa_service_account_name" {
+  type        = string
+  description = "Name of the IRSA-enabled Kubernetes service account for RDS IAM auth"
+  default     = "onyx-rds-access"
 }

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -73,8 +73,8 @@ module "eks" {
 
   # Wire RDS IAM connection for the same IRSA service account used by apps
   enable_rds_iam_for_service_account = var.enable_rds_iam_auth
-  rds_dbi_resource_id                = module.postgres.dbi_resource_id
   rds_db_username                    = var.postgres_username
+  rds_db_connect_arn                 = var.rds_db_connect_arn
 
   # These variables must be defined in variables.tf or passed in via parent module
   public_cluster_enabled  = var.public_cluster_enabled

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -52,7 +52,7 @@ module "postgres" {
   username         = var.postgres_username
   password         = var.postgres_password
   tags             = local.merged_tags
-  iam_auth_enabled = var.enable_rds_iam_auth
+  enable_rds_iam_auth = var.enable_rds_iam_auth
 }
 
 module "s3" {

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -49,9 +49,10 @@ module "postgres" {
   subnet_ids    = local.private_subnets
   ingress_cidrs = [local.vpc_cidr_block]
 
-  username = var.postgres_username
-  password = var.postgres_password
-  tags     = local.merged_tags
+  username         = var.postgres_username
+  password         = var.postgres_password
+  tags             = local.merged_tags
+  iam_auth_enabled = var.enable_rds_iam_auth
 }
 
 module "s3" {
@@ -69,6 +70,11 @@ module "eks" {
   subnet_ids      = concat(local.private_subnets, local.public_subnets)
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
+
+  # Wire RDS IAM connection for the same IRSA service account used by apps
+  enable_rds_iam_for_service_account = var.enable_rds_iam_auth
+  rds_dbi_resource_id                = module.postgres.dbi_resource_id
+  rds_db_username                    = var.postgres_username
 
   # These variables must be defined in variables.tf or passed in via parent module
   public_cluster_enabled  = var.public_cluster_enabled

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -6,3 +6,29 @@ output "redis_connection_url" {
 output "cluster_name" {
   value = module.eks.cluster_name
 }
+
+output "postgres_endpoint" {
+  description = "RDS endpoint hostname"
+  value       = module.postgres.endpoint
+}
+
+output "postgres_port" {
+  description = "RDS port"
+  value       = module.postgres.port
+}
+
+output "postgres_db_name" {
+  description = "RDS database name"
+  value       = module.postgres.db_name
+}
+
+output "postgres_username" {
+  description = "RDS master username"
+  value       = module.postgres.username
+  sensitive   = true
+}
+
+output "postgres_dbi_resource_id" {
+  description = "RDS DB instance resource id"
+  value       = module.postgres.dbi_resource_id
+}

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -87,6 +87,12 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
+variable "enable_rds_iam_auth" {
+  type        = bool
+  description = "Enable AWS IAM authentication for the RDS Postgres instance"
+  default     = false
+}
+
 # WAF Configuration Variables
 variable "waf_rate_limit_requests_per_5_minutes" {
   type        = number

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -93,6 +93,12 @@ variable "enable_rds_iam_auth" {
   default     = false
 }
 
+variable "rds_db_connect_arn" {
+  type        = string
+  description = "Full rds-db:connect ARN to pass to the EKS module. Required when enable_rds_iam_auth is true."
+  default     = null
+}
+
 # WAF Configuration Variables
 variable "waf_rate_limit_requests_per_5_minutes" {
   type        = number

--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -36,6 +36,9 @@ resource "aws_db_instance" "this" {
   username          = var.username
   password          = var.password
 
+  # Enable IAM authentication for the RDS instance
+  iam_database_authentication_enabled = var.iam_auth_enabled
+
   db_subnet_group_name   = aws_db_subnet_group.this.name
   vpc_security_group_ids = [aws_security_group.this.id]
   publicly_accessible    = false

--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "this" {
   password          = var.password
 
   # Enable IAM authentication for the RDS instance
-  iam_database_authentication_enabled = var.iam_auth_enabled
+  iam_database_authentication_enabled = var.enable_rds_iam_auth
 
   db_subnet_group_name   = aws_db_subnet_group.this.name
   vpc_security_group_ids = [aws_security_group.this.id]

--- a/deployment/terraform/modules/aws/postgres/outputs.tf
+++ b/deployment/terraform/modules/aws/postgres/outputs.tf
@@ -1,0 +1,25 @@
+output "endpoint" {
+  description = "RDS endpoint hostname"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "port" {
+  description = "RDS port"
+  value       = aws_db_instance.this.port
+}
+
+output "db_name" {
+  description = "Database name"
+  value       = aws_db_instance.this.db_name
+}
+
+output "username" {
+  description = "Master username"
+  value       = aws_db_instance.this.username
+  sensitive   = true
+}
+
+output "dbi_resource_id" {
+  description = "DB instance resource ID used for IAM auth resource ARNs"
+  value       = aws_db_instance.this.resource_id
+}

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -62,7 +62,7 @@ variable "tags" {
   default     = {}
 }
 
-variable "iam_auth_enabled" {
+variable "enable_rds_iam_auth" {
   type        = bool
   description = "Enable AWS IAM database authentication for this RDS instance"
   default     = false

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -61,3 +61,9 @@ variable "tags" {
   description = "Tags to apply to RDS resources"
   default     = {}
 }
+
+variable "iam_auth_enabled" {
+  type        = bool
+  description = "Enable AWS IAM database authentication for this RDS instance"
+  default     = false
+}

--- a/deployment/terraform/modules/aws/vpc/main.tf
+++ b/deployment/terraform/modules/aws/vpc/main.tf
@@ -20,7 +20,7 @@ module "vpc" {
   map_public_ip_on_launch = true
 
   enable_nat_gateway   = true
-  single_nat_gateway   = false
+  single_nat_gateway   = true
   enable_dns_hostnames = true
 
   public_subnet_tags = {

--- a/deployment/terraform/modules/aws/vpc/main.tf
+++ b/deployment/terraform/modules/aws/vpc/main.tf
@@ -20,7 +20,7 @@ module "vpc" {
   map_public_ip_on_launch = true
 
   enable_nat_gateway   = true
-  single_nat_gateway   = true
+  single_nat_gateway   = false
   enable_dns_hostnames = true
 
   public_subnet_tags = {


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding new workflow to configure AWS IAM RDS Auth for your EKS cluster. This allows you to not use a password but rather an IAM token to access the database. This is to improve the security posture of Onyx. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran an internal cluster deployment

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

Closes https://linear.app/danswer/issue/DAN-2330/iam-for-rds-permissions-codification

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
