### PR TITLE
Allow moving chats out of folders

### DIFF
--- a/web/src/components/sidebar/ChatSessionDisplay.tsx
+++ b/web/src/components/sidebar/ChatSessionDisplay.tsx
@@ -8,6 +8,7 @@ import {
   getChatRetentionInfo,
   renameChatSession,
 } from "@/app/chat/lib";
+import { removeChatFromFolder } from "@/app/chat/folders/FolderManagement";
 import { BasicSelectable } from "@/components/BasicClickable";
 import Link from "next/link";
 import {
@@ -17,6 +18,7 @@ import {
   FiShare2,
   FiTrash,
   FiX,
+  FiFolderMinus,
 } from "react-icons/fi";
 import { DefaultDropdownElement } from "@/components/Dropdown";
 import { Popover } from "@/components/popover/Popover";
@@ -95,6 +97,23 @@ export function ChatSessionDisplay({
       setPopoverOpen(false);
     },
     [chatSession, showDeleteModal, refreshChatSessions, refreshFolders]
+  );
+
+  const handleMoveOutOfFolder = useCallback(
+    async () => {
+      if (chatSession.folder_id) {
+        try {
+          await removeChatFromFolder(chatSession.folder_id, chatSession.id);
+          await refreshChatSessions();
+          await refreshFolders();
+          setPopoverOpen(false);
+        } catch (error) {
+          console.error("Failed to move chat out of folder:", error);
+          alert("Failed to move chat out of folder");
+        }
+      }
+    },
+    [chatSession, refreshChatSessions, refreshFolders]
   );
 
   const onRename = useCallback(
@@ -326,7 +345,7 @@ export function ChatSessionDisplay({
                             popover={
                               <div
                                 className={`border border-border text-text-dark rounded-lg bg-background z-50 ${
-                                  isDeleteModalOpen ? "w-64" : "w-32"
+                                  isDeleteModalOpen ? "w-64" : "w-44"
                                 }`}
                               >
                                 {!isDeleteModalOpen ? (
@@ -345,6 +364,13 @@ export function ChatSessionDisplay({
                                         name="Rename"
                                         icon={FiEdit2}
                                         onSelect={() => setIsRenamingChat(true)}
+                                      />
+                                    )}
+                                    {chatSession.folder_id && (
+                                      <DefaultDropdownElement
+                                        name="Move out of folder"
+                                        icon={FiFolderMinus}
+                                        onSelect={handleMoveOutOfFolder}
                                       />
                                     )}
                                     <DefaultDropdownElement


### PR DESCRIPTION
## Description

Adds a "Move out of folder" option to the chat session's 3-dots menu, allowing users to move a chat from a custom folder back to the time-based, auto-managed section. This option is only visible when a chat is currently within a folder. The existing backend `remove_chat_from_folder` functionality is leveraged, which sets the chat's `folder_id` to `null`, enabling it to be re-indexed by the date-based grouping.

## How Has This Been Tested?

- Verified successful application build using `npm install` and `npm run build`. A type error was identified and fixed during this process.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C09AZ9GBWRM/p1755743843641559?thread_ts=1755743843.641559&cid=C09AZ9GBWRM)

<a href="https://cursor.com/background-agent?bcId=bc-dcfc9cb8-0147-47fb-9a92-a51d7708d8c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dcfc9cb8-0147-47fb-9a92-a51d7708d8c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a “Move out of folder” option in the chat session menu so users can return a chat to the date-based list. The action only appears for chats in a folder, calls removeChatFromFolder, refreshes sessions/folders, and closes the menu; errors show an alert.

<!-- End of auto-generated description by cubic. -->

