### PR TITLE
Shorten info icon hover delay

### DIFF
--- a/web/src/app/admin/actions/ActionEditor.tsx
+++ b/web/src/app/admin/actions/ActionEditor.tsx
@@ -269,7 +269,7 @@ function ActionForm({
             {isOAuthEnabled ? (
               <div className="flex flex-col gap-y-2">
                 <div className="flex items-center space-x-2">
-                  <TooltipProvider>
+                  <TooltipProvider delayDuration={300}>
                     <Tooltip>
                       <TooltipTrigger>
                         <div

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -94,7 +94,7 @@ function SourceTileTooltipWrapper({
   }
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <div>

--- a/web/src/app/admin/connector/[ccPairId]/DeletionErrorStatus.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DeletionErrorStatus.tsx
@@ -11,7 +11,7 @@ export default function DeletionErrorStatus({
         <h3 className="text-base font-medium">Deletion Error</h3>
         <div className="ml-2 relative group">
           <FiInfo className="h-4 w-4 text-error-600 cursor-help" />
-          <div className="absolute z-10 w-64 p-2 mt-2 text-sm bg-white rounded-md shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 border border-background-200">
+          <div className="absolute z-10 w-64 p-2 mt-2 text-sm bg-white rounded-md shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 delay-300 border border-background-200">
             This error occurred while attempting to delete the connector. You
             may re-attempt a deletion by clicking the &quot;Delete&quot; button.
           </div>

--- a/web/src/app/admin/connector/[ccPairId]/IndexingAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexingAttemptsTable.tsx
@@ -79,7 +79,7 @@ export function IndexingAttemptsTable({
             <TableHead className="whitespace-nowrap">New Docs</TableHead>
             <TableHead>
               <div className="w-fit whitespace-nowrap">
-                <TooltipProvider>
+                <TooltipProvider delayDuration={300}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="flex items-center">
@@ -142,7 +142,7 @@ export function IndexingAttemptsTable({
                   <div className="flex items-center">
                     {indexAttempt.total_docs_indexed}
                     {indexAttempt.from_beginning && (
-                      <TooltipProvider>
+                      <TooltipProvider delayDuration={300}>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="cursor-help flex items-center">

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -120,7 +120,7 @@ const EditRow = ({
 
   return (
     <div className="relative flex">
-      <TooltipProvider>
+      <TooltipProvider delayDuration={300}>
         <Tooltip>
           <TooltipTrigger asChild>
             <div

--- a/web/src/app/chat/message/ContinueMessage.tsx
+++ b/web/src/app/chat/message/ContinueMessage.tsx
@@ -27,7 +27,7 @@ export function ContinueGenerating({
           </>
         </EmphasizedClickable>
         {showExplanation && (
-          <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1 bg-background-800 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 whitespace-nowrap">
+          <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-1 bg-background-800 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 delay-300 whitespace-nowrap">
             LLM reached its token limit. Click to continue.
           </div>
         )}

--- a/web/src/app/chat/message/Messages.tsx
+++ b/web/src/app/chat/message/Messages.tsx
@@ -1159,7 +1159,7 @@ export const HumanMessage = ({
                       isHovered &&
                       !isEditing &&
                       (!files || files.length === 0) ? (
-                        <TooltipProvider delayDuration={1000}>
+                        <TooltipProvider delayDuration={300}>
                           <Tooltip>
                             <TooltipTrigger>
                               <HoverableIcon

--- a/web/src/app/chat/message/SearchSummary.tsx
+++ b/web/src/app/chat/message/SearchSummary.tsx
@@ -229,7 +229,7 @@ export function SearchSummary({
           </div>
 
           {handleSearchQueryEdit && (
-            <TooltipProvider delayDuration={1000}>
+            <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -144,7 +144,7 @@ export function ToolTipDetails({
   children: string | JSX.Element;
 }) {
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger type="button">
           <FiInfo size={12} />
@@ -708,7 +708,7 @@ export const BooleanFormField = ({
   return (
     <div>
       <label className="flex items-center text-sm cursor-pointer">
-        <TooltipProvider>
+        <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger>
               <CheckboxField

--- a/web/src/components/HoverPopup.tsx
+++ b/web/src/components/HoverPopup.tsx
@@ -20,7 +20,7 @@ export const HoverPopup = ({
   direction = "bottom",
 }: HoverPopupProps) => {
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <div>{mainContent}</div>

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -34,7 +34,7 @@ export function IndexAttemptStatus({
     );
     if (errorMsg) {
       badge = (
-        <TooltipProvider>
+        <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="cursor-pointer">{icon}</div>

--- a/web/src/components/TokenDisplay.tsx
+++ b/web/src/components/TokenDisplay.tsx
@@ -23,7 +23,7 @@ export function TokenDisplay({
 }: TokenDisplayProps) {
   return (
     <div className="flex items-center">
-      <TooltipProvider>
+      <TooltipProvider delayDuration={300}>
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="flex items-center space-x-3 bg-neutral-100 dark:bg-neutral-800 rounded-full px-4 py-1.5">

--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -473,7 +473,7 @@ export function FederatedConnectorForm({
             <Badge variant="outline" className="text-xs">
               Federated
             </Badge>
-            <TooltipProvider>
+            <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Info className="cursor-help" size={16} />

--- a/web/src/components/assistants/AssistantIcon.tsx
+++ b/web/src/components/assistants/AssistantIcon.tsx
@@ -127,7 +127,7 @@ export function AssistantIcon({
   const style = { width: dimension, height: dimension };
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <div className={className + " text-[#000] dark:text-[#fff]"}>

--- a/web/src/components/header/LogoWithText.tsx
+++ b/web/src/components/header/LogoWithText.tsx
@@ -82,7 +82,7 @@ export default function LogoWithText({
         </div>
       )}
       {page == "chat" && !showArrow && (
-        <TooltipProvider delayDuration={1000}>
+        <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
               <Link

--- a/web/src/components/sidebar/PagesTab.tsx
+++ b/web/src/components/sidebar/PagesTab.tsx
@@ -326,7 +326,7 @@ export function PagesTab({
         <div className="flex  group justify-between text-sm gap-x-2 text-text-300/80 items-center font-normal leading-normal">
           <p>Chats</p>
 
-          <TooltipProvider delayDuration={1000}>
+          <TooltipProvider delayDuration={300}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button

--- a/web/src/components/tooltip/CustomTooltip.tsx
+++ b/web/src/components/tooltip/CustomTooltip.tsx
@@ -45,7 +45,7 @@ export const CustomTooltip = ({
   medium,
   wrap,
   showTick = false,
-  delay = 500,
+  delay = 300,
   position = "bottom",
   disabled = false,
   className,

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -145,7 +145,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     if (tooltip) {
       return (
-        <TooltipProvider>
+        <TooltipProvider delayDuration={300}>
           <Tooltip>
             <TooltipTrigger asChild>
               <div className={disabled ? "cursor-not-allowed" : ""}>

--- a/web/src/components/ui/truncatedText.tsx
+++ b/web/src/components/ui/truncatedText.tsx
@@ -49,7 +49,7 @@ export function TruncatedText({
   }, [text]);
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
           <span


### PR DESCRIPTION
## Description

Standardizes tooltip hover delays to 300ms across the application. This improves user experience by making tooltips appear more responsively and consistently, aligning with UX best practices for optimal hover timing.

## How Has This Been Tested?

No specific tests were run by the AI.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C09AZ9GBWRM/p1755749133749679?thread_ts=1755749133.749679&cid=C09AZ9GBWRM)

<a href="https://cursor.com/background-agent?bcId=bc-7406d966-a7df-40d5-811b-20d77ac82ed9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7406d966-a7df-40d5-811b-20d77ac82ed9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shortens tooltip hover delay to 300ms across the app for faster, consistent behavior. Improves UX on info icons, truncated text, buttons, and chat controls.

- **Refactors**
  - Set TooltipProvider delayDuration and CustomTooltip default to 300ms; aligned CSS hover popups with delay-300.
  - Applies across admin pages, chat views, forms, header/sidebar, and shared components.

<!-- End of auto-generated description by cubic. -->

