### PR TITLE
Fix chat share link generation and UI state

### DIFF
--- a/web/src/app/chat/ChatPage.tsx
+++ b/web/src/app/chat/ChatPage.tsx
@@ -2618,6 +2618,13 @@ export function ChatPage({
           chatSessionId={chatSessionIdRef.current}
           existingSharedStatus={chatSessionSharedStatus}
           onClose={() => setSharingModalVisible(false)}
+          onShare={(shared) =>
+            setChatSessionSharedStatus(
+              shared
+                ? ChatSessionSharedStatus.Public
+                : ChatSessionSharedStatus.Private
+            )
+          }
         />
       )}
 

--- a/web/src/components/sidebar/ChatSessionDisplay.tsx
+++ b/web/src/components/sidebar/ChatSessionDisplay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ChatSession } from "@/app/chat/interfaces";
+import { ChatSession, ChatSessionSharedStatus } from "@/app/chat/interfaces";
 import { useState, useEffect, useContext, useRef, useCallback } from "react";
 import {
   deleteChatSession,
@@ -52,7 +52,13 @@ export function ChatSessionDisplay({
   const [chatName, setChatName] = useState(chatSession.name);
   const settings = useContext(SettingsContext);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [localSharedStatus, setLocalSharedStatus] = useState(chatSession.shared_status);
   const chatSessionRef = useRef<HTMLDivElement>(null);
+
+  // Sync local shared status with the chatSession prop
+  useEffect(() => {
+    setLocalSharedStatus(chatSession.shared_status);
+  }, [chatSession.shared_status]);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const renamingRef = useRef<HTMLDivElement>(null);
@@ -173,8 +179,15 @@ export function ChatSessionDisplay({
       {isShareModalVisible && (
         <ShareChatSessionModal
           chatSessionId={chatSession.id}
-          existingSharedStatus={chatSession.shared_status}
+          existingSharedStatus={localSharedStatus}
           onClose={() => setIsShareModalVisible(false)}
+          onShare={(shared) => {
+            setLocalSharedStatus(
+              shared
+                ? ChatSessionSharedStatus.Public
+                : ChatSessionSharedStatus.Private
+            );
+          }}
         />
       )}
 
@@ -336,7 +349,7 @@ export function ChatSessionDisplay({
                                         name="Share"
                                         icon={FiShare2}
                                         onSelect={() =>
-                                          showShareModal(chatSession)
+                                          setIsShareModalVisible(true)
                                         }
                                       />
                                     )}


### PR DESCRIPTION
## Description

This PR resolves an issue where the "Share" button in chat sessions would display an incorrect state (e.g., "Generate" instead of "Delete") after a share link was created or deleted. The problem stemmed from inconsistent state management between the `ShareChatSessionModal` and its parent components, leading to stale `shared_status` information.

The fix involves:
1.  Introducing local state management within `ChatSessionDisplay` for the sidebar's share modal, ensuring its UI reflects the current sharing status.
2.  Implementing `onShare` callbacks in both the sidebar and header share modals to correctly update the parent component's `shared_status` when a link is generated or deleted.
3.  Modifying the sidebar's "Share" button to open its local modal instance, allowing for proper state synchronization.

This ensures the "Share" button consistently displays the correct action (generate or delete) based on the chat session's actual sharing status.

## How Has This Been Tested?

Manually tested by:
1.  Generating a share link from the sidebar's three-dots menu and verifying the button changes to "Delete Share Link".
2.  Deleting the share link and verifying the button changes back to "Generate and Copy Share Link".
3.  Closing and reopening the modal to confirm the state persists.
4.  Repeating steps 1-3 for the share button in the chat page header.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/C09AZ9GBWRM/p1755749340668409?thread_ts=1755749340.668409&cid=C09AZ9GBWRM)

<a href="https://cursor.com/background-agent?bcId=bc-13873059-5665-402a-8578-7c1720172c9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13873059-5665-402a-8578-7c1720172c9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

