### PR TITLE
fix: use only celery-shared for security context

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -30,11 +30,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_beat.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-beat
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_beat.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docfetching.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-docfetching
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docfetching.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_docprocessing.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-docprocessing
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_docprocessing.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_heavy.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-heavy
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_heavy.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_light.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-light
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_light.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_monitoring.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-monitoring
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_monitoring.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_primary.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-primary
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_primary.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml (default .Values.celery_shared.podSecurityContext .Values.celery_worker_user_files_indexing.podSecurityContext) | nindent 8 }}
+        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-user-files-indexing
           securityContext:
-            {{- toYaml (default .Values.celery_shared.securityContext .Values.celery_worker_user_files_indexing.securityContext) | nindent 12 }}
+            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -339,11 +339,6 @@ celery_beat:
     app: celery-beat
   deploymentLabels:
     app: celery-beat
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -367,11 +362,6 @@ celery_worker_heavy:
     app: celery-worker-heavy
   deploymentLabels:
     app: celery-worker-heavy
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -395,11 +385,6 @@ celery_worker_docprocessing:
     app: celery-worker-docprocessing
   deploymentLabels:
     app: celery-worker-docprocessing
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m
@@ -423,11 +408,6 @@ celery_worker_light:
     app: celery-worker-light
   deploymentLabels:
     app: celery-worker-light
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -451,11 +431,6 @@ celery_worker_monitoring:
     app: celery-worker-monitoring
   deploymentLabels:
     app: celery-worker-monitoring
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m
@@ -479,11 +454,6 @@ celery_worker_primary:
     app: celery-worker-primary
   deploymentLabels:
     app: celery-worker-primary
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 1000m
@@ -507,11 +477,6 @@ celery_worker_user_files_indexing:
     app: celery-worker-user-files-indexing
   deploymentLabels:
     app: celery-worker-user-files-indexing
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 2000m
@@ -558,11 +523,6 @@ celery_worker_docfetching:
     app: celery-worker-docfetching
   deploymentLabels:
     app: celery-worker-docfetching
-  podSecurityContext:
-    {}
-  securityContext:
-    privileged: true
-    runAsUser: 0
   resources:
     requests:
       cpu: 500m


### PR DESCRIPTION
## Description

This PR fixes a bug related to leveraging the `celery_shared` values block for `securityContext` and `podSecuirtyContext` in the Helm chart. 

By having the `securityContext` and `podSecurityContext` set in each individual celery worker values block, the inflated helm chart always overwrote the `celery_shared` values.

After further consideration, we determined that it wasn't necessary to provide the `securityContext` or `podSecurityContext` for any particular celery worker as there is no likely scenario where you would need different security contexts for different celery workloads. We decided to always use the `celery-shared` values block. This simplifies both the template and the values file. 

## How Has This Been Tested?

Yes, verified by running `helm template`. Confirmed that manifests rendered as expected.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
