### PR TITLE
fix: update all log paths to reflect change related to non-root user

### DIFF
--- a/backend/onyx/background/celery/memory_monitoring.py
+++ b/backend/onyx/background/celery/memory_monitoring.py
@@ -14,7 +14,7 @@ logger = setup_logger()
 # Only set up memory monitoring in container environment
 if is_running_in_container():
     # Set up a dedicated memory monitoring logger
-    MEMORY_LOG_DIR = "/var/log/memory"
+    MEMORY_LOG_DIR = "/var/log/onyx/memory"
     MEMORY_LOG_FILE = os.path.join(MEMORY_LOG_DIR, "memory_usage.log")
     MEMORY_LOG_MAX_BYTES = 10 * 1024 * 1024  # 10MB
     MEMORY_LOG_BACKUP_COUNT = 5  # Keep 5 backup files

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -148,7 +148,7 @@ services:
         max-file: "6"
     # optional, only for debugging purposes
     volumes:
-      - api_server_logs:/var/log
+      - api_server_logs:/var/log/onyx
 
   background:
     image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
@@ -286,7 +286,7 @@ services:
       - "host.docker.internal:host-gateway"
     # optional, only for debugging purposes
     volumes:
-      - background_logs:/var/log
+      - background_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -356,7 +356,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log
+      - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -390,7 +390,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log
+      - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.gpu-dev.yml
+++ b/deployment/docker_compose/docker-compose.gpu-dev.yml
@@ -118,7 +118,7 @@ services:
         max-file: "6"
     volumes:
       # optional, only for debugging purposes
-      - api_server_logs:/var/log
+      - api_server_logs:/var/log/onyx
 
   background:
     image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
@@ -232,7 +232,7 @@ services:
       - "host.docker.internal:host-gateway"
     # optional, only for debugging purposes
     volumes:
-      - background_logs:/var/log
+      - background_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -295,7 +295,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log
+      - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -334,7 +334,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log
+      - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -43,7 +43,7 @@ services:
         max-file: "6"
     volumes:
       # optional, only for debugging purposes
-      - api_server_logs:/var/log
+      - api_server_logs:/var/log/onyx
 
 
   background:
@@ -82,7 +82,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - background_logs:/var/log
+      - background_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -136,7 +136,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log
+      - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -166,7 +166,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log
+      - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -43,7 +43,7 @@ services:
         max-size: "50m"
         max-file: "6"
     volumes:
-      - api_server_logs:/var/log
+      - api_server_logs:/var/log/onyx
 
   background:
     image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
@@ -86,7 +86,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - background_logs:/var/log
+      - background_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -164,7 +164,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - model_cache_huggingface:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log
+      - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
@@ -194,7 +194,7 @@ services:
       # Not necessary, this is just to reduce download time during startup
       - indexing_huggingface_model_cache:/app/.cache/huggingface/
       # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log
+      - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -74,7 +74,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
-      - log_store:/var/log
+      - log_store:/var/log/onyx
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Description

This PR fixes a bug when running the `docfetching`, `monitoring`, and `user-files-indexing` workers as non-root users. Unfortunately we ran into a permissions error when running as non-root as these three apps were configured to create a log file under `/var/log/`. 

Following suit with the change we made in `logger.py`, we are now creating the `memory' logs in the `/var/log/onyx/` directory. 

We also updated docker compose files to fix volume mounts in the case a user wants to persist container logs on the host machine. 

## How Has This Been Tested?

Built images and tested the startup of the `docfetching`, `monitoring`, and `user-files-indexing` workers as non-root user.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix non-root permission errors by moving all service logs to /var/log/onyx and adjusting Docker Compose volume mounts. Workers now start cleanly as non-root, and logs still persist on the host.

- **Bug Fixes**
  - Memory monitor logs moved to /var/log/onyx/memory.
  - Docker Compose volumes now mount /var/log/onyx for api_server, background, inference, and indexing across dev, gpu-dev, prod, and search-testing files.

- **Migration**
  - If you maintain custom deployments, update any /var/log mounts and log paths to /var/log/onyx.

<!-- End of auto-generated description by cubic. -->

