### PR TITLE
Small improvement

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -145,7 +145,7 @@ def get_connector_credential_pairs_for_user(
         stmt = stmt.where(ConnectorCredentialPair.id.in_(ids))
 
     if not include_user_files:
-        stmt = stmt.where(ConnectorCredentialPair.is_user_file != True)  # noqa: E712
+        stmt = stmt.where(ConnectorCredentialPair.is_user_file.is_(False))
 
     if order_by_desc:
         stmt = stmt.order_by(desc(ConnectorCredentialPair.id))


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use .is_(False) to filter out user files in get_connector_credential_pairs_for_user. This follows SQLAlchemy best practices and removes the linter suppression.

<!-- End of auto-generated description by cubic. -->

