### PR TITLE
Helm changes

### DIFF
--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -81,3 +81,19 @@ Create env vars from secrets
     {{- end }}
 {{- end }}
 
+{{/*
+Define postgres host
+*/}}
+{{- define "onyx-stack.postgresHost" -}}
+{{- if and .Values.postgres (hasKey .Values.postgres "host") -}}
+  {{- $host := .Values.postgres.host | trim -}}
+  {{- if eq $host "" -}}
+    {{ printf "%s-postgresql" .Release.Name }}
+  {{- else -}}
+    {{ $host }}
+  {{- end -}}
+{{- else -}}
+  {{ printf "%s-postgresql" .Release.Name }}
+{{- end -}}
+{{- end }}
+

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -57,11 +57,3 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.api.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.api.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -30,11 +30,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_beat.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-beat
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_beat.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -52,10 +52,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_beat.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -78,7 +74,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_beat_liveness.txt
-      {{- with .Values.celery_beat.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_docfetching.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-docfetching
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_docfetching.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -46,12 +46,12 @@ spec:
               "onyx.background.celery.versioned_apps.docfetching",
               "worker",
               "--pool=threads",
-              "--concurrency=2",
+              "--concurrency=12",
               "--prefetch-multiplier=1",
               "--loglevel=INFO",
               "--hostname=docfetching@%n",
               "-Q",
-              "connector_doc_fetching,user_files_indexing",
+              "connector_doc_fetching",
             ]
           resources:
             {{- toYaml .Values.celery_worker_docfetching.resources | nindent 12 }}
@@ -60,10 +60,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_docfetching.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -85,8 +81,4 @@ spec:
                 - >
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
-                    --filename /tmp/onyx_k8s_docfetching_liveness.txt
-      {{- with .Values.celery_worker_docfetching.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }} 
+                    --filename /tmp/onyx_k8s_docfetching_liveness.txt 

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_docprocessing.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-docprocessing
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_docprocessing.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -62,10 +62,6 @@ spec:
             - name: ENABLE_MULTIPASS_INDEXING
               value: "{{ .Values.celery_worker_docprocessing.enableMiniChunk }}"
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_docprocessing.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -88,7 +84,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_docprocessing_liveness.txt
-      {{- with .Values.celery_worker_docprocessing.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_heavy.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-heavy
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_heavy.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -57,10 +57,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_heavy.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -83,7 +79,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_heavy_liveness.txt
-      {{- with .Values.celery_worker_heavy.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_light.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-light
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_light.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -48,7 +48,7 @@ spec:
               "--loglevel=INFO",
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup",
             ]
           resources:
             {{- toYaml .Values.celery_worker_light.resources | nindent 12 }}
@@ -57,10 +57,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_light.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -83,7 +79,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_light_liveness.txt
-      {{- with .Values.celery_worker_light.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_monitoring.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-monitoring
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_monitoring.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -57,10 +57,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_monitoring.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -83,7 +79,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_monitoring_liveness.txt
-      {{- with .Values.celery_worker_monitoring.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_primary.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-primary
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_primary.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -57,10 +57,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_primary.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -83,7 +79,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_primary_liveness.txt
-      {{- with .Values.celery_worker_primary.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -32,11 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.celery_worker_user_files_indexing.podSecurityContext | nindent 8 }}
       containers:
         - name: celery-worker-user-files-indexing
           securityContext:
-            {{- toYaml .Values.celery_shared.securityContext | nindent 12 }}
+            {{- toYaml .Values.celery_worker_user_files_indexing.securityContext | nindent 12 }}
           image: "{{ .Values.celery_shared.image.repository }}:{{ .Values.celery_shared.image.tag | default .Values.global.version }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           command:
@@ -45,6 +45,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.docfetching",
               "worker",
+              "--pool=threads",
+              "--concurrency=2",
+              "--prefetch-multiplier=1",
               "--loglevel=INFO",
               "--hostname=user-files-indexing@%n",
               "-Q",
@@ -57,10 +60,6 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_user_files_indexing.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
           readinessProbe:
@@ -83,7 +82,3 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_userfilesindexing_liveness.txt
-      {{- with .Values.celery_worker_user_files_indexing.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "onyx-stack.labels" . | nindent 4 }}
 data:
   INTERNAL_URL: "http://{{ include "onyx-stack.fullname" . }}-api-service:{{ .Values.api.service.port | default 8080 }}"
-  POSTGRES_HOST: {{ .Release.Name }}-postgresql
+  POSTGRES_HOST: {{ include "onyx-stack.postgresHost" . | quote }}
   VESPA_HOST: {{ .Values.vespa.name }}.{{ .Values.vespa.service.name }}.{{ .Release.Namespace }}.svc.cluster.local
   REDIS_HOST: {{ .Release.Name }}-redis-master
   MODEL_SERVER_HOST: "{{ include "onyx-stack.fullname" . }}-inference-model-service"

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -24,9 +24,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.indexCapability.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.indexCapability.podSecurityContext | nindent 8 }}
+      {{- if .Values.indexCapability.serviceAccountName }}
+      serviceAccountName: {{ .Values.indexCapability.serviceAccountName }}
       {{- end }}
       containers:
       - name: {{ .Values.indexCapability.name }}
@@ -44,11 +43,5 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx-stack.envSecrets" . | nindent 10}}
-        {{- if .Values.indexCapability.securityContext }}
-        securityContext:
-          {{- toYaml .Values.indexCapability.securityContext | nindent 10 }}
-        {{- end }}
-        {{- if .Values.indexCapability.resources }}
         resources:
-          {{- toYaml .Values.indexCapability.resources | nindent 10 }}
-        {{- end }}
+          {{- toYaml .Values.indexCapability.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -20,9 +20,8 @@ spec:
         {{ .key }}: {{ .value }}
         {{- end }}
     spec:
-      {{- if .Values.inferenceCapability.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.inferenceCapability.podSecurityContext | nindent 8 }}
+      {{- if .Values.inferenceCapability.serviceAccountName }}
+      serviceAccountName: {{ .Values.inferenceCapability.serviceAccountName }}
       {{- end }}
       containers:
       - name: model-server-inference
@@ -38,12 +37,5 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx-stack.envSecrets" . | nindent 12}}
-        {{- if .Values.inferenceCapability.securityContext }}
-        securityContext:
-          {{- toYaml .Values.inferenceCapability.securityContext | nindent 10 }}
-        {{- end }}
-        {{- if .Values.inferenceCapability.resources }}
         resources:
-          {{- toYaml .Values.inferenceCapability.resources | nindent 10 }}
-        {{- end }}
-
+          {{- toYaml .Values.inferenceCapability.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -4,17 +4,21 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-api
   annotations:
-    kubernetes.io/ingress.class: nginx
+  {{- with .Values.ingress.api.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.api.host }}
       http:
         paths:
-          - path: /api(/|$)(.*)
-            pathType: Prefix
+          - path: {{ .Values.ingress.api.path | default "/api(/|$)(.*)" }}
+            pathType: {{ .Values.ingress.api.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ include "onyx-stack.fullname" . }}-api-service

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -3,11 +3,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-webserver
+  {{- with .Values.ingress.webserver.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
-    kubernetes.io/tls-acme: "true"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.webserver.host }}
       http:

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -45,12 +45,4 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx-stack.envSecrets" . | nindent 12}}
-          {{- with .Values.slackbot.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.slackbot.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

This is a PR to discuss possible changes to make Helm chart more enterprise ready

## How Has This Been Tested?

We have used this to deploy to our environments

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the Helm chart more enterprise-ready with flexible ingress settings, external Postgres support, per-worker security controls, and a dedicated user-files-indexing worker. Also adds service account overrides for model pods and simplifies templates.

- **New Features**
  - Postgres host is configurable via values.postgres.host (defaults to <release>-postgresql).
  - Ingress is configurable via values: className, api/webserver annotations, path, and pathType.
  - Per-worker securityContext/podSecurityContext overrides (no longer shared).
  - Split user-files-indexing to its own worker; docfetching concurrency set to 12 and queue updated; light worker queue updated.
  - Model deployments support serviceAccountName overrides; resource rendering simplified.

- **Migration**
  - Remove .values for volumes/volumeMounts under api, slackbot, and all celery workers (no longer used).
  - If you relied on celery_shared security settings, move them to each worker’s values.
  - Set ingress.className and ingress.*.annotations to replace previous hard-coded annotations.
  - For external Postgres, set values.postgres.host; otherwise the in-cluster default is used.
  - If needed, set inferenceCapability.serviceAccountName and indexCapability.serviceAccountName.

<!-- End of auto-generated description by cubic. -->

