### PR TITLE
Helm improvements for Ingress

### DIFF
--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -4,24 +4,28 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-api
   annotations:
-    kubernetes.io/ingress.class: nginx
+  {{- with .Values.ingress.api.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
 spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
     - host: {{ .Values.ingress.api.host }}
       http:
         paths:
-          - path: /api(/|$)(.*)
-            pathType: Prefix
+          - path: {{ .Values.ingress.api.path | default "/api(/|$)(.*)" }}
+            pathType: {{ .Values.ingress.api.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ include "onyx-stack.fullname" . }}-api-service
                 port:
                   number: {{ .Values.api.service.servicePort }}
+  {{- if .Values.ingress.api.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ include "onyx-stack.fullname" . }}-ingress-api-tls
+      secretName: {{ .Values.ingress.api.tlsSecretName }}
+  {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -3,11 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-webserver
+  {{- with .Values.ingress.webserver.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
-    kubernetes.io/tls-acme: "true"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
     - host: {{ .Values.ingress.webserver.host }}
       http:
@@ -19,8 +20,10 @@ spec:
                 name: {{ include "onyx-stack.fullname" . }}-webserver
                 port:
                   number: {{ .Values.webserver.service.servicePort }}
+  {{- if .Values.ingress.webserver.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.webserver.host }}
-      secretName: {{ include "onyx-stack.fullname" . }}-ingress-webserver-tls
+      secretName: {{ .Values.ingress.webserver.tlsSecretName }}
+    {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -588,7 +588,7 @@ minio:
 
 ingress:
   enabled: false
-  className: ""
+  className: "nginx"
   api:
     host: onyx.local
   webserver:


### PR DESCRIPTION
## Description

Improves Ingress resource template by:
 - Using standard ingressClassName element
 - Supporting custom annotations
 - Supporting custom TLS secret names
 - WARNING: Breaking change; clusterIssuer default has been removed 

## How Has This Been Tested?

I have deployed a working Onyx instance with this.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
