### PR TITLE
fix: Handle disabled auth in connector indexing status endpoint

### DIFF
--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -24,6 +24,7 @@ from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.auth.users import current_user
 from onyx.background.celery.versioned_apps.client import app as client_app
+from onyx.configs.app_configs import DISABLE_AUTH
 from onyx.configs.app_configs import ENABLED_CONNECTOR_TYPES
 from onyx.configs.app_configs import MOCK_CONNECTOR_FILE_PATH
 from onyx.configs.constants import DocumentSource
@@ -766,7 +767,7 @@ def get_connector_indexing_status(
         (get_latest_index_attempts_parallel, (request.secondary_index, True, True)),
     ]
 
-    if user.role == UserRole.ADMIN:
+    if (user is None and DISABLE_AUTH) or (user and user.role == UserRole.ADMIN):
         # For Admin users, we already got all the cc pair in editable_cc_pairs
         # its not needed to get them again
         (


### PR DESCRIPTION
## Description

The `get_connector_indexing_status` function was attempting to access `user.role` without checking if user is `None` when `AUTH_TYPE=disabled`. This caused a `'NoneType'` object has no attribute 'role' error.  Added proper null check following the same pattern used elsewhere in the codebase: (`user` is `None` and `DISABLE_AUTH`) or (`user` and `user.role == UserRole.ADMIN`) 

Fixes indexing status page loading error when authentication is disabled.

## How Has This Been Tested?

Manual testing has been done from my own usage.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix a crash in the connector indexing status endpoint when authentication is disabled by checking for a missing user before reading user.role. When DISABLE_AUTH is true, requests without a user are treated as admin so the indexing status page loads correctly.

<!-- End of auto-generated description by cubic. -->

