### PR TITLE
fix: Update gemini model names.

### DIFF
--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -121,8 +121,11 @@ VERTEXAI_DEFAULT_MODEL = "gemini-2.0-flash"
 VERTEXAI_DEFAULT_FAST_MODEL = "gemini-2.0-flash-lite"
 VERTEXAI_MODEL_NAMES = [
     # 2.5 pro models
-    "gemini-2.5-pro-preview-06-05",
-    "gemini-2.5-pro-preview-05-06",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    #"gemini-2.5-pro-preview-06-05",
+    #"gemini-2.5-pro-preview-05-06",
     # 2.0 flash-lite models
     VERTEXAI_DEFAULT_FAST_MODEL,
     "gemini-2.0-flash-lite-001",

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -882,7 +882,10 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   // Google Models
 
   // 2.5 pro models
-  "gemini-2.5-pro-preview-05-06": "Gemini 2.5 Pro (Preview May 6th)",
+  "gemini-2.5-pro": "Gemini 2.5 Pro",
+  "gemini-2.5-flash": "Gemini 2.5 Flash",
+  "gemini-2.5-flash-lite": "Gemini 2.5 Flash Lite",
+  // "gemini-2.5-pro-preview-05-06": "Gemini 2.5 Pro (Preview May 6th)",
 
   // 2.0 flash lite models
   "gemini-2.0-flash-lite": "Gemini 2.0 Flash Lite",
@@ -894,7 +897,7 @@ const MODEL_DISPLAY_NAMES: { [key: string]: string } = {
   "gemini-2.0-flash": "Gemini 2.0 Flash",
   "gemini-2.0-flash-001": "Gemini 2.0 Flash (v1)",
   "gemini-2.0-flash-exp": "Gemini 2.0 Flash (Experimental)",
-  "gemini-2.5-flash-preview-05-20": "Gemini 2.5 Flash (Preview May 20th)",
+  // "gemini-2.5-flash-preview-05-20": "Gemini 2.5 Flash (Preview May 20th)",
   // "gemini-2.0-flash-thinking-exp-01-02":
   //   "Gemini 2.0 Flash Thinking (Experimental January 2nd)",
   // "gemini-2.0-flash-thinking-exp-01-21":


### PR DESCRIPTION
## Description

This PR adds support for the new Gemini 2.5 Pro, Gemini 2.5 Flash, and Gemini 2.5 Flash Lite models in Onyx. This includes adding the model names to the backend list of available models and updating the frontend to display these models with user-friendly names. The older "preview" model names have been commented out, but retained in the code for possible future use.

## How Has This Been Tested?

I verified that each new model name ("gemini-2.5-pro", "gemini-2.5-flash", and "gemini-2.5-flash-lite") works correctly when used in a search query within the Onyx application. This confirms that the models are properly integrated into both the backend and frontend and can be selected and used by users.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add support for Gemini 2.5 Pro, Flash, and Flash Lite by updating the backend model list and UI display names. Replaces preview IDs with stable ones; preview entries are commented out for reference.

<!-- End of auto-generated description by cubic. -->

