### PR TITLE
fix: logger startup

### DIFF
--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -209,6 +209,11 @@ def setup_logger(
                 if is_containerized
                 else f"./log/{LOG_FILE_NAME}_{level}.log"
             )
+            # Ensure the log directory exists
+            log_dir = os.path.dirname(file_name)
+            if not os.path.exists(log_dir):
+                os.makedirs(log_dir, exist_ok=True)
+
             file_handler = RotatingFileHandler(
                 file_name,
                 maxBytes=25 * 1024 * 1024,  # 25 MB


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

👀 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes logger startup by creating the log directory before initializing the rotating file handler. Prevents crashes when the log folder is missing in both containerized and local runs.

<!-- End of auto-generated description by cubic. -->

