### PR TITLE
feat(infra): Add IAM support for Redis

### DIFF
--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -12,6 +12,7 @@ from onyx.configs.app_configs import REDIS_PORT
 from onyx.configs.app_configs import REDIS_SSL
 from onyx.configs.app_configs import REDIS_SSL_CA_CERTS
 from onyx.configs.app_configs import REDIS_SSL_CERT_REQS
+from onyx.configs.app_configs import USE_REDIS_IAM_AUTH
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import REDIS_SOCKET_KEEPALIVE_OPTIONS
 
@@ -25,7 +26,7 @@ REDIS_SCHEME = "redis"
 
 # SSL-specific query parameters for Redis URL
 SSL_QUERY_PARAMS = ""
-if REDIS_SSL:
+if REDIS_SSL and not USE_REDIS_IAM_AUTH:
     REDIS_SCHEME = "rediss"
     SSL_QUERY_PARAMS = f"?ssl_cert_reqs={REDIS_SSL_CERT_REQS}"
     if REDIS_SSL_CA_CERTS:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -231,9 +231,12 @@ try:
 except ValueError:
     POSTGRES_POOL_RECYCLE = POSTGRES_POOL_RECYCLE_DEFAULT
 
+# RDS IAM authentication - enables IAM-based authentication for PostgreSQL
 USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
 
-
+# Redis IAM authentication - enables IAM-based authentication for Redis ElastiCache
+# Note: This is separate from RDS IAM auth as they use different authentication mechanisms
+USE_REDIS_IAM_AUTH = os.getenv("USE_REDIS_IAM_AUTH", "False").lower() == "true"
 REDIS_SSL = os.getenv("REDIS_SSL", "").lower() == "true"
 REDIS_HOST = os.environ.get("REDIS_HOST") or "localhost"
 REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))

--- a/backend/onyx/redis/iam_auth.py
+++ b/backend/onyx/redis/iam_auth.py
@@ -26,13 +26,7 @@ def configure_redis_iam_auth(connection_kwargs: dict[str, Any]) -> None:
 
     # Ensure SSL is enabled for IAM authentication
     connection_kwargs["ssl"] = True
-
-    # Create SSL context using system CA certificates by default
-    # This works with AWS ElastiCache without requiring additional CA files
-    ssl_context = ssl.create_default_context()
-    ssl_context.check_hostname = True
-    ssl_context.verify_mode = ssl.CERT_REQUIRED
-    connection_kwargs["ssl_context"] = ssl_context
+    connection_kwargs["ssl_context"] = create_redis_ssl_context_if_iam()
 
 
 def create_redis_ssl_context_if_iam() -> ssl.SSLContext:

--- a/backend/onyx/redis/iam_auth.py
+++ b/backend/onyx/redis/iam_auth.py
@@ -1,0 +1,44 @@
+"""
+Redis IAM Authentication Module
+This module provides Redis IAM authentication functionality for AWS ElastiCache.
+Unlike RDS IAM auth, Redis IAM auth relies on IAM roles and policies rather than
+generating authentication tokens.
+Key functions:
+- configure_redis_iam_auth: Configure Redis connection parameters for IAM auth
+- create_redis_ssl_context_if_iam: Create SSL context for secure connections
+"""
+
+import ssl
+from typing import Any
+
+
+def configure_redis_iam_auth(connection_kwargs: dict[str, Any]) -> None:
+    """
+    Configure Redis connection parameters for IAM authentication.
+    Modifies the connection_kwargs dict in-place to:
+    1. Remove password (not needed with IAM)
+    2. Enable SSL with system CA certificates
+    3. Set proper SSL context for secure connections
+    """
+    # Remove password as it's not needed with IAM authentication
+    if "password" in connection_kwargs:
+        del connection_kwargs["password"]
+
+    # Ensure SSL is enabled for IAM authentication
+    connection_kwargs["ssl"] = True
+
+    # Create SSL context using system CA certificates by default
+    # This works with AWS ElastiCache without requiring additional CA files
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = True
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    connection_kwargs["ssl_context"] = ssl_context
+
+
+def create_redis_ssl_context_if_iam() -> ssl.SSLContext:
+    """Create an SSL context for Redis IAM authentication using system CA certificates."""
+    # Use system CA certificates by default - no need for additional CA files
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = True
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    return ssl_context


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding support for Redis IAM

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Redis IAM authentication for AWS ElastiCache behind a USE_REDIS_IAM_AUTH flag. Enables passwordless, TLS-secured connections for both sync and async Redis usage, and updates Celery config to work with IAM.

- **New Features**
  - Added USE_REDIS_IAM_AUTH env flag to enable Redis IAM auth.
  - New onyx/redis/iam_auth.py to configure IAM SSL context and strip passwords.
  - redis_pool: IAM takes precedence over REDIS_SSL, uses system CAs, no password, SSL enforced.
  - Async Redis connection path updated to apply IAM settings when enabled.
  - Celery Redis URL no longer forces rediss query params when IAM is on.

<!-- End of auto-generated description by cubic. -->

