### PR TITLE
feat: add api/versions to onyx

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import urllib.parse
 from datetime import datetime
 from datetime import timezone
@@ -26,13 +25,6 @@ APP_PORT = 8080
 APP_API_PREFIX = os.environ.get("API_PREFIX", "")
 
 SKIP_WARM_UP = os.environ.get("SKIP_WARM_UP", "").lower() == "true"
-
-#####
-# Version Pattern Configs
-#####
-# Version patterns for Docker image tags
-STABLE_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-DEV_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$")
 
 #####
 # User Facing Features Configs

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import urllib.parse
 from datetime import datetime
 from datetime import timezone
@@ -25,6 +26,13 @@ APP_PORT = 8080
 APP_API_PREFIX = os.environ.get("API_PREFIX", "")
 
 SKIP_WARM_UP = os.environ.get("SKIP_WARM_UP", "").lower() == "true"
+
+#####
+# Version Pattern Configs
+#####
+# Version patterns for Docker image tags
+STABLE_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+DEV_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$")
 
 #####
 # User Facing Features Configs

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -1,4 +1,5 @@
 import platform
+import re
 import socket
 from enum import auto
 from enum import Enum
@@ -46,6 +47,12 @@ DISABLED_GEN_AI_MSG = (
     "You can still use Onyx as a search engine."
 )
 
+#####
+# Version Pattern Configs
+#####
+# Version patterns for Docker image tags
+STABLE_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+DEV_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$")
 
 DEFAULT_PERSONA_ID = 0
 

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -30,6 +30,8 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/auth/type", {"GET"}),
     # just gets the version of Onyx (e.g. 0.3.11)
     ("/version", {"GET"}),
+    # Gets stable and beta versions for Onyx docker images
+    ("/versions", {"GET"}),
     # stuff related to basic auth
     ("/auth/refresh", {"POST"}),
     ("/auth/register", {"POST"}),

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -56,7 +56,7 @@ def get_versions() -> AllVersions:
         url = f"https://hub.docker.com/v2/repositories/{repo}/tags"
         tags = []
         for _ in range(pages):
-            response = requests.get(url)
+            response = requests.get(url, timeout=10)
             response.raise_for_status()
             data = response.json()
             tags.extend(

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -9,6 +9,8 @@ from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.app_configs import DEV_VERSION_PATTERN
+from onyx.configs.app_configs import STABLE_VERSION_PATTERN
 from onyx.server.manage.models import AllVersions
 from onyx.server.manage.models import AuthTypeResponse
 from onyx.server.manage.models import ContainerVersions
@@ -42,10 +44,6 @@ def get_versions() -> AllVersions:
     """
     Fetches the latest stable and beta versions of Onyx Docker images
     """
-    # Define strict version patterns
-    STABLE_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-    DEV_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$")
-
     # Fetch the latest tags from DockerHub for each Onyx component
     dockerhub_repos = [
         "onyxdotapp/onyx-model-server",
@@ -90,7 +88,7 @@ def get_versions() -> AllVersions:
     if not dev_tags:
         raise HTTPException(
             status_code=500,
-            detail="No valid dev versions found matching pattern v(number).(number).(number)-beta",
+            detail="No valid dev versions found matching pattern v(number).(number).(number)-beta.(number)",
         )
     if not stable_tags:
         raise HTTPException(
@@ -120,19 +118,19 @@ def get_versions() -> AllVersions:
 
     return AllVersions(
         stable=ContainerVersions(
-            danswer=latest_stable_version,
+            onyx=latest_stable_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
             nginx="nginx:1.23.4-alpine",
         ),
         dev=ContainerVersions(
-            danswer=latest_dev_version,
+            onyx=latest_dev_version,
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
             nginx="nginx:1.23.4-alpine",
         ),
         migration=ContainerVersions(
-            danswer="airgapped-intfloat-nomic-migration",
+            onyx="airgapped-intfloat-nomic-migration",
             relational_db="postgres:15.2-alpine",
             index="vespaengine/vespa:8.277.17",
             nginx="nginx:1.23.4-alpine",

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -1,10 +1,17 @@
+import concurrent.futures
+import re
+
+import requests
 from fastapi import APIRouter
+from fastapi import HTTPException
 
 from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
+from onyx.server.manage.models import AllVersions
 from onyx.server.manage.models import AuthTypeResponse
+from onyx.server.manage.models import ContainerVersions
 from onyx.server.manage.models import VersionResponse
 from onyx.server.models import StatusResponse
 
@@ -28,3 +35,106 @@ def get_auth_type() -> AuthTypeResponse:
 @router.get("/version")
 def get_version() -> VersionResponse:
     return VersionResponse(backend_version=__version__)
+
+
+@router.get("/versions")
+def get_versions() -> AllVersions:
+    """
+    Fetches the latest stable and beta versions of Onyx Docker images
+    """
+    # Define strict version patterns
+    STABLE_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+    DEV_VERSION_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-beta\.(\d+)$")
+
+    # Fetch the latest tags from DockerHub for each Onyx component
+    dockerhub_repos = [
+        "onyxdotapp/onyx-model-server",
+        "onyxdotapp/onyx-backend",
+        "onyxdotapp/onyx-web-server",
+    ]
+
+    # For good measure, we fetch 10 pages of tags
+    def get_dockerhub_tags(repo: str, pages: int = 10) -> list[str]:
+        url = f"https://hub.docker.com/v2/repositories/{repo}/tags"
+        tags = []
+        for _ in range(pages):
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.json()
+            tags.extend(
+                [
+                    tag["name"]
+                    for tag in data["results"]
+                    if re.match(r"^v\d", tag["name"])
+                ]
+            )
+            url = data.get("next")
+            if not url:
+                break
+        return tags
+
+    # Get tags for all repos in parallel
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        all_tags = list(
+            executor.map(lambda repo: set(get_dockerhub_tags(repo)), dockerhub_repos)
+        )
+
+    # Find common tags across all repos
+    common_tags = set.intersection(*all_tags)
+
+    # Filter tags by strict version patterns
+    dev_tags = [tag for tag in common_tags if DEV_VERSION_PATTERN.match(tag)]
+    stable_tags = [tag for tag in common_tags if STABLE_VERSION_PATTERN.match(tag)]
+
+    # Ensure we have at least one tag of each type
+    if not dev_tags:
+        raise HTTPException(
+            status_code=500,
+            detail="No valid dev versions found matching pattern v(number).(number).(number)-beta",
+        )
+    if not stable_tags:
+        raise HTTPException(
+            status_code=500,
+            detail="No valid stable versions found matching pattern v(number).(number).(number)",
+        )
+
+    # Sort common tags and get the latest one
+    def version_key(version: str) -> tuple[int, int, int, int]:
+        """Extract major, minor, patch, beta as integers for sorting"""
+        # Remove 'v' prefix
+        clean_version = version[1:]
+
+        # Check if it's a beta version
+        if "-beta." in clean_version:
+            # Split on '-beta.' to separate version and beta number
+            base_version, beta_num = clean_version.split("-beta.")
+            parts = base_version.split(".")
+            return (int(parts[0]), int(parts[1]), int(parts[2]), int(beta_num))
+        else:
+            # Stable version - no beta number
+            parts = clean_version.split(".")
+            return (int(parts[0]), int(parts[1]), int(parts[2]), 0)
+
+    latest_dev_version = sorted(dev_tags, key=version_key, reverse=True)[0]
+    latest_stable_version = sorted(stable_tags, key=version_key, reverse=True)[0]
+
+    return AllVersions(
+        stable=ContainerVersions(
+            danswer=latest_stable_version,
+            relational_db="postgres:15.2-alpine",
+            index="vespaengine/vespa:8.277.17",
+            nginx="nginx:1.23.4-alpine",
+        ),
+        dev=ContainerVersions(
+            danswer=latest_dev_version,
+            relational_db="postgres:15.2-alpine",
+            index="vespaengine/vespa:8.277.17",
+            nginx="nginx:1.23.4-alpine",
+        ),
+        migration=ContainerVersions(
+            danswer="airgapped-intfloat-nomic-migration",
+            relational_db="postgres:15.2-alpine",
+            index="vespaengine/vespa:8.277.17",
+            nginx="nginx:1.23.4-alpine",
+        ),
+    )

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -9,8 +9,8 @@ from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE
-from onyx.configs.app_configs import DEV_VERSION_PATTERN
-from onyx.configs.app_configs import STABLE_VERSION_PATTERN
+from onyx.configs.constants import DEV_VERSION_PATTERN
+from onyx.configs.constants import STABLE_VERSION_PATTERN
 from onyx.server.manage.models import AllVersions
 from onyx.server.manage.models import AuthTypeResponse
 from onyx.server.manage.models import ContainerVersions
@@ -42,7 +42,9 @@ def get_version() -> VersionResponse:
 @router.get("/versions")
 def get_versions() -> AllVersions:
     """
-    Fetches the latest stable and beta versions of Onyx Docker images
+    Fetches the latest stable and beta versions of Onyx Docker images.
+    Since DockerHub does not explicitly flag stable and beta images,
+    this endpoint can be used to programmatically check for new images.
     """
     # Fetch the latest tags from DockerHub for each Onyx component
     dockerhub_repos = [

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -409,7 +409,7 @@ class StandardAnswerCreationRequest(BaseModel):
 
 
 class ContainerVersions(BaseModel):
-    danswer: str
+    onyx: str
     relational_db: str
     index: str
     nginx: str

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -406,3 +406,16 @@ class StandardAnswerCreationRequest(BaseModel):
                         ["invalid regex pattern", pattern, f"in `keyword`: {err.msg}"]
                     )
                 )
+
+
+class ContainerVersions(BaseModel):
+    danswer: str
+    relational_db: str
+    index: str
+    nginx: str
+
+
+class AllVersions(BaseModel):
+    stable: ContainerVersions
+    dev: ContainerVersions
+    migration: ContainerVersions

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -6,6 +6,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from onyx.configs.app_configs import DEV_VERSION_PATTERN
+from onyx.configs.app_configs import STABLE_VERSION_PATTERN
 from onyx.main import fetch_versioned_implementation
 from onyx.utils.logger import setup_logger
 
@@ -103,3 +105,71 @@ def test_handle_send_message_simple_with_history(client: TestClient) -> None:
 
     # persona must have LLM relevance enabled for this to pass
     assert len(resp_json["llm_selected_doc_indices"]) > 0
+
+
+def test_versions_endpoint(client: TestClient) -> None:
+    """Test that /api/versions endpoint returns valid stable, dev, and migration configurations"""
+    response = client.get("/versions")
+    assert response.status_code == 200
+
+    data = response.json()
+
+    # Verify the top-level structure
+    assert "stable" in data
+    assert "dev" in data
+    assert "migration" in data
+
+    # Verify stable configuration
+    stable = data["stable"]
+    assert "onyx" in stable
+    assert "relational_db" in stable
+    assert "index" in stable
+    assert "nginx" in stable
+
+    # Verify stable version follows correct pattern (v1.2.3)
+    # If this fails, revise latest Github release for typo or incorrect version name
+    assert STABLE_VERSION_PATTERN.match(
+        stable["onyx"]
+    ), f"Stable version {stable['onyx']} doesn't match pattern v(number).(number).(number)"
+
+    # Verify dev configuration
+    dev = data["dev"]
+    assert "onyx" in dev
+    assert "relational_db" in dev
+    assert "index" in dev
+    assert "nginx" in dev
+
+    # Verify dev version follows correct pattern (v1.2.3-beta.4)
+    assert DEV_VERSION_PATTERN.match(
+        dev["onyx"]
+    ), f"Dev version {dev['onyx']} doesn't match pattern v(number).(number).(number)-beta.(number)"
+
+    # Verify migration configuration
+    migration = data["migration"]
+    assert "onyx" in migration
+    assert "relational_db" in migration
+    assert "index" in migration
+    assert "nginx" in migration
+
+    # Verify migration has expected values
+    assert migration["onyx"] == "airgapped-intfloat-nomic-migration"
+    assert migration["relational_db"] == "postgres:15.2-alpine"
+    assert migration["index"] == "vespaengine/vespa:8.277.17"
+    assert migration["nginx"] == "nginx:1.23.4-alpine"
+
+    # Verify versions are different between stable and dev
+    assert stable["onyx"] != dev["onyx"], "Stable and dev versions should be different"
+
+    # Additional validation: ensure all required fields are strings
+    for config_name, config in [
+        ("stable", stable),
+        ("dev", dev),
+        ("migration", migration),
+    ]:
+        for field_name, field_value in config.items():
+            assert isinstance(
+                field_value, str
+            ), f"{config_name}.{field_name} should be a string, got {type(field_value)}"
+            assert (
+                field_value.strip() != ""
+            ), f"{config_name}.{field_name} should not be empty"

--- a/backend/tests/api/test_api.py
+++ b/backend/tests/api/test_api.py
@@ -6,8 +6,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from onyx.configs.app_configs import DEV_VERSION_PATTERN
-from onyx.configs.app_configs import STABLE_VERSION_PATTERN
+from onyx.configs.constants import DEV_VERSION_PATTERN
+from onyx.configs.constants import STABLE_VERSION_PATTERN
 from onyx.main import fetch_versioned_implementation
 from onyx.utils.logger import setup_logger
 


### PR DESCRIPTION
## Description

- Replicates app.danswer.ai/api/versions in onyx 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a public GET /versions endpoint that returns the latest stable and beta Onyx Docker image versions across components, mirroring app.danswer.ai/api/versions. Also whitelists the route in auth to allow unauthenticated reads.

- **New Features**
  - New GET /versions returns AllVersions {stable, dev, migration} with image tags for: danswer (Onyx), relational_db, index, and nginx.
  - Pulls tags from DockerHub for onyxdotapp/onyx-model-server, onyxdotapp/onyx-backend, and onyxdotapp/onyx-web-server.
  - Uses strict patterns (vX.Y.Z and vX.Y.Z-beta.N), finds tags common to all repos, and selects the latest for each stream.
  - Returns fixed companion tags: postgres:15.2-alpine, vespaengine/vespa:8.277.17, nginx:1.23.4-alpine; migration image set to airgapped-intfloat-nomic-migration.

<!-- End of auto-generated description by cubic. -->

