### PR TITLE
feat: mcp client1

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -71,6 +71,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client \
+            --skip-validate-spec \
             --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -71,7 +71,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client \
-            --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
+            --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -71,6 +71,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client
+            --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
             -i /local/openapi.json \
             -g python \
             -o /local/onyx_openapi_client \
-            --package-name onyx_openapi_client
+            --package-name onyx_openapi_client \
             --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
 
       - name: Set up Docker Buildx

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -68,7 +68,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client \
-            --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
+            --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
             
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
             -i /local/openapi.json \
             -g python \
             -o /local/onyx_openapi_client \
-            --package-name onyx_openapi_client
+            --package-name onyx_openapi_client \
             --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
             
       - name: Set up Docker Buildx

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -68,6 +68,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client \
+            --skip-validate-spec \
             --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
             
       - name: Set up Docker Buildx

--- a/.github/workflows/pr-mit-integration-tests.yml
+++ b/.github/workflows/pr-mit-integration-tests.yml
@@ -68,6 +68,7 @@ jobs:
             -g python \
             -o /local/onyx_openapi_client \
             --package-name onyx_openapi_client
+            --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
             
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -48,6 +48,7 @@ jobs:
           -g python \
           -o /local/onyx_openapi_client \
           --package-name onyx_openapi_client \
+          --skip-validate-spec \
           --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
             
     - name: Run MyPy

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -48,6 +48,7 @@ jobs:
           -g python \
           -o /local/onyx_openapi_client \
           --package-name onyx_openapi_client \
+          --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
             
     - name: Run MyPy
       run: |

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -48,7 +48,7 @@ jobs:
           -g python \
           -o /local/onyx_openapi_client \
           --package-name onyx_openapi_client \
-          --openapi-normalizer SIMPLIFY_ONEOF_ANYOF=true
+          --openapi-normalizer "SIMPLIFY_ONEOF_ANYOF=true,SET_OAS3_NULLABLE=true"
             
     - name: Run MyPy
       run: |

--- a/backend/alembic/versions/7ed603b64d5a_add_mcp_server_and_connection_config_.py
+++ b/backend/alembic/versions/7ed603b64d5a_add_mcp_server_and_connection_config_.py
@@ -1,0 +1,219 @@
+"""add_mcp_server_and_connection_config_models
+
+Revision ID: 7ed603b64d5a
+Revises: b329d00a9ea6
+Create Date: 2025-07-28 17:35:59.900680
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from onyx.db.enums import MCPAuthenticationType
+
+# revision identifiers, used by Alembic.
+revision = "7ed603b64d5a"
+down_revision = "b329d00a9ea6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create tables and columns for MCP Server support"""
+
+    # 1. MCP Server main table (no FK constraints yet to avoid circular refs)
+    op.create_table(
+        "mcp_server",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("owner", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("server_url", sa.String(), nullable=False),
+        sa.Column(
+            "auth_type",
+            sa.Enum(
+                MCPAuthenticationType,
+                name="mcp_authentication_type",
+                native_enum=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("admin_connection_config_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),  # type: ignore
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),  # type: ignore
+            nullable=False,
+        ),
+    )
+
+    # 2. MCP Connection Config table (can reference mcp_server now that it exists)
+    op.create_table(
+        "mcp_connection_config",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("mcp_server_id", sa.Integer(), nullable=True),
+        sa.Column("user_email", sa.String(), nullable=False, default=""),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),  # type: ignore
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),  # type: ignore
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["mcp_server_id"], ["mcp_server.id"], ondelete="CASCADE"
+        ),
+    )
+
+    # Helpful indexes
+    op.create_index(
+        "ix_mcp_connection_config_server_user",
+        "mcp_connection_config",
+        ["mcp_server_id", "user_email"],
+    )
+    op.create_index(
+        "ix_mcp_connection_config_user_email",
+        "mcp_connection_config",
+        ["user_email"],
+    )
+
+    # 3. Add the back-references from mcp_server to connection configs
+    op.create_foreign_key(
+        "mcp_server_admin_config_fk",
+        "mcp_server",
+        "mcp_connection_config",
+        ["admin_connection_config_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # 4. Association / access-control tables
+    op.create_table(
+        "mcp_server__user",
+        sa.Column("mcp_server_id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.UUID(), primary_key=True),
+        sa.ForeignKeyConstraint(
+            ["mcp_server_id"], ["mcp_server.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+    )
+
+    op.create_table(
+        "mcp_server__user_group",
+        sa.Column("mcp_server_id", sa.Integer(), primary_key=True),
+        sa.Column("user_group_id", sa.Integer(), primary_key=True),
+        sa.ForeignKeyConstraint(
+            ["mcp_server_id"], ["mcp_server.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_group_id"], ["user_group.id"]),
+    )
+
+    # 5. Update existing `tool` table – allow tools to belong to an MCP server
+    op.add_column(
+        "tool",
+        sa.Column("mcp_server_id", sa.Integer(), nullable=True),
+    )
+    # Add column for MCP tool input schema
+    op.add_column(
+        "tool",
+        sa.Column("mcp_input_schema", postgresql.JSONB(), nullable=True),
+    )
+    op.create_foreign_key(
+        "tool_mcp_server_fk",
+        "tool",
+        "mcp_server",
+        ["mcp_server_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # 6. Update persona__tool foreign keys to cascade delete
+    # This ensures that when a tool is deleted (including via MCP server deletion),
+    # the corresponding persona__tool rows are also deleted
+    op.drop_constraint(
+        "persona__tool_tool_id_fkey", "persona__tool", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "persona__tool_persona_id_fkey", "persona__tool", type_="foreignkey"
+    )
+
+    op.create_foreign_key(
+        "persona__tool_persona_id_fkey",
+        "persona__tool",
+        "persona",
+        ["persona_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "persona__tool_tool_id_fkey",
+        "persona__tool",
+        "tool",
+        ["tool_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Drop all MCP-related tables / columns"""
+
+    # 0. Restore original persona__tool foreign keys (without CASCADE)
+    op.drop_constraint(
+        "persona__tool_persona_id_fkey", "persona__tool", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "persona__tool_tool_id_fkey", "persona__tool", type_="foreignkey"
+    )
+
+    op.create_foreign_key(
+        "persona__tool_persona_id_fkey",
+        "persona__tool",
+        "persona",
+        ["persona_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "persona__tool_tool_id_fkey",
+        "persona__tool",
+        "tool",
+        ["tool_id"],
+        ["id"],
+    )
+
+    # # 1. Drop FK & columns from tool
+    op.drop_constraint("tool_mcp_server_fk", "tool", type_="foreignkey")
+    op.execute("DELETE FROM tool WHERE mcp_server_id IS NOT NULL")
+    op.drop_column("tool", "mcp_input_schema")
+    op.drop_column("tool", "mcp_server_id")
+
+    # 2. Drop association tables
+    op.drop_table("mcp_server__user_group")
+    op.drop_table("mcp_server__user")
+
+    # 3. Drop FK from mcp_server to connection configs
+    op.drop_constraint("mcp_server_admin_config_fk", "mcp_server", type_="foreignkey")
+
+    # 4. Drop connection config indexes & table
+    op.drop_index(
+        "ix_mcp_connection_config_user_email", table_name="mcp_connection_config"
+    )
+    op.drop_index(
+        "ix_mcp_connection_config_server_user", table_name="mcp_connection_config"
+    )
+    op.drop_table("mcp_connection_config")
+
+    # 5. Finally drop mcp_server table
+    op.drop_table("mcp_server")

--- a/backend/alembic/versions/7ed603b64d5a_add_mcp_server_and_connection_config_.py
+++ b/backend/alembic/versions/7ed603b64d5a_add_mcp_server_and_connection_config_.py
@@ -107,7 +107,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["mcp_server_id"], ["mcp_server.id"], ondelete="CASCADE"
         ),
-        sa.ForeignKeyConstraint(["user_id"], ["user.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
     )
 
     op.create_table(

--- a/backend/ee/onyx/external_permissions/perm_sync_types.py
+++ b/backend/ee/onyx/external_permissions/perm_sync_types.py
@@ -3,13 +3,13 @@ from collections.abc import Generator
 from typing import Optional
 from typing import Protocol
 
-from ee.onyx.db.external_perm import ExternalUserGroup
-from onyx.access.models import DocExternalAccess
+from ee.onyx.db.external_perm import ExternalUserGroup  # noqa
+from onyx.access.models import DocExternalAccess  # noqa
 from onyx.context.search.models import InferenceChunk
-from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import ConnectorCredentialPair  # noqa
 from onyx.db.utils import DocumentRow
 from onyx.db.utils import SortOrder
-from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface  # noqa
 
 
 class FetchAllDocumentsFunction(Protocol):

--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a1_orchestrator.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a1_orchestrator.py
@@ -253,7 +253,7 @@ def orchestrator(
                     ],
                 )
 
-        # for Thoightful mode, we force a tool if requested an available
+        # for Thoughtful mode, we force a tool if requested an available
         available_tools_for_decision = available_tools
         force_use_tool = graph_config.tooling.force_use_tool
         if iteration_nr == 1 and force_use_tool and force_use_tool.force_use:

--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a3_logger.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a3_logger.py
@@ -120,8 +120,9 @@ def save_iteration(
     # lastly, insert the citations
     citation_dict: dict[int, int] = {}
     cited_doc_nrs = _extract_citation_numbers(final_answer)
-    for cited_doc_nr in cited_doc_nrs:
-        citation_dict[cited_doc_nr] = search_docs[cited_doc_nr - 1].id
+    if search_docs:
+        for cited_doc_nr in cited_doc_nrs:
+            citation_dict[cited_doc_nr] = search_docs[cited_doc_nr - 1].id
 
     # TODO: generate plan as dict in the first place
     plan_of_record = state.plan_of_record.plan if state.plan_of_record else ""

--- a/backend/onyx/agents/agent_search/dr/sub_agents/custom_tool/dr_custom_tool_2_act.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/custom_tool/dr_custom_tool_2_act.py
@@ -18,6 +18,7 @@ from onyx.prompts.dr_prompts import CUSTOM_TOOL_USE_PROMPT
 from onyx.tools.tool_implementations.custom.custom_tool import CUSTOM_TOOL_RESPONSE_ID
 from onyx.tools.tool_implementations.custom.custom_tool import CustomTool
 from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCP_TOOL_RESPONSE_ID
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -40,7 +41,7 @@ def custom_tool_act(
         raise ValueError("available_tools is not set")
 
     custom_tool_info = state.available_tools[state.tools_used[-1]]
-    custom_tool_name = custom_tool_info.llm_path
+    custom_tool_name = custom_tool_info.name
     custom_tool = cast(CustomTool, custom_tool_info.tool_object)
 
     branch_query = state.branch_question
@@ -94,7 +95,7 @@ def custom_tool_act(
     # run the tool
     response_summary: CustomToolCallSummary | None = None
     for tool_response in custom_tool.run(**tool_args):
-        if tool_response.id == CUSTOM_TOOL_RESPONSE_ID:
+        if tool_response.id in {CUSTOM_TOOL_RESPONSE_ID, MCP_TOOL_RESPONSE_ID}:
             response_summary = cast(CustomToolCallSummary, tool_response.response)
             break
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -572,22 +572,19 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             logger.debug(f"Current tenant user count: {user_count}")
 
             with get_session_with_tenant(tenant_id=tenant_id) as db_session:
-                if user_count == 1:
-                    create_milestone_and_report(
-                        user=user,
-                        distinct_id=user.email,
-                        event_type=MilestoneRecordType.USER_SIGNED_UP,
-                        properties=None,
-                        db_session=db_session,
-                    )
-                else:
-                    create_milestone_and_report(
-                        user=user,
-                        distinct_id=user.email,
-                        event_type=MilestoneRecordType.MULTIPLE_USERS,
-                        properties=None,
-                        db_session=db_session,
-                    )
+                event_type = (
+                    MilestoneRecordType.USER_SIGNED_UP
+                    if user_count == 1
+                    else MilestoneRecordType.MULTIPLE_USERS
+                )
+                create_milestone_and_report(
+                    user=user,
+                    distinct_id=user.email,
+                    event_type=event_type,
+                    properties=None,
+                    db_session=db_session,
+                )
+
         finally:
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -11,7 +11,6 @@ from onyx.connectors.asana.connector import AsanaConnector
 from onyx.connectors.axero.connector import AxeroConnector
 from onyx.connectors.blob.connector import BlobStorageConnector
 from onyx.connectors.bookstack.connector import BookstackConnector
-from onyx.connectors.outline.connector import OutlineConnector
 from onyx.connectors.clickup.connector import ClickupConnector
 from onyx.connectors.confluence.connector import ConfluenceConnector
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
@@ -48,6 +47,7 @@ from onyx.connectors.mediawiki.wiki import MediaWikiConnector
 from onyx.connectors.mock_connector.connector import MockConnector
 from onyx.connectors.models import InputType
 from onyx.connectors.notion.connector import NotionConnector
+from onyx.connectors.outline.connector import OutlineConnector
 from onyx.connectors.productboard.connector import ProductboardConnector
 from onyx.connectors.salesforce.connector import SalesforceConnector
 from onyx.connectors.sharepoint.connector import SharepointConnector

--- a/backend/onyx/connectors/outline/client.py
+++ b/backend/onyx/connectors/outline/client.py
@@ -1,26 +1,25 @@
-import json
 from typing import Any
 
 import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import RequestException
 from requests.exceptions import Timeout
-from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 
 
 class OutlineClientRequestFailedError(ConnectionError):
     """Custom error class for handling failed requests to the Outline API with status code and error message"""
+
     def __init__(self, status: int, error: str) -> None:
         self.status_code = status
         self.error = error
-        super().__init__(
-            f"Outline Client request failed with status {status}: {error}"
-        )
+        super().__init__(f"Outline Client request failed with status {status}: {error}")
 
 
 class OutlineApiClient:
     """Client for interacting with the Outline API. Handles authentication and making HTTP requests."""
+
     def __init__(
         self,
         api_token: str,
@@ -34,21 +33,22 @@ class OutlineApiClient:
             data = {}
         url: str = self._build_url(endpoint)
         headers = self._build_headers()
-        
+
         try:
-            response = requests.post(url, headers=headers, json=data, timeout=REQUEST_TIMEOUT_SECONDS)
+            response = requests.post(
+                url, headers=headers, json=data, timeout=REQUEST_TIMEOUT_SECONDS
+            )
         except Timeout:
             raise OutlineClientRequestFailedError(
-                408, f"Request timed out - server did not respond within {REQUEST_TIMEOUT_SECONDS} seconds"
+                408,
+                f"Request timed out - server did not respond within {REQUEST_TIMEOUT_SECONDS} seconds",
             )
         except RequestsConnectionError as e:
             raise OutlineClientRequestFailedError(
                 -1, f"Connection error - unable to reach Outline server: {e}"
             )
         except RequestException as e:
-            raise OutlineClientRequestFailedError(
-                -1, f"Network error occurred: {e}"
-            )
+            raise OutlineClientRequestFailedError(-1, f"Network error occurred: {e}")
 
         if response.status_code >= 300:
             error = response.reason
@@ -68,8 +68,8 @@ class OutlineApiClient:
             return response.json()
         except Exception:
             raise OutlineClientRequestFailedError(
-                response.status_code, 
-                f"Response was successful but contained invalid JSON: {response.text}"
+                response.status_code,
+                f"Response was successful but contained invalid JSON: {response.text}",
             )
 
     def _build_headers(self) -> dict[str, str]:

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -56,6 +56,17 @@ class SyncStatus(str, PyEnum):
         return self in terminal_states
 
 
+class MCPAuthenticationType(str, PyEnum):
+    NONE = "NONE"
+    API_TOKEN = "API_TOKEN"
+    OAUTH = "OAUTH"
+
+
+class MCPAuthenticationPerformer(str, PyEnum):
+    ADMIN = "ADMIN"
+    PER_USER = "PER_USER"
+
+
 # Consistent with Celery task statuses
 class TaskStatus(str, PyEnum):
     PENDING = "PENDING"

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -1,0 +1,384 @@
+from typing import Any
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy import and_
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.models import MCPAuthenticationType
+from onyx.db.models import MCPConnectionConfig
+from onyx.db.models import MCPServer
+from onyx.db.models import Persona
+from onyx.db.models import Tool
+from onyx.db.models import User
+from onyx.server.features.mcp.models import MCPConnectionData
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# MCPServer operations
+def get_all_mcp_servers(db_session: Session) -> list[MCPServer]:
+    """Get all MCP servers"""
+    return list(db_session.scalars(select(MCPServer)).all())
+
+
+def get_mcp_server_by_id(server_id: int, db_session: Session) -> MCPServer:
+    """Get MCP server by ID"""
+    server = db_session.scalar(select(MCPServer).where(MCPServer.id == server_id))
+    if not server:
+        raise ValueError("MCP server by specified id does not exist")
+    return server
+
+
+def get_mcp_servers_by_owner(owner_email: str, db_session: Session) -> list[MCPServer]:
+    """Get all MCP servers owned by a specific user"""
+    return list(
+        db_session.scalars(
+            select(MCPServer).where(MCPServer.owner == owner_email)
+        ).all()
+    )
+
+
+def get_mcp_servers_for_persona(
+    persona_id: int, db_session: Session, user: User | None = None
+) -> list[MCPServer]:
+    """Get all MCP servers associated with a persona via its tools"""
+    # Get the persona and its tools
+    persona = db_session.query(Persona).filter(Persona.id == persona_id).first()
+    if not persona:
+        return []
+
+    # Collect unique MCP server IDs from the persona's tools
+    mcp_server_ids = set()
+    for tool in persona.tools:
+        if tool.mcp_server_id:
+            mcp_server_ids.add(tool.mcp_server_id)
+
+    if not mcp_server_ids:
+        return []
+
+    # Fetch the MCP servers
+    mcp_servers = (
+        db_session.query(MCPServer).filter(MCPServer.id.in_(mcp_server_ids)).all()
+    )
+
+    return list(mcp_servers)
+
+
+def get_mcp_servers_accessible_to_user(
+    user_id: UUID, db_session: Session
+) -> list[MCPServer]:
+    """Get all MCP servers accessible to a user (directly or through groups)"""
+    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    if not user:
+        return []
+    user = cast(User, user)
+    # Get servers accessible directly to user
+    user_servers = list(user.accessible_mcp_servers)
+
+    # TODO: Add group-based access once relationships are fully implemented
+    # For now, just return direct user access
+    return user_servers
+
+
+def create_mcp_server(
+    owner_email: str,
+    name: str,
+    description: str | None,
+    server_url: str,
+    auth_type: MCPAuthenticationType,
+    db_session: Session,
+    admin_connection_config_id: int | None = None,
+) -> MCPServer:
+    """Create a new MCP server"""
+    new_server = MCPServer(
+        owner=owner_email,
+        name=name,
+        description=description,
+        server_url=server_url,
+        auth_type=auth_type,
+        admin_connection_config_id=admin_connection_config_id,
+    )
+    db_session.add(new_server)
+    db_session.flush()  # Get the ID without committing
+    return new_server
+
+
+def update_mcp_server(
+    server_id: int,
+    db_session: Session,
+    name: str | None = None,
+    description: str | None = None,
+    server_url: str | None = None,
+    auth_type: MCPAuthenticationType | None = None,
+    admin_connection_config_id: int | None = None,
+) -> MCPServer:
+    """Update an existing MCP server"""
+    server = get_mcp_server_by_id(server_id, db_session)
+
+    if name is not None:
+        server.name = name
+    if description is not None:
+        server.description = description
+    if server_url is not None:
+        server.server_url = server_url
+    if auth_type is not None:
+        server.auth_type = auth_type
+    if admin_connection_config_id is not None:
+        server.admin_connection_config_id = admin_connection_config_id
+
+    db_session.flush()  # Don't commit yet, let caller decide when to commit
+    return server
+
+
+def delete_mcp_server(server_id: int, db_session: Session) -> None:
+    """Delete an MCP server and all associated tools (via CASCADE)"""
+    server = get_mcp_server_by_id(server_id, db_session)
+
+    # Log for debugging
+    from onyx.utils.logger import setup_logger
+
+    logger = setup_logger()
+
+    # Count tools that will be deleted
+    tools_count = db_session.query(Tool).filter(Tool.mcp_server_id == server_id).count()
+    logger.info(f"Deleting MCP server {server_id} with {tools_count} associated tools")
+
+    db_session.delete(server)
+    db_session.commit()
+
+    logger.info(f"Successfully deleted MCP server {server_id} and its tools")
+
+
+# TODO: this is pretty hacky
+def get_mcp_server_auth_performer(mcp_server: MCPServer) -> MCPAuthenticationPerformer:
+    """Get the authentication performer for an MCP server"""
+    if mcp_server.auth_type == MCPAuthenticationType.OAUTH:
+        return MCPAuthenticationPerformer.PER_USER
+    if not mcp_server.admin_connection_config:
+        return MCPAuthenticationPerformer.ADMIN
+    if not mcp_server.admin_connection_config.config.get("header_substitutions"):
+        return MCPAuthenticationPerformer.ADMIN
+    return MCPAuthenticationPerformer.PER_USER
+
+
+def get_all_mcp_tools_for_server(server_id: int, db_session: Session) -> list[Tool]:
+    """Get all MCP tools for a server"""
+    return list(
+        db_session.scalars(select(Tool).where(Tool.mcp_server_id == server_id)).all()
+    )
+
+
+def add_user_to_mcp_server(server_id: int, user_id: UUID, db_session: Session) -> None:
+    """Grant a user access to an MCP server"""
+    server = get_mcp_server_by_id(server_id, db_session)
+    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    if not user:
+        raise ValueError("User not found")
+
+    if user not in server.users:
+        server.users.append(user)
+        db_session.commit()
+
+
+def remove_user_from_mcp_server(
+    server_id: int, user_id: UUID, db_session: Session
+) -> None:
+    """Remove a user's access to an MCP server"""
+    server = get_mcp_server_by_id(server_id, db_session)
+    user = db_session.scalar(select(User).where(User.id == user_id))  # type: ignore
+    if not user:
+        raise ValueError("User not found")
+
+    if user in server.users:
+        server.users.remove(user)
+        db_session.commit()
+
+
+# MCPConnectionConfig operations
+def get_connection_config_by_id(
+    config_id: int, db_session: Session
+) -> MCPConnectionConfig:
+    """Get connection config by ID"""
+    config = db_session.scalar(
+        select(MCPConnectionConfig).where(MCPConnectionConfig.id == config_id)
+    )
+    if not config:
+        raise ValueError("Connection config by specified id does not exist")
+    return config
+
+
+def get_user_connection_config(
+    server_id: int, user_email: str, db_session: Session
+) -> MCPConnectionConfig | None:
+    """Get a user's connection config for a specific MCP server"""
+    return db_session.scalar(
+        select(MCPConnectionConfig).where(
+            and_(
+                MCPConnectionConfig.mcp_server_id == server_id,
+                MCPConnectionConfig.user_email == user_email,
+            )
+        )
+    )
+
+
+def refresh_oauth_token(
+    server_url: str,
+    config: dict[str, Any],
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    redirect_uri: str | None = None,
+) -> dict[str, Any] | None:
+    """Refresh OAuth token if refresh_token present. Returns new token payload or None.
+
+    If client credentials are not provided, attempts to use credentials stored in config.
+    """
+    import httpx
+    import os
+
+    refresh_token = config.get("refresh_token")
+    if not refresh_token:
+        return None
+
+    # Use provided credentials or try to get from config
+    if not client_id:
+        client_id = config.get("client_id") or os.getenv(
+            "MCP_OAUTH_CLIENT_ID", "test-client-id"
+        )
+    if not client_secret:
+        client_secret = config.get("client_secret") or os.getenv(
+            "MCP_OAUTH_CLIENT_SECRET", "test-client-secret"
+        )
+    if not redirect_uri:
+        redirect_uri = os.getenv(
+            "MCP_OAUTH_REDIRECT_URI",
+            "http://localhost:3000/api/chat/mcp/oauth/callback",
+        )
+
+    token_url = (
+        os.getenv("MCP_OAUTH_TOKEN_URL") or f"{server_url.rstrip('/')}/oauth/token"
+    )
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+    }
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.post(token_url, data=data)
+            resp.raise_for_status()
+            return resp.json()
+    except Exception:
+        return None
+
+
+def get_user_connection_configs_for_server(
+    server_id: int, db_session: Session
+) -> list[MCPConnectionConfig]:
+    """Get all user connection configs for a specific MCP server"""
+    return list(
+        db_session.scalars(
+            select(MCPConnectionConfig).where(
+                MCPConnectionConfig.mcp_server_id == server_id
+            )
+        ).all()
+    )
+
+
+def create_connection_config(
+    config_data: MCPConnectionData,
+    db_session: Session,
+    mcp_server_id: int | None = None,
+    user_email: str = "",
+) -> MCPConnectionConfig:
+    """Create a new connection config"""
+    new_config = MCPConnectionConfig(
+        mcp_server_id=mcp_server_id,
+        user_email=user_email,
+        config=config_data,
+    )
+    db_session.add(new_config)
+    db_session.flush()  # Don't commit yet, let caller decide when to commit
+    return new_config
+
+
+def update_connection_config(
+    config_id: int,
+    db_session: Session,
+    config_data: MCPConnectionData | None = None,
+) -> MCPConnectionConfig:
+    """Update an existing connection config"""
+    config = get_connection_config_by_id(config_id, db_session)
+
+    if config_data is not None:
+        config.config = config_data
+
+    db_session.commit()
+    return config
+
+
+def upsert_user_connection_config(
+    server_id: int,
+    user_email: str,
+    config_data: MCPConnectionData,
+    db_session: Session,
+) -> MCPConnectionConfig:
+    """Create or update a user's connection config for an MCP server"""
+    existing_config = get_user_connection_config(server_id, user_email, db_session)
+
+    if existing_config:
+        existing_config.config = config_data
+        db_session.flush()  # Don't commit yet, let caller decide when to commit
+        return existing_config
+    else:
+        return create_connection_config(
+            config_data=config_data,
+            mcp_server_id=server_id,
+            user_email=user_email,
+            db_session=db_session,
+        )
+
+
+# TODO: do this in one db call
+def get_server_auth_template(
+    server_id: int, db_session: Session
+) -> MCPConnectionConfig | None:
+    """Get the authentication template for a server (from the admin connection config)"""
+    server = get_mcp_server_by_id(server_id, db_session)
+    if not server.admin_connection_config_id:
+        return None
+
+    if get_mcp_server_auth_performer(server) == MCPAuthenticationPerformer.ADMIN:
+        return None  # admin server implies no template
+    return server.admin_connection_config
+
+
+def delete_connection_config(config_id: int, db_session: Session) -> None:
+    """Delete a connection config"""
+    config = get_connection_config_by_id(config_id, db_session)
+    db_session.delete(config)
+    db_session.flush()  # Don't commit yet, let caller decide when to commit
+
+
+def delete_user_connection_configs_for_server(
+    server_id: int, user_email: str, db_session: Session
+) -> None:
+    """Delete all connection configs for a user on a specific server"""
+    configs = db_session.scalars(
+        select(MCPConnectionConfig).where(
+            and_(
+                MCPConnectionConfig.mcp_server_id == server_id,
+                MCPConnectionConfig.user_email == user_email,
+            )
+        )
+    ).all()
+
+    for config in configs:
+        db_session.delete(config)
+
+    db_session.commit()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3565,9 +3565,11 @@ class MCPServer(Base):
 class MCPServer__User(Base):
     __tablename__ = "mcp_server__user"
     mcp_server_id: Mapped[int] = mapped_column(
-        ForeignKey("mcp_server.id"), primary_key=True
+        ForeignKey("mcp_server.id", ondelete="CASCADE"), primary_key=True
     )
-    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id"), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class MCPServer__UserGroup(Base):
@@ -3605,7 +3607,7 @@ class MCPConnectionConfig(Base):
     #   "registration_client_uri": "<uri>",  # For managing registration
     # }
     config: Mapped[MCPConnectionData] = mapped_column(
-        postgresql.JSONB(), nullable=False, default=dict
+        EncryptedJson(), nullable=False, default=dict
     )
 
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3469,7 +3469,7 @@ class ResearchAgentIterationSubStep(Base):
     )
     sub_step_instructions: Mapped[str | None] = mapped_column(String, nullable=True)
     sub_step_tool_id: Mapped[int | None] = mapped_column(
-        ForeignKey("tool.id"), nullable=True
+        ForeignKey("tool.id", ondelete="SET NULL"), nullable=True
     )
 
     # for all step-types

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -62,6 +62,7 @@ from onyx.db.enums import (
     IndexingMode,
     SyncType,
     SyncStatus,
+    MCPAuthenticationType,
 )
 from onyx.configs.constants import NotificationType
 from onyx.configs.constants import SearchFeedbackType
@@ -81,6 +82,7 @@ from onyx.llm.override_models import LLMOverride
 from onyx.llm.override_models import PromptOverride
 from onyx.context.search.enums import RecencyBiasSetting
 from onyx.kg.models import KGStage
+from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.utils.encryption import decrypt_bytes_to_string
 from onyx.utils.encryption import encrypt_string_to_bytes
 from onyx.utils.headers import HeaderItemDict
@@ -231,6 +233,10 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         "UserFolder", back_populates="user"
     )
     files: Mapped[list["UserFile"]] = relationship("UserFile", back_populates="user")
+    # MCP servers accessible to this user
+    accessible_mcp_servers: Mapped[list["MCPServer"]] = relationship(
+        "MCPServer", secondary="mcp_server__user", back_populates="users"
+    )
 
     @validates("email")
     def validate_email(self, key: str, value: str) -> str:
@@ -389,8 +395,12 @@ class Document__Tag(Base):
 class Persona__Tool(Base):
     __tablename__ = "persona__tool"
 
-    persona_id: Mapped[int] = mapped_column(ForeignKey("persona.id"), primary_key=True)
-    tool_id: Mapped[int] = mapped_column(ForeignKey("tool.id"), primary_key=True)
+    persona_id: Mapped[int] = mapped_column(
+        ForeignKey("persona.id", ondelete="CASCADE"), primary_key=True
+    )
+    tool_id: Mapped[int] = mapped_column(
+        ForeignKey("tool.id", ondelete="CASCADE"), primary_key=True
+    )
 
 
 class StandardAnswer__StandardAnswerCategory(Base):
@@ -2507,6 +2517,10 @@ class Tool(Base):
     openapi_schema: Mapped[dict[str, Any] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
+    # MCP tool input schema. Only applies to MCP tools.
+    mcp_input_schema: Mapped[dict[str, Any] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
     custom_headers: Mapped[list[HeaderItemDict] | None] = mapped_column(
         postgresql.JSONB(), nullable=True
     )
@@ -2516,6 +2530,10 @@ class Tool(Base):
     )
     # whether to pass through the user's OAuth token as Authorization header
     passthrough_auth: Mapped[bool] = mapped_column(Boolean, default=False)
+    # MCP server this tool is associated with (null for non-MCP tools)
+    mcp_server_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("mcp_server.id", ondelete="CASCADE"), nullable=True
+    )
 
     user: Mapped[User | None] = relationship("User", back_populates="custom_tools")
     # Relationship to Persona through the association table
@@ -2523,6 +2541,10 @@ class Tool(Base):
         "Persona",
         secondary=Persona__Tool.__table__,
         back_populates="tools",
+    )
+    # MCP server relationship
+    mcp_server: Mapped["MCPServer | None"] = relationship(
+        "MCPServer", back_populates="current_actions"
     )
 
 
@@ -2658,6 +2680,7 @@ class Persona(Base):
         secondary=Persona__PersonaLabel.__table__,
         back_populates="personas",
     )
+
     # Default personas loaded via yaml cannot have the same name
     __table_args__ = (
         Index(
@@ -3056,6 +3079,10 @@ class UserGroup(Base):
     credentials: Mapped[list[Credential]] = relationship(
         "Credential",
         secondary=Credential__UserGroup.__table__,
+    )
+    # MCP servers accessible to this user group
+    accessible_mcp_servers: Mapped[list["MCPServer"]] = relationship(
+        "MCPServer", secondary="mcp_server__user_group", back_populates="user_groups"
     )
 
 
@@ -3475,4 +3502,132 @@ class ResearchAgentIterationSubStep(Base):
             ],
             ondelete="CASCADE",
         ),
+    )
+
+
+class MCPServer(Base):
+    """Model for storing MCP server configurations"""
+
+    __tablename__ = "mcp_server"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # Owner email of user who configured this server
+    owner: Mapped[str] = mapped_column(String, nullable=False)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str | None] = mapped_column(String, nullable=True)
+    server_url: Mapped[str] = mapped_column(String, nullable=False)
+    # Auth type: "none", "api_token", or "oauth"
+    auth_type: Mapped[MCPAuthenticationType] = mapped_column(
+        Enum(MCPAuthenticationType, native_enum=False), nullable=False
+    )
+    # Admin connection config - used for the config page
+    # and (when applicable) admin-managed auth
+    # and (when applicable) per-user auth
+    admin_connection_config_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("mcp_connection_config.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    admin_connection_config: Mapped["MCPConnectionConfig | None"] = relationship(
+        "MCPConnectionConfig",
+        foreign_keys=[admin_connection_config_id],
+        back_populates="admin_servers",
+    )
+
+    user_connection_configs: Mapped[list["MCPConnectionConfig"]] = relationship(
+        "MCPConnectionConfig",
+        foreign_keys="MCPConnectionConfig.mcp_server_id",
+        back_populates="mcp_server",
+    )
+    current_actions: Mapped[list["Tool"]] = relationship(
+        "Tool", back_populates="mcp_server", cascade="all, delete-orphan"
+    )
+    # Many-to-many relationships for access control
+    users: Mapped[list["User"]] = relationship(
+        "User", secondary="mcp_server__user", back_populates="accessible_mcp_servers"
+    )
+    user_groups: Mapped[list["UserGroup"]] = relationship(
+        "UserGroup",
+        secondary="mcp_server__user_group",
+        back_populates="accessible_mcp_servers",
+    )
+
+
+class MCPServer__User(Base):
+    __tablename__ = "mcp_server__user"
+    mcp_server_id: Mapped[int] = mapped_column(
+        ForeignKey("mcp_server.id"), primary_key=True
+    )
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("user.id"), primary_key=True)
+
+
+class MCPServer__UserGroup(Base):
+    __tablename__ = "mcp_server__user_group"
+    mcp_server_id: Mapped[int] = mapped_column(
+        ForeignKey("mcp_server.id"), primary_key=True
+    )
+    user_group_id: Mapped[int] = mapped_column(
+        ForeignKey("user_group.id"), primary_key=True
+    )
+
+
+class MCPConnectionConfig(Base):
+    """Model for storing MCP connection configurations (credentials, auth data)"""
+
+    __tablename__ = "mcp_connection_config"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # Server this config is for (nullable for template configs)
+    mcp_server_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("mcp_server.id", ondelete="CASCADE"), nullable=True
+    )
+    # User email this config is for (empty for admin configs and templates)
+    user_email: Mapped[str] = mapped_column(String, nullable=False, default="")
+    # Config data stored as JSON
+    # Format: {
+    #   "refresh_token": "<token>",  # OAuth only
+    #   "access_token": "<token>",   # OAuth only
+    #   "headers": {"key": "value", "key2": "value2"},
+    #   "header_substitutions": {"<key>": "<value>"}, # stored header template substitutions
+    #   "request_body": ["path/in/body:value", "path2/in2/body2:value2"] # TBD
+    #   "client_id": "<id>",  # For dynamically registered OAuth clients
+    #   "client_secret": "<secret>",  # For confidential clients
+    #   "registration_access_token": "<token>",  # For managing registration
+    #   "registration_client_uri": "<uri>",  # For managing registration
+    # }
+    config: Mapped[MCPConnectionData] = mapped_column(
+        postgresql.JSONB(), nullable=False, default=dict
+    )
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    # Relationships
+    mcp_server: Mapped["MCPServer | None"] = relationship(
+        "MCPServer",
+        foreign_keys=[mcp_server_id],
+        back_populates="user_connection_configs",
+    )
+    admin_servers: Mapped[list["MCPServer"]] = relationship(
+        "MCPServer",
+        foreign_keys="MCPServer.admin_connection_config_id",
+        back_populates="admin_connection_config",
+    )
+
+    __table_args__ = (
+        Index("ix_mcp_connection_config_user_email", "user_email"),
+        Index("ix_mcp_connection_config_server_user", "mcp_server_id", "user_email"),
     )

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -97,7 +97,7 @@ def update_tool(
     return tool
 
 
-def delete_tool(tool_id: int, db_session: Session) -> None:
+def delete_tool__no_commit(tool_id: int, db_session: Session) -> None:
     tool = get_tool_by_id(tool_id, db_session)
     if tool is None:
         raise ValueError(f"Tool with ID {tool_id} does not exist")

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -17,6 +17,14 @@ def get_tools(db_session: Session) -> list[Tool]:
     return list(db_session.scalars(select(Tool)).all())
 
 
+def get_tools_by_mcp_server_id(mcp_server_id: int, db_session: Session) -> list[Tool]:
+    return list(
+        db_session.scalars(
+            select(Tool).where(Tool.mcp_server_id == mcp_server_id)
+        ).all()
+    )
+
+
 def get_tool_by_id(tool_id: int, db_session: Session) -> Tool:
     tool = db_session.scalar(select(Tool).where(Tool.id == tool_id))
     if not tool:
@@ -31,7 +39,7 @@ def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:
     return tool
 
 
-def create_tool(
+def create_tool__no_commit(
     name: str,
     description: str | None,
     openapi_schema: dict[str, Any] | None,
@@ -52,7 +60,7 @@ def create_tool(
         passthrough_auth=passthrough_auth,
     )
     db_session.add(new_tool)
-    db_session.commit()
+    db_session.flush()  # Don't commit yet, let caller decide when to commit
     return new_tool
 
 
@@ -95,4 +103,4 @@ def delete_tool(tool_id: int, db_session: Session) -> None:
         raise ValueError(f"Tool with ID {tool_id} does not exist")
 
     db_session.delete(tool)
-    db_session.commit()
+    db_session.flush()  # Don't commit yet, let caller decide when to commit

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -67,6 +67,8 @@ from onyx.server.features.input_prompt.api import (
 from onyx.server.features.input_prompt.api import (
     basic_router as input_prompt_router,
 )
+from onyx.server.features.mcp.api import admin_router as mcp_admin_router
+from onyx.server.features.mcp.api import router as mcp_router
 from onyx.server.features.notifications.api import router as notification_router
 from onyx.server.features.password.api import router as password_router
 from onyx.server.features.persona.api import admin_router as admin_persona_router
@@ -352,6 +354,8 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, notification_router)
     include_router_with_global_prefix_prepended(application, tool_router)
     include_router_with_global_prefix_prepended(application, admin_tool_router)
+    include_router_with_global_prefix_prepended(application, mcp_router)
+    include_router_with_global_prefix_prepended(application, mcp_admin_router)
     include_router_with_global_prefix_prepended(application, state_router)
     include_router_with_global_prefix_prepended(application, onyx_api_router)
     include_router_with_global_prefix_prepended(application, gpts_router)

--- a/backend/onyx/prompts/dr_prompts.py
+++ b/backend/onyx/prompts/dr_prompts.py
@@ -887,7 +887,7 @@ Here is the base question that ultimately needs to be answered:
 ---base_question---
 {SEPARATOR_LINE}
 
-Here is the tool response:
+Here is the tool, its description, and the results that it returned:
 {SEPARATOR_LINE}
 ---tool_response---
 {SEPARATOR_LINE}
@@ -896,6 +896,7 @@ Notes:
    - clearly state in your answer if the tool response did not provide relevant information, \
 or the response does not apply to this specific context. Do not make up information!
    - It is critical to avoid hallucinations as well as taking information out of context.
+   - Make sure you consider the tool description as context for the provided result.
    - clearly indicate any assumptions you make in your answer.
    - while the base question is important, really focus on answering the specific task query. \
 That is your task.

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1,0 +1,1561 @@
+import base64
+import hashlib
+import random
+import string
+from secrets import token_urlsafe
+from typing import Any
+from typing import cast
+from urllib.parse import urlencode
+
+import httpx
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import Request
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import current_admin_user
+from onyx.auth.users import current_user
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.mcp import create_connection_config
+from onyx.db.mcp import create_mcp_server
+from onyx.db.mcp import delete_connection_config
+from onyx.db.mcp import delete_mcp_server
+from onyx.db.mcp import delete_user_connection_configs_for_server
+from onyx.db.mcp import get_all_mcp_servers
+from onyx.db.mcp import get_mcp_server_auth_performer
+from onyx.db.mcp import get_mcp_server_by_id
+from onyx.db.mcp import get_mcp_servers_for_persona
+from onyx.db.mcp import get_server_auth_template
+from onyx.db.mcp import get_user_connection_config
+from onyx.db.mcp import update_connection_config
+from onyx.db.mcp import update_mcp_server
+from onyx.db.mcp import upsert_user_connection_config
+from onyx.db.models import MCPConnectionConfig
+from onyx.db.models import MCPServer as DbMCPServer
+from onyx.db.models import User
+from onyx.db.tools import create_tool__no_commit
+from onyx.db.tools import delete_tool
+from onyx.db.tools import get_tools_by_mcp_server_id
+from onyx.redis.redis_pool import get_redis_client
+from onyx.server.documents.standard_oauth import _OAUTH_STATE_EXPIRATION_SECONDS
+from onyx.server.documents.standard_oauth import _OAUTH_STATE_KEY_FMT
+from onyx.server.features.mcp.models import MCPApiKeyResponse
+from onyx.server.features.mcp.models import MCPAuthTemplate
+from onyx.server.features.mcp.models import MCPConnectionData
+from onyx.server.features.mcp.models import MCPDynamicClientRegistrationRequest
+from onyx.server.features.mcp.models import MCPDynamicClientRegistrationResponse
+from onyx.server.features.mcp.models import MCPOAuthCallbackResponse
+from onyx.server.features.mcp.models import MCPServer
+from onyx.server.features.mcp.models import MCPServerCreateResponse
+from onyx.server.features.mcp.models import MCPServersResponse
+from onyx.server.features.mcp.models import MCPServerUpdateResponse
+from onyx.server.features.mcp.models import MCPToolCreateRequest
+from onyx.server.features.mcp.models import MCPToolListResponse
+from onyx.server.features.mcp.models import MCPToolUpdateRequest
+from onyx.server.features.mcp.models import MCPUserCredentialsRequest
+from onyx.server.features.mcp.models import MCPUserOAuthInitiateRequest
+from onyx.server.features.mcp.models import MCPUserOAuthInitiateResponse
+from onyx.tools.tool_implementations.mcp.mcp_client import discover_mcp_tools
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/mcp")
+admin_router = APIRouter(prefix="/admin/mcp")
+STATE_TTL_SECONDS = 60 * 15  # 15 minutes
+
+
+def generate_state() -> str:
+    """Generate a random state parameter for OAuth"""
+    return "".join(random.choices(string.ascii_letters + string.digits, k=15))
+
+
+def _parse_www_authenticate(header_value: str) -> str:
+    """Parse a WWW-Authenticate header into a dict of scheme/params.
+
+    Example: 'Bearer realm="example", authorization_uri="https://as.example/.well-known/..."'
+    Returns only the parameter map, lower-cased keys.
+    """
+    params: dict[str, str] = {}
+    try:
+        # Split off auth scheme (e.g., Bearer, DPoP)
+        parts = header_value.split(" ", 1)
+        rest = parts[1] if len(parts) > 1 else header_value
+        for item in rest.split(","):
+            if "=" in item:
+                k, v = item.split("=", 1)
+                k = k.strip().lower()
+                v = v.strip().strip('"')
+                if "bearer" in k and "resource" in k:
+                    return v
+                params[k] = v
+    except Exception:
+        logger.exception(f"Failed to parse WWW-Authenticate header: {header_value}")
+    return ""
+
+
+def _build_headers_from_template(
+    template_data: MCPAuthTemplate, credentials: dict[str, str], user_email: str
+) -> dict[str, str]:
+    """Build headers dict from template and credentials"""
+    headers = {}
+    template_headers = template_data.headers
+
+    for name, value_template in template_headers.items():
+        # Replace placeholders
+        value = value_template
+        for key, cred_value in credentials.items():
+            value = value.replace(f"{{{key}}}", cred_value)
+        value = value.replace("{user_email}", user_email)
+
+        if name:
+            headers[name] = value
+
+    return headers
+
+
+def test_mcp_server_credentials(
+    server_url: str,
+    connection_headers: dict[str, str] | None,
+    transport: str = "streamable-http",
+) -> tuple[bool, str]:
+    """Test if credentials work by calling the MCP server's tools/list endpoint"""
+    try:
+        # Attempt to discover tools using the provided credentials
+        tools = discover_mcp_tools(server_url, connection_headers, transport=transport)
+
+        if (
+            tools is not None and len(tools) >= 0
+        ):  # Even 0 tools is a successful connection
+            return True, f"Successfully connected. Found {len(tools)} tools."
+        else:
+            return False, "Failed to retrieve tools list from server."
+
+    except Exception as e:
+        logger.error(f"Failed to test MCP server credentials: {e}")
+
+        # Per MCP Authorization spec, on 401 the server MUST include
+        # a WWW-Authenticate header pointing to resource metadata (RFC9728 §5.1).
+        # Attempt an unauthenticated probe to discover that header and extract
+        # an authorization/resource metadata URL for next steps.
+        try:
+
+            # Probe without auth to trigger 401 + WWW-Authenticate
+            probe_url = server_url
+            if "?" not in probe_url:
+                # include transport hint if needed
+                probe_url = (
+                    probe_url.rstrip("/")
+                    + "?"
+                    + urlencode({"transportType": transport})
+                )
+
+            with httpx.Client(timeout=5.0, follow_redirects=False) as client:
+                resp = client.get(probe_url)
+                www = resp.headers.get("WWW-Authenticate") or resp.headers.get(
+                    "www-authenticate"
+                )
+                if resp.status_code == 401 and www:
+                    auth_meta_url = _parse_www_authenticate(www)
+                    # Common keys per RFCs: authorization, authorization_uri, as_uri, resource,
+                    # or link to resource metadata
+                    # auth_meta_url = (
+                    #     meta.get("authorization")
+                    #     or meta.get("authorization_uri")
+                    #     or meta.get("as_uri")
+                    #     or meta.get("authorization_server")
+                    #     or meta.get("resource_metadata")
+                    #     or meta.get("resource_server")
+                    # )
+                    if auth_meta_url:
+                        return False, (
+                            "Unauthorized (401). Server advertised authorization metadata; "
+                            f"next discover at: {auth_meta_url}"
+                        )
+                    # If no explicit URL, still include parsed params for operator visibility
+        except Exception as d_err:
+            logger.debug(f"Discovery probe after 401 failed: {d_err}")
+
+        return False, f"Connection failed: {str(e)}"
+
+
+# TODO: make this work
+def _get_or_register_oauth_client(
+    mcp_server: DbMCPServer,
+    authorization_server_url: str,
+    db: Session,
+) -> tuple[str, str | None]:
+    """Get existing OAuth client registration or dynamically register a new one.
+
+    Returns (client_id, client_secret) tuple.
+    """
+    # Check if we already have a registered client for this authorization server
+    admin_config = mcp_server.admin_connection_config
+    if admin_config and admin_config.config:
+        config = admin_config.config
+        if isinstance(config, dict) and config.get("client_id"):
+            # We have a previously registered client
+            return config["client_id"], config.get("client_secret")
+
+    # Need to dynamically register a client
+    import os
+
+    # Discover registration endpoint from authorization server metadata
+    # Per RFC 8414, the metadata should be at .well-known/oauth-authorization-server
+    metadata_url = (
+        authorization_server_url.rstrip("/") + "/.well-known/oauth-authorization-server"
+    )
+
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            # Get authorization server metadata
+            resp = client.get(metadata_url)
+            if resp.status_code == 404:
+                # Try alternative location
+                metadata_url = (
+                    authorization_server_url.rstrip("/")
+                    + "/.well-known/openid-configuration"
+                )
+                resp = client.get(metadata_url)
+
+            if resp.status_code != 200:
+                logger.warning(
+                    f"Could not fetch authorization server metadata from {metadata_url}"
+                )
+                # Fall back to environment variables
+                client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
+                client_secret = os.getenv(
+                    "MCP_OAUTH_CLIENT_SECRET", "test-client-secret"
+                )
+                return client_id, client_secret
+
+            metadata = resp.json()
+            registration_endpoint = metadata.get("registration_endpoint")
+
+            if not registration_endpoint:
+                logger.warning(
+                    "Authorization server does not advertise registration endpoint"
+                )
+                # Fall back to environment variables
+                client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
+                client_secret = os.getenv(
+                    "MCP_OAUTH_CLIENT_SECRET", "test-client-secret"
+                )
+                return client_id, client_secret
+
+            # Register a new client per RFC 7591
+            redirect_uri = os.getenv(
+                "MCP_OAUTH_REDIRECT_URI",
+                "http://localhost:8000/api/mcp/oauth/callback",
+            )
+
+            registration_request = {
+                "application_type": "web",
+                "redirect_uris": [redirect_uri],
+                "client_name": f"Onyx MCP Client for {mcp_server.name}",
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "scope": os.getenv("MCP_OAUTH_SCOPE", "mcp:use"),
+                "token_endpoint_auth_method": "client_secret_post",
+            }
+
+            reg_resp = client.post(
+                registration_endpoint,
+                json=registration_request,
+                headers={"Content-Type": "application/json"},
+            )
+
+            if reg_resp.status_code not in (200, 201):
+                logger.error(f"Dynamic client registration failed: {reg_resp.text}")
+                # Fall back to environment variables
+                client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
+                client_secret = os.getenv(
+                    "MCP_OAUTH_CLIENT_SECRET", "test-client-secret"
+                )
+                return client_id, client_secret
+
+            reg_data = reg_resp.json()
+            client_id = reg_data.get("client_id")
+            client_secret = reg_data.get("client_secret")
+
+            # Ensure we have a valid client_id
+            if not client_id or not isinstance(client_id, str):
+                logger.error(f"Invalid client_id in registration response: {client_id}")
+                # Fall back to environment variables
+                client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
+                client_secret = os.getenv(
+                    "MCP_OAUTH_CLIENT_SECRET", "test-client-secret"
+                )
+                return client_id, client_secret
+
+            # Store the registered client info in the admin connection config
+            if not admin_config:
+                admin_config = create_connection_config(
+                    mcp_server_id=mcp_server.id,
+                    user_email="",  # Admin config
+                    config_data=MCPConnectionData(
+                        client_id=client_id,
+                        client_secret=client_secret
+                        or "",  # Provide empty string if None
+                        registration_access_token=reg_data.get(
+                            "registration_access_token"
+                        ),
+                        registration_client_uri=reg_data.get("registration_client_uri"),
+                        headers={},
+                    ),
+                    db_session=db,
+                )
+                mcp_server.admin_connection_config = admin_config
+            else:
+                # Update existing config with client registration
+                if not admin_config.config:
+                    admin_config.config = {}
+                admin_config.config.update(
+                    {
+                        "client_id": client_id,
+                        "client_secret": client_secret
+                        or "",  # Provide empty string if None
+                        "registration_access_token": reg_data.get(
+                            "registration_access_token"
+                        ),
+                        "registration_client_uri": reg_data.get(
+                            "registration_client_uri"
+                        ),
+                    }
+                )
+
+            db.add(admin_config)
+            db.commit()
+
+            logger.info(
+                f"Successfully registered OAuth client for {mcp_server.name}: {client_id}"
+            )
+            return client_id, client_secret
+
+    except Exception as e:
+        logger.error(f"Failed to register OAuth client: {e}")
+        # Fall back to environment variables
+        return (
+            os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id"),
+            os.getenv("MCP_OAUTH_CLIENT_SECRET", "test-client-secret"),
+        )
+
+
+@router.post("/oauth/register", response_model=MCPDynamicClientRegistrationResponse)
+def register_oauth_client(
+    request: MCPDynamicClientRegistrationRequest,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPDynamicClientRegistrationResponse:
+    """Manually trigger dynamic client registration for an MCP server."""
+
+    try:
+        mcp_server = get_mcp_server_by_id(request.server_id, db)
+    except Exception:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    client_id, client_secret = _get_or_register_oauth_client(
+        mcp_server, request.authorization_server_url, db
+    )
+
+    return MCPDynamicClientRegistrationResponse(
+        client_id=client_id,
+        client_secret=client_secret,
+        registration_access_token=None,  # Not exposed via API for security
+        registration_client_uri=None,  # Not exposed via API for security
+    )
+
+
+def fetch_json(url: str) -> dict:
+    with httpx.Client(timeout=15.0) as c:
+        r = c.get(url)
+        r.raise_for_status()
+        return r.json()
+
+
+def fetch_as_metadata(issuer: str) -> dict:
+    # RFC 8414 discovery
+    # Try the OAuth AS metadata path first; fall back to OIDC if needed
+    urls = [
+        f"{issuer}/.well-known/oauth-authorization-server",
+        f"{issuer}/.well-known/openid-configuration",
+    ]
+    for u in urls:
+        try:
+            return fetch_json(u)
+        except Exception as e:
+            logger.debug(f"Failed to fetch authorization server metadata from {u}: {e}")
+    raise RuntimeError("Could not fetch authorization server metadata")
+
+
+def b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def make_pkce_pair() -> tuple[str, str]:
+    verifier = b64url(token_urlsafe(64).encode())
+    challenge = b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+class MCPOauthState(BaseModel):
+    server_id: int
+    verifier: str
+    return_path: str
+    token_endpoint: str
+    is_admin: bool
+
+
+def redis_state_key(state: str) -> str:
+    return _OAUTH_STATE_KEY_FMT.format(state=state)
+
+
+@admin_router.post("/oauth/initiate", response_model=MCPUserOAuthInitiateResponse)
+def initiate_admin_oauth(
+    request: MCPUserOAuthInitiateRequest,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPUserOAuthInitiateResponse:
+    """Initiate OAuth flow for admin MCP server authentication"""
+    return _initiate_oauth(request, db, is_admin=True)
+
+
+@router.post("/oauth/initiate", response_model=MCPUserOAuthInitiateResponse)
+def initiate_user_oauth(
+    request: MCPUserOAuthInitiateRequest,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPUserOAuthInitiateResponse:
+    return _initiate_oauth(request, db, is_admin=False)
+
+
+def _initiate_oauth(
+    request: MCPUserOAuthInitiateRequest,
+    db: Session,
+    is_admin: bool,
+) -> MCPUserOAuthInitiateResponse:
+    """Initiate OAuth flow for per-user MCP server authentication"""
+
+    logger.info(f"Initiating per-user OAuth for server: {request.server_id}")
+
+    try:
+        server_id = int(request.server_id)
+        mcp_server = get_mcp_server_by_id(server_id, db)
+    except Exception:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    if mcp_server.auth_type != MCPAuthenticationType.OAUTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Server was configured with authentication type {mcp_server.auth_type.value}",
+        )
+    if (
+        mcp_server.admin_connection_config is None
+        or mcp_server.admin_connection_config.config.get("client_id") is None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="MCP server is not configured with an OAuth client ID",
+        )
+
+    # Step 1: make unauthenticated request and parse returned www authenticate header
+    # Ensure we have a trailing slash for the MCP endpoint
+    probe_url = mcp_server.server_url.rstrip("/") + "/"
+    logger.info(f"Probing OAuth server at: {probe_url}")
+
+    auth_info = ""
+    auth_server_url = ""
+    scopes = []
+    with httpx.Client(timeout=5.0, follow_redirects=True) as client:
+        resp = client.post(probe_url)  # POST for MCP streamable-http
+
+        if resp.status_code == 401:
+
+            # 401 means we need to authenticate
+            auth_info = _parse_www_authenticate(resp.headers["WWW-Authenticate"])
+            logger.info(f"WWW-Authenticate header: {auth_info}")
+
+            well_known_resp = client.get(auth_info)
+            logger.info(f"Response: {well_known_resp.text}")
+            wk_json = well_known_resp.json()
+            as_uris = wk_json.get("authorization_servers", [])
+            if not as_uris:
+                raise HTTPException(
+                    status_code=400,
+                    detail="No authorization servers retrieved from MCP resource discovery",
+                )
+            auth_server_url = as_uris[0]
+            logger.info(f"Authorization server URL: {auth_server_url}")
+            scopes = wk_json.get("scopes_supported", [])
+            logger.info(f"Scopes: {scopes}")
+
+    issuer_meta = fetch_as_metadata(auth_server_url)
+
+    authz_ep = issuer_meta["authorization_endpoint"]
+    token_ep = issuer_meta["token_endpoint"]
+    logger.info(f"Authorization endpoint: {authz_ep}")
+    logger.info(f"Token endpoint: {token_ep}")
+
+    if not authz_ep or not token_ep:
+        raise HTTPException(
+            status_code=400,
+            detail="No authorization or token endpoint found in authorization server metadata",
+        )
+
+    verifier, challenge = make_pkce_pair()
+    state = token_urlsafe(24)
+    scope_str = " ".join(scopes)
+    redis_client = get_redis_client()
+    state_data = MCPOauthState(
+        server_id=int(request.server_id),
+        verifier=verifier,
+        return_path=request.return_path,
+        token_endpoint=token_ep,
+        is_admin=is_admin,
+    )
+    redis_client.set(
+        redis_state_key(state),
+        state_data.model_dump_json(),
+        ex=_OAUTH_STATE_EXPIRATION_SECONDS,
+    )
+
+    redirect_uri = f"{WEB_DOMAIN}/mcp/oauth/callback"
+
+    # Build authorization URL
+    authz_params = {
+        "response_type": "code",
+        "client_id": mcp_server.admin_connection_config.config.get("client_id"),
+        "redirect_uri": redirect_uri,
+        "scope": scope_str,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    # Many AS’s (and the MCP OAuth guidance) support binding tokens to the resource URL.
+    if request.include_resource_param:
+        authz_params["resource"] = (
+            mcp_server.server_url
+        )  # ignored if server doesn’t support RFC 8707
+
+    authz_url = f"{authz_ep}?{urlencode(authz_params)}"
+
+    logger.info(f"Generated OAuth URL: {authz_url}")
+
+    return MCPUserOAuthInitiateResponse(
+        oauth_url=authz_url,
+        state=state,
+        server_id=int(request.server_id),
+        server_name=mcp_server.name,
+        code_verifier=verifier,
+    )
+
+
+@router.post("/oauth/callback", response_model=MCPOAuthCallbackResponse)
+def process_oauth_callback(
+    request: Request,
+    db_session: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPOAuthCallbackResponse:
+    """Complete OAuth flow by exchanging code for tokens and storing them.
+
+    Notes:
+    - For demo/test servers (like run_mcp_server_oauth.py), the token endpoint
+      and parameters may be fixed. In production, use the server's metadata
+      (e.g., well-known endpoints) to discover token URL and scopes.
+    """
+
+    # Get callback data from query parameters (like federated OAuth does)
+    callback_data = dict(request.query_params)
+
+    redis_client = get_redis_client()
+    state = callback_data.get("state")
+    code = callback_data.get("code")
+    if not state:
+        raise HTTPException(status_code=400, detail="Missing state parameter")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing code parameter")
+    stored_data = cast(bytes, redis_client.get(redis_state_key(state)))
+    if not stored_data:
+        raise HTTPException(
+            status_code=400, detail="Invalid or expired state parameter"
+        )
+    state_data = MCPOauthState.model_validate_json(stored_data)
+    try:
+        server_id = state_data.server_id
+        mcp_server = get_mcp_server_by_id(server_id, db_session)
+    except Exception:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    if not mcp_server.admin_connection_config:
+        raise HTTPException(
+            status_code=400,
+            detail="Server referenced by callback is not configured, try recreating",
+        )
+    client_id = mcp_server.admin_connection_config.config.get("client_id")
+    client_secret = mcp_server.admin_connection_config.config.get("client_secret")
+    if not client_id or not client_secret:
+        raise HTTPException(status_code=400, detail="No client ID or secret found")
+
+    if mcp_server.auth_type != MCPAuthenticationType.OAUTH.value:
+        raise HTTPException(status_code=400, detail="Server is not OAuth-enabled")
+
+    email = user.email if user else ""
+
+    redirect_uri = f"{WEB_DOMAIN}/mcp/oauth/callback"
+
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": state_data.verifier,
+        # optional if using resource indicators:
+        "resource": mcp_server.server_url,
+    }
+
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    with httpx.Client(timeout=30) as client:
+        # confidential client → HTTP Basic
+        resp = client.post(
+            state_data.token_endpoint,
+            data=form,
+            headers=headers,
+            auth=(client_id, client_secret),
+        )
+        resp.raise_for_status()
+        token_payload = resp.json()
+        access_token = token_payload.get("access_token")
+        refresh_token = token_payload.get("refresh_token")
+        token_type = token_payload.get("token_type", "Bearer")
+
+    if not access_token:
+        raise HTTPException(status_code=400, detail="No access_token in OAuth response")
+
+    # Persist tokens in user's connection config
+    config_data: dict[str, Any] = {
+        "access_token": access_token,
+        "token_type": token_type,
+    }
+    if refresh_token:
+        config_data["refresh_token"] = refresh_token
+
+    cfg_headers = {"Authorization": f"{token_type} {access_token}"}
+
+    cfg = MCPConnectionData(
+        headers=cfg_headers,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        client_id=client_id,
+        client_secret=client_secret,
+        header_substitutions={},
+    )
+
+    upsert_user_connection_config(
+        server_id=mcp_server.id,
+        user_email=email,
+        config_data=cfg,
+        db_session=db_session,
+    )
+
+    if state_data.is_admin:
+        update_connection_config(
+            mcp_server.admin_connection_config.id,
+            db_session,
+            cfg,
+        )
+
+    db_session.commit()
+
+    # Optionally validate by listing tools
+    validated = False
+    try:
+        is_valid, _ = test_mcp_server_credentials(
+            mcp_server.server_url,
+            {"Authorization": f"{token_type} {access_token}"},
+            "streamable-http",  # TODO: make configurable?
+        )
+        validated = is_valid
+    except Exception as e:
+        logger.warning(f"Could not validate OAuth token with MCP server: {e}")
+
+    logger.info(
+        f"OAuth tokens saved: {validated} "
+        f"server_id={str(mcp_server.id)} "
+        f"server_name={mcp_server.name} "
+        f"return_path={state_data.return_path}"
+    )
+
+    # Return typed response for the frontend API call
+    return MCPOAuthCallbackResponse(
+        success=True,
+        server_id=mcp_server.id,
+        server_name=mcp_server.name,
+        authenticated=validated,
+        message=f"OAuth authorization completed successfully for {mcp_server.name}",
+        redirect_url=state_data.return_path,
+    )
+
+
+@router.post("/user-credentials", response_model=MCPApiKeyResponse)
+def save_user_credentials(
+    request: MCPUserCredentialsRequest,
+    db_session: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPApiKeyResponse:
+    """Save user credentials for template-based MCP server authentication"""
+
+    logger.info(f"Saving user credentials for server: {request.server_id}")
+
+    try:
+        server_id = request.server_id
+        mcp_server = get_mcp_server_by_id(server_id, db_session)
+    except Exception:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    if mcp_server.auth_type == "none":
+        raise HTTPException(
+            status_code=400,
+            detail="Server does not require authentication",
+        )
+
+    email = user.email if user else ""
+
+    # Get the authentication template for this server
+    auth_template = get_server_auth_template(server_id, db_session)
+    if not auth_template:
+        # Fallback to simple API key storage for servers without templates
+        if "api_key" not in request.credentials:
+            raise HTTPException(
+                status_code=400,
+                detail="No authentication template found and no api_key provided",
+            )
+        config_data = MCPConnectionData(
+            headers={"Authorization": f"Bearer {request.credentials['api_key']}"},
+        )
+    else:
+        # Use template to create the full connection config
+        try:
+            # TODO: fix and/or type correctly w/base model
+            config_data = MCPConnectionData(
+                headers=auth_template.config.get("headers", {}),
+                header_substitutions=auth_template.config.get(
+                    "header_substitutions", {}
+                ),
+                client_id=auth_template.config.get("client_id", ""),
+                client_secret=auth_template.config.get("client_secret", ""),
+                registration_access_token=auth_template.config.get(
+                    "registration_access_token", ""
+                ),
+                registration_client_uri=auth_template.config.get(
+                    "registration_client_uri", ""
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to process authentication template: {e}")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Failed to process authentication template: {str(e)}",
+            )
+
+    # Test the credentials before saving
+    validation_tested = False
+    validation_message = "Credentials saved successfully"
+
+    try:
+        is_valid, test_message = test_mcp_server_credentials(
+            mcp_server.server_url, config_data["headers"], transport=request.transport
+        )
+        validation_tested = True
+
+        if not is_valid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Credentials validation failed: {test_message}",
+            )
+        else:
+            validation_message = (
+                f"Credentials saved and validated successfully. {test_message}"
+            )
+
+    except HTTPException:
+        raise  # Re-raise HTTP exceptions
+    except Exception as e:
+        logger.warning(
+            f"Could not validate credentials for server {mcp_server.name}: {e}"
+        )
+        validation_message = "Credentials saved but could not be validated"
+
+    try:
+        # Save the processed credentials
+        upsert_user_connection_config(
+            server_id=server_id,
+            user_email=email,
+            config_data=config_data,
+            db_session=db_session,
+        )
+
+        logger.info(
+            f"User credentials saved for server {mcp_server.name} and user {email}"
+        )
+        db_session.commit()
+
+        return MCPApiKeyResponse(
+            success=True,
+            message=validation_message,
+            server_id=request.server_id,
+            server_name=mcp_server.name,
+            authenticated=True,
+            validation_tested=validation_tested,
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to save user credentials: {e}")
+        raise HTTPException(status_code=500, detail="Failed to save user credentials")
+
+
+class MCPToolDescription(BaseModel):
+    id: int
+    name: str
+    display_name: str
+    description: str
+
+
+class ServerToolsResponse(BaseModel):
+    server_id: int
+    server_name: str
+    server_url: str
+    tools: list[MCPToolDescription]
+
+
+def _db_mcp_server_to_api_mcp_server(
+    db_server: DbMCPServer, email: str, db: Session, include_auth_config: bool = False
+) -> MCPServer:
+    """Convert database MCP server to API model"""
+
+    # Determine auth performer based on whether per_user_template exists
+    auth_performer = get_mcp_server_auth_performer(db_server)
+
+    # Check if user has authentication configured and extract credentials
+    user_authenticated: bool | None = None
+    user_credentials = None
+    admin_credentials = None
+    if db_server.auth_type == MCPAuthenticationType.NONE:
+        user_authenticated = True  # No auth required
+    elif auth_performer == MCPAuthenticationPerformer.ADMIN:
+        user_authenticated = db_server.admin_connection_config is not None
+        if include_auth_config and db_server.admin_connection_config is not None:
+            if db_server.auth_type == MCPAuthenticationType.API_TOKEN:
+                admin_credentials = {
+                    "api_key": db_server.admin_connection_config.config["headers"][
+                        "Authorization"
+                    ].split(" ")[-1]
+                }
+            elif db_server.auth_type == MCPAuthenticationType.OAUTH:
+                user_authenticated = False
+                admin_credentials = {
+                    "client_id": db_server.admin_connection_config.config["client_id"],
+                    "client_secret": db_server.admin_connection_config.config[
+                        "client_secret"
+                    ],
+                }
+    else:  # currently: per user auth using api key OR oauth
+        user_config = get_user_connection_config(db_server.id, email, db)
+        user_authenticated = user_config is not None
+
+        # Test existing credentials if they exist
+        if user_authenticated and user_config:
+            try:
+                is_valid, _ = test_mcp_server_credentials(
+                    db_server.server_url, user_config.config.get("headers", {})
+                )
+                user_authenticated = is_valid
+                if (
+                    include_auth_config
+                    and db_server.auth_type != MCPAuthenticationType.OAUTH
+                ):
+                    user_credentials = user_config.config.get(
+                        "header_substitutions", {}
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to test user credentials for server {db_server.name}: {e}"
+                )
+                # Keep user_authenticated as True if we can't test, to avoid breaking existing flows
+
+        if (
+            db_server.auth_type == MCPAuthenticationType.OAUTH
+            and db_server.admin_connection_config
+        ):
+            admin_credentials = {
+                "client_id": db_server.admin_connection_config.config["client_id"],
+                "client_secret": db_server.admin_connection_config.config[
+                    "client_secret"
+                ],
+            }
+
+    # Get auth template if this is a per-user auth server
+    auth_template = None
+    if auth_performer == MCPAuthenticationPerformer.PER_USER:
+        try:
+            template_config = db_server.admin_connection_config
+            if template_config:
+                headers = template_config.config.get("headers", {})
+                auth_template = MCPAuthTemplate(
+                    headers=headers,
+                    required_fields=[],  # would need to regex, not worth it
+                )
+        except Exception as e:
+            logger.warning(
+                f"Failed to parse auth template for server {db_server.name}: {e}"
+            )
+
+    is_authenticated: bool = (
+        db_server.auth_type == MCPAuthenticationType.NONE.value
+        or (
+            auth_performer == MCPAuthenticationPerformer.ADMIN
+            and db_server.auth_type != MCPAuthenticationType.OAUTH
+            and db_server.admin_connection_config_id is not None
+        )
+        or (
+            auth_performer == MCPAuthenticationPerformer.PER_USER and user_authenticated
+        )
+    )
+
+    return MCPServer(
+        id=db_server.id,
+        name=db_server.name,
+        description=db_server.description,
+        server_url=db_server.server_url,
+        auth_type=db_server.auth_type,
+        auth_performer=auth_performer,
+        is_authenticated=is_authenticated,
+        user_authenticated=user_authenticated,
+        auth_template=auth_template,
+        user_credentials=user_credentials,
+        admin_credentials=admin_credentials,
+    )
+
+
+@router.get("/servers/{assistant_id}", response_model=MCPServersResponse)
+def get_mcp_servers_for_assistant(
+    assistant_id: str,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPServersResponse:
+    """Get MCP servers for an assistant"""
+
+    logger.info(f"Fetching MCP servers for assistant: {assistant_id}")
+
+    email = user.email if user else ""
+    try:
+        persona_id = int(assistant_id)
+        db_mcp_servers = get_mcp_servers_for_persona(persona_id, db, user)
+
+        # Convert to API model format with opportunistic token refresh for OAuth
+        mcp_servers: list[MCPServer] = []
+        for db_server in db_mcp_servers:
+            # TODO: oauth stuff
+            # if db_server.auth_type == MCPAuthenticationType.OAUTH.value:
+            #     # Try refresh if we have refresh token
+            #     user_cfg = get_user_connection_config(db_server.id, email, db)
+            #     if user_cfg and isinstance(user_cfg.config, dict):
+            #         cfg = user_cfg.config
+            #         if cfg.get("refresh_token"):
+            #             # Get client credentials from admin config if available
+            #             client_id = None
+            #             client_secret = None
+            #             admin_cfg = db_server.admin_connection_config
+            #             if admin_cfg and admin_cfg.config and isinstance(admin_cfg.config, dict):
+            #                 client_id = admin_cfg.config.get("client_id")
+            #                 client_secret = admin_cfg.config.get("client_secret")
+
+            #             token_payload = refresh_oauth_token(
+            #                 db_server.server_url,
+            #                 cfg,
+            #                 client_id=client_id,
+            #                 client_secret=client_secret,
+            #             )
+            #             if token_payload and token_payload.get("access_token"):
+            #                 # Update stored tokens and headers
+            #                 access_token = token_payload["access_token"]
+            #                 token_type = token_payload.get("token_type", "Bearer")
+            #                 refresh_token = token_payload.get("refresh_token") or cfg.get("refresh_token")
+            #                 user_cfg.config.update(
+            #                     {
+            #                         "access_token": access_token,
+            #                         "refresh_token": refresh_token,
+            #                         "token_type": token_type,
+            #                         "headers": {"Authorization": f"{token_type} {access_token}"},
+            #                     }
+            #                 )
+            #                 db.add(user_cfg)
+            #                 db.commit()
+
+            mcp_servers.append(_db_mcp_server_to_api_mcp_server(db_server, email, db))
+
+        return MCPServersResponse(assistant_id=assistant_id, mcp_servers=mcp_servers)
+
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid assistant ID")
+    except Exception as e:
+        logger.error(f"Failed to fetch MCP servers: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch MCP servers")
+
+
+@admin_router.get("/server/{server_id}/tools")
+def admin_list_mcp_tools_by_id(
+    server_id: int,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPToolListResponse:
+    return _list_mcp_tools_by_id(server_id, db, True, user)
+
+
+@router.get("/server/{server_id}/tools")
+def user_list_mcp_tools_by_id(
+    server_id: int,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> MCPToolListResponse:
+    return _list_mcp_tools_by_id(server_id, db, False, user)
+
+
+def _get_connection_config(
+    mcp_server: DbMCPServer, is_admin: bool, user: User | None, db_session: Session
+) -> MCPConnectionConfig | None:
+    """Get the connection config for an MCP server"""
+    if mcp_server.auth_type == MCPAuthenticationType.NONE:
+        return None
+
+    if (
+        mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
+        and get_mcp_server_auth_performer(mcp_server)
+        == MCPAuthenticationPerformer.ADMIN
+    ) or (mcp_server.auth_type == MCPAuthenticationType.OAUTH and is_admin):
+        connection_config = mcp_server.admin_connection_config
+    else:
+        user_email = user.email if user else ""
+        connection_config = get_user_connection_config(
+            server_id=mcp_server.id, user_email=user_email, db_session=db_session
+        )
+
+    if not connection_config:
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required for this MCP server",
+        )
+
+    return connection_config
+
+
+def _list_mcp_tools_by_id(
+    server_id: int,
+    db: Session,
+    is_admin: bool,
+    user: User | None,
+) -> MCPToolListResponse:
+    """List available tools from an existing MCP server"""
+    logger.info(f"Listing tools for MCP server: {server_id}")
+
+    try:
+        # Get the MCP server
+        mcp_server = get_mcp_server_by_id(server_id, db)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    # Get connection config based on auth type
+    # TODO: for now, only the admin that set up a per-user api key server can
+    # see their configuration. This is probably not ideal. Other admins
+    # can of course put their own credentials in and list the tools.
+    connection_config = _get_connection_config(mcp_server, is_admin, user, db)
+
+    # Discover tools from the MCP server
+    tools = discover_mcp_tools(
+        mcp_server.server_url,
+        connection_config.config.get("headers", {}) if connection_config else {},
+    )
+
+    # TODO: Also list resources from the MCP server
+    # resources = discover_mcp_resources(mcp_server, connection_config)
+
+    return MCPToolListResponse(
+        server_id=server_id,
+        server_name=mcp_server.name,
+        server_url=mcp_server.server_url,
+        tools=tools,
+    )
+
+
+def _upsert_mcp_server(
+    request: MCPToolCreateRequest,
+    db_session: Session,
+    user: User | None,
+) -> DbMCPServer:
+    """
+    Creates a new or edits an existing MCP server. Returns the DB model
+    """
+    mcp_server = None
+    admin_config = None
+
+    changing_connection_config = True
+
+    # Handle existing server update
+    if request.existing_server_id:
+        try:
+            mcp_server = get_mcp_server_by_id(request.existing_server_id, db_session)
+        except ValueError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"MCP server with ID {request.existing_server_id} not found",
+            )
+        changing_connection_config = (
+            not mcp_server.admin_connection_config
+            or (
+                request.auth_type == MCPAuthenticationType.OAUTH
+                and (
+                    request.oauth_client_id
+                    != mcp_server.admin_connection_config.config["client_id"]
+                    or request.oauth_client_secret
+                    != mcp_server.admin_connection_config.config["client_secret"]
+                )
+            )
+            or (request.auth_type == MCPAuthenticationType.API_TOKEN)
+        )
+
+        # Cleanup: Delete existing connection configs
+        if changing_connection_config and mcp_server.admin_connection_config_id:
+            delete_connection_config(mcp_server.admin_connection_config_id, db_session)
+            if user and user.email:
+                delete_user_connection_configs_for_server(
+                    mcp_server.id, user.email, db_session
+                )
+
+        # Update the server with new values
+        mcp_server = update_mcp_server(
+            server_id=request.existing_server_id,
+            db_session=db_session,
+            name=request.name,
+            description=request.description,
+            server_url=request.server_url,
+            auth_type=request.auth_type,
+        )
+
+        logger.info(
+            f"Updated existing MCP server '{request.name}' with ID {mcp_server.id}"
+        )
+
+    else:
+        # Handle new server creation
+        # Prevent duplicate server creation with same URL
+        normalized_url = (request.server_url or "").strip()
+        if not normalized_url:
+            raise HTTPException(status_code=400, detail="server_url is required")
+
+        # Check existing servers for same server_url
+        existing_servers = get_all_mcp_servers(db_session)
+        existing_server = None
+        for server in existing_servers:
+            if server.server_url == normalized_url:
+                existing_server = server
+                break
+        if existing_server:
+            raise HTTPException(
+                status_code=409,
+                detail="An MCP server with this URL already exists for this owner",
+            )
+
+        # Create new MCP server
+        mcp_server = create_mcp_server(
+            owner_email=user.email if user else "",
+            name=request.name,
+            description=request.description,
+            server_url=request.server_url,
+            auth_type=request.auth_type,
+            db_session=db_session,
+        )
+
+        logger.info(f"Created new MCP server '{request.name}' with ID {mcp_server.id}")
+
+    if not changing_connection_config:
+        return mcp_server
+
+    # Create connection configs
+    admin_connection_config_id = None
+    if request.auth_performer == MCPAuthenticationPerformer.ADMIN and request.api_token:
+        # Admin-managed server: create admin config with API token
+        admin_config = create_connection_config(
+            config_data=MCPConnectionData(
+                headers={"Authorization": f"Bearer {request.api_token}"},
+            ),
+            mcp_server_id=mcp_server.id,
+            db_session=db_session,
+        )
+        admin_connection_config_id = admin_config.id
+
+    elif request.auth_performer == MCPAuthenticationPerformer.PER_USER:
+        if request.auth_type == MCPAuthenticationType.API_TOKEN:
+            # handled by model validation, this is just for mypy
+            assert request.auth_template and request.admin_credentials
+
+            # Per-user server: create template and save creator's per-user config
+            template_data = request.auth_template
+
+            # Create template config: faithful representation of what's in the admin panel
+            template_config = create_connection_config(
+                config_data=MCPConnectionData(
+                    headers=template_data.headers,
+                    header_substitutions=request.admin_credentials,
+                ),
+                mcp_server_id=mcp_server.id,
+                user_email="",
+                db_session=db_session,
+            )
+
+            # seed the user config for this admin user
+            if user:
+                user_config = create_connection_config(
+                    config_data=MCPConnectionData(
+                        headers=_build_headers_from_template(
+                            template_data, request.admin_credentials, user.email
+                        ),
+                        header_substitutions=request.admin_credentials,
+                    ),
+                    mcp_server_id=mcp_server.id,
+                    user_email=user.email if user else "",
+                    db_session=db_session,
+                )
+                user_config.mcp_server_id = mcp_server.id
+            admin_connection_config_id = template_config.id
+        elif request.auth_type == MCPAuthenticationType.OAUTH:
+            assert request.oauth_client_id and request.oauth_client_secret
+            admin_config = create_connection_config(
+                config_data=MCPConnectionData(
+                    client_id=request.oauth_client_id,
+                    client_secret=request.oauth_client_secret,
+                    headers={},  # will be set during oauth connection flow
+                ),
+                mcp_server_id=mcp_server.id,
+                user_email="",
+                db_session=db_session,
+            )
+            admin_connection_config_id = admin_config.id
+    elif request.auth_performer == MCPAuthenticationPerformer.ADMIN:
+        raise HTTPException(
+            status_code=400,
+            detail="Admin authentication is not yet supported for MCP servers: user per-user",
+        )
+
+    # Update server with config IDs
+    if admin_connection_config_id is not None:
+        mcp_server = update_mcp_server(
+            server_id=mcp_server.id,
+            db_session=db_session,
+            admin_connection_config_id=admin_connection_config_id,
+        )
+
+    return mcp_server
+
+
+def _add_tools_to_server(
+    mcp_server: DbMCPServer,
+    selected_tools: list[str],
+    keep_tool_names: set[str],
+    user: User | None,
+    db_session: Session,
+) -> int:
+    created_tools = 0
+    # First, discover available tools from the server to get full definitions
+    # TODO: make this configurable
+    transport = "streamable-http"
+
+    connection_config = _get_connection_config(mcp_server, True, user, db_session)
+    headers = connection_config.config.get("headers", {}) if connection_config else {}
+
+    available_tools = discover_mcp_tools(
+        mcp_server.server_url, headers, transport=transport
+    )
+    tools_by_name = {tool.name: tool for tool in available_tools}
+
+    for tool_name in selected_tools:
+        if tool_name not in tools_by_name:
+            logger.warning(f"Tool '{tool_name}' not found in MCP server")
+            continue
+
+        if tool_name in keep_tool_names:
+            # tool was not deleted earlier and not added now
+            continue
+
+        tool_def = tools_by_name[tool_name]
+
+        # Create Tool entry for each selected tool
+        tool = create_tool__no_commit(
+            name=tool_name,
+            description=tool_def.description,
+            openapi_schema=None,  # MCP tools don't use OpenAPI
+            custom_headers=None,
+            user_id=user.id if user else None,
+            db_session=db_session,
+            passthrough_auth=False,
+        )
+
+        # Update the tool with MCP server ID, display name, and input schema
+        tool.mcp_server_id = mcp_server.id
+        annotations_title = tool_def.annotations.title if tool_def.annotations else None
+        tool.display_name = tool_def.title or annotations_title or tool_name
+        tool.mcp_input_schema = tool_def.inputSchema
+
+        created_tools += 1
+
+        logger.info(f"Created MCP tool '{tool.name}' with ID {tool.id}")
+    return created_tools
+
+
+@admin_router.get("/servers/{server_id}", response_model=MCPServer)
+def get_mcp_server_detail(
+    server_id: int,
+    db_session: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPServer:
+    """Return details for one MCP server if user has access"""
+    try:
+        server = get_mcp_server_by_id(server_id, db_session)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    email = user.email if user else ""
+
+    # TODO: user permissions per mcp server not yet implemented, for now
+    # permissions are based on access to assistants
+    # # Quick permission check – admin or user has access
+    # if user and server not in user.accessible_mcp_servers and not user.is_superuser:
+    #     raise HTTPException(status_code=403, detail="Forbidden")
+
+    return _db_mcp_server_to_api_mcp_server(
+        server, email, db_session, include_auth_config=True
+    )
+
+
+@admin_router.get("/servers", response_model=MCPServersResponse)
+def get_mcp_servers_for_admin(
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPServersResponse:
+    """Get all MCP servers for admin display"""
+
+    logger.info("Fetching all MCP servers for admin display")
+
+    email = user.email if user else ""
+    try:
+        db_mcp_servers = get_all_mcp_servers(db)
+
+        # Convert to API model format
+        mcp_servers = [
+            _db_mcp_server_to_api_mcp_server(db_server, email, db)
+            for db_server in db_mcp_servers
+        ]
+
+        return MCPServersResponse(mcp_servers=mcp_servers)
+
+    except Exception as e:
+        logger.error(f"Failed to fetch MCP servers: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch MCP servers")
+
+
+@admin_router.get("/server/{server_id}/db-tools")
+def get_mcp_server_db_tools(
+    server_id: int,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_user),
+) -> ServerToolsResponse:
+    """Get existing database tools created for an MCP server"""
+    logger.info(f"Getting database tools for MCP server: {server_id}")
+
+    try:
+        # Verify the server exists
+        mcp_server = get_mcp_server_by_id(server_id, db)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    # Get all tools associated with this MCP server
+    mcp_tools = get_tools_by_mcp_server_id(server_id, db)
+
+    # Convert to response format
+    tools_data = []
+    for tool in mcp_tools:
+        # Extract the tool name from the full name (remove server prefix)
+        tool_name = tool.name
+        if tool.mcp_server and tool_name.startswith(f"{tool.mcp_server.name}_"):
+            tool_name = tool_name[len(f"{tool.mcp_server.name}_") :]
+
+        tools_data.append(
+            MCPToolDescription(
+                id=tool.id,
+                name=tool_name,
+                display_name=tool.display_name or tool_name,
+                description=tool.description or "",
+            )
+        )
+
+    return ServerToolsResponse(
+        server_id=server_id,
+        server_name=mcp_server.name,
+        server_url=mcp_server.server_url,
+        tools=tools_data,
+    )
+
+
+@admin_router.post("/servers/create", response_model=MCPServerCreateResponse)
+def upsert_mcp_server_with_tools(
+    request: MCPToolCreateRequest,
+    db_session: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPServerCreateResponse:
+    """Create or update an MCP server and associated tools"""
+
+    # Validate auth_performer for non-none auth types
+    if request.auth_type != MCPAuthenticationType.NONE and not request.auth_performer:
+        raise HTTPException(
+            status_code=400, detail="auth_performer is required for non-none auth types"
+        )
+
+    try:
+        mcp_server = _upsert_mcp_server(request, db_session, user)
+
+        if (
+            request.auth_type != MCPAuthenticationType.NONE
+            and mcp_server.admin_connection_config_id is None
+        ):
+            raise HTTPException(
+                status_code=500, detail="Failed to set admin connection config"
+            )
+        db_session.commit()
+
+        action_verb = "Updated" if request.existing_server_id else "Created"
+        logger.info(
+            f"{action_verb} MCP server '{request.name}' with ID {mcp_server.id}"
+        )
+
+        return MCPServerCreateResponse(
+            server_id=mcp_server.id,
+            server_name=mcp_server.name,
+            server_url=mcp_server.server_url,
+            auth_type=mcp_server.auth_type,
+            auth_performer=(
+                request.auth_performer.value if request.auth_performer else None
+            ),
+            is_authenticated=(
+                mcp_server.auth_type == MCPAuthenticationType.NONE.value
+                or request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            ),
+        )
+
+    except HTTPException:
+        # Re-raise HTTP exceptions as-is
+        raise
+    except Exception as e:
+        logger.exception("Failed to create/update MCP tool")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to create/update MCP tool: {str(e)}"
+        )
+
+
+@admin_router.post("/servers/update", response_model=MCPServerUpdateResponse)
+def update_mcp_server_with_tools(
+    request: MCPToolUpdateRequest,
+    db_session: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> MCPServerUpdateResponse:
+    """Update an MCP server and associated tools"""
+
+    try:
+        mcp_server = get_mcp_server_by_id(request.server_id, db_session)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+
+    if (
+        mcp_server.admin_connection_config_id is None
+        and mcp_server.auth_type != MCPAuthenticationType.NONE
+    ):
+        raise HTTPException(
+            status_code=400, detail="MCP server has no admin connection config"
+        )
+
+    # Cleanup: Delete tools for this server that are not in the selected_tools list
+    selected_names = set(request.selected_tools or [])
+    existing_tools = get_tools_by_mcp_server_id(request.server_id, db_session)
+    keep_tool_names = set()
+    updated_tools = 0
+    for tool in existing_tools:
+        if tool.name in selected_names:
+            keep_tool_names.add(tool.name)
+        else:
+            delete_tool(tool.id, db_session)
+            updated_tools += 1
+    # If selected_tools is provided, create individual tools for each
+
+    if request.selected_tools:
+        updated_tools += _add_tools_to_server(
+            mcp_server,
+            request.selected_tools,
+            keep_tool_names,
+            user,
+            db_session,
+        )
+
+    db_session.commit()
+
+    return MCPServerUpdateResponse(
+        server_id=mcp_server.id,
+        updated_tools=updated_tools,
+    )
+
+
+@admin_router.delete("/server/{server_id}")
+def delete_mcp_server_admin(
+    server_id: int,
+    db: Session = Depends(get_session),
+    user: User | None = Depends(current_admin_user),
+) -> dict:
+    """Delete an MCP server and cascading related objects (tools, configs)."""
+    try:
+        # Ensure it exists
+        server = get_mcp_server_by_id(server_id, db)
+
+        # Log tools that will be deleted for debugging
+        tools_to_delete = get_tools_by_mcp_server_id(server_id, db)
+        logger.info(
+            f"Deleting MCP server {server_id} ({server.name}) with {len(tools_to_delete)} tools"
+        )
+        for tool in tools_to_delete:
+            logger.debug(f"  - Tool to delete: {tool.name} (ID: {tool.id})")
+
+        # Cascade behavior handled by FK ondelete in DB
+        delete_mcp_server(server_id, db)
+
+        # Verify tools were deleted
+        remaining_tools = get_tools_by_mcp_server_id(server_id, db)
+        if remaining_tools:
+            logger.error(
+                f"WARNING: {len(remaining_tools)} tools still exist after deleting MCP server {server_id}"
+            )
+            # Manually delete them as a fallback
+            for tool in remaining_tools:
+                logger.info(
+                    f"Manually deleting orphaned tool: {tool.name} (ID: {tool.id})"
+                )
+                delete_tool(tool.id, db)
+            db.commit()
+
+        return {"success": True}
+    except ValueError:
+        raise HTTPException(status_code=404, detail="MCP server not found")
+    except Exception as e:
+        logger.error(f"Failed to delete MCP server {server_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to delete MCP server")

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,0 +1,301 @@
+from typing import List
+from typing import NotRequired
+from typing import Optional
+from typing import TypedDict
+
+from mcp.types import Tool as MCPLibTool
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+
+
+class MCPConnectionData(TypedDict):
+    """TypedDict to allow use as a type hint for a JSONB column
+    in Postgres"""
+
+    refresh_token: NotRequired[str]
+    access_token: NotRequired[str]
+    headers: dict[str, str]
+    header_substitutions: NotRequired[dict[str, str]]
+    client_id: NotRequired[str]
+    client_secret: NotRequired[str]
+    registration_access_token: NotRequired[str]
+    registration_client_uri: NotRequired[str]
+
+
+class MCPAuthTemplate(BaseModel):
+    """Template for per-user authentication configuration"""
+
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="Map of header names to templates with placeholders",
+    )
+    # request_body_params: List[dict[str, str]] = Field(
+    #     default_factory=list,
+    #     description="List of request body parameter templates with path/value pairs",
+    # ) # not used yet
+    required_fields: List[str] = Field(
+        default_factory=list,
+        description="List of required field names that users must provide",
+    )
+
+
+class MCPToolCreateRequest(BaseModel):
+    name: str = Field(..., description="Name of the MCP tool")
+    description: Optional[str] = Field(None, description="Description of the MCP tool")
+    server_url: str = Field(..., description="URL of the MCP server")
+    auth_type: MCPAuthenticationType = Field(..., description="Authentication type")
+    auth_performer: Optional[MCPAuthenticationPerformer] = Field(
+        None, description="Who performs authentication"
+    )
+    api_token: Optional[str] = Field(
+        None, description="API token for api_token auth type"
+    )
+    oauth_client_id: Optional[str] = Field(None, description="OAuth client ID")
+    oauth_client_secret: Optional[str] = Field(None, description="OAuth client secret")
+    auth_template: Optional[MCPAuthTemplate] = Field(
+        None, description="Template configuration for per-user authentication"
+    )
+    admin_credentials: Optional[dict[str, str]] = Field(
+        None,
+        description="Admin's credential key-value pairs for template substitution and storage",
+    )
+    existing_server_id: Optional[int] = Field(
+        None, description="ID of existing server to update (for editing)"
+    )
+
+    @model_validator(mode="after")
+    def validate_auth_configuration(self) -> "MCPToolCreateRequest":
+        # Validate API token requirements for admin auth
+        if (
+            self.auth_type == MCPAuthenticationType.API_TOKEN
+            and self.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and not self.api_token
+        ):
+            raise ValueError(
+                "api_token is required when auth_type is 'api_token' and auth_performer is 'admin'"
+            )
+
+        # Validate that API token is not provided for per-user auth
+        if (
+            self.auth_type == MCPAuthenticationType.API_TOKEN
+            and self.auth_performer == MCPAuthenticationPerformer.PER_USER
+            and self.api_token
+            and self.api_token.strip()
+        ):
+            raise ValueError(
+                "api_token should not be provided when auth_performer is 'per_user'. Users will provide their own credentials."
+            )
+
+        # Validate that auth_template is provided for per-user auth
+        if (
+            self.auth_type == MCPAuthenticationType.API_TOKEN
+            and self.auth_performer == MCPAuthenticationPerformer.PER_USER
+        ):
+            if not self.auth_template:
+                raise ValueError(
+                    "auth_template is required when auth_performer is 'per_user'"
+                )
+            if not self.admin_credentials:
+                raise ValueError(
+                    "admin_credentials is required when auth_performer is 'per_user'"
+                )
+
+        if self.auth_type == MCPAuthenticationType.OAUTH and not self.oauth_client_id:
+            raise ValueError("oauth_client_id is required when auth_type is 'oauth'")
+        if (
+            self.auth_type == MCPAuthenticationType.OAUTH
+            and not self.oauth_client_secret
+        ):
+            raise ValueError(
+                "oauth_client_secret is required when auth_type is 'oauth'"
+            )
+
+        return self
+
+
+class MCPToolUpdateRequest(BaseModel):
+    server_id: int = Field(..., description="ID of the MCP server")
+    selected_tools: Optional[List[str]] = Field(
+        None, description="List of selected tool names to create"
+    )
+
+
+class MCPToolResponse(BaseModel):
+    id: int
+    name: str
+    display_name: str
+    description: str
+    definition: Optional[dict] = None  # MCP tools don't use OpenAPI definitions
+    custom_headers: List[dict] = []
+    in_code_tool_id: Optional[str] = None
+    passthrough_auth: bool = False
+    # MCP-specific fields
+    server_url: str
+    auth_type: str
+    auth_performer: Optional[str] = None
+    is_authenticated: bool
+
+
+class MCPOAuthInitiateRequest(BaseModel):
+    name: str = Field(..., description="Name of the MCP tool")
+    description: Optional[str] = Field(None, description="Description of the MCP tool")
+    server_url: str = Field(..., description="URL of the MCP server")
+    selected_tools: Optional[List[str]] = Field(
+        None, description="List of selected tool names to create"
+    )
+    existing_server_id: Optional[int] = Field(
+        None, description="ID of existing server to update (for editing)"
+    )
+
+
+class MCPOAuthInitiateResponse(BaseModel):
+    oauth_url: str = Field(..., description="OAuth URL to redirect user to")
+    state: str = Field(..., description="OAuth state parameter")
+    pending_tool: dict = Field(..., description="Pending tool configuration")
+
+
+class MCPUserOAuthInitiateRequest(BaseModel):
+    server_id: int = Field(..., description="ID of the MCP server")
+    return_path: str = Field(..., description="Path to redirect to after callback")
+    include_resource_param: bool = Field(..., description="Include resource parameter")
+
+    @model_validator(mode="after")
+    def validate_return_path(self) -> "MCPUserOAuthInitiateRequest":
+        if not self.return_path.startswith("/"):
+            raise ValueError("return_path must start with a slash")
+        return self
+
+
+class MCPUserOAuthInitiateResponse(BaseModel):
+    oauth_url: str = Field(..., description="OAuth URL to redirect user to")
+    state: str = Field(..., description="OAuth state parameter")
+    server_id: int = Field(..., description="Server ID")
+    server_name: str = Field(..., description="Server name")
+    code_verifier: Optional[str] = Field(
+        None, description="PKCE code verifier to be used at callback"
+    )
+
+
+class MCPOAuthCallbackRequest(BaseModel):
+    """Request payload for completing OAuth flow (authorization code exchange)."""
+
+    code: str = Field(..., description="Authorization code returned by the IdP")
+    state: Optional[str] = Field(
+        None, description="State parameter for CSRF protection"
+    )
+
+
+class MCPOAuthCallbackResponse(BaseModel):
+    success: bool
+    message: str
+    server_id: int
+    server_name: str
+    authenticated: bool
+    redirect_url: str
+
+
+class MCPDynamicClientRegistrationRequest(BaseModel):
+    """Request for dynamic client registration per RFC 7591"""
+
+    server_id: int = Field(..., description="MCP server ID")
+    authorization_server_url: str = Field(
+        ...,
+        description="Authorization server URL discovered from WWW-Authenticate or metadata",
+    )
+
+
+class MCPDynamicClientRegistrationResponse(BaseModel):
+    """Response from dynamic client registration"""
+
+    client_id: str = Field(..., description="Registered client ID")
+    client_secret: Optional[str] = Field(
+        None, description="Client secret if confidential client"
+    )
+    registration_access_token: Optional[str] = Field(
+        None, description="Token for managing this client registration"
+    )
+    registration_client_uri: Optional[str] = Field(
+        None, description="URI for managing this client registration"
+    )
+
+
+class MCPApiKeyRequest(BaseModel):
+    server_id: int = Field(..., description="ID of the MCP server")
+    api_key: str = Field(..., description="API key to store")
+    transport: str = Field(..., description="Transport type")
+
+
+class MCPUserCredentialsRequest(BaseModel):
+    """Enhanced request for template-based user credentials"""
+
+    server_id: int = Field(..., description="ID of the MCP server")
+    credentials: dict[str, str] = Field(
+        ..., description="User-provided credentials (api_key, custom_token, etc.)"
+    )
+    transport: str = Field(..., description="Transport type")
+
+
+class MCPApiKeyResponse(BaseModel):
+    success: bool
+    message: str
+    server_id: int
+    server_name: str
+    authenticated: bool
+    validation_tested: bool = Field(
+        default=False, description="Whether credentials were tested against MCP server"
+    )
+
+
+class MCPServer(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    server_url: str
+    auth_type: MCPAuthenticationType
+    auth_performer: MCPAuthenticationPerformer
+    is_authenticated: bool
+    user_authenticated: Optional[bool] = None
+    auth_template: Optional[MCPAuthTemplate] = Field(
+        None, description="Authentication template for per-user auth"
+    )
+    user_credentials: Optional[dict[str, str]] = Field(
+        None, description="User's existing credentials for pre-filling forms"
+    )
+    admin_credentials: Optional[dict[str, str]] = Field(
+        None,
+        description="Admin's credential key-value pairs for template substitution and storage",
+    )
+
+
+class MCPServersResponse(BaseModel):
+    assistant_id: str | None = None
+    mcp_servers: List[MCPServer]
+
+
+class MCPServerCreateResponse(BaseModel):
+    """Response for creating multiple MCP tools"""
+
+    server_id: int
+    server_name: str
+    server_url: str
+    auth_type: str
+    auth_performer: Optional[str]
+    is_authenticated: bool
+
+
+class MCPServerUpdateResponse(BaseModel):
+    """Response for updating multiple MCP tools"""
+
+    server_id: int
+    updated_tools: int
+
+
+class MCPToolListResponse(BaseModel):
+    server_id: int
+    server_name: str
+    server_url: str
+    tools: list[MCPLibTool]

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -11,7 +11,7 @@ from onyx.auth.users import current_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.models import User
-from onyx.db.tools import create_tool
+from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool
 from onyx.db.tools import get_tool_by_id
 from onyx.db.tools import get_tools
@@ -63,7 +63,7 @@ def create_custom_tool(
 ) -> ToolSnapshot:
     _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
-    tool = create_tool(
+    tool = create_tool__no_commit(
         name=tool_data.name,
         description=tool_data.description,
         openapi_schema=tool_data.definition,
@@ -72,6 +72,7 @@ def create_custom_tool(
         db_session=db_session,
         passthrough_auth=tool_data.passthrough_auth,
     )
+    db_session.commit()
     return ToolSnapshot.from_model(tool)
 
 
@@ -111,6 +112,7 @@ def delete_custom_tool(
     except Exception as e:
         # handles case where tool is still used by an Assistant
         raise HTTPException(status_code=400, detail=str(e))
+    db_session.commit()
 
 
 class ValidateToolRequest(BaseModel):

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -12,7 +12,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.models import User
 from onyx.db.tools import create_tool__no_commit
-from onyx.db.tools import delete_tool
+from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_tool_by_id
 from onyx.db.tools import get_tools
 from onyx.db.tools import update_tool
@@ -106,7 +106,7 @@ def delete_custom_tool(
     _: User | None = Depends(current_admin_user),
 ) -> None:
     try:
-        delete_tool(tool_id, db_session)
+        delete_tool__no_commit(tool_id, db_session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -14,6 +14,7 @@ class ToolSnapshot(BaseModel):
     in_code_tool_id: str | None
     custom_headers: list[Any] | None
     passthrough_auth: bool
+    mcp_server_id: int | None = None
 
     @classmethod
     def from_model(cls, tool: Tool) -> "ToolSnapshot":
@@ -26,6 +27,7 @@ class ToolSnapshot(BaseModel):
             in_code_tool_id=tool.in_code_tool_id,
             custom_headers=tool.custom_headers,
             passthrough_auth=tool.passthrough_auth,
+            mcp_server_id=tool.mcp_server_id,
         )
 
 

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -25,9 +25,9 @@ from onyx.context.search.enums import OptionalSearchSetting
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.models import RetrievalDetails
-from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
+from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.mcp import get_all_mcp_tools_for_server
 from onyx.db.mcp import get_mcp_server_auth_performer

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -26,7 +26,13 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import RerankingDetails
 from onyx.context.search.models import RetrievalDetails
 from onyx.db.kg_config import get_kg_config_settings
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
 from onyx.db.llm import fetch_existing_llm_providers
+from onyx.db.mcp import get_all_mcp_tools_for_server
+from onyx.db.mcp import get_mcp_server_auth_performer
+from onyx.db.mcp import get_mcp_server_by_id
+from onyx.db.mcp import get_user_connection_config
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.file_store.models import InMemoryChatFile
@@ -48,6 +54,7 @@ from onyx.tools.tool_implementations.internet_search.internet_search_tool import
 from onyx.tools.tool_implementations.knowledge_graph.knowledge_graph_tool import (
     KnowledgeGraphTool,
 )
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
 from onyx.tools.tool_implementations.okta_profile.okta_profile_tool import (
     OktaProfileTool,
 )
@@ -189,6 +196,7 @@ def construct_tools(
     """Constructs tools based on persona configuration and available APIs"""
     tool_dict: dict[int, list[Tool]] = {}
 
+    mcp_tool_cache: dict[int, dict[int, MCPTool]] = {}
     # Get user's OAuth token if available
     user_oauth_token = None
     if user and user.oauth_accounts:
@@ -341,6 +349,64 @@ def construct_tools(
                     ),
                 ),
             )
+
+        # Handle MCP tools
+        elif db_tool_model.mcp_server_id:
+            if db_tool_model.mcp_server_id in mcp_tool_cache:
+                tool_dict[db_tool_model.id] = [
+                    mcp_tool_cache[db_tool_model.mcp_server_id][db_tool_model.id]
+                ]
+                continue
+
+            mcp_server = get_mcp_server_by_id(db_tool_model.mcp_server_id, db_session)
+
+            # Get user-specific connection config if needed
+            connection_config = None
+            user_email = user.email if user else ""
+
+            if (
+                mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
+                or mcp_server.auth_type == MCPAuthenticationType.OAUTH
+            ):
+                # If server has a per-user template, only use that user's config
+                if (
+                    get_mcp_server_auth_performer(mcp_server)
+                    == MCPAuthenticationPerformer.PER_USER
+                ):
+                    connection_config = get_user_connection_config(
+                        mcp_server.id, user_email, db_session
+                    )
+                else:
+                    # No per-user template: use admin config
+                    connection_config = mcp_server.admin_connection_config
+
+            # Get all saved tools for this MCP server
+            saved_tools = get_all_mcp_tools_for_server(mcp_server.id, db_session)
+
+            # Find the specific tool that this database entry represents
+            expected_tool_name = db_tool_model.display_name
+
+            mcp_tool_cache[db_tool_model.mcp_server_id] = {}
+            # Find the matching tool definition
+            for saved_tool in saved_tools:
+                # Create MCPTool instance for this specific tool
+                mcp_tool = MCPTool(
+                    tool_id=saved_tool.id,
+                    mcp_server=mcp_server,
+                    tool_name=saved_tool.name,
+                    tool_description=saved_tool.description,
+                    tool_definition=saved_tool.mcp_input_schema or {},
+                    connection_config=connection_config,
+                    user_email=user_email,
+                )
+                mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
+
+                if saved_tool.name == expected_tool_name:
+                    tool_dict[saved_tool.id] = [cast(Tool, mcp_tool)]
+            if db_tool_model.id not in tool_dict:
+                logger.warning(
+                    f"Tool '{expected_tool_name}' not found in MCP server '{mcp_server.name}'"
+                )
 
     tools: list[Tool] = []
     for tool_list in tool_dict.values():

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -1,0 +1,260 @@
+"""
+MCP (Model Context Protocol) Client Implementation
+
+This module provides a proper MCP client that follows the JSON-RPC 2.0 specification
+and handles connection initialization, session management, and protocol communication.
+"""
+
+import asyncio
+from collections.abc import Awaitable
+from collections.abc import Callable
+from enum import Enum
+from typing import Any
+from typing import Dict
+from typing import TypeVar
+from urllib.parse import urlencode
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client  # or use stdio_client
+from mcp.types import CallToolResult
+from mcp.types import Tool as MCPLibTool
+from mcp.types import InitializeResult
+from mcp.types import ListResourcesResult
+from pydantic import BaseModel
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+T = TypeVar("T", covariant=True)
+
+MCPClientFunction = Callable[[ClientSession], Awaitable[T]]
+
+
+class MCPTransport(str, Enum):
+    """MCP transport types"""
+
+    STDIO = "stdio"
+    SSE = "sse"  # Server-Sent Events (deprecated but still used)
+    HTTP_STREAM = "streamable-http"  # Modern HTTP streaming
+
+
+class MCPMessageType(str, Enum):
+    """MCP message types"""
+
+    REQUEST = "request"
+    RESPONSE = "response"
+    NOTIFICATION = "notification"
+
+
+class ContentBlockTypes(str, Enum):
+    """MCP content block types"""  # Unfortunstely these aren't exposed by the mcp library
+
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    RESOURCE = "resource"
+    RESOURCE_LINK = "resource_link"
+
+
+class MCPMessage(BaseModel):
+    """Base MCP message following JSON-RPC 2.0"""
+
+    jsonrpc: str = "2.0"
+    method: str | None = None
+    params: Dict[str, Any] | None = None
+    id: Any | None = None
+    result: Any | None = None
+    error: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to JSON-RPC message dict"""
+        msg: Dict[str, Any] = {"jsonrpc": self.jsonrpc}
+
+        if self.id is not None:
+            msg["id"] = self.id
+
+        if self.method is not None:
+            msg["method"] = self.method
+
+        if self.params is not None:
+            msg["params"] = self.params
+
+        if self.result is not None:
+            msg["result"] = self.result
+
+        if self.error is not None:
+            msg["error"] = self.error
+
+        return msg
+
+
+# TODO: in the future we should do things like manage sessions and handle errors better
+# using an abstraction like this. For now things are purely functional and we initialize
+# a new session for each tool call.
+# class MCPClient:
+#     """
+#     MCP Client implementation that properly handles the protocol lifecycle
+#     and different transport mechanisms.
+#     """
+
+#     def __init__(
+#         self,
+#         server_url: str,
+#         transport: MCPTransport = MCPTransport.HTTP_STREAM,
+#         auth_token: str | None = None,
+#     ):
+#         self.server_url = server_url
+#         self.transport = transport
+#         self.auth_token = auth_token
+
+#         # Session management
+#         self.session: Optional[aiohttp.ClientSession] = None
+#         self.initialized = False
+#         self.capabilities: Dict[str, Any] = {}
+#         self.protocol_version = "2025-03-26"  # Current MCP protocol version
+#         self.session_id: str | None = None
+#         # Legacy HTTP+SSE transport support (backwards compatibility)
+#         self.legacy_post_endpoint: str | None = None
+
+#         # Message ID counter
+#         self._message_id_counter = 0
+
+#         # For stdio transport
+#         self.process: Optional[subprocess.Popen] = None
+
+
+def _call_mcp_client_function(
+    function: Callable[[ClientSession], Awaitable[T]],
+    server_url: str,
+    connection_headers: dict[str, Any] | None = None,
+    transport: MCPTransport = MCPTransport.HTTP_STREAM,
+    **kwargs: Any,
+) -> T:
+    auth_headers = connection_headers or {}
+    server_url = (
+        server_url.rstrip("/") + "?" + urlencode({"transportType": transport.value})
+    )
+
+    async def run_client_function() -> T:
+        async with streamablehttp_client(server_url, headers=auth_headers) as (
+            read,
+            write,
+            _,
+        ):
+            async with ClientSession(read, write) as session:
+                return await function(session, **kwargs)
+
+    try:
+        # Run the async function in a new event loop
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(run_client_function())
+        finally:
+            loop.close()
+    except Exception as e:
+        logger.error(f"Failed to call MCP client function: {e}")
+        if isinstance(e, ExceptionGroup):
+            err = e
+            for err in e.exceptions:
+                logger.error(err)
+            raise err
+        raise e
+
+
+def process_mcp_result(call_tool_result: CallToolResult) -> str:
+    """Flatten MCP CallToolResult->text (prefers text content blocks)."""
+    # TODO: use structured_content if available
+    parts = []
+    for content_block in call_tool_result.content:
+        if content_block.type == ContentBlockTypes.TEXT.value:
+            parts.append(content_block.text or "")
+        # TODO: handle other content block types
+
+    return "\n".join(p for p in parts if p) or str(call_tool_result.structuredContent)
+
+
+def _call_mcp_tool(tool_name: str, arguments: dict[str, Any]) -> MCPClientFunction[str]:
+    async def call_tool(session: ClientSession) -> str:
+        await session.initialize()
+        result = await session.call_tool(tool_name, arguments)
+        return process_mcp_result(result)
+
+    return call_tool
+
+
+def call_mcp_tool(
+    server_url: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    connection_headers: dict[str, Any] | None = None,
+    transport: str = "streamable-http",
+) -> str:
+    """Call a specific tool on the MCP server"""
+    return _call_mcp_client_function(
+        _call_mcp_tool(tool_name, arguments),
+        server_url,
+        connection_headers,
+        MCPTransport(transport),
+    )
+
+
+def initialize_mcp_client(
+    server_url: str,
+    connection_headers: dict[str, Any] | None = None,
+    transport: str = "streamable-http",
+) -> InitializeResult:
+    return _call_mcp_client_function(
+        lambda session: session.initialize(),
+        server_url,
+        connection_headers,
+        MCPTransport(transport),
+    )
+
+
+async def _discover_mcp_tools(session: ClientSession) -> list[MCPLibTool]:
+    # 1) initialize
+    init_result = await session.initialize()  # sends JSON-RPC "initialize"
+    logger.info(f"Initialized with server: {init_result.serverInfo}")
+
+    # 2) tools/list
+    tools_response = await session.list_tools()  # sends JSON-RPC "tools/list"
+    return tools_response.tools
+
+
+def discover_mcp_tools(
+    server_url: str,
+    connection_headers: dict[str, str] | None = None,
+    transport: str = "streamable-http",
+) -> list[MCPLibTool]:
+    """
+    Synchronous wrapper for discovering MCP tools.
+    """
+    return _call_mcp_client_function(
+        _discover_mcp_tools,
+        server_url,
+        connection_headers,
+        MCPTransport(transport),
+    )
+
+
+async def _discover_mcp_resources(session: ClientSession) -> ListResourcesResult:
+    return await session.list_resources()
+
+
+def discover_mcp_resources_sync(
+    server_url: str,
+    connection_headers: dict[str, Any] | None = None,
+    transport: str = "streamable-http",
+) -> ListResourcesResult:
+    """
+    Synchronous wrapper for discovering MCP resources.
+    This is for compatibility with the existing codebase.
+    """
+    return _call_mcp_client_function(
+        _discover_mcp_resources,
+        server_url,
+        connection_headers,
+        MCPTransport(transport),
+    )

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -17,9 +17,9 @@ from urllib.parse import urlencode
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client  # or use stdio_client
 from mcp.types import CallToolResult
-from mcp.types import Tool as MCPLibTool
 from mcp.types import InitializeResult
 from mcp.types import ListResourcesResult
+from mcp.types import Tool as MCPLibTool
 from pydantic import BaseModel
 
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -16,13 +16,12 @@ from onyx.llm.models import PreviousMessage
 from onyx.tools.base_tool import BaseTool
 from onyx.tools.message import ToolCallSummary
 from onyx.tools.models import ToolResponse
+from onyx.tools.tool_implementations.custom.custom_tool import CUSTOM_TOOL_RESPONSE_ID
 from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
 from onyx.tools.tool_implementations.mcp.mcp_client import call_mcp_tool
 from onyx.tools.tool_implementations.mcp.mcp_client import discover_mcp_resources_sync
 from onyx.utils.logger import setup_logger
 from onyx.utils.special_types import JSON_ro
-from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
-from onyx.tools.tool_implementations.custom.custom_tool import CUSTOM_TOOL_RESPONSE_ID
 
 logger = setup_logger()
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,0 +1,331 @@
+import json
+from collections.abc import Generator
+from typing import Any
+from typing import cast
+
+from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
+from mcp.types import Resource
+
+from onyx.chat.prompt_builder.answer_prompt_builder import AnswerPromptBuilder
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.models import MCPConnectionConfig
+from onyx.db.models import MCPServer
+from onyx.llm.interfaces import LLM
+from onyx.llm.models import PreviousMessage
+from onyx.tools.base_tool import BaseTool
+from onyx.tools.message import ToolCallSummary
+from onyx.tools.models import ToolResponse
+from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
+from onyx.tools.tool_implementations.mcp.mcp_client import call_mcp_tool
+from onyx.tools.tool_implementations.mcp.mcp_client import discover_mcp_resources_sync
+from onyx.utils.logger import setup_logger
+from onyx.utils.special_types import JSON_ro
+from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
+from onyx.tools.tool_implementations.custom.custom_tool import CUSTOM_TOOL_RESPONSE_ID
+
+logger = setup_logger()
+
+MCP_TOOL_RESPONSE_ID = "mcp_tool_response"
+
+# TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class
+# In the future we may want custom handling for MCP tool responses
+# class MCPToolCallSummary(BaseModel):
+#     tool_name: str
+#     server_url: str
+#     tool_result: Any
+#     server_name: str
+
+
+class MCPTool(BaseTool):
+    """Tool implementation for MCP (Model Context Protocol) servers"""
+
+    def __init__(
+        self,
+        tool_id: int,
+        mcp_server: MCPServer,  # TODO: these should be basemodels instead of db objects
+        tool_name: str,
+        tool_description: str,
+        tool_definition: dict[str, Any],
+        connection_config: MCPConnectionConfig | None = None,
+        user_email: str = "",
+    ) -> None:
+        self._id = tool_id
+        self.mcp_server = mcp_server
+        self.connection_config = connection_config
+        self.user_email = user_email
+
+        self._name = tool_name
+        self._tool_definition = tool_definition
+        self._description = tool_description
+        self._display_name = tool_definition.get("displayName", tool_name)
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
+    def tool_definition(self) -> dict:
+        """Return the tool definition from the MCP server"""
+        # Convert MCP tool definition to OpenAI function calling format
+        return {
+            "type": "function",
+            "function": {
+                "name": self._name,
+                "description": self._description,
+                "parameters": self._tool_definition,
+            },
+        }
+
+    def build_tool_message_content(
+        self, *args: ToolResponse
+    ) -> str | list[str | dict[str, Any]]:
+        """Build message content from tool response"""
+        response = cast(CustomToolCallSummary, args[0].response)
+        # For now, just return the JSON result
+        # Future versions might handle base64 content differently
+        return json.dumps(response.tool_result)
+
+    def get_args_for_non_tool_calling_llm(
+        self,
+        query: str,
+        history: list[PreviousMessage],
+        llm: LLM,
+        force_run: bool = False,
+    ) -> dict[str, Any] | None:
+        """Get arguments for non-tool-calling LLMs using prompt-based extraction"""
+
+        # Simple implementation for now - in production this would use more sophisticated prompting
+        if not force_run:
+            # Basic check if we should use this tool
+            should_use_prompt = f"""
+Should the following query use the {self._name} tool from mcp server {self.mcp_server.name}?
+Tool description: {self._description}
+Query: {query}
+
+Answer with 'YES' or 'NO' only.
+"""
+            should_use_result = llm.invoke(
+                [
+                    SystemMessage(
+                        content="You are a helpful assistant that determines if a tool should be used."
+                    ),
+                    HumanMessage(content=should_use_prompt),
+                ]
+            )
+
+            if "YES" not in cast(str, should_use_result.content).upper():
+                return None
+
+        # Extract arguments using the tool schema
+        args_prompt = f"""
+Extract the arguments for the {self._name} tool from the following query.
+Tool description: {self._description}
+Tool parameters: {json.dumps(self._tool_definition.get('inputSchema', {}), indent=2)}
+Query: {query}
+Chat history: {history}
+
+Return ONLY a valid JSON object with the extracted arguments. If no arguments are needed, return {{}}.
+"""
+
+        args_result = llm.invoke(
+            [
+                SystemMessage(
+                    content="You are a helpful assistant that extracts tool arguments from user queries."
+                ),
+                HumanMessage(content=args_prompt),
+            ]
+        )
+
+        args_result_str = cast(str, args_result.content)
+
+        try:
+            return json.loads(args_result_str.strip())
+        except json.JSONDecodeError:
+            # Try removing code block markers
+            try:
+                cleaned = (
+                    args_result_str.strip().strip("```").strip("json").strip("```")
+                )
+                return json.loads(cleaned)
+            except json.JSONDecodeError:
+                logger.error(
+                    f"Failed to parse args for MCP tool '{self._name}'. Received: {args_result_str}"
+                )
+                return {}
+
+    def run(
+        self, override_kwargs: dict[str, Any] | None = None, **kwargs: Any
+    ) -> Generator[ToolResponse, None, None]:
+        """Execute the MCP tool by calling the MCP server"""
+        try:
+            # Build headers from connection config; prefer explicit headers
+            headers: dict[str, str] = (
+                self.connection_config.config["headers"]
+                if self.connection_config
+                else {}
+            )
+
+            # Check if this is an authentication issue before making the call
+            requires_auth = (
+                self.mcp_server.auth_type != MCPAuthenticationType.NONE
+                and self.mcp_server.auth_type is not None
+            )
+            has_auth_config = self.connection_config is not None and bool(headers)
+
+            if requires_auth and not has_auth_config:
+                # Authentication required but not configured
+                auth_error_msg = (
+                    f"The {self._name} tool from {self.mcp_server.name} requires authentication "
+                    f"but no credentials have been provided. Tell the user to use the MCP dropdown in the "
+                    f"chat bar to authenticate with the {self.mcp_server.name} server before "
+                    f"using this tool."
+                )
+                logger.warning(
+                    f"Authentication required for MCP tool '{self._name}' but no credentials found"
+                )
+
+                yield ToolResponse(
+                    id=CUSTOM_TOOL_RESPONSE_ID,
+                    response=CustomToolCallSummary(
+                        tool_name=self._name,
+                        response_type="json",
+                        tool_result={"error": auth_error_msg},
+                    ),
+                )
+                return
+
+            tool_result = call_mcp_tool(
+                self.mcp_server.server_url,
+                self._name,
+                kwargs,
+                connection_headers=headers,
+            )
+
+            logger.info(f"MCP tool '{self._name}' executed successfully")
+
+            yield ToolResponse(
+                id=CUSTOM_TOOL_RESPONSE_ID,
+                response=CustomToolCallSummary(
+                    tool_name=self._name,
+                    response_type="json",
+                    tool_result=json.dumps({"tool_result": tool_result}),
+                ),
+            )
+
+        except Exception as e:
+            error_str = str(e).lower()
+            logger.error(f"Failed to execute MCP tool '{self._name}': {e}")
+
+            # Check for authentication-related errors
+            auth_error_indicators = [
+                "401",
+                "unauthorized",
+                "authentication",
+                "auth",
+                "forbidden",
+                "access denied",
+                "invalid token",
+                "invalid api key",
+                "invalid credentials",
+            ]
+
+            is_auth_error = any(
+                indicator in error_str for indicator in auth_error_indicators
+            )
+
+            if is_auth_error:
+                auth_error_msg = (
+                    f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
+                    f"Please use the MCP dropdown in the chat bar to update your credentials "
+                    f"for the {self.mcp_server.name} server. Original error: {str(e)}"
+                )
+                error_result = {"error": auth_error_msg}
+            else:
+                error_result = {"error": f"Tool execution failed: {str(e)}"}
+
+            # Return error as tool result
+            yield ToolResponse(
+                id=CUSTOM_TOOL_RESPONSE_ID,
+                response=CustomToolCallSummary(
+                    tool_name=self._name,
+                    response_type="json",
+                    tool_result=error_result,
+                ),
+            )
+
+    def final_result(self, *args: ToolResponse) -> JSON_ro:
+        """Return the final result for storage in the database"""
+        response = cast(CustomToolCallSummary, args[0].response)
+        return response.tool_result
+
+    def build_next_prompt(
+        self,
+        prompt_builder: AnswerPromptBuilder,
+        tool_call_summary: ToolCallSummary,
+        tool_responses: list[ToolResponse],
+        using_tool_calling_llm: bool,
+    ) -> AnswerPromptBuilder:
+        """Build the next prompt with MCP tool results"""
+
+        # For now, use the default behavior from BaseTool
+        # Future versions could add MCP-specific prompt building
+        return super().build_next_prompt(
+            prompt_builder,
+            tool_call_summary,
+            tool_responses,
+            using_tool_calling_llm,
+        )
+
+
+def discover_mcp_resources(
+    mcp_server: MCPServer, connection_config: MCPConnectionConfig | None = None
+) -> list[Resource]:
+    """Discover available resources from an MCP server"""
+
+    try:
+        # TODO: extract shared code with tool discovery
+        # Build headers from connection config
+        headers: dict[str, str] = {}
+        if connection_config and connection_config.config:
+            cfg = connection_config.config
+            if isinstance(cfg, dict):
+                if "headers" in cfg and isinstance(cfg["headers"], dict):
+                    headers = {k: str(v) for k, v in cfg["headers"].items()}
+                elif "headers" in cfg and isinstance(cfg["headers"], list):
+                    for h in cfg["headers"]:
+                        name = h.get("name")
+                        value = h.get("value")
+                        if name and value is not None:
+                            headers[str(name)] = str(value)
+                elif "api_key" in cfg:
+                    headers = {"Authorization": f"Bearer {cfg['api_key']}"}
+
+        # Use the new MCP client to discover resources
+        resources = discover_mcp_resources_sync(
+            server_url=mcp_server.server_url,
+            connection_headers=headers,
+            transport="streamable-http",  # Default to streamable HTTP
+        ).resources
+
+        logger.info(
+            f"Discovered {len(resources)} resources from MCP server '{mcp_server.name}'"
+        )
+        return resources
+
+    except Exception as e:
+        logger.error(
+            f"Failed to discover resources from MCP server '{mcp_server.name}': {e}"
+        )
+        return []

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -15,6 +15,7 @@ distributed==2023.8.1
 fastapi==0.115.12
 fastapi-users==14.0.1
 fastapi-users-db-sqlalchemy==5.0.0
+fastmcp==2.11.3
 filelock==3.15.4
 google-api-python-client==2.86.0
 google-cloud-aiplatform==1.58.0

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -46,6 +46,7 @@ lxml==5.3.0
 lxml_html_clean==0.2.2
 Mako==1.2.4
 markitdown[pdf, docx, pptx, xlsx, xls]==0.1.2
+mcp[cli]==1.12.4
 msal==1.28.0
 nltk==3.9.1
 Office365-REST-Python-Client==2.5.9
@@ -87,7 +88,7 @@ timeago==1.0.16
 transformers==4.49.0
 unstructured==0.15.1
 unstructured-client==0.25.4
-uvicorn==0.21.1
+uvicorn==0.35.0
 zulip==0.8.2
 hubspot-api-client==8.1.0
 asana==5.0.8
@@ -104,4 +105,4 @@ prometheus_fastapi_instrumentator==7.1.0
 sendgrid==6.11.0
 voyageai==0.2.3
 cohere==5.6.1
-exa_py==1.15.3
+exa_py==1.15.4

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -13,7 +13,7 @@ sentencepiece==0.2.0
 setfit==1.1.1
 torch==2.6.0
 transformers==4.49.0
-uvicorn==0.21.1
+uvicorn==0.35.0
 voyageai==0.2.3
 litellm==1.72.2
 sentry-sdk[fastapi,celery,starlette]==2.14.0

--- a/backend/scripts/onyx_openapi_schema.py
+++ b/backend/scripts/onyx_openapi_schema.py
@@ -10,14 +10,10 @@ from fastapi.openapi.utils import get_openapi
 
 from onyx.main import app as app_fn
 
-# TODO: remove this once openapi fixes the anyof/none issues
-OPENAPI_VERSION = "3.0.3"
-
 
 def go(filename: str) -> None:
     with open(filename, "w") as f:
         app: FastAPI = app_fn()
-        app.openapi_version = OPENAPI_VERSION
         json.dump(
             get_openapi(
                 title=app.title,

--- a/backend/scripts/onyx_openapi_schema.py
+++ b/backend/scripts/onyx_openapi_schema.py
@@ -10,10 +10,14 @@ from fastapi.openapi.utils import get_openapi
 
 from onyx.main import app as app_fn
 
+# TODO: remove this once openapi fixes the anyof/none issues
+OPENAPI_VERSION = "3.0.3"
+
 
 def go(filename: str) -> None:
     with open(filename, "w") as f:
         app: FastAPI = app_fn()
+        app.openapi_version = OPENAPI_VERSION
         json.dump(
             get_openapi(
                 title=app.title,

--- a/backend/tests/daily/connectors/outline/test_outline_connector.py
+++ b/backend/tests/daily/connectors/outline/test_outline_connector.py
@@ -5,12 +5,11 @@ from typing import Any
 import pytest
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
 from onyx.connectors.outline.connector import OutlineConnector
-from onyx.connectors.models import Document, ConnectorMissingCredentialError
-from onyx.connectors.exceptions import (
-    CredentialExpiredError,
-    ConnectorValidationError,
-)
 
 
 class TestOutlineConnector:
@@ -54,9 +53,9 @@ class TestOutlineConnector:
         assert result is None
         assert connector.outline_client is not None
         assert connector.outline_client.api_token == credentials["outline_api_token"]
-        assert connector.outline_client.base_url == credentials["outline_base_url"].rstrip(
-            "/"
-        )
+        assert connector.outline_client.base_url == credentials[
+            "outline_base_url"
+        ].rstrip("/")
 
     def test_outline_connector_basic(
         self, connector: OutlineConnector, credentials: dict[str, Any]
@@ -190,12 +189,15 @@ class TestOutlineConnector:
     def test_outline_connector_invalid_url(self) -> None:
         """Invalid URL should raise validation error during validation."""
         connector = OutlineConnector()
-        
+
         # Load credentials with invalid URL
         connector.load_credentials(
-            {"outline_base_url": "https://not-a-valid-url.invalid", "outline_api_token": "token"}
+            {
+                "outline_base_url": "https://not-a-valid-url.invalid",
+                "outline_api_token": "token",
+            }
         )
-        
+
         # Validation should catch invalid URL
         with pytest.raises(ConnectorValidationError):
             connector.validate_connector_settings()

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
@@ -1,0 +1,39 @@
+import sys
+
+from fastmcp import FastMCP
+from fastmcp.server.auth import StaticTokenVerifier
+from fastmcp.server.server import FunctionTool
+
+
+def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
+    def make_tool(i: int) -> FunctionTool:
+        @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
+        def tool_name(name: str) -> str:
+            """Get secret value."""
+            return f"Secret value {200 - i}!"
+
+        return tool_name
+
+    tools = []
+    for i in range(100):
+        tools.append(make_tool(i))
+    return tools
+
+
+if __name__ == "__main__":
+    # Streamable HTTP transport (recommended)
+    # Accept only these tokens (treat them like API keys) and require a scope
+    if len(sys.argv) > 1:
+        api_key = sys.argv[1]
+    else:
+        api_key = "dev-api-key-123"
+    auth = StaticTokenVerifier(
+        tokens={
+            "dev-api-key-123": {"client_id": "evan", "scopes": ["mcp:use"]},
+        },
+        required_scopes=["mcp:use"],
+    )
+
+    mcp = FastMCP("My HTTP MCP", auth=auth)
+    make_many_tools(mcp)
+    mcp.run(transport="http", host="127.0.0.1", port=8001, path="/mcp")

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_api_key.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         api_key = "dev-api-key-123"
     auth = StaticTokenVerifier(
         tokens={
-            "dev-api-key-123": {"client_id": "evan", "scopes": ["mcp:use"]},
+            api_key: {"client_id": "evan", "scopes": ["mcp:use"]},
         },
         required_scopes=["mcp:use"],
     )

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
@@ -1,0 +1,31 @@
+from fastmcp import FastMCP
+from fastmcp.server.server import FunctionTool
+
+mcp = FastMCP("My HTTP MCP")
+
+
+@mcp.tool
+def hello(name: str) -> str:
+    """Say hi."""
+    return f"Hello, {name}!"
+
+
+def make_many_tools() -> list[FunctionTool]:
+    def make_tool(i: int) -> FunctionTool:
+        @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
+        def tool_name(name: str) -> str:
+            """Get secret value."""
+            return f"Secret value {100 - i}!"
+
+        return tool_name
+
+    tools = []
+    for i in range(100):
+        tools.append(make_tool(i))
+    return tools
+
+
+if __name__ == "__main__":
+    # Streamable HTTP transport (recommended)
+    make_many_tools()
+    mcp.run(transport="http", host="127.0.0.1", port=8000, path="/mcp")

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
@@ -1,0 +1,195 @@
+import os
+import sys
+from collections.abc import Awaitable
+from collections.abc import Callable
+from collections.abc import Iterable
+from typing import Any
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
+
+import uvicorn
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.responses import PlainTextResponse
+from fastapi.responses import Response
+from fastmcp import FastMCP
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.server import FunctionTool
+from starlette.middleware.base import BaseHTTPMiddleware
+
+"""
+Setup Okta:
+1. Create an authorization Server (Admin Console → Security →
+API → Authorization Servers), and get the Issuer, JWKS uri,
+audience (i.e. api://mcp). Add the mcp:use scope.
+2. Create a client (Admin Console → Applications → Create App Integration)
+Enable authorization code and store the client id and secret.
+"""
+
+
+def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
+    def make_tool(i: int) -> FunctionTool:
+        @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
+        def tool_name(name: str) -> str:
+            """Get secret value."""
+            return f"Secret value {500 - i}!"
+
+        return tool_name
+
+    tools = []
+    for i in range(100):
+        tools.append(make_tool(i))
+
+    @mcp.tool
+    async def whoami() -> dict[str, Any]:
+        tok = get_access_token()  # None if unauthenticated
+        return {
+            "client_id": tok.client_id if tok else None,
+            "scopes": tok.scopes if tok else [],
+            "claims": tok.claims if tok else {},
+        }
+
+    tools.append(whoami)
+    return tools
+
+
+# ---------- FASTAPI APP ----------
+
+
+def init_app(
+    app: FastAPI,
+    mcp_resource_url: str,
+    authorization_servers: list[str],
+    scopes_supported: list[str],
+) -> None:
+    # 1) Protected Resource Metadata (RFC 9728) at well-known URL.
+    #    We accept both with and without the trailing resource suffix to be lenient in dev.
+    @app.get("/.well-known/oauth-protected-resource")
+    @app.get("/.well-known/oauth-protected-resource/{_suffix:path}")
+    def oauth_protected_resource(_suffix: str = "") -> JSONResponse:
+        """
+        Return PRM document. The 'resource' MUST equal the MCP resource identifier (the URL clients use),
+        and should be validated by clients per RFC 9728 §3.3.
+        """
+        return JSONResponse(
+            {
+                "resource": mcp_resource_url,
+                "authorization_servers": authorization_servers,
+                "bearer_methods_supported": ["header"],
+                "scopes_supported": scopes_supported,
+                # (Optional extras: jwks_uri, resource_signing_alg_values_supported, etc.)
+            }
+        )
+
+    # Health check (unprotected)
+    @app.get("/healthz")
+    def health() -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+
+def metadata_url_for_resource(resource_url: str) -> str:
+    """
+    RFC 9728: insert '/.well-known/oauth-protected-resource' between host and path.
+    If the resource has a path (e.g., '/mcp'), append it after the well-known suffix.
+    """
+    u = urlsplit(resource_url)
+    path = u.path.lstrip("/")
+    suffix = "/.well-known/oauth-protected-resource"
+    if path:
+        suffix += f"/{path}"
+    return urlunsplit((u.scheme, u.netloc, suffix, "", ""))
+
+
+PRM_URL = "replace me"
+
+
+# 2) Middleware that ensures 401s include a proper WWW-Authenticate challenge
+#    pointing clients to our PRM URL (RFC 9728 §5.1), and includes RFC 6750 error info.
+class WWWAuthenticateMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, protected_prefixes: Iterable[str]) -> None:
+        super().__init__(app)
+        self.protected_prefixes = tuple(protected_prefixes)
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
+        # Only guard MCP endpoints (both Streamable HTTP and SSE)
+        if not request.url.path.startswith(self.protected_prefixes):
+            return await call_next(request)
+
+        # Let FastMCP/verifier run first
+        response = await call_next(request)
+
+        # If unauthenticated or invalid token, attach RFC-compliant challenge header
+        if response.status_code == 401:
+            # RFC 9728: include resource_metadata param pointing to PRM URL.
+            # RFC 6750: include error + error_description when appropriate.
+            challenge = (
+                f'Bearer resource_metadata="{PRM_URL}", '
+                f'error="invalid_token", '
+                f'error_description="Authentication required"'
+            )
+            # Don't clobber if already present; append or set.
+            if "www-authenticate" in response.headers:
+                response.headers["www-authenticate"] += ", " + challenge
+            else:
+                response.headers["www-authenticate"] = challenge
+            # Helpful cache headers
+            response.headers.setdefault("cache-control", "no-store")
+            response.headers.setdefault("pragma", "no-cache")
+        return response
+
+
+if __name__ == "__main__":
+    # Streamable HTTP transport (recommended)
+    # Accept only these tokens (treat them like API keys) and require a scope
+    if len(sys.argv) > 1:
+        api_key = sys.argv[1]
+    else:
+        api_key = "dev-api-key-123"
+
+    client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
+    client_secret = os.getenv("MCP_OAUTH_CLIENT_SECRET", "test-client-secret")
+    audience = os.getenv("MCP_OAUTH_AUDIENCE", "api://mcp")
+    issuer = os.getenv(
+        "MCP_OAUTH_ISSUER", "https://test-domain.okta.com/oauth2/default"
+    )
+    jwks_uri = os.getenv(
+        "MCP_OAUTH_JWKS_URI", "https://test-domain.okta.com/oauth2/default/v1/keys"
+    )
+    required_scopes = os.getenv("MCP_OAUTH_REQUIRED_SCOPES", "mcp:use")
+
+    verifier = JWTVerifier(
+        issuer=issuer,
+        audience=audience,  # exactly what you set on the AS
+        jwks_uri=jwks_uri,
+        required_scopes=required_scopes.split(
+            ","
+        ),  # must be present in the token's `scp`
+    )
+
+    mcp = FastMCP("My HTTP MCP", auth=verifier)
+    make_many_tools(mcp)
+    mcp_app = mcp.http_app()
+
+    app = FastAPI(title="MCP over HTTP/SSE with OAuth", lifespan=mcp_app.lifespan)
+
+    mcp_resource_url = "http://127.0.0.1:8004/mcp/"
+    authorization_servers = [issuer]
+    scopes_supported = ["mcp:use"]
+
+    init_app(app, mcp_resource_url, authorization_servers, scopes_supported)
+    PRM_URL = metadata_url_for_resource(mcp_resource_url)
+
+    # Apply middleware at the parent app so it wraps mounted sub-apps too
+    app.add_middleware(WWWAuthenticateMiddleware, protected_prefixes=["/mcp", "/sse"])
+
+    # 3) Mount MCP apps
+    # Streamable HTTP transport (recommended for modern MCP clients)
+    app.mount("/", mcp_app)
+    # SSE transport (some clients still use this)
+    # app.mount("/sse", mcp.sse_app()) # TODO: v2
+
+    uvicorn.run(app, host="127.0.0.1", port=8004)

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_oauth.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Iterable
@@ -143,15 +142,7 @@ class WWWAuthenticateMiddleware(BaseHTTPMiddleware):
 
 
 if __name__ == "__main__":
-    # Streamable HTTP transport (recommended)
-    # Accept only these tokens (treat them like API keys) and require a scope
-    if len(sys.argv) > 1:
-        api_key = sys.argv[1]
-    else:
-        api_key = "dev-api-key-123"
 
-    client_id = os.getenv("MCP_OAUTH_CLIENT_ID", "test-client-id")
-    client_secret = os.getenv("MCP_OAUTH_CLIENT_SECRET", "test-client-secret")
     audience = os.getenv("MCP_OAUTH_AUDIENCE", "api://mcp")
     issuer = os.getenv(
         "MCP_OAUTH_ISSUER", "https://test-domain.okta.com/oauth2/default"

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -1,0 +1,125 @@
+import sys
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+import bcrypt
+from fastmcp import FastMCP
+from fastmcp.server.auth.auth import AccessToken
+from fastmcp.server.auth.auth import TokenVerifier
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.server import FunctionTool
+
+# pip install fastmcp bcrypt
+
+
+# ---- pretend database --------------------------------------------------------
+# Keys look like: "mcp_live_<key_id>_<secret>"
+def _hash(secret: str) -> bytes:
+    return bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=12))
+
+
+API_KEY_RECORDS: Dict[str, Dict[str, Any]] = {
+    # key_id -> record
+    "kid_alice_001": {
+        "user_id": "alice",
+        "hashed_secret": _hash("S3cr3tAlice"),
+        "scopes": ["mcp:use"],
+        "revoked": False,
+        "expires_at": None,  # or datetime(...)
+        "metadata": {"plan": "pro"},
+    },
+    "kid_bob_001": {
+        "user_id": "bob",
+        "hashed_secret": _hash("S3cr3tBob"),
+        "scopes": ["mcp:use"],
+        "revoked": False,
+        "expires_at": None,
+        "metadata": {"plan": "free"},
+    },
+}
+
+
+# ---- verifier ---------------------------------------------------------------
+class ApiKeyVerifier(TokenVerifier):
+    """
+    Accepts API keys in Authorization: Bearer mcp_live_<key_id>_<secret>
+    Looks up <key_id> in storage, bcrypt-verifies <secret>, returns AccessToken.
+    """
+
+    def __init__(self, api_key_dict: dict[str, Any]):
+        super().__init__()
+        self.api_key_dict = api_key_dict
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        print(f"Verifying token: {token}")
+        try:
+            prefix, key_id, secret = token.split("-")
+            print(f"Prefix: {prefix}, Key ID: {key_id}, Secret: {secret}")
+            if prefix not in ("mcp_live", "mcp_test"):
+                return None
+        except ValueError:
+            return None
+
+        rec = self.api_key_dict.get(key_id)
+        if not rec or rec.get("revoked"):
+            return None
+        if rec.get("expires_at") and rec["expires_at"] < datetime.now(timezone.utc):
+            return None
+
+        # constant-time bcrypt verification
+        if not bcrypt.checkpw(secret.encode(), rec["hashed_secret"]):
+            return None
+
+        # Build an AccessToken with claims FastMCP can pass to your tools
+        return AccessToken(
+            token=token,
+            client_id=rec["user_id"],
+            scopes=rec.get("scopes", []),
+            expires_at=rec.get("expires_at"),
+            resource=None,
+            claims={"key_id": key_id, **rec.get("metadata", {})},
+        )
+
+
+# ---- server -----------------------------------------------------------------
+
+
+def make_many_tools(mcp: FastMCP) -> list[FunctionTool]:
+    def make_tool(i: int) -> FunctionTool:
+        @mcp.tool(name=f"tool_{i}", description=f"Get secret value {i}")
+        def tool_name(name: str) -> str:
+            """Get secret value."""
+            return f"Secret value {400 - i}!"
+
+        return tool_name
+
+    tools = []
+    for i in range(100):
+        tools.append(make_tool(i))
+    return tools
+
+
+if __name__ == "__main__":
+
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    else:
+        port = 8003
+
+    mcp = FastMCP("My HTTP MCP", auth=ApiKeyVerifier(API_KEY_RECORDS))
+
+    @mcp.tool
+    def whoami() -> dict:
+        """Return authenticated identity info (for demo)."""
+        # FastMCP exposes the verified AccessToken to tools; see docs for helpers
+        tok = get_access_token()
+        return {
+            "user": tok.client_id if tok else None,
+            "scopes": tok.scopes if tok else [],
+        }
+
+    make_many_tools(mcp)
+    mcp.run(transport="http", host="127.0.0.1", port=port, path="/mcp")

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -54,10 +54,10 @@ class ApiKeyVerifier(TokenVerifier):
         self.api_key_dict = api_key_dict
 
     async def verify_token(self, token: str) -> Optional[AccessToken]:
-        print(f"Verifying token: {token}")
+        # print(f"Verifying token: {token}")
         try:
             prefix, key_id, secret = token.split("-")
-            print(f"Prefix: {prefix}, Key ID: {key_id}, Secret: {secret}")
+            # print(f"Prefix: {prefix}, Key ID: {key_id}, Secret: {secret}")
             if prefix not in ("mcp_live", "mcp_test"):
                 return None
         except ValueError:

--- a/web/src/app/admin/actions/ActionTable.tsx
+++ b/web/src/app/admin/actions/ActionTable.tsx
@@ -7,20 +7,35 @@ import {
   TableBody,
   TableCell,
 } from "@/components/ui/table";
-import { ToolSnapshot } from "@/lib/tools/interfaces";
+import { ToolSnapshot, MCPServer } from "@/lib/tools/interfaces";
 import { useRouter } from "next/navigation";
 import { usePopup } from "@/components/admin/connectors/Popup";
-import { FiCheckCircle, FiEdit2, FiXCircle } from "react-icons/fi";
+import {
+  FiCheckCircle,
+  FiCode,
+  FiEdit2,
+  FiServer,
+  FiXCircle,
+} from "react-icons/fi";
 import { TrashIcon } from "@/components/icons/icons";
-import { deleteCustomTool } from "@/lib/tools/edit";
+import { deleteCustomTool, deleteMCPServer } from "@/lib/tools/edit";
 import { TableHeader } from "@/components/ui/table";
 
-export function ActionsTable({ tools }: { tools: ToolSnapshot[] }) {
+export function ActionsTable({
+  tools,
+  mcpServers = [],
+}: {
+  tools: ToolSnapshot[];
+  mcpServers?: MCPServer[];
+}) {
   const router = useRouter();
   const { popup, setPopup } = usePopup();
 
   const sortedTools = [...tools];
   sortedTools.sort((a, b) => a.id - b.id);
+
+  const sortedMcpServers = [...mcpServers];
+  sortedMcpServers.sort((a, b) => a.id - b.id);
 
   return (
     <div>
@@ -31,23 +46,80 @@ export function ActionsTable({ tools }: { tools: ToolSnapshot[] }) {
           <TableRow>
             <TableHead>Name</TableHead>
             <TableHead>Description</TableHead>
-            <TableHead>Built In?</TableHead>
+            <TableHead>Creation Method</TableHead>
             <TableHead>Delete</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
+          {/* Render MCP Servers first */}
+          {sortedMcpServers.map((server) => (
+            <TableRow key={`mcp-${server.id}`}>
+              <TableCell>
+                <div className="flex">
+                  <FiEdit2
+                    className="mr-1 my-auto cursor-pointer"
+                    onClick={() => {
+                      router.push(
+                        `/admin/actions/edit-mcp?server_id=${server.id}`
+                      );
+                    }}
+                  />
+                  <p className="text font-medium whitespace-normal break-none">
+                    {server.name}
+                  </p>
+                </div>
+              </TableCell>
+              <TableCell className="whitespace-normal break-all max-w-2xl">
+                MCP Server - {server.server_url}
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                <span>
+                  <FiServer className="inline-block mr-1 my-auto" />
+                  MCP Server
+                </span>
+              </TableCell>
+              <TableCell className="whitespace-nowrap">
+                <div className="flex">
+                  <div className="my-auto">
+                    <div
+                      className="hover:bg-accent-background-hovered rounded p-1 cursor-pointer"
+                      onClick={async () => {
+                        const confirmDelete = window.confirm(
+                          "Delete this MCP server and all its tools and configs? This cannot be undone."
+                        );
+                        if (!confirmDelete) return;
+                        const response = await deleteMCPServer(server.id);
+                        if (response.data?.success) {
+                          router.refresh();
+                        } else {
+                          setPopup({
+                            message: `Failed to delete MCP server - ${response.error}`,
+                            type: "error",
+                          });
+                        }
+                      }}
+                    >
+                      <TrashIcon />
+                    </div>
+                  </div>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+
+          {/* Render regular tools */}
           {sortedTools.map((tool) => (
-            <TableRow key={tool.id.toString()}>
+            <TableRow key={`tool-${tool.id}`}>
               <TableCell>
                 <div className="flex">
                   {tool.in_code_tool_id === null && (
                     <FiEdit2
                       className="mr-1 my-auto cursor-pointer"
-                      onClick={() =>
+                      onClick={() => {
                         router.push(
                           `/admin/actions/edit/${tool.id}?u=${Date.now()}`
-                        )
-                      }
+                        );
+                      }}
                     />
                   )}
                   <p className="text font-medium whitespace-normal break-none">
@@ -61,13 +133,13 @@ export function ActionsTable({ tools }: { tools: ToolSnapshot[] }) {
               <TableCell className="whitespace-nowrap">
                 {tool.in_code_tool_id === null ? (
                   <span>
-                    <FiXCircle className="inline-block mr-1 my-auto" />
-                    No
+                    <FiCode className="inline-block mr-1 my-auto" />
+                    OpenAPI
                   </span>
                 ) : (
                   <span>
                     <FiCheckCircle className="inline-block mr-1 my-auto" />
-                    Yes
+                    Built In
                   </span>
                 )}
               </TableCell>

--- a/web/src/app/admin/actions/edit-mcp/page.tsx
+++ b/web/src/app/admin/actions/edit-mcp/page.tsx
@@ -6,8 +6,8 @@ import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { BackButton } from "@/components/BackButton";
 import { AdminPageTitle } from "@/components/admin/Title";
-import { ToolIcon, SearchIcon } from "@/components/icons/icons";
-import { FiInfo, FiPlus, FiX, FiLink, FiCheck } from "react-icons/fi";
+import { ToolIcon } from "@/components/icons/icons";
+import { FiLink, FiCheck } from "react-icons/fi";
 import CardSection from "@/components/admin/CardSection";
 import { TextFormField } from "@/components/Field";
 import { Button } from "@/components/ui/button";
@@ -23,12 +23,9 @@ import {
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import Text from "@/components/ui/text";
-import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   MCPAuthenticationPerformer,
   MCPAuthenticationType,
-  MCPTransportType,
 } from "@/lib/tools/interfaces";
 import {
   PerUserAuthTemplateConfig,
@@ -48,28 +45,35 @@ const validationSchema = Yup.object().shape({
     .url("Must be a valid URL")
     .required("Server URL is required"),
   auth_type: Yup.string()
-    .oneOf(["none", "api_token", "oauth"])
+    .oneOf([
+      MCPAuthenticationType.NONE,
+      MCPAuthenticationType.API_TOKEN,
+      MCPAuthenticationType.OAUTH,
+    ])
     .required("Authentication type is required"),
   auth_performer: Yup.string().when("auth_type", {
-    is: (auth_type: string) => auth_type !== "none",
+    is: (auth_type: string) => auth_type !== MCPAuthenticationType.NONE,
     then: (schema) =>
       schema
-        .oneOf(["admin", "per_user"])
+        .oneOf([
+          MCPAuthenticationPerformer.ADMIN,
+          MCPAuthenticationPerformer.PER_USER,
+        ])
         .required("Authentication performer is required"),
     otherwise: (schema) => schema.notRequired(),
   }),
   api_token: Yup.string().when("auth_type", {
-    is: "api_token",
+    is: MCPAuthenticationType.API_TOKEN,
     then: (schema) => schema.required("API token is required"),
     otherwise: (schema) => schema.notRequired(),
   }),
   oauth_client_id: Yup.string().when("auth_type", {
-    is: "oauth",
+    is: MCPAuthenticationType.OAUTH,
     then: (schema) => schema.required("OAuth client ID is required"),
     otherwise: (schema) => schema.notRequired(),
   }),
   oauth_client_secret: Yup.string().when("auth_type", {
-    is: "oauth",
+    is: MCPAuthenticationType.OAUTH,
     then: (schema) => schema.required("OAuth client secret is required"),
     otherwise: (schema) => schema.notRequired(),
   }),

--- a/web/src/app/admin/actions/edit-mcp/page.tsx
+++ b/web/src/app/admin/actions/edit-mcp/page.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import { useState, useEffect, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Formik, Form } from "formik";
+import * as Yup from "yup";
+import { BackButton } from "@/components/BackButton";
+import { AdminPageTitle } from "@/components/admin/Title";
+import { ToolIcon, SearchIcon } from "@/components/icons/icons";
+import { FiInfo, FiPlus, FiX, FiLink, FiCheck } from "react-icons/fi";
+import CardSection from "@/components/admin/CardSection";
+import { TextFormField } from "@/components/Field";
+import { Button } from "@/components/ui/button";
+
+import { usePopup } from "@/components/admin/connectors/Popup";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import Text from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  MCPAuthenticationPerformer,
+  MCPAuthenticationType,
+  MCPTransportType,
+} from "@/lib/tools/interfaces";
+import {
+  PerUserAuthTemplateConfig,
+  OAuthConfig,
+} from "@/components/admin/actions/forms";
+import {
+  MCPFormValues,
+  MCPAuthTemplate,
+  MCPServerDetail,
+} from "@/components/admin/actions/interfaces";
+import { ToolList } from "@/components/admin/actions/ToolList";
+
+const validationSchema = Yup.object().shape({
+  name: Yup.string().required("Name is required"),
+  description: Yup.string(),
+  server_url: Yup.string()
+    .url("Must be a valid URL")
+    .required("Server URL is required"),
+  auth_type: Yup.string()
+    .oneOf(["none", "api_token", "oauth"])
+    .required("Authentication type is required"),
+  auth_performer: Yup.string().when("auth_type", {
+    is: (auth_type: string) => auth_type !== "none",
+    then: (schema) =>
+      schema
+        .oneOf(["admin", "per_user"])
+        .required("Authentication performer is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  api_token: Yup.string().when("auth_type", {
+    is: "api_token",
+    then: (schema) => schema.required("API token is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  oauth_client_id: Yup.string().when("auth_type", {
+    is: "oauth",
+    then: (schema) => schema.required("OAuth client ID is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  oauth_client_secret: Yup.string().when("auth_type", {
+    is: "oauth",
+    then: (schema) => schema.required("OAuth client secret is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+});
+
+export default function NewMCPToolPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { popup, setPopup } = usePopup();
+
+  const [loading, setLoading] = useState(false);
+
+  const [oauthConnected, setOauthConnected] = useState(false);
+  const [checkingOAuthStatus, setCheckingOAuthStatus] = useState(false);
+  const [initialValues, setInitialValues] = useState<MCPFormValues>({
+    name: "",
+    description: "",
+    server_url: "",
+    auth_type: MCPAuthenticationType.NONE,
+    auth_performer: MCPAuthenticationPerformer.ADMIN,
+    api_token: "",
+    oauth_client_id: "",
+    oauth_client_secret: "",
+  });
+  const fetchedServerRef = useRef<string | null>(null);
+
+  const probeOAuthConnection = async (id: number) => {
+    setCheckingOAuthStatus(true);
+    try {
+      const resp = await fetch(`/api/admin/mcp/server/${id}/tools`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+      setOauthConnected(resp.ok);
+    } catch (e) {
+      setOauthConnected(false);
+    } finally {
+      setCheckingOAuthStatus(false);
+    }
+  };
+
+  // Memoize the server ID to prevent unnecessary re-renders
+  const serverId = useMemo(() => searchParams.get("server_id"), [searchParams]);
+
+  // Check for OAuth callback return
+  useEffect(() => {
+    const oauthReturn = sessionStorage.getItem("mcp_oauth_return");
+    if (oauthReturn) {
+      try {
+        const { serverId: returnServerId, formValues } =
+          JSON.parse(oauthReturn);
+        sessionStorage.removeItem("mcp_oauth_return");
+
+        // Set the form values and mark OAuth as connected
+        setInitialValues(formValues);
+        if (returnServerId) {
+          // Actively probe connectivity instead of assuming connected
+          probeOAuthConnection(Number(returnServerId));
+        }
+
+        // Update URL to include the server ID
+        router.push(`/admin/actions/edit-mcp?server_id=${returnServerId}`);
+      } catch (error) {
+        console.error("Failed to restore OAuth state:", error);
+      }
+    }
+  }, []);
+
+  // Load existing server data if server_id is provided
+  useEffect(() => {
+    if (!serverId || fetchedServerRef.current === serverId) return;
+
+    const fetchServerData = async () => {
+      setLoading(true);
+      fetchedServerRef.current = serverId; // Mark as fetching/fetched
+
+      try {
+        const response = await fetch(`/api/admin/mcp/servers/${serverId}`);
+        if (!response.ok) {
+          throw new Error(await response.text());
+        }
+        const server: MCPServerDetail = await response.json();
+
+        // Build auth_template if this is a per-user server
+        let auth_template: MCPAuthTemplate | undefined;
+        if (
+          server.auth_performer === MCPAuthenticationPerformer.PER_USER &&
+          server.auth_template
+        ) {
+          auth_template = server.auth_template;
+        }
+
+        if (server.auth_type === MCPAuthenticationType.OAUTH) {
+          // Probe by listing tools with current configuration
+          probeOAuthConnection(Number(serverId));
+        }
+
+        setInitialValues({
+          name: server.name,
+          description: server.description || "",
+          server_url: server.server_url,
+          auth_type: server.auth_type,
+          auth_performer:
+            server.auth_performer || MCPAuthenticationPerformer.ADMIN,
+          api_token: server.admin_credentials?.api_key || "",
+          auth_template,
+          user_credentials: server.user_credentials || {},
+          oauth_client_id: server.admin_credentials?.client_id || "",
+          oauth_client_secret: server.admin_credentials?.client_secret || "",
+        });
+      } catch (error) {
+        console.error("Failed to load server data:", error);
+        setPopup({
+          message: "Failed to load server configuration",
+          type: "error",
+        });
+        fetchedServerRef.current = null; // Reset on error so user can retry
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchServerData();
+  }, [serverId]); // Only depend on the memoized server ID
+
+  const handleOAuthConnect = async (values: MCPFormValues) => {
+    setCheckingOAuthStatus(true);
+    try {
+      // First, create the MCP server if it doesn't exist
+      console.log("option 1");
+      const createResponse = await fetch("/api/admin/mcp/servers/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: values.name,
+          description: values.description,
+          server_url: values.server_url,
+          auth_type: values.auth_type,
+          auth_performer: values.auth_performer,
+          oauth_client_id: values.oauth_client_id,
+          oauth_client_secret: values.oauth_client_secret,
+          existing_server_id: serverId ? parseInt(serverId) : undefined,
+        }),
+      });
+
+      if (!createResponse.ok) {
+        const error = await createResponse.json();
+        throw new Error(error.detail || "Failed to create OAuth server");
+      }
+
+      const currServerId = (await createResponse.json()).server_id;
+
+      // Initiate OAuth flow
+      const oauthResponse = await fetch("/api/admin/mcp/oauth/initiate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          server_id: currServerId.toString(),
+          oauth_client_id: values.oauth_client_id,
+          oauth_client_secret: values.oauth_client_secret,
+          return_path:
+            "/admin/actions/edit-mcp?server_id=" + currServerId.toString(),
+          include_resource_param: true,
+        }),
+      });
+
+      if (!oauthResponse.ok) {
+        const error = await oauthResponse.json();
+        throw new Error("Failed to initiate OAuth: " + error.detail);
+      }
+
+      const { oauth_url } = await oauthResponse.json();
+
+      // Store current form state to restore after OAuth callback
+      sessionStorage.setItem(
+        "mcp_oauth_return",
+        JSON.stringify({
+          serverId: currServerId,
+          formValues: values,
+        })
+      );
+
+      // Redirect to OAuth provider
+      window.location.href = oauth_url;
+    } catch (error) {
+      console.error("OAuth connect error:", error);
+      setPopup({
+        message:
+          error instanceof Error ? error.message : "Failed to connect OAuth",
+        type: "error",
+      });
+    } finally {
+      setCheckingOAuthStatus(false);
+    }
+  };
+
+  const verbRoot = serverId ? "Updat" : "Creat";
+  return (
+    <div className="mx-auto container">
+      {popup}
+      <BackButton routerOverride="/admin/actions" />
+
+      <AdminPageTitle
+        title={verbRoot + "e MCP Server Actions"}
+        icon={<ToolIcon size={32} className="my-auto" />}
+      />
+
+      <Text className="mb-4">
+        Configure an MCP (Model Context Protocol) server to create actions that
+        can interact with external systems.
+      </Text>
+
+      <CardSection>
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-2"></div>
+              <Text>Loading server configuration...</Text>
+            </div>
+          </div>
+        ) : (
+          <Formik
+            initialValues={initialValues}
+            enableReinitialize={true}
+            validationSchema={validationSchema}
+            onSubmit={() => {}}
+          >
+            {({ values, setFieldValue, errors, touched }) => {
+              return (
+                <Form
+                  style={{ width: 600, position: "relative" }}
+                  className="isolate"
+                >
+                  <div className="space-y-6 relative">
+                    <div>
+                      <h3 className="text-lg font-medium mb-4">
+                        Basic Information
+                      </h3>
+                      <div className="space-y-4">
+                        <TextFormField
+                          name="name"
+                          label="Action Name"
+                          placeholder="e.g., My MCP Tool"
+                          width="min-w-96"
+                        />
+                        <TextFormField
+                          name="description"
+                          label="Description"
+                          placeholder="Brief description of what this MCP server does"
+                          width="min-w-96"
+                        />
+                        <TextFormField
+                          name="server_url"
+                          label="Server URL"
+                          placeholder="https://your-mcp-server.com"
+                          width="min-w-96"
+                        />
+                      </div>
+                    </div>
+
+                    <Separator />
+
+                    <div>
+                      <h3 className="text-lg font-medium mb-4">
+                        Authentication Configuration
+                      </h3>
+                      <div className="space-y-4">
+                        <div>
+                          <Label htmlFor="auth_type">Authentication Type</Label>
+                          <Select
+                            value={values.auth_type}
+                            onValueChange={(value) =>
+                              setFieldValue("auth_type", value)
+                            }
+                          >
+                            <SelectTrigger className="mt-1">
+                              <SelectValue placeholder="Select authentication type" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value={MCPAuthenticationType.NONE}>
+                                None
+                              </SelectItem>
+                              <SelectItem
+                                value={MCPAuthenticationType.API_TOKEN}
+                              >
+                                API Token
+                              </SelectItem>
+                              <SelectItem value={MCPAuthenticationType.OAUTH}>
+                                OAuth
+                              </SelectItem>
+                            </SelectContent>
+                          </Select>
+                          {errors.auth_type && touched.auth_type && (
+                            <div className="text-red-500 text-sm mt-1">
+                              {errors.auth_type}
+                            </div>
+                          )}
+                        </div>
+
+                        {values.auth_type !== MCPAuthenticationType.NONE && (
+                          <div>
+                            <Label htmlFor="auth_performer">
+                              Who performs authentication?
+                            </Label>
+                            <Select
+                              value={values.auth_performer}
+                              onValueChange={(value) =>
+                                setFieldValue("auth_performer", value)
+                              }
+                            >
+                              <SelectTrigger className="mt-1">
+                                <SelectValue placeholder="Select authentication performer" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem
+                                  value={MCPAuthenticationPerformer.ADMIN}
+                                >
+                                  Admin (shared credentials)
+                                </SelectItem>
+                                <SelectItem
+                                  value={MCPAuthenticationPerformer.PER_USER}
+                                >
+                                  Per-user (individual credentials)
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                            {errors.auth_performer &&
+                              touched.auth_performer && (
+                                <div className="text-red-500 text-sm mt-1">
+                                  {errors.auth_performer}
+                                </div>
+                              )}
+                          </div>
+                        )}
+
+                        {values.auth_type === MCPAuthenticationType.API_TOKEN &&
+                          values.auth_performer ===
+                            MCPAuthenticationPerformer.ADMIN && (
+                            <TextFormField
+                              name="api_token"
+                              label="API Token"
+                              placeholder="Enter your API token"
+                              type="password"
+                              width="min-w-96"
+                            />
+                          )}
+
+                        {values.auth_type === MCPAuthenticationType.API_TOKEN &&
+                          values.auth_performer ===
+                            MCPAuthenticationPerformer.PER_USER && (
+                            <PerUserAuthTemplateConfig
+                              values={values}
+                              setFieldValue={setFieldValue}
+                              errors={errors}
+                              touched={touched}
+                            />
+                          )}
+
+                        {values.auth_type === MCPAuthenticationType.OAUTH && (
+                          <OAuthConfig
+                            values={values}
+                            setFieldValue={setFieldValue}
+                            errors={errors}
+                            touched={touched}
+                          />
+                        )}
+                      </div>
+                    </div>
+
+                    {values.auth_type === MCPAuthenticationType.OAUTH && (
+                      <div className="flex items-center gap-2">
+                        <Button
+                          type="button"
+                          onClick={() => handleOAuthConnect(values)}
+                          disabled={
+                            checkingOAuthStatus ||
+                            !values.name.trim() ||
+                            !values.server_url.trim() ||
+                            !values.oauth_client_id?.trim() ||
+                            !values.oauth_client_secret?.trim()
+                          }
+                          className="flex-1"
+                        >
+                          {checkingOAuthStatus ? (
+                            "Connecting..."
+                          ) : oauthConnected ? (
+                            <>
+                              <FiCheck className="mr-2 h-4 w-4" />
+                              OAuth Connected
+                            </>
+                          ) : (
+                            <>
+                              <FiLink className="mr-2 h-4 w-4" />
+                              Connect OAuth
+                            </>
+                          )}
+                        </Button>
+                      </div>
+                    )}
+                    <Separator />
+                    <ToolList
+                      values={values}
+                      verbRoot={verbRoot}
+                      serverId={serverId ? parseInt(serverId) : undefined}
+                      oauthConnected={oauthConnected}
+                      setPopup={setPopup}
+                    />
+                  </div>
+                </Form>
+              );
+            }}
+          </Formik>
+        )}
+      </CardSection>
+    </div>
+  );
+}

--- a/web/src/app/admin/actions/page.tsx
+++ b/web/src/app/admin/actions/page.tsx
@@ -1,5 +1,5 @@
 import { ActionsTable } from "./ActionTable";
-import { ToolSnapshot } from "@/lib/tools/interfaces";
+import { ToolSnapshot, MCPServersResponse } from "@/lib/tools/interfaces";
 import { Separator } from "@/components/ui/separator";
 import Text from "@/components/ui/text";
 import Title from "@/components/ui/title";
@@ -8,9 +8,22 @@ import { ErrorCallout } from "@/components/ErrorCallout";
 import { AdminPageTitle } from "@/components/admin/Title";
 import { ToolIcon } from "@/components/icons/icons";
 import CreateButton from "@/components/ui/createButton";
+import { Button } from "@/components/ui/button";
+import { FiPlusCircle, FiHelpCircle } from "react-icons/fi";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import Link from "next/link";
 
 export default async function Page() {
-  const toolResponse = await fetchSS("/tool");
+  // Fetch both tools and MCP servers
+  const [toolResponse, mcpResponse] = await Promise.all([
+    fetchSS("/tool"),
+    fetchSS("/admin/mcp/servers"),
+  ]);
 
   if (!toolResponse.ok) {
     return (
@@ -22,6 +35,26 @@ export default async function Page() {
   }
 
   const tools = (await toolResponse.json()) as ToolSnapshot[];
+
+  // Filter out MCP tools from the regular tools list
+  const nonMcpTools = tools.filter((tool) => !tool.mcp_server_id);
+
+  let mcpServers: MCPServersResponse["mcp_servers"] = [];
+  if (mcpResponse.ok) {
+    try {
+      const mcpData = (await mcpResponse.json()) as MCPServersResponse;
+      mcpServers = mcpData.mcp_servers;
+    } catch (error) {
+      console.error("Error parsing MCP servers response:", error);
+    }
+  } else {
+    return (
+      <ErrorCallout
+        errorTitle="Something went wrong :("
+        errorMsg={`Failed to fetch MCP servers - ${await mcpResponse.text()}`}
+      />
+    );
+  }
 
   return (
     <div className="mx-auto container">
@@ -37,13 +70,39 @@ export default async function Page() {
       <div>
         <Separator />
 
-        <Title>Create an Action</Title>
-        <CreateButton href="/admin/actions/new" text="New Action" />
+        <Title>Create Actions</Title>
+        <div className="flex gap-4 mt-2 items-center">
+          <CreateButton
+            href="/admin/actions/new"
+            text="From OpenAPI schema"
+            icon={<FiPlusCircle />}
+          />
+          <CreateButton
+            href="/admin/actions/edit-mcp"
+            text="From MCP server"
+            icon={<FiPlusCircle />}
+          />
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <FiHelpCircle className="h-4 w-4 text-subtle hover:text-emphasis cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-xs">
+                  MCP (Model Context Protocol) servers provide structured ways
+                  for AI models to interact with external systems and data
+                  sources. They offer a standardized interface for tools and
+                  resources.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
 
         <Separator />
 
         <Title>Existing Actions</Title>
-        <ActionsTable tools={tools} />
+        <ActionsTable tools={nonMcpTools} mcpServers={mcpServers} />
       </div>
     </div>
   );

--- a/web/src/app/admin/actions/page.tsx
+++ b/web/src/app/admin/actions/page.tsx
@@ -8,7 +8,6 @@ import { ErrorCallout } from "@/components/ErrorCallout";
 import { AdminPageTitle } from "@/components/admin/Title";
 import { ToolIcon } from "@/components/icons/icons";
 import CreateButton from "@/components/ui/createButton";
-import { Button } from "@/components/ui/button";
 import { FiPlusCircle, FiHelpCircle } from "react-icons/fi";
 import {
   Tooltip,
@@ -16,7 +15,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import Link from "next/link";
 
 export default async function Page() {
   // Fetch both tools and MCP servers

--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -431,8 +431,6 @@ export function AssistantEditor({
         const data = await response.json();
         setMcpServers(data.mcp_servers || []);
       }
-      console.log("mcpServers", mcpServers);
-      console.log("response", response);
     };
 
     fetchMcpServers();

--- a/web/src/app/admin/assistants/AssistantEditor.tsx
+++ b/web/src/app/admin/assistants/AssistantEditor.tsx
@@ -25,7 +25,7 @@ import {
   modelSupportsImageInput,
   structureValue,
 } from "@/lib/llm/utils";
-import { ToolSnapshot } from "@/lib/tools/interfaces";
+import { ToolSnapshot, MCPServer } from "@/lib/tools/interfaces";
 import { checkUserIsNoAuthUser } from "@/lib/user";
 
 import {
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/tooltip";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { FiChevronDown, FiChevronRight } from "react-icons/fi";
 import { useContext, useEffect, useMemo, useState } from "react";
 import * as Yup from "yup";
 import { SettingsContext } from "@/components/settings/SettingsProvider";
@@ -212,15 +213,80 @@ export function AssistantEditor({
   const imageGenerationTool = findImageGenerationTool(tools);
   const internetSearchTool = findInternetSearchTool(tools);
 
-  const customTools = tools.filter(
+  // Separate MCP tools from regular custom tools
+  const allCustomTools = tools.filter(
     (tool) =>
       tool.in_code_tool_id !== searchTool?.in_code_tool_id &&
       tool.in_code_tool_id !== imageGenerationTool?.in_code_tool_id &&
       tool.in_code_tool_id !== internetSearchTool?.in_code_tool_id
   );
 
+  const mcpTools = allCustomTools.filter((tool) => tool.mcp_server_id);
+  const customTools = allCustomTools.filter((tool) => !tool.mcp_server_id);
+
+  // Group MCP tools by server
+  const mcpToolsByServer = useMemo(() => {
+    const groups: { [serverId: number]: ToolSnapshot[] } = {};
+    mcpTools.forEach((tool) => {
+      if (tool.mcp_server_id) {
+        if (!groups[tool.mcp_server_id]) {
+          groups[tool.mcp_server_id] = [];
+        }
+        groups[tool.mcp_server_id]!.push(tool);
+      }
+    });
+    return groups;
+  }, [mcpTools]);
+
+  // Helper functions for MCP server checkbox state
+  const getMCPServerCheckboxState = (
+    serverId: number,
+    enabledToolsMap: { [key: number]: boolean }
+  ) => {
+    const serverTools = mcpToolsByServer[serverId] || [];
+    const enabledCount = serverTools.filter(
+      (tool) => enabledToolsMap[tool.id]
+    ).length;
+
+    if (enabledCount === 0) return false; // unchecked
+    if (enabledCount === serverTools.length) return true; // checked
+    return "indeterminate"; // partially checked
+  };
+
+  const toggleMCPServerTools = (
+    serverId: number,
+    enabledToolsMap: { [key: number]: boolean },
+    setFieldValue: any
+  ) => {
+    const serverTools = mcpToolsByServer[serverId] || [];
+    const currentState = getMCPServerCheckboxState(serverId, enabledToolsMap);
+    const shouldEnable = currentState !== true; // enable if not fully checked
+
+    const updatedMap = { ...enabledToolsMap };
+    serverTools.forEach((tool) => {
+      updatedMap[tool.id] = shouldEnable;
+    });
+
+    setFieldValue("enabled_tools_map", updatedMap);
+  };
+
+  const toggleServerCollapse = (serverId: number) => {
+    const newCollapsed = new Set(collapsedServers);
+    if (newCollapsed.has(serverId)) {
+      newCollapsed.delete(serverId);
+    } else {
+      newCollapsed.add(serverId);
+    }
+    setCollapsedServers(newCollapsed);
+  };
+
+  const getMCPServerInfo = (serverId: number): MCPServer | null => {
+    return mcpServers.find((server) => server.id === serverId) || null;
+  };
+
   const availableTools = [
     ...customTools,
+    ...mcpTools, // Include MCP tools for form logic
     ...(searchTool ? [searchTool] : []),
     ...(imageGenerationTool ? [imageGenerationTool] : []),
     ...(internetSearchTool ? [internetSearchTool] : []),
@@ -343,6 +409,10 @@ export function AssistantEditor({
 
   const [labelToDelete, setLabelToDelete] = useState<PersonaLabel | null>(null);
   const [isRequestSuccessful, setIsRequestSuccessful] = useState(false);
+  const [mcpServers, setMcpServers] = useState<MCPServer[]>([]);
+  const [collapsedServers, setCollapsedServers] = useState<Set<number>>(
+    new Set()
+  );
 
   const { data: userGroups } = useUserGroups();
 
@@ -352,6 +422,21 @@ export function AssistantEditor({
   );
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
+  // Fetch MCP servers for URL display
+  useEffect(() => {
+    const fetchMcpServers = async () => {
+      const response = await fetch("/api/admin/mcp/servers");
+      if (response.ok) {
+        const data = await response.json();
+        setMcpServers(data.mcp_servers || []);
+      }
+      console.log("mcpServers", mcpServers);
+      console.log("response", response);
+    };
+
+    fetchMcpServers();
+  }, []);
 
   if (!labels) {
     return <></>;
@@ -1133,6 +1218,7 @@ export function AssistantEditor({
                         </>
                       )}
 
+                      {/* Regular Custom Tools */}
                       {customTools.length > 0 &&
                         customTools.map((tool) => (
                           <BooleanFormField
@@ -1142,6 +1228,98 @@ export function AssistantEditor({
                             subtext={tool.description}
                           />
                         ))}
+
+                      {/* MCP Server Tools - Hierarchical Structure */}
+                      {Object.keys(mcpToolsByServer).length > 0 &&
+                        Object.entries(mcpToolsByServer).map(
+                          ([serverId, serverTools]) => {
+                            const serverIdNum = parseInt(serverId);
+                            const serverInfo = getMCPServerInfo(serverIdNum);
+                            const isCollapsed =
+                              collapsedServers.has(serverIdNum);
+
+                            // Extract server name from tool name (format: "server_name_tool_name")
+                            const firstTool = serverTools[0];
+                            const serverName =
+                              serverInfo?.name ||
+                              firstTool?.name
+                                ?.split("_")
+                                .slice(0, -1)
+                                .join("_") ||
+                              `MCP Server ${serverId}`;
+
+                            const serverUrl =
+                              serverInfo?.server_url || "Unknown URL";
+
+                            const checkboxState = getMCPServerCheckboxState(
+                              serverIdNum,
+                              values.enabled_tools_map
+                            );
+
+                            return (
+                              <div
+                                key={`mcp-server-${serverId}`}
+                                className="border rounded-lg p-4 space-y-3 dark:border-gray-700"
+                              >
+                                {/* Server-level header with collapse button */}
+                                <div className="flex items-center space-x-3">
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      toggleServerCollapse(serverIdNum)
+                                    }
+                                    className="flex-shrink-0 p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                                  >
+                                    {isCollapsed ? (
+                                      <FiChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                                    ) : (
+                                      <FiChevronDown className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+                                    )}
+                                  </button>
+                                  <input
+                                    type="checkbox"
+                                    checked={checkboxState === true}
+                                    ref={(el) => {
+                                      if (el)
+                                        el.indeterminate =
+                                          checkboxState === "indeterminate";
+                                    }}
+                                    onChange={() =>
+                                      toggleMCPServerTools(
+                                        serverIdNum,
+                                        values.enabled_tools_map,
+                                        setFieldValue
+                                      )
+                                    }
+                                    className="w-4 h-4 text-blue-600 bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500"
+                                  />
+                                  <div className="flex-grow">
+                                    <div className="font-medium text-sm text-gray-900 dark:text-gray-100">
+                                      {serverName}
+                                    </div>
+                                    <div className="text-xs text-gray-600 dark:text-gray-400">
+                                      {serverUrl} ({serverTools.length} tools)
+                                    </div>
+                                  </div>
+                                </div>
+
+                                {/* Individual tool checkboxes - only show when not collapsed */}
+                                {!isCollapsed && (
+                                  <div className="ml-7 space-y-2">
+                                    {serverTools.map((tool) => (
+                                      <BooleanFormField
+                                        key={tool.id}
+                                        name={`enabled_tools_map.${tool.id}`}
+                                        label={tool.display_name}
+                                        subtext={tool.description}
+                                      />
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          }
+                        )}
                     </div>
                   </div>
                 </div>

--- a/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
@@ -184,11 +184,6 @@ const AdvancedEmbeddingFormPage = forwardRef<
                         function (value) {
                           const enableContextualRag =
                             this.parent.enable_contextual_rag;
-                          console.log(
-                            "enableContextualRag2",
-                            enableContextualRag
-                          );
-                          console.log("value2", value);
                           return !enableContextualRag || value !== null;
                         }
                       ),

--- a/web/src/app/api/chat/mcp/oauth/callback/route.ts
+++ b/web/src/app/api/chat/mcp/oauth/callback/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Proxies browser callback to backend OAuth callback endpoint and then
+// redirects back to the chat UI.
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const serverId = url.searchParams.get("server_id") || url.searchParams.get("serverId");
+  const codeVerifier = url.searchParams.get("code_verifier");
+
+  if (!code || !serverId) {
+    return NextResponse.json({ error: "Missing code or server_id" }, { status: 400 });
+  }
+
+  try {
+    const resp = await fetch(`${process.env.NEXT_PUBLIC_ONYX_BACKEND_URL || ""}/api/mcp/oauth/callback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        server_id: serverId,
+        code,
+        state,
+        code_verifier: codeVerifier,
+        transport: "streamable-http",
+      }),
+      // Ensure cookies/auth forwarded if needed
+      credentials: "include",
+    });
+
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({} as any));
+      return NextResponse.json({ error: err.detail || "OAuth callback failed" }, { status: 400 });
+    }
+
+    // Check if this is an admin OAuth flow
+    const isAdminFlow = url.searchParams.get("admin") === "true";
+    
+    // Redirect back to appropriate page
+    let redirectTo = url.searchParams.get("redirect_to");
+    if (!redirectTo) {
+      if (isAdminFlow) {
+        // For admin flow, redirect back to the MCP edit page
+        redirectTo = `/admin/actions/edit-mcp?server_id=${serverId}`;
+      } else {
+        // For user flow, redirect to chat
+        redirectTo = "/chat";
+      }
+    }
+    
+    return NextResponse.redirect(new URL(redirectTo, req.url));
+  } catch (e) {
+    return NextResponse.json({ error: "OAuth callback error" }, { status: 500 });
+  }
+}
+
+

--- a/web/src/app/api/chat/mcp/oauth/callback/route.ts
+++ b/web/src/app/api/chat/mcp/oauth/callback/route.ts
@@ -7,36 +7,46 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
-  const serverId = url.searchParams.get("server_id") || url.searchParams.get("serverId");
+  const serverId =
+    url.searchParams.get("server_id") || url.searchParams.get("serverId");
   const codeVerifier = url.searchParams.get("code_verifier");
 
   if (!code || !serverId) {
-    return NextResponse.json({ error: "Missing code or server_id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing code or server_id" },
+      { status: 400 }
+    );
   }
 
   try {
-    const resp = await fetch(`${process.env.NEXT_PUBLIC_ONYX_BACKEND_URL || ""}/api/mcp/oauth/callback`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        server_id: serverId,
-        code,
-        state,
-        code_verifier: codeVerifier,
-        transport: "streamable-http",
-      }),
-      // Ensure cookies/auth forwarded if needed
-      credentials: "include",
-    });
+    const resp = await fetch(
+      `${process.env.NEXT_PUBLIC_ONYX_BACKEND_URL || ""}/api/mcp/oauth/callback`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          server_id: serverId,
+          code,
+          state,
+          code_verifier: codeVerifier,
+          transport: "streamable-http",
+        }),
+        // Ensure cookies/auth forwarded if needed
+        credentials: "include",
+      }
+    );
 
     if (!resp.ok) {
-      const err = await resp.json().catch(() => ({} as any));
-      return NextResponse.json({ error: err.detail || "OAuth callback failed" }, { status: 400 });
+      const err = await resp.json().catch(() => ({}) as any);
+      return NextResponse.json(
+        { error: err.detail || "OAuth callback failed" },
+        { status: 400 }
+      );
     }
 
     // Check if this is an admin OAuth flow
     const isAdminFlow = url.searchParams.get("admin") === "true";
-    
+
     // Redirect back to appropriate page
     let redirectTo = url.searchParams.get("redirect_to");
     if (!redirectTo) {
@@ -48,11 +58,12 @@ export async function GET(req: NextRequest) {
         redirectTo = "/chat";
       }
     }
-    
+
     return NextResponse.redirect(new URL(redirectTo, req.url));
   } catch (e) {
-    return NextResponse.json({ error: "OAuth callback error" }, { status: 500 });
+    return NextResponse.json(
+      { error: "OAuth callback error" },
+      { status: 500 }
+    );
   }
 }
-
-

--- a/web/src/app/chat/components/input/ActionManagement.tsx
+++ b/web/src/app/chat/components/input/ActionManagement.tsx
@@ -7,18 +7,33 @@ import {
   IconProps,
   MoreActionsIcon,
 } from "@/components/icons/icons";
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
-import { ToolSnapshot } from "@/lib/tools/interfaces";
+import {
+  ToolSnapshot,
+  MCPAuthenticationType,
+  MCPAuthenticationPerformer,
+} from "@/lib/tools/interfaces";
 import { useAssistantsContext } from "@/components/context/AssistantsContext";
 import Link from "next/link";
 import { getIconForAction } from "../../services/actionUtils";
 import { useUser } from "@/components/user/UserProvider";
+import {
+  FiServer,
+  FiChevronRight,
+  FiKey,
+  FiLock,
+  FiCheck,
+  FiAlertTriangle,
+  FiLoader,
+} from "react-icons/fi";
+import { MCPApiKeyModal } from "@/components/chat/MCPApiKeyModal";
 
 interface ActionItemProps {
   tool?: ToolSnapshot;
@@ -113,6 +128,249 @@ export function ActionItem({
   );
 }
 
+interface MCPServer {
+  id: number;
+  name: string;
+  server_url: string;
+  auth_type: MCPAuthenticationType;
+  auth_performer: MCPAuthenticationPerformer;
+  is_authenticated: boolean;
+  user_authenticated?: boolean;
+  auth_template?: any;
+  user_credentials?: Record<string, string>;
+}
+
+interface MCPTool {
+  name: string;
+  display_name?: string;
+  description?: string;
+  parameters?: any;
+}
+
+interface MCPServerItemProps {
+  server: MCPServer;
+  isExpanded: boolean;
+  onToggleExpand: (element: HTMLElement) => void;
+  onAuthenticate: () => void;
+  tools: ToolSnapshot[];
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+function MCPServerItem({
+  server,
+  isExpanded,
+  onToggleExpand,
+  onAuthenticate,
+  tools,
+  isAuthenticated,
+  isLoading,
+}: MCPServerItemProps) {
+  const itemRef = useRef<HTMLDivElement>(null);
+
+  const getServerIcon = () => {
+    if (isLoading) {
+      return <FiLoader className="animate-spin" />;
+    }
+    if (isAuthenticated) {
+      return <FiCheck className="text-green-500" />;
+    }
+    if (server.auth_type === MCPAuthenticationType.NONE) {
+      return <FiServer />;
+    }
+    if (server.auth_performer === MCPAuthenticationPerformer.PER_USER) {
+      return <FiKey className="text-yellow-500" />;
+    }
+    return <FiLock className="text-red-500" />;
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent closing the main popup
+    if (isAuthenticated && itemRef.current) {
+      console.log("MCPServerItem handleClick - passing element:", {
+        element: itemRef.current,
+        rect: itemRef.current.getBoundingClientRect(),
+        tagName: itemRef.current.tagName,
+        classes: itemRef.current.className,
+      });
+      onToggleExpand(itemRef.current);
+    } else if (!isAuthenticated) {
+      onAuthenticate();
+    }
+  };
+
+  return (
+    <div
+      ref={itemRef}
+      className={`
+        group
+        flex 
+        items-center 
+        justify-between 
+        px-2 
+        cursor-pointer 
+        hover:bg-background-100 
+        dark:hover:bg-neutral-800
+        dark:text-neutral-300
+        rounded-lg 
+        py-2 
+        mx-1
+        ${isExpanded ? "bg-accent-100 hover:bg-accent-200" : ""}
+      `}
+      onClick={handleClick}
+      data-mcp-server-id={server.id}
+      data-mcp-server-name={server.name}
+    >
+      <div className="flex items-center gap-2 flex-1">
+        {getServerIcon()}
+        <span className="text-sm font-medium select-none">{server.name}</span>
+        {isAuthenticated && tools.length > 0 && (
+          <span className="text-xs text-text-400">({tools.length} tools)</span>
+        )}
+      </div>
+      {isAuthenticated && tools.length > 0 && (
+        <FiChevronRight
+          className={`transition-transform ${isExpanded ? "rotate-90" : ""}`}
+          size={14}
+        />
+      )}
+    </div>
+  );
+}
+
+interface MCPToolsListProps {
+  tools: ToolSnapshot[];
+  serverName: string;
+  onClose: () => void;
+  selectedAssistant: MinimalPersonaSnapshot;
+  preventMainPopupClose: () => void;
+}
+
+function MCPToolsList({
+  tools,
+  serverName,
+  onClose,
+  selectedAssistant,
+  preventMainPopupClose,
+}: MCPToolsListProps) {
+  console.log("MCPToolsList", tools, serverName, onClose, selectedAssistant);
+  const [searchTerm, setSearchTerm] = useState("");
+  console.log("searchTerm", searchTerm);
+  const {
+    assistantPreferences,
+    setSpecificAssistantPreferences,
+    forcedToolIds,
+    setForcedToolIds,
+  } = useAssistantsContext();
+
+  console.log("assistantPreferences", assistantPreferences);
+  const assistantPreference = assistantPreferences?.[selectedAssistant.id];
+  const disabledToolIds = assistantPreference?.disabled_tool_ids || [];
+
+  const toggleToolForCurrentAssistant = (toolId: number) => {
+    const disabled = disabledToolIds.includes(toolId);
+    setSpecificAssistantPreferences(selectedAssistant.id, {
+      disabled_tool_ids: disabled
+        ? disabledToolIds.filter((id) => id !== toolId)
+        : [...disabledToolIds, toolId],
+    });
+  };
+
+  const toggleForcedTool = (toolId: number) => {
+    // Keep both popovers open; only outside clicks should close
+    preventMainPopupClose();
+    if (forcedToolIds.includes(toolId)) {
+      setForcedToolIds([]);
+    } else {
+      setForcedToolIds([toolId]);
+    }
+  };
+
+  // Filter tools based on search
+  const filteredTools = tools.filter((tool) => {
+    if (!searchTerm) return true;
+    const searchLower = searchTerm.toLowerCase();
+    return (
+      tool.display_name?.toLowerCase().includes(searchLower) ||
+      tool.name.toLowerCase().includes(searchLower) ||
+      tool.description?.toLowerCase().includes(searchLower)
+    );
+  });
+
+  console.log("filteredTools2", filteredTools);
+  return (
+    <div
+      className="
+        w-[244px] 
+        max-h-[300px]
+        text-text-600 
+        text-sm 
+        p-0 
+        bg-background 
+        border 
+        border-border 
+        rounded-xl 
+        shadow-xl 
+        overflow-hidden
+        flex
+        flex-col
+      "
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Search Input */}
+      <div className="pt-1 mx-1">
+        <div className="relative">
+          <SearchIcon
+            size={16}
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-400"
+          />
+          <input
+            type="text"
+            placeholder={`Search ${serverName} tools`}
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="
+              w-full 
+              pl-9 
+              pr-3 
+              py-2 
+              bg-background-50 
+              rounded-lg 
+              text-sm 
+              outline-none 
+              text-text-700
+              placeholder:text-text-400
+              dark:placeholder:text-neutral-600
+              dark:bg-neutral-950
+            "
+            autoFocus
+          />
+        </div>
+      </div>
+
+      {/* Tools List */}
+      <div className="pt-2 flex-1 overflow-y-auto mx-1 pb-2">
+        {filteredTools.length === 0 ? (
+          <div className="text-center py-1 text-text-400">
+            No matching tools found
+          </div>
+        ) : (
+          filteredTools.map((tool) => (
+            <ActionItem
+              key={tool.id}
+              tool={tool}
+              disabled={disabledToolIds.includes(tool.id)}
+              isForced={forcedToolIds.includes(tool.id)}
+              onToggle={() => toggleToolForCurrentAssistant(tool.id)}
+              onForceToggle={() => toggleForcedTool(tool.id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
 interface ActionToggleProps {
   selectedAssistant: MinimalPersonaSnapshot;
 }
@@ -120,6 +378,49 @@ interface ActionToggleProps {
 export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [mcpServers, setMcpServers] = useState<MCPServer[]>([]);
+  const [mcpToolsPopup, setMcpToolsPopup] = useState<{
+    serverId: number | null;
+    serverName: string;
+    anchorElement: HTMLElement | null;
+  }>({ serverId: null, serverName: "", anchorElement: null });
+
+  // Track if we're in the process of opening an MCP popup
+  const [isOpeningMcpPopup, setIsOpeningMcpPopup] = useState(false);
+  const preventCloseRef = useRef(false);
+
+  // Debug logging
+  console.log(
+    "ActionToggle render - open:",
+    open,
+    "mcpToolsPopup.serverId:",
+    mcpToolsPopup.serverId
+  );
+
+  // Store MCP server auth/loading state (tools are part of selectedAssistant.tools)
+  const [mcpServerData, setMcpServerData] = useState<{
+    [serverId: number]: {
+      isAuthenticated: boolean;
+      isLoading: boolean;
+    };
+  }>({});
+
+  const [mcpApiKeyModal, setMcpApiKeyModal] = useState<{
+    isOpen: boolean;
+    serverId: number | null;
+    serverName: string;
+    authTemplate?: any;
+    onSuccess?: () => void;
+    isAuthenticated?: boolean;
+    existingCredentials?: Record<string, string>;
+  }>({
+    isOpen: false,
+    serverId: null,
+    serverName: "",
+    authTemplate: undefined,
+    onSuccess: undefined,
+    isAuthenticated: false,
+  });
 
   // Get the assistant preference for this assistant
   const {
@@ -129,7 +430,7 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
     setForcedToolIds,
   } = useAssistantsContext();
 
-  const { isAdmin, isCurator } = useUser();
+  const { isAdmin, isCurator, user } = useUser();
 
   const assistantPreference = assistantPreferences?.[selectedAssistant.id];
   const disabledToolIds = assistantPreference?.disabled_tool_ids || [];
@@ -152,8 +453,187 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
     }
   };
 
+  // Filter out MCP tools from the main list (they have mcp_server_id)
+  const displayTools = selectedAssistant.tools.filter(
+    (tool) => !tool.mcp_server_id
+  );
+
+  // Fetch MCP servers for the assistant on mount
+  useEffect(() => {
+    const fetchMCPServers = async () => {
+      if (!selectedAssistant?.id) return;
+
+      try {
+        const response = await fetch(
+          `/api/mcp/servers/${selectedAssistant.id}`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          const servers = data.mcp_servers || [];
+          setMcpServers(servers);
+          // Seed auth/loading state based on response
+          setMcpServerData((prev) => {
+            const next = { ...prev } as any;
+            servers.forEach((s: any) => {
+              next[s.id as number] = {
+                isAuthenticated: !!s.user_authenticated || !!s.is_authenticated,
+                isLoading: false,
+              };
+            });
+            return next;
+          });
+        }
+      } catch (error) {
+        console.error("Error fetching MCP servers:", error);
+      }
+    };
+
+    fetchMCPServers();
+  }, [selectedAssistant?.id]);
+
+  // No separate MCP tool loading; tools already exist in selectedAssistant.tools
+
+  // Handle clicking outside MCP tools popup
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (mcpToolsPopup.serverId && mcpToolsPopup.anchorElement) {
+        const target = event.target as Node;
+        const mcpPopupElement = document.querySelector(
+          '[data-mcp-popup="true"]'
+        );
+
+        // If click is not on the anchor element or inside the MCP popup, close it
+        if (
+          !mcpToolsPopup.anchorElement.contains(target) &&
+          (!mcpPopupElement || !mcpPopupElement.contains(target))
+        ) {
+          console.log("Closing MCP popup due to outside click");
+          setMcpToolsPopup({
+            serverId: null,
+            serverName: "",
+            anchorElement: null,
+          });
+        }
+      }
+    };
+
+    if (mcpToolsPopup.serverId) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [mcpToolsPopup.serverId, mcpToolsPopup.anchorElement]);
+
+  // Handle MCP authentication
+  const handleMCPAuthenticate = async (
+    serverId: number,
+    authType: MCPAuthenticationType
+  ) => {
+    if (authType === MCPAuthenticationType.OAUTH) {
+      try {
+        const response = await fetch("/api/mcp/oauth/initiate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            server_id: serverId,
+            return_path: window.location.pathname + window.location.search,
+            include_resource_param: true,
+          }),
+        });
+
+        if (response.ok) {
+          const { oauth_url } = await response.json();
+          window.location.href = oauth_url;
+        }
+      } catch (error) {
+        console.error("Error initiating OAuth:", error);
+      }
+    }
+  };
+
+  const handleMCPApiKeySubmit = async (serverId: number, apiKey: string) => {
+    try {
+      const response = await fetch("/api/mcp/user-credentials", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          server_id: serverId,
+          credentials: { api_key: apiKey },
+          transport: "streamable-http",
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMessage = errorData.detail || "Failed to save API key";
+        throw new Error(errorMessage);
+      }
+    } catch (error) {
+      console.error("Error saving API key:", error);
+      throw error;
+    }
+  };
+
+  const handleMCPCredentialsSubmit = async (
+    serverId: number,
+    credentials: Record<string, string>
+  ) => {
+    try {
+      const response = await fetch("/api/mcp/user-credentials", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          server_id: serverId,
+          credentials: credentials,
+          transport: "streamable-http",
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const errorMessage = errorData.detail || "Failed to save credentials";
+        throw new Error(errorMessage);
+      }
+    } catch (error) {
+      console.error("Error saving credentials:", error);
+      throw error;
+    }
+  };
+
+  const handleServerAuthentication = (server: MCPServer) => {
+    const authType = server.auth_type;
+    const performer = server.auth_performer;
+
+    if (
+      authType === MCPAuthenticationType.NONE ||
+      performer === MCPAuthenticationPerformer.ADMIN
+    ) {
+      return;
+    }
+
+    if (authType === MCPAuthenticationType.OAUTH) {
+      handleMCPAuthenticate(server.id, MCPAuthenticationType.OAUTH);
+    } else if (authType === MCPAuthenticationType.API_TOKEN) {
+      setMcpApiKeyModal({
+        isOpen: true,
+        serverId: server.id,
+        serverName: server.name,
+        authTemplate: server.auth_template,
+        onSuccess: undefined,
+        isAuthenticated: server.user_authenticated,
+        existingCredentials: server.user_credentials,
+      });
+    }
+  };
+
   // Filter tools based on search term
-  const filteredTools = selectedAssistant.tools.filter((tool) => {
+  const filteredTools = displayTools.filter((tool) => {
     if (!searchTerm) return true;
     const searchLower = searchTerm.toLowerCase();
     return (
@@ -163,26 +643,52 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
     );
   });
 
-  // If no tools are available, don't render the component
-  if (selectedAssistant.tools.length === 0) {
+  // Filter MCP servers based on search term
+  const filteredMCPServers = mcpServers.filter((server) => {
+    if (!searchTerm) return true;
+    const searchLower = searchTerm.toLowerCase();
+    return server.name.toLowerCase().includes(searchLower);
+  });
+
+  // If no tools or MCP servers are available, don't render the component
+  if (displayTools.length === 0 && mcpServers.length === 0) {
     return null;
   }
-
   return (
-    <Popover
-      open={open}
-      onOpenChange={(newOpen) => {
-        setOpen(newOpen);
-        // Clear search when closing
-        if (!newOpen) {
-          setSearchTerm("");
-        }
-      }}
-    >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="
+    <>
+      <Popover
+        open={open}
+        onOpenChange={(newOpen) => {
+          console.log(
+            "Popover onOpenChange",
+            newOpen,
+            "preventCloseRef.current",
+            preventCloseRef.current
+          );
+
+          // If we're trying to close but we should prevent it, don't close
+          if (!newOpen && preventCloseRef.current) {
+            console.log("Preventing popover close due to preventCloseRef");
+            preventCloseRef.current = false; // Reset the flag
+            return;
+          }
+
+          setOpen(newOpen);
+          // Clear search when closing
+          if (!newOpen) {
+            setSearchTerm("");
+            setMcpToolsPopup({
+              serverId: null,
+              serverName: "",
+              anchorElement: null,
+            }); // Close expanded MCP server
+          }
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="
             relative 
             cursor-pointer 
             flex 
@@ -200,16 +706,34 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
             overflow-hidden 
             focus:outline-none
           "
-          data-testid="action-popover-trigger"
-          title={open ? undefined : "Configure actions"}
-        >
-          <SlidersVerticalIcon size={16} className="my-auto flex-none" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        side="top"
-        align="start"
-        className="
+            data-testid="action-popover-trigger"
+            title={open ? undefined : "Configure actions"}
+          >
+            <SlidersVerticalIcon size={16} className="my-auto flex-none" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="start"
+          // Keep main popover open when interacting with nested MCP popup
+          onPointerDownOutside={(e) => {
+            const target = e.target as Node | null;
+            const mcpPopup = document.querySelector('[data-mcp-popup="true"]');
+            if (target && mcpPopup && mcpPopup.contains(target)) {
+              // Prevent Radix from closing and set guard
+              preventCloseRef.current = true;
+              e.preventDefault();
+            }
+          }}
+          onFocusOutside={(e) => {
+            const target = e.target as Node | null;
+            const mcpPopup = document.querySelector('[data-mcp-popup="true"]');
+            if (target && mcpPopup && mcpPopup.contains(target)) {
+              preventCloseRef.current = true;
+              e.preventDefault();
+            }
+          }}
+          className="
           w-[244px] 
           max-h-[300px]
           text-text-600 
@@ -224,20 +748,20 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
           flex
           flex-col
         "
-      >
-        {/* Search Input */}
-        <div className="pt-1 mx-1">
-          <div className="relative">
-            <SearchIcon
-              size={16}
-              className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-400"
-            />
-            <input
-              type="text"
-              placeholder="Search Menu"
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="
+        >
+          {/* Search Input */}
+          <div className="pt-1 mx-1">
+            <div className="relative">
+              <SearchIcon
+                size={16}
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-400"
+              />
+              <input
+                type="text"
+                placeholder="Search Menu"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="
                 w-full 
                 pl-9 
                 pr-3 
@@ -251,42 +775,106 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
                 dark:placeholder:text-neutral-600
                 dark:bg-neutral-950
               "
-              autoFocus
-            />
-          </div>
-        </div>
-
-        {/* Options */}
-        <div className="pt-2 flex-1 overflow-y-auto mx-1 pb-2">
-          {filteredTools.length === 0 ? (
-            <div className="text-center py-1 text-text-400">
-              No matching actions found
-            </div>
-          ) : (
-            filteredTools.map((tool) => (
-              <ActionItem
-                key={tool.id}
-                tool={tool}
-                disabled={disabledToolIds.includes(tool.id)}
-                isForced={forcedToolIds.includes(tool.id)}
-                onToggle={() => toggleToolForCurrentAssistant(tool.id)}
-                onForceToggle={() => {
-                  toggleForcedTool(tool.id);
-                  setOpen(false);
-                }}
+                autoFocus
               />
-            ))
-          )}
-        </div>
+            </div>
+          </div>
 
-        <div className="border-b border-border mx-3.5" />
+          {/* Options */}
+          <div className="pt-2 flex-1 overflow-y-auto mx-1 pb-2 relative">
+            {filteredTools.length === 0 && filteredMCPServers.length === 0 ? (
+              <div className="text-center py-1 text-text-400">
+                No matching actions found
+              </div>
+            ) : (
+              <>
+                {/* Regular Tools */}
+                {filteredTools.map((tool) => (
+                  <ActionItem
+                    key={tool.id}
+                    tool={tool}
+                    disabled={disabledToolIds.includes(tool.id)}
+                    isForced={forcedToolIds.includes(tool.id)}
+                    onToggle={() => toggleToolForCurrentAssistant(tool.id)}
+                    onForceToggle={() => {
+                      toggleForcedTool(tool.id);
+                      setOpen(false);
+                    }}
+                  />
+                ))}
 
-        {/* More Connectors & Actions. Only show if user is admin or curator, since
+                {/* MCP Servers */}
+                {filteredMCPServers.map((server) => {
+                  const serverData = mcpServerData[server.id] || {
+                    isAuthenticated:
+                      !!server.user_authenticated || !!server.is_authenticated,
+                    isLoading: false,
+                  };
+
+                  // Tools for this server come from assistant.tools
+                  const serverTools = selectedAssistant.tools.filter(
+                    (t) => t.mcp_server_id === Number(server.id)
+                  );
+
+                  return (
+                    <MCPServerItem
+                      key={server.id}
+                      server={server}
+                      isExpanded={mcpToolsPopup.serverId === server.id}
+                      tools={serverTools}
+                      isAuthenticated={serverData.isAuthenticated}
+                      isLoading={serverData.isLoading}
+                      onToggleExpand={(element: HTMLElement) => {
+                        const serverName = element.getAttribute(
+                          "data-mcp-server-name"
+                        );
+                        console.log(
+                          "onToggleExpand called",
+                          server.id,
+                          mcpToolsPopup.serverId
+                        );
+
+                        if (mcpToolsPopup.serverId === server.id) {
+                          // Close if already open
+                          console.log("Closing MCP popup");
+                          setMcpToolsPopup({
+                            serverId: null,
+                            serverName: "",
+                            anchorElement: null,
+                          });
+                        } else {
+                          // Set flag to prevent popover from closing
+                          console.log("Setting preventCloseRef to true");
+                          preventCloseRef.current = true;
+
+                          console.log(
+                            "Opening MCP popup",
+                            server.id,
+                            serverName
+                          );
+                          setMcpToolsPopup({
+                            serverId: server.id,
+                            serverName: serverName || server.name,
+                            anchorElement: element,
+                          });
+                        }
+                      }}
+                      onAuthenticate={() => handleServerAuthentication(server)}
+                    />
+                  );
+                })}
+              </>
+            )}
+          </div>
+
+          <div className="border-b border-border mx-3.5" />
+
+          {/* More Connectors & Actions. Only show if user is admin or curator, since
         they are the only ones who can manage actions. */}
-        {(isAdmin || isCurator) && (
-          <Link href="/admin/actions">
-            <button
-              className="
+          {(isAdmin || isCurator) && (
+            <Link href="/admin/actions">
+              <button
+                className="
                 w-full 
                 flex 
                 items-center 
@@ -295,9 +883,9 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
                 text-sm
                 mt-2.5
               "
-            >
-              <div
-                className="
+              >
+                <div
+                  className="
                   mx-2 
                   mb-2 
                   px-2 
@@ -313,14 +901,88 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
                   rounded-lg
                   w-full
                 "
-              >
-                <MoreActionsIcon className="text-text-500 dark:text-neutral-200" />
-                <div className="ml-2">More Actions</div>
-              </div>
-            </button>
-          </Link>
-        )}
-      </PopoverContent>
-    </Popover>
+                >
+                  <MoreActionsIcon className="text-text-500 dark:text-neutral-200" />
+                  <div className="ml-2">More Actions</div>
+                </div>
+              </button>
+            </Link>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* MCP API Key Modal */}
+      {mcpApiKeyModal.isOpen && (
+        <MCPApiKeyModal
+          isOpen={mcpApiKeyModal.isOpen}
+          onClose={() =>
+            setMcpApiKeyModal({
+              isOpen: false,
+              serverId: null,
+              serverName: "",
+              authTemplate: undefined,
+              onSuccess: undefined,
+              isAuthenticated: false,
+              existingCredentials: undefined,
+            })
+          }
+          serverName={mcpApiKeyModal.serverName}
+          serverId={mcpApiKeyModal.serverId ?? 0}
+          authTemplate={mcpApiKeyModal.authTemplate}
+          onSubmit={handleMCPApiKeySubmit}
+          onSubmitCredentials={handleMCPCredentialsSubmit}
+          onSuccess={mcpApiKeyModal.onSuccess}
+          isAuthenticated={mcpApiKeyModal.isAuthenticated}
+          existingCredentials={mcpApiKeyModal.existingCredentials}
+        />
+      )}
+
+      {/* MCP Tools Popup */}
+      {mcpToolsPopup.serverId !== null &&
+        mcpToolsPopup.anchorElement &&
+        (() => {
+          const rect = mcpToolsPopup.anchorElement.getBoundingClientRect();
+          // Anchor the popup to the server element using viewport coordinates
+          const positioning = {
+            position: "fixed" as const,
+            left: rect.right + 8,
+            top: rect.top,
+            zIndex: 1000,
+          };
+
+          return createPortal(
+            <div
+              style={positioning}
+              onClick={(e) => e.stopPropagation()}
+              onMouseDownCapture={() => {
+                preventCloseRef.current = true;
+              }}
+              onPointerDownCapture={() => {
+                preventCloseRef.current = true;
+              }}
+              data-mcp-popup="true"
+            >
+              <MCPToolsList
+                tools={selectedAssistant.tools.filter(
+                  (t) => t.mcp_server_id === Number(mcpToolsPopup.serverId)
+                )}
+                serverName={mcpToolsPopup.serverName}
+                onClose={() =>
+                  setMcpToolsPopup({
+                    serverId: null,
+                    serverName: "",
+                    anchorElement: null,
+                  })
+                }
+                selectedAssistant={selectedAssistant}
+                preventMainPopupClose={() => {
+                  preventCloseRef.current = true;
+                }}
+              />
+            </div>,
+            document.body
+          );
+        })()}
+    </>
   );
 }

--- a/web/src/app/chat/components/input/ActionManagement.tsx
+++ b/web/src/app/chat/components/input/ActionManagement.tsx
@@ -465,7 +465,7 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
 
       try {
         const response = await fetch(
-          `/api/mcp/servers/${selectedAssistant.id}`
+          `/api/mcp/servers/persona/${selectedAssistant.id}`
         );
         if (response.ok) {
           const data = await response.json();

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -37,6 +37,7 @@ import { UnconfiguredLlmProviderText } from "@/components/chat/UnconfiguredLlmPr
 import { DeepResearchToggle } from "./DeepResearchToggle";
 import { ActionToggle } from "./ActionManagement";
 import { SelectedTool } from "./SelectedTool";
+import { getProviderIcon } from "@/app/admin/configuration/llm/utils";
 
 const MAX_INPUT_HEIGHT = 200;
 

--- a/web/src/app/federated/oauth/callback/page.tsx
+++ b/web/src/app/federated/oauth/callback/page.tsx
@@ -8,7 +8,8 @@ export default function FederatedOAuthCallbackPage() {
     processingMessage: "Processing...",
     processingDetails: "Please wait while we complete the setup.",
     successMessage: "Success!",
-    successDetailsTemplate: "Your {serviceName} authorization completed successfully. You can now use this connector for search.",
+    successDetailsTemplate:
+      "Your {serviceName} authorization completed successfully. You can now use this connector for search.",
     errorMessage: "Something Went Wrong",
     backButtonText: "Back to Chat",
     redirectingMessage: "Redirecting to chat in 2 seconds...",
@@ -16,11 +17,11 @@ export default function FederatedOAuthCallbackPage() {
     defaultRedirectPath: "/chat",
     callbackApiUrl: "/api/federated/callback",
     errorMessageMap: {
-      "validation errors": "Configuration error - please check your connector settings",
-      "client_secret": "Authentication credentials are missing or invalid",
-      "oauth": "OAuth authorization failed",
+      "validation errors":
+        "Configuration error - please check your connector settings",
+      client_secret: "Authentication credentials are missing or invalid",
+      oauth: "OAuth authorization failed",
     },
-
   };
 
   return <OAuthCallbackPage config={federatedConfig} />;

--- a/web/src/app/federated/oauth/callback/page.tsx
+++ b/web/src/app/federated/oauth/callback/page.tsx
@@ -1,206 +1,27 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { CheckmarkIcon, TriangleAlertIcon } from "@/components/icons/icons";
-import CardSection from "@/components/admin/CardSection";
-import { Button } from "@/components/ui/button";
+import OAuthCallbackPage from "@/components/oauth/OAuthCallbackPage";
 import { getSourceDisplayName } from "@/lib/sources";
 
 export default function FederatedOAuthCallbackPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const federatedConfig = {
+    processingMessage: "Processing...",
+    processingDetails: "Please wait while we complete the setup.",
+    successMessage: "Success!",
+    successDetailsTemplate: "Your {serviceName} authorization completed successfully. You can now use this connector for search.",
+    errorMessage: "Something Went Wrong",
+    backButtonText: "Back to Chat",
+    redirectingMessage: "Redirecting to chat in 2 seconds...",
+    autoRedirectDelay: 2000,
+    defaultRedirectPath: "/chat",
+    callbackApiUrl: "/api/federated/callback",
+    errorMessageMap: {
+      "validation errors": "Configuration error - please check your connector settings",
+      "client_secret": "Authentication credentials are missing or invalid",
+      "oauth": "OAuth authorization failed",
+    },
 
-  const [statusMessage, setStatusMessage] = useState("Processing...");
-  const [statusDetails, setStatusDetails] = useState(
-    "Please wait while we complete the setup."
-  );
-  const [isError, setIsError] = useState(false);
-  const [isSuccess, setIsSuccess] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-
-  // Extract query parameters
-  const code = searchParams?.get("code");
-  const state = searchParams?.get("state");
-  const error = searchParams?.get("error");
-  const errorDescription = searchParams?.get("error_description");
-
-  // Auto-redirect for success cases
-  useEffect(() => {
-    if (isSuccess) {
-      const timer = setTimeout(() => {
-        router.push("/chat");
-      }, 2000);
-      return () => clearTimeout(timer);
-    }
-  }, [isSuccess, router]);
-
-  useEffect(() => {
-    const handleOAuthCallback = async () => {
-      // Handle OAuth error from provider
-      if (error) {
-        setStatusMessage("Authorization Failed");
-        setStatusDetails(
-          errorDescription ||
-            "The authorization was cancelled or failed. Please try again."
-        );
-        setIsError(true);
-        setIsLoading(false);
-        return;
-      }
-
-      // Validate required parameters
-      if (!code || !state) {
-        setStatusMessage("Invalid Request");
-        setStatusDetails(
-          "The authorization request was incomplete. Please try again."
-        );
-        setIsError(true);
-        setIsLoading(false);
-        return;
-      }
-
-      try {
-        // Use the generic callback endpoint
-        const url = `/api/federated/callback?code=${encodeURIComponent(
-          code
-        )}&state=${encodeURIComponent(state)}`;
-
-        const response = await fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        });
-
-        if (!response.ok) {
-          let errorMessage = "Failed to complete authorization";
-          try {
-            const errorData = await response.json();
-            if (errorData.detail) {
-              // Clean up technical error messages for user-friendly display
-              if (errorData.detail.includes("validation errors")) {
-                errorMessage =
-                  "Configuration error - please check your connector settings";
-              } else if (errorData.detail.includes("client_secret")) {
-                errorMessage =
-                  "Authentication credentials are missing or invalid";
-              } else if (errorData.detail.includes("oauth")) {
-                errorMessage = "OAuth authorization failed";
-              } else {
-                errorMessage = "Authorization failed - please try again";
-              }
-            }
-          } catch (parseError) {
-            console.error("Error parsing response:", parseError);
-          }
-          throw new Error(errorMessage);
-        }
-
-        // Parse the response to get source information
-        const responseData = await response.json();
-        const source = responseData.source;
-        const displayName = source ? getSourceDisplayName(source) : "connector";
-
-        setStatusMessage("Success!");
-        setStatusDetails(
-          `Your ${displayName} authorization completed successfully. You can now use this connector for search.`
-        );
-        setIsSuccess(true);
-        setIsError(false);
-        setIsLoading(false);
-      } catch (error) {
-        console.error("Federated OAuth callback error:", error);
-        setStatusMessage("Something Went Wrong");
-        setStatusDetails(
-          error instanceof Error
-            ? error.message
-            : "An error occurred during the OAuth process. Please try again."
-        );
-        setIsError(true);
-        setIsLoading(false);
-      }
-    };
-
-    handleOAuthCallback();
-  }, [code, state, error, errorDescription]);
-
-  const getStatusIcon = () => {
-    if (isLoading) {
-      return (
-        <div className="w-16 h-16 border-4 border-blue-200 dark:border-blue-800 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin mx-auto mb-4"></div>
-      );
-    }
-    if (isSuccess) {
-      return (
-        <CheckmarkIcon
-          size={64}
-          className="text-green-500 dark:text-green-400 mx-auto mb-4"
-        />
-      );
-    }
-    if (isError) {
-      return (
-        <TriangleAlertIcon
-          size={64}
-          className="text-red-500 dark:text-red-400 mx-auto mb-4"
-        />
-      );
-    }
-    return null;
   };
 
-  const getStatusColor = () => {
-    if (isSuccess) return "text-green-600 dark:text-green-400";
-    if (isError) return "text-red-600 dark:text-red-400";
-    return "text-gray-600 dark:text-gray-300";
-  };
-
-  return (
-    <div className="min-h-screen flex flex-col">
-      <div className="flex-1 flex flex-col items-center justify-center p-4">
-        <CardSection className="max-w-md w-full mx-auto p-8 shadow-lg bg-white dark:bg-gray-800 rounded-lg">
-          <div className="text-center">
-            {getStatusIcon()}
-
-            <h1 className={`text-2xl font-bold mb-4 ${getStatusColor()}`}>
-              {statusMessage}
-            </h1>
-
-            <p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">
-              {statusDetails}
-            </p>
-
-            {isSuccess && (
-              <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
-                <p className="text-green-800 dark:text-green-200 text-sm">
-                  Redirecting to chat in 2 seconds...
-                </p>
-              </div>
-            )}
-
-            <div className="flex flex-col space-y-3">
-              {isError && (
-                <div className="flex flex-col space-y-2">
-                  <Button
-                    onClick={() => router.push("/chat")}
-                    variant="navigate"
-                    className="w-full"
-                  >
-                    Back to Chat
-                  </Button>
-                </div>
-              )}
-
-              {isLoading && (
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  This may take a few moments...
-                </p>
-              )}
-            </div>
-          </div>
-        </CardSection>
-      </div>
-    </div>
-  );
+  return <OAuthCallbackPage config={federatedConfig} />;
 }

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import OAuthCallbackPage from "@/components/oauth/OAuthCallbackPage";
+
+export default function MCPOAuthCallbackPage() {
+  const mcpConfig = {
+    processingMessage: "Processing...",
+    processingDetails: "Please wait while we complete the MCP server setup.",
+    successMessage: "Success!",
+    successDetailsTemplate: "Your {serviceName} authorization completed successfully. You can now use this server's tools in chat.",
+    errorMessage: "Something Went Wrong",
+    backButtonText: "Back to Chat",
+    redirectingMessage: "Redirecting back in 2 seconds...",
+    autoRedirectDelay: 2000,
+    defaultRedirectPath: "/chat",
+    callbackApiUrl: "/api/mcp/oauth/callback",
+    errorMessageMap: {
+      "server not found": "MCP server configuration not found",
+      "credentials": "Authentication credentials are invalid",
+      "oauth": "OAuth authorization failed",
+      "validation": "Could not validate connection to MCP server",
+    },
+  };
+
+  return <OAuthCallbackPage config={mcpConfig} />;
+}

--- a/web/src/app/mcp/oauth/callback/page.tsx
+++ b/web/src/app/mcp/oauth/callback/page.tsx
@@ -7,7 +7,8 @@ export default function MCPOAuthCallbackPage() {
     processingMessage: "Processing...",
     processingDetails: "Please wait while we complete the MCP server setup.",
     successMessage: "Success!",
-    successDetailsTemplate: "Your {serviceName} authorization completed successfully. You can now use this server's tools in chat.",
+    successDetailsTemplate:
+      "Your {serviceName} authorization completed successfully. You can now use this server's tools in chat.",
     errorMessage: "Something Went Wrong",
     backButtonText: "Back to Chat",
     redirectingMessage: "Redirecting back in 2 seconds...",
@@ -16,9 +17,9 @@ export default function MCPOAuthCallbackPage() {
     callbackApiUrl: "/api/mcp/oauth/callback",
     errorMessageMap: {
       "server not found": "MCP server configuration not found",
-      "credentials": "Authentication credentials are invalid",
-      "oauth": "OAuth authorization failed",
-      "validation": "Could not validate connection to MCP server",
+      credentials: "Authentication credentials are invalid",
+      oauth: "OAuth authorization failed",
+      validation: "Could not validate connection to MCP server",
     },
   };
 

--- a/web/src/components/admin/actions/ToolList.tsx
+++ b/web/src/components/admin/actions/ToolList.tsx
@@ -1,0 +1,465 @@
+import {
+  MCPAuthenticationPerformer,
+  MCPAuthenticationType,
+} from "@/lib/tools/interfaces";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import Text from "@/components/ui/text";
+import { SearchIcon } from "lucide-react";
+import { FiCheck, FiLink } from "react-icons/fi";
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  MCPFormValues,
+  MCPTool,
+  ToolListProps,
+  ToolListResponse,
+} from "@/components/admin/actions/interfaces";
+import { createMCPServer, attachMCPTools } from "@/lib/tools/edit";
+
+const ITEMS_PER_PAGE = 10;
+
+export function ToolList({
+  values,
+  verbRoot,
+  serverId,
+  setPopup,
+  oauthConnected,
+}: ToolListProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [listingTools, setListingTools] = useState(false);
+  const [tools, setTools] = useState<MCPTool[]>([]);
+  const [selectedTools, setSelectedTools] = useState<Set<string>>(new Set());
+  const [searchTerm, setSearchTerm] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showToolList, setShowToolList] = useState(
+    searchParams.get("listing_tools") === "true"
+  );
+  const [currentServerId, setCurrentServerId] = useState<number | undefined>(
+    serverId
+  );
+
+  const clearListingState = () => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("listing_tools");
+    router.push(`?${params.toString()}`, { scroll: false });
+    setShowToolList(false);
+  };
+
+  const handleListActions = async (values: MCPFormValues) => {
+    // Check if OAuth needs connection first
+    if (values.auth_type === MCPAuthenticationType.OAUTH && !oauthConnected) {
+      setPopup({
+        message: "Please connect OAuth first using the button above",
+        type: "info",
+      });
+      return;
+    }
+
+    setListingTools(true);
+
+    try {
+      // Step 1: Create/update the MCP server with credentials
+      const serverData = {
+        name: values.name,
+        description: values.description,
+        server_url: values.server_url,
+        auth_type: values.auth_type,
+        auth_performer:
+          values.auth_type !== MCPAuthenticationType.NONE
+            ? values.auth_performer
+            : undefined,
+        api_token:
+          values.auth_type === MCPAuthenticationType.API_TOKEN &&
+          values.auth_performer === MCPAuthenticationPerformer.ADMIN
+            ? values.api_token
+            : undefined,
+        auth_template:
+          values.auth_performer === MCPAuthenticationPerformer.PER_USER
+            ? values.auth_template
+            : undefined,
+        admin_credentials:
+          values.auth_performer === MCPAuthenticationPerformer.PER_USER
+            ? values.user_credentials || {}
+            : undefined,
+        oauth_client_id:
+          values.auth_type === MCPAuthenticationType.OAUTH
+            ? values.oauth_client_id
+            : undefined,
+        oauth_client_secret:
+          values.auth_type === MCPAuthenticationType.OAUTH
+            ? values.oauth_client_secret
+            : undefined,
+        existing_server_id: serverId,
+      };
+
+      const { data: serverResult, error: serverError } =
+        await createMCPServer(serverData);
+
+      if (serverError || !serverResult) {
+        setPopup({
+          message: serverError || "Failed to create server",
+          type: "error",
+        });
+        setListingTools(false);
+        return;
+      }
+
+      // Update serverId for subsequent operations
+      const newServerId = serverResult.server_id;
+      setCurrentServerId(newServerId);
+
+      // Update URL with server ID and listing state
+      const params = new URLSearchParams(searchParams);
+      params.set("server_id", newServerId.toString());
+      params.set("listing_tools", "true");
+      router.push(`?${params.toString()}`, { scroll: false });
+
+      // Step 2: List available tools from the saved server
+      const promises: Promise<Response>[] = [
+        fetch(`/api/admin/mcp/server/${newServerId}/tools`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+        fetch(`/api/admin/mcp/server/${newServerId}/db-tools`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+      ];
+
+      const responses = await Promise.all(promises);
+
+      // Check if list-tools request failed
+      if (!responses[0]?.ok) {
+        const errorData = await responses[0]?.json();
+        setPopup({
+          message: `Failed to list tools: ${errorData?.detail || "Unknown error"}`,
+          type: "error",
+        });
+        setListingTools(false);
+        return;
+      }
+
+      // Process available tools
+      const toolsData: ToolListResponse = await responses[0]?.json();
+      setTools(toolsData.tools);
+
+      // Pre-populate selected tools from existing database tools
+      if (responses[1]?.ok) {
+        const existingToolsData = await responses[1]?.json();
+        const existingToolNames = new Set<string>(
+          existingToolsData.tools.map((tool: any) => tool.name as string)
+        );
+        setSelectedTools(existingToolNames);
+      } else {
+        setSelectedTools(new Set());
+      }
+
+      setShowToolList(true);
+      setCurrentPage(1);
+    } catch (error) {
+      console.error("Error listing tools:", error);
+      setPopup({
+        message: "Error listing tools from MCP server",
+        type: "error",
+      });
+    } finally {
+      setListingTools(false);
+    }
+  };
+
+  const handleCreateActions = async (values: MCPFormValues) => {
+    if (selectedTools.size === 0) {
+      setPopup({
+        message: "Please select at least one tool",
+        type: "error",
+      });
+      return;
+    }
+
+    if (!currentServerId) {
+      setPopup({
+        message: "Server not created yet. Please list actions first.",
+        type: "error",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const { data, error } = await attachMCPTools({
+      server_id: currentServerId,
+      selected_tools: Array.from(selectedTools),
+    });
+
+    if (error) {
+      setPopup({
+        message: error,
+        type: "error",
+      });
+    } else if (data) {
+      const toolCount = data.updated_tools;
+      const action = serverId ? "updated" : "created";
+      setPopup({
+        message: `Successfully ${action} ${toolCount} MCP tool${toolCount !== 1 ? "s" : ""}!`,
+        type: "success",
+      });
+      // Clear query params and navigate to actions page
+      router.push("/admin/actions");
+    }
+
+    setIsSubmitting(false);
+  };
+
+  // Filter tools based on search term
+  const filteredTools = useMemo(() => {
+    if (!searchTerm) return tools;
+    const lowerSearchTerm = searchTerm.toLowerCase();
+    return tools.filter(
+      (tool) =>
+        tool.name.toLowerCase().includes(lowerSearchTerm) ||
+        tool.description?.toLowerCase().includes(lowerSearchTerm) ||
+        tool.displayName?.toLowerCase().includes(lowerSearchTerm)
+    );
+  }, [tools, searchTerm]);
+
+  // Paginate filtered tools
+  const paginatedTools = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    return filteredTools.slice(startIndex, endIndex);
+  }, [filteredTools, currentPage]);
+
+  const totalPages = Math.ceil(filteredTools.length / ITEMS_PER_PAGE);
+
+  const handleSelectAllFiltered = () => {
+    const allFilteredToolNames = filteredTools.map((tool) => tool.name);
+    setSelectedTools((prev) => {
+      const newSet = new Set(prev);
+      allFilteredToolNames.forEach((name) => newSet.add(name));
+      return newSet;
+    });
+  };
+
+  const handleDeselectAllFiltered = () => {
+    const allFilteredToolNames = filteredTools.map((tool) => tool.name);
+    setSelectedTools((prev) => {
+      const newSet = new Set(prev);
+      allFilteredToolNames.forEach((name) => newSet.delete(name));
+      return newSet;
+    });
+  };
+
+  const handleToggleTool = (toolName: string) => {
+    setSelectedTools((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(toolName)) {
+        newSet.delete(toolName);
+      } else {
+        newSet.add(toolName);
+      }
+      return newSet;
+    });
+  };
+
+  const allFilteredSelected = filteredTools.every((tool) =>
+    selectedTools.has(tool.name)
+  );
+
+  const someFilteredSelected = filteredTools.some((tool) =>
+    selectedTools.has(tool.name)
+  );
+
+  const handleToggleAllFiltered = () => {
+    if (allFilteredSelected) {
+      handleDeselectAllFiltered();
+    } else {
+      handleSelectAllFiltered();
+    }
+  };
+
+  return !showToolList ? (
+    <div className="flex gap-2">
+      <Button
+        type="button"
+        onClick={() => handleListActions(values)}
+        disabled={
+          listingTools ||
+          !values.name.trim() ||
+          !values.server_url.trim() ||
+          (values.auth_type === MCPAuthenticationType.OAUTH && !oauthConnected)
+        }
+        className="flex-1"
+      >
+        {listingTools ? "Listing Actions..." : "List Actions"}
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => router.push("/admin/actions")}
+      >
+        Cancel
+      </Button>
+    </div>
+  ) : (
+    <div className="space-y-4 w-full">
+      <h3 className="text-lg font-medium">Available Tools</h3>
+
+      {/* Search bar */}
+      <div className="relative">
+        <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+        <Input
+          type="text"
+          placeholder="Search tools..."
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="pl-10"
+        />
+      </div>
+
+      {/* Tool list with header */}
+      <div className="border rounded-lg w-full overflow-hidden relative">
+        {/* Header row with select all checkbox */}
+        <div className="flex items-center p-4 border-b bg-gray-50 dark:bg-gray-800 rounded-t-lg">
+          <div className="w-6 flex-none mr-3">
+            <Checkbox
+              checked={allFilteredSelected}
+              onCheckedChange={handleToggleAllFiltered}
+              className="mt-0"
+              data-state={
+                allFilteredSelected
+                  ? "checked"
+                  : someFilteredSelected
+                    ? "indeterminate"
+                    : "unchecked"
+              }
+            />
+          </div>
+          <div className="flex-1 font-medium text-sm text-gray-700 dark:text-gray-300">
+            {searchTerm
+              ? `Select all ${filteredTools.length} filtered tools`
+              : `Select all ${filteredTools.length} tools`}
+          </div>
+        </div>
+
+        {/* Tool list */}
+        <div className="p-4 space-y-2 w-full">
+          {paginatedTools.length === 0 ? (
+            <Text className="text-gray-500 text-center py-4">
+              {searchTerm ? "No tools match your search" : "No tools available"}
+            </Text>
+          ) : (
+            paginatedTools.map((tool) => (
+              <div
+                key={tool.name}
+                className="flex items-start p-2 hover:bg-gray-50 dark:hover:bg-gray-700 rounded w-full"
+              >
+                <div className="w-6 flex-none mr-3 pt-1">
+                  <Checkbox
+                    checked={selectedTools.has(tool.name)}
+                    onCheckedChange={() => handleToggleTool(tool.name)}
+                    className="mt-0"
+                  />
+                </div>
+                <div className="flex-1">
+                  <div className="font-medium">
+                    {tool.displayName || tool.name}
+                  </div>
+                  {tool.description && (
+                    <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                      {tool.description}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex justify-between items-center">
+          <Text className="text-sm text-gray-600 dark:text-gray-400">
+            Page {currentPage} of {totalPages} ({filteredTools.length} tools)
+          </Text>
+          <div className="flex gap-2 ml-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+            >
+              Previous
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Selected count */}
+      <div className="pt-4">
+        <Text className="text-sm text-gray-600 dark:text-gray-400">
+          {selectedTools.size} tool
+          {selectedTools.size !== 1 ? "s" : ""} selected
+        </Text>
+        {selectedTools.size > 0 && (
+          <div className="mt-2">
+            <div className="text-xs text-gray-500 dark:text-gray-500 mb-1">
+              Selected tools:
+            </div>
+            <div className="max-w-xs overflow-hidden">
+              <div className="flex flex-wrap gap-1 items-start">
+                {Array.from(selectedTools).map((toolName) => (
+                  <span
+                    key={toolName}
+                    className="inline-block px-2 py-1 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded whitespace-nowrap flex-shrink-0"
+                  >
+                    {toolName}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex justify-end gap-2 pt-4 border-t">
+        <Button
+          type="button"
+          onClick={() => handleCreateActions(values)}
+          disabled={selectedTools.size === 0 || isSubmitting}
+        >
+          {verbRoot + (isSubmitting ? "ing..." : "e MCP Server Actions")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setShowToolList(false)}
+        >
+          Back
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/actions/ToolList.tsx
+++ b/web/src/components/admin/actions/ToolList.tsx
@@ -41,12 +41,7 @@ export function ToolList({
     serverId
   );
 
-  const clearListingState = () => {
-    const params = new URLSearchParams(searchParams);
-    params.delete("listing_tools");
-    router.push(`?${params.toString()}`, { scroll: false });
-    setShowToolList(false);
-  };
+  console.log(tools);
 
   const handleListActions = async (values: MCPFormValues) => {
     // Check if OAuth needs connection first
@@ -111,13 +106,7 @@ export function ToolList({
       const newServerId = serverResult.server_id;
       setCurrentServerId(newServerId);
 
-      // Update URL with server ID and listing state
-      const params = new URLSearchParams(searchParams);
-      params.set("server_id", newServerId.toString());
-      params.set("listing_tools", "true");
-      router.push(`?${params.toString()}`, { scroll: false });
-
-      // Step 2: List available tools from the saved server
+      // List available tools from the saved server
       const promises: Promise<Response>[] = [
         fetch(`/api/admin/mcp/server/${newServerId}/tools`, {
           method: "GET",
@@ -134,10 +123,12 @@ export function ToolList({
       ];
 
       const responses = await Promise.all(promises);
+      const toolResponse = await responses[0]?.json();
+      console.log(toolResponse);
 
       // Check if list-tools request failed
       if (!responses[0]?.ok) {
-        const errorData = await responses[0]?.json();
+        const errorData = await toolResponse;
         setPopup({
           message: `Failed to list tools: ${errorData?.detail || "Unknown error"}`,
           type: "error",
@@ -146,8 +137,10 @@ export function ToolList({
         return;
       }
 
+      setShowToolList(true);
+      setCurrentPage(1);
       // Process available tools
-      const toolsData: ToolListResponse = await responses[0]?.json();
+      const toolsData: ToolListResponse = toolResponse;
       setTools(toolsData.tools);
 
       // Pre-populate selected tools from existing database tools
@@ -161,8 +154,7 @@ export function ToolList({
         setSelectedTools(new Set());
       }
 
-      setShowToolList(true);
-      setCurrentPage(1);
+      // Tool list is already shown; nothing else to do
     } catch (error) {
       console.error("Error listing tools:", error);
       setPopup({
@@ -283,6 +275,7 @@ export function ToolList({
       handleSelectAllFiltered();
     }
   };
+  console.log(filteredTools);
 
   return !showToolList ? (
     <div className="flex gap-2">

--- a/web/src/components/admin/actions/ToolList.tsx
+++ b/web/src/components/admin/actions/ToolList.tsx
@@ -7,7 +7,6 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import Text from "@/components/ui/text";
 import { SearchIcon } from "lucide-react";
-import { FiCheck, FiLink } from "react-icons/fi";
 import { useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {

--- a/web/src/components/admin/actions/forms.tsx
+++ b/web/src/components/admin/actions/forms.tsx
@@ -1,0 +1,322 @@
+import { FiInfo, FiPlus, FiX, FiKey } from "react-icons/fi";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useEffect } from "react";
+
+interface PerUserAuthTemplateConfigProps {
+  values: any;
+  setFieldValue: (field: string, value: any) => void;
+  errors: any;
+  touched: any;
+}
+
+export function PerUserAuthTemplateConfig({
+  values,
+  setFieldValue,
+  errors,
+  touched,
+}: PerUserAuthTemplateConfigProps) {
+  // Initialize auth template if not exists
+  if (!values.auth_template) {
+    setFieldValue("auth_template", {
+      headers: { Authorization: "Bearer {api_key}" },
+      required_fields: ["api_key"],
+    });
+  }
+
+  const addHeader = () => {
+    const currentHeaders = values.auth_template?.headers || {};
+    setFieldValue("auth_template.headers", {
+      ...currentHeaders,
+      [""]: "",
+    });
+  };
+
+  const removeHeader = (name: string) => {
+    const currentHeaders = values.auth_template?.headers || {};
+    const { [name]: _, ...rest } = currentHeaders;
+    setFieldValue("auth_template.headers", rest);
+  };
+
+  const updateHeader = (name: string, value: string) => {
+    const currentHeaders = values.auth_template?.headers || {};
+    const newHeaders = {
+      ...currentHeaders,
+      [name]: value,
+    };
+    setFieldValue("auth_template.headers", newHeaders);
+    // Update required fields based on placeholders
+    updateRequiredFields(newHeaders);
+  };
+
+  const renameHeader = (oldName: string, newName: string) => {
+    if (oldName === newName) return;
+    const currentHeaders: Record<string, string> = values.auth_template?.headers || {};
+    // Preserve insertion order while renaming the key
+    const newHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(currentHeaders)) {
+      if (k === oldName) {
+        newHeaders[newName] = v ?? "";
+      } else {
+        newHeaders[k] = v;
+      }
+    }
+    setFieldValue("auth_template.headers", newHeaders);
+    updateRequiredFields(newHeaders);
+  };
+
+  const updateRequiredFields = (headers: Record<string, string>) => {
+    const placeholderRegex = /\{([^}]+)\}/g;
+    const requiredFields = new Set<string>();
+
+    Object.values(headers).forEach((value) => {
+      const matches = value.match(placeholderRegex);
+      console.log(matches);
+      if (matches) {
+        matches.forEach((match: string) => {
+          const field = match.slice(1, -1);
+          if (field !== "user_email") {
+            // user_email is automatically provided
+            requiredFields.add(field);
+          }
+        });
+      }
+    });
+
+    setFieldValue("auth_template.required_fields", Array.from(requiredFields));
+  };
+
+  const updateAdminCredential = (field: string, value: string) => {
+    const currentCreds = values.user_credentials || {};
+    setFieldValue("user_credentials", {
+      ...currentCreds,
+      [field]: value,
+    });
+  };
+
+  const headers: Record<string, string> = values.auth_template?.headers || {};
+  const requiredFields: string[] = values.auth_template?.required_fields || [];
+  const adminCredentials = values.user_credentials || {};
+
+  // Initialize required fields on component mount
+  useEffect(() => {
+    if (headers && Object.keys(headers).length > 0) {
+      updateRequiredFields(headers);
+    }
+  }, []); // Empty dependency array - only run on mount
+
+  console.log(headers, requiredFields, adminCredentials);
+
+  return (
+    <div className="space-y-4 p-4 bg-background-100 border border-border-strong rounded-lg">
+      <div className="flex items-center space-x-2">
+        <FiInfo className="h-4 w-4 text-text-700" />
+        <h4 className="font-medium text-text-900">
+          Per-User Authentication Template
+        </h4>
+      </div>
+
+      <p className="text-sm text-text-800">
+        Configure how users will authenticate with this MCP server. Define
+        headers with placeholders that will be filled in by each user's
+        credentials.
+      </p>
+
+      <div className="space-y-4">
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <Label>Authentication Headers</Label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addHeader}
+              className="flex items-center space-x-1"
+            >
+              <FiPlus className="h-3 w-3" />
+              <span>Add Header</span>
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {Object.entries(headers).map(([name, value], idx) => (
+              <div key={idx} className="flex items-center space-x-2">
+                <Input
+                  placeholder="Header name (e.g., Authorization)"
+                  value={name}
+                  onChange={(e) => renameHeader(name, e.target.value)}
+                  className="flex-1"
+                />
+                <Input
+                  placeholder="Header value (e.g., Bearer {api_key})"
+                  value={value}
+                  onChange={(e) => updateHeader(name, e.target.value)}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeHeader(name)}
+                  className="text-red-600 hover:text-red-800"
+                >
+                  <FiX className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+
+          <p className="text-xs text-text-600 mt-1">
+            Use placeholders like{" "}
+            <code className="bg-background-200 px-1 rounded">{`{api_key}`}</code>{" "}
+            or{" "}
+            <code className="bg-background-200 px-1 rounded">{`{user_email}`}</code>
+            . Users will be prompted to provide values for placeholders (except
+            user_email).
+          </p>
+        </div>
+
+        {requiredFields.length > 0 && (
+          <div>
+            <Label>
+              Your Credentials (for listing tools and saving your own access)
+            </Label>
+            <p className="text-xs text-text-600 mb-2">
+              Provide values to validate the server configuration when listing
+              tools. These will be saved as your per-user credentials if
+              creation succeeds.
+            </p>
+            <div className="space-y-2">
+              {requiredFields.map((field: string) => (
+                <div key={field}>
+                  <Label htmlFor={`test_${field}`} className="text-sm">
+                    {field
+                      .replace(/_/g, " ")
+                      .replace(/\b\w/g, (l) => l.toUpperCase())}
+                  </Label>
+                  <Input
+                    id={`test_${field}`}
+                    type={
+                      field.toLowerCase().includes("key") ||
+                      field.toLowerCase().includes("token")
+                        ? "password"
+                        : "text"
+                    }
+                    placeholder={`Enter ${field.replace(/_/g, " ")}`}
+                    value={adminCredentials[field] || ""}
+                    onChange={(e) =>
+                      updateAdminCredential(field, e.target.value)
+                    }
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="text-xs text-text-600 space-y-1">
+          <p>
+            <strong>How it works:</strong>
+          </p>
+          <p>
+            • Users will see a form asking for:{" "}
+            {requiredFields.length > 0 ? requiredFields.join(", ") : "api_key"}
+          </p>
+          <p>
+            • Their credentials will be validated against the server before
+            being saved
+          </p>
+          <p>• Each user's credentials are stored securely and separately</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface OAuthConfigProps {
+  values: any;
+  setFieldValue: (field: string, value: any) => void;
+  errors: any;
+  touched: any;
+}
+
+export function OAuthConfig({
+  values,
+  setFieldValue,
+  errors,
+  touched,
+}: OAuthConfigProps) {
+  const clientId = values.oauth_client_id || "";
+  const clientSecret = values.oauth_client_secret || "";
+
+  return (
+    <div className="space-y-4 p-4 bg-background-100 border border-border-strong rounded-lg">
+      <div className="flex items-center space-x-2">
+        <FiKey className="h-4 w-4 text-text-700" />
+        <h4 className="font-medium text-text-900">OAuth Configuration</h4>
+      </div>
+
+      <p className="text-sm text-text-800">
+        Configure OAuth 2.0 credentials to authenticate with the MCP server.
+        These credentials will be used to obtain access tokens.
+      </p>
+
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="oauth_client_id">Client ID</Label>
+          <Input
+            id="oauth_client_id"
+            type="text"
+            placeholder="Enter your OAuth client ID"
+            value={clientId}
+            onChange={(e) => setFieldValue("oauth_client_id", e.target.value)}
+            className="mt-1"
+          />
+          {errors.oauth_client_id && touched.oauth_client_id && (
+            <div className="text-red-500 text-sm mt-1">
+              {errors.oauth_client_id}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="oauth_client_secret">Client Secret</Label>
+          <Input
+            id="oauth_client_secret"
+            type="password"
+            placeholder="Enter your OAuth client secret"
+            value={clientSecret}
+            onChange={(e) =>
+              setFieldValue("oauth_client_secret", e.target.value)
+            }
+            className="mt-1"
+          />
+          {errors.oauth_client_secret && touched.oauth_client_secret && (
+            <div className="text-red-500 text-sm mt-1">
+              {errors.oauth_client_secret}
+            </div>
+          )}
+        </div>
+
+        <div className="text-xs text-text-600 space-y-1">
+          <p>
+            <strong>Note:</strong> You'll need to register your application with
+            the MCP server provider to obtain these credentials.
+          </p>
+          <p>
+            • The redirect URI should be set to:{" "}
+            <code className="bg-background-200 px-1 rounded">
+              {typeof window !== "undefined" ? window.location.origin : ""}
+              /api/mcp/oauth/callback
+            </code>
+          </p>
+          <p>
+            • Make sure the OAuth app has the necessary scopes/permissions for
+            the MCP server's operations
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin/actions/forms.tsx
+++ b/web/src/components/admin/actions/forms.tsx
@@ -17,13 +17,15 @@ export function PerUserAuthTemplateConfig({
   errors,
   touched,
 }: PerUserAuthTemplateConfigProps) {
-  // Initialize auth template if not exists
-  if (!values.auth_template) {
-    setFieldValue("auth_template", {
-      headers: { Authorization: "Bearer {api_key}" },
-      required_fields: ["api_key"],
-    });
-  }
+  useEffect(() => {
+    // Initialize auth template if not exists
+    if (!values.auth_template) {
+      setFieldValue("auth_template", {
+        headers: { Authorization: "Bearer {api_key}" },
+        required_fields: ["api_key"],
+      });
+    }
+  }, [values.auth_template, setFieldValue]);
 
   const addHeader = () => {
     const currentHeaders = values.auth_template?.headers || {};

--- a/web/src/components/admin/actions/forms.tsx
+++ b/web/src/components/admin/actions/forms.tsx
@@ -311,7 +311,7 @@ export function OAuthConfig({
             • The redirect URI should be set to:{" "}
             <code className="bg-background-200 px-1 rounded">
               {typeof window !== "undefined" ? window.location.origin : ""}
-              /api/mcp/oauth/callback
+              /mcp/oauth/callback
             </code>
           </p>
           <p>

--- a/web/src/components/admin/actions/forms.tsx
+++ b/web/src/components/admin/actions/forms.tsx
@@ -52,7 +52,8 @@ export function PerUserAuthTemplateConfig({
 
   const renameHeader = (oldName: string, newName: string) => {
     if (oldName === newName) return;
-    const currentHeaders: Record<string, string> = values.auth_template?.headers || {};
+    const currentHeaders: Record<string, string> =
+      values.auth_template?.headers || {};
     // Preserve insertion order while renaming the key
     const newHeaders: Record<string, string> = {};
     for (const [k, v] of Object.entries(currentHeaders)) {

--- a/web/src/components/admin/actions/interfaces.tsx
+++ b/web/src/components/admin/actions/interfaces.tsx
@@ -1,0 +1,57 @@
+import {
+  MCPAuthenticationPerformer,
+  MCPAuthenticationType,
+} from "@/lib/tools/interfaces";
+import { PopupSpec } from "../connectors/Popup";
+
+export interface MCPTool {
+  name: string;
+  description?: string;
+  displayName?: string;
+  inputSchema?: any;
+}
+
+export interface ToolListResponse {
+  server_name: string;
+  server_url: string;
+  tools: MCPTool[];
+}
+
+export interface MCPAuthTemplate {
+  headers: Record<string, string>;
+  required_fields: string[];
+}
+
+export interface MCPFormValues {
+  name: string;
+  description: string;
+  server_url: string;
+  auth_type: MCPAuthenticationType;
+  auth_performer: MCPAuthenticationPerformer;
+  api_token: string;
+  auth_template?: MCPAuthTemplate;
+  user_credentials?: Record<string, string>;
+  oauth_client_id?: string;
+  oauth_client_secret?: string;
+}
+
+export interface ToolListProps {
+  values: MCPFormValues;
+  verbRoot: string;
+  serverId: number | undefined;
+  setPopup: (popup: PopupSpec | null) => void;
+  oauthConnected: boolean;
+}
+
+export interface MCPServerDetail {
+  id: number;
+  name: string;
+  server_url: string;
+  auth_type: MCPAuthenticationType;
+  auth_performer: MCPAuthenticationPerformer | null;
+  description: string | null;
+  is_authenticated: boolean;
+  auth_template: MCPAuthTemplate | null;
+  admin_credentials: Record<string, string> | null; // "api_key": value
+  user_credentials: Record<string, string> | null; // map from placeholder to value
+}

--- a/web/src/components/admin/actions/interfaces.tsx
+++ b/web/src/components/admin/actions/interfaces.tsx
@@ -8,7 +8,7 @@ export interface MCPTool {
   name: string;
   description?: string;
   displayName?: string;
-  inputSchema?: any;
+  inputSchema?: Record<string, any>;
 }
 
 export interface ToolListResponse {
@@ -48,7 +48,7 @@ export interface MCPServerDetail {
   name: string;
   server_url: string;
   auth_type: MCPAuthenticationType;
-  auth_performer: MCPAuthenticationPerformer | null;
+  auth_performer: MCPAuthenticationPerformer;
   description: string | null;
   is_authenticated: boolean;
   auth_template: MCPAuthTemplate | null;

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -150,12 +150,15 @@ export function MCPApiKeyModal({
     }));
   };
 
+  const credsType = isTemplateMode ? "Credentials" : "API Key";
   return (
     <Modal
       title={
         <div className="flex items-center space-x-2">
           <FiKey className="h-5 w-5" />
-          <span>{isAuthenticated ? "Manage API Key" : "Enter API Key"}</span>
+          <span>
+            {isAuthenticated ? `Manage ${credsType}` : `Enter ${credsType}`}
+          </span>
         </div>
       }
       onOutsideClick={handleClose}
@@ -165,19 +168,13 @@ export function MCPApiKeyModal({
         <div>
           <p className="text-sm text-subtle mb-2">
             {isAuthenticated
-              ? isTemplateMode
-                ? `Update your credentials for ${serverName}.`
-                : `Update your API key for ${serverName}.`
-              : isTemplateMode
-                ? `Enter your credentials for ${serverName} to enable authentication.`
-                : `Enter your API key for ${serverName} to enable authentication.`}
+              ? `Update your ${credsType} for ${serverName}.`
+              : `Enter your ${credsType} for ${serverName} to enable authentication.`}
           </p>
           <p className="text-xs text-subtle">
             {isAuthenticated
               ? "Changes will be validated against the server before being saved."
-              : isTemplateMode
-                ? "Your credentials will be validated against the server and stored securely."
-                : "This key will be stored securely and used only for this MCP server."}
+              : `Your ${credsType} will be validated against the server and stored securely.`}
           </p>
         </div>
 
@@ -227,14 +224,14 @@ export function MCPApiKeyModal({
           ) : (
             // Legacy API key field
             <div className="space-y-2">
-              <Label htmlFor="apiKey">API Key</Label>
+              <Label htmlFor="apiKey">{credsType}</Label>
               <div className="relative">
                 <Input
                   id="apiKey"
                   type={showApiKey ? "text" : "password"}
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
-                  placeholder="Enter your API key"
+                  placeholder={`Enter your ${credsType}`}
                   className="pr-10"
                   required
                 />
@@ -276,12 +273,8 @@ export function MCPApiKeyModal({
               {isSubmitting
                 ? "Saving..."
                 : isAuthenticated
-                  ? isTemplateMode
-                    ? "Update Credentials"
-                    : "Update API Key"
-                  : isTemplateMode
-                    ? "Save Credentials"
-                    : "Save API Key"}
+                  ? `Update ${credsType}`
+                  : `Save ${credsType}`}
             </Button>
           </div>
         </form>

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Modal } from "@/components/Modal";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { FiKey, FiEye, FiEyeOff, FiAlertCircle } from "react-icons/fi";
+
+interface MCPAuthTemplate {
+  headers: Array<{ name: string; value: string }>;
+  request_body_params: Array<{ path: string; value: string }>;
+  required_fields: string[];
+}
+
+interface MCPApiKeyModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  serverName: string;
+  serverId: number;
+  authTemplate?: MCPAuthTemplate;
+  onSubmit: (serverId: number, apiKey: string) => void;
+  onSubmitCredentials?: (
+    serverId: number,
+    credentials: Record<string, string>
+  ) => void;
+  onSuccess?: () => void;
+  isAuthenticated?: boolean;
+  existingCredentials?: Record<string, string>;
+}
+
+export function MCPApiKeyModal({
+  isOpen,
+  onClose,
+  serverName,
+  serverId,
+  authTemplate,
+  onSubmit,
+  onSubmitCredentials,
+  onSuccess,
+  isAuthenticated = false,
+  existingCredentials,
+}: MCPApiKeyModalProps) {
+  const [apiKey, setApiKey] = useState("");
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [showCredentials, setShowCredentials] = useState<
+    Record<string, boolean>
+  >({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isTemplateMode =
+    authTemplate && authTemplate.required_fields.length > 0;
+
+  // Initialize form with existing credentials when modal opens
+  useEffect(() => {
+    if (isOpen && existingCredentials) {
+      if (isTemplateMode) {
+        // For template mode, set the credentials object
+        setCredentials(existingCredentials);
+      } else {
+        // For legacy API key mode, set the api_key field
+        const apiKeyValue = existingCredentials.api_key || "";
+        setApiKey(apiKeyValue);
+      }
+    }
+  }, [isOpen, existingCredentials, isTemplateMode]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null); // Clear any previous errors
+
+    if (isTemplateMode) {
+      // Check all required fields are filled
+      const hasAllFields = authTemplate!.required_fields.every((field) =>
+        credentials[field]?.trim()
+      );
+      if (!hasAllFields) return;
+
+      setIsSubmitting(true);
+      try {
+        if (onSubmitCredentials) {
+          await onSubmitCredentials(serverId, credentials);
+        }
+        setCredentials({});
+        if (onSuccess) {
+          onSuccess();
+        }
+        onClose();
+      } catch (error) {
+        console.error("Error submitting credentials:", error);
+        let errorMessage = "Failed to save credentials";
+        if (error instanceof Error) {
+          errorMessage = error.message;
+        } else if (typeof error === "string") {
+          errorMessage = error;
+        }
+        setError(errorMessage);
+      } finally {
+        setIsSubmitting(false);
+      }
+    } else {
+      // Legacy API key mode
+      if (!apiKey.trim()) return;
+
+      setIsSubmitting(true);
+      try {
+        await onSubmit(serverId, apiKey);
+        setApiKey("");
+        if (onSuccess) {
+          onSuccess();
+        }
+        onClose();
+      } catch (error) {
+        console.error("Error submitting API key:", error);
+        let errorMessage = "Failed to save API key";
+        if (error instanceof Error) {
+          errorMessage = error.message;
+        } else if (typeof error === "string") {
+          errorMessage = error;
+        }
+        setError(errorMessage);
+      } finally {
+        setIsSubmitting(false);
+      }
+    }
+  };
+
+  const handleClose = () => {
+    setApiKey("");
+    setShowApiKey(false);
+    setCredentials({});
+    setShowCredentials({});
+    setError(null);
+    onClose();
+  };
+
+  const toggleCredentialVisibility = (field: string) => {
+    setShowCredentials((prev) => ({
+      ...prev,
+      [field]: !prev[field],
+    }));
+  };
+
+  const updateCredential = (field: string, value: string) => {
+    setCredentials((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  return (
+    <Modal
+      title={
+        <div className="flex items-center space-x-2">
+          <FiKey className="h-5 w-5" />
+          <span>{isAuthenticated ? "Manage API Key" : "Enter API Key"}</span>
+        </div>
+      }
+      onOutsideClick={handleClose}
+      width="max-w-md"
+    >
+      <div className="space-y-4">
+        <div>
+          <p className="text-sm text-subtle mb-2">
+            {isAuthenticated
+              ? isTemplateMode
+                ? `Update your credentials for ${serverName}.`
+                : `Update your API key for ${serverName}.`
+              : isTemplateMode
+                ? `Enter your credentials for ${serverName} to enable authentication.`
+                : `Enter your API key for ${serverName} to enable authentication.`}
+          </p>
+          <p className="text-xs text-subtle">
+            {isAuthenticated
+              ? "Changes will be validated against the server before being saved."
+              : isTemplateMode
+                ? "Your credentials will be validated against the server and stored securely."
+                : "This key will be stored securely and used only for this MCP server."}
+          </p>
+        </div>
+
+        {error && (
+          <div className="flex items-center space-x-2 p-3 bg-red-50 border border-red-200 rounded-md text-red-800 text-sm">
+            <FiAlertCircle className="h-4 w-4 flex-shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {isTemplateMode ? (
+            // Template-based credential fields
+            <div className="space-y-4">
+              {authTemplate!.required_fields.map((field) => (
+                <div key={field} className="space-y-2">
+                  <Label htmlFor={field}>
+                    {field
+                      .replace(/_/g, " ")
+                      .replace(/\b\w/g, (l) => l.toUpperCase())}
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id={field}
+                      type={showCredentials[field] ? "text" : "password"}
+                      value={credentials[field] || ""}
+                      onChange={(e) => updateCredential(field, e.target.value)}
+                      placeholder={`Enter your ${field.replace(/_/g, " ")}`}
+                      className="pr-10"
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => toggleCredentialVisibility(field)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
+                    >
+                      {showCredentials[field] ? (
+                        <FiEyeOff className="h-4 w-4" />
+                      ) : (
+                        <FiEye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            // Legacy API key field
+            <div className="space-y-2">
+              <Label htmlFor="apiKey">API Key</Label>
+              <div className="relative">
+                <Input
+                  id="apiKey"
+                  type={showApiKey ? "text" : "password"}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="Enter your API key"
+                  className="pr-10"
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowApiKey(!showApiKey)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
+                >
+                  {showApiKey ? (
+                    <FiEyeOff className="h-4 w-4" />
+                  ) : (
+                    <FiEye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                isSubmitting ||
+                (isTemplateMode
+                  ? !authTemplate!.required_fields.every((field) =>
+                      credentials[field]?.trim()
+                    )
+                  : !apiKey.trim())
+              }
+            >
+              {isSubmitting
+                ? "Saving..."
+                : isAuthenticated
+                  ? isTemplateMode
+                    ? "Update Credentials"
+                    : "Update API Key"
+                  : isTemplateMode
+                    ? "Save Credentials"
+                    : "Save API Key"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/oauth/OAuthCallbackPage.tsx
+++ b/web/src/components/oauth/OAuthCallbackPage.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { CheckmarkIcon, TriangleAlertIcon } from "@/components/icons/icons";
+import CardSection from "@/components/admin/CardSection";
+import { Button } from "@/components/ui/button";
+
+interface OAuthCallbackConfig {
+  // UI customization
+  processingMessage?: string;
+  processingDetails?: string;
+  successMessage?: string;
+  successDetailsTemplate?: string; // Template with {serviceName} placeholder
+  errorMessage?: string;
+  backButtonText?: string;
+  redirectingMessage?: string;
+
+  // Behavior
+  autoRedirectDelay?: number; // milliseconds
+  defaultRedirectPath?: string;
+
+  // API integration - all flows now use the same pattern
+  callbackApiUrl: string; // Required - API endpoint to call
+
+  // Error message mapping
+  errorMessageMap?: Record<string, string>;
+}
+
+interface OAuthCallbackPageProps {
+  config: OAuthCallbackConfig;
+}
+
+export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [statusMessage, setStatusMessage] = useState(
+    config.processingMessage || "Processing..."
+  );
+  const [statusDetails, setStatusDetails] = useState(
+    config.processingDetails || "Please wait while we complete the setup."
+  );
+  const [isError, setIsError] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [serviceName, setServiceName] = useState<string>("");
+  const [redirectPath, setRedirectPath] = useState<string | undefined>(
+    undefined
+  );
+  const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
+
+  // Extract query parameters
+  const code = searchParams?.get("code");
+  const state = searchParams?.get("state");
+  const error = searchParams?.get("error");
+  const errorDescription = searchParams?.get("error_description");
+
+  // Auto-redirect for success cases (with countdown)
+  useEffect(() => {
+    if (!isSuccess) return;
+
+    const delayMs = config.autoRedirectDelay ?? 2000;
+    setSecondsLeft(Math.ceil(delayMs / 1000));
+
+    const interval = setInterval(() => {
+      setSecondsLeft((prev) => (prev !== null && prev > 0 ? prev - 1 : prev));
+    }, 1000);
+
+    const timer = setTimeout(() => {
+      const target = redirectPath || config.defaultRedirectPath || "/chat";
+      router.push(target);
+    }, delayMs);
+
+    return () => {
+      clearInterval(interval);
+      clearTimeout(timer);
+    };
+  }, [
+    isSuccess,
+    redirectPath,
+    router,
+    config.autoRedirectDelay,
+    config.defaultRedirectPath,
+  ]);
+
+  useEffect(() => {
+    const handleOAuthCallback = async () => {
+      // Handle OAuth error from provider
+      if (error) {
+        setStatusMessage(config.errorMessage || "Authorization Failed");
+        setStatusDetails(
+          errorDescription ||
+            "The authorization was cancelled or failed. Please try again."
+        );
+        setIsError(true);
+        setIsLoading(false);
+        return;
+      }
+
+      // Validate required parameters
+      if (!code || !state) {
+        setStatusMessage("Invalid Request");
+        setStatusDetails(
+          "The authorization request was incomplete. Please try again."
+        );
+        setIsError(true);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        // Make API call to process callback - all flows use this pattern now
+        const url = `${config.callbackApiUrl}?code=${encodeURIComponent(
+          code
+        )}&state=${encodeURIComponent(state)}`;
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+        });
+
+        if (!response.ok) {
+          let errorMessage = "Failed to complete authorization";
+          try {
+            const errorData = await response.json();
+            if (errorData.detail && config.errorMessageMap) {
+              // Use custom error mapping
+              for (const [pattern, message] of Object.entries(
+                config.errorMessageMap
+              )) {
+                if (errorData.detail.includes(pattern)) {
+                  errorMessage = message;
+                  break;
+                }
+              }
+            } else if (errorData.error) {
+              errorMessage = errorData.error;
+            }
+          } catch (parseError) {
+            console.error("Error parsing response:", parseError);
+          }
+          throw new Error(errorMessage);
+        }
+
+        // Parse the response to get service and redirect information
+        const responseData = await response.json();
+        const result = {
+          success: true,
+          serviceName:
+            responseData.source ||
+            responseData.server_name ||
+            responseData.service_name,
+        };
+
+        setServiceName(result.serviceName || "");
+        // Respect backend-provided redirect path (from state.return_path)
+        setRedirectPath(
+          responseData.redirect_url ||
+            searchParams?.get("return_path") ||
+            config.defaultRedirectPath ||
+            "/chat"
+        );
+        setStatusMessage(config.successMessage || "Success!");
+
+        const successDetails = config.successDetailsTemplate
+          ? config.successDetailsTemplate.replace(
+              "{serviceName}",
+              result.serviceName || "service"
+            )
+          : `Your ${result.serviceName || "service"} authorization completed successfully.`;
+
+        setStatusDetails(successDetails);
+        setIsSuccess(true);
+        setIsError(false);
+        setIsLoading(false);
+      } catch (error) {
+        console.error("OAuth callback error:", error);
+        setStatusMessage(config.errorMessage || "Something Went Wrong");
+        setStatusDetails(
+          error instanceof Error
+            ? error.message
+            : "An error occurred during the OAuth process. Please try again."
+        );
+        setIsError(true);
+        setIsLoading(false);
+      }
+    };
+
+    handleOAuthCallback();
+  }, [code, state, error, errorDescription, searchParams, config]);
+
+  const getStatusIcon = () => {
+    if (isLoading) {
+      return (
+        <div className="w-16 h-16 border-4 border-blue-200 dark:border-blue-800 border-t-blue-600 dark:border-t-blue-400 rounded-full animate-spin mx-auto mb-4"></div>
+      );
+    }
+    if (isSuccess) {
+      return (
+        <CheckmarkIcon
+          size={64}
+          className="text-green-500 dark:text-green-400 mx-auto mb-4"
+        />
+      );
+    }
+    if (isError) {
+      return (
+        <TriangleAlertIcon
+          size={64}
+          className="text-red-500 dark:text-red-400 mx-auto mb-4"
+        />
+      );
+    }
+    return null;
+  };
+
+  const getStatusColor = () => {
+    if (isSuccess) return "text-green-600 dark:text-green-400";
+    if (isError) return "text-red-600 dark:text-red-400";
+    return "text-gray-600 dark:text-gray-300";
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="flex-1 flex flex-col items-center justify-center p-4">
+        <CardSection className="max-w-md w-full mx-auto p-8 shadow-lg bg-white dark:bg-gray-800 rounded-lg">
+          <div className="text-center">
+            {getStatusIcon()}
+
+            <h1 className={`text-2xl font-bold mb-4 ${getStatusColor()}`}>
+              {statusMessage}
+            </h1>
+
+            <p className="text-gray-600 dark:text-gray-300 mb-6 leading-relaxed">
+              {statusDetails}
+            </p>
+
+            {isSuccess && secondsLeft !== null && (
+              <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 mb-6">
+                <p className="text-green-800 dark:text-green-200 text-sm">
+                  Redirecting in {secondsLeft}{" "}
+                  {secondsLeft === 1 ? "second" : "seconds"}...
+                </p>
+              </div>
+            )}
+
+            <div className="flex flex-col space-y-3">
+              {isError && (
+                <div className="flex flex-col space-y-2">
+                  <Button
+                    onClick={() => {
+                      const target =
+                        redirectPath || config.defaultRedirectPath || "/chat";
+                      router.push(target);
+                    }}
+                    variant="navigate"
+                    className="w-full"
+                  >
+                    {config.backButtonText || "Back to Chat"}
+                  </Button>
+                </div>
+              )}
+
+              {isLoading && (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  This may take a few moments...
+                </p>
+              )}
+            </div>
+          </div>
+        </CardSection>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/createButton.tsx
+++ b/web/src/components/ui/createButton.tsx
@@ -5,16 +5,18 @@ interface CreateButtonProps {
   href?: string;
   onClick?: () => void;
   text?: string;
+  icon?: React.ReactNode;
 }
 
 export default function CreateButton({
   href,
   onClick,
   text = "Create",
+  icon = <FiPlusCircle />,
 }: CreateButtonProps) {
   const content = (
     <Button className="font-normal mt-2" variant="create" onClick={onClick}>
-      <FiPlusCircle />
+      {icon}
       {text}
     </Button>
   );

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -464,7 +464,8 @@ export const credentialDisplayNames: Record<string, string> = {
   bookstack_api_token_secret: "Bookstack API Token Secret",
 
   // Outline
-  outline_base_url: "Outline Base URL (e.g. https://app.getoutline.com or your self-hosted URL)",
+  outline_base_url:
+    "Outline Base URL (e.g. https://app.getoutline.com or your self-hosted URL)",
   outline_api_token: "Outline API Token",
 
   // Confluence

--- a/web/src/lib/tools/edit.ts
+++ b/web/src/lib/tools/edit.ts
@@ -1,4 +1,10 @@
-import { MethodSpec, ToolSnapshot } from "./interfaces";
+import {
+  MethodSpec,
+  ToolSnapshot,
+  MCPServersResponse,
+  MCPAuthenticationPerformer,
+  MCPAuthenticationType,
+} from "./interfaces";
 
 interface ApiResponse<T> {
   data: T | null;
@@ -111,5 +117,131 @@ export async function validateToolDefinition(toolData: {
   } catch (error) {
     console.error("Error validating tool:", error);
     return { data: null, error: "Unexpected error validating tool definition" };
+  }
+}
+
+interface MCPServerCreateResponse {
+  server_id: number;
+  server_name: string;
+  server_url: string;
+  auth_type: string;
+  auth_performer?: string;
+  is_authenticated: boolean;
+}
+
+interface MCPToolsUpdateResponse {
+  server_id: number;
+  updated_tools: number;
+}
+
+export async function createMCPServer(serverData: {
+  name: string;
+  description?: string;
+  server_url: string;
+  auth_type: MCPAuthenticationType;
+  auth_performer?: MCPAuthenticationPerformer;
+  api_token?: string;
+  oauth_client_id?: string;
+  oauth_client_secret?: string;
+  auth_template?: any;
+  admin_credentials?: Record<string, string>;
+  existing_server_id?: number;
+}): Promise<ApiResponse<MCPServerCreateResponse>> {
+  try {
+    const response = await fetch("/api/admin/mcp/servers/create", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(serverData),
+    });
+
+    if (!response.ok) {
+      const errorDetail = (await response.json()).detail;
+      return {
+        data: null,
+        error: `Failed to create MCP server: ${errorDetail}`,
+      };
+    }
+
+    const result: MCPServerCreateResponse = await response.json();
+    return { data: result, error: null };
+  } catch (error) {
+    console.error("Error creating MCP server:", error);
+    return { data: null, error: `Error creating MCP server: ${error}` };
+  }
+}
+
+export async function attachMCPTools(toolsData: {
+  server_id: number;
+  selected_tools: string[];
+}): Promise<ApiResponse<MCPToolsUpdateResponse>> {
+  try {
+    const response = await fetch("/api/admin/mcp/servers/update", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toolsData),
+    });
+
+    if (!response.ok) {
+      const errorDetail = (await response.json()).detail;
+      return { data: null, error: `Failed to attach tools: ${errorDetail}` };
+    }
+
+    const result: MCPToolsUpdateResponse = await response.json();
+    return { data: result, error: null };
+  } catch (error) {
+    console.error("Error attaching MCP tools:", error);
+    return { data: null, error: "Error attaching MCP tools" };
+  }
+}
+
+export async function fetchMCPServers(): Promise<
+  ApiResponse<MCPServersResponse>
+> {
+  try {
+    const response = await fetch("/api/admin/mcp/servers", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `HTTP error! status: ${response.status}, message: ${errorText}`
+      );
+    }
+
+    const result: MCPServersResponse = await response.json();
+    return { data: result, error: null };
+  } catch (error) {
+    console.error("Error fetching MCP servers:", error);
+    return { data: null, error: "Error fetching MCP servers" };
+  }
+}
+
+export async function deleteMCPServer(
+  serverId: string | number
+): Promise<ApiResponse<{ success: boolean }>> {
+  try {
+    const response = await fetch(`/api/admin/mcp/server/${serverId}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `HTTP error! status: ${response.status}, message: ${errorText}`
+      );
+    }
+    const result = (await response.json()) as { success: boolean };
+    return { data: result, error: null };
+  } catch (error) {
+    console.error("Error deleting MCP server:", error);
+    return { data: null, error: "Error deleting MCP server" };
   }
 }

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -1,3 +1,18 @@
+export enum MCPAuthenticationType {
+  NONE = "NONE",
+  API_TOKEN = "API_TOKEN",
+  OAUTH = "OAUTH",
+}
+
+export enum MCPAuthenticationPerformer {
+  ADMIN = "ADMIN",
+  PER_USER = "PER_USER",
+}
+
+export enum MCPTransportType {
+  STDIO = "stdio",
+  STREAMABLE_HTTP = "streamable-http",
+}
 export interface ToolSnapshot {
   id: number;
   name: string;
@@ -16,6 +31,24 @@ export interface ToolSnapshot {
 
   // whether to pass through the user's OAuth token as Authorization header
   passthrough_auth: boolean;
+
+  // If this is an MCP tool, which server it belongs to
+  mcp_server_id?: number | null;
+}
+
+export interface MCPServer {
+  id: number;
+  name: string;
+  server_url: string;
+  auth_type: MCPAuthenticationType;
+  auth_performer: MCPAuthenticationPerformer;
+  is_authenticated: boolean;
+  user_authenticated?: boolean | null;
+}
+
+export interface MCPServersResponse {
+  assistant_id: string;
+  mcp_servers: MCPServer[];
 }
 
 export interface MethodSpec {


### PR DESCRIPTION
## Description

Addresses https://linear.app/danswer/issue/DAN-2273/mcp-support

Onyx as an MCP client! 
currently supports:
- No Auth
- Admin API key auth
- per-user API key auth
- OAuth

potentially will move to dynamic client registration for OAuth in v2.

Also, The OAuth interface is still a bit clunky. This v1 is functional but not pretty; v2 will be based on designs from someone better at designing UIs :)

## How Has This Been Tested?

All tested in UI, see tests/integration/mock_services_mcp_test_server for more info. These files will likely be moved somewhere more appropriate in the future + We'll add automated tests that use the configured servers.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds MCP client support so assistants can use tools from external MCP servers. Supports no auth, admin API token, and per-user API token; OAuth groundwork is in place but not enabled.

- New Features
  - Database: new MCPServer and MCPConnectionConfig models, enums for auth type and performer, and relationships to users/tools; Alembic migration included.
  - Backend APIs: admin and user routes to create/manage MCP servers, define per-user auth templates, store user credentials, discover server tools, and create MCP-backed tools.
  - MCP client: streamable HTTP client for resource discovery and tool calls; MCPTool integrated into tool constructor and execution flow.
  - Tool model: added mcp_server_id and snapshots updated; list tools by MCP server.
  - UI: admin pages to add/edit MCP servers, discover/import tools, and manage servers in Actions; assistant editor shows MCP tools; chat input adds an MCP server selector and per-user API key modal.
  - Testing: mock MCP servers for no-auth, admin API key, per-user key, and OAuth (stub) to support integration testing.

- Migration
  - Run Alembic migration to create MCP tables.
  - Install new dependency: mcp[cli]==1.12.2 and restart services.
  - Note: tool create/delete now use DB flush; callers must commit (tool API updated accordingly).

<!-- End of auto-generated description by cubic. -->

