### PR TITLE
Explicitly add limit to the function calls

### DIFF
--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -118,6 +118,7 @@ async def _fetch_documents_from_channel(
         start_time = discord_epoch
 
     async for channel_message in channel.history(
+        limit=None,
         after=start_time,
         before=end_time,
     ):
@@ -136,6 +137,7 @@ async def _fetch_documents_from_channel(
 
     for active_thread in channel.threads:
         async for thread_message in active_thread.history(
+            limit=None,
             after=start_time,
             before=end_time,
         ):
@@ -152,8 +154,11 @@ async def _fetch_documents_from_channel(
 
             yield _convert_message_to_document(thread_message, sections)
 
-    async for archived_thread in channel.archived_threads():
+    async for archived_thread in channel.archived_threads(
+        limit=None
+        ):
         async for thread_message in archived_thread.history(
+            limit=None,
             after=start_time,
             before=end_time,
         ):


### PR DESCRIPTION


## Description
The code is not specifying a limit in most of the calls
The default limit is 1000 for archived and 100 for history.

Before change limit
```
Total documents processed: 707
```
Roughly like
```
select count(id) from document
where id like('DISCORD_%') count|
-----+
  702|
```

With limit None
```
Total documents processed: 1169
```
It seems we need to specify limit=None in several places like the diff.

## How Has This Been Tested?

This was tested with local data, manually. It does not affect unit test

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [x] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
