### PR TITLE
fix: explain why limit=None is appropriate for discord

### DIFF
--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -118,9 +118,9 @@ async def _fetch_documents_from_channel(
         start_time = discord_epoch
 
     # NOTE: limit=None is the correct way to fetch all messages and threads with pagination
-    # The discord package erroneously uses limit for both pagination AND number of results.
-    # This causes the history and archived_threads methods to return 100 results even if there are more results within the filters.
-    # Pagination is handled automatically (100 results at a time) when limit=None.
+    # The discord package erroneously uses limit for both pagination AND number of results
+    # This causes the history and archived_threads methods to return 100 results even if there are more results within the filters
+    # Pagination is handled automatically (100 results at a time) when limit=None
 
     async for channel_message in channel.history(
         limit=None,
@@ -161,7 +161,7 @@ async def _fetch_documents_from_channel(
 
     async for archived_thread in channel.archived_threads(
         limit=None,
-        ):
+    ):
         async for thread_message in archived_thread.history(
             limit=None,
             after=start_time,

--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -117,6 +117,11 @@ async def _fetch_documents_from_channel(
     if start_time and start_time < discord_epoch:
         start_time = discord_epoch
 
+    # NOTE: limit=None is the correct way to fetch all messages and threads with pagination
+    # The discord package erroneously uses limit for both pagination AND number of results.
+    # This causes the history and archived_threads methods to return 100 results even if there are more results within the filters.
+    # Pagination is handled automatically (100 results at a time) when limit=None.
+
     async for channel_message in channel.history(
         limit=None,
         after=start_time,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ ignore_errors = true
 
 [tool.ruff]
 line-length = 130
+target-version = "py311"
 
 [tool.ruff.lint]
 ignore = []


### PR DESCRIPTION
## Description

- Clarification comment + test/linting/formatting for a community contribution

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Clarified why the Discord connector uses limit=None so history and archived_threads paginate automatically and don’t silently truncate to 100 results. Adds an inline note to prevent future regressions and confusion.

<!-- End of auto-generated description by cubic. -->

