### PR TITLE
fix: improve index attempts API

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -275,6 +275,19 @@ def get_connector_credential_pair_from_id_for_user(
     return result.scalar_one_or_none()
 
 
+def verify_user_has_access_to_cc_pair(
+    cc_pair_id: int,
+    db_session: Session,
+    user: User,
+    get_editable: bool = True,
+) -> bool:
+    stmt = select(ConnectorCredentialPair.id)
+    stmt = _add_user_filters(stmt, user, get_editable)
+    stmt = stmt.where(ConnectorCredentialPair.id == cc_pair_id)
+    result = db_session.execute(stmt)
+    return result.scalars().first() is not None
+
+
 def get_connector_credential_pair_from_id(
     db_session: Session,
     cc_pair_id: int,

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -11,7 +11,6 @@ from sqlalchemy import func
 from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy import update
-from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
@@ -583,16 +582,14 @@ def get_latest_index_attempt_for_cc_pair_id(
     return db_session.execute(stmt).scalar_one_or_none()
 
 
-def count_index_attempts_for_connector(
+def count_index_attempts_for_cc_pair(
     db_session: Session,
-    connector_id: int,
+    cc_pair_id: int,
     only_current: bool = True,
     disinclude_finished: bool = False,
 ) -> int:
-    stmt = (
-        select(IndexAttempt)
-        .join(ConnectorCredentialPair)
-        .where(ConnectorCredentialPair.connector_id == connector_id)
+    stmt = select(IndexAttempt).where(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id
     )
     if disinclude_finished:
         stmt = stmt.where(
@@ -612,16 +609,14 @@ def count_index_attempts_for_connector(
 
 def get_paginated_index_attempts_for_cc_pair_id(
     db_session: Session,
-    connector_id: int,
+    cc_pair_id: int,
     page: int,
     page_size: int,
     only_current: bool = True,
     disinclude_finished: bool = False,
 ) -> list[IndexAttempt]:
-    stmt = (
-        select(IndexAttempt)
-        .join(ConnectorCredentialPair)
-        .where(ConnectorCredentialPair.connector_id == connector_id)
+    stmt = select(IndexAttempt).where(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id
     )
     if disinclude_finished:
         stmt = stmt.where(
@@ -638,10 +633,6 @@ def get_paginated_index_attempts_for_cc_pair_id(
 
     # Apply pagination
     stmt = stmt.offset(page * page_size).limit(page_size)
-    stmt = stmt.options(
-        contains_eager(IndexAttempt.connector_credential_pair),
-        joinedload(IndexAttempt.error_rows),
-    )
 
     return list(db_session.execute(stmt).scalars().unique().all())
 

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -35,7 +35,7 @@ export interface IndexingAttemptsTableProps {
   onPageChange: (page: number) => void;
 }
 
-export function IndexingAttemptsTable({
+export function IndexAttemptsTable({
   indexAttempts,
   currentPage,
   totalPages,

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -23,7 +23,7 @@ import {
   ConfigDisplay,
 } from "./ConfigDisplay";
 import DeletionErrorStatus from "./DeletionErrorStatus";
-import { IndexingAttemptsTable } from "./IndexingAttemptsTable";
+import { IndexAttemptsTable } from "./IndexingAttemptsTable";
 
 import { buildCCPairInfoUrl, triggerIndexing } from "./lib";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -109,17 +109,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
   } = usePaginatedFetch<IndexAttemptSnapshot>({
     itemsPerPage: ITEMS_PER_PAGE,
     pagesPerBatch: PAGES_PER_BATCH,
-    endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
-  });
-
-  // need to always have the most recent index attempts around
-  // so just kick off a separate fetch
-  const {
-    currentPageData: mostRecentIndexAttempts,
-    isLoading: isLoadingMostRecentIndexAttempts,
-  } = usePaginatedFetch<IndexAttemptSnapshot>({
-    itemsPerPage: ITEMS_PER_PAGE,
-    pagesPerBatch: 1,
     endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
   });
 
@@ -351,11 +340,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     }
   };
 
-  if (
-    isLoadingCCPair ||
-    isLoadingIndexAttempts ||
-    isLoadingMostRecentIndexAttempts
-  ) {
+  if (isLoadingCCPair || isLoadingIndexAttempts) {
     return <ThreeDotsLoader />;
   }
 
@@ -728,7 +713,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
               Indexing Attempts
             </Title>
             {indexAttempts && (
-              <IndexingAttemptsTable
+              <IndexAttemptsTable
                 ccPair={ccPair}
                 indexAttempts={indexAttempts}
                 currentPage={currentPage}

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -23,7 +23,7 @@ import {
   ConfigDisplay,
 } from "./ConfigDisplay";
 import DeletionErrorStatus from "./DeletionErrorStatus";
-import { IndexAttemptsTable } from "./IndexingAttemptsTable";
+import { IndexAttemptsTable } from "./IndexAttemptsTable";
 
 import { buildCCPairInfoUrl, triggerIndexing } from "./lib";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

Tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Shifted the index attempts API to use cc_pair_id instead of connector_id, added a direct access check, and simplified the frontend. This fixes mixed counts/pagination when a connector has multiple CC pairs and removes redundant requests.

- **Bug Fixes**
  - Count and paginate attempts by cc_pair_id to avoid mixing data across CC pairs.
  - Enforce user access to the CC pair before returning attempts.

- **Refactors**
  - Added verify_user_has_access_to_cc_pair for lightweight permission checks.
  - Simplified DB queries (no join/eager loads) and updated server handlers to use cc_pair_id.
  - Renamed IndexingAttemptsTable to IndexAttemptsTable and removed the extra “most recent attempts” fetch.

<!-- End of auto-generated description by cubic. -->

