### PR TITLE
feat(infra): Adding KEDA Templates for the Helm Charts

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/keda/api-server-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/api-server-scaledobject.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keda.enabled (and .Values.keda.apiServer .Values.keda.apiServer.enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-api-server-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+    app: api-server
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" . }}-api-server
+  pollingInterval: {{ .Values.keda.apiServer.pollingInterval | default .Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.apiServer.cooldownPeriod | default .Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.apiServer.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.apiServer.maxReplicas }}
+  triggers:
+    {{- range .Values.keda.apiServer.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/celery-worker-common-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/celery-worker-common-scaledobject.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.keda.enabled .Values.keda.celeryWorkers.enabled }}
+{{- range $workerType, $workerConfig := .Values.keda.celeryWorkers }}
+{{- if and (ne $workerType "enabled") $workerConfig.enabled }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" $ }}-celery-worker-{{ $workerType }}-scaledobject
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" $ | nindent 4 }}
+    app: celery-worker-{{ $workerType }}
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" $ }}-celery-worker-{{ $workerType }}
+  pollingInterval: {{ $workerConfig.pollingInterval | default $.Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ $workerConfig.cooldownPeriod | default $.Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ $workerConfig.minReplicas }}
+  maxReplicaCount: {{ $workerConfig.maxReplicas }}
+  triggers:
+    {{- range $workerConfig.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/celery-worker-docfetching-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/celery-worker-docfetching-scaledobject.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keda.enabled (and .Values.keda.celeryWorkers .Values.keda.celeryWorkers.enabled) (and .Values.keda.celeryWorkers.docfetching .Values.keda.celeryWorkers.docfetching.enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+    app: celery-worker-docfetching
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching
+  pollingInterval: {{ .Values.keda.celeryWorkers.docfetching.pollingInterval | default .Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.celeryWorkers.docfetching.cooldownPeriod | default .Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.celeryWorkers.docfetching.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.celeryWorkers.docfetching.maxReplicas }}
+  triggers:
+    {{- range .Values.keda.celeryWorkers.docfetching.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/celery-worker-docprocessing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/celery-worker-docprocessing-scaledobject.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keda.enabled (and .Values.keda.celeryWorkers .Values.keda.celeryWorkers.enabled) (and .Values.keda.celeryWorkers.docprocessing .Values.keda.celeryWorkers.docprocessing.enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+    app: celery-worker-docprocessing
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing
+  pollingInterval: {{ .Values.keda.celeryWorkers.docprocessing.pollingInterval | default .Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.celeryWorkers.docprocessing.cooldownPeriod | default .Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.celeryWorkers.docprocessing.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.celeryWorkers.docprocessing.maxReplicas }}
+  triggers:
+    {{- range .Values.keda.celeryWorkers.docprocessing.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/model-server-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/model-server-scaledobject.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.keda.enabled .Values.keda.modelServers.enabled }}
+{{- range $serverType, $serverConfig := .Values.keda.modelServers }}
+{{- if and (ne $serverType "enabled") $serverConfig.enabled }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" $ }}-{{ $serverType }}-model-server-scaledobject
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" $ | nindent 4 }}
+    app: {{ $serverType }}-model-server
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" $ }}-{{ $serverType }}-model-server
+  pollingInterval: {{ $serverConfig.pollingInterval | default $.Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ $serverConfig.cooldownPeriod | default $.Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ $serverConfig.minReplicas }}
+  maxReplicaCount: {{ $serverConfig.maxReplicas }}
+  triggers:
+    {{- range $serverConfig.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/slackbot-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/slackbot-scaledobject.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keda.enabled (and .Values.keda.slackbot .Values.keda.slackbot.enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-slackbot-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+    app: slackbot
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" . }}-slackbot
+  pollingInterval: {{ .Values.keda.slackbot.pollingInterval | default .Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.slackbot.cooldownPeriod | default .Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.slackbot.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.slackbot.maxReplicas }}
+  triggers:
+    {{- range .Values.keda.slackbot.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/keda/web-server-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/keda/web-server-scaledobject.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.keda.enabled (and .Values.keda.webServer .Values.keda.webServer.enabled) }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-web-server-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+    app: web-server
+spec:
+  scaleTargetRef:
+    name: {{ include "onyx-stack.fullname" . }}-web-server
+  pollingInterval: {{ .Values.keda.webServer.pollingInterval | default .Values.keda.global.pollingInterval }}
+  cooldownPeriod: {{ .Values.keda.webServer.cooldownPeriod | default .Values.keda.global.cooldownPeriod }}
+  minReplicaCount: {{ .Values.keda.webServer.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.webServer.maxReplicas }}
+  triggers:
+    {{- range .Values.keda.webServer.triggers }}
+    - type: {{ .type }}
+      metadata:
+        {{- range $key, $value := .metadata }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding new KEDA Templates to introduce KEDA to helm. This is the first step to get autoscaling pods in our helm chart users.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran helm template commands locally to figure out if the manifests were properly generated. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
