### PR TITLE
fix: cleanup on ChatPage/MessagesDisply

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -362,39 +362,6 @@ export function ChatPage({
     }
   }, [setMessage, setCurrentMessageFiles]);
 
-  const clientScrollToBottom = useCallback((fast?: boolean) => {
-    waitForScrollRef.current = true;
-
-    setTimeout(() => {
-      if (!endDivRef.current || !scrollableDivRef.current) {
-        console.error("endDivRef or scrollableDivRef not found");
-        return;
-      }
-
-      const rect = endDivRef.current.getBoundingClientRect();
-      const isVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-
-      if (isVisible) return;
-
-      // Check if all messages are currently rendered
-      // If all messages are already rendered, scroll immediately
-      endDivRef.current.scrollIntoView({
-        behavior: fast ? "auto" : "smooth",
-      });
-
-      if (chatSessionIdRef.current) {
-        useChatSessionStore
-          .getState()
-          .updateHasPerformedInitialScroll(chatSessionIdRef.current, true);
-      }
-    }, 50);
-
-    // Reset waitForScrollRef after 1.5 seconds
-    setTimeout(() => {
-      waitForScrollRef.current = false;
-    }, 1500);
-  }, []);
-
   const debounceNumber = 100; // time for debouncing
 
   // handle re-sizing of the text area
@@ -488,6 +455,40 @@ export function ChatPage({
   );
   const updateCurrentChatSessionSharedStatus = useChatSessionStore(
     (state) => state.updateCurrentChatSessionSharedStatus
+  );
+
+  const clientScrollToBottom = useCallback(
+    (fast?: boolean) => {
+      waitForScrollRef.current = true;
+
+      setTimeout(() => {
+        if (!endDivRef.current || !scrollableDivRef.current) {
+          console.error("endDivRef or scrollableDivRef not found");
+          return;
+        }
+
+        const rect = endDivRef.current.getBoundingClientRect();
+        const isVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+
+        if (isVisible) return;
+
+        // Check if all messages are currently rendered
+        // If all messages are already rendered, scroll immediately
+        endDivRef.current.scrollIntoView({
+          behavior: fast ? "auto" : "smooth",
+        });
+
+        if (chatSessionIdRef.current) {
+          updateHasPerformedInitialScroll(chatSessionIdRef.current, true);
+        }
+      }, 50);
+
+      // Reset waitForScrollRef after 1.5 seconds
+      setTimeout(() => {
+        waitForScrollRef.current = false;
+      }, 1500);
+    },
+    [updateHasPerformedInitialScroll]
   );
 
   const { onSubmit, stopGenerating, handleMessageSpecificFileUpload } =

--- a/web/src/app/chat/components/MessagesDisplay.tsx
+++ b/web/src/app/chat/components/MessagesDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { RefObject, useCallback, useMemo } from "react";
-import { CitationMap, Message } from "../interfaces";
+import { Message } from "../interfaces";
 import { OnyxDocument, MinimalOnyxDocument } from "@/lib/search/interfaces";
 import { MemoizedHumanMessage } from "../message/MemoizedHumanMessage";
 import { ErrorBanner } from "../message/Resubmit";


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleaned up ChatPage scroll-to-bottom logic and removed an unused import. The scroll handler now uses a store selector with proper dependencies instead of getState to avoid stale updates.

- **Refactors**
  - Replaced useChatSessionStore.getState() with selector for updateHasPerformedInitialScroll and added it as a useCallback dependency.
  - Repositioned clientScrollToBottom to use the selected store function.
  - Removed unused CitationMap import from MessagesDisplay.tsx.

<!-- End of auto-generated description by cubic. -->

