### PR TITLE
fix(infra): Onyx User Playwright Cache access

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -122,7 +122,11 @@ RUN groupadd -g 1001 onyx && \
     chown -R onyx:onyx /app && \
     mkdir -p /var/log/onyx && \
     chmod 755 /var/log/onyx && \
-    chown onyx:onyx /var/log/onyx
+    chown onyx:onyx /var/log/onyx && \
+    # Ensure onyx user can access Playwright cache and browser files
+    # Make root Playwright installation accessible to onyx user
+    chmod -R 755 /root/.cache/ms-playwright && \
+    chmod -R 755 /root/.local/share/ms-playwright
 
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
A customer is reporting that they are not able to access the playwright directories that are installed when using the pod security context change and running as a different user. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Built and run the images locally.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Playwright permission issues for the onyx user in the backend image. Non-root runs (via pod security context) can now read and execute the preinstalled Playwright browsers and cache.

- **Bug Fixes**
  - Set 755 on /root/.cache/ms-playwright and /root/.local/share/ms-playwright in the Dockerfile so the onyx user can access Playwright files.

<!-- End of auto-generated description by cubic. -->

