### PR TITLE
fix(jira): Upgrade the Jira Python Version

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -29,7 +29,7 @@ httpx[http2]==0.28.1
 httpx-oauth==0.15.1
 huggingface-hub==0.29.0
 inflection==0.5.1
-jira==3.5.1
+jira==3.10.5
 jsonref==1.1.0
 trafilatura==1.12.2
 langchain==0.3.23


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
We are using an old version of the Jira Python Client that has issues with the new path that is required in order to search against the cloud environments.

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested that this works on Jira and Jira Datacenter and we are still able to index properly.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
