### PR TITLE
fix: specify playwright location using env var

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,8 @@ ARG ONYX_VERSION=0.0.0-dev
 # DO_NOT_TRACK is used to disable telemetry for Unstructured
 ENV ONYX_VERSION=${ONYX_VERSION} \
     DANSWER_RUNNING_IN_DOCKER="true" \
-    DO_NOT_TRACK="true"
+    DO_NOT_TRACK="true" \
+    PLAYWRIGHT_BROWSERS_PATH=/app/.cache/playwright
 
 
 RUN echo "ONYX_VERSION: ${ONYX_VERSION}"


### PR DESCRIPTION
## Description

The PR fixes file system permission issues encountered when running as non-root using a web connector. By default, Playwright places all files and executables in the `/root` directory. Adding the environment variable in this PR overwrites the default location for Playwright.  

## How Has This Been Tested?

Ran a docker build and verified the contents and ownership of the `/app/.cache/playwright` directory.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
