### PR TITLE
fix: allow chats to be moved out of chat groups

### DIFF
--- a/backend/onyx/server/features/folder/api.py
+++ b/backend/onyx/server/features/folder/api.py
@@ -151,7 +151,7 @@ def add_chat_to_folder_endpoint(
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/{folder_id}/remove-chat-session/")
+@router.post("/{folder_id}/remove-chat-session")
 def remove_chat_from_folder_endpoint(
     request: FolderChatSessionRequest,
     folder_id: int = Path(

--- a/web/src/app/chat/components/folders/FolderList.tsx
+++ b/web/src/app/chat/components/folders/FolderList.tsx
@@ -305,6 +305,7 @@ const FolderItem = ({
               isSelected={chatSession.id === currentChatId}
               showShareModal={showShareModal}
               showDeleteModal={showDeleteModal}
+              parentFolderName={folder.folder_name}
             />
           ))}
         </div>

--- a/web/src/components/sidebar/ChatSessionDisplay.tsx
+++ b/web/src/components/sidebar/ChatSessionDisplay.tsx
@@ -11,6 +11,7 @@ import {
 import { BasicSelectable } from "@/components/BasicClickable";
 import Link from "next/link";
 import {
+  FiArrowRight,
   FiCheck,
   FiEdit2,
   FiMoreHorizontal,
@@ -27,6 +28,7 @@ import { DragHandle } from "@/components/table/DragHandle";
 import { WarningCircle } from "@phosphor-icons/react";
 import { CustomTooltip } from "@/components/tooltip/CustomTooltip";
 import { useChatContext } from "@/components/context/ChatContext";
+import { removeChatFromFolder } from "@/app/chat/components/folders/FolderManagement";
 
 export function ChatSessionDisplay({
   chatSession,
@@ -36,6 +38,7 @@ export function ChatSessionDisplay({
   showShareModal,
   showDeleteModal,
   isDragging,
+  parentFolderName,
 }: {
   chatSession: ChatSession;
   isSelected: boolean;
@@ -44,6 +47,7 @@ export function ChatSessionDisplay({
   showShareModal?: (chatSession: ChatSession) => void;
   showDeleteModal?: (chatSession: ChatSession) => void;
   isDragging?: boolean;
+  parentFolderName?: string;
 }) {
   const router = useRouter();
   const [isHovered, setIsHovered] = useState(false);
@@ -96,6 +100,23 @@ export function ChatSessionDisplay({
     },
     [chatSession, showDeleteModal, refreshChatSessions, refreshFolders]
   );
+
+  const handleMoveOutOfFolder = useCallback(async () => {
+    try {
+      if (chatSession.folder_id == null) return;
+      await removeChatFromFolder(chatSession.folder_id, chatSession.id);
+      await refreshChatSessions();
+      await refreshFolders();
+      setPopoverOpen(false);
+    } catch (e) {
+      console.error("Failed to move chat out of folder", e);
+    }
+  }, [
+    chatSession.folder_id,
+    chatSession.id,
+    refreshChatSessions,
+    refreshFolders,
+  ]);
 
   const onRename = useCallback(
     async (e?: React.MouseEvent) => {
@@ -326,7 +347,7 @@ export function ChatSessionDisplay({
                             popover={
                               <div
                                 className={`border border-border text-text-dark rounded-lg bg-background z-50 ${
-                                  isDeleteModalOpen ? "w-64" : "w-32"
+                                  isDeleteModalOpen ? "w-64" : "w-50"
                                 }`}
                               >
                                 {!isDeleteModalOpen ? (
@@ -345,6 +366,13 @@ export function ChatSessionDisplay({
                                         name="Rename"
                                         icon={FiEdit2}
                                         onSelect={() => setIsRenamingChat(true)}
+                                      />
+                                    )}
+                                    {chatSession.folder_id !== null && (
+                                      <DefaultDropdownElement
+                                        name={`Move out of ${parentFolderName ?? "group"}?`}
+                                        icon={FiArrowRight}
+                                        onSelect={handleMoveOutOfFolder}
                                       />
                                     )}
                                     <DefaultDropdownElement

--- a/web/src/components/sidebar/ChatSessionDisplay.tsx
+++ b/web/src/components/sidebar/ChatSessionDisplay.tsx
@@ -347,7 +347,7 @@ export function ChatSessionDisplay({
                             popover={
                               <div
                                 className={`border border-border text-text-dark rounded-lg bg-background z-50 ${
-                                  isDeleteModalOpen ? "w-64" : "w-50"
+                                  isDeleteModalOpen ? "w-64" : "w-48"
                                 }`}
                               >
                                 {!isDeleteModalOpen ? (

--- a/web/src/components/sidebar/ChatSessionDisplay.tsx
+++ b/web/src/components/sidebar/ChatSessionDisplay.tsx
@@ -103,7 +103,7 @@ export function ChatSessionDisplay({
 
   const handleMoveOutOfFolder = useCallback(async () => {
     try {
-      if (chatSession.folder_id == null) return;
+      if (chatSession.folder_id === null) return;
       await removeChatFromFolder(chatSession.folder_id, chatSession.id);
       await refreshChatSessions();
       await refreshFolders();

--- a/web/src/components/sidebar/PagesTab.tsx
+++ b/web/src/components/sidebar/PagesTab.tsx
@@ -247,7 +247,11 @@ export function PagesTab({
   );
 
   const renderChatSession = useCallback(
-    (chat: ChatSession, foldersExisting: boolean) => {
+    (
+      chat: ChatSession,
+      foldersExisting: boolean,
+      parentFolderName?: string
+    ) => {
       return (
         <div
           key={chat.id}
@@ -269,6 +273,7 @@ export function PagesTab({
             showDeleteModal={showDeleteModal}
             closeSidebar={closeSidebar}
             isDragging={isDraggingSessionId === chat.id}
+            parentFolderName={parentFolderName}
           />
         </div>
       );
@@ -424,7 +429,8 @@ export function PagesTab({
                       folder.chat_sessions.map((chat) =>
                         renderChatSession(
                           chat,
-                          folders != undefined && folders.length > 0
+                          folders != undefined && folders.length > 0,
+                          folder.folder_name
                         )
                       )}
                   </SortableFolder>


### PR DESCRIPTION
## Description

- No way to move chats out of groups other than deleting the group
- Allow with new button in 3 dot menu --> identical to ChatGPT's adding chat to Project functionality
 
fixes: https://linear.app/danswer/issue/DAN-2306/moving-chat-into-group-is-one-way-cannot-remove

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
