### PR TITLE
fix: adjust search tool display

### DIFF
--- a/backend/onyx/agents/agent_search/dr/enums.py
+++ b/backend/onyx/agents/agent_search/dr/enums.py
@@ -20,7 +20,7 @@ class ResearchAnswerPurpose(str, Enum):
 class DRPath(str, Enum):
     CLARIFIER = "Clarifier"
     ORCHESTRATOR = "Orchestrator"
-    INTERNAL_SEARCH = "Search Tool"
+    INTERNAL_SEARCH = "App Search"
     GENERIC_TOOL = "Generic Tool"
     KNOWLEDGE_GRAPH = "Knowledge Graph Search"
     INTERNET_SEARCH = "Internet Search"

--- a/backend/onyx/agents/agent_search/dr/enums.py
+++ b/backend/onyx/agents/agent_search/dr/enums.py
@@ -20,7 +20,7 @@ class ResearchAnswerPurpose(str, Enum):
 class DRPath(str, Enum):
     CLARIFIER = "Clarifier"
     ORCHESTRATOR = "Orchestrator"
-    INTERNAL_SEARCH = "App Search"
+    INTERNAL_SEARCH = "Internal Search"
     GENERIC_TOOL = "Generic Tool"
     KNOWLEDGE_GRAPH = "Knowledge Graph Search"
     INTERNET_SEARCH = "Internet Search"

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -82,7 +82,7 @@ HINT: if you are unfamiliar with the user input OR think the user input is a typ
 
 class SearchTool(Tool[SearchToolOverrideKwargs]):
     _NAME = "run_search"
-    _DISPLAY_NAME = "Search Tool"
+    _DISPLAY_NAME = "Internal Search"
     _DESCRIPTION = SEARCH_TOOL_DESCRIPTION
 
     def __init__(

--- a/web/src/app/chat/components/input/ActionManagement.tsx
+++ b/web/src/app/chat/components/input/ActionManagement.tsx
@@ -30,7 +30,6 @@ import {
   FiKey,
   FiLock,
   FiCheck,
-  FiAlertTriangle,
   FiLoader,
 } from "react-icons/fi";
 import { MCPApiKeyModal } from "@/components/chat/MCPApiKeyModal";
@@ -187,12 +186,6 @@ function MCPServerItem({
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent closing the main popup
     if (isAuthenticated && itemRef.current) {
-      console.log("MCPServerItem handleClick - passing element:", {
-        element: itemRef.current,
-        rect: itemRef.current.getBoundingClientRect(),
-        tagName: itemRef.current.tagName,
-        classes: itemRef.current.className,
-      });
       onToggleExpand(itemRef.current);
     } else if (!isAuthenticated) {
       onAuthenticate();
@@ -253,9 +246,7 @@ function MCPToolsList({
   selectedAssistant,
   preventMainPopupClose,
 }: MCPToolsListProps) {
-  console.log("MCPToolsList", tools, serverName, onClose, selectedAssistant);
   const [searchTerm, setSearchTerm] = useState("");
-  console.log("searchTerm", searchTerm);
   const {
     assistantPreferences,
     setSpecificAssistantPreferences,
@@ -263,7 +254,6 @@ function MCPToolsList({
     setForcedToolIds,
   } = useAssistantsContext();
 
-  console.log("assistantPreferences", assistantPreferences);
   const assistantPreference = assistantPreferences?.[selectedAssistant.id];
   const disabledToolIds = assistantPreference?.disabled_tool_ids || [];
 
@@ -297,7 +287,6 @@ function MCPToolsList({
     );
   });
 
-  console.log("filteredTools2", filteredTools);
   return (
     <div
       className="
@@ -385,17 +374,7 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
     anchorElement: HTMLElement | null;
   }>({ serverId: null, serverName: "", anchorElement: null });
 
-  // Track if we're in the process of opening an MCP popup
-  const [isOpeningMcpPopup, setIsOpeningMcpPopup] = useState(false);
   const preventCloseRef = useRef(false);
-
-  // Debug logging
-  console.log(
-    "ActionToggle render - open:",
-    open,
-    "mcpToolsPopup.serverId:",
-    mcpToolsPopup.serverId
-  );
 
   // Store MCP server auth/loading state (tools are part of selectedAssistant.tools)
   const [mcpServerData, setMcpServerData] = useState<{
@@ -659,13 +638,6 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
       <Popover
         open={open}
         onOpenChange={(newOpen) => {
-          console.log(
-            "Popover onOpenChange",
-            newOpen,
-            "preventCloseRef.current",
-            preventCloseRef.current
-          );
-
           // If we're trying to close but we should prevent it, don't close
           if (!newOpen && preventCloseRef.current) {
             console.log("Preventing popover close due to preventCloseRef");
@@ -734,20 +706,20 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
             }
           }}
           className="
-          w-[244px] 
-          max-h-[300px]
-          text-text-600 
-          text-sm 
-          p-0 
-          bg-background 
-          border 
-          border-border 
-          rounded-xl 
-          shadow-xl 
-          overflow-hidden
-          flex
-          flex-col
-        "
+            w-[244px] 
+            max-h-[300px]
+            text-text-600 
+            text-sm 
+            p-0 
+            bg-background 
+            border 
+            border-border 
+            rounded-xl 
+            shadow-xl 
+            overflow-hidden
+            flex
+            flex-col
+          "
         >
           {/* Search Input */}
           <div className="pt-1 mx-1">
@@ -762,19 +734,19 @@ export function ActionToggle({ selectedAssistant }: ActionToggleProps) {
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="
-                w-full 
-                pl-9 
-                pr-3 
-                py-2 
-                bg-background-50 
-                rounded-lg 
-                text-sm 
-                outline-none 
-                text-text-700
-                placeholder:text-text-400
-                dark:placeholder:text-neutral-600
-                dark:bg-neutral-950
-              "
+                  w-full 
+                  pl-9 
+                  pr-3 
+                  py-2 
+                  bg-background-50 
+                  rounded-lg 
+                  text-sm 
+                  outline-none 
+                  text-text-700
+                  placeholder:text-text-400
+                  dark:placeholder:text-neutral-600
+                  dark:bg-neutral-950
+                "
                 autoFocus
               />
             </div>


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

Local

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized the internal search tool’s display names for clarity and cleaned up noisy debug logs. The UI now shows “Internal Search” and research traces show “App Search.”

- **Bug Fixes**
  - Renamed SearchTool display name to “Internal Search” in the UI.
  - Updated DR path label from “Search Tool” to “App Search.”
  - Removed stray console logs and an unused icon in ActionManagement.tsx (no behavior change).

<!-- End of auto-generated description by cubic. -->

