### PR TITLE
fix(admin): Block access to Custom Analytics Page

### DIFF
--- a/web/src/components/admin/ClientLayout.tsx
+++ b/web/src/components/admin/ClientLayout.tsx
@@ -42,6 +42,7 @@ import Link from "next/link";
 import { Button } from "../ui/button";
 import { useIsKGExposed } from "@/app/admin/kg/utils";
 import { useFederatedOAuthStatus } from "@/lib/hooks/useFederatedOAuthStatus";
+import { useCustomAnalyticsEnabled } from "@/lib/hooks/useCustomAnalyticsEnabled";
 
 const connectors_items = () => [
   {
@@ -153,7 +154,8 @@ const collections = (
   enableCloud: boolean,
   enableEnterprise: boolean,
   settings: CombinedSettings | null,
-  kgExposed: boolean
+  kgExposed: boolean,
+  customAnalyticsEnabled: boolean
 ) => [
   {
     name: "Connectors",
@@ -311,7 +313,7 @@ const collections = (
                         },
                       ]
                     : []),
-                  ...(!enableCloud
+                  ...(!enableCloud && customAnalyticsEnabled
                     ? [
                         {
                           name: (
@@ -393,6 +395,7 @@ export function ClientLayout({
   enableCloud: boolean;
 }) {
   const { kgExposed, isLoading } = useIsKGExposed();
+  const { customAnalyticsEnabled } = useCustomAnalyticsEnabled();
 
   const isCurator =
     user?.role === UserRole.CURATOR || user?.role === UserRole.GLOBAL_CURATOR;
@@ -464,7 +467,8 @@ export function ClientLayout({
             enableCloud,
             enableEnterprise,
             settings,
-            kgExposed
+            kgExposed,
+            customAnalyticsEnabled
           )}
         />
       </div>

--- a/web/src/lib/hooks/useCustomAnalyticsEnabled.ts
+++ b/web/src/lib/hooks/useCustomAnalyticsEnabled.ts
@@ -1,0 +1,18 @@
+import { CUSTOM_ANALYTICS_ENABLED } from "@/lib/constants";
+
+export type CustomAnalyticsStatus = {
+  customAnalyticsEnabled: boolean;
+  isLoading: boolean;
+};
+
+/**
+ * Hook to check if custom analytics is enabled.
+ * Returns the status and loading state for consistency with other hooks.
+ * Since this is based on an environment variable, there's no actual loading state.
+ */
+export function useCustomAnalyticsEnabled(): CustomAnalyticsStatus {
+  return {
+    customAnalyticsEnabled: CUSTOM_ANALYTICS_ENABLED,
+    isLoading: false,
+  };
+}


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Any user who is an admin can access the page `/admin/performance/custom-analytics` but if the flag is not enabled they see a giant error message. This PR aims to just redirect the user back to the chat page if they try and access endpoints that are not enabled. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

fixes: https://linear.app/danswer/issue/DAN-2378/give-more-meaningful-instructions-for-custom-analytics-tab
