### PR TITLE
fix(teams): sanitize None displayName to 'Unknown User' before parsing

### DIFF
--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -289,7 +289,8 @@ def _construct_semantic_identifier(channel: Channel, top_message: Message) -> st
     top_message_user_name: str
 
     if top_message.from_ and top_message.from_.user:
-        top_message_user_name = top_message.from_.user.display_name
+        user_display_name = top_message.from_.user.display_name
+        top_message_user_name = user_display_name if user_display_name else "Unknown User"
     else:
         logger.warn(f"Message {top_message=} has no `from.user` field")
         top_message_user_name = "Unknown User"

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -284,6 +284,11 @@ class TeamsConnector(
                         yield slim_doc_buffer
                         slim_doc_buffer = []
 
+                # Flush any remaining slim documents collected for this channel
+                if slim_doc_buffer:
+                    yield slim_doc_buffer
+                    slim_doc_buffer = []
+
 
 def _construct_semantic_identifier(channel: Channel, top_message: Message) -> str:
     top_message_user_name: str

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -20,6 +20,23 @@ logger = setup_logger()
 _PUBLIC_MEMBERSHIP_TYPE = "standard"  # public teams channel
 
 
+def _sanitize_message_user_display_name(value: dict) -> dict:
+    try:
+        from_obj = value.get("from")
+        if isinstance(from_obj, dict):
+            user_obj = from_obj.get("user")
+            if isinstance(user_obj, dict) and user_obj.get("displayName") is None:
+                value = dict(value)
+                from_obj = dict(from_obj)
+                user_obj = dict(user_obj)
+                user_obj["displayName"] = "Unknown User"
+                from_obj["user"] = user_obj
+                value["from"] = from_obj
+    except Exception:
+        pass
+    return value
+
+
 def _retry(
     graph_client: GraphClient,
     request_url: str,
@@ -117,7 +134,7 @@ def fetch_messages(
         json_response = _retry(graph_client=graph_client, request_url=request_url)
 
         for value in json_response.get("value", []):
-            yield Message(**value)
+            yield Message(**_sanitize_message_user_display_name(value))
 
         request_url = _get_next_url(
             graph_client=graph_client, json_response=json_response
@@ -140,7 +157,7 @@ def fetch_replies(
         json_response = _retry(graph_client=graph_client, request_url=request_url)
 
         for value in json_response.get("value", []):
-            yield Message(**value)
+            yield Message(**_sanitize_message_user_display_name(value))
 
         request_url = _get_next_url(
             graph_client=graph_client, json_response=json_response

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -32,7 +32,7 @@ def _sanitize_message_user_display_name(value: dict) -> dict:
                 user_obj["displayName"] = "Unknown User"
                 from_obj["user"] = user_obj
                 value["from"] = from_obj
-    except Exception:
+    except (AttributeError, TypeError, KeyError):
         pass
     return value
 


### PR DESCRIPTION
Fixes #5258 by sanitizing from.user.displayName before parsing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Handle Teams messages with missing user display names by defaulting to "Unknown User" during parsing and when building semantic identifiers to prevent ingestion errors.

- **Bug Fixes**
  - Sanitize Teams payloads to set from.user.displayName to "Unknown User" when null in fetch_messages and fetch_replies.
  - Fallback to "Unknown User" in _construct_semantic_identifier when display_name is None.

<!-- End of auto-generated description by cubic. -->

