### PR TITLE
fix: incorrect assumptions about fields

### DIFF
--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -32,6 +32,7 @@ from onyx.connectors.salesforce.sqlite_functions import OnyxSalesforceSQLite
 from onyx.connectors.salesforce.utils import ACCOUNT_OBJECT_TYPE
 from onyx.connectors.salesforce.utils import BASE_DATA_PATH
 from onyx.connectors.salesforce.utils import get_sqlite_db_path
+from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.connectors.salesforce.utils import MODIFIED_FIELD
 from onyx.connectors.salesforce.utils import NAME_FIELD
 from onyx.connectors.salesforce.utils import USER_OBJECT_TYPE
@@ -920,8 +921,9 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnector):
 
                 # Get custom fields for parent type
                 field_set = set(custom_fields)
-                # these are expected and used during doc conversion
-                field_set.add(NAME_FIELD)
+                # used during doc conversion
+                # field_set.add(NAME_FIELD) # does not always exist
+                field_set.add(ID_FIELD)
                 field_set.add(MODIFIED_FIELD)
 
                 # Use only the specified fields
@@ -985,7 +987,8 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnector):
                 ):
                     field_set = set(config_fields)
                     # these are expected and used during doc conversion
-                    field_set.add(NAME_FIELD)
+                    # field_set.add(NAME_FIELD) # does not always exist
+                    field_set.add(ID_FIELD)
                     field_set.add(MODIFIED_FIELD)
                     queryable_fields = field_set
                 else:

--- a/backend/onyx/connectors/salesforce/doc_conversion.py
+++ b/backend/onyx/connectors/salesforce/doc_conversion.py
@@ -207,7 +207,7 @@ def convert_sf_object_to_doc(
 ) -> Document:
     """Would be nice if this function was documented"""
     object_dict = sf_object.data
-    salesforce_id = object_dict["Id"]
+    salesforce_id = object_dict[ID_FIELD]
     onyx_salesforce_id = f"{ID_PREFIX}{salesforce_id}"
     base_url = f"https://{sf_instance}"
     extracted_doc_updated_at = time_str_to_utc(object_dict[MODIFIED_FIELD])

--- a/backend/onyx/connectors/salesforce/doc_conversion.py
+++ b/backend/onyx/connectors/salesforce/doc_conversion.py
@@ -10,6 +10,7 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.connectors.salesforce.onyx_salesforce import OnyxSalesforce
 from onyx.connectors.salesforce.sqlite_functions import OnyxSalesforceSQLite
+from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.connectors.salesforce.utils import MODIFIED_FIELD
 from onyx.connectors.salesforce.utils import NAME_FIELD
 from onyx.connectors.salesforce.utils import SalesforceObject
@@ -169,7 +170,9 @@ def convert_sf_query_result_to_doc(
 
     base_url = f"https://{sf_client.sf_instance}"
     extracted_doc_updated_at = time_str_to_utc(record[MODIFIED_FIELD])
-    extracted_semantic_identifier = record.get(NAME_FIELD, "Unknown Object")
+    extracted_semantic_identifier = record.get(NAME_FIELD) or record.get(
+        ID_FIELD, "Unknown Object"
+    )
 
     sections = [_extract_section(record, f"{base_url}/{record_id}")]
     for child_record_key, child_record in child_records.items():
@@ -208,7 +211,9 @@ def convert_sf_object_to_doc(
     onyx_salesforce_id = f"{ID_PREFIX}{salesforce_id}"
     base_url = f"https://{sf_instance}"
     extracted_doc_updated_at = time_str_to_utc(object_dict[MODIFIED_FIELD])
-    extracted_semantic_identifier = object_dict.get(NAME_FIELD, "Unknown Object")
+    extracted_semantic_identifier = object_dict.get(NAME_FIELD) or object_dict.get(
+        ID_FIELD, "Unknown Object"
+    )
 
     sections = [_extract_section(sf_object.data, f"{base_url}/{sf_object.id}")]
     for id in sf_db.get_child_ids(sf_object.id):

--- a/backend/onyx/connectors/salesforce/onyx_salesforce.py
+++ b/backend/onyx/connectors/salesforce/onyx_salesforce.py
@@ -12,6 +12,7 @@ from onyx.connectors.salesforce.blacklist import SALESFORCE_BLACKLISTED_OBJECTS
 from onyx.connectors.salesforce.blacklist import SALESFORCE_BLACKLISTED_PREFIXES
 from onyx.connectors.salesforce.blacklist import SALESFORCE_BLACKLISTED_SUFFIXES
 from onyx.connectors.salesforce.salesforce_calls import get_object_by_id_query
+from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 
@@ -218,7 +219,7 @@ class OnyxSalesforce(Salesforce):
                             continue
 
                         for child_record in child_result["records"]:
-                            child_record_id = child_record["Id"]
+                            child_record_id = child_record[ID_FIELD]
                             if not child_record_id:
                                 logger.warning("Child record has no id")
                                 continue

--- a/backend/onyx/connectors/salesforce/sqlite_functions.py
+++ b/backend/onyx/connectors/salesforce/sqlite_functions.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+from typing import cast
 
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.salesforce.utils import ACCOUNT_OBJECT_TYPE
@@ -409,7 +410,7 @@ class OnyxSalesforceSQLite:
             # if this id is a parent type, yield it directly
             if changed_type in parent_types:
                 yield changed_id, changed_type, num_examined
-                changed_parent_ids.update(changed_id)
+                changed_parent_ids.add(changed_id)
                 continue
 
             # if this id is a child type, then check the columns
@@ -432,7 +433,7 @@ class OnyxSalesforceSQLite:
                     logger.warning(f"{field_name=} not in data for {changed_type=}!")
                     continue
 
-                parent_id = sf_object.data[field_name]
+                parent_id = cast(str, sf_object.data[field_name])
                 parent_id_prefix = parent_id[:3]
 
                 if parent_id_prefix not in prefix_to_type:
@@ -446,7 +447,7 @@ class OnyxSalesforceSQLite:
                     continue
 
                 yield parent_id, parent_type, num_examined
-                changed_parent_ids.update(parent_id)
+                changed_parent_ids.add(parent_id)
                 break
 
     def object_type_count(self, object_type: str) -> int:

--- a/backend/onyx/connectors/salesforce/sqlite_functions.py
+++ b/backend/onyx/connectors/salesforce/sqlite_functions.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.salesforce.utils import ACCOUNT_OBJECT_TYPE
+from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.connectors.salesforce.utils import NAME_FIELD
 from onyx.connectors.salesforce.utils import SalesforceObject
 from onyx.connectors.salesforce.utils import USER_OBJECT_TYPE
@@ -498,7 +499,7 @@ class OnyxSalesforceSQLite:
 
             # remove salesforce id's (and add to parent id set)
             if (
-                field != "Id"
+                field != ID_FIELD
                 and isinstance(value, str)
                 and validate_salesforce_id(value)
             ):
@@ -535,13 +536,13 @@ class OnyxSalesforceSQLite:
                 reader = csv.DictReader(f)
                 uncommitted_rows = 0
                 for row in reader:
-                    if "Id" not in row:
+                    if ID_FIELD not in row:
                         logger.warning(
-                            f"Row {row} does not have an Id field in {csv_download_path}"
+                            f"Row {row} does not have an {ID_FIELD} field in {csv_download_path}"
                         )
                         continue
 
-                    row_id = row["Id"]
+                    row_id = row[ID_FIELD]
 
                     normalized_record, parent_ids = (
                         OnyxSalesforceSQLite.normalize_record(row, remove_ids)

--- a/backend/onyx/connectors/salesforce/utils.py
+++ b/backend/onyx/connectors/salesforce/utils.py
@@ -25,7 +25,7 @@ class SalesforceObject:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "SalesforceObject":
         return cls(
-            id=data["Id"],
+            id=data[ID_FIELD],
             type=data["Type"],
             data=data,
         )

--- a/backend/onyx/connectors/salesforce/utils.py
+++ b/backend/onyx/connectors/salesforce/utils.py
@@ -4,6 +4,7 @@ from typing import Any
 
 NAME_FIELD = "Name"
 MODIFIED_FIELD = "LastModifiedDate"
+ID_FIELD = "Id"
 ACCOUNT_OBJECT_TYPE = "Account"
 USER_OBJECT_TYPE = "User"
 


### PR DESCRIPTION
## Description

Not all objects have a Name which was causing problems with custom queries, AND we weren't guaranteeing the retrieval of Id. Both resolved now.

## How Has This Been Tested?

tested in UI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Salesforce field assumptions that caused errors when objects don’t have Name. Always selects Id and uses it as a safe fallback for identifiers to prevent query and doc conversion issues.

- **Bug Fixes**
  - Include Id in all Salesforce field sets; stop requiring Name.
  - In doc conversion, use Name or fall back to Id for the semantic identifier.
  - Add ID_FIELD constant and apply it across connector and conversion code.

<!-- End of auto-generated description by cubic. -->

