### PR TITLE
fix: freshdesk password and rate limits

### DIFF
--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -70,6 +70,7 @@ _STATUS_NUMBER_TYPE_MAP: dict[int, str] = {
 }
 
 
+# TODO: unify this with other generic rate limited requests with retries (e.g. Axero)
 @retry_builder()
 @rate_limit_builder(max_calls=5, period=1)
 def _rate_limited_freshdesk_get(

--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -161,8 +161,27 @@ class FreshdeskConnector(PollConnector, LoadConnector):
                 "All Freshdesk credentials must be strings"
             )
 
+        # TODO: Move the domain to the connector-specific configuration instead of part of the credential
+        # Then apply normalization and validation against the config
+        # Clean and normalize the domain URL
+        domain = str(domain).strip().lower()
+
+        # Remove any trailing slashes
+        domain = domain.rstrip("/")
+
+        # Remove protocol if present
+        if domain.startswith(("http://", "https://")):
+            domain = domain.replace("http://", "").replace("https://", "")
+
+        # Remove .freshdesk.com suffix and any API paths if present
+        if ".freshdesk.com" in domain:
+            domain = domain.split(".freshdesk.com")[0]
+
+        if not domain:
+            raise ConnectorMissingCredentialError("Freshdesk domain cannot be empty")
+
         self.api_key = str(api_key)
-        self.domain = str(domain)
+        self.domain = domain
         self.password = str(password)
 
     def _fetch_tickets(

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -230,7 +230,6 @@ export interface DiscordCredentialJson {
 
 export interface FreshdeskCredentialJson {
   freshdesk_domain: string;
-  freshdesk_password: string;
   freshdesk_api_key: string;
 }
 
@@ -365,6 +364,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
     clickup_api_token: "",
     clickup_team_id: "",
   } as ClickupCredentialJson,
+
   s3: {
     authentication_method: "access_key",
     authMethods: [
@@ -409,7 +409,6 @@ export const credentialTemplates: Record<ValidSources, any> = {
   } as OCICredentialJson,
   freshdesk: {
     freshdesk_domain: "",
-    freshdesk_password: "",
     freshdesk_api_key: "",
   } as FreshdeskCredentialJson,
   fireflies: {
@@ -587,7 +586,6 @@ export const credentialDisplayNames: Record<string, string> = {
 
   // Freshdesk
   freshdesk_domain: "Freshdesk Domain",
-  freshdesk_password: "Freshdesk Password",
   freshdesk_api_key: "Freshdesk API Key",
 
   // Fireflies


### PR DESCRIPTION
## Description

- Remove useless password field
- handle fresdesk domain better
- add retries and backoffs to the fetch

freshdesk connector is not ideal and deserves a full refactor 

addresses https://linear.app/danswer/issue/DAN-2404/remove-freshdesk-password-field
also addresses https://linear.app/danswer/issue/DAN-2406/make-freshdesk-domain-field-more-clear-or-change-how-we-process-it

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removes the Freshdesk password field, normalizes the domain input, and adds retry with rate limiting to make the Freshdesk connector more reliable and easier to configure.

- **Bug Fixes**
  - Normalize freshdesk_domain (strip protocol, trailing slashes, and .freshdesk.com).
  - Add retries with backoff and 50 calls/min rate limiting to _fetch_tickets to handle 429s.
  - Use API key as username with a placeholder password for Basic Auth.

- **Refactors**
  - Remove freshdesk_password from backend credentials, UI templates, and display names.
  - Validate only freshdesk_domain and freshdesk_api_key.

<!-- End of auto-generated description by cubic. -->

