### PR TITLE
fix: old send-message

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -67,8 +67,6 @@ from onyx.server.features.input_prompt.api import (
 from onyx.server.features.input_prompt.api import (
     basic_router as input_prompt_router,
 )
-from onyx.server.features.mcp.api import admin_router as mcp_admin_router
-from onyx.server.features.mcp.api import router as mcp_router
 from onyx.server.features.notifications.api import router as notification_router
 from onyx.server.features.password.api import router as password_router
 from onyx.server.features.persona.api import admin_router as admin_persona_router
@@ -99,6 +97,7 @@ from onyx.server.openai_assistants_api.full_openai_assistants_api import (
     get_full_openai_assistants_api_router,
 )
 from onyx.server.query_and_chat.chat_backend import router as chat_router
+from onyx.server.query_and_chat.chat_backend_v0 import router as chat_v0_router
 from onyx.server.query_and_chat.query_backend import (
     admin_router as admin_query_router,
 )
@@ -332,6 +331,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
 
     include_router_with_global_prefix_prepended(application, password_router)
     include_router_with_global_prefix_prepended(application, chat_router)
+    include_router_with_global_prefix_prepended(application, chat_v0_router)
     include_router_with_global_prefix_prepended(application, query_router)
     include_router_with_global_prefix_prepended(application, document_router)
     include_router_with_global_prefix_prepended(application, user_router)
@@ -354,8 +354,6 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, notification_router)
     include_router_with_global_prefix_prepended(application, tool_router)
     include_router_with_global_prefix_prepended(application, admin_tool_router)
-    include_router_with_global_prefix_prepended(application, mcp_router)
-    include_router_with_global_prefix_prepended(application, mcp_admin_router)
     include_router_with_global_prefix_prepended(application, state_router)
     include_router_with_global_prefix_prepended(application, onyx_api_router)
     include_router_with_global_prefix_prepended(application, gpts_router)

--- a/backend/onyx/server/query_and_chat/chat_backend_v0.py
+++ b/backend/onyx/server/query_and_chat/chat_backend_v0.py
@@ -138,7 +138,7 @@ def transform_packet_to_v0_format(packet: Any) -> dict[str, Any] | None:
 
             # Add query if present
             if obj.queries:
-                query = obj.queries[0] if obj.queries else ""
+                query = obj.queries[0]
                 tool_response["tool_args"] = {"query": query}
 
             # If documents are returned, we need to format them

--- a/backend/onyx/server/query_and_chat/chat_backend_v0.py
+++ b/backend/onyx/server/query_and_chat/chat_backend_v0.py
@@ -1,0 +1,325 @@
+"""
+Legacy v0 API endpoints for chat functionality.
+Provides backwards compatibility with older response formats.
+"""
+
+import json
+from collections.abc import Callable
+from collections.abc import Generator
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+
+from onyx.auth.users import current_chat_accessible_user
+from onyx.chat.chat_utils import extract_headers
+from onyx.chat.models import LLMRelevanceFilterResponse
+from onyx.chat.models import MessageResponseIDInfo
+from onyx.chat.models import QADocsResponse
+from onyx.chat.models import StreamingError
+from onyx.chat.models import StreamStopInfo
+from onyx.chat.process_message import stream_chat_message_objects
+from onyx.configs.model_configs import LITELLM_PASS_THROUGH_HEADERS
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.models import User
+from onyx.server.query_and_chat.chat_backend import is_connected
+from onyx.server.query_and_chat.models import CreateChatMessageRequest
+from onyx.server.query_and_chat.streaming_models import CitationDelta
+from onyx.server.query_and_chat.streaming_models import CitationStart
+from onyx.server.query_and_chat.streaming_models import CustomToolDelta
+from onyx.server.query_and_chat.streaming_models import CustomToolStart
+from onyx.server.query_and_chat.streaming_models import ImageGenerationToolDelta
+from onyx.server.query_and_chat.streaming_models import ImageGenerationToolStart
+from onyx.server.query_and_chat.streaming_models import MessageDelta
+from onyx.server.query_and_chat.streaming_models import MessageStart
+from onyx.server.query_and_chat.streaming_models import OverallStop
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.server.query_and_chat.streaming_models import ReasoningDelta
+from onyx.server.query_and_chat.streaming_models import ReasoningStart
+from onyx.server.query_and_chat.streaming_models import SearchToolDelta
+from onyx.server.query_and_chat.streaming_models import SearchToolStart
+from onyx.server.query_and_chat.streaming_models import SectionEnd
+from onyx.server.query_and_chat.token_limit import check_token_rate_limits
+from onyx.utils.headers import get_custom_tool_additional_request_headers
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/v0/chat")
+
+
+def transform_packet_to_v0_format(packet: Any) -> dict[str, Any] | None:
+    """
+    Transform modern packet format to v0 API format.
+    Returns None if the packet should not be included in v0 output.
+    """
+    # Handle MessageResponseIDInfo
+    if isinstance(packet, MessageResponseIDInfo):
+        return {
+            "user_message_id": packet.user_message_id,
+            "reserved_assistant_message_id": packet.reserved_assistant_message_id,
+        }
+
+    # Handle QADocsResponse
+    if isinstance(packet, QADocsResponse):
+        response = {
+            "level": packet.level,
+            "level_question_num": packet.level_question_num,
+            "top_documents": [doc.model_dump() for doc in packet.top_documents],
+            "rephrased_query": packet.rephrased_query,
+            "predicted_flow": packet.predicted_flow,
+            "predicted_search": packet.predicted_search,
+            "applied_source_filters": packet.applied_source_filters,
+            "applied_time_cutoff": (
+                packet.applied_time_cutoff.isoformat()
+                if packet.applied_time_cutoff
+                else None
+            ),
+            "recency_bias_multiplier": packet.recency_bias_multiplier,
+        }
+        return response
+
+    # Handle LLM Relevance Filter Response
+    if isinstance(packet, LLMRelevanceFilterResponse):
+        return {"llm_selected_doc_indices": packet.llm_selected_doc_indices}
+
+    # Handle StreamingError
+    if isinstance(packet, StreamingError):
+        return {
+            "error": packet.error,
+            "stack_trace": packet.stack_trace,
+        }
+
+    # Handle StreamStopInfo
+    if isinstance(packet, StreamStopInfo):
+        # This appears at the end - we might want to include message_id and other final info
+        return {
+            "agentic_message_ids": [],  # This would be populated with actual data if available
+        }
+
+    # Handle Packet objects containing various sub-objects
+    if isinstance(packet, Packet):
+        obj = packet.obj
+
+        # Handle MessageStart
+        if isinstance(obj, MessageStart):
+            # First message piece
+            result = {}
+            if obj.content:
+                result["answer_piece"] = obj.content
+            if obj.final_documents:
+                # Return final context docs separately
+                return {
+                    "final_context_docs": [
+                        doc.model_dump() for doc in obj.final_documents
+                    ]
+                }
+            return result if result else None
+
+        # Handle MessageDelta
+        if isinstance(obj, MessageDelta):
+            return {"answer_piece": obj.content}
+
+        # Handle SearchToolStart
+        if isinstance(obj, SearchToolStart):
+            # We'll capture the tool info in the delta
+            return None
+
+        # Handle SearchToolDelta
+        if isinstance(obj, SearchToolDelta):
+            tool_response = {
+                "tool_name": "run_search",
+                "tool_args": {},
+            }
+
+            # Add query if present
+            if obj.queries:
+                query = obj.queries[0] if obj.queries else ""
+                tool_response["tool_args"] = {"query": query}
+
+            # If documents are returned, we need to format them
+            if obj.documents:
+                # Return the tool call first
+                return tool_response
+
+            return tool_response
+
+        # Handle CustomToolStart
+        if isinstance(obj, CustomToolStart):
+            return {
+                "tool_name": obj.tool_name,
+                "tool_args": {},
+            }
+
+        # Handle CustomToolDelta
+        if isinstance(obj, CustomToolDelta):
+            tool_delta_result: dict[str, Any] = {
+                "tool_name": obj.tool_name,
+            }
+            if obj.data:
+                tool_delta_result["tool_result"] = obj.data
+            if obj.file_ids:
+                tool_delta_result["tool_file_ids"] = obj.file_ids
+            return tool_delta_result
+
+        # Handle ImageGenerationToolStart
+        if isinstance(obj, ImageGenerationToolStart):
+            return {
+                "tool_name": "generate_image",
+                "tool_args": {},
+            }
+
+        # Handle ImageGenerationToolDelta
+        if isinstance(obj, ImageGenerationToolDelta):
+            return {
+                "tool_name": "generate_image",
+                "tool_result": [img.model_dump() for img in obj.images],
+            }
+
+        # Handle CitationStart
+        if isinstance(obj, CitationStart):
+            return None
+
+        # Handle CitationDelta
+        if isinstance(obj, CitationDelta):
+            if obj.citations:
+                citations_data = []
+                for citation in obj.citations:
+                    citations_data.append(
+                        {
+                            "level": citation.level,
+                            "level_question_num": citation.level_question_num,
+                            "citation_num": citation.citation_num,
+                            "document_id": citation.document_id,
+                        }
+                    )
+                return {"citations": citations_data}
+            return None
+
+        # Handle ReasoningStart
+        if isinstance(obj, ReasoningStart):
+            return None
+
+        # Handle ReasoningDelta
+        if isinstance(obj, ReasoningDelta):
+            return {"reasoning_piece": obj.reasoning}
+
+        # Handle OverallStop
+        if isinstance(obj, OverallStop):
+            # This signals the end of streaming
+            return None
+
+        # Handle SectionEnd
+        if isinstance(obj, SectionEnd):
+            return None
+
+    # Unknown packet type - log and skip
+    logger.debug(f"Unknown packet type in v0 transformation: {type(packet)}")
+    return None
+
+
+@router.post("/send-message")
+def handle_new_chat_message_v0(
+    chat_message_req: CreateChatMessageRequest,
+    request: Request,
+    user: User | None = Depends(current_chat_accessible_user),
+    _rate_limit_check: None = Depends(check_token_rate_limits),
+    is_connected_func: Callable[[], bool] = Depends(is_connected),
+) -> StreamingResponse:
+    """
+    TODO: deprecate this shortly.
+
+    V0 API endpoint for sending chat messages.
+    Returns responses in the legacy format for backwards compatibility.
+
+    The response format is newline-delimited JSON objects:
+    - {"user_message_id": int, "reserved_assistant_message_id": int}
+    - {"answer_piece": str}
+    - {"tool_name": str, "tool_args": dict}
+    - {"level": int, "level_question_num": int, "top_documents": list}
+    - {"llm_selected_doc_indices": list}
+    - {"final_context_docs": list}
+    - {"citations": list}
+    - etc.
+    """
+    tenant_id = get_current_tenant_id()
+    logger.debug(f"V0 API - Received new chat message: {chat_message_req.message}")
+
+    if (
+        not chat_message_req.message
+        and chat_message_req.prompt_id is not None
+        and not chat_message_req.use_existing_user_message
+    ):
+        raise HTTPException(status_code=400, detail="Empty chat message is invalid")
+
+    def stream_generator() -> Generator[str, None, None]:
+        """Generate v0 format responses from the modern streaming objects."""
+        try:
+            # Track state for aggregating certain responses
+            final_message_info = {}
+            all_citations = []
+
+            with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+                # Get the stream of objects from the modern chat processor
+                objects = stream_chat_message_objects(
+                    new_msg_req=chat_message_req,
+                    user=user,
+                    db_session=db_session,
+                    litellm_additional_headers=extract_headers(
+                        request.headers, LITELLM_PASS_THROUGH_HEADERS
+                    ),
+                    custom_tool_additional_headers=get_custom_tool_additional_request_headers(
+                        request.headers
+                    ),
+                    is_connected=is_connected_func,
+                )
+
+                # Transform and yield each packet
+                for obj in objects:
+                    v0_response = transform_packet_to_v0_format(obj)
+
+                    if v0_response is not None:
+                        # Special handling for certain response types
+                        if "citations" in v0_response:
+                            # Aggregate citations
+                            all_citations.extend(v0_response["citations"])
+                        elif "user_message_id" in v0_response:
+                            # Store message info for potential later use
+                            final_message_info.update(v0_response)
+                            yield json.dumps(v0_response) + "\n"
+                        else:
+                            # Yield the transformed response
+                            yield json.dumps(v0_response) + "\n"
+
+                # At the end, yield aggregated citations if any
+                if all_citations:
+                    yield json.dumps({"citations": all_citations}) + "\n"
+
+                # Always yield a final message with aggregated info
+                final_response: dict[str, Any] = {
+                    "message_id": final_message_info.get(
+                        "reserved_assistant_message_id"
+                    ),
+                    "agentic_message_ids": [],  # Would be populated if using agents
+                }
+
+                # Only yield non-empty final response
+                if final_response.get("message_id"):
+                    yield json.dumps(final_response) + "\n"
+
+        except Exception as e:
+            logger.exception("Error in v0 chat message streaming")
+            error_response = {
+                "error": str(e),
+                "stack_trace": None,
+            }
+            yield json.dumps(error_response) + "\n"
+
+    return StreamingResponse(
+        stream_generator(),
+        media_type="application/x-ndjson",  # Newline-delimited JSON
+    )

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_v0_api.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_v0_api.py
@@ -1,0 +1,481 @@
+"""
+Integration tests for the v0 chat API endpoint.
+Tests the legacy response format for backwards compatibility.
+"""
+
+import json
+from typing import Any
+from uuid import UUID
+
+import requests
+
+from onyx.context.search.enums import OptionalSearchSetting
+from onyx.context.search.models import RetrievalDetails
+from onyx.server.query_and_chat.models import CreateChatMessageRequest
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.chat import ChatSessionManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.streaming_endpoints.conftest import DocumentBuilderType
+
+
+def parse_v0_streaming_response(response_text: str) -> list[dict[str, Any]]:
+    """Parse newline-delimited JSON response into a list of dictionaries."""
+    lines = response_text.strip().split("\n")
+    parsed_responses = []
+    for line in lines:
+        if line.strip():
+            try:
+                parsed_responses.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"Failed to parse line: {line}")
+                print(f"Error: {e}")
+    return parsed_responses
+
+
+def send_message_v0(
+    chat_session_id: UUID,
+    message: str,
+    user_performing_action: DATestUser | None = None,
+    parent_message_id: int | None = None,
+    retrieval_options: RetrievalDetails | None = None,
+) -> list[dict[str, Any]]:
+    """Send a message to the v0 chat API endpoint and return parsed response."""
+    chat_message_req = CreateChatMessageRequest(
+        chat_session_id=chat_session_id,
+        parent_message_id=parent_message_id,
+        message=message,
+        file_descriptors=[],
+        prompt_id=None,
+        search_doc_ids=[],
+        retrieval_options=retrieval_options,
+    )
+
+    headers = user_performing_action.headers if user_performing_action else {}
+    cookies = user_performing_action.cookies if user_performing_action else None
+
+    response = requests.post(
+        f"{API_SERVER_URL}/v0/chat/send-message",
+        json=chat_message_req.model_dump(),
+        headers=headers,
+        stream=True,
+        cookies=cookies,
+    )
+
+    response.raise_for_status()
+
+    # Collect all response content
+    full_response = ""
+    for chunk in response.iter_lines():
+        if chunk:
+            # Decode bytes to string
+            full_response += chunk.decode("utf-8") + "\n"
+
+    return parse_v0_streaming_response(full_response)
+
+
+class TestChatV0API:
+    """Test suite for the v0 chat API endpoint."""
+
+    def test_v0_message_response_format(
+        self,
+        admin_user: DATestUser,
+    ) -> None:
+        """Test that the v0 endpoint returns the correct response format."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test v0 API Session",
+            user_performing_action=admin_user,
+        )
+
+        # Send a message using v0 API
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="What is Onyx?",
+            user_performing_action=admin_user,
+        )
+
+        # Validate response format structure
+        assert len(responses) > 0, "Should receive responses"
+
+        # Check for expected response types
+        response_types = set()
+        for response in responses:
+            if "user_message_id" in response:
+                response_types.add("message_ids")
+                assert isinstance(response["user_message_id"], (int, type(None)))
+                assert isinstance(response["reserved_assistant_message_id"], int)
+            elif "answer_piece" in response:
+                response_types.add("answer")
+                assert isinstance(response["answer_piece"], str)
+            elif "tool_name" in response:
+                response_types.add("tool")
+                assert isinstance(response["tool_name"], str)
+            elif "top_documents" in response:
+                response_types.add("documents")
+                assert isinstance(response["top_documents"], list)
+            elif "llm_selected_doc_indices" in response:
+                response_types.add("llm_filter")
+                assert isinstance(response["llm_selected_doc_indices"], list)
+            elif "citations" in response:
+                response_types.add("citations")
+                assert isinstance(response["citations"], list)
+            elif "message_id" in response and "agentic_message_ids" in response:
+                response_types.add("final_message")
+                assert isinstance(response["message_id"], (int, type(None)))
+                assert isinstance(response["agentic_message_ids"], list)
+            elif "error" in response:
+                response_types.add("error")
+                assert isinstance(response["error"], str)
+
+        # Should have message IDs and answer pieces at minimum
+        assert "message_ids" in response_types, "Should have message ID response"
+        assert "answer" in response_types, "Should have answer pieces"
+
+    def test_v0_search_response_format(
+        self,
+        admin_user: DATestUser,
+        document_builder: DocumentBuilderType,
+    ) -> None:
+        """Test that search responses are formatted correctly in v0 format."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create test documents
+        document_builder(["This is a test document about Onyx"])
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test v0 Search Session",
+            user_performing_action=admin_user,
+        )
+
+        # Send a message that triggers search
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="Search for information about Onyx",
+            user_performing_action=admin_user,
+            retrieval_options=RetrievalDetails(
+                run_search=OptionalSearchSetting.ALWAYS,
+                real_time=False,
+            ),
+        )
+
+        # Find document response or tool result with documents
+        doc_response = None
+        for response in responses:
+            if "top_documents" in response:
+                doc_response = response
+                break
+            elif "tool_result" in response and isinstance(
+                response.get("tool_result"), list
+            ):
+                # Tool result might contain the documents
+                doc_response = {"top_documents": response["tool_result"]}
+                break
+
+        # Documents may not always be returned depending on the search
+        # Just verify the structure if documents are present
+        if doc_response and "top_documents" in doc_response:
+            assert isinstance(doc_response["top_documents"], list)
+
+            if len(doc_response["top_documents"]) > 0:
+                doc = doc_response["top_documents"][0]
+                required_fields = [
+                    "document_id",
+                    "chunk_ind",
+                    "semantic_identifier",
+                    "blurb",
+                    "source_type",
+                    "boost",
+                    "hidden",
+                    "metadata",
+                    "score",
+                    "match_highlights",
+                    "db_doc_id",
+                ]
+                for field in required_fields:
+                    assert field in doc, f"Missing required field: {field}"
+
+    def test_v0_tool_invocation_format(
+        self,
+        admin_user: DATestUser,
+    ) -> None:
+        """Test that tool invocations are formatted correctly in v0 format."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test Tool Invocation",
+            user_performing_action=admin_user,
+        )
+
+        # Send a message that might trigger tool use
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="Search for information about Onyx features",
+            user_performing_action=admin_user,
+            retrieval_options=RetrievalDetails(
+                run_search=OptionalSearchSetting.ALWAYS,
+                real_time=False,
+            ),
+        )
+
+        # Check for tool responses
+        tool_responses = [r for r in responses if "tool_name" in r]
+
+        # Tool responses are optional since not all queries trigger tools
+        for response in tool_responses:
+            assert isinstance(response["tool_name"], str)
+
+            if "tool_args" in response:
+                assert isinstance(response["tool_args"], dict)
+
+            if "tool_result" in response:
+                # Tool result can be various types depending on the tool
+                tool_result = response["tool_result"]
+                tool_name = response.get("tool_name", "")
+
+                if tool_name == "run_search":
+                    # Search tool returns a list of documents
+                    assert isinstance(tool_result, list)
+                    for doc in tool_result:
+                        assert isinstance(doc, dict)
+                        # Documents should have at least these fields
+                        if doc:  # Only check if list is not empty
+                            assert "document_id" in doc or "id" in doc
+
+                elif tool_name == "generate_image":
+                    # Image generation returns a list of image data
+                    assert isinstance(tool_result, list)
+                    for img in tool_result:
+                        assert isinstance(img, dict)
+
+                else:
+                    # Custom tools can return various types
+                    # Should be one of: dict, list, str, int, float, bool, or None
+                    assert tool_result is None or isinstance(
+                        tool_result, (dict, list, str, int, float, bool)
+                    )
+
+            if "tool_file_ids" in response:
+                assert isinstance(response["tool_file_ids"], list)
+
+    def test_v0_citation_format(
+        self,
+        admin_user: DATestUser,
+        document_builder: DocumentBuilderType,
+    ) -> None:
+        """Test that citations are formatted correctly."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create test documents with specific content
+        _ = document_builder(
+            [
+                "Onyx is an AI assistant that helps with information retrieval.",
+                "Onyx supports multiple document sources and search capabilities.",
+            ]
+        )
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test Citations",
+            user_performing_action=admin_user,
+        )
+
+        # Send a message that should generate citations
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="What are the key features of Onyx? Please cite your sources.",
+            user_performing_action=admin_user,
+            retrieval_options=RetrievalDetails(
+                run_search=OptionalSearchSetting.ALWAYS,
+                real_time=False,
+            ),
+        )
+
+        # Find citation response
+        citation_responses = [r for r in responses if "citations" in r]
+
+        # Citations are optional - may not always be present
+        if citation_responses:
+            citation_response = citation_responses[0]
+            assert "citations" in citation_response
+            assert isinstance(citation_response["citations"], list)
+
+            for citation in citation_response["citations"]:
+                assert "citation_num" in citation
+                assert "document_id" in citation
+                assert isinstance(citation["citation_num"], int)
+                assert isinstance(citation["document_id"], str)
+
+    def test_v0_llm_filter_format(
+        self,
+        admin_user: DATestUser,
+        document_builder: DocumentBuilderType,
+    ) -> None:
+        """Test LLM relevance filter response format."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create multiple test documents
+        _ = document_builder(
+            [
+                "Onyx is an AI assistant",
+                "This document is about something else",
+                "Another document about Onyx features",
+                "Unrelated content here",
+                "More Onyx documentation",
+            ]
+        )
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test LLM Filter",
+            user_performing_action=admin_user,
+        )
+
+        # Send a message that should trigger filtering
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="Tell me specifically about Onyx features",
+            user_performing_action=admin_user,
+            retrieval_options=RetrievalDetails(
+                run_search=OptionalSearchSetting.ALWAYS,
+                real_time=False,
+            ),
+        )
+
+        # Find LLM filter response
+        filter_responses = [r for r in responses if "llm_selected_doc_indices" in r]
+
+        if filter_responses:
+            filter_response = filter_responses[0]
+            assert "llm_selected_doc_indices" in filter_response
+            assert isinstance(filter_response["llm_selected_doc_indices"], list)
+            for idx in filter_response["llm_selected_doc_indices"]:
+                assert isinstance(idx, int)
+
+    def test_v0_final_response_format(
+        self,
+        admin_user: DATestUser,
+    ) -> None:
+        """Test the final response format with message ID and agent info."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test Final Response",
+            user_performing_action=admin_user,
+        )
+
+        # Send a simple message
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="Hello, how are you?",
+            user_performing_action=admin_user,
+        )
+
+        # Find final response (usually last or near last)
+        final_response = None
+        for response in responses:
+            if "message_id" in response and "agentic_message_ids" in response:
+                final_response = response
+                break
+
+        if final_response:
+            assert "message_id" in final_response
+            assert "agentic_message_ids" in final_response
+            assert isinstance(final_response["agentic_message_ids"], list)
+
+    def test_v0_error_format(
+        self,
+        admin_user: DATestUser,
+    ) -> None:
+        """Test that errors are formatted correctly in v0 format."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test Error Format",
+            user_performing_action=admin_user,
+        )
+
+        # Try to trigger an error (this might not always work depending on system state)
+        # We'll test the error format structure even if we don't get an actual error
+
+        # Send a normal message first
+        responses = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="Test message",
+            user_performing_action=admin_user,
+        )
+
+        # Check if any errors occurred
+        error_responses = [r for r in responses if "error" in r]
+
+        for error_response in error_responses:
+            assert "error" in error_response
+            assert isinstance(error_response["error"], str)
+            assert "stack_trace" in error_response
+            # stack_trace can be None or a string
+
+    def test_v0_streaming_with_history(
+        self,
+        admin_user: DATestUser,
+    ) -> None:
+        """Test that the v0 endpoint works correctly with chat history."""
+        # Create LLM provider
+        LLMProviderManager.create(user_performing_action=admin_user)
+
+        # Create a chat session
+        chat_session = ChatSessionManager.create(
+            description="Test Chat History",
+            user_performing_action=admin_user,
+        )
+
+        # Send first message
+        responses1 = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="My name is TestUser",
+            user_performing_action=admin_user,
+        )
+
+        # Get the assistant message ID from first response
+        assistant_msg_id = None
+        for response in responses1:
+            if "reserved_assistant_message_id" in response:
+                assistant_msg_id = response["reserved_assistant_message_id"]
+                break
+
+        assert assistant_msg_id is not None, "Should have assistant message ID"
+
+        # Send second message referencing the first
+        responses2 = send_message_v0(
+            chat_session_id=chat_session.id,
+            message="What is my name?",
+            user_performing_action=admin_user,
+            parent_message_id=assistant_msg_id,
+        )
+
+        # Check that we got a response
+        assert len(responses2) > 0, "Should receive responses for second message"
+
+        # Collect answer pieces
+        answer_pieces = []
+        for response in responses2:
+            if "answer_piece" in response:
+                answer_pieces.append(response["answer_piece"])
+
+        # The answer should reference TestUser
+        full_answer = "".join(answer_pieces).lower()
+        # The model should recognize the name from history
+        # (exact response will vary, but it should acknowledge the name somehow)
+        assert len(full_answer) > 0, "Should have an answer"


### PR DESCRIPTION
## Description

^

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restore the legacy /v0/chat/send-message endpoint to maintain backward compatibility with clients expecting the old NDJSON streaming format. Adds a transformer that maps modern streaming packets to the v0 schema and comprehensive integration tests to validate the format.

- New Features
  - Added /v0/chat/send-message (NDJSON) that streams legacy fields: answer_piece, tool_name/tool_args/tool_result, top_documents, citations, llm_selected_doc_indices, final_context_docs, user_message_id/reserved_assistant_message_id, final message_id, and error.
  - Introduced packet-to-v0 transformer covering message, search, custom tool, image generation, citations, reasoning, and stop events.
  - Wired the v0 router into the app and added integration tests for message IDs, answers, tools, documents, citations, LLM filter, final message, errors, and history.

<!-- End of auto-generated description by cubic. -->

