### PR TITLE
fix: skip large sharepoint files

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -661,6 +661,8 @@ class SharepointConnector(
                         folder_path=folder_path,
                     )
                 )
+            else:
+                logger.warning(f"Site URL '{site_url}' is not a valid Sharepoint URL")
         return site_data_list
 
     def _get_drive_items_for_drive_name(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -203,9 +203,14 @@ def _convert_driveitem_to_document_with_permissions(
                     f"File '{driveitem.name}' exceeds size threshold of {SHAREPOINT_CONNECTOR_SIZE_THRESHOLD} bytes. "
                     f"File size: {file_size} bytes. Skipping."
                 )
-                raise RuntimeError(
-                    f"File '{driveitem.name}' exceeds size threshold of {SHAREPOINT_CONNECTOR_SIZE_THRESHOLD} bytes. "
-                    f"File size: {file_size} bytes."
+
+                return Document(
+                    id=driveitem.id,
+                    sections=[],
+                    source=DocumentSource.SHAREPOINT,
+                    semantic_identifier="",
+                    external_access=ExternalAccess.empty(),
+                    metadata={},
                 )
         else:
             logger.warning(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -601,13 +601,21 @@ class SharepointConnector(
     ) -> None:
         self.batch_size = batch_size
         self._graph_client: GraphClient | None = None
-        self.site_descriptors: list[SiteDescriptor] = self._extract_site_and_drive_info(
-            sites
-        )
         self.msal_app: msal.ConfidentialClientApplication | None = None
         self.include_site_pages = include_site_pages
         self.include_site_documents = include_site_documents
         self.sp_tenant_domain: str | None = None
+
+        # Ensure sites are sharepoint urls
+        for site_url in sites:
+            if not site_url.startswith("https://") or "/sites/" not in site_url:
+                raise ConnectorValidationError(
+                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site)"
+                )
+
+        self.site_descriptors: list[SiteDescriptor] = self._extract_site_and_drive_info(
+            sites
+        )
 
     def validate_connector_settings(self) -> None:
         # Validate that at least one content type is enabled

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -600,22 +600,15 @@ class SharepointConnector(
         include_site_documents: bool = True,
     ) -> None:
         self.batch_size = batch_size
+        self.sites = sites
+        self.site_descriptors: list[SiteDescriptor] = self._extract_site_and_drive_info(
+            sites
+        )
         self._graph_client: GraphClient | None = None
         self.msal_app: msal.ConfidentialClientApplication | None = None
         self.include_site_pages = include_site_pages
         self.include_site_documents = include_site_documents
         self.sp_tenant_domain: str | None = None
-
-        # Ensure sites are sharepoint urls
-        for site_url in sites:
-            if not site_url.startswith("https://") or "/sites/" not in site_url:
-                raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site)"
-                )
-
-        self.site_descriptors: list[SiteDescriptor] = self._extract_site_and_drive_info(
-            sites
-        )
 
     def validate_connector_settings(self) -> None:
         # Validate that at least one content type is enabled
@@ -624,6 +617,13 @@ class SharepointConnector(
                 "At least one content type must be enabled. "
                 "Please check either 'Include Site Documents' or 'Include Site Pages' (or both)."
             )
+
+        # Ensure sites are sharepoint urls
+        for site_url in self.sites:
+            if not site_url.startswith("https://") or "/sites/" not in site_url:
+                raise ConnectorValidationError(
+                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site)"
+                )
 
     @property
     def graph_client(self) -> GraphClient:


### PR DESCRIPTION
## Description

- skip large files like Google Drive connector
- validate site urls if entered

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip oversized SharePoint files instead of throwing errors, and validate site URLs. This prevents sync failures and aligns behavior with the Google Drive connector.

- **Bug Fixes**
  - Return an empty document when a SharePoint file exceeds the size threshold, instead of raising an error.
  - Validate site URLs; require full SharePoint URLs (https://{tenant}.sharepoint.com/sites/{site}), otherwise raise a ConnectorValidationError.

<!-- End of auto-generated description by cubic. -->

