### PR TITLE
fix: whitelabeling

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -1233,7 +1233,7 @@ export function ChatPage({
                               )}
                             {enterpriseSettings &&
                               enterpriseSettings.use_custom_logotype && (
-                                <div className="hidden lg:block absolute right-0 bottom-0">
+                                <div className="hidden lg:block fixed right-4 bottom-4 pointer-events-none z-10">
                                   <img
                                     src="/api/enterprise-settings/logotype"
                                     alt="logotype"

--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -1233,12 +1233,12 @@ export function ChatPage({
                               )}
                             {enterpriseSettings &&
                               enterpriseSettings.use_custom_logotype && (
-                                <div className="hidden lg:block fixed right-4 bottom-4 pointer-events-none z-10">
+                                <div className="hidden lg:block fixed right-12 bottom-8 pointer-events-none z-10">
                                   <img
                                     src="/api/enterprise-settings/logotype"
                                     alt="logotype"
                                     style={{ objectFit: "contain" }}
-                                    className="w-fit h-8"
+                                    className="w-fit h-9"
                                   />
                                 </div>
                               )}


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2359/whitelabel-positioning

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes whitelabeling by anchoring the enterprise custom logotype to the viewport and preventing it from blocking clicks. The logo now sits consistently at the bottom-right on large screens.

- **Bug Fixes**
  - Switched from absolute to fixed positioning for the logotype.
  - Added pointer-events-none so the logo doesn’t intercept clicks.
  - Set z-10 to ensure it appears above content and adjusted offset to right-4/bottom-4.

<!-- End of auto-generated description by cubic. -->

