### PR TITLE
Fix mypy

### DIFF
--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a0_clarification.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a0_clarification.py
@@ -529,7 +529,7 @@ def clarifier(
                 update_db_session_with_messages(
                     db_session=db_session,
                     chat_message_id=message_id,
-                    chat_session_id=str(graph_config.persistence.chat_session_id),
+                    chat_session_id=graph_config.persistence.chat_session_id,
                     is_agentic=graph_config.behavior.use_agentic_search,
                     message=answer_str,
                     update_parent_message=True,
@@ -586,7 +586,7 @@ def clarifier(
                 update_db_session_with_messages(
                     db_session=db_session,
                     chat_message_id=message_id,
-                    chat_session_id=str(graph_config.persistence.chat_session_id),
+                    chat_session_id=graph_config.persistence.chat_session_id,
                     is_agentic=graph_config.behavior.use_agentic_search,
                     message=full_answer,
                     update_parent_message=True,
@@ -707,7 +707,7 @@ def clarifier(
                 update_db_session_with_messages(
                     db_session=db_session,
                     chat_message_id=message_id,
-                    chat_session_id=str(graph_config.persistence.chat_session_id),
+                    chat_session_id=graph_config.persistence.chat_session_id,
                     is_agentic=graph_config.behavior.use_agentic_search,
                     message=clarification_response.clarification_question,
                     update_parent_message=True,
@@ -735,7 +735,7 @@ def clarifier(
         update_db_session_with_messages(
             db_session=db_session,
             chat_message_id=message_id,
-            chat_session_id=str(graph_config.persistence.chat_session_id),
+            chat_session_id=graph_config.persistence.chat_session_id,
             is_agentic=graph_config.behavior.use_agentic_search,
             message=clarification.clarification_question,
             update_parent_message=True,

--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a2_closer.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a2_closer.py
@@ -152,7 +152,7 @@ def save_iteration(
     update_db_session_with_messages(
         db_session=db_session,
         chat_message_id=message_id,
-        chat_session_id=str(graph_config.persistence.chat_session_id),
+        chat_session_id=graph_config.persistence.chat_session_id,
         is_agentic=graph_config.behavior.use_agentic_search,
         message=final_answer,
         citations=citation_dict,

--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a3_logger.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a3_logger.py
@@ -134,7 +134,7 @@ def save_iteration(
     update_db_session_with_messages(
         db_session=db_session,
         chat_message_id=message_id,
-        chat_session_id=str(graph_config.persistence.chat_session_id),
+        chat_session_id=graph_config.persistence.chat_session_id,
         is_agentic=graph_config.behavior.use_agentic_search,
         message=final_answer,
         citations=citation_dict,


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes mypy errors by removing unnecessary str() casts for chat_session_id when saving messages. We now pass graph_config.persistence.chat_session_id directly to update_db_session_with_messages across the DR nodes; no behavior change.

<!-- End of auto-generated description by cubic. -->

