### PR TITLE
feat: add toggles for slack and api key users

### DIFF
--- a/web/src/components/admin/users/UserStatusButtons.tsx
+++ b/web/src/components/admin/users/UserStatusButtons.tsx
@@ -197,7 +197,8 @@ export const UserRoleDropdown = ({
                   role === UserRole.GLOBAL_CURATOR) ||
                 role === UserRole.CURATOR ||
                 role === UserRole.LIMITED ||
-                role === UserRole.SLACK_USER;
+                role === UserRole.SLACK_USER ||
+                role === UserRole.API_KEY;
 
               // Always show the current role
               const isCurrentRole = user.role === role;

--- a/web/src/components/admin/users/buttons/UserRoleDropdown.tsx
+++ b/web/src/components/admin/users/buttons/UserRoleDropdown.tsx
@@ -84,7 +84,8 @@ const UserRoleDropdown = ({
                   role === UserRole.GLOBAL_CURATOR) ||
                 role === UserRole.CURATOR ||
                 role === UserRole.LIMITED ||
-                role === UserRole.SLACK_USER;
+                role === UserRole.SLACK_USER ||
+                role === UserRole.API_KEY;
 
               // Always show the current role
               const isCurrentRole = user.role === role;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -32,6 +32,7 @@ export enum UserRole {
   GLOBAL_CURATOR = "global_curator",
   EXT_PERM_USER = "ext_perm_user",
   SLACK_USER = "slack_user",
+  API_KEY = "api_key",
 }
 
 export const USER_ROLE_LABELS: Record<UserRole, string> = {
@@ -42,6 +43,7 @@ export const USER_ROLE_LABELS: Record<UserRole, string> = {
   [UserRole.LIMITED]: "Limited",
   [UserRole.EXT_PERM_USER]: "External Permissioned User",
   [UserRole.SLACK_USER]: "Slack User",
+  [UserRole.API_KEY]: "API Key",
 };
 
 export const INVALID_ROLE_HOVER_TEXT: Partial<Record<UserRole, string>> = {


### PR DESCRIPTION
## Summary
- add switches to show or hide Slack users and API key accounts on the admin users page
- detect API key accounts using the user role

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68be5380261483218426ba1a379683a9
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add toggles on the admin Users page to show or hide Slack users and API key accounts. Introduces an API_KEY role so API key accounts are detected and shown with a read-only role label.

- **New Features**
  - Two switches: Show Slack Users and Show API Keys, filtering the visible list.
  - Added UserRole.API_KEY and label; API key accounts detected via role.
  - Slack/API key users display a static role label instead of the editable role dropdown.

<!-- End of auto-generated description by cubic. -->

