### PR TITLE
Toggle slack users and api keys visibility

### DIFF
--- a/web/src/components/admin/users/SignedUpUserTable.tsx
+++ b/web/src/components/admin/users/SignedUpUserTable.tsx
@@ -4,7 +4,7 @@ import {
   InvitedUserSnapshot,
   USER_ROLE_LABELS,
 } from "@/lib/types";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import CenteredPageSelector from "./CenteredPageSelector";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
 import {
@@ -46,6 +46,9 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { UserTypeToggle } from "./UserTypeToggle";
+import { useUserTypeFilters } from "@/hooks/useUserTypeFilters";
+import { getDisplayEmail, getUserTypeLabel } from "@/lib/userUtils";
 
 const ITEMS_PER_PAGE = 10;
 const PAGES_PER_BATCH = 2;
@@ -81,7 +84,7 @@ const SignedUpUserTable = ({
   const [resetPasswordUser, setResetPasswordUser] = useState<User | null>(null);
 
   const {
-    currentPageData: pageOfUsers,
+    currentPageData: allPageUsers,
     isLoading,
     error,
     currentPage,
@@ -95,6 +98,14 @@ const SignedUpUserTable = ({
     query: q,
     filter: filters,
   });
+
+  // User type filtering
+  const {
+    filters: userTypeFilters,
+    setFilters: setUserTypeFilters,
+    filteredUsers: pageOfUsers,
+    userCounts,
+  } = useUserTypeFilters(allPageUsers || []);
 
   const { user: currentUser } = useUser();
 
@@ -325,6 +336,11 @@ const SignedUpUserTable = ({
 
   return (
     <>
+      <UserTypeToggle
+        filters={userTypeFilters}
+        onFiltersChange={setUserTypeFilters}
+        userCounts={userCounts}
+      />
       {renderFilters()}
       <Table className="overflow-visible">
         <TableHeader>
@@ -362,7 +378,16 @@ const SignedUpUserTable = ({
             ) : (
               pageOfUsers.map((user) => (
                 <TableRow key={user.id}>
-                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    <div className="flex flex-col">
+                      <span>{getDisplayEmail(user.email)}</span>
+                      {getUserTypeLabel(user) && (
+                        <span className="text-xs text-muted-foreground">
+                          {getUserTypeLabel(user)}
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
                   <TableCell className="w-[180px]">
                     {renderUserRoleDropdown(user)}
                   </TableCell>

--- a/web/src/components/admin/users/UserTypeToggle.tsx
+++ b/web/src/components/admin/users/UserTypeToggle.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import React from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import { Users, Key, MessageSquare } from "lucide-react";
+import { UserTypeFilter } from "@/lib/userUtils";
+
+interface UserTypeToggleProps {
+  filters: UserTypeFilter;
+  onFiltersChange: (filters: UserTypeFilter) => void;
+  userCounts?: {
+    slackUsers: number;
+    apiKeys: number;
+    totalUsers: number;
+  };
+}
+
+export const UserTypeToggle: React.FC<UserTypeToggleProps> = ({
+  filters,
+  onFiltersChange,
+  userCounts,
+}) => {
+  const handleSlackToggle = (checked: boolean) => {
+    onFiltersChange({
+      ...filters,
+      showSlackUsers: checked,
+    });
+  };
+
+  const handleApiKeyToggle = (checked: boolean) => {
+    onFiltersChange({
+      ...filters,
+      showApiKeys: checked,
+    });
+  };
+
+  return (
+    <Card className="mb-4">
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-foreground">User Type Filters</h3>
+          <div className="text-xs text-muted-foreground">
+            {userCounts && (
+              <span>
+                Showing{" "}
+                {userCounts.totalUsers -
+                  (!filters.showSlackUsers ? userCounts.slackUsers : 0) -
+                  (!filters.showApiKeys ? userCounts.apiKeys : 0)}{" "}
+                of {userCounts.totalUsers} users
+              </span>
+            )}
+          </div>
+        </div>
+        
+        <div className="space-y-4">
+          <div className="flex items-center justify-between space-x-3">
+            <div className="flex items-center space-x-3">
+              <MessageSquare className="h-4 w-4 text-blue-500" />
+              <div className="flex flex-col">
+                <Label htmlFor="slack-toggle" className="text-sm font-medium">
+                  Slack Users
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Users who access Onyx through Slack
+                  {userCounts && ` (${userCounts.slackUsers})`}
+                </p>
+              </div>
+            </div>
+            <Switch
+              id="slack-toggle"
+              checked={filters.showSlackUsers}
+              onCheckedChange={handleSlackToggle}
+            />
+          </div>
+
+          <div className="flex items-center justify-between space-x-3">
+            <div className="flex items-center space-x-3">
+              <Key className="h-4 w-4 text-green-500" />
+              <div className="flex flex-col">
+                <Label htmlFor="api-key-toggle" className="text-sm font-medium">
+                  API Keys
+                </Label>
+                <p className="text-xs text-muted-foreground">
+                  Programmatic access keys
+                  {userCounts && ` (${userCounts.apiKeys})`}
+                </p>
+              </div>
+            </div>
+            <Switch
+              id="api-key-toggle"
+              checked={filters.showApiKeys}
+              onCheckedChange={handleApiKeyToggle}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/web/src/hooks/useUserTypeFilters.ts
+++ b/web/src/hooks/useUserTypeFilters.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { User } from "@/lib/types";
+import { 
+  UserTypeFilter, 
+  filterUsersByType, 
+  isSlackUser, 
+  isApiKeyUser 
+} from "@/lib/userUtils";
+
+const STORAGE_KEY = "admin-user-type-filters";
+
+const DEFAULT_FILTERS: UserTypeFilter = {
+  showSlackUsers: true,
+  showApiKeys: true,
+};
+
+/**
+ * Custom hook to manage user type filters with localStorage persistence
+ */
+export function useUserTypeFilters(users: User[] = []) {
+  const [filters, setFilters] = useState<UserTypeFilter>(DEFAULT_FILTERS);
+
+  // Load filters from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsedFilters = JSON.parse(stored);
+        setFilters({
+          showSlackUsers: parsedFilters.showSlackUsers ?? true,
+          showApiKeys: parsedFilters.showApiKeys ?? true,
+        });
+      }
+    } catch (error) {
+      console.warn("Failed to load user type filters from localStorage:", error);
+    }
+  }, []);
+
+  // Save filters to localStorage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+    } catch (error) {
+      console.warn("Failed to save user type filters to localStorage:", error);
+    }
+  }, [filters]);
+
+  // Calculate user counts and filtered users
+  const { filteredUsers, userCounts } = useMemo(() => {
+    const slackUsers = users.filter(isSlackUser).length;
+    const apiKeys = users.filter(isApiKeyUser).length;
+    const totalUsers = users.length;
+
+    const filtered = filterUsersByType(users, filters);
+
+    return {
+      filteredUsers: filtered,
+      userCounts: {
+        slackUsers,
+        apiKeys,
+        totalUsers,
+      },
+    };
+  }, [users, filters]);
+
+  return {
+    filters,
+    setFilters,
+    filteredUsers,
+    userCounts,
+  };
+}

--- a/web/src/lib/userUtils.ts
+++ b/web/src/lib/userUtils.ts
@@ -1,0 +1,66 @@
+import { User, UserRole } from "@/lib/types";
+
+// Constants from backend
+const API_KEY_EMAIL_DOMAIN = "onyxapikey.ai";
+
+/**
+ * Check if a user is a Slack user
+ */
+export function isSlackUser(user: User): boolean {
+  return user.role === UserRole.SLACK_USER;
+}
+
+/**
+ * Check if a user is an API key (identified by email domain)
+ */
+export function isApiKeyUser(user: User): boolean {
+  return user.email.endsWith(API_KEY_EMAIL_DOMAIN);
+}
+
+/**
+ * Get display name for API key users
+ */
+export function getDisplayEmail(email: string): string {
+  if (email.endsWith(API_KEY_EMAIL_DOMAIN)) {
+    const name = email.split("@")[0];
+    if (!name) return email;
+    if (name === "API_KEY__Unnamed API Key") {
+      return "Unnamed API Key";
+    }
+    return name.replace("API_KEY__", "API Key: ");
+  }
+  return email;
+}
+
+export type UserTypeFilter = {
+  showSlackUsers: boolean;
+  showApiKeys: boolean;
+};
+
+/**
+ * Filter users based on type preferences
+ */
+export function filterUsersByType(users: User[], filters: UserTypeFilter): User[] {
+  return users.filter((user) => {
+    if (isSlackUser(user) && !filters.showSlackUsers) {
+      return false;
+    }
+    if (isApiKeyUser(user) && !filters.showApiKeys) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Get user type label for display
+ */
+export function getUserTypeLabel(user: User): string | null {
+  if (isSlackUser(user)) {
+    return "Slack User";
+  }
+  if (isApiKeyUser(user)) {
+    return "API Key";
+  }
+  return null;
+}


### PR DESCRIPTION
## Description

This PR introduces filter toggles on the Admin Users page to hide or show Slack users and API keys. This enhances the usability of the user list by allowing administrators to focus on specific user types, such as human users, without being cluttered by programmatic access keys or integration-specific accounts.

Key features:
*   **Toggle Controls:** New switches to show/hide Slack users and API keys.
*   **Persistent Preferences:** Filter settings are saved in `localStorage` and restored across sessions.
*   **Client-Side Filtering:** All filtering logic is handled in the frontend, ensuring instant response times without additional API calls.
*   **Improved Display:** API key emails are formatted for readability (e.g., "API Key: MyKey"), and user type labels ("Slack User", "API Key") are displayed below the email.
*   **Dynamic Counts:** The total and filtered user counts are updated in real-time.

This solution adheres to the requirements of not modifying the database schema and ensuring high performance through client-side memoized filtering.

## How Has This Been Tested?

The changes were verified by:
*   Running lint checks and resolving TypeScript errors.
*   Starting the development server and confirming the application runs.
*   Verifying the new components (`UserTypeToggle`, `useUserTypeFilters`, `userUtils`) were correctly integrated and functional.
*   Confirming that toggling the filters instantly updates the user list and persists preferences across page reloads.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

---
[Slack Thread](https://onyx-company.slack.com/archives/D09BA441UMB/p1757304291649689?thread_ts=1757304291.649689&cid=D09BA441UMB)

<a href="https://cursor.com/background-agent?bcId=bc-bc9eebe6-d16d-4268-90eb-374e16ded209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc9eebe6-d16d-4268-90eb-374e16ded209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

