### PR TITLE
Fix image gen

### DIFF
--- a/backend/onyx/db/pydantic_type.py
+++ b/backend/onyx/db/pydantic_type.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 from typing import Optional
 from typing import Type
@@ -21,12 +20,12 @@ class PydanticType(TypeDecorator):
         self, value: Optional[BaseModel], dialect: Any
     ) -> Optional[dict]:
         if value is not None:
-            return json.loads(value.json())
+            return value.model_dump()
         return None
 
     def process_result_value(
         self, value: Optional[dict], dialect: Any
     ) -> Optional[BaseModel]:
         if value is not None:
-            return self.pydantic_model.parse_obj(value)
+            return self.pydantic_model.model_validate(value)
         return None


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes image generation not showing in chat and stabilizes Pydantic model persistence. We now render meaningful tool/message packets (including image gen) and avoid JSON round-trips in the backend.

- **Bug Fixes**
  - AIMessage: render all non-empty display groups; always include image generation tool packets; mark display complete only after the final group; skip empty message deltas.
  - MultiToolRenderer: filter to tool groups with real content; explicitly include image_generation_tool_start/delta.
  - Backend: switch to Pydantic v2 APIs (model_dump/model_validate) to store/load dicts directly and prevent serialization issues.

<!-- End of auto-generated description by cubic. -->

