### PR TITLE
feat(infra): Add Node Selector option to all Templates

### DIFF
--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: api-server
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_beat.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-beat
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_docfetching.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-docfetching
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_docprocessing.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-docprocessing
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_heavy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-heavy
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_light.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-light
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_monitoring.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-monitoring
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_primary.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-primary
           securityContext:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
+      {{- with .Values.celery_worker_user_files_indexing.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: celery-worker-user-files-indexing
           securityContext:

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -28,6 +28,10 @@ spec:
       securityContext:
         {{- toYaml .Values.indexCapability.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- with .Values.indexCapability.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.indexCapability.name }}
         image: "{{ .Values.indexCapability.image.repository }}:{{ .Values.indexCapability.image.tag | default .Values.global.version }}"

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       securityContext:
         {{- toYaml .Values.inferenceCapability.podSecurityContext | nindent 8 }}
       {{- end }}
+      {{- with .Values.inferenceCapability.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: model-server-inference
         image: "{{ .Values.inferenceCapability.image.repository }}:{{ .Values.inferenceCapability.image.tag | default .Values.global.version }}"
@@ -46,4 +50,3 @@ spec:
         resources:
           {{- toYaml .Values.inferenceCapability.resources | nindent 10 }}
         {{- end }}
-

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.slackbot.podSecurityContext | nindent 8 }}
+      {{- with .Values.slackbot.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: slackbot
           securityContext:

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       serviceAccountName: {{ include "onyx-stack.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.webserver.podSecurityContext | nindent 8 }}
+      {{- with .Values.webserver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: web-server
           securityContext:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -100,6 +100,7 @@ inferenceCapability:
   securityContext:
     privileged: true
     runAsUser: 0
+  nodeSelector: {}
 
 indexCapability:
   service:
@@ -133,6 +134,7 @@ indexCapability:
   securityContext:
     privileged: true
     runAsUser: 0
+  nodeSelector: {}
 config:
   envConfigMapName: env-configmap
 
@@ -513,6 +515,7 @@ slackbot:
     limits:
       cpu: "1000m"
       memory: "2000Mi"
+  nodeSelector: {}
 
 celery_worker_docfetching:
   replicaCount: 1


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Adding in the Node Selector option into the templates in order to allow users to configure specific nodes for their pods to be able to schedule them on specific instances. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran helm template and validated that the template was properly generated and created proper labels for the pods. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
