### PR TITLE
[Running GitHub actions for #5253]

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.2.9
+version: 0.3.0
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -4,28 +4,29 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-api
   annotations:
-  {{- with .Values.ingress.api.annotations }}
+    {{- if .Values.letsencrypt.enabled -}}
+    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
+    {{- end }}
+    {{- with .Values.ingress.api.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.api.host }}
       http:
         paths:
-          - path: {{ .Values.ingress.api.path | default "/api(/|$)(.*)" }}
-            pathType: {{ .Values.ingress.api.pathType | default "ImplementationSpecific" }}
+          - path: {{ .Values.ingress.api.path }}
+            pathType: {{ .Values.ingress.api.pathType }}
             backend:
               service:
                 name: {{ include "onyx-stack.fullname" . }}-api-service
                 port:
                   number: {{ .Values.api.service.servicePort }}
-  {{- if .Values.ingress.api.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ .Values.ingress.api.tlsSecretName }}
-  {{- end }}
+      secretName: {{ .Values.ingress.api.tlsSecretName | default (printf "%s-ingress-api-tls" (include "onyx-stack.fullname" .)) }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -4,24 +4,28 @@ kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-api
   annotations:
-    kubernetes.io/ingress.class: nginx
+  {{- with .Values.ingress.api.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/use-regex: "true"
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
 spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
     - host: {{ .Values.ingress.api.host }}
       http:
         paths:
-          - path: /api(/|$)(.*)
-            pathType: Prefix
+          - path: {{ .Values.ingress.api.path | default "/api(/|$)(.*)" }}
+            pathType: {{ .Values.ingress.api.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ include "onyx-stack.fullname" . }}-api-service
                 port:
                   number: {{ .Values.api.service.servicePort }}
+  {{- if .Values.ingress.api.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.api.host }}
-      secretName: {{ include "onyx-stack.fullname" . }}-ingress-api-tls
+      secretName: {{ .Values.ingress.api.tlsSecretName }}
+  {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -3,11 +3,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-webserver
+  {{- with .Values.ingress.webserver.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
-    kubernetes.io/tls-acme: "true"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
     - host: {{ .Values.ingress.webserver.host }}
       http:
@@ -19,8 +20,10 @@ spec:
                 name: {{ include "onyx-stack.fullname" . }}-webserver
                 port:
                   number: {{ .Values.webserver.service.servicePort }}
+  {{- if .Values.ingress.webserver.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.webserver.host }}
-      secretName: {{ include "onyx-stack.fullname" . }}-ingress-webserver-tls
+      secretName: {{ .Values.ingress.webserver.tlsSecretName }}
+    {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-webserver.yaml
@@ -3,12 +3,18 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "onyx-stack.fullname" . }}-ingress-webserver
-  {{- with .Values.ingress.webserver.annotations }}
   annotations:
+    {{- if .Values.letsencrypt.enabled -}}
+    cert-manager.io/cluster-issuer: {{ include "onyx-stack.fullname" . }}-letsencrypt
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- with .Values.ingress.webserver.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.webserver.host }}
       http:
@@ -20,10 +26,8 @@ spec:
                 name: {{ include "onyx-stack.fullname" . }}-webserver
                 port:
                   number: {{ .Values.webserver.service.servicePort }}
-  {{- if .Values.ingress.webserver.tlsSecretName }}
   tls:
     - hosts:
         - {{ .Values.ingress.webserver.host }}
-      secretName: {{ .Values.ingress.webserver.tlsSecretName }}
-    {{- end }}
+      secretName: {{ .Values.ingress.webserver.tlsSecretName | default (printf "%s-ingress-webserver-tls" (include "onyx-stack.fullname" .)) }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -591,11 +591,14 @@ ingress:
   className: "nginx"
   api:
     host: onyx.local
+    # Ingress controller specific section start
+    # Default values are appropriate for NGinx ingress controller. If you use a different ingress controller, you will need to adjust ALL these values.
     path: /api(/|$)(.*)
     pathType: ImplementationSpecific
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: /$2
       nginx.ingress.kubernetes.io/use-regex: "true"
+    # Ingress controller specific section end
   webserver:
     host: onyx.local
 

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -591,6 +591,11 @@ ingress:
   className: "nginx"
   api:
     host: onyx.local
+    path: /api(/|$)(.*)
+    pathType: ImplementationSpecific
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+      nginx.ingress.kubernetes.io/use-regex: "true"
   webserver:
     host: onyx.local
 

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -588,7 +588,7 @@ minio:
 
 ingress:
   enabled: false
-  className: ""
+  className: "nginx"
   api:
     host: onyx.local
   webserver:


### PR DESCRIPTION
Automated mirror of PR #5253 so private CI can run.

- [x] [Optional] Override Linear Check
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves the Onyx Helm chart ingress configuration with support for ingressClassName, per-ingress annotations, configurable API path/pathType, and customizable TLS secret names. Defaults preserve existing NGinx behavior; chart version bumped to 0.3.0.

- **New Features**
  - Add spec.ingressClassName from values (default: nginx).
  - Support custom annotations via ingress.api.annotations and ingress.webserver.annotations.
  - Gate cert-manager annotations behind letsencrypt.enabled.
  - Make API path and pathType configurable; defaults keep NGinx regex + rewrite.
  - Allow overriding TLS secrets via ingress.api.tlsSecretName and ingress.webserver.tlsSecretName.

- **Migration**
  - No changes needed for NGinx users.
  - For other controllers, set ingress.className and adjust api.path/pathType and annotations.
  - If managing certs manually, set the tlsSecretName values.

<!-- End of auto-generated description by cubic. -->

