### PR TITLE
fix(sharepoint): Disallow specific Image types

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -55,6 +55,7 @@ from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.connectors.sharepoint.connector_utils import get_sharepoint_external_access
 from onyx.file_processing.extract_file_text import ACCEPTED_IMAGE_FILE_EXTENSIONS
+from onyx.file_processing.extract_file_text import EXCLUDED_IMAGE_FILE_EXTENSIONS
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.image_utils import store_image_and_create_section
@@ -346,6 +347,10 @@ def _convert_driveitem_to_document_with_permissions(
     if not content_bytes:
         logger.warning(
             f"Zero-length content for '{driveitem.name}'. Skipping text/image extraction."
+        )
+    elif "." + file_ext in EXCLUDED_IMAGE_FILE_EXTENSIONS:
+        logger.info(
+            f"Skipping excluded image type: '{driveitem.name}' (extension: .{file_ext})"
         )
     elif "." + file_ext in ACCEPTED_IMAGE_FILE_EXTENSIONS:
         image_section, _ = store_image_and_create_section(

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -68,6 +68,15 @@ ACCEPTED_IMAGE_FILE_EXTENSIONS = [
     ".webp",
 ]
 
+EXCLUDED_IMAGE_FILE_EXTENSIONS = [
+    ".tiff",
+    ".tif",
+    ".bmp",
+    ".gif",
+    ".svg",
+    ".avif",
+]
+
 ALL_ACCEPTED_FILE_EXTENSIONS = (
     ACCEPTED_PLAIN_TEXT_FILE_EXTENSIONS
     + ACCEPTED_DOCUMENT_FILE_EXTENSIONS


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The cloud has docprocessing pods that are OOMing because Sharepoint allows users to still index on TIFF files. This is a dangerous operation as these files can be GB's in size and cause a lot of our pods to OOM unexpectedly and thus needs to be fixed. 

There was a fix for sharepoint here: https://github.com/onyx-dot-app/onyx/pull/5204

The issue with the above fix is that it allowed non-accepted images to start getting indexed upon and thus this PR aims to fix this. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested locally as well as writing unit tests to ensure that specific image types were now being skipped to avoid OOMs.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
