### PR TITLE
fix: skip excluded img files in sharepoint

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -292,12 +292,12 @@ def _convert_driveitem_to_document_with_permissions(
     try:
         item_json = driveitem.to_json()
         mime_type = item_json.get("file", {}).get("mimeType")
-        if mime_type in EXCLUDED_IMAGE_TYPES:
+        if not mime_type or mime_type in EXCLUDED_IMAGE_TYPES:
             # NOTE: this function should be refactored to look like Drive doc_conversion.py pattern
             # for now, this skip must happen before we download the file
             # Similar to Google Drive, we'll just semi-silently skip excluded image types
             logger.debug(
-                f"Skipping excluded image type {mime_type} for {driveitem.name}"
+                f"Skipping malformed or excluded mime type {mime_type} for {driveitem.name}"
             )
             return None
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -58,7 +58,6 @@ from onyx.file_processing.extract_file_text import ACCEPTED_IMAGE_FILE_EXTENSION
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_validation import EXCLUDED_IMAGE_TYPES
-from onyx.file_processing.file_validation import is_valid_image_type
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.utils.logger import setup_logger
 
@@ -353,12 +352,14 @@ def _convert_driveitem_to_document_with_permissions(
         content_bytes = bytes(content.value)
 
     sections: list[TextSection | ImageSection] = []
+    file_ext = driveitem.name.split(".")[-1]
 
     if not content_bytes:
         logger.warning(
             f"Zero-length content for '{driveitem.name}'. Skipping text/image extraction."
         )
-    elif is_valid_image_type(mime_type):
+    elif "." + file_ext in ACCEPTED_IMAGE_FILE_EXTENSIONS:
+        # NOTE: this if should use is_valid_image_type instead with mime_type
         image_section, _ = store_image_and_create_section(
             image_data=content_bytes,
             file_id=driveitem.id,

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -57,6 +57,8 @@ from onyx.connectors.sharepoint.connector_utils import get_sharepoint_external_a
 from onyx.file_processing.extract_file_text import ACCEPTED_IMAGE_FILE_EXTENSIONS
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
+from onyx.file_processing.file_validation import EXCLUDED_IMAGE_TYPES
+from onyx.file_processing.file_validation import is_valid_image_type
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.utils.logger import setup_logger
 
@@ -289,6 +291,16 @@ def _convert_driveitem_to_document_with_permissions(
     file_size: int | None = None
     try:
         item_json = driveitem.to_json()
+        mime_type = item_json.get("file", {}).get("mimeType")
+        if mime_type in EXCLUDED_IMAGE_TYPES:
+            # NOTE: this function should be refactored to look like Drive doc_conversion.py pattern
+            # for now, this skip must happen before we download the file
+            # Similar to Google Drive, we'll just semi-silently skip excluded image types
+            logger.debug(
+                f"Skipping excluded image type {mime_type} for {driveitem.name}"
+            )
+            return None
+
         size_value = item_json.get("size")
         if size_value is not None:
             file_size = int(size_value)
@@ -341,13 +353,12 @@ def _convert_driveitem_to_document_with_permissions(
         content_bytes = bytes(content.value)
 
     sections: list[TextSection | ImageSection] = []
-    file_ext = driveitem.name.split(".")[-1]
 
     if not content_bytes:
         logger.warning(
             f"Zero-length content for '{driveitem.name}'. Skipping text/image extraction."
         )
-    elif "." + file_ext in ACCEPTED_IMAGE_FILE_EXTENSIONS:
+    elif is_valid_image_type(mime_type):
         image_section, _ = store_image_and_create_section(
             image_data=content_bytes,
             file_id=driveitem.id,


### PR DESCRIPTION
## Description

title

## How Has This Been Tested?

locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Skip excluded image files in the SharePoint connector by checking MIME type before download. Prevents processing unsupported images and reduces unnecessary downloads, aligning behavior with Google Drive.

- **Bug Fixes**
  - Early-return when file.mimeType is in EXCLUDED_IMAGE_TYPES (skip before download).
  - Switch image detection to is_valid_image_type(mime_type) instead of extension-based check.
  - Add debug log when skipping excluded image types.

<!-- End of auto-generated description by cubic. -->

