### PR TITLE
Added OpenRouter as model provider

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,14 +23,7 @@ RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 # curl included just for users' convenience
 # zip for Vespa step futher down
 # ca-certificates for HTTPS
-## Use HTTPS Debian mirrors to avoid environments blocking HTTP (port 80)
-RUN set -eux; \
-    if [ -f /etc/apt/sources.list ]; then \
-      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list; \
-    fi; \
-    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources; \
-    fi
+
 RUN apt-get update && \
     apt-get install -y \
         cmake \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,14 @@ RUN echo "ONYX_VERSION: ${ONYX_VERSION}"
 # curl included just for users' convenience
 # zip for Vespa step futher down
 # ca-certificates for HTTPS
+## Use HTTPS Debian mirrors to avoid environments blocking HTTP (port 80)
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list ]; then \
+      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list; \
+    fi; \
+    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources; \
+    fi
 RUN apt-get update && \
     apt-get install -y \
         cmake \

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -28,6 +28,15 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
+## Use HTTPS Debian mirrors to avoid environments blocking HTTP (port 80)
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list ]; then \
+      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list; \
+    fi; \
+    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
+      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources; \
+    fi
+
 RUN set -eux; \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -28,15 +28,6 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-## Use HTTPS Debian mirrors to avoid environments blocking HTTP (port 80)
-RUN set -eux; \
-    if [ -f /etc/apt/sources.list ]; then \
-      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list; \
-    fi; \
-    if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources; \
-    fi
-
 RUN set -eux; \
     apt-get update && apt-get install -y --no-install-recommends \
         build-essential \

--- a/backend/onyx/llm/llm_provider_options.py
+++ b/backend/onyx/llm/llm_provider_options.py
@@ -169,6 +169,34 @@ _PROVIDER_TO_VISIBLE_MODELS_MAP = {
     VERTEXAI_PROVIDER_NAME: VERTEXAI_VISIBLE_MODEL_NAMES,
 }
 
+# OpenRouter Provider
+
+# LiteLLM expects models in the form: "openrouter/vendor/model"
+OPENROUTER_PROVIDER_NAME = "openrouter"
+OPENROUTER_DEFAULT_MODEL = "openai/gpt-4o"
+OPENROUTER_DEFAULT_FAST_MODEL = "openai/gpt-4o-mini"
+OPENROUTER_MODEL_NAMES = [
+    # OpenAI
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    # Anthropic
+    "anthropic/claude-3-7-sonnet",
+    "anthropic/claude-3-5-sonnet",
+    # Google
+    "google/gemini-1.5-pro",
+    "google/gemini-1.5-flash",
+]
+OPENROUTER_VISIBLE_MODEL_NAMES = [
+    OPENROUTER_DEFAULT_MODEL,
+    OPENROUTER_DEFAULT_FAST_MODEL,
+]
+
+# Register in maps
+_PROVIDER_TO_MODELS_MAP[OPENROUTER_PROVIDER_NAME] = OPENROUTER_MODEL_NAMES
+_PROVIDER_TO_VISIBLE_MODELS_MAP[OPENROUTER_PROVIDER_NAME] = (
+    OPENROUTER_VISIBLE_MODEL_NAMES
+)
+
 
 def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
     return [
@@ -184,6 +212,36 @@ def fetch_available_well_known_llms() -> list[WellKnownLLMProviderDescriptor]:
             ),
             default_model="gpt-4o",
             default_fast_model="gpt-4o-mini",
+        ),
+        WellKnownLLMProviderDescriptor(
+            name=OPENROUTER_PROVIDER_NAME,
+            display_name="OpenRouter",
+            api_key_required=True,
+            api_base_required=False,
+            api_version_required=False,
+            custom_config_keys=[
+                CustomConfigKey(
+                    name="OR_SITE_URL",
+                    display_name="Site URL (Referer)",
+                    is_required=False,
+                    description=(
+                        "Optional. Used by OpenRouter for analytics and rate limits."
+                    ),
+                ),
+                CustomConfigKey(
+                    name="OR_APP_NAME",
+                    display_name="App Name",
+                    is_required=False,
+                    description=(
+                        "Optional. Human-readable app name sent to OpenRouter."
+                    ),
+                ),
+            ],
+            model_configurations=fetch_model_configurations_for_provider(
+                OPENROUTER_PROVIDER_NAME
+            ),
+            default_model=OPENROUTER_DEFAULT_MODEL,
+            default_fast_model=OPENROUTER_DEFAULT_FAST_MODEL,
         ),
         WellKnownLLMProviderDescriptor(
             name=ANTHROPIC_PROVIDER_NAME,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -196,3 +196,8 @@ class BedrockModelsRequest(BaseModel):
     aws_secret_access_key: str | None = None
     aws_bearer_token_bedrock: str | None = None
     provider_name: str | None = None  # Optional: to save models to existing provider
+
+
+class OpenRouterModelsRequest(BaseModel):
+    api_key: str
+    api_base: str | None = None


### PR DESCRIPTION
## Description

This PR adds OpenRouter as a dedicated provider in Onyx, replacing the current workaround of using the "Custom Inference Provider." The integration uses our existing LiteLLM infrastructure without adding any extra dependency.

## How Has This Been Tested?

- Built locally and tested OpenRouter provider end-to-end
- Verified API key configuration and model fetching
- Tested chat functionality with various OpenRouter models
- Confirmed existing providers remain unaffected
