### PR TITLE
fix: initial DR context & 4o 'laziness' fixes

### DIFF
--- a/backend/onyx/agents/agent_search/dr/nodes/dr_a1_orchestrator.py
+++ b/backend/onyx/agents/agent_search/dr/nodes/dr_a1_orchestrator.py
@@ -98,8 +98,12 @@ def orchestrator(
     research_type = graph_config.behavior.research_type
     remaining_time_budget = state.remaining_time_budget
     chat_history_string = state.chat_history_string or "(No chat history yet available)"
-    answer_history_string = (
+    answer_history_w_docs_string = (
         aggregate_context(state.iteration_responses, include_documents=True).context
+        or "(No answer history yet available)"
+    )
+    answer_history_wo_docs_string = (
+        aggregate_context(state.iteration_responses, include_documents=False).context
         or "(No answer history yet available)"
     )
 
@@ -222,7 +226,7 @@ def orchestrator(
             reasoning_prompt = base_reasoning_prompt.build(
                 question=question,
                 chat_history_string=chat_history_string,
-                answer_history_string=answer_history_string,
+                answer_history_string=answer_history_w_docs_string,
                 iteration_nr=str(iteration_nr),
                 remaining_time_budget=str(remaining_time_budget),
                 uploaded_context=uploaded_context,
@@ -314,7 +318,7 @@ def orchestrator(
         decision_prompt = base_decision_prompt.build(
             question=question,
             chat_history_string=chat_history_string,
-            answer_history_string=answer_history_string,
+            answer_history_string=answer_history_w_docs_string,
             iteration_nr=str(iteration_nr),
             remaining_time_budget=str(remaining_time_budget),
             reasoning_result=reasoning_result,
@@ -441,7 +445,7 @@ def orchestrator(
             available_tools=available_tools,
         )
         decision_prompt = base_decision_prompt.build(
-            answer_history_string=answer_history_string,
+            answer_history_string=answer_history_wo_docs_string,
             question_history_string=question_history_string,
             question=prompt_question,
             iteration_nr=str(iteration_nr),

--- a/backend/onyx/prompts/dr_prompts.py
+++ b/backend/onyx/prompts/dr_prompts.py
@@ -49,7 +49,9 @@ You generally should not need to ask clarification questions about the topics be
 by the {INTERNAL_SEARCH} tool, as the retrieved documents will likely provide you with more context.
 Each request to the {INTERNAL_SEARCH} tool should largely be written as a SEARCH QUERY, and NOT as a question \
 or an instruction! Also, \
-The {INTERNAL_SEARCH} tool DOES support parallel calls of up to {MAX_DR_PARALLEL_SEARCH} queries.
+The {INTERNAL_SEARCH} tool DOES support parallel calls of up to {MAX_DR_PARALLEL_SEARCH} queries. \
+You should take advantage of that and ask MULTIPLE DISTINCT questions, each that explores a different \
+aspect of the question.
 """
 
 TOOL_DESCRIPTION[


### PR DESCRIPTION
## Description

This PR fixes the following issues:
  - DR context should only be based on sub-questions and claims, not docs
  - encouraged to ask more questions for internal search, improving a laziness issue for 4o

Fixes: 
 https://linear.app/danswer/issue/DAN-2539/dr-iterations-should-only-rely-on-sub-questions-and-claims
 https://linear.app/danswer/issue/DAN-2540/encourage-models-to-ask-more-questions-when-parallel-answering-is

## How Has This Been Tested?

locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
