### PR TITLE
Revert "fix(infra): Add KEDA Dependency"

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.3.1
+version: 0.3.0
 appVersion: latest
 annotations:
   category: Productivity
@@ -22,9 +22,6 @@ dependencies:
     version: 14.3.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-  - name: keda
-    version: 2.14.2
-    repository: https://kedacore.github.io/charts
   - name: vespa
     version: 0.2.24
     repository: https://onyx-dot-app.github.io/vespa-helm-charts


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#5431
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restores the Helm chart to its previous configuration by reverting the recent KEDA change.

- **Dependencies**
  - Removed keda (2.14.2) from Chart.yaml dependencies.
  - Rolled chart version back from 0.3.1 to 0.3.0.

<!-- End of auto-generated description by cubic. -->

