### PR TITLE
fix(infra): Update chart releaser

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
+          helm repo add keda https://kedacore.github.io/charts
           helm repo update
 
       - name: Build chart dependencies


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
The chart releaser did not have the kedacore chart so it failed to build

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Will run in CI

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
