### PR TITLE
fix: HF Cache Warmup Fix and Celery Pool Management

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -43,8 +43,6 @@ def get_embedding_model(
     """
     from sentence_transformers import SentenceTransformer  # type: ignore
     import torch
-    import threading
-    import functools
 
     def _pick_device() -> str:
         if torch.cuda.is_available():
@@ -59,13 +57,11 @@ def get_embedding_model(
         Works by calling the underlying HF model directly with dummy IDs/attention.
         """
         try:
-            # Get underlying HF model + tokenizer from the first transformer module
-            tfm = st_model[0]  # sentence_transformers.models.Transformer
+            tfm = st_model[0]
             hf_model = getattr(tfm, "auto_model", None)
             tok = getattr(tfm, "tokenizer", None)
 
             if hf_model is None:
-                # Fallback: trigger through the ST pipeline (slower, but still builds caches)
                 dummy_text = "x " * max(1, target_len - 2)
                 st_model.encode(
                     [dummy_text],
@@ -77,7 +73,6 @@ def get_embedding_model(
                 st_model._rope_prewarmed_to = int(target_len)
                 return
 
-            # Respect model limits; don't exceed its configured max positions
             conf = getattr(hf_model, "config", None)
             max_pos = getattr(conf, "max_position_embeddings", None)
             L = min(target_len, max_pos) if max_pos else target_len
@@ -97,26 +92,12 @@ def get_embedding_model(
 
             st_model._rope_prewarmed_to = int(L)
         except Exception as e:
-            # Non-fatal: we still have the lock below as a safety net
             try:
                 logger.warning(f"RoPE pre-warm skipped/failed: {e}")
             except Exception:
                 pass
 
-    def _wrap_encode_with_lock(st_model: "SentenceTransformer") -> None:
-        """Serialize encode() to avoid concurrent cache resizes."""
-        lock = threading.Lock()
-        real_encode = st_model.encode
-
-        @functools.wraps(real_encode)
-        def locked_encode(*args, **kwargs):
-            with lock:
-                return real_encode(*args, **kwargs)
-
-        st_model.encode = locked_encode  # type: ignore[attr-defined]
-        st_model._encode_lock = lock  # for debugging/inspection
-
-    global _GLOBAL_MODELS_DICT  # dict[str, SentenceTransformer]
+    global _GLOBAL_MODELS_DICT
 
     if model_name not in _GLOBAL_MODELS_DICT:
         logger.notice(f"Loading {model_name}")
@@ -124,20 +105,15 @@ def get_embedding_model(
         model = SentenceTransformer(
             model_name_or_path=model_name,
             trust_remote_code=True,
-            device=device,  # ensure final device is fixed before pre-warm
+            device=device,
         )
         model.max_seq_length = max_context_length
-
-        # Pre-warm once (so RoPE caches are built and stable) and wrap with a lock
         _prewarm_rope(model, max_context_length)
-        # _wrap_encode_with_lock(model)
-
         _GLOBAL_MODELS_DICT[model_name] = model
     else:
         model = _GLOBAL_MODELS_DICT[model_name]
         if max_context_length != model.max_seq_length:
             model.max_seq_length = max_context_length
-            # If caller raised the context length above previous pre-warm, rebuild once
             prev = getattr(model, "_rope_prewarmed_to", 0)
             if max_context_length > int(prev or 0):
                 _prewarm_rope(model, max_context_length)

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -67,6 +67,7 @@ def get_embedding_model(
                 show_progress_bar=False,
                 normalize_embeddings=False,
             )
+            logger.info("RoPE pre-warm successful")
         except Exception as e:
             logger.warning(f"RoPE pre-warm skipped/failed: {e}")
 

--- a/backend/onyx/background/celery/configs/primary.py
+++ b/backend/onyx/background/celery/configs/primary.py
@@ -1,4 +1,5 @@
 import onyx.background.celery.configs.base as shared_config
+from onyx.configs.app_configs import CELERY_WORKER_PRIMARY_CONCURRENCY
 
 broker_url = shared_config.broker_url
 broker_connection_retry_on_startup = shared_config.broker_connection_retry_on_startup
@@ -15,6 +16,6 @@ result_expires = shared_config.result_expires  # 86400 seconds is the default
 task_default_priority = shared_config.task_default_priority
 task_acks_late = shared_config.task_acks_late
 
-worker_concurrency = 4
+worker_concurrency = CELERY_WORKER_PRIMARY_CONCURRENCY
 worker_pool = "threads"
 worker_prefetch_multiplier = 1

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -355,6 +355,14 @@ CELERY_WORKER_KG_PROCESSING_CONCURRENCY = int(
     os.environ.get("CELERY_WORKER_KG_PROCESSING_CONCURRENCY") or 4
 )
 
+CELERY_WORKER_PRIMARY_CONCURRENCY = int(
+    os.environ.get("CELERY_WORKER_PRIMARY_CONCURRENCY") or 4
+)
+
+CELERY_WORKER_PRIMARY_POOL_OVERFLOW = int(
+    os.environ.get("CELERY_WORKER_PRIMARY_POOL_OVERFLOW") or 4
+)
+
 # The maximum number of tasks that can be queued up to sync to Vespa in a single pass
 VESPA_SYNC_MAX_TASKS = 8192
 


### PR DESCRIPTION
## Description

RoPE cache is the root cause of the HF issues. It's part of the attention calculation (attention KV cache), and sometimes the cache needs to be resized up.

During concurrency, if code is interleaved where one thread resizes the cache up, the other thread will fail. 

The max size is 2048 which is not problematic -- it's ok to warm it up to max size at the beginning. The Rope cache only needs to be warmed up once per server restart and seems to take about 4 s locally. If it fails for whatever reason, the pod won't crash (there's a try except block handling it)

Also added env variables for managing the queue pool for sqlalchemy

## How Has This Been Tested?

Tested locally and on test.onyx.app

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pre-warms SentenceTransformer (HF) caches and pins the device to remove first-request stalls and cache thrash. Adds env-driven controls for Celery primary worker concurrency and DB pool overflow for steadier connection usage.

- Bug Fixes
  - Pre-warm RoPE caches on model load and when max_seq_length increases.
  - Pin device (cuda/mps/cpu) before warmup; respect max_position_embeddings.

- New Features
  - CELERY_WORKER_PRIMARY_CONCURRENCY sets primary worker_concurrency.
  - CELERY_WORKER_PRIMARY_POOL_OVERFLOW sets SqlAlchemy max_overflow for primary workers.

<!-- End of auto-generated description by cubic. -->

