### PR TITLE
fix(Federated Slack): Persist Document Set for Federated Connectors

### DIFF
--- a/backend/tests/unit/onyx/utils/test_vespa_tasks.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_tasks.py
@@ -1,0 +1,97 @@
+from types import SimpleNamespace
+
+from onyx.background.celery.tasks.vespa import tasks as vespa_tasks
+
+
+class _StubRedisDocumentSet:
+    """Lightweight stand-in for RedisDocumentSet used by monitor tests."""
+
+    reset_called = False
+
+    @staticmethod
+    def get_id_from_fence_key(key: str) -> str | None:
+        parts = key.split("_")
+        return parts[-1] if len(parts) == 3 else None
+
+    def __init__(self, tenant_id: str, object_id: str) -> None:
+        self.taskset_key = f"documentset_taskset_{object_id}"
+        self._payload = 0
+
+    @property
+    def fenced(self) -> bool:
+        return True
+
+    @property
+    def payload(self) -> int:
+        return self._payload
+
+    def reset(self) -> None:
+        self.__class__.reset_called = True
+
+
+def _setup_common_patches(monkeypatch, document_set):
+    calls: dict[str, bool] = {"deleted": False, "synced": False}
+
+    monkeypatch.setattr(vespa_tasks, "RedisDocumentSet", _StubRedisDocumentSet)
+
+    monkeypatch.setattr(
+        vespa_tasks,
+        "get_document_set_by_id",
+        lambda db_session, document_set_id: document_set,
+    )
+
+    def _delete(document_set_row, db_session) -> None:
+        calls["deleted"] = True
+
+    monkeypatch.setattr(vespa_tasks, "delete_document_set", _delete)
+
+    def _mark(document_set_id, db_session) -> None:
+        calls["synced"] = True
+
+    monkeypatch.setattr(vespa_tasks, "mark_document_set_as_synced", _mark)
+
+    monkeypatch.setattr(
+        vespa_tasks,
+        "update_sync_record_status",
+        lambda db_session, entity_id, sync_type, sync_status, num_docs_synced: None,
+    )
+
+    return calls
+
+
+def test_monitor_preserves_federated_only_document_set(monkeypatch):
+    document_set = SimpleNamespace(
+        connector_credential_pairs=[],
+        federated_connectors=[object()],
+    )
+
+    calls = _setup_common_patches(monkeypatch, document_set)
+
+    vespa_tasks.monitor_document_set_taskset(
+        tenant_id="tenant",
+        key_bytes=b"documentset_fence_1",
+        r=SimpleNamespace(scard=lambda key: 0),
+        db_session=SimpleNamespace(),
+    )
+
+    assert calls["synced"] is True
+    assert calls["deleted"] is False
+
+
+def test_monitor_deletes_document_set_with_no_connectors(monkeypatch):
+    document_set = SimpleNamespace(
+        connector_credential_pairs=[],
+        federated_connectors=[],
+    )
+
+    calls = _setup_common_patches(monkeypatch, document_set)
+
+    vespa_tasks.monitor_document_set_taskset(
+        tenant_id="tenant",
+        key_bytes=b"documentset_fence_2",
+        r=SimpleNamespace(scard=lambda key: 0),
+        db_session=SimpleNamespace(),
+    )
+
+    assert calls["deleted"] is True
+    assert calls["synced"] is False

--- a/backend/tests/unit/onyx/utils/test_vespa_tasks.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_tasks.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any
 
 from onyx.background.celery.tasks.vespa import tasks as vespa_tasks
 
@@ -29,7 +30,7 @@ class _StubRedisDocumentSet:
         self.__class__.reset_called = True
 
 
-def _setup_common_patches(monkeypatch, document_set):
+def _setup_common_patches(monkeypatch: Any, document_set: Any) -> dict[str, bool]:
     calls: dict[str, bool] = {"deleted": False, "synced": False}
 
     monkeypatch.setattr(vespa_tasks, "RedisDocumentSet", _StubRedisDocumentSet)
@@ -40,12 +41,12 @@ def _setup_common_patches(monkeypatch, document_set):
         lambda db_session, document_set_id: document_set,
     )
 
-    def _delete(document_set_row, db_session) -> None:
+    def _delete(document_set_row: Any, db_session: Any) -> None:
         calls["deleted"] = True
 
     monkeypatch.setattr(vespa_tasks, "delete_document_set", _delete)
 
-    def _mark(document_set_id, db_session) -> None:
+    def _mark(document_set_id: Any, db_session: Any) -> None:
         calls["synced"] = True
 
     monkeypatch.setattr(vespa_tasks, "mark_document_set_as_synced", _mark)
@@ -59,7 +60,7 @@ def _setup_common_patches(monkeypatch, document_set):
     return calls
 
 
-def test_monitor_preserves_federated_only_document_set(monkeypatch):
+def test_monitor_preserves_federated_only_document_set(monkeypatch: Any) -> None:
     document_set = SimpleNamespace(
         connector_credential_pairs=[],
         federated_connectors=[object()],
@@ -70,15 +71,15 @@ def test_monitor_preserves_federated_only_document_set(monkeypatch):
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_1",
-        r=SimpleNamespace(scard=lambda key: 0),
-        db_session=SimpleNamespace(),
+        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]
+        db_session=SimpleNamespace(),  # type: ignore[arg-type]
     )
 
     assert calls["synced"] is True
     assert calls["deleted"] is False
 
 
-def test_monitor_deletes_document_set_with_no_connectors(monkeypatch):
+def test_monitor_deletes_document_set_with_no_connectors(monkeypatch: Any) -> None:
     document_set = SimpleNamespace(
         connector_credential_pairs=[],
         federated_connectors=[],
@@ -89,8 +90,8 @@ def test_monitor_deletes_document_set_with_no_connectors(monkeypatch):
     vespa_tasks.monitor_document_set_taskset(
         tenant_id="tenant",
         key_bytes=b"documentset_fence_2",
-        r=SimpleNamespace(scard=lambda key: 0),
-        db_session=SimpleNamespace(),
+        r=SimpleNamespace(scard=lambda key: 0),  # type: ignore[arg-type]
+        db_session=SimpleNamespace(),  # type: ignore[arg-type]
     )
 
     assert calls["deleted"] is True


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
A customer was noticing that the Federated Slack Connector being the only connector in the document set would cause the document set to get deleted or disappear immediately. This is a bug in which we deleted any document set that was just a federated slack connector since it wouldn't have a `connector_credential_pair`. This PR aims to fix this and allow the Document Set to persist if it is only a Federated Slack Connector. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally as well as created tests to ensure that this is tracked and checked when we have any new Federated Connectors. 

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes deletion of document sets that only include Federated connectors (e.g., Federated Slack). These sets now persist without connector_credential_pairs; only truly empty sets are deleted.

- **Bug Fixes**
  - Updated monitor_document_set_taskset to keep document sets alive if federated_connectors are present; delete only when both connector_credential_pairs and federated_connectors are empty.
  - Added unit tests for federated-only persistence and empty-set deletion.

<!-- End of auto-generated description by cubic. -->

