### PR TITLE
feat: docs link on connector creation

### DIFF
--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -8,7 +8,11 @@ import { AdminPageTitle } from "@/components/admin/Title";
 import { buildSimilarCredentialInfoURL } from "@/app/admin/connector/[ccPairId]/lib";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { useFormContext } from "@/components/context/FormContext";
-import { getSourceDisplayName, getSourceMetadata } from "@/lib/sources";
+import {
+  getSourceDisplayName,
+  getSourceDocLink,
+  getSourceMetadata,
+} from "@/lib/sources";
 import { SourceIcon } from "@/components/SourceIcon";
 import { useEffect, useRef, useState } from "react";
 import { deleteCredential, linkCredential } from "@/lib/credential";
@@ -219,6 +223,7 @@ export default function AddConnector({
   };
 
   const displayName = getSourceDisplayName(connector) || connector;
+  const docsLink = getSourceDocLink(connector);
   if (!credentials || !editableCredentials) {
     return <></>;
   }
@@ -640,6 +645,20 @@ export default function AddConnector({
                   null
                 }
               />
+              {docsLink && (
+                <p className="text-sm mb-4">
+                  Check our
+                  <a
+                    className="text-blue-600 hover:underline"
+                    target="_blank"
+                    href={docsLink}
+                  >
+                    {" "}
+                    docs{" "}
+                  </a>
+                  for information on setting up this connector.
+                </p>
+              )}
             </CardSection>
           )}
 

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -8,11 +8,7 @@ import { AdminPageTitle } from "@/components/admin/Title";
 import { buildSimilarCredentialInfoURL } from "@/app/admin/connector/[ccPairId]/lib";
 import { usePopup } from "@/components/admin/connectors/Popup";
 import { useFormContext } from "@/components/context/FormContext";
-import {
-  getSourceDisplayName,
-  getSourceDocLink,
-  getSourceMetadata,
-} from "@/lib/sources";
+import { getSourceDisplayName, getSourceMetadata } from "@/lib/sources";
 import { SourceIcon } from "@/components/SourceIcon";
 import { useEffect, useRef, useState } from "react";
 import { deleteCredential, linkCredential } from "@/lib/credential";
@@ -63,6 +59,7 @@ import { CreateStdOAuthCredential } from "@/components/credentials/actions/Creat
 import { Spinner } from "@/components/Spinner";
 import { Button } from "@/components/ui/button";
 import { deleteConnector } from "@/lib/connector";
+import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
 
 export interface AdvancedConfig {
   refreshFreq: number;
@@ -223,7 +220,6 @@ export default function AddConnector({
   };
 
   const displayName = getSourceDisplayName(connector) || connector;
-  const docsLink = getSourceDocLink(connector);
   if (!credentials || !editableCredentials) {
     return <></>;
   }
@@ -645,20 +641,7 @@ export default function AddConnector({
                   null
                 }
               />
-              {docsLink && (
-                <p className="text-sm mb-4">
-                  Check out
-                  <a
-                    className="text-blue-600 hover:underline"
-                    target="_blank"
-                    href={docsLink}
-                  >
-                    {" "}
-                    our docs{" "}
-                  </a>
-                  for more information on setting up this connector.
-                </p>
-              )}
+              <ConnectorDocsLink sourceType={connector} />
             </CardSection>
           )}
 

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -647,16 +647,16 @@ export default function AddConnector({
               />
               {docsLink && (
                 <p className="text-sm mb-4">
-                  Check our
+                  Check out
                   <a
                     className="text-blue-600 hover:underline"
                     target="_blank"
                     href={docsLink}
                   >
                     {" "}
-                    docs{" "}
+                    our docs{" "}
                   </a>
-                  for information on setting up this connector.
+                  for more information on setting up this connector.
                 </p>
               )}
             </CardSection>

--- a/web/src/components/admin/connectors/ConnectorDocsLink.tsx
+++ b/web/src/components/admin/connectors/ConnectorDocsLink.tsx
@@ -22,6 +22,7 @@ export default function ConnectorDocsLink({
       <a
         className="text-blue-600 hover:underline"
         target="_blank"
+        rel="noopener"
         href={docsLink}
       >
         {" "}

--- a/web/src/components/admin/connectors/ConnectorDocsLink.tsx
+++ b/web/src/components/admin/connectors/ConnectorDocsLink.tsx
@@ -1,0 +1,33 @@
+import { ValidSources } from "@/lib/types";
+import { getSourceDocLink } from "@/lib/sources";
+
+export default function ConnectorDocsLink({
+  sourceType,
+  className,
+}: {
+  sourceType: ValidSources;
+  className?: string;
+}) {
+  const docsLink = getSourceDocLink(sourceType);
+
+  if (!docsLink) {
+    return null;
+  }
+
+  const paragraphClass = ["text-sm", className].filter(Boolean).join(" ");
+
+  return (
+    <p className={paragraphClass}>
+      Check out
+      <a
+        className="text-blue-600 hover:underline"
+        target="_blank"
+        href={docsLink}
+      >
+        {" "}
+        our docs{" "}
+      </a>
+      for more info on configuring this connector.
+    </p>
+  );
+}

--- a/web/src/components/credentials/actions/CreateCredential.tsx
+++ b/web/src/components/credentials/actions/CreateCredential.tsx
@@ -6,7 +6,6 @@ import { submitCredential } from "@/components/admin/connectors/CredentialForm";
 import { TextFormField } from "@/components/Field";
 import { Form, Formik, FormikHelpers } from "formik";
 import { PopupSpec } from "@/components/admin/connectors/Popup";
-import { getSourceDocLink } from "@/lib/sources";
 import GDriveMain from "@/app/admin/connectors/[connector]/pages/gdrive/GoogleDrivePage";
 import { Connector } from "@/lib/connectors/connectors";
 import { Credential, credentialTemplates } from "@/lib/connectors/credentials";
@@ -24,6 +23,7 @@ import { useUser } from "@/components/user/UserProvider";
 import CardSection from "@/components/admin/CardSection";
 import { CredentialFieldsRenderer } from "./CredentialFieldsRenderer";
 import { TypedFile } from "@/lib/connectors/fileTypes";
+import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
 
 const CreateButton = ({
   onClick,
@@ -213,20 +213,7 @@ export default function CreateCredential({
 
         return (
           <Form className="w-full flex items-stretch">
-            {!hideSource && (
-              <p className="text-sm">
-                Check our
-                <a
-                  className="text-blue-600 hover:underline"
-                  target="_blank"
-                  href={getSourceDocLink(sourceType) || ""}
-                >
-                  {" "}
-                  docs{" "}
-                </a>
-                for information on setting up this connector.
-              </p>
-            )}
+            {!hideSource && <ConnectorDocsLink sourceType={sourceType} />}
             <CardSection className="w-full items-start dark:bg-neutral-900 mt-4 flex flex-col gap-y-6">
               <TextFormField
                 name="name"


### PR DESCRIPTION
## Description

add docs link to the main connector creation page (previously only show on credential creation screen)

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a docs link to the main connector creation page so users can access setup instructions earlier. Also consolidates docs link rendering into a reusable component.

- **New Features**
  - Show a “docs” link on AddConnectorPage for the selected source (opens in a new tab, hidden if no link).

- **Refactors**
  - Introduced ConnectorDocsLink component and replaced inline link in CreateCredential.

<!-- End of auto-generated description by cubic. -->

