### PR TITLE
fix(infra): remove setfit dependency from api server

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -75,7 +75,6 @@ requests==2.32.5
 requests-oauthlib==1.3.1
 retry==0.9.2  # This pulls in py which is in CVE-2022-42969, must remove py from image
 rfc3986==1.5.0
-setfit==1.1.1
 simple-salesforce==1.12.6
 slack-sdk==3.20.2
 SQLAlchemy[mypy]==2.0.15


### PR DESCRIPTION
## Description

SetFit is a machine learning library for few-shot text classification
we use it in model server but not api server, not sure why its in the api server requirements txt rn

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
