### PR TITLE
fix: braintrust masking was over truncating

### DIFF
--- a/backend/onyx/evals/tracing.py
+++ b/backend/onyx/evals/tracing.py
@@ -7,18 +7,24 @@ from braintrust_langchain.callbacks import BraintrustCallbackHandler
 from onyx.configs.app_configs import BRAINTRUST_API_KEY
 from onyx.configs.app_configs import BRAINTRUST_PROJECT
 
+MASKING_LENGTH = 20000
 
-def _truncate_str(s: str, head: int = 800, tail: int = 200) -> str:
-    if len(s) <= head + tail:
-        return s
-    return f"{s[:head]}…{s[-tail:]}[TRUNCATED {len(s)} chars to 10,000]"
+
+def _truncate_str(s: str) -> str:
+    tail = MASKING_LENGTH // 5
+    head = MASKING_LENGTH - tail
+    return f"{s[:head]}…{s[-tail:]}[TRUNCATED {len(s)} chars to {MASKING_LENGTH}]"
+
+
+def _should_mask(data: Any) -> bool:
+    return len(str(data)) > MASKING_LENGTH
 
 
 def _mask(data: Any) -> Any:
-    data_str = str(data)
-    if len(data_str) > 10_000:
-        return _truncate_str(data_str)
-    return data
+    """Mask data based on span type. Only mask generic and function spans, not root, task, score, or LLM spans."""
+    if not _should_mask(data):
+        return data
+    return _truncate_str(str(data))
 
 
 def setup_braintrust() -> None:

--- a/backend/onyx/evals/tracing.py
+++ b/backend/onyx/evals/tracing.py
@@ -21,7 +21,7 @@ def _should_mask(data: Any) -> bool:
 
 
 def _mask(data: Any) -> Any:
-    """Mask data based on span type. Only mask generic and function spans, not root, task, score, or LLM spans."""
+    """Mask data if it exceeds the maximum length threshold."""
     if not _should_mask(data):
         return data
     return _truncate_str(str(data))

--- a/backend/onyx/evals/tracing.py
+++ b/backend/onyx/evals/tracing.py
@@ -18,7 +18,7 @@ def _truncate_str(s: str) -> str:
 
 def _mask(data: Any) -> Any:
     """Mask data if it exceeds the maximum length threshold."""
-    if not len(str(data)) <= MASKING_LENGTH:
+    if len(str(data)) <= MASKING_LENGTH:
         return data
     return _truncate_str(str(data))
 

--- a/backend/onyx/evals/tracing.py
+++ b/backend/onyx/evals/tracing.py
@@ -16,13 +16,9 @@ def _truncate_str(s: str) -> str:
     return f"{s[:head]}…{s[-tail:]}[TRUNCATED {len(s)} chars to {MASKING_LENGTH}]"
 
 
-def _should_mask(data: Any) -> bool:
-    return len(str(data)) > MASKING_LENGTH
-
-
 def _mask(data: Any) -> Any:
     """Mask data if it exceeds the maximum length threshold."""
-    if not _should_mask(data):
+    if not len(str(data)) <= MASKING_LENGTH:
         return data
     return _truncate_str(str(data))
 


### PR DESCRIPTION
## Description

was masking to 1000 characters (too aggressive)

## How Has This Been Tested?

tested locally

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes over-aggressive Braintrust tracing masking to preserve useful context while still limiting very large payloads. Increases the mask threshold to 20,000 characters and applies masking only when needed.

- **Bug Fixes**
  - Raised masking length to 20,000 chars with an 80/20 head/tail split.
  - Added a guard to skip masking for payloads under the threshold.
  - Standardized the truncation marker to include original length and target size.

<!-- End of auto-generated description by cubic. -->

