### PR TITLE
feat: add configurable LLM summarization for DR custom tools

### DIFF
--- a/backend/onyx/agents/agent_search/models.py
+++ b/backend/onyx/agents/agent_search/models.py
@@ -40,6 +40,8 @@ class GraphTooling(BaseModel):
     # force tool args IF the tool is used
     force_use_tool: ForceUseTool
     using_tool_calling_llm: bool = False
+    # Whether to use LLM to summarize custom tool responses in DR agent
+    dr_custom_tool_use_llm_summary: bool = True
 
     class Config:
         arbitrary_types_allowed = True

--- a/backend/onyx/chat/answer.py
+++ b/backend/onyx/chat/answer.py
@@ -20,6 +20,7 @@ from onyx.chat.prompt_builder.answer_prompt_builder import AnswerPromptBuilder
 from onyx.configs.agent_configs import AGENT_ALLOW_REFINEMENT
 from onyx.configs.agent_configs import INITIAL_SEARCH_DECOMPOSITION_ENABLED
 from onyx.configs.agent_configs import TF_DR_DEFAULT_FAST
+from onyx.configs.tool_configs import DR_CUSTOM_TOOL_USE_LLM_SUMMARY
 from onyx.context.search.models import RerankingDetails
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.models import Persona
@@ -105,6 +106,7 @@ class Answer:
             tools=tools or [],
             force_use_tool=force_use_tool,
             using_tool_calling_llm=using_tool_calling_llm,
+            dr_custom_tool_use_llm_summary=DR_CUSTOM_TOOL_USE_LLM_SUMMARY,
         )
         self.graph_persistence = GraphPersistence(
             db_session=db_session,

--- a/backend/onyx/configs/tool_configs.py
+++ b/backend/onyx/configs/tool_configs.py
@@ -24,3 +24,8 @@ if _CUSTOM_TOOL_PASS_THROUGH_HEADERS_RAW:
         logger.error(
             "Failed to parse CUSTOM_TOOL_PASS_THROUGH_HEADERS, must be a valid JSON object"
         )
+
+# Whether to use LLM to summarize custom tool responses in DR agent
+DR_CUSTOM_TOOL_USE_LLM_SUMMARY = (
+    os.environ.get("DR_CUSTOM_TOOL_USE_LLM_SUMMARY", "true").lower() == "true"
+)


### PR DESCRIPTION
Add DR_CUSTOM_TOOL_USE_LLM_SUMMARY config to control whether custom tool responses are summarized by LLM in DR agent. Defaults to true for backward compatibility. Set to false to return raw tool results directly.

## Description

In my case, I wanted the response of tool directly without being altered by LLM so put this logic behind a flag

## How Has This Been Tested?

Manual Testing

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [ ] [Optional] Override Linear Check
