### PR TITLE
feat(infra): Default to HPA w/ KEDA option

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -57,3 +57,14 @@ In the helm charts, we have resource suggestions for all Onyx-owned components.
 These are simply initial suggestions, and may need to be tuned for your specific use case.
 
 Please talk to us in Slack if you have any questions!
+
+## Autoscaling options
+The chart renders Kubernetes HorizontalPodAutoscalers by default. To keep this behavior, leave
+`autoscaling.engine` as `hpa` and adjust the per-component `autoscaling.*` values as needed.
+
+If you would like to use KEDA ScaledObjects instead:
+
+1. Install and manage the KEDA operator in your cluster yourself (for example via the official KEDA Helm chart). KEDA is no longer packaged as a dependency of the Onyx chart.
+2. Set `autoscaling.engine: keda` in your `values.yaml` and enable autoscaling for the components you want to scale.
+
+When `autoscaling.engine` is set to `keda`, the chart will render the existing ScaledObject templates; otherwise HPAs will be rendered.

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -2,9 +2,6 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 14.3.1
-- name: keda
-  repository: https://kedacore.github.io/charts
-  version: 2.17.2
 - name: vespa
   repository: https://onyx-dot-app.github.io/vespa-helm-charts
   version: 0.2.24
@@ -17,5 +14,5 @@ dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.0.4
-digest: sha256:65f817c945890803354d0c458f65c45c031d3578f724d35fd4b7ae54527db67a
-generated: "2025-09-16T16:50:26.180259-07:00"
+digest: sha256:dddd687525764f5698adc339a11d268b0ee9c3ca81f8d46c9e65a6bf2c21cf25
+generated: "2025-09-24T12:16:33.661608-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: latest
 annotations:
   category: Productivity
@@ -22,9 +22,6 @@ dependencies:
     version: 14.3.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
-  - name: keda
-    version: 2.17.2
-    repository: https://kedacore.github.io/charts
   - name: vespa
     version: 0.2.24
     repository: https://onyx-dot-app.github.io/vespa-helm-charts

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -85,3 +85,10 @@ Create env vars from secrets
     {{- end }}
 {{- end }}
 
+{{/*
+Return the configured autoscaling engine; defaults to HPA when unset.
+*/}}
+{{- define "onyx-stack.autoscaling.engine" -}}
+{{- $engine := default "hpa" .Values.autoscaling.engine -}}
+{{- $engine | lower -}}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/api-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/api-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.api.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.api.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -9,11 +9,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-<<<<<<< HEAD:deployment/helm/charts/onyx/templates_disabled/api-hpa.yaml
     name: {{ include "onyx.fullname" . }}
-=======
-    name: {{ include "onyx-stack.fullname" . }}-api-server
->>>>>>> 59a5dc26a (feat(infra): Defaul to HPA w/ KEDA option):deployment/helm/charts/onyx/templates/api-hpa.yaml
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/api-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/api-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.autoscaling.enabled }}
+{{- if and (.Values.api.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -9,7 +9,11 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
+<<<<<<< HEAD:deployment/helm/charts/onyx/templates_disabled/api-hpa.yaml
     name: {{ include "onyx.fullname" . }}
+=======
+    name: {{ include "onyx-stack.fullname" . }}-api-server
+>>>>>>> 59a5dc26a (feat(infra): Defaul to HPA w/ KEDA option):deployment/helm/charts/onyx/templates/api-hpa.yaml
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/api-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.api.autoscaling.enabled }}
+{{- if and (.Values.api.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_docfetching.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_docfetching.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching
+  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching
+    name: {{ include "onyx.fullname" . }}-celery-worker-docfetching
   minReplicas: {{ .Values.celery_worker_docfetching.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_docfetching.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_docfetching.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docfetching
+  minReplicas: {{ .Values.celery_worker_docfetching.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_docfetching.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_docfetching.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_docfetching.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_docfetching.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_docfetching.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_docfetching.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_docfetching.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_docprocessing.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_docprocessing.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing
+  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing
+    name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing
   minReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_docprocessing.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-docprocessing
+  minReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_docprocessing.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_docprocessing.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_docprocessing.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_docprocessing.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_docprocessing.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_docprocessing.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_docprocessing.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_heavy.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_heavy.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-heavy
+  name: {{ include "onyx.fullname" . }}-celery-worker-heavy
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-heavy
+    name: {{ include "onyx.fullname" . }}-celery-worker-heavy
   minReplicas: {{ .Values.celery_worker_heavy.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_heavy.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_heavy.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-heavy
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-heavy
+  minReplicas: {{ .Values.celery_worker_heavy.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_heavy.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_heavy.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_heavy.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_heavy.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_heavy.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_heavy.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_heavy.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_light.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-light
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-light
+  minReplicas: {{ .Values.celery_worker_light.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_light.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_light.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_light.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_light.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_light.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_light.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_light.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-light
+  name: {{ include "onyx.fullname" . }}-celery-worker-light
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-light
+    name: {{ include "onyx.fullname" . }}-celery-worker-light
   minReplicas: {{ .Values.celery_worker_light.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_light.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_light.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_light.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_monitoring.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_monitoring.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-monitoring
+  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-monitoring
+    name: {{ include "onyx.fullname" . }}-celery-worker-monitoring
   minReplicas: {{ .Values.celery_worker_monitoring.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_monitoring.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_monitoring.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-monitoring
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-monitoring
+  minReplicas: {{ .Values.celery_worker_monitoring.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_monitoring.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_monitoring.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_monitoring.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_monitoring.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_monitoring.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_monitoring.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_monitoring.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_primary.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-primary
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-primary
+  minReplicas: {{ .Values.celery_worker_primary.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_primary.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_primary.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_primary.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_primary.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_primary.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_primary.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_primary.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-primary
+  name: {{ include "onyx.fullname" . }}-celery-worker-primary
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-primary
+    name: {{ include "onyx.fullname" . }}-celery-worker-primary
   minReplicas: {{ .Values.celery_worker_primary.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_primary.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_primary.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_primary.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-hpa.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.celery_worker_user_files_indexing.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onyx-stack.fullname" . }}-celery-worker-user-files-indexing
+  labels:
+    {{- include "onyx-stack.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onyx-stack.fullname" . }}-celery-worker-user-files-indexing
+  minReplicas: {{ .Values.celery_worker_user_files_indexing.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.celery_worker_user_files_indexing.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.celery_worker_user_files_indexing.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_user_files_indexing.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.celery_worker_user_files_indexing.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.celery_worker_user_files_indexing.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-hpa.yaml
@@ -1,15 +1,15 @@
-{{- if and (.Values.celery_worker_user_files_indexing.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.celery_worker_user_files_indexing.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx-stack.fullname" . }}-celery-worker-user-files-indexing
+  name: {{ include "onyx.fullname" . }}-celery-worker-user-files-indexing
   labels:
-    {{- include "onyx-stack.labels" . | nindent 4 }}
+    {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx-stack.fullname" . }}-celery-worker-user-files-indexing
+    name: {{ include "onyx.fullname" . }}-celery-worker-user-files-indexing
   minReplicas: {{ .Values.celery_worker_user_files_indexing.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_user_files_indexing.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-files-indexing-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.celery_worker_user_files_indexing.autoscaling.enabled }}
+{{- if and (.Values.celery_worker_user_files_indexing.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.webserver.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
+{{- if and (.Values.webserver.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webserver.autoscaling.enabled }}
+{{- if and (.Values.webserver.autoscaling.enabled) (ne (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webserver.autoscaling.enabled }}
+{{- if and (.Values.webserver.autoscaling.enabled) (eq (include "onyx-stack.autoscaling.engine" .) "keda") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -69,6 +69,12 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+autoscaling:
+  # Valid options: 'hpa' (default) or 'keda'.
+  # Set to 'keda' to render KEDA ScaledObjects for components that have autoscaling enabled.
+  # When using KEDA you must install and manage the KEDA operator separately; it is not bundled with this chart.
+  engine: hpa
+
 inferenceCapability:
   service:
     portName: modelserver
@@ -213,7 +219,7 @@ webserver:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -294,7 +300,7 @@ api:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -390,7 +396,7 @@ celery_worker_heavy:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -425,7 +431,7 @@ celery_worker_docprocessing:
     maxReplicas: 20
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -460,7 +466,7 @@ celery_worker_light:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -495,7 +501,7 @@ celery_worker_monitoring:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -530,7 +536,7 @@ celery_worker_primary:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -565,7 +571,7 @@ celery_worker_user_files_indexing:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle
@@ -625,7 +631,7 @@ celery_worker_docfetching:
     maxReplicas: 20
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80
-    # KEDA specific configurations
+    # KEDA specific configurations (only used when autoscaling.engine is set to 'keda')
     pollingInterval: 30  # seconds
     cooldownPeriod: 300  # seconds
     idleReplicaCount: 1  # minimum replicas when idle


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Making KEDA an option that the customer can choose. This is to ensure that the dependency is not added. 

The customer is then in charge of adding the KEDA dependency and can manage that in their cluster. 

We needed to add HPA's for celery workers that did not have them previously to introduce autoscaling as well. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran helm template commands to validate that the charts were provisioned properly.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
