### PR TITLE
feat: support SharePoint Teams URLs

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -73,7 +73,8 @@ class SiteDescriptor(BaseModel):
     """Data class for storing SharePoint site information.
 
     Args:
-        url: The base site URL (e.g. https://danswerai.sharepoint.com/sites/sharepoint-tests)
+        url: The base site URL (e.g. https://danswerai.sharepoint.com/sites/sharepoint-tests
+             or https://danswerai.sharepoint.com/teams/team-name)
         drive_name: The name of the drive to access (e.g. "Shared Documents", "Other Library")
                    If None, all drives will be accessed.
         folder_path: The folder path within the drive to access (e.g. "test/nested with spaces")
@@ -703,9 +704,11 @@ class SharepointConnector(
 
         # Ensure sites are sharepoint urls
         for site_url in self.sites:
-            if not site_url.startswith("https://") or "/sites/" not in site_url:
+            if not site_url.startswith("https://") or not (
+                "/sites/" in site_url or "/teams/" in site_url
+            ):
                 raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site)"
+                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
                 )
 
     @property
@@ -720,10 +723,17 @@ class SharepointConnector(
         site_data_list = []
         for url in site_urls:
             parts = url.strip().split("/")
+
+            site_type_index = None
             if "sites" in parts:
-                sites_index = parts.index("sites")
-                site_url = "/".join(parts[: sites_index + 2])
-                remaining_parts = parts[sites_index + 2 :]
+                site_type_index = parts.index("sites")
+            elif "teams" in parts:
+                site_type_index = parts.index("teams")
+
+            if site_type_index is not None:
+                # Extract the base site URL (up to and including the site/team name)
+                site_url = "/".join(parts[: site_type_index + 2])
+                remaining_parts = parts[site_type_index + 2 :]
 
                 # Extract drive name and folder path
                 if remaining_parts:
@@ -745,7 +755,9 @@ class SharepointConnector(
                     )
                 )
             else:
-                logger.warning(f"Site URL '{url}' is not a valid Sharepoint URL")
+                logger.warning(
+                    f"Site URL '{url}' is not a valid Sharepoint URL (must contain /sites/ or /teams/)"
+                )
         return site_data_list
 
     def _get_drive_items_for_drive_name(


### PR DESCRIPTION
## Description

This commit adds support for Microsoft Teams SharePoint URLs (/teams/) in addition to the existing SharePoint site collection URLs (/sites/). Previously, the connector only worked with URLs like https://tenant.sharepoint.com/sites/sitename, but now it also supports https://gteu.sharepoint.com/teams/teamname.

## How Has This Been Tested?

I tested the functionality manually by building the images locally and starting the application.

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds support for SharePoint Teams URLs (/teams/) so the connector works with team sites as well as site collections. This enables URLs like https://tenant.sharepoint.com/teams/team-name to be validated and parsed correctly.

- **New Features**
  - Accepts /teams/ URLs in validation and parsing alongside /sites/.
  - Extracts base site/team URL, drive name, and optional folder path.

<!-- End of auto-generated description by cubic. -->

