### PR TITLE
feat(docker): Add DEV_MODE flag for exposing service ports

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Standard Dependencies
         run: |
           cd deployment/docker_compose
-          docker compose up -d minio relational_db cache index
+          DEV_MODE=true docker compose up -d minio relational_db cache index
 
       - name: Wait for services
         run: |

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -53,8 +53,9 @@ services:
       - inference_model_server
       - minio
     restart: unless-stopped
-    # ports:
-    #   - "8080:8080"
+    ports:
+      # DEV MODE: Exposed when DEV_MODE=true
+      - "${DEV_MODE:+8080:8080}"
     environment:
       # Auth Settings
       - AUTH_TYPE=${AUTH_TYPE:-basic}
@@ -228,8 +229,9 @@ services:
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
-    # ports:
-    #   - "5432:5432"
+    ports:
+      # DEV MODE: Exposed when DEV_MODE=true
+      - "${DEV_MODE:+5432:5432}"
     volumes:
       - db_volume:/var/lib/postgresql/data
 
@@ -239,9 +241,10 @@ services:
     restart: unless-stopped
     environment:
       - VESPA_SKIP_UPGRADE_CHECK=${VESPA_SKIP_UPGRADE_CHECK:-true}
-    # ports:
-    #   - "19071:19071"
-    #   - "8081:8081"
+    ports:
+      # DEV MODE: Exposed when DEV_MODE=true
+      - "${DEV_MODE:+19071:19071}"
+      - "${DEV_MODE:+8081:8081}"
     volumes:
       - vespa_volume:/opt/vespa/var
     logging:
@@ -286,8 +289,9 @@ services:
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    # ports:
-    #   - "6379:6379"
+    ports:
+      # DEV MODE: Exposed when DEV_MODE=true
+      - "${DEV_MODE:+6379:6379}"
     # docker silently mounts /data even without an explicit volume mount, which enables
     # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
@@ -295,9 +299,10 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
-    # ports:
-    #   - "9004:9000"
-    #   - "9005:9001"
+    ports:
+      # DEV MODE: Exposed when DEV_MODE=true
+      - "${DEV_MODE:+9000:9000}"
+      - "${DEV_MODE:+9001:9001}"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}


### PR DESCRIPTION
- Add single DEV_MODE environment variable to control port exposure
- When DEV_MODE=true, exposes ports for api_server, postgres, vespa, redis, and minio
- Update external dependency unit test workflow to use DEV_MODE=true
- Simplifies switching between production (no exposed ports) and dev/test configurations

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check
