### PR TITLE
fix: update seeded docs connector name

### DIFF
--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -178,7 +178,7 @@ def seed_initial_documents(
     # Create a connector so the user can delete it if they want
     # or reindex it with a new search model if they want
     connector_data = ConnectorBase(
-        name="Sample Use Cases",
+        name="Onyx Docs Overview",
         source=DocumentSource.WEB,
         input_type=InputType.LOAD_STATE,
         connector_specific_config={


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the default seeded docs connector from "Sample Use Cases" to "Onyx Docs Overview" to better match the content and reduce UI confusion. Applies to new seeding runs; existing connectors are unchanged.

<!-- End of auto-generated description by cubic. -->

