### PR TITLE
fix: LlmPopover after filling in an initial model

### DIFF
--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -703,7 +703,7 @@ export function useLlmManager(
     } else {
       setTemperature(0.5);
     }
-  }, [liveAssistant, currentChatSession]);
+  }, [liveAssistant, currentChatSession, llmProviders]);
 
   const updateTemperature = (temperature: number) => {
     if (isAnthropic(currentLlm.provider, currentLlm.modelName)) {


### PR DESCRIPTION
## Description

^

Fixes https://linear.app/danswer/issue/DAN-2501/after-putting-in-llm-key-models-dont-automatically-update-giving-the

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes startup by ensuring temperature is initialized when LLM providers load. Added llmProviders to the useLlmManager effect dependencies to avoid stale temperature on initial run.

<!-- End of auto-generated description by cubic. -->

