### PR TITLE
fix:modal content cut off got fix

### DIFF
--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -91,7 +91,7 @@ export function Modal({
           flex-col
 
           ${heightOverride ? `h-${heightOverride}` : "max-h-[90vh]"}
-          ${hideOverflow ? "overflow-hidden" : "overflow-visible"}
+          ${hideOverflow ? "overflow-hidden" : "overflow-scroll"}
         `}
       >
         {onOutsideClick && !hideCloseButton && (


### PR DESCRIPTION
## Description

* Updated the scroll effect from `visible` to `scroll` to allow modal content to be scrollable when overflowing.

## How Has This Been Tested?

* Manually verified the modal content overflow behavior.

### Previously

<img width="1016" height="703" alt="Screenshot 2025-09-27 at 12 11 55 PM" src="https://github.com/user-attachments/assets/afa21031-8f12-4382-90c7-b7427e3b4c98" />

### Now


https://github.com/user-attachments/assets/a6db9255-7c16-4012-b4a0-d4fb4fe1ecf0



---

**Fixes:** #5515



    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed modal content being cut off by making the modal container scrollable when content overflows.

- **Bug Fixes**
  - In Modal.tsx, replaced overflow-visible with overflow-scroll when overflow is not hidden, allowing content past max-h-[90vh] to be scrolled.

<!-- End of auto-generated description by cubic. -->

