### PR TITLE
feat(chat): add popup handling for image file selection in ChatInputBar

### DIFF
--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -1256,6 +1256,7 @@ export function ChatPage({
                                 }
                                 textAreaRef={textAreaRef}
                                 setPresentingDocument={setPresentingDocument}
+                                setPopup={setPopup}
                               />
                             </div>
 


### PR DESCRIPTION
## Description
Prevent users from attaching images in chat from recent files when a non-vision model is selected.
ticket -> https://linear.app/danswer/issue/DAN-2681/chat-page-functionality-with-non-vision-models-is-very-inconsistent

## How Has This Been Tested?
In the UI

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent image attachments from recent files when the selected model doesn’t support vision. Shows an error popup and avoids duplicate attachments.

- **Bug Fixes**
  - Validate recent-file picks with modelSupportsImageInput; detect images via MIME or ChatFileType.
  - Show an error popup prompting users to switch to a Vision-capable model (wired via setPopup from ChatPage).
  - Skip adding files that are already attached.

<!-- End of auto-generated description by cubic. -->

