### PR TITLE
fix(saml): GET Method for SAML Callback

### DIFF
--- a/backend/ee/onyx/server/auth_check.py
+++ b/backend/ee/onyx/server/auth_check.py
@@ -15,7 +15,8 @@ EE_PUBLIC_ENDPOINT_SPECS = PUBLIC_ENDPOINT_SPECS + [
     ("/auth/oidc/callback", {"GET"}),
     # saml
     ("/auth/saml/authorize", {"GET"}),
-    ("/auth/saml/callback", {"GET", "POST"}),
+    ("/auth/saml/callback", {"POST"}),
+    ("/auth/saml/callback", {"GET"}),
     ("/auth/saml/logout", {"POST"}),
 ]
 

--- a/backend/ee/onyx/server/auth_check.py
+++ b/backend/ee/onyx/server/auth_check.py
@@ -15,7 +15,7 @@ EE_PUBLIC_ENDPOINT_SPECS = PUBLIC_ENDPOINT_SPECS + [
     ("/auth/oidc/callback", {"GET"}),
     # saml
     ("/auth/saml/authorize", {"GET"}),
-    ("/auth/saml/callback", {"POST"}),
+    ("/auth/saml/callback", {"GET", "POST"}),
     ("/auth/saml/logout", {"POST"}),
 ]
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
SAML seemed to be only implemented to handle POST requests for the callback function. This may have worked for Okta and some other applications but for Entra ID it seems that we will need to handle the callback as a GET request not a POST request. 

Customer reported issue: 
<img width="2474" height="1293" alt="image" src="https://github.com/user-attachments/assets/74ff9ff0-e1cf-4b09-bc11-a093930a350d" />

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran tests locally to ensure that the old workflow is still intact while supporting GET functions now moving forward.

## Additional Options

- [x] [Optional] Override Linear Check
