### PR TITLE
fix: set gpt-5 thinking setting

### DIFF
--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -438,6 +438,23 @@ class DefaultMultiLLM(LLM):
                     else {}
                 ),  # TODO: remove once LITELLM has patched
                 **(
+                    {"reasoning_effort": "minimal"}
+                    if self.config.model_name
+                    in [
+                        "gpt-5",
+                    ]
+                    else {}
+                ),  # TODO: remove once LITELLM has better support
+                **(
+                    {"reasoning_effort": "minimal"}
+                    if self.config.model_name
+                    in [
+                        "gpt-5-mini",
+                        "gpt-5-nano",
+                    ]
+                    else {}
+                ),  # TODO: remove once LITELLM has better support
+                **(
                     {"response_format": structured_response_format}
                     if structured_response_format
                     else {}

--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -453,7 +453,7 @@ class DefaultMultiLLM(LLM):
                         "gpt-5-nano",
                     ]
                     else {}
-                ),  # TODO: remove once LITELLM has better support
+                ),  # TODO: remove later. Separate from GPT-5 setting in case we want to set this to low.
                 **(
                     {"response_format": structured_response_format}
                     if structured_response_format

--- a/backend/onyx/llm/chat_llm.py
+++ b/backend/onyx/llm/chat_llm.py
@@ -442,18 +442,11 @@ class DefaultMultiLLM(LLM):
                     if self.config.model_name
                     in [
                         "gpt-5",
-                    ]
-                    else {}
-                ),  # TODO: remove once LITELLM has better support
-                **(
-                    {"reasoning_effort": "minimal"}
-                    if self.config.model_name
-                    in [
                         "gpt-5-mini",
                         "gpt-5-nano",
                     ]
                     else {}
-                ),  # TODO: remove later. Separate from GPT-5 setting in case we want to set this to low.
+                ),  # TODO: remove once LITELLM has better support/we change API
                 **(
                     {"response_format": structured_response_format}
                     if structured_response_format

--- a/backend/onyx/prompts/dr_prompts.py
+++ b/backend/onyx/prompts/dr_prompts.py
@@ -714,13 +714,15 @@ information that will be necessary to provide a succinct answer to the specific 
 the documents. Again, start out here as well with a brief statement whether the SPECIFIC CONTEXT is \
 mentioned in the documents. (Example: 'I was not able to find information about yellow curry specifically, \
 but I found information about curry...'). But this should be be precise and concise, and specifically \
-answer the question. Please cite the document sources inline in format [[1]][[7]], etc.>",
+answer the question. Please cite the document sources inline in format [[1]][[7]], etc., where it \
+is essential that the document NUMBERS are in the brackets, not any titles.>",
    "claims": "<a list of short claims discussed in the documents as they pertain to the query and/or \
 the original question. These will later be used for follow-up questions and verifications. Note that \
 these may not actually be in the succinct answer above. Note also that each claim \
 should include ONE fact that contains enough context to be verified/questioned by a different system \
 without the need for going back to these documents for additional context. Also here, please cite the \
-document sources inline in format [[1]][[7]], etc.. So this should have format like \
+document sources inline in format [[1]][[7]], etc., where it is essential that the document NUMBERS are \
+in the brackets, not any titles. So this should have format like \
 [<claim 1>, <claim 2>, <claim 3>, ...], each with citations.>"
 }
 """
@@ -1043,8 +1045,9 @@ find information about yellow curry specifically, but here is what I found about
 - do not make anything up! Only use the information provided in the documents, or, \
 if no documents are provided for a sub-answer, in the actual sub-answer.
 - Provide a thoughtful answer that is concise and to the point, but that is detailed.
-- Please cite your sources INLINE in format [[2]][[4]], etc! The numbers of the documents \
-are provided above. So the appropriate citation number should be close to the corresponding /
+- Please cite your sources INLINE in format [[2]][[4]], etc! The NUMBERS of the documents \
+are provided above, and the NUMBERS need to be in the brackets. And the appropriate citation \
+ should be close to the corresponding /
 information it supports!
 - If you are not that certain that the information does relate to the question topic, \
 point out the ambiguity in your answer. But DO NOT say something like 'I was not able to find \
@@ -1098,14 +1101,16 @@ find information about yellow curry specifically, but here is what I found about
 - do not make anything up! Only use the information provided in the documents, or, \
 if no documents are provided for a sub-answer, in the actual sub-answer.
 - Provide a thoughtful answer that is concise and to the point, but that is detailed.
-- Please cite your sources inline in format [[2]][[4]], etc! The numbers of the documents \
-are provided above. So the appropriate citation number should be close to the corresponding /
+- Please cite your sources inline in format [[2]][[4]], etc! The NUMBERS of the documents \
+are provided above, and the NUMBERS need to be in the brackets. And the appropriate citation \
+should be close to the corresponding /
 information it supports!
 - If you are not that certain that the information does relate to the question topic, \
 point out the ambiguity in your answer. But DO NOT say something like 'I was not able to find \
 information on <X> specifically, but here is what I found about <X> generally....'. Rather say, \
 'Here is what I found about <X> and I hope this is the <X> you were looking for...', or similar.
-- Again... CITE YOUR SOURCES INLINE IN FORMAT [[2]][[4]], etc! This is CRITICAL!
+- Again... CITE YOUR SOURCES INLINE IN FORMAT [[2]][[4]], etc! This is CRITICAL! Note that \
+the DOCUMENT NUMBERS need to be in the brackets.
 
 ANSWER:
 """
@@ -1150,8 +1155,9 @@ find information about yellow curry specifically, but here is what I found about
 - do not make anything up! Only use the information provided in the documents, or, \
 if no documents are provided for a sub-answer, in the actual sub-answer.
 - Provide a thoughtful answer that is concise and to the point, but that is detailed.
-- THIS IS VERY IMPORTANT: Please cite your sources inline in format [[2]][[4]], etc! The numbers of the documents \
-are provided above. Also, if you refer to sub-answers, the provided reference numbers \
+- THIS IS VERY IMPORTANT: Please cite your sources inline in format [[2]][[4]], etc! \
+The NUMBERS of the documents - provided above -need to be in the brackets. \
+Also, if you refer to sub-answers, the provided reference numbers \
 in the sub-answers are the same as the ones provided for the documents!
 
 ANSWER:


### PR DESCRIPTION
## Description

Set thinking effort to 'minimal' for gpt-5 and its faster siblings, effectively making them (for now) for our purposes non-thinking models. 

The change also incorporates minor prompt changes to avoid citations of the form [[<document title>]]

Linear: https://linear.app/danswer/issue/DAN-2685/make-gpt-5-useful

NOTE: this is not a transition to the new OpenAI response API. It is rather applying the reasoning_effort parameter in LightLLMs Completion API also to GPT-5 models.

## How Has This Been Tested?

Locally

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Forces minimal reasoning for the gpt-5 family and tightens prompt citation rules to stop title-based brackets. Improves speed and consistency and addresses Linear DAN-2685.

- **Bug Fixes**
  - Set reasoning_effort: "minimal" for gpt-5, gpt-5-mini, and gpt-5-nano in Completion calls.
  - Updated prompts to require numeric inline citations (e.g., [[1]]) and disallow titles in brackets.

<!-- End of auto-generated description by cubic. -->

