### PR TITLE
fix: project migration tweak

### DIFF
--- a/backend/alembic/versions/2b75d0a8ffcb_user_file_schema_cleanup.py
+++ b/backend/alembic/versions/2b75d0a8ffcb_user_file_schema_cleanup.py
@@ -128,7 +128,7 @@ def upgrade() -> None:
                     AND a.attname = 'cc_pair_id'
                   )
               ) LOOP
-                EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT %I', r.conname);
+                EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT IF EXISTS %I', r.conname);
               END LOOP;
             END$$;
         """

--- a/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
+++ b/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
@@ -170,7 +170,7 @@ def upgrade() -> None:
         # Clean child tables first to satisfy foreign key constraints,
         # then the parent tables
         tables_to_clean = [
-            ("index_attempt_errors", "cc_pair_id"),
+            ("index_attempt_errors", "connector_credential_pair_id"),
             ("index_attempt", "connector_credential_pair_id"),
             ("background_error", "cc_pair_id"),
             ("document_set__connector_credential_pair", "connector_credential_pair_id"),

--- a/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
+++ b/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
@@ -245,7 +245,7 @@ def upgrade() -> None:
                   AND t.relname = 'user_file'
                   AND ft.relname = 'connector_credential_pair'
               ) LOOP
-                EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT %I', r.conname);
+                EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT IF EXISTS %I', r.conname);
               END LOOP;
             END$$;
         """

--- a/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
+++ b/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
@@ -167,7 +167,10 @@ def upgrade() -> None:
         )
 
         # Delete related records
+        # Clean child tables first to satisfy foreign key constraints,
+        # then the parent tables
         tables_to_clean = [
+            ("index_attempt_errors", "cc_pair_id"),
             ("index_attempt", "connector_credential_pair_id"),
             ("background_error", "cc_pair_id"),
             ("document_set__connector_credential_pair", "connector_credential_pair_id"),


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix migration cleanup order to delete index_attempt_errors (child table) before parent tables, satisfying foreign key constraints and preventing upgrade failures during user_file legacy data cleanup.

<!-- End of auto-generated description by cubic. -->

