### PR TITLE
fix(projects): Fix Migration

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -236,7 +236,11 @@ def process_single_user_file(self: Task, *, user_file_id: str, tenant_id: str) -
                     f"process_single_user_file - Indexing pipeline completed ={index_pipeline_result}"
                 )
 
-                if index_pipeline_result.failures:
+                if (
+                    index_pipeline_result.failures
+                    or index_pipeline_result.total_docs != len(documents)
+                    or index_pipeline_result.total_chunks == 0
+                ):
                     task_logger.error(
                         f"process_single_user_file - Indexing pipeline failed id={user_file_id}"
                     )
@@ -543,33 +547,58 @@ def user_file_docid_migration_task(self: Task, *, tenant_id: str) -> bool:
                         f"Tenant={tenant_id} failed Vespa update for doc_id={new_uuid} - {e.__class__.__name__}"
                     )
             # Update search_doc records to refer to the UUID string
-            # Use a grouped mapping (one row per legacy document_id) to avoid scalar subquery cardinality errors
-            uf_map = (
-                sa.select(
-                    UserFile.document_id.label("document_id"),
-                    sa.cast(sa.func.min(UserFile.id), sa.String).label("new_id"),
+            # we are not using document_id_migrated = false because if the migration already completed,
+            # it will not run again and we will not update the search_doc records because of the issue currently fixed
+            user_files = (
+                db_session.execute(
+                    sa.select(UserFile).where(UserFile.document_id.is_not(None))
                 )
-                .where(
-                    UserFile.document_id.is_not(None),
-                    UserFile.document_id_migrated.is_(False),
-                )
-                .group_by(UserFile.document_id)
-                .subquery()
+                .scalars()
+                .all()
             )
 
-            db_session.execute(
-                sa.update(SearchDoc)
-                .where(SearchDoc.document_id == uf_map.c.document_id)
-                .values(document_id=uf_map.c.new_id)
-            )
-            # Mark all processed user_files as migrated
-            db_session.execute(
-                sa.update(UserFile)
-                .where(
-                    UserFile.document_id.is_not(None),
-                    UserFile.document_id_migrated.is_(False),
+            # Query all SearchDocs that need updating
+            search_docs = (
+                db_session.execute(
+                    sa.select(SearchDoc).where(
+                        SearchDoc.document_id.like("%FILE_CONNECTOR__%")
+                    )
                 )
-                .values(document_id_migrated=True)
+                .scalars()
+                .all()
+            )
+
+            task_logger.info(f"Found {len(user_files)} user files to update")
+            task_logger.info(f"Found {len(search_docs)} search docs to update")
+
+            # Build a map of normalized doc IDs to SearchDocs
+            search_doc_map: dict[str, list[SearchDoc]] = {}
+            for sd in search_docs:
+                doc_id = sd.document_id
+                if search_doc_map.get(doc_id) is None:
+                    search_doc_map[doc_id] = []
+                search_doc_map[doc_id].append(sd)
+
+            # Process each UserFile and update matching SearchDocs
+            updated_count = 0
+            for uf in user_files:
+                doc_id = uf.document_id
+                if doc_id.startswith("USER_FILE_CONNECTOR__"):
+                    doc_id = "FILE_CONNECTOR__" + doc_id[len("USER_FILE_CONNECTOR__") :]
+
+                if doc_id in search_doc_map:
+                    # Update the SearchDoc to use the UserFile's UUID
+                    for search_doc in search_doc_map[doc_id]:
+                        search_doc.document_id = str(uf.id)
+                        db_session.add(search_doc)
+
+                    # Mark UserFile as migrated
+                    uf.document_id_migrated = True
+                    db_session.add(uf)
+                    updated_count += 1
+
+            task_logger.info(
+                f"Updated {updated_count} SearchDoc records with new UUIDs"
             )
             db_session.commit()
 


### PR DESCRIPTION
## Description
This pull request improves the reliability of user file indexing and refactors the user file document ID migration process to ensure all relevant records are correctly updated, even if previous migrations were incomplete.
## How Has This Been Tested?
I tested by running the migration

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improves user file indexing reliability and makes the document ID migration resilient so SearchDoc records correctly point to UserFile UUIDs, even when previous migrations were incomplete.

- **Bug Fixes**
  - Treat indexing as failed if there are failures, doc count mismatch, or zero chunks to avoid partial indexing.

- **Migration**
  - Iteratively match UserFiles to SearchDocs, normalizing legacy IDs (USER_FILE_CONNECTOR__ → FILE_CONNECTOR__), and update SearchDoc.document_id to the UserFile UUID.
  - Do not rely on document_id_migrated=false so SearchDocs still get fixed after earlier partial runs.
  - Mark updated UserFiles as migrated and log update counts; commit once after batch updates.

<!-- End of auto-generated description by cubic. -->

