### PR TITLE
avoid attempting to retrieve with non-org owners

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1137,7 +1137,9 @@ class GoogleDriveConnector(
                         convert_func,
                         (
                             [file.user_email, self.primary_admin_email]
-                            + get_file_owners(file.drive_file),
+                            + get_file_owners(
+                                file.drive_file, self.primary_admin_email
+                            ),
                             file.drive_file,
                         ),
                     )

--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -97,14 +97,15 @@ def _execute_with_retry(request: Any) -> Any:
     raise Exception(f"Failed to execute request after {max_attempts} attempts")
 
 
-def get_file_owners(file: GoogleDriveFileType) -> list[str]:
+def get_file_owners(file: GoogleDriveFileType, primary_admin_email: str) -> list[str]:
     """
     Get the owners of a file if the attribute is present.
     """
     return [
-        owner.get("emailAddress")
+        email
         for owner in file.get("owners", [])
-        if owner.get("emailAddress")
+        if (email := owner.get("emailAddress"))
+        and email.split("@")[-1] == primary_admin_email.split("@")[-1]
     ]
 
 


### PR DESCRIPTION
## Description

We expected some calls to result in 403s before due to non-Drive owners; these calls will always fail so we're just not going to make them anymore. This hopefully will address some unauthorized_client issues we've been seeing as well.

## How Has This Been Tested?

n/a, minor change that should be completely safe. Will rely on CI drive tests as a sanity check

## Additional Options

- [ ] [Optional] Override Linear Check
