### PR TITLE
trial/search-as-you-type

### DIFF
--- a/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
+++ b/backend/onyx/document_index/vespa/app_config/schemas/danswer_chunk.sd.jinja
@@ -37,6 +37,7 @@ schema {{ schema_name }} {
         field title type string {
             indexing: summary | index | attribute
             index: enable-bm25
+            match: text
         }
         field content type string {
             indexing: summary | index


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds search-as-you-type suggestions in the chat input that surface top matching documents with quick links. Introduces a low-latency backend keyword search endpoint to power the typeahead.

- **New Features**
  - Backend: new POST /api/query/fast-document-search returning top_matching_document_candidates (title, blurb, source_link), deduped by document_id and limited via retrieval_options.limit.
  - Backend: fast Vespa query on title OR content (contains @query), filters out hidden and non-public docs.
  - Backend: updates Vespa schema to enable text matching on title (match: text).
  - Frontend: typeahead in ChatInputBar with 25ms debounce, request aborting, keyboard navigation (ArrowUp/Down, Enter), accessible listbox, and opens links in a new tab.

<!-- End of auto-generated description by cubic. -->

