### PR TITLE
fix: minor mcp fixes + test

### DIFF
--- a/backend/onyx/connectors/hubspot/rate_limit.py
+++ b/backend/onyx/connectors/hubspot/rate_limit.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+from typing import TypeVar
+
+from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
+    rate_limit_builder,
+)
+from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
+    RateLimitTriedTooManyTimesError,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+T = TypeVar("T")
+
+# HubSpot exposes a ten second rolling window (x-hubspot-ratelimit-interval-milliseconds)
+# with a maximum of 190 requests, and a per-second limit of 19 requests.
+_HUBSPOT_TEN_SECOND_LIMIT = 190
+_HUBSPOT_TEN_SECOND_PERIOD = 10  # seconds
+_HUBSPOT_SECONDLY_LIMIT = 19
+_HUBSPOT_SECONDLY_PERIOD = 1  # second
+_DEFAULT_SLEEP_SECONDS = 10
+_SLEEP_PADDING_SECONDS = 1.0
+_MAX_RATE_LIMIT_RETRIES = 5
+
+
+def _extract_header(headers: Any, key: str) -> str | None:
+    if headers is None:
+        return None
+
+    getter = getattr(headers, "get", None)
+    if callable(getter):
+        value = getter(key)
+        if value is not None:
+            return value
+
+    if isinstance(headers, dict):
+        value = headers.get(key)
+        if value is not None:
+            return value
+
+    return None
+
+
+def is_rate_limit_error(exception: Exception) -> bool:
+    status = getattr(exception, "status", None)
+    if status == 429:
+        return True
+
+    headers = getattr(exception, "headers", None)
+    if headers is not None:
+        remaining = _extract_header(headers, "x-hubspot-ratelimit-remaining")
+        if remaining == "0":
+            return True
+        secondly_remaining = _extract_header(
+            headers, "x-hubspot-ratelimit-secondly-remaining"
+        )
+        if secondly_remaining == "0":
+            return True
+
+    message = str(exception)
+    return "RATE_LIMIT" in message or "Too Many Requests" in message
+
+
+def get_rate_limit_retry_delay_seconds(exception: Exception) -> float:
+    headers = getattr(exception, "headers", None)
+
+    retry_after = _extract_header(headers, "Retry-After")
+    if retry_after:
+        try:
+            return float(retry_after) + _SLEEP_PADDING_SECONDS
+        except ValueError:
+            logger.debug(
+                "Failed to parse Retry-After header '%s' as float", retry_after
+            )
+
+    interval_ms = _extract_header(headers, "x-hubspot-ratelimit-interval-milliseconds")
+    if interval_ms:
+        try:
+            return float(interval_ms) / 1000.0 + _SLEEP_PADDING_SECONDS
+        except ValueError:
+            logger.debug(
+                "Failed to parse x-hubspot-ratelimit-interval-milliseconds '%s' as float",
+                interval_ms,
+            )
+
+    secondly_limit = _extract_header(headers, "x-hubspot-ratelimit-secondly")
+    if secondly_limit:
+        try:
+            per_second = max(float(secondly_limit), 1.0)
+            return (1.0 / per_second) + _SLEEP_PADDING_SECONDS
+        except ValueError:
+            logger.debug(
+                "Failed to parse x-hubspot-ratelimit-secondly '%s' as float",
+                secondly_limit,
+            )
+
+    return _DEFAULT_SLEEP_SECONDS + _SLEEP_PADDING_SECONDS
+
+
+class HubSpotRateLimiter:
+    def __init__(
+        self,
+        *,
+        ten_second_limit: int = _HUBSPOT_TEN_SECOND_LIMIT,
+        ten_second_period: int = _HUBSPOT_TEN_SECOND_PERIOD,
+        secondly_limit: int = _HUBSPOT_SECONDLY_LIMIT,
+        secondly_period: int = _HUBSPOT_SECONDLY_PERIOD,
+        max_retries: int = _MAX_RATE_LIMIT_RETRIES,
+    ) -> None:
+        self._max_retries = max_retries
+
+        @rate_limit_builder(max_calls=secondly_limit, period=secondly_period)
+        @rate_limit_builder(max_calls=ten_second_limit, period=ten_second_period)
+        def _execute(callable_: Callable[[], T]) -> T:
+            return callable_()
+
+        self._execute = _execute
+
+    def call(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        attempts = 0
+
+        while True:
+            try:
+                return self._execute(lambda: func(*args, **kwargs))
+            except Exception as exc:  # pylint: disable=broad-except
+                if not is_rate_limit_error(exc):
+                    raise
+
+                attempts += 1
+                if attempts > self._max_retries:
+                    raise RateLimitTriedTooManyTimesError(
+                        "Exceeded configured HubSpot rate limit retries"
+                    ) from exc
+
+                wait_time = get_rate_limit_retry_delay_seconds(exc)
+                logger.notice(
+                    "HubSpot rate limit reached. Sleeping %.2f seconds before retrying.",
+                    wait_time,
+                )
+                time.sleep(wait_time)

--- a/backend/onyx/server/documents/standard_oauth.py
+++ b/backend/onyx/server/documents/standard_oauth.py
@@ -22,7 +22,7 @@ from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import CredentialBase
 from onyx.utils.logger import setup_logger
-from onyx.utils.subclasses import find_all_subclasses_in_dir
+from onyx.utils.subclasses import find_all_subclasses_in_package
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -44,7 +44,8 @@ def _discover_oauth_connectors() -> dict[DocumentSource, type[OAuthConnector]]:
     if _OAUTH_CONNECTORS:  # Return cached connectors if already discovered
         return _OAUTH_CONNECTORS
 
-    oauth_connectors = find_all_subclasses_in_dir(
+    # Import submodules using package-based discovery to avoid sys.path mutations
+    oauth_connectors = find_all_subclasses_in_package(
         cast(type[OAuthConnector], OAuthConnector), "onyx.connectors"
     )
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1218,7 +1218,10 @@ def _upsert_mcp_server(
 
         logger.info(f"Created new MCP server '{request.name}' with ID {mcp_server.id}")
 
-    if not changing_connection_config:
+    if (
+        not changing_connection_config
+        or request.auth_type == MCPAuthenticationType.NONE
+    ):
         return mcp_server
 
     # Create connection configs

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -56,7 +56,7 @@ class MCPTool(BaseTool):
         self._tool_definition = tool_definition
         self._description = tool_description
         self._display_name = tool_definition.get("displayName", tool_name)
-        self._llm_name = f"mcp_{mcp_server.name}_{tool_name}"
+        self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
 
     @property
     def id(self) -> int:

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_no_auth.py
@@ -1,3 +1,5 @@
+import os
+
 from fastmcp import FastMCP
 from fastmcp.server.server import FunctionTool
 
@@ -28,4 +30,7 @@ def make_many_tools() -> list[FunctionTool]:
 if __name__ == "__main__":
     # Streamable HTTP transport (recommended)
     make_many_tools()
-    mcp.run(transport="http", host="127.0.0.1", port=8000, path="/mcp")
+    host = os.getenv("MCP_SERVER_BIND_HOST", "0.0.0.0")
+    port = int(os.getenv("MCP_SERVER_PORT", "8000"))
+    path = os.getenv("MCP_SERVER_PATH", "/mcp")
+    mcp.run(transport="http", host=host, port=port, path=path)

--- a/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
@@ -21,12 +21,8 @@ MCP_SERVER_PORT = 8000
 MCP_SERVER_URL = f"http://{MCP_SERVER_HOST}:{MCP_SERVER_PORT}/mcp"
 MCP_HELLO_TOOL = "hello"
 
-REPO_ROOT = Path(__file__).resolve().parents[5]
 MCP_SERVER_SCRIPT = (
-    REPO_ROOT
-    / "backend"
-    / "tests"
-    / "integration"
+    Path(__file__).resolve().parents[2]
     / "mock_services"
     / "mcp_test_server"
     / "run_mcp_server_no_auth.py"
@@ -59,7 +55,7 @@ def _wait_for_port(
 def mcp_no_auth_server() -> Generator[None, None, None]:
     process = subprocess.Popen(
         [sys.executable, str(MCP_SERVER_SCRIPT)],
-        cwd=REPO_ROOT,
+        cwd=MCP_SERVER_SCRIPT.parent,
     )
 
     try:

--- a/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import subprocess
 import sys
@@ -16,8 +17,8 @@ from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
 
-MCP_SERVER_HOST = "127.0.0.1"
-MCP_SERVER_PORT = 8000
+MCP_SERVER_HOST = os.getenv("TEST_WEB_HOSTNAME", "127.0.0.1")
+MCP_SERVER_PORT = int(os.getenv("MCP_SERVER_PORT", "8000"))
 MCP_SERVER_URL = f"http://{MCP_SERVER_HOST}:{MCP_SERVER_PORT}/mcp"
 MCP_HELLO_TOOL = "hello"
 

--- a/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_no_auth_flow.py
@@ -1,0 +1,151 @@
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+import requests
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+MCP_SERVER_HOST = "127.0.0.1"
+MCP_SERVER_PORT = 8000
+MCP_SERVER_URL = f"http://{MCP_SERVER_HOST}:{MCP_SERVER_PORT}/mcp"
+MCP_HELLO_TOOL = "hello"
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+MCP_SERVER_SCRIPT = (
+    REPO_ROOT
+    / "backend"
+    / "tests"
+    / "integration"
+    / "mock_services"
+    / "mcp_test_server"
+    / "run_mcp_server_no_auth.py"
+)
+
+
+def _wait_for_port(
+    host: str,
+    port: int,
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float = 10.0,
+) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_seconds:
+        if process.poll() is not None:
+            raise RuntimeError("MCP server process exited unexpectedly during startup")
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect((host, port))
+                return
+            except OSError:
+                time.sleep(0.1)
+
+    raise TimeoutError("Timed out waiting for MCP server to accept connections")
+
+
+@pytest.fixture(scope="module")
+def mcp_no_auth_server() -> Generator[None, None, None]:
+    process = subprocess.Popen(
+        [sys.executable, str(MCP_SERVER_SCRIPT)],
+        cwd=REPO_ROOT,
+    )
+
+    try:
+        _wait_for_port(MCP_SERVER_HOST, MCP_SERVER_PORT, process)
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_mcp_server_exists() -> None:
+    if not MCP_SERVER_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"Expected MCP server script at {MCP_SERVER_SCRIPT}, but it was not found"
+        )
+
+
+def test_mcp_no_auth_flow(
+    mcp_no_auth_server: None,
+    reset: None,
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+) -> None:
+    # Step a) Create a no-auth MCP server via the admin API
+    create_response = requests.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/create",
+        json={
+            "name": "integration-mcp-no-auth",
+            "description": "Integration test MCP server",
+            "server_url": MCP_SERVER_URL,
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+            "auth_type": MCPAuthenticationType.NONE.value,
+            "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
+        },
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    create_response.raise_for_status()
+    server_id = create_response.json()["server_id"]
+
+    # Step b) Attach the "hello" tool from the MCP server
+    update_response = requests.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/update",
+        json={
+            "server_id": server_id,
+            "selected_tools": [MCP_HELLO_TOOL],
+        },
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    update_response.raise_for_status()
+    assert update_response.json()["updated_tools"] >= 1
+
+    tools_response = requests.get(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}/db-tools",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    tools_response.raise_for_status()
+    tool_entries = tools_response.json()["tools"]
+    hello_tool_entry = next(
+        tool for tool in tool_entries if tool["name"] == MCP_HELLO_TOOL
+    )
+    tool_id = hello_tool_entry["id"]
+
+    # Step c) Create an assistant (persona) with the MCP tool attached
+    persona = PersonaManager.create(
+        name="integration-mcp-persona",
+        description="Persona for MCP integration test",
+        tool_ids=[tool_id],
+        user_performing_action=admin_user,
+    )
+    persona_tools_response = requests.get(
+        f"{API_SERVER_URL}/persona",
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+    )
+    persona_tools_response.raise_for_status()
+    persona_entries = persona_tools_response.json()
+    persona_entry = next(
+        entry for entry in persona_entries if entry["id"] == persona.id
+    )
+    persona_tool_ids = {tool["id"] for tool in persona_entry["tools"]}
+    assert tool_id in persona_tool_ids

--- a/web/src/components/admin/actions/ToolList.tsx
+++ b/web/src/components/admin/actions/ToolList.tsx
@@ -109,10 +109,6 @@ export function ToolList({
         // Update serverId for subsequent operations
         newServerId = serverResult.server_id;
         setCurrentServerId(newServerId);
-        // Ensure URL reflects the created server and listing state to avoid duplicate creation (409)
-        router.replace(
-          `/admin/actions/edit-mcp?server_id=${newServerId}&listing_tools=true`
-        );
       } else {
         // For OAuth servers, use the existing serverId
         if (!serverId) {
@@ -125,6 +121,11 @@ export function ToolList({
         }
         newServerId = serverId;
       }
+      // Ensure URL reflects the created server and listing state to avoid duplicate creation
+      // and set listing_tools=true so the tool list is shown
+      router.replace(
+        `/admin/actions/edit-mcp?server_id=${newServerId}&listing_tools=true`
+      );
 
       // List available tools from the saved server
       const promises: Promise<Response>[] = [

--- a/web/src/components/admin/actions/ToolList.tsx
+++ b/web/src/components/admin/actions/ToolList.tsx
@@ -34,9 +34,6 @@ export function ToolList({
   const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showToolList, setShowToolList] = useState(
-    searchParams.get("listing_tools") === "true"
-  );
   const [currentServerId, setCurrentServerId] = useState<number | undefined>(
     serverId
   );
@@ -46,14 +43,13 @@ export function ToolList({
     if (
       searchParams.get("listing_tools") === "true" &&
       serverId &&
-      !showToolList &&
       values.name.trim() &&
       values.server_url.trim()
     ) {
       // Only auto-trigger for servers that have required form values and a serverId
       handleListActions(values);
     }
-  }, [searchParams, serverId, showToolList, values.name, values.server_url]);
+  }, [searchParams, serverId, values.name, values.server_url]);
 
   const handleListActions = async (values: MCPFormValues) => {
     // Check if OAuth needs connection first
@@ -175,7 +171,6 @@ export function ToolList({
         return;
       }
 
-      setShowToolList(true);
       setCurrentPage(1);
 
       // Process available tools
@@ -315,7 +310,7 @@ export function ToolList({
     }
   };
 
-  return !showToolList ? (
+  return listingTools || searchParams.get("listing_tools") !== "true" ? (
     <div className="flex gap-2">
       <Button
         type="button"
@@ -490,7 +485,6 @@ export function ToolList({
             const currentUrl = new URL(window.location.href);
             currentUrl.searchParams.delete("listing_tools");
             router.replace(currentUrl.toString());
-            setShowToolList(false);
           }}
         >
           Back


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2701/mcp-server-first-time-listing-actions-always-returns-nothing
tested no-auth MCP server creation and some minor bug fixes

## How Has This Been Tested?

ran new test and checked behavior in UI

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable creating MCP servers with auth_type=NONE and add an end-to-end test that registers the server, selects the hello tool, and attaches it to a persona. Fix the admin tool listing auto-trigger and standardize MCP tool LLM names.

- **Bug Fixes**
  - Backend: Skip connection config creation when auth_type is NONE in _upsert_mcp_server.
  - Frontend: Remove redundant showToolList state; auto-list tools when listing_tools=true and required fields are set, and Back clears the URL param.

- **Refactors**
  - Use LLM name format mcp:{server}:{tool} to avoid collisions and improve consistency.

<!-- End of auto-generated description by cubic. -->

