### PR TITLE
fix: user info 404s

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -219,12 +219,19 @@ def _get_batch_rate_limited(
 
 
 def _get_userinfo(user: NamedUser) -> dict[str, str]:
+    def _safe_get(attr_name: str) -> str | None:
+        try:
+            return cast(str | None, getattr(user, attr_name))
+        except GithubException:
+            logger.debug(f"Error getting {attr_name} for user")
+            return None
+
     return {
         k: v
         for k, v in {
-            "login": user.login,
-            "name": user.name,
-            "email": user.email,
+            "login": _safe_get("login"),
+            "name": _safe_get("name"),
+            "email": _safe_get("email"),
         }.items()
         if v is not None
     }


### PR DESCRIPTION
## Description

Fixes https://linear.app/danswer/issue/DAN-2741/fix-user-info-404s
the github client sometimes tries and fails to get some info about a user; these failures can break an entire index attempt when they happen consistently. This is relatively less important information, so we gracefully handle retrieval failures.

## How Has This Been Tested?

n/a, generally safe change

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Gracefully handle GitHub user info 404s so indexing doesn’t fail. We now safely fetch login, name, and email and skip missing fields.

- **Bug Fixes**
  - Added a safe getter that catches GithubException when reading user attributes.
  - Filter out None values and log debug messages on attribute retrieval failures.

<!-- End of auto-generated description by cubic. -->

