### PR TITLE
fix(infra): replace bitnami postgres and redis

### DIFF
--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -41,7 +41,16 @@ jobs:
 #     - name: Force run chart-testing (list-changed)
 #       id: list-changed
 #       run: echo "changed=true" >> $GITHUB_OUTPUT
-        
+
+    - name: Add Helm repositories and update
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        echo "=== Adding Helm repositories ==="
+        helm repo add bitnami https://charts.bitnami.com/bitnami
+        helm repo add cnpg https://cloudnative-pg.github.io/charts
+        helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
+        helm repo update
+
     # lint all charts if any changes were detected
     - name: Run chart-testing (lint)
       if: steps.list-changed.outputs.changed == 'true'
@@ -60,15 +69,6 @@ jobs:
         kubectl get nodes -o wide
         kubectl get pods --all-namespaces
         kubectl get storageclass
-
-    - name: Add Helm repositories and update
-      if: steps.list-changed.outputs.changed == 'true'
-      run: |
-        echo "=== Adding Helm repositories ==="
-        helm repo add bitnami https://charts.bitnami.com/bitnami
-        helm repo add cnpg https://cloudnative-pg.github.io/charts
-        helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
-        helm repo update
 
     - name: Pre-pull critical images
       if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         echo "=== Adding Helm repositories ==="
         helm repo add bitnami https://charts.bitnami.com/bitnami
+        helm repo add cnpg https://cloudnative-pg.github.io/charts
         helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
         helm repo update
 
@@ -94,6 +95,20 @@ jobs:
         
         echo "=== Images loaded into Kind cluster ==="
         docker exec $KIND_CLUSTER-control-plane crictl images | grep -E "(postgres|redis|onyx)" || echo "Some images may still be loading..."
+
+    - name: Install CloudNativePG Operator
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        echo "=== Installing CloudNativePG Operator ==="
+        helm upgrade --install cnpg \
+          --namespace cnpg-system \
+          --create-namespace \
+          cnpg/cloudnative-pg \
+          --wait --timeout 300s
+
+        echo "=== Verifying operator installation ==="
+        kubectl get pods -n cnpg-system
+        kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cloudnative-pg -n cnpg-system --timeout=300s
 
     - name: Validate chart dependencies
       if: steps.list-changed.outputs.changed == 'true'
@@ -156,8 +171,10 @@ jobs:
             --set=vespa.enabled=false \
             --set=slackbot.enabled=false \
             --set=postgresql.enabled=true \
-            --set=postgresql.primary.persistence.enabled=false \
+            --set=postgresql.cluster.instances=1 \
+            --set=postgresql.cluster.storage.size=1Gi \
             --set=redis.enabled=true \
+            --set=redis.image.tag=7.4.2-debian-12-r5 \
             --set=webserver.replicaCount=1 \
             --set=api.replicaCount=0 \
             --set=inferenceCapability.replicaCount=0 \

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -48,6 +48,7 @@ jobs:
         echo "=== Adding Helm repositories ==="
         helm repo add bitnami https://charts.bitnami.com/bitnami
         helm repo add cnpg https://cloudnative-pg.github.io/charts
+        helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
         helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
         helm repo update
 
@@ -109,6 +110,20 @@ jobs:
         echo "=== Verifying operator installation ==="
         kubectl get pods -n cnpg-system
         kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=cloudnative-pg -n cnpg-system --timeout=300s
+
+    - name: Install OpsTree Redis Operator
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        echo "=== Installing OpsTree Redis Operator ==="
+        helm upgrade --install redis-operator \
+          --namespace ot-operators \
+          --create-namespace \
+          ot-helm/redis-operator \
+          --wait --timeout 300s
+
+        echo "=== Verifying Redis operator installation ==="
+        kubectl get pods -n ot-operators
+        kubectl wait --for=condition=ready pod -l control-plane=redis-operator -n ot-operators --timeout=300s || true
 
     - name: Validate chart dependencies
       if: steps.list-changed.outputs.changed == 'true'
@@ -174,7 +189,7 @@ jobs:
             --set=postgresql.cluster.instances=1 \
             --set=postgresql.cluster.storage.size=1Gi \
             --set=redis.enabled=true \
-            --set=redis.image.tag=7.4.2-debian-12-r5 \
+            --set=redis.storageSpec.volumeClaimTemplate.spec.resources.requests.storage=1Gi \
             --set=webserver.replicaCount=1 \
             --set=api.replicaCount=0 \
             --set=inferenceCapability.replicaCount=0 \

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -9,10 +9,10 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.14.0
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.1.0
+  repository: https://ot-container-kit.github.io/helm-charts/
+  version: 0.16.6
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.0.4
-digest: sha256:27667f497bb881db08f1e6905707b71a9117af115876273f9ecb66cf99a798ba
-generated: "2025-10-01T16:07:10.523724-07:00"
+digest: sha256:3e6840437b1b880cd11ebec7c967535f26f3fe9f1ae1f1817f1a448401859fe3
+generated: "2025-10-01T16:47:26.518909-07:00"

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 14.3.1
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.3.1
 - name: vespa
   repository: https://onyx-dot-app.github.io/vespa-helm-charts
   version: 0.2.24
@@ -14,5 +14,5 @@ dependencies:
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.0.4
-digest: sha256:dddd687525764f5698adc339a11d268b0ee9c3ca81f8d46c9e65a6bf2c21cf25
-generated: "2025-09-24T12:16:33.661608-07:00"
+digest: sha256:27667f497bb881db08f1e6905707b71a9117af115876273f9ecb66cf99a798ba
+generated: "2025-10-01T16:07:10.523724-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -32,8 +32,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: nginx.enabled
   - name: redis
-    version: 20.1.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.16.6
+    repository: https://ot-container-kit.github.io/helm-charts/
     condition: redis.enabled
   - name: minio
     version: 17.0.4

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -18,10 +18,11 @@ annotations:
     - name: vespa
       image: vespaengine/vespa:8.526.15
 dependencies:
-  - name: postgresql
-    version: 14.3.1
-    repository: https://charts.bitnami.com/bitnami
+  - name: cluster
+    version: 0.3.1
+    repository: https://cloudnative-pg.github.io/charts
     condition: postgresql.enabled
+    alias: postgresql
   - name: vespa
     version: 0.2.24
     repository: https://onyx-dot-app.github.io/vespa-helm-charts

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -9,19 +9,29 @@ global:
   pullPolicy: "IfNotPresent"
 
 postgresql:
-  primary:
-    persistence:
-      storageClass: ""
-      size: 10Gi
-    shmVolume:
-      enabled: true
-      sizeLimit: 2Gi
   enabled: true
-  auth:
-    existingSecret: onyx-postgresql
-    secretKeys:
-      # overwriting as postgres typically expects 'postgres-password'
-      adminPasswordKey: postgres_password
+  type: postgresql
+  version:
+    postgresql: "16"
+  mode: standalone
+  cluster:
+    instances: 1
+    storage:
+      size: 10Gi
+      storageClass: ""
+    resources: {}
+    # Uncomment to set resource limits:
+    resources:
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+      requests:
+        cpu: 1000m
+        memory: 2Gi
+  # Use existing secret for superuser password
+  # CloudNativePG expects a secret with keys: username, password
+  superuserSecret: onyx-postgresql
+  enableSuperuserAccess: true
 
 vespa:
   name: da-vespa-0

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -19,7 +19,6 @@ postgresql:
     storage:
       size: 10Gi
       storageClass: ""
-    # Uncomment to set resource limits:
     resources:
       limits:
         cpu: 2000m

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -19,7 +19,6 @@ postgresql:
     storage:
       size: 10Gi
       storageClass: ""
-    resources: {}
     # Uncomment to set resource limits:
     resources:
       limits:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -715,27 +715,36 @@ celery_worker_docfetching:
 
 redis:
   enabled: true
-  architecture: standalone
-  commonConfiguration: |-
-    # Enable AOF https://redis.io/topics/persistence#append-only-file
-    appendonly no
-    # Disable RDB persistence, AOF persistence already enabled.
-    save ""
-  master:
-    replicaCount: 1
-    image:
-      registry: docker.io
-      repository: bitnami/redis
-      tag: "7.4.0"
-      pullPolicy: IfNotPresent
-    persistence:
-      enabled: false
-  service:
-    type: ClusterIP
-    port: 6379
-  auth:
-    existingSecret: onyx-redis
-    existingSecretPasswordKey: redis_password
+  redisStandalone:
+    image: quay.io/opstree/redis
+    tag: v7.0.15
+    imagePullPolicy: IfNotPresent
+    serviceType: ClusterIP
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    # Use existing secret for Redis password
+    redisSecret:
+      secretName: onyx-redis
+      secretKey: redis_password
+  # Redis configuration
+  externalConfig:
+    enabled: true
+    data: |
+      appendonly no
+      save ""
+  # Storage configuration - disabled persistence for simplicity
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
 
 minio:
   enabled: true

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -21,8 +21,8 @@ postgresql:
       storageClass: ""
     resources:
       limits:
-        cpu: 2000m
-        memory: 4Gi
+        cpu: 1000m
+        memory: 2Gi
       requests:
         cpu: 1000m
         memory: 2Gi


### PR DESCRIPTION
## Description

uh claude code generated but migrating away from bitnami since they sold out to paid version

https://www.reddit.com/r/kubernetes/comments/1midh11/any_alternative_to_bitnami_ha_postgres_helm_chart/
cloud native recommended as alternative for postgres

https://github.com/OT-CONTAINER-KIT/redis-operator
and this one seemed to come up a bit in search



https://linear.app/danswer/issue/DAN-2740/fix-helm-chart-cicd-btinami-deprecation

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch the Helm PostgreSQL dependency from Bitnami to CloudNativePG and update CI to install the CNPG operator, keeping chart tests working after the Bitnami deprecation. Addresses Linear DAN-2740.

- **Dependencies**
  - Replace bitnami/postgresql with cnpg/cluster (aliased as postgresql), v0.3.1.
  - Pin Redis image tag to 7.4.2-debian-12-r5.
  - Update Chart.lock and add the CNPG Helm repo.

- **Migration**
  - Ensure the CloudNativePG operator is installed (namespace cnpg-system).
  - Use superuserSecret=onyx-postgresql with keys: username, password.
  - Update values to CNPG schema: postgresql.cluster.instances, postgresql.cluster.storage.size, version.postgresql=16, optional CPU/memory requests/limits.
  - CI uses a single instance with 1Gi storage for fast tests.

<!-- End of auto-generated description by cubic. -->

