### PR TITLE
fix: deny invalid space keys

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -5,6 +5,7 @@ from datetime import timezone
 from typing import Any
 from urllib.parse import quote
 
+from atlassian.errors import ApiError  # type: ignore
 from requests.exceptions import HTTPError
 from typing_extensions import override
 
@@ -679,6 +680,14 @@ class ConfluenceConnector(
             raise UnexpectedValidationError(
                 f"Unexpected error while validating Confluence settings: {e}"
             )
+
+        if self.space:
+            try:
+                self.low_timeout_confluence_client.get_space(self.space)
+            except ApiError as e:
+                raise ConnectorValidationError(
+                    "Invalid Confluence space key provided."
+                ) from e
 
         if not spaces or not spaces.get("results"):
             raise ConnectorValidationError(

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -686,7 +686,7 @@ class ConfluenceConnector(
                 self.low_timeout_confluence_client.get_space(self.space)
             except ApiError as e:
                 raise ConnectorValidationError(
-                    "Invalid Confluence space key provided."
+                    "Invalid Confluence space key provided"
                 ) from e
 
         if not spaces or not spaces.get("results"):

--- a/backend/tests/integration/tests/connector/test_connector_creation.py
+++ b/backend/tests/integration/tests/connector/test_connector_creation.py
@@ -37,7 +37,7 @@ def test_overlapping_connector_creation(reset: None) -> None:
 
     config = {
         "wiki_base": os.environ["CONFLUENCE_TEST_SPACE_URL"],
-        "space": "DailyConnectorTestSpace",
+        "space": "DailyConne",
         "is_cloud": True,
     }
 


### PR DESCRIPTION
## Description

fixes https://linear.app/danswer/issue/DAN-2743/no-invalid-space-keys-in-confluence
previously we allowed users to specify invalid space keys; this stops the user from successfully creating an invalid connector.

## How Has This Been Tested?

tested in UI

## Additional Options

- [ ] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Validate Confluence space keys during connector setup. Invalid keys now show a clear error and the connector is not created.

- **Bug Fixes**
  - Verify the provided space key with get_space; on ApiError, raise ConnectorValidationError with “Invalid Confluence space key provided.”

<!-- End of auto-generated description by cubic. -->

