### PR TITLE
feat: enable DR by default

### DIFF
--- a/web/src/app/admin/settings/SettingsForm.tsx
+++ b/web/src/app/admin/settings/SettingsForm.tsx
@@ -255,7 +255,7 @@ export function SettingsForm() {
       <Checkbox
         label="Deep Research"
         sublabel="If set, users will be able to use Deep Research."
-        checked={settings.deep_research_enabled ?? false}
+        checked={settings.deep_research_enabled ?? true}
         onChange={(e) =>
           handleToggleSettingsField("deep_research_enabled", e.target.checked)
         }

--- a/web/src/components/settings/lib.ts
+++ b/web/src/components/settings/lib.ts
@@ -58,7 +58,7 @@ export async function fetchSettingsSS(): Promise<CombinedSettings | null> {
           notifications: [],
           needs_reindexing: false,
           anonymous_user_enabled: false,
-          deep_research_enabled: false,
+          deep_research_enabled: true,
           temperature_override_enabled: true,
           query_history_type: QueryHistoryType.NORMAL,
         };
@@ -114,7 +114,7 @@ export async function fetchSettingsSS(): Promise<CombinedSettings | null> {
     }
 
     if (settings.deep_research_enabled == null) {
-      settings.deep_research_enabled = false;
+      settings.deep_research_enabled = true;
     }
 
     const webVersion = getWebVersion();


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable Deep Research by default across the app. New installs or missing values will default to on, and the Admin Settings checkbox now starts checked.

<!-- End of auto-generated description by cubic. -->

