### PR TITLE
fix: reindex logic and allow seeded docs to refresh

### DIFF
--- a/backend/onyx/seeding/load_docs.py
+++ b/backend/onyx/seeding/load_docs.py
@@ -184,7 +184,7 @@ def seed_initial_documents(
             "base_url": "https://docs.onyx.app/",
             "web_connector_type": "recursive",
         },
-        refresh_freq=None,  # Never refresh by default
+        refresh_freq=3600,  # 1 hour
         prune_freq=None,
         indexing_start=None,
     )

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
@@ -18,7 +18,7 @@ export function useReIndexModal(
   const [reIndexPopupVisible, setReIndexPopupVisible] = useState(false);
 
   const showReIndexModal = () => {
-    if (!connectorId || !credentialId || !ccPairId) {
+    if (connectorId == null || credentialId == null || ccPairId == null) {
       return;
     }
     setReIndexPopupVisible(true);
@@ -29,7 +29,7 @@ export function useReIndexModal(
   };
 
   const triggerReIndex = async (fromBeginning: boolean) => {
-    if (!connectorId || !credentialId || !ccPairId) {
+    if (connectorId == null || credentialId == null || ccPairId == null) {
       return;
     }
 
@@ -64,7 +64,10 @@ export function useReIndexModal(
   };
 
   const FinalReIndexModal =
-    reIndexPopupVisible && connectorId && credentialId && ccPairId ? (
+    reIndexPopupVisible &&
+    connectorId != null &&
+    credentialId != null &&
+    ccPairId != null ? (
       <ReIndexModal
         setPopup={setPopup}
         hide={hideReIndexModal}

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -121,8 +121,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   // Initialize hooks at top level to avoid conditional hook calls
   const { showReIndexModal, ReIndexModal } = useReIndexModal(
-    ccPair?.connector?.id || null,
-    ccPair?.credential?.id || null,
+    ccPair?.connector?.id ?? null,
+    ccPair?.credential?.id ?? null,
     ccPairId,
     setPopup
   );


### PR DESCRIPTION
## Description

- Default credential id 0 evaluates to false and hides the re-index modal
- Added refresh frequency to seeded connector
- With these 2 changes, users can resume and re-index the seeded connector to have all of the Onyx docs indexed

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the hidden re-index modal when credentialId is 0 and enables hourly refresh for seeded Onyx docs. Users can now resume and re-index the seeded connector to index all docs and keep them fresh.

- **Bug Fixes**
  - Allow id=0 by checking for null instead of falsy in re-index logic.

- **New Features**
  - Seeded connector now refreshes hourly (refresh_freq=3600).

<!-- End of auto-generated description by cubic. -->

