### PR TITLE
Handle Confluence attachments as individual documents

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -443,9 +443,9 @@ class OnyxConfluence:
             return attr
 
         # wrap the method with our retry handler
-        rate_limited_method: Callable[..., Any] = (
-            self._make_rate_limited_confluence_method(name, self._credentials_provider)
-        )
+        rate_limited_method: Callable[
+            ..., Any
+        ] = self._make_rate_limited_confluence_method(name, self._credentials_provider)
 
         return rate_limited_method
 


### PR DESCRIPTION
## Description

This PR changes the current behavior that considers page attachments as part of the page itself, to individual documents.

Mainly due to 3 reasons:

1) Documents only show up once in search results - Pages with lots of attachments might make the search lose context;
2) Lack of direct reference to the document can make very hard to compare source when page has lots of attachments;
3) Small updates of the page can trigger large updates forcing all of the related attachments to be reindexed, even if they didn't change.

## How Has This Been Tested?
Index a Confluence page with attachments, check each attachment is treated as individual doc.

## Additional Options

- [ ] [Optional] Override Linear Check
