### PR TITLE
fix: allow web connector to recurse www even if not specified

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -219,6 +219,18 @@ def is_valid_url(url: str) -> bool:
         return False
 
 
+def _same_site(base_url: str, candidate_url: str) -> bool:
+    base, candidate = urlparse(base_url), urlparse(candidate_url)
+    if base.netloc.lower().lstrip("www.") != candidate.netloc.lower().lstrip("www."):
+        return False
+
+    base_path = (base.path or "/").rstrip("/")
+    if base_path in ("", "/"):
+        return True
+
+    return (candidate.path or "/").startswith(base_path)
+
+
 def get_internal_links(
     base_url: str, url: str, soup: BeautifulSoup, should_ignore_pound: bool = True
 ) -> set[str]:
@@ -239,7 +251,7 @@ def get_internal_links(
             # Relative path handling
             href = urljoin(url, href)
 
-        if urlparse(href).netloc == urlparse(url).netloc and base_url in href:
+        if _same_site(base_url, href):
             internal_links.add(href)
     return internal_links
 

--- a/backend/tests/daily/connectors/web/test_web_connector.py
+++ b/backend/tests/daily/connectors/web/test_web_connector.py
@@ -71,3 +71,15 @@ def test_web_connector_bot_protection() -> None:
     doc = doc_batch[0]
     assert doc.sections[0].text is not None
     assert MERCURY_EXPECTED_QUOTE in doc.sections[0].text
+
+
+def test_web_connector_recursive_www_redirect() -> None:
+    # Check that onyx.app can be recursed if re-directed to www.onyx.app
+    connector = WebConnector(
+        base_url="https://onyx.app",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value,
+    )
+
+    documents = [doc for batch in connector.load_from_state() for doc in batch]
+
+    assert len(documents) > 1


### PR DESCRIPTION
## Description

- Recursive web scrape would not correctly index https://onyx.app because it all child pages have www.[domain]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [ ] [Optional] Override Linear Check
