### PR TITLE
Confluence: gate permission expansions to SYNC connectors

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/doc_sync.py
@@ -37,6 +37,8 @@ def confluence_doc_sync(
     confluence_connector = ConfluenceConnector(
         **cc_pair.connector.connector_specific_config
     )
+    # Set permission mode from the connector's access type; only SYNC enables enumeration
+    confluence_connector.set_permission_mode(cc_pair.access_type)
 
     provider = OnyxDBCredentialsProvider(
         get_current_tenant_id(), "confluence", cc_pair.credential_id

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 
 from requests.exceptions import HTTPError
 from typing_extensions import override
+from onyx.db.enums import AccessType
 
 from onyx.access.models import ExternalAccess
 from onyx.configs.app_configs import CONFLUENCE_CONNECTOR_LABELS_TO_SKIP
@@ -124,6 +125,8 @@ class ConfluenceConnector(
         self._low_timeout_confluence_client: OnyxConfluence | None = None
         self._fetched_titles: set[str] = set()
         self.allow_images = False
+        # Permission mode: controls whether to compute external_access during slim-doc retrieval
+        self._permission_mode: AccessType | None = None
 
         # Remove trailing slash from wiki_base if present
         self.wiki_base = wiki_base.rstrip("/")
@@ -219,6 +222,11 @@ class ConfluenceConnector(
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         raise NotImplementedError("Use set_credentials_provider with this connector.")
+
+    def set_permission_mode(self, access_type: AccessType) -> None:
+        """Set the connector permission mode (PUBLIC, PRIVATE, SYNC). Only when set to
+        SYNC do we expand and compute external_access during slim-doc retrieval."""
+        self._permission_mode = access_type
 
     def _construct_page_cql_query(
         self,
@@ -573,18 +581,30 @@ class ConfluenceConnector(
         Does not fetch actual text. Used primarily for incremental permission sync.
         """
         doc_metadata_list: list[SlimDocument] = []
-        restrictions_expand = ",".join(_RESTRICTIONS_EXPANSION_FIELDS)
-
-        space_level_access_info = get_all_space_permissions(
-            self.confluence_client, self.is_cloud
+        # Only expand restrictions when access type is SYNC
+        restrictions_expand = (
+            ",".join(_RESTRICTIONS_EXPANSION_FIELDS)
+            if self._permission_mode == AccessType.SYNC
+            else None
         )
+
+        space_level_access_info: dict[str, ExternalAccess] = {}
+        if self._permission_mode == AccessType.SYNC:
+            space_level_access_info = get_all_space_permissions(
+                self.confluence_client, self.is_cloud
+            )
 
         def get_external_access(
             doc_id: str, restrictions: dict[str, Any], ancestors: list[dict[str, Any]]
         ) -> ExternalAccess | None:
-            return get_page_restrictions(
-                self.confluence_client, doc_id, restrictions, ancestors
-            ) or space_level_access_info.get(page_space_key)
+            if self._permission_mode != AccessType.SYNC:
+                return None
+            return (
+                get_page_restrictions(
+                    self.confluence_client, doc_id, restrictions, ancestors
+                )
+                or space_level_access_info.get(page_space_key)
+            )
 
         # Query pages
         page_query = self.base_cql_page_query + self.cql_label_filter
@@ -604,8 +624,10 @@ class ConfluenceConnector(
             doc_metadata_list.append(
                 SlimDocument(
                     id=page_id,
-                    external_access=get_external_access(
-                        page_id, page_restrictions, page_ancestors
+                    external_access=(
+                        get_external_access(page_id, page_restrictions, page_ancestors)
+                        if self._permission_mode == AccessType.SYNC
+                        else None
                     ),
                 )
             )
@@ -625,7 +647,7 @@ class ConfluenceConnector(
                     continue
 
                 attachment_restrictions = attachment.get("restrictions", {})
-                if not attachment_restrictions:
+                if self._permission_mode == AccessType.SYNC and not attachment_restrictions:
                     attachment_restrictions = page_restrictions or {}
 
                 attachment_space_key = attachment.get("space", {}).get("key")
@@ -640,8 +662,12 @@ class ConfluenceConnector(
                 doc_metadata_list.append(
                     SlimDocument(
                         id=attachment_id,
-                        external_access=get_external_access(
-                            attachment_id, attachment_restrictions, []
+                        external_access=(
+                            get_external_access(
+                                attachment_id, attachment_restrictions, []
+                            )
+                            if self._permission_mode == AccessType.SYNC
+                            else None
                         ),
                     )
                 )


### PR DESCRIPTION
## Description

This PR gates the retrieval of Confluence permissions metadata only for connector configured to auto-sync.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Gates Confluence permission enumeration to SYNC connectors. Non-SYNC connectors skip restriction expansion and external_access computation during slim doc retrieval to reduce API calls and speed up syncs.

- **Refactors**
  - Added set_permission_mode(access_type) to ConfluenceConnector; doc_sync passes cc_pair.access_type.
  - Only SYNC expands restrictions and computes ExternalAccess; others return None for external_access.
  - Skips space-permission fetch and restriction expansions for PUBLIC/PRIVATE connectors.

<!-- End of auto-generated description by cubic. -->

