### PR TITLE
fix(helm): Update DB Dependencies

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 14.3.1
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.26.0
 - name: vespa
   repository: https://onyx-dot-app.github.io/vespa-helm-charts
   version: 0.2.24
@@ -9,10 +9,10 @@ dependencies:
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 15.14.0
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 20.1.0
+  repository: https://ot-container-kit.github.io/helm-charts
+  version: 0.16.6
 - name: minio
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 17.0.4
-digest: sha256:dddd687525764f5698adc339a11d268b0ee9c3ca81f8d46c9e65a6bf2c21cf25
-generated: "2025-09-24T12:16:33.661608-07:00"
+digest: sha256:aa3456d2410437fd93c21c5d836b2809cba5fc199736e56ef321bc371608a30e
+generated: "2025-10-02T15:18:26.4418-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: latest
 annotations:
   category: Productivity
@@ -18,10 +18,11 @@ annotations:
     - name: vespa
       image: vespaengine/vespa:8.526.15
 dependencies:
-  - name: postgresql
-    version: 14.3.1
-    repository: https://charts.bitnami.com/bitnami
+  - name: cloudnative-pg
+    version: 0.26.0
+    repository: https://cloudnative-pg.github.io/charts
     condition: postgresql.enabled
+    alias: postgresql
   - name: vespa
     version: 0.2.24
     repository: https://onyx-dot-app.github.io/vespa-helm-charts
@@ -31,8 +32,8 @@ dependencies:
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: nginx.enabled
   - name: redis
-    version: 20.1.0
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.16.6
+    repository: https://ot-container-kit.github.io/helm-charts
     condition: redis.enabled
   - name: minio
     version: 17.0.4

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.port | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
-  POSTGRES_HOST: {{ .Release.Name }}-postgresql
+  POSTGRES_HOST: {{ .Release.Name }}-postgresql-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}
   VESPA_HOST: {{ .Values.vespa.name }}.{{ .Values.vespa.service.name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -9,19 +9,15 @@ global:
   pullPolicy: "IfNotPresent"
 
 postgresql:
-  primary:
-    persistence:
+  enabled: true
+  nameOverride: postgresql
+  cluster:
+    instances: 1
+    storage:
       storageClass: ""
       size: 10Gi
-    shmVolume:
-      enabled: true
-      sizeLimit: 2Gi
-  enabled: true
-  auth:
-    existingSecret: onyx-postgresql
-    secretKeys:
-      # overwriting as postgres typically expects 'postgres-password'
-      adminPasswordKey: postgres_password
+    enableSuperuserAccess: true
+    superuserSecret: onyx-postgresql # keep in sync with auth.postgresql secretName/existingSecret
 
 vespa:
   name: da-vespa-0
@@ -707,27 +703,36 @@ celery_worker_docfetching:
 
 redis:
   enabled: true
-  architecture: standalone
-  commonConfiguration: |-
-    # Enable AOF https://redis.io/topics/persistence#append-only-file
-    appendonly no
-    # Disable RDB persistence, AOF persistence already enabled.
-    save ""
-  master:
-    replicaCount: 1
-    image:
-      registry: docker.io
-      repository: bitnami/redis
-      tag: "7.4.0"
-      pullPolicy: IfNotPresent
-    persistence:
-      enabled: false
-  service:
-    type: ClusterIP
-    port: 6379
-  auth:
-    existingSecret: onyx-redis
-    existingSecretPasswordKey: redis_password
+  redisStandalone:
+    image: quay.io/opstree/redis
+    tag: v7.0.15
+    imagePullPolicy: IfNotPresent
+    serviceType: ClusterIP
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    # Use existing secret for Redis password
+    redisSecret:
+      secretName: onyx-redis
+      secretKey: redis_password
+  # Redis configuration
+  externalConfig:
+    enabled: true
+    data: |
+      appendonly no
+      save ""
+  # Storage configuration - disabled persistence for simplicity
+  storageSpec:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
 
 minio:
   enabled: true
@@ -772,10 +777,13 @@ auth:
     existingSecret: ""
     # -- This defines the env var to secret map, key is always upper-cased as an env var
     secretKeys:
-      POSTGRES_PASSWORD: "postgres_password"
+      # CloudNativePG requires `username` and `password` keys for the superuser secret.
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.
     values:
-      postgres_password: "postgres"
+      username: "postgres"
+      password: "postgres"
   redis:
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: true


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Updated the chart dependencies since the https://github.com/bitnami/charts/issues/35164 notice is deprecating a ton of the bitnami images. 

This PR specifically targets the Postgres DB and the Redis DB. 

Thank you @edwin-onyx for investigating and looking into this first 

From the man himself:
> https://www.reddit.com/r/kubernetes/comments/1midh11/any_alternative_to_bitnami_ha_postgres_helm_chart/
> cloud native recommended as alternative for postgres
> 
> https://github.com/OT-CONTAINER-KIT/redis-operator
> and this one seemed to come up a bit in search

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran a couple of different tests locally to ensure that this was correct and we were getting the proper charts and values for the new dependencies

## Additional Options

- [ ] [Optional] Override Linear Check
