### PR TITLE
fix(helm): MinIO Migration from Bitnami

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -29,6 +29,7 @@ jobs:
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
+          helm repo add minio https://charts.min.io/
           helm repo update
 
       - name: Build chart dependencies

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -69,6 +69,7 @@ jobs:
         helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
         helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
         helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
+        helm repo add minio https://charts.min.io/
         helm repo update
 
     - name: Install Redis operator

--- a/ct.yaml
+++ b/ct.yaml
@@ -9,6 +9,7 @@ chart-repos:
   - vespa=https://onyx-dot-app.github.io/vespa-helm-charts
   - postgresql=https://cloudnative-pg.github.io/charts
   - redis=https://ot-container-kit.github.io/helm-charts
+  - minio=https://charts.min.io/
   
 # have seen postgres take 10 min to pull ... so 15 min seems like a good timeout?
 helm-extra-args: --debug --timeout 900s

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -12,7 +12,7 @@ dependencies:
   repository: https://ot-container-kit.github.io/helm-charts
   version: 0.16.6
 - name: minio
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 17.0.4
-digest: sha256:aa3456d2410437fd93c21c5d836b2809cba5fc199736e56ef321bc371608a30e
-generated: "2025-10-02T15:18:26.4418-07:00"
+  repository: https://charts.min.io/
+  version: 5.4.0
+digest: sha256:02aa26a26b820cb26f4b9fd4b951c45e5717cc65a1e13fa643d059b60c3a843b
+generated: "2025-10-03T10:56:28.377747-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -36,6 +36,6 @@ dependencies:
     repository: https://ot-container-kit.github.io/helm-charts
     condition: redis.enabled
   - name: minio
-    version: 17.0.4
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 5.4.0
+    repository: https://charts.min.io/
     condition: minio.enabled

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -23,5 +23,5 @@ data:
 {{- end }}
 {{- end }}
   {{- if .Values.minio.enabled }}
-  S3_ENDPOINT_URL: "http://{{ .Release.Name }}-minio:{{ .Values.minio.service.ports.api | default 9000 }}"
+  S3_ENDPOINT_URL: "http://{{ .Release.Name }}-minio:{{ default 9000 .Values.minio.service.port }}"
   {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -735,23 +735,22 @@ redis:
 
 minio:
   enabled: true
-  auth:
-    existingSecret: onyx-objectstorage
-    rootUserSecretKey: s3_aws_access_key_id
-    rootPasswordSecretKey: s3_aws_secret_access_key
-  defaultBuckets: "onyx-file-store-bucket"
+  mode: standalone
+  replicas: 1
+  drivesPerNode: 1
+  existingSecret: onyx-objectstorage
+  buckets:
+    - name: onyx-file-store-bucket
   persistence:
     enabled: true
     size: 30Gi
+    storageClass: ""
   service:
     type: ClusterIP
-    ports:
-      api: 9000
-      console: 9001
+    port: 9000
   consoleService:
     type: ClusterIP
-    ports:
-      http: 9001
+    port: 9001
 
 ingress:
   enabled: false
@@ -811,6 +810,8 @@ auth:
     values:
       s3_aws_access_key_id: "minioadmin"
       s3_aws_secret_access_key: "minioadmin"
+      rootUser: "minioadmin"
+      rootPassword: "minioadmin"
   oauth:
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: false


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Migrating away from the bitnami for our MinIO setup since this is going to cause another breaking change even though the OCI registry seems like it's still active. 

Validated that the values have been updated to match the new chart that is published to https://github.com/minio/minio/tree/master/helm-releases

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Validated that the templating was generated properly and ran CT tests locally. 

## Additional Options

- [x] [Optional] Override Linear Check
