### PR TITLE
fix(helm): Migrate from Bitanmi NGINX

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add required Helm repositories
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
           helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -65,7 +65,7 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
       run: |
         echo "=== Adding Helm repositories ==="
-        helm repo add bitnami https://charts.bitnami.com/bitnami
+        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
         helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
         helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,6 +7,7 @@ chart-dirs:
 # must be kept in sync with Chart.yaml
 chart-repos:
   - vespa=https://onyx-dot-app.github.io/vespa-helm-charts
+  - ingress-nginx=https://kubernetes.github.io/ingress-nginx
   - postgresql=https://cloudnative-pg.github.io/charts
   - redis=https://ot-container-kit.github.io/helm-charts
   - minio=https://charts.min.io/

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -5,14 +5,14 @@ dependencies:
 - name: vespa
   repository: https://onyx-dot-app.github.io/vespa-helm-charts
   version: 0.2.24
-- name: nginx
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.14.0
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.13.3
 - name: redis
   repository: https://ot-container-kit.github.io/helm-charts
   version: 0.16.6
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:02aa26a26b820cb26f4b9fd4b951c45e5717cc65a1e13fa643d059b60c3a843b
-generated: "2025-10-03T10:56:28.377747-07:00"
+digest: sha256:c5604f05ed5b7cbe4d1b2167370e1e42cb3d97c879fbccc6ef881934ba4683e2
+generated: "2025-10-03T13:48:55.815175-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.3.5
+version: 0.4.0
 appVersion: latest
 annotations:
   category: Productivity
@@ -27,10 +27,11 @@ dependencies:
     version: 0.2.24
     repository: https://onyx-dot-app.github.io/vespa-helm-charts
     condition: vespa.enabled
-  - name: nginx
-    version: 15.14.0
-    repository: oci://registry-1.docker.io/bitnamicharts
+  - name: ingress-nginx
+    version: 4.13.3
+    repository: https://kubernetes.github.io/ingress-nginx
     condition: nginx.enabled
+    alias: nginx
   - name: redis
     version: 0.16.6
     repository: https://ot-container-kit.github.io/helm-charts

--- a/deployment/helm/charts/onyx/templates/nginx-conf.yaml
+++ b/deployment/helm/charts/onyx/templates/nginx-conf.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: onyx-nginx-conf
 data:
-  nginx.conf: |
+  upstreams.conf: |
     upstream api_server {
         server {{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }} fail_timeout=0;
     }
@@ -12,33 +12,32 @@ data:
         server {{ include "onyx.fullname" . }}-webserver:{{ .Values.webserver.service.servicePort }} fail_timeout=0;
     }
 
-    server {
-        listen 1024;
-        server_name $$DOMAIN;
+  server-snippet.conf: |
+    listen 1024;
+    server_name $$DOMAIN;
 
-        client_max_body_size 5G;    # Maximum upload size
+    client_max_body_size 5G;
 
-        location ~ ^/api(.*)$ {
-            rewrite ^/api(/.*)$ $1 break;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header Host $host;
-            proxy_http_version 1.1;
-            proxy_buffering off;
-            proxy_redirect off;
-            proxy_pass http://api_server;
-        }
+    location ~ ^/api(.*)$ {
+        rewrite ^/api(/.*)$ $1 break;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_redirect off;
+        proxy_pass http://api_server;
+    }
 
-        location / {
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header Host $host;
-            proxy_http_version 1.1;
-            proxy_redirect off;
-            proxy_pass http://web_server;
-        }
+    location / {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header Host $host;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+        proxy_pass http://web_server;
     }

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -153,21 +153,40 @@ serviceAccount:
 
 nginx:
   enabled: true
-  containerPorts:
-    http: 1024
-  extraEnvVars:
-    - name: DOMAIN
-      value: localhost
-  service:
-    type: LoadBalancer
-    ports:
-      http: 80
-      onyx: 3000
-    targetPort:
-      http: http
-      onyx: http
+  controller:
+    containerPort:
+      http: 1024
 
-  existingServerBlockConfigmap: onyx-nginx-conf
+    # Propagate DOMAIN into nginx so server_name continues to use the same env var
+    extraEnvs:
+      - name: DOMAIN
+        value: localhost
+
+    config:
+      # Expose DOMAIN to the nginx config and pull in our custom snippets
+      main-snippet: |
+        env DOMAIN;
+      http-snippet: |
+        include /etc/nginx/custom-snippets/upstreams.conf;
+      server-snippet: |
+        include /etc/nginx/custom-snippets/server-snippet.conf;
+
+    # Mount the existing nginx ConfigMap that holds the upstream and server snippets
+    extraVolumes:
+      - name: nginx-config
+        configMap:
+          name: onyx-nginx-conf
+    extraVolumeMounts:
+      - name: nginx-config
+        mountPath: /etc/nginx/custom-snippets
+        readOnly: true
+
+    service:
+      type: LoadBalancer
+      ports:
+        http: 80
+      targetPorts:
+        http: http
 
 webserver:
   replicaCount: 1


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Due to this change: https://github.com/bitnami/charts/issues/35164 I am migrating all of the charts off of Bitnami and Nginx is the last chart to migrate over. We are leveraging the standard Nginx charts that are published by the main authors. We try to keep everything in tact while migrating over so we validated against the values from the charts to ensure that we are able to get the proper setup in the new charts that mimic the old workflow. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran templates locally using `helm template` and validating that everything was setup properly. Also running CT tests to ensure that everything is brought up properly and running properly.

## Additional Options

- [x] [Optional] Override Linear Check
