### PR TITLE
feat(auth): Add Auth0 support for authentication.

### DIFF
--- a/backend/onyx/auth/auth0_client.py
+++ b/backend/onyx/auth/auth0_client.py
@@ -1,0 +1,43 @@
+import httpx
+from typing import Any, Dict, Optional, Tuple
+from httpx_oauth.oauth2 import BaseOAuth2
+
+
+class Auth0OAuth2(BaseOAuth2[Dict[str, Any]]):
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        auth0_domain: str,
+        scopes: Optional[list[str]] = None,
+        name: str = "auth0",
+    ):
+        if scopes is None:
+            scopes = ["openid", "email", "profile"]
+        
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            authorize_endpoint=f"https://{auth0_domain}/authorize",
+            access_token_endpoint=f"https://{auth0_domain}/oauth/token",
+            refresh_token_endpoint=f"https://{auth0_domain}/oauth/token",
+            name=name,
+            base_scopes=scopes,
+            token_endpoint_auth_method="client_secret_post",
+        )
+        self.auth0_domain = auth0_domain
+
+    async def get_id_email(self, token: str) -> Tuple[str, Optional[str]]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://{self.auth0_domain}/userinfo",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            user_id = data.get("sub")
+            email = data.get("email")
+            
+            return str(user_id), email

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -134,10 +134,10 @@ def is_user_admin(user: User | None) -> bool:
 
 
 def verify_auth_setting() -> None:
-    if AUTH_TYPE not in [AuthType.DISABLED, AuthType.BASIC, AuthType.GOOGLE_OAUTH]:
+    if AUTH_TYPE not in [AuthType.DISABLED, AuthType.BASIC, AuthType.GOOGLE_OAUTH, AuthType.AUTH0]:
         raise ValueError(
             "User must choose a valid user authentication method: "
-            "disabled, basic, or google_oauth"
+            "disabled, basic, auth0 or google_oauth"
         )
     logger.notice(f"Using Auth Type: {AUTH_TYPE.value}")
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -14,6 +14,11 @@ from onyx.prompts.image_analysis import DEFAULT_IMAGE_ANALYSIS_SYSTEM_PROMPT
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_SYSTEM_PROMPT
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT
 
+# Auth0
+AUTH0_CLIENT_ID = os.environ.get("AUTH0_CLIENT_ID")
+AUTH0_CLIENT_SECRET = os.environ.get("AUTH0_CLIENT_SECRET")
+AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
+
 #####
 # App Configs
 #####

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -245,6 +245,7 @@ class AuthType(str, Enum):
     DISABLED = "disabled"
     BASIC = "basic"
     GOOGLE_OAUTH = "google_oauth"
+    AUTH0 = "auth0"
     OIDC = "oidc"
     SAML = "saml"
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -18,6 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from httpx_oauth.clients.google import GoogleOAuth2
+from httpx_oauth.oauth2 import BaseOAuth2
 from prometheus_fastapi_instrumentator import Instrumentator
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -40,6 +41,9 @@ from onyx.configs.app_configs import DISABLE_GENERATIVE_AI
 from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
+from onyx.configs.app_configs import AUTH0_CLIENT_ID
+from onyx.configs.app_configs import AUTH0_CLIENT_SECRET
+from onyx.configs.app_configs import AUTH0_DOMAIN
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
 from onyx.configs.app_configs import POSTGRES_API_SERVER_READ_ONLY_POOL_OVERFLOW
@@ -140,6 +144,47 @@ file_handlers = [
 
 setup_uvicorn_logger(shared_file_handlers=file_handlers)
 
+import httpx
+from typing import Dict, Optional, Tuple
+
+class Auth0OAuth2(BaseOAuth2[Dict[str, Any]]):
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        auth0_domain: str,
+        scopes: Optional[list[str]] = None,
+        name: str = "auth0",
+    ):
+        if scopes is None:
+            scopes = ["openid", "email", "profile"]
+        
+        super().__init__(
+            client_id=client_id,
+            client_secret=client_secret,
+            authorize_endpoint=f"https://{auth0_domain}/authorize",
+            access_token_endpoint=f"https://{auth0_domain}/oauth/token",
+            refresh_token_endpoint=f"https://{auth0_domain}/oauth/token",
+            name=name,
+            base_scopes=scopes,
+            token_endpoint_auth_method="client_secret_post",
+        )
+        self.auth0_domain = auth0_domain
+
+    async def get_id_email(self, token: str) -> Tuple[str, Optional[str]]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"https://{self.auth0_domain}/userinfo",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            user_id = data.get("sub")
+            email = data.get("email")
+            
+            return str(user_id), email
 
 def validation_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     if not isinstance(exc, RequestValidationError):
@@ -451,10 +496,42 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
             prefix="/auth",
         )
 
+    if AUTH_TYPE == AuthType.AUTH0:
+        if not all([AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN]):
+            raise ValueError(
+                "In order to use Auth0, it requires AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, and AUTH0_DOMAIN to be set."
+            )
+        
+        oauth_client = Auth0OAuth2(
+            client_id=AUTH0_CLIENT_ID,
+            client_secret=AUTH0_CLIENT_SECRET,
+            auth0_domain=AUTH0_DOMAIN,
+        )
+        
+        include_auth_router_with_prefix(
+            application,
+            create_onyx_oauth_router(
+                oauth_client,
+                auth_backend,
+                USER_AUTH_SECRET,
+                associate_by_email=True,
+                is_verified_by_default=True,
+                redirect_url=f"{WEB_DOMAIN}/auth/oauth/callback",
+            ),
+            prefix="/auth/oauth",
+        )
+
+        include_auth_router_with_prefix(
+            application,
+            fastapi_users.get_logout_router(auth_backend),
+            prefix="/auth",
+        )
+
     if (
         AUTH_TYPE == AuthType.CLOUD
         or AUTH_TYPE == AuthType.BASIC
         or AUTH_TYPE == AuthType.GOOGLE_OAUTH
+        or AUTH_TYPE == AuthType.AUTH0
     ):
         # Add refresh token endpoint for OAuth as well
         include_auth_router_with_prefix(

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -13,10 +13,16 @@ EXA_API_KEY=
 # The following are for configuring User Authentication, supported flows are:
 # disabled
 # basic (standard username / password)
+# auth0 (login through auth0 providers)
 # google_oauth (login with google/gmail account)
 # oidc (only in Onyx enterprise edition)
 # saml (only in Onyx enterprise edition)
 AUTH_TYPE=google_oauth
+
+# Set the values below to use Auth0 as your login client. 
+AUTH0_CLIENT_ID=
+AUTH0_CLIENT_SECRET=
+AUTH0_DOMAIN=
 
 # Set the values below to use with Google OAuth
 GOOGLE_OAUTH_CLIENT_ID=

--- a/web/src/app/auth/login/SignInButton.tsx
+++ b/web/src/app/auth/login/SignInButton.tsx
@@ -1,5 +1,7 @@
 import { AuthType } from "@/lib/constants";
 import { FaGoogle } from "react-icons/fa";
+import { SiAuth0 } from "react-icons/si";
+
 
 export function SignInButton({
   authorizeUrl,
@@ -18,6 +20,16 @@ export function SignInButton({
         <p className="text-sm font-medium select-none">Continue with Google</p>
       </div>
     );
+  } else if (authType === "auth0") {
+    button = (
+      <div className="mx-auto flex">
+        <div className="my-auto mr-2">
+          <SiAuth0 />
+        </div>
+        <p className="text-sm font-medium select-none">Continue with Auth0</p>
+      </div>
+    );
+
   } else if (authType === "oidc") {
     button = (
       <div className="mx-auto flex">

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -2,6 +2,7 @@ export type AuthType =
   | "disabled"
   | "basic"
   | "google_oauth"
+  | "auth0"
   | "oidc"
   | "saml"
   | "cloud";

--- a/web/src/lib/userSS.ts
+++ b/web/src/lib/userSS.ts
@@ -88,6 +88,25 @@ const getGoogleOAuthUrlSS = async (nextUrl: string | null): Promise<string> => {
   return data.authorization_url;
 };
 
+const getAuth0OAuthUrlSS = async (nextUrl: string | null): Promise<string> => {
+  const url = UrlBuilder.fromInternalUrl("/auth/oauth/authorize");
+  if (nextUrl) {
+    url.addParam("next", nextUrl);
+  }
+
+  const res = await fetch(url.toString(), {
+    headers: {
+      cookie: processCookies(await cookies()),
+    },
+  });
+  if (!res.ok) {
+    throw new Error("Failed to fetch data");
+  }
+
+  const data: { authorization_url: string } = await res.json();
+  return data.authorization_url;
+};
+
 const getSAMLAuthUrlSS = async (nextUrl: string | null): Promise<string> => {
   const url = UrlBuilder.fromInternalUrl("/auth/saml/authorize");
   if (nextUrl) {
@@ -116,6 +135,9 @@ export const getAuthUrlSS = async (
       return "";
     case "google_oauth": {
       return await getGoogleOAuthUrlSS(nextUrl);
+    }
+	case "auth0": {
+	  return await getAuth0OAuthUrlSS(nextUrl);
     }
     case "cloud": {
       return await getGoogleOAuthUrlSS(nextUrl);


### PR DESCRIPTION
## Description
This commit introduces Auth0 as a primary authentication method for Onyx, providing a robust and secure way for users to log in via Single Sign-On (SSO). This change is particularly important for enterprise customers who need to integrate Onyx with their existing identity providers like Microsoft Active Directory.

## How Has This Been Tested?
This feature has been tested in our production environment, including a successful implementation with Microsoft Active Directory integrated through Auth0.

## Additional Options
We implemented the following three options to be included in the .env:
- AUTH0_CLIENT_ID=
- AUTH0_CLIENT_SECRET=
- AUTH0_DOMAIN= 

In addition to this, you also have to set the authentication type to Auth0.
- AUTH_TYPE=auth0