### PR TITLE
fix: remove duplicate "file" option in Add Connector page

### DIFF
--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -445,7 +445,9 @@ export function listSourceMetadata(): SourceMetadata[] {
         source !== "ingestion_api" &&
         source !== "mock_connector" &&
         // use the "regular" slack connector when listing
-        source !== "federated_slack"
+        source !== "federated_slack" &&
+        // user_file is for internal use (projects), not the Add Connector page
+        source !== "user_file"
     )
     .map(([source, metadata]) => {
       return fillSourceMetadata(metadata, source as ValidSources);


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Excluded the internal user_file source from listSourceMetadata so it no longer shows on the Add Connector page. This removes a duplicate connector and avoids confusion.

<!-- End of auto-generated description by cubic. -->

