### PR TITLE
fix(UI): Update User Settings Model Selection

### DIFF
--- a/web/src/sections/sidebar/Settings.tsx
+++ b/web/src/sections/sidebar/Settings.tsx
@@ -26,6 +26,9 @@ import { ModalIds, useModal } from "@/refresh-components/contexts/ModalContext";
 import SvgUser from "@/icons/user";
 import { UserSettings } from "@/app/chat/components/modal/UserSettingsModal";
 import { cn } from "@/lib/utils";
+import { useChatContext } from "@/refresh-components/contexts/ChatContext";
+import { usePopup } from "@/components/admin/connectors/Popup";
+import { useFederatedOAuthStatus } from "@/lib/hooks/useFederatedOAuthStatus";
 
 function getUsernameFromEmail(email?: string): string {
   if (!email) return ANONYMOUS_USER_NAME;
@@ -186,11 +189,18 @@ export default function Settings({
     "Settings" | "Notifications" | undefined
   >(undefined);
   const { user } = useUser();
+  const { llmProviders, ccPairs } = useChatContext();
+  const {
+    connectors: federatedConnectors,
+    refetch: refetchFederatedConnectors,
+  } = useFederatedOAuthStatus();
+  const { popup, setPopup } = usePopup();
 
   const username = getUsernameFromEmail(user?.email);
 
   return (
     <>
+      {popup}
       <Modal
         id={ModalIds.UserSettingsModal}
         title="User Settings"
@@ -199,13 +209,13 @@ export default function Settings({
         sm
       >
         <UserSettings
-          setPopup={() => toggleModal(ModalIds.UserSettingsModal, false)}
-          llmProviders={[]}
-          onClose={() => {}}
-          defaultModel={null}
-          ccPairs={[]}
-          federatedConnectors={[]}
-          refetchFederatedConnectors={() => {}}
+          setPopup={setPopup}
+          llmProviders={llmProviders}
+          onClose={() => toggleModal(ModalIds.UserSettingsModal, false)}
+          defaultModel={user?.preferences?.default_model ?? null}
+          ccPairs={ccPairs}
+          federatedConnectors={federatedConnectors}
+          refetchFederatedConnectors={refetchFederatedConnectors}
         />
       </Modal>
 


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Currently with the updated FE, the User Settings page has a Model Selection dropdown that does not work and does not display anything. 

Our old setup had a different issue in which it would show all of the models that were usable with the provider selected but this causes confusion amongst users and thus we need to limit it to the models that have already been selected to be visible by the admin users. 

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Tested this locally and ensured that it was working properly 

Fe-dev:
<img width="1092" height="806" alt="Screenshot 2025-10-06 at 4 25 36 PM" src="https://github.com/user-attachments/assets/55186361-6f49-49bc-a83d-ef7f56d4ad5c" />

Localhost:
<img width="1010" height="961" alt="Screenshot 2025-10-06 at 4 26 18 PM" src="https://github.com/user-attachments/assets/a3ecb14f-98dd-4547-877d-95e3616c2754" />


## Additional Options

- [x] [Optional] Override Linear Check
