### PR TITLE
fix(images): Update Image Gen workflow after Refactor

### DIFF
--- a/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/dr_image_generation_2_act.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/dr_image_generation_2_act.py
@@ -94,11 +94,15 @@ def image_generation(
     # Generate images using the image generation tool
     image_generation_responses: list[ImageGenerationResponse] = []
 
-    tool_kwargs: dict[str, str] = {"prompt": image_prompt}
     if requested_shape is not None:
-        tool_kwargs["shape"] = requested_shape.value
+        tool_iterator = image_tool.run(
+            prompt=image_prompt,
+            shape=requested_shape.value,
+        )
+    else:
+        tool_iterator = image_tool.run(prompt=image_prompt)
 
-    for tool_response in image_tool.run(**tool_kwargs):
+    for tool_response in tool_iterator:
         if tool_response.id == IMAGE_GENERATION_HEARTBEAT_ID:
             # Stream heartbeat to frontend
             write_custom_event(

--- a/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/dr_image_generation_2_act.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/dr_image_generation_2_act.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import cast
 
@@ -28,6 +29,7 @@ from onyx.tools.tool_implementations.images.image_generation_tool import (
 from onyx.tools.tool_implementations.images.image_generation_tool import (
     ImageGenerationTool,
 )
+from onyx.tools.tool_implementations.images.image_generation_tool import ImageShape
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -62,6 +64,29 @@ def image_generation(
     image_tool_info = state.available_tools[state.tools_used[-1]]
     image_tool = cast(ImageGenerationTool, image_tool_info.tool_object)
 
+    image_prompt = branch_query
+    requested_shape: ImageShape | None = None
+
+    try:
+        parsed_query = json.loads(branch_query)
+    except json.JSONDecodeError:
+        parsed_query = None
+
+    if isinstance(parsed_query, dict):
+        prompt_from_llm = parsed_query.get("prompt")
+        if isinstance(prompt_from_llm, str) and prompt_from_llm.strip():
+            image_prompt = prompt_from_llm.strip()
+
+        raw_shape = parsed_query.get("shape")
+        if isinstance(raw_shape, str):
+            try:
+                requested_shape = ImageShape(raw_shape)
+            except ValueError:
+                logger.warning(
+                    "Received unsupported image shape '%s' from LLM. Falling back to square.",
+                    raw_shape,
+                )
+
     logger.debug(
         f"Image generation start for {iteration_nr}.{parallelization_nr} at {datetime.now()}"
     )
@@ -69,7 +94,11 @@ def image_generation(
     # Generate images using the image generation tool
     image_generation_responses: list[ImageGenerationResponse] = []
 
-    for tool_response in image_tool.run(prompt=branch_query):
+    tool_kwargs: dict[str, str] = {"prompt": image_prompt}
+    if requested_shape is not None:
+        tool_kwargs["shape"] = requested_shape.value
+
+    for tool_response in image_tool.run(**tool_kwargs):
         if tool_response.id == IMAGE_GENERATION_HEARTBEAT_ID:
             # Stream heartbeat to frontend
             write_custom_event(
@@ -95,6 +124,7 @@ def image_generation(
             file_id=file_id,
             url=build_frontend_file_url(file_id),
             revised_prompt=img.revised_prompt,
+            shape=(requested_shape or ImageShape.SQUARE).value,
         )
         for file_id, img in zip(file_ids, image_generation_responses)
     ]
@@ -107,15 +137,29 @@ def image_generation(
     if final_generated_images:
         image_descriptions = []
         for i, img in enumerate(final_generated_images, 1):
-            image_descriptions.append(f"Image {i}: {img.revised_prompt}")
+            if img.shape and img.shape != ImageShape.SQUARE.value:
+                image_descriptions.append(
+                    f"Image {i}: {img.revised_prompt} (shape: {img.shape})"
+                )
+            else:
+                image_descriptions.append(f"Image {i}: {img.revised_prompt}")
 
         answer_string = (
-            f"Generated {len(final_generated_images)} image(s) based on the request: {branch_query}\n\n"
+            f"Generated {len(final_generated_images)} image(s) based on the request: {image_prompt}\n\n"
             + "\n".join(image_descriptions)
         )
-        reasoning = f"Used image generation tool to create {len(final_generated_images)} image(s) based on the user's request."
+        if requested_shape:
+            reasoning = (
+                "Used image generation tool to create "
+                f"{len(final_generated_images)} image(s) in {requested_shape.value} orientation."
+            )
+        else:
+            reasoning = (
+                "Used image generation tool to create "
+                f"{len(final_generated_images)} image(s) based on the user's request."
+            )
     else:
-        answer_string = f"Failed to generate images for request: {branch_query}"
+        answer_string = f"Failed to generate images for request: {image_prompt}"
         reasoning = "Image generation tool did not return any results."
 
     return BranchUpdate(

--- a/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/models.py
+++ b/backend/onyx/agents/agent_search/dr/sub_agents/image_generation/models.py
@@ -5,6 +5,7 @@ class GeneratedImage(BaseModel):
     file_id: str
     url: str
     revised_prompt: str
+    shape: str | None = None
 
 
 # Needed for PydanticType

--- a/backend/onyx/prompts/dr_prompts.py
+++ b/backend/onyx/prompts/dr_prompts.py
@@ -172,6 +172,14 @@ written as a list of one question.
     DRPath.CLOSER.value: f"""if the tool is {CLOSER}, the list of questions should simply be \
 ['Answer the original question with the information you have.'].
 """,
+    DRPath.IMAGE_GENERATION.value: """
+if the tool is Image Generation, respond with a list that contains exactly one JSON object
+string describing the tool call. The JSON must include a "prompt" field with the text to
+render. When the user specifies or implies an orientation, also include a "shape" field whose
+value is one of "square", "landscape", or "portrait" (use "landscape" for wide/horizontal
+requests and "portrait" for tall/vertical ones). Example: {"prompt": "Create a poster of a
+coral reef", "shape": "landscape"}. Do not surround the JSON with backticks or narration.
+""",
 }
 
 

--- a/web/src/app/chat/components/files/images/InMessageImage.tsx
+++ b/web/src/app/chat/components/files/images/InMessageImage.tsx
@@ -3,9 +3,39 @@ import { FiDownload } from "react-icons/fi";
 import { FullImageModal } from "./FullImageModal";
 import { buildImgUrl } from "./utils";
 
-export function InMessageImage({ fileId }: { fileId: string }) {
+type ImageShape = "square" | "landscape" | "portrait";
+
+const DEFAULT_SHAPE: ImageShape = "square";
+
+const SHAPE_CLASSES: Record<ImageShape, { container: string; image: string }> =
+  {
+    square: {
+      container: "max-w-96 max-h-96",
+      image: "max-w-96 max-h-96",
+    },
+    landscape: {
+      container: "max-w-[28rem] max-h-72",
+      image: "max-w-[28rem] max-h-72",
+    },
+    portrait: {
+      container: "max-w-72 max-h-[28rem]",
+      image: "max-w-72 max-h-[28rem]",
+    },
+  };
+
+export function InMessageImage({
+  fileId,
+  shape = DEFAULT_SHAPE,
+}: {
+  fileId: string;
+  shape?: ImageShape;
+}) {
   const [fullImageShowing, setFullImageShowing] = useState(false);
   const [imageLoaded, setImageLoaded] = useState(false);
+
+  const normalizedShape = SHAPE_CLASSES[shape] ? shape : DEFAULT_SHAPE;
+  const { container: shapeContainerClasses, image: shapeImageClasses } =
+    SHAPE_CLASSES[normalizedShape];
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent opening the full image modal
@@ -34,7 +64,7 @@ export function InMessageImage({ fileId }: { fileId: string }) {
         onOpenChange={(open) => setFullImageShowing(open)}
       />
 
-      <div className="relative w-full h-full max-w-96 max-h-96 group">
+      <div className={`relative w-full h-full group ${shapeContainerClasses}`}>
         {!imageLoaded && (
           <div className="absolute inset-0 bg-background-200 animate-pulse rounded-lg" />
         )}
@@ -51,11 +81,10 @@ export function InMessageImage({ fileId }: { fileId: string }) {
             rounded-lg 
             w-full 
             h-full 
-            max-w-96 
-            max-h-96 
             transition-opacity 
             duration-300 
             cursor-pointer
+            ${shapeImageClasses}
             ${imageLoaded ? "opacity-100" : "opacity-0"}
           `}
           onClick={() => setFullImageShowing(true)}

--- a/web/src/app/chat/components/files/images/InMessageImage.tsx
+++ b/web/src/app/chat/components/files/images/InMessageImage.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
 import { FiDownload } from "react-icons/fi";
+import { ImageShape } from "@/app/chat/services/streamingModels";
 import { FullImageModal } from "./FullImageModal";
 import { buildImgUrl } from "./utils";
-
-type ImageShape = "square" | "landscape" | "portrait";
 
 const DEFAULT_SHAPE: ImageShape = "square";
 

--- a/web/src/app/chat/message/messageComponents/renderers/ImageToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/ImageToolRenderer.tsx
@@ -96,7 +96,12 @@ export const ImageToolRenderer: MessageRenderer<
                     key={image.file_id || index}
                     className="transition-all group"
                   >
-                    {image.file_id && <InMessageImage fileId={image.file_id} />}
+                    {image.file_id && (
+                      <InMessageImage
+                        fileId={image.file_id}
+                        shape={image.shape}
+                      />
+                    )}
                   </div>
                 ))}
               </div>

--- a/web/src/app/chat/services/streamingModels.ts
+++ b/web/src/app/chat/services/streamingModels.ts
@@ -72,10 +72,13 @@ export interface SearchToolDelta extends BaseObj {
   documents: OnyxDocument[] | null;
 }
 
+type ImageShape = "square" | "landscape" | "portrait";
+
 interface GeneratedImage {
   file_id: string;
   url: string;
   revised_prompt: string;
+  shape?: ImageShape;
 }
 
 export interface ImageGenerationToolStart extends BaseObj {

--- a/web/src/app/chat/services/streamingModels.ts
+++ b/web/src/app/chat/services/streamingModels.ts
@@ -72,7 +72,7 @@ export interface SearchToolDelta extends BaseObj {
   documents: OnyxDocument[] | null;
 }
 
-type ImageShape = "square" | "landscape" | "portrait";
+export type ImageShape = "square" | "landscape" | "portrait";
 
 interface GeneratedImage {
   file_id: string;


### PR DESCRIPTION
## Description

[Provide a brief description of the changes in this PR]
Allowing people to generate images that are not square. This allows the user to set certain images with landscape or vertical dimensions to be able to change the layout.

Fixing the loading state and download button as well when image is generated

## How Has This Been Tested?

[Describe the tests you ran to verify your changes]
Ran this locally and allows to test multiple different prompts to ensure that the image can generate different types of dimensions. 

Landscape:
<img width="836" height="442" alt="Screenshot 2025-10-06 at 6 39 59 PM" src="https://github.com/user-attachments/assets/821e182a-9c01-4b5e-a729-56b85f0642fc" />

Portrait:
<img width="813" height="618" alt="Screenshot 2025-10-06 at 6 42 26 PM" src="https://github.com/user-attachments/assets/d1a8964e-708f-487e-9793-f60b5bceccba" />

Square:
<img width="808" height="519" alt="Screenshot 2025-10-06 at 6 41 08 PM" src="https://github.com/user-attachments/assets/37730956-c61f-4f70-814e-ccfd8a7e6fa3" />

## Additional Options

- [x] [Optional] Override Linear Check

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable non-square image generation (landscape and portrait) and wire the shape through the backend and UI. Also updates the prompt format to a JSON tool call and fixes loading and download behavior.

- **New Features**
  - Parse JSON tool calls with prompt and optional shape (square | landscape | portrait), pass shape to the generator, and include it in responses.
  - Update DR prompts to request the JSON format with prompt and shape.
  - Render images with shape-aware sizing in the chat UI; InMessageImage accepts a shape prop and applies layout classes.

- **Bug Fixes**
  - Stabilized image loading state to remove flicker.
  - Fixed the download button to work reliably after generation.

<!-- End of auto-generated description by cubic. -->

