### PR TITLE
chore(tests): fetch keys at runtime

### DIFF
--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -23,6 +23,13 @@ from onyx.db.models import UserRole
 from onyx.main import get_application
 from onyx.utils.logger import setup_logger
 
+# Opt into the shared @pytest.mark.secrets / test_secrets infrastructure.
+from tests.utils.pytest_secrets import (
+    pytest_collection_modifyitems as pytest_collection_modifyitems,
+    pytest_configure as pytest_configure,
+    test_secrets as test_secrets,
+)
+
 logger = setup_logger()
 
 load_dotenv()

--- a/backend/tests/daily/embedding/test_embeddings.py
+++ b/backend/tests/daily/embedding/test_embeddings.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from tenacity import retry
 from tenacity import retry_if_exception_type
@@ -9,6 +7,7 @@ from tenacity import wait_exponential
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from shared_configs.enums import EmbedTextType
 from shared_configs.model_server_models import EmbeddingProvider
+from tests.utils.secret_names import TestSecret
 
 VALID_SAMPLE = ["hi", "hello my name is bob", "woah there!!!. 😃"]
 VALID_LONG_SAMPLE = ["hi " * 999]
@@ -27,7 +26,7 @@ def _run_embeddings(
 
 
 @pytest.fixture
-def openai_embedding_model() -> EmbeddingModel:
+def openai_embedding_model(test_secrets: dict[TestSecret, str]) -> EmbeddingModel:
     return EmbeddingModel(
         server_host="localhost",
         server_port=9000,
@@ -35,19 +34,20 @@ def openai_embedding_model() -> EmbeddingModel:
         normalize=True,
         query_prefix=None,
         passage_prefix=None,
-        api_key=os.environ["OPENAI_API_KEY"],
+        api_key=test_secrets[TestSecret.OPENAI_API_KEY],
         provider_type=EmbeddingProvider.OPENAI,
         api_url=None,
     )
 
 
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
 def test_openai_embedding(openai_embedding_model: EmbeddingModel) -> None:
     _run_embeddings(VALID_SAMPLE, openai_embedding_model, 1536)
     _run_embeddings(TOO_LONG_SAMPLE, openai_embedding_model, 1536)
 
 
 @pytest.fixture
-def cohere_embedding_model() -> EmbeddingModel:
+def cohere_embedding_model(test_secrets: dict[TestSecret, str]) -> EmbeddingModel:
     return EmbeddingModel(
         server_host="localhost",
         server_port=9000,
@@ -55,12 +55,13 @@ def cohere_embedding_model() -> EmbeddingModel:
         normalize=True,
         query_prefix=None,
         passage_prefix=None,
-        api_key=os.environ["COHERE_API_KEY"],
+        api_key=test_secrets[TestSecret.COHERE_API_KEY],
         provider_type=EmbeddingProvider.COHERE,
         api_url=None,
     )
 
 
+@pytest.mark.secrets(TestSecret.COHERE_API_KEY)
 def test_cohere_embedding(cohere_embedding_model: EmbeddingModel) -> None:
     _run_embeddings(VALID_SAMPLE, cohere_embedding_model, 384)
     _run_embeddings(TOO_LONG_SAMPLE, cohere_embedding_model, 384)
@@ -87,7 +88,7 @@ def test_local_nomic_embedding(local_nomic_embedding_model: EmbeddingModel) -> N
 
 
 @pytest.fixture
-def azure_embedding_model() -> EmbeddingModel:
+def azure_embedding_model(test_secrets: dict[TestSecret, str]) -> EmbeddingModel:
     return EmbeddingModel(
         server_host="localhost",
         server_port=9000,
@@ -95,14 +96,15 @@ def azure_embedding_model() -> EmbeddingModel:
         normalize=True,
         query_prefix=None,
         passage_prefix=None,
-        api_key=os.environ["AZURE_API_KEY"],
+        api_key=test_secrets[TestSecret.AZURE_API_KEY],
         provider_type=EmbeddingProvider.AZURE,
-        api_url=os.environ["AZURE_API_URL"],
+        api_url=test_secrets[TestSecret.AZURE_API_URL],
     )
 
 
 # Azure has strict rate limits on their embedding API, so we retry with exponential
 # backoff to handle transient RateLimitError responses
+@pytest.mark.secrets(TestSecret.AZURE_API_KEY, TestSecret.AZURE_API_URL)
 @retry(
     retry=retry_if_exception_type(RuntimeError),
     stop=stop_after_attempt(5),

--- a/backend/tests/integration/Dockerfile
+++ b/backend/tests/integration/Dockerfile
@@ -14,6 +14,7 @@ COPY ./pytest.ini /app/pytest.ini
 COPY ./tests/integration /app/tests/integration
 # copies all files, but not folders, in the tests directory
 COPY ./tests/* /app/tests/
+COPY ./tests/utils/* /app/tests/utils/
 
 FROM base AS openapi-schema
 COPY ./scripts/onyx_openapi_schema.py /app/scripts/onyx_openapi_schema.py

--- a/backend/tests/utils/aws_secrets.py
+++ b/backend/tests/utils/aws_secrets.py
@@ -59,7 +59,8 @@ def _get_local_secrets(keys: Sequence[AnySecret]) -> dict[AnySecret, str]:
     found: dict[AnySecret, str] = {}
 
     for key in keys:
-        value = os.environ.get(key.value) or dotenv.get(key.value)
+        env_val = os.environ.get(key.value)
+        value = env_val if env_val is not None else dotenv.get(key.value)
         if value:
             found[key] = value
 

--- a/backend/tests/utils/aws_secrets.py
+++ b/backend/tests/utils/aws_secrets.py
@@ -1,0 +1,171 @@
+"""
+Secrets utilities for fetching test secrets.
+
+Secrets are resolved in order:
+    1. Environment variables (already set in the process)
+    2. .env file at the repo root (loaded via dotenv)
+    3. AWS Secrets Manager (batch fetch for any remaining keys)
+
+The AWS environment (prefix) is derived from the enum type passed in, so
+mixing ``TestSecret`` and ``DeploySecret`` values in one call is rejected
+by the type checker.
+
+Usage:
+    In conftest.py, set up a session-scoped fixture driven by the
+    ``@pytest.mark.secrets(...)`` markers collected from tests:
+
+        @pytest.fixture(scope="session")
+        def test_secrets(request) -> dict[TestSecret, str]:
+            needed = getattr(request.config, "_onyx_test_secrets_needed", set())
+            return get_secrets(sorted(needed, key=lambda s: s.value))
+
+    Then in a test module:
+
+        @pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+        def test_openai(openai_client): ...
+
+Configuration via OS environment variables:
+    - AWS_REGION: AWS region for Secrets Manager (default: "us-east-2")
+
+AWS SSO Authentication:
+    boto3 automatically uses SSO credentials if configured in ~/.aws/config.
+    Run ``aws sso login`` to authenticate before running tests.
+"""
+
+import logging
+import os
+from collections.abc import Sequence
+from typing import cast
+from typing import overload
+
+from dotenv import dotenv_values
+
+from tests.utils.secret_names import AnySecret
+from tests.utils.secret_names import DeploySecret
+from tests.utils.secret_names import TestSecret
+
+logger = logging.getLogger(__name__)
+
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-2")
+
+_DOTENV_PATH = os.path.join(
+    os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, ".vscode", ".env"
+)
+
+
+def _get_local_secrets(keys: Sequence[AnySecret]) -> dict[AnySecret, str]:
+    """Resolve secrets from ``os.environ`` first, then ``.vscode/.env``."""
+    dotenv = dotenv_values(_DOTENV_PATH)
+    found: dict[AnySecret, str] = {}
+
+    for key in keys:
+        value = os.environ.get(key.value) or dotenv.get(key.value)
+        if value:
+            found[key] = value
+
+    return found
+
+
+def _get_aws_secrets(
+    keys: Sequence[AnySecret],
+    enum_type: type[AnySecret],
+) -> dict[AnySecret, str]:
+    """Fetch secrets from AWS Secrets Manager in a single batch request."""
+    import boto3
+    from botocore.exceptions import ClientError
+
+    prefix = enum_type.aws_prefix()
+
+    session = boto3.Session()
+    client = session.client(
+        service_name="secretsmanager",
+        region_name=AWS_REGION,
+    )
+
+    secret_ids = [f"{prefix}{name.value}" for name in keys]
+
+    try:
+        response = client.batch_get_secret_value(SecretIdList=secret_ids)
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "AccessDeniedException":
+            raise RuntimeError(
+                f"Access denied to secrets with prefix '{prefix}'. "
+                f"Please check your AWS credentials/permissions or run 'aws sso login'."
+            ) from e
+        elif error_code == "UnrecognizedClientException":
+            raise RuntimeError(
+                "AWS credentials not found or expired. "
+                "If using SSO, run 'aws sso login' to authenticate."
+            ) from e
+        else:
+            raise RuntimeError(
+                f"Failed to fetch secrets from AWS Secrets Manager: {e}"
+            ) from e
+
+    secrets: dict[AnySecret, str] = {}
+    for secret in response.get("SecretValues", []):
+        secret_id = secret.get("Name", "")
+        secret_value = secret.get("SecretString")
+
+        if secret_value:
+            key_name = (
+                secret_id[len(prefix) :] if secret_id.startswith(prefix) else secret_id
+            )
+            try:
+                secrets[enum_type(key_name)] = secret_value
+            except ValueError:
+                logger.warning(
+                    f"Secret '{key_name}' not in {enum_type.__name__}, skipping"
+                )
+
+    for error in response.get("Errors", []):
+        secret_id = error.get("SecretId", "unknown")
+        error_code = error.get("ErrorCode", "unknown")
+        message = error.get("Message", "unknown error")
+        logger.warning(
+            f"Failed to fetch secret '{secret_id}': [{error_code}] {message}"
+        )
+
+    return secrets
+
+
+@overload
+def get_secrets(keys: list[TestSecret]) -> dict[TestSecret, str]: ...
+@overload
+def get_secrets(keys: list[DeploySecret]) -> dict[DeploySecret, str]: ...
+def get_secrets(
+    keys: list[TestSecret] | list[DeploySecret],
+) -> dict[TestSecret, str] | dict[DeploySecret, str]:
+    """Resolve secrets from local sources, then AWS Secrets Manager.
+
+    The AWS prefix is derived from the enum type of the keys. All keys must
+    belong to the same enum; mixing environments in one call is a programming
+    error (and the type checker will reject it at call sites).
+    """
+    if not keys:
+        return cast("dict[TestSecret, str]", {})
+
+    enum_type = type(keys[0])
+    if not all(isinstance(k, enum_type) for k in keys):
+        raise ValueError(
+            "All secrets passed to get_secrets() must belong to the same enum "
+            f"(got a mix including {enum_type.__name__})"
+        )
+
+    secrets = _get_local_secrets(keys)
+
+    if secrets:
+        local_names = ", ".join(k.value for k in secrets)
+        logger.info(f"Resolved {len(secrets)} secret(s) locally: {local_names}")
+
+    remaining: list[AnySecret] = [k for k in keys if k not in secrets]
+    if remaining:
+        aws_secrets = _get_aws_secrets(remaining, enum_type)
+        secrets.update(aws_secrets)
+        logger.info(
+            f"Fetched {len(aws_secrets)}/{len(remaining)} secret(s) from AWS "
+            f"(prefix: {enum_type.aws_prefix()!r})"
+        )
+
+    return cast("dict[TestSecret, str] | dict[DeploySecret, str]", secrets)

--- a/backend/tests/utils/pytest_secrets.py
+++ b/backend/tests/utils/pytest_secrets.py
@@ -1,0 +1,62 @@
+"""Pytest plugin for declaring and batch-fetching test secrets.
+
+Exposes a ``secrets`` marker and a session-scoped ``test_secrets`` fixture
+that resolves the union of ``TestSecret`` values declared across the
+collected tests in a single AWS call.
+
+To opt a test suite in, re-export the hooks and fixture from that suite's
+conftest.py using the PEP 484 explicit re-export form (``name as name``)
+so linters recognize the imports as intentional re-exports:
+
+    from tests.utils.pytest_secrets import (
+        pytest_collection_modifyitems as pytest_collection_modifyitems,
+    )
+    from tests.utils.pytest_secrets import pytest_configure as pytest_configure
+    from tests.utils.pytest_secrets import test_secrets as test_secrets
+
+Then in tests:
+
+    @pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+    def test_something(test_secrets: dict[TestSecret, str]) -> None:
+        ...
+"""
+
+import pytest
+
+from tests.utils.aws_secrets import get_secrets
+from tests.utils.secret_names import TestSecret
+
+_NEEDED_SECRETS_KEY = "_onyx_test_secrets_needed"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "secrets(*secrets: TestSecret): declare which test secrets this test needs. "
+        "All declared secrets across collected tests are batch-fetched once per "
+        "session by the `test_secrets` fixture.",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Collect the union of `@pytest.mark.secrets(...)` args across all items."""
+    needed: set[TestSecret] = set()
+    for item in items:
+        for marker in item.iter_markers(name="secrets"):
+            for arg in marker.args:
+                if not isinstance(arg, TestSecret):
+                    raise TypeError(
+                        f"@pytest.mark.secrets expects TestSecret members, "
+                        f"got {arg!r} on {item.nodeid}"
+                    )
+                needed.add(arg)
+    setattr(config, _NEEDED_SECRETS_KEY, needed)
+
+
+@pytest.fixture(scope="session")
+def test_secrets(request: pytest.FixtureRequest) -> dict[TestSecret, str]:
+    """Resolve only the secrets declared by collected tests, in one batch."""
+    needed: set[TestSecret] = getattr(request.config, _NEEDED_SECRETS_KEY, set())
+    return get_secrets(sorted(needed, key=lambda s: s.value))

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -1,0 +1,46 @@
+"""
+Secret name enums for test secrets.
+
+Each AWS Secrets Manager environment gets its own enum class. The environment
+is derived from the enum type when fetching, so the type checker ensures you
+can't mix secrets from different environments in a single batch call.
+
+Usage:
+    from tests.utils.aws_secrets import get_secrets
+    from tests.utils.secret_names import TestSecret
+
+    secrets = get_secrets([TestSecret.OPENAI_API_KEY, TestSecret.COHERE_API_KEY])
+"""
+
+from enum import StrEnum
+
+
+class TestSecret(StrEnum):
+    """Secrets available in the test environment (AWS prefix: ``test/``)."""
+
+    __test__ = False
+
+    OPENAI_API_KEY = "OPENAI_API_KEY"
+    COHERE_API_KEY = "COHERE_API_KEY"
+    AZURE_API_KEY = "AZURE_API_KEY"
+    AZURE_API_URL = "AZURE_API_URL"
+    LITELLM_API_KEY = "LITELLM_API_KEY"
+    LITELLM_API_URL = "LITELLM_API_URL"
+
+    @classmethod
+    def aws_prefix(cls) -> str:
+        return "test/"
+
+
+class DeploySecret(StrEnum):
+    """Secrets available in the deploy environment (AWS prefix: ``deploy/``).
+
+    Add members here when deploy-scoped secrets are needed.
+    """
+
+    @classmethod
+    def aws_prefix(cls) -> str:
+        return "deploy/"
+
+
+AnySecret = TestSecret | DeploySecret


### PR DESCRIPTION
## Description

Adds a library for fetching AWS secrets in tests at runtime rather than relying on `.env` or environment variables. Values from `.env` (specifically `.vscode/.env`) and environment variables are preferred if set.

Secrets are fetched in batches during pytest initialization and only keys from the tests scheduled to run are fetched.

## How Has This Been Tested?

`uv run pytest backend/tests/daily/embedding/test_embeddings.py`

https://github.com/onyx-dot-app/onyx/actions/runs/24797484749/job/72571021905

## Additional Options

- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch test API keys at runtime and expand chat E2E coverage for file uploads, generated images, and code preview. Adds a `ChatPage` POM and an `npm run playwright` script; refactors existing chat specs to use it.

- **New Features**
  - Runtime secrets for tests: prefer local `.env` and env vars; single-batch `boto3` fetch for missing keys; scoped prefixes (`test/`, `deploy/`); default `AWS_REGION=us-east-2`.
  - `pytest` plugin with `@pytest.mark.secrets` and session `test_secrets`; daily suite opts in via `backend/tests/daily/conftest.py`.
  - Embedding tests declare required keys and use the fixture (`OPENAI_API_KEY`, `COHERE_API_KEY`, `AZURE_API_KEY`, `AZURE_API_URL`); added `LITELLM_API_KEY` and `LITELLM_API_URL`.
  - Integration test image copies `tests/utils` in the Dockerfile.
  - E2E: new `@playwright/test` specs for chat file uploads, LLM image rendering, and the code preview modal; introduced `ChatPage` POM; updated existing specs; added `playwright` npm script.

- **Migration**
  - Ensure `test/*` secrets exist in AWS Secrets Manager; in CI, use `configure-aws-credentials` with OIDC (`ci-protected`).
  - Set `AWS_REGION` if not `us-east-2`. For local runs, put vars in `.vscode/.env` or run `aws sso login`.

<sup>Written for commit 65c9e1007e45cbd3c119790ccb4f8b2d4bf3abbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





