### PR TITLE
feat: add multi-agent support

### DIFF
--- a/backend/alembic/versions/d40c36228074_add_persona_callable_persona_table.py
+++ b/backend/alembic/versions/d40c36228074_add_persona_callable_persona_table.py
@@ -1,0 +1,40 @@
+"""add_persona_callable_persona_table
+
+Revision ID: d40c36228074
+Revises: 41fa44bef321
+Create Date: 2026-01-26 22:34:25.941121
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "d40c36228074"
+down_revision = "41fa44bef321"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persona__callable_persona",
+        sa.Column("caller_persona_id", sa.Integer(), nullable=False),
+        sa.Column("callee_persona_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["caller_persona_id"],
+            ["persona.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["callee_persona_id"],
+            ["persona.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("caller_persona_id", "callee_persona_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("persona__callable_persona")

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -438,6 +438,14 @@ def run_llm_loop(
         system_prompt = None
         custom_agent_prompt_msg = None
 
+        # Extract sub-agent names for orchestrator reminder (AgentTools have negative IDs)
+        # We check by attribute rather than isinstance to avoid circular import with agent_tool.py
+        sub_agent_names: list[str] = [
+            t.target_persona.name  # type: ignore[attr-defined]
+            for t in tools
+            if t.id < 0 and hasattr(t, "target_persona")
+        ]
+
         reasoning_cycles = 0
         for llm_cycle_count in range(MAX_LLM_CYCLES):
             out_of_cycles = llm_cycle_count == MAX_LLM_CYCLES - 1
@@ -535,6 +543,7 @@ def run_llm_loop(
                     include_citation_reminder=should_cite_documents
                     or always_cite_documents,
                     is_last_cycle=out_of_cycles,
+                    sub_agent_names=sub_agent_names if sub_agent_names else None,
                 )
 
             reminder_msg = (

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -78,6 +78,7 @@ from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.tools.constants import SEARCH_TOOL_ID
 from onyx.tools.interface import Tool
 from onyx.tools.models import SearchToolUsage
+from onyx.tools.tool_constructor import AgentToolConfig
 from onyx.tools.tool_constructor import construct_tools
 from onyx.tools.tool_constructor import CustomToolConfig
 from onyx.tools.tool_constructor import SearchToolConfig
@@ -532,6 +533,9 @@ def handle_stream_message_objects(
                 message_id=user_message.id if user_message else None,
                 additional_headers=custom_tool_additional_headers,
                 mcp_headers=mcp_headers,
+            ),
+            agent_tool_config=AgentToolConfig(
+                runtime_callable_persona_ids=new_msg_req.runtime_callable_persona_ids,
             ),
             allowed_tool_ids=new_msg_req.allowed_tool_ids,
             search_usage_forcing_setting=project_search_config.search_usage,

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -12,6 +12,7 @@ from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN
 from onyx.prompts.chat_prompts import DEFAULT_SYSTEM_PROMPT
 from onyx.prompts.chat_prompts import LAST_CYCLE_CITATION_REMINDER
 from onyx.prompts.chat_prompts import REQUIRE_CITATION_GUIDANCE
+from onyx.prompts.chat_prompts import SUB_AGENT_ORCHESTRATOR_REMINDER
 from onyx.prompts.chat_prompts import USER_INFO_HEADER
 from onyx.prompts.prompt_utils import get_company_context
 from onyx.prompts.prompt_utils import handle_onyx_date_awareness
@@ -120,12 +121,17 @@ def build_reminder_message(
     reminder_text: str | None,
     include_citation_reminder: bool,
     is_last_cycle: bool,
+    sub_agent_names: list[str] | None = None,
 ) -> str | None:
     reminder = reminder_text.strip() if reminder_text else ""
     if is_last_cycle:
         reminder += "\n\n" + LAST_CYCLE_CITATION_REMINDER
     if include_citation_reminder:
         reminder += "\n\n" + CITATION_REMINDER
+    if sub_agent_names:
+        reminder += "\n\n" + SUB_AGENT_ORCHESTRATOR_REMINDER.format(
+            sub_agent_names=", ".join(sub_agent_names)
+        )
     reminder = reminder.strip()
     return reminder if reminder else None
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -503,6 +503,23 @@ class Persona__Tool(Base):
     )
 
 
+class Persona__CallablePersona(Base):
+    """Defines which personas a given persona can call as sub-agents.
+
+    The `caller_persona_id` is the persona that initiates the call,
+    and `callee_persona_id` is the target persona being called.
+    """
+
+    __tablename__ = "persona__callable_persona"
+
+    caller_persona_id: Mapped[int] = mapped_column(
+        ForeignKey("persona.id", ondelete="CASCADE"), primary_key=True
+    )
+    callee_persona_id: Mapped[int] = mapped_column(
+        ForeignKey("persona.id", ondelete="CASCADE"), primary_key=True
+    )
+
+
 class StandardAnswer__StandardAnswerCategory(Base):
     __tablename__ = "standard_answer__standard_answer_category"
 
@@ -2870,6 +2887,13 @@ class Persona(Base):
         "Tool",
         secondary=Persona__Tool.__table__,
         back_populates="personas",
+    )
+    # Personas that this persona can call as sub-agents
+    callable_personas: Mapped[list["Persona"]] = relationship(
+        "Persona",
+        secondary=Persona__CallablePersona.__table__,
+        primaryjoin="Persona.id == Persona__CallablePersona.caller_persona_id",
+        secondaryjoin="Persona.id == Persona__CallablePersona.callee_persona_id",
     )
     # Owner
     user: Mapped[User | None] = relationship("User", back_populates="personas")

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -278,6 +278,7 @@ def create_update_persona(
             name=create_persona_request.name,
             document_set_ids=create_persona_request.document_set_ids,
             tool_ids=create_persona_request.tool_ids,
+            callable_persona_ids=create_persona_request.callable_persona_ids,
             is_public=create_persona_request.is_public,
             recency_bias=create_persona_request.recency_bias,
             llm_model_provider_override=create_persona_request.llm_model_provider_override,
@@ -443,6 +444,7 @@ def get_persona_snapshots_for_user(
         selectinload(Persona.user_files),
         selectinload(Persona.users),
         selectinload(Persona.groups),
+        selectinload(Persona.callable_personas),
     )
 
     results = db_session.scalars(stmt).all()
@@ -591,6 +593,7 @@ def get_persona_snapshots_paginated(
         selectinload(Persona.user_files),
         selectinload(Persona.users),
         selectinload(Persona.groups),
+        selectinload(Persona.callable_personas),
     )
 
     results = db_session.scalars(stmt).all()
@@ -807,6 +810,7 @@ def upsert_persona(
     db_session: Session,
     document_set_ids: list[int] | None = None,
     tool_ids: list[int] | None = None,
+    callable_persona_ids: list[int] | None = None,
     persona_id: int | None = None,
     commit: bool = True,
     uploaded_image_id: str | None = None,
@@ -880,6 +884,20 @@ def upsert_persona(
         if not user_files and user_file_ids:
             raise ValueError("user_files not found")
 
+    # Fetch callable personas (sub-agents)
+    callable_personas = None
+    if callable_persona_ids is not None:
+        callable_personas = (
+            db_session.query(Persona)
+            .filter(Persona.id.in_(callable_persona_ids))
+            .filter(Persona.deleted.is_(False))
+            .all()
+        )
+        if len(callable_personas) != len(callable_persona_ids):
+            raise ValueError(
+                "Some callable personas not found or have been deleted"
+            )
+
     labels = None
     if label_ids is not None:
         labels = (
@@ -947,6 +965,10 @@ def upsert_persona(
             existing_persona.user_files.clear()
             existing_persona.user_files = user_files or []
 
+        if callable_persona_ids is not None:
+            existing_persona.callable_personas.clear()
+            existing_persona.callable_personas = callable_personas or []
+
         # We should only update display priority if it is not already set
         if existing_persona.display_priority is None:
             existing_persona.display_priority = display_priority
@@ -986,6 +1008,7 @@ def upsert_persona(
                 is_default_persona if is_default_persona is not None else False
             ),
             user_files=user_files or [],
+            callable_personas=callable_personas or [],
             labels=labels or [],
         )
         db_session.add(new_persona)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -417,6 +417,7 @@ def get_minimal_persona_snapshots_for_user(
         selectinload(Persona.labels),
         selectinload(Persona.document_sets),
         selectinload(Persona.user),
+        selectinload(Persona.callable_personas),
     )
     results = db_session.scalars(stmt).all()
     return [MinimalPersonaSnapshot.from_model(persona) for persona in results]
@@ -535,6 +536,7 @@ def get_minimal_persona_snapshots_paginated(
         selectinload(Persona.labels),
         selectinload(Persona.document_sets),
         selectinload(Persona.user),
+        selectinload(Persona.callable_personas),
     )
 
     results = db_session.scalars(stmt).all()
@@ -967,7 +969,7 @@ def upsert_persona(
 
         if callable_persona_ids is not None:
             existing_persona.callable_personas.clear()
-            existing_persona.callable_personas = callable_personas or []
+            existing_persona.callable_personas = list(callable_personas) if callable_personas else []
 
         # We should only update display priority if it is not already set
         if existing_persona.display_priority is None:

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -887,12 +887,12 @@ def upsert_persona(
     # Fetch callable personas (sub-agents)
     callable_personas = None
     if callable_persona_ids is not None:
-        callable_personas = (
-            db_session.query(Persona)
-            .filter(Persona.id.in_(callable_persona_ids))
-            .filter(Persona.deleted.is_(False))
-            .all()
+        stmt = select(Persona).where(
+            Persona.id.in_(callable_persona_ids),
+            Persona.deleted.is_(False),
         )
+        stmt = _add_user_filters(stmt, user, get_editable=False)
+        callable_personas = db_session.scalars(stmt).all()
         if len(callable_personas) != len(callable_persona_ids):
             raise ValueError(
                 "Some callable personas not found or have been deleted"

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -74,6 +74,13 @@ Do not acknowledge this hint/message in your response.
 """.strip()
 
 
+SUB_AGENT_ORCHESTRATOR_REMINDER = """
+You have specialized sub-agents available: {sub_agent_names}. As an orchestrator, delegate relevant sub-tasks to these agents when appropriate, then synthesize their responses into a cohesive answer for the user.
+
+Do not acknowledge this hint in your response.
+""".strip()
+
+
 # Specifically for OpenAI models, this prefix needs to be in place for the model to output markdown and correct styling
 CODE_BLOCK_MARKDOWN = "Formatting re-enabled. "
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -124,6 +124,9 @@ class MinimalPersonaSnapshot(BaseModel):
     # Used to display ownership
     owner: MinimalUserSnapshot | None
 
+    # IDs of personas that this persona can call as sub-agents (for chat UI)
+    callable_persona_ids: list[int]
+
     @classmethod
     def from_model(cls, persona: Persona) -> "MinimalPersonaSnapshot":
         return MinimalPersonaSnapshot(
@@ -158,6 +161,7 @@ class MinimalPersonaSnapshot(BaseModel):
                 if persona.user
                 else None
             ),
+            callable_persona_ids=[p.id for p in persona.callable_personas],
         )
 
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -80,6 +80,8 @@ class PersonaUpsertRequest(BaseModel):
     display_priority: int | None = None
     # Accept string UUIDs from frontend
     user_file_ids: list[str] | None = None
+    # IDs of other personas that this persona can call as sub-agents
+    callable_persona_ids: list[int] | None = None
 
     # prompt fields
     system_prompt: str
@@ -184,6 +186,8 @@ class PersonaSnapshot(BaseModel):
     llm_model_provider_override: str | None
     llm_model_version_override: str | None
     num_chunks: float | None
+    # IDs of personas that this persona can call as sub-agents
+    callable_persona_ids: list[int]
 
     # Embedded prompt fields (no longer separate prompt_ids)
     system_prompt: str | None = None
@@ -231,6 +235,7 @@ class PersonaSnapshot(BaseModel):
             llm_model_provider_override=persona.llm_model_provider_override,
             llm_model_version_override=persona.llm_model_version_override,
             num_chunks=persona.num_chunks,
+            callable_persona_ids=[p.id for p in persona.callable_personas],
             system_prompt=persona.system_prompt,
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
@@ -290,6 +295,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
                 for document_set_model in persona.document_sets
             ],
             num_chunks=persona.num_chunks,
+            callable_persona_ids=[p.id for p in persona.callable_personas],
             search_start_date=persona.search_start_date,
             llm_relevance_filter=persona.llm_relevance_filter,
             llm_filter_extraction=persona.llm_filter_extraction,

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -92,6 +92,10 @@ class SendMessageRequest(BaseModel):
     allowed_tool_ids: list[int] | None = None
     forced_tool_id: int | None = None
 
+    # Additional personas to make callable as sub-agents at runtime
+    # These are merged with the persona's pre-configured callable_personas
+    runtime_callable_persona_ids: list[int] | None = None
+
     file_descriptors: list[FileDescriptor] = []
 
     internal_search_filters: BaseFilters | None = None

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -45,6 +45,11 @@ class StreamingType(Enum):
     INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta"
     INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs"
 
+    # Agent Tool (sub-agent delegation) packets
+    AGENT_TOOL_START = "agent_tool_start"
+    AGENT_TOOL_TASK = "agent_tool_task"
+    AGENT_TOOL_RESULT = "agent_tool_result"
+
 
 class BaseObj(BaseModel):
     type: str = ""
@@ -285,6 +290,36 @@ class IntermediateReportCitedDocs(BaseObj):
 
 
 ################################################
+# Agent Tool (Sub-Agent Delegation) Packets
+################################################
+class AgentToolStart(BaseObj):
+    """Signal that an agent tool (sub-agent delegation) has started."""
+
+    type: Literal["agent_tool_start"] = StreamingType.AGENT_TOOL_START.value
+
+    tool_name: str  # Display name like "Call Sales Expert"
+    agent_name: str  # Target agent/persona name
+
+
+class AgentToolTask(BaseObj):
+    """The task being delegated to the sub-agent."""
+
+    type: Literal["agent_tool_task"] = StreamingType.AGENT_TOOL_TASK.value
+
+    task: str
+    agent_name: str
+
+
+class AgentToolResult(BaseObj):
+    """The final result from the sub-agent."""
+
+    type: Literal["agent_tool_result"] = StreamingType.AGENT_TOOL_RESULT.value
+
+    answer: str
+    agent_name: str
+
+
+################################################
 # Packet Object
 ################################################
 # Discriminated union of all possible packet object types
@@ -324,6 +359,10 @@ PacketObj = Union[
     IntermediateReportStart,
     IntermediateReportDelta,
     IntermediateReportCitedDocs,
+    # Agent Tool (Sub-Agent Delegation) Packets
+    AgentToolStart,
+    AgentToolTask,
+    AgentToolResult,
 ]
 
 

--- a/backend/onyx/tools/built_in_tools.py
+++ b/backend/onyx/tools/built_in_tools.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Type
 from typing import Union
 
 from onyx.tools.tool_implementations.images.image_generation_tool import (
@@ -25,53 +25,19 @@ BUILT_IN_TOOL_TYPES = Union[
     KnowledgeGraphTool,
     OpenURLTool,
     PythonTool,
-    Any,  # AgentTool loaded lazily
 ]
 
-
-class _LazyToolMap(dict):
-    """Dict subclass that lazily loads AgentTool on first access."""
-
-    def __init__(self):
-        super().__init__({
-            SearchTool.__name__: SearchTool,
-            ImageGenerationTool.__name__: ImageGenerationTool,
-            WebSearchTool.__name__: WebSearchTool,
-            KnowledgeGraphTool.__name__: KnowledgeGraphTool,
-            OpenURLTool.__name__: OpenURLTool,
-            PythonTool.__name__: PythonTool,
-        })
-        self._agent_tool_loaded = False
-
-    def _ensure_agent_tool(self):
-        """Lazy load AgentTool to avoid circular import."""
-        if not self._agent_tool_loaded:
-            from onyx.tools.tool_implementations.agent.agent_tool import AgentTool
-            self[AgentTool.__name__] = AgentTool
-            self._agent_tool_loaded = True
-
-    def __getitem__(self, key):
-        self._ensure_agent_tool()
-        return super().__getitem__(key)
-
-    def __iter__(self):
-        self._ensure_agent_tool()
-        return super().__iter__()
-
-    def items(self):
-        self._ensure_agent_tool()
-        return super().items()
-
-    def keys(self):
-        self._ensure_agent_tool()
-        return super().keys()
-
-    def values(self):
-        self._ensure_agent_tool()
-        return super().values()
-
-
-BUILT_IN_TOOL_MAP: dict[str, Type[Any]] = _LazyToolMap()
+# Note: AgentTool is not included here because it's constructed dynamically
+# based on the persona's callable_personas relationship, not via database
+# tool entries with in_code_tool_id.
+BUILT_IN_TOOL_MAP: dict[str, Type[BUILT_IN_TOOL_TYPES]] = {
+    SearchTool.__name__: SearchTool,
+    ImageGenerationTool.__name__: ImageGenerationTool,
+    WebSearchTool.__name__: WebSearchTool,
+    KnowledgeGraphTool.__name__: KnowledgeGraphTool,
+    OpenURLTool.__name__: OpenURLTool,
+    PythonTool.__name__: PythonTool,
+}
 
 
 STOPPING_TOOLS_NAMES: list[str] = [ImageGenerationTool.NAME]
@@ -86,5 +52,5 @@ def get_built_in_tool_ids() -> list[str]:
     return list(BUILT_IN_TOOL_MAP.keys())
 
 
-def get_built_in_tool_by_id(in_code_tool_id: str) -> Type[Any]:
+def get_built_in_tool_by_id(in_code_tool_id: str) -> Type[BUILT_IN_TOOL_TYPES]:
     return BUILT_IN_TOOL_MAP[in_code_tool_id]

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -192,6 +192,23 @@ class PythonToolOverrideKwargs(BaseModel):
     chat_files: list[ChatFile] = []
 
 
+class AgentToolOverrideKwargs(BaseModel):
+    """Override kwargs for agent-as-tool calls."""
+
+    agent_call_stack: list[int] = []
+    max_recursion_depth: int = 2
+    starting_citation_num: int = 1
+    citation_mapping: dict[int, str] = {}
+
+
+class AgentCallResult(BaseModel):
+    """Result from a sub-agent execution."""
+
+    answer: str
+    citation_mapping: dict[int, SearchDoc] = {}
+    token_count: int = 0
+
+
 class SearchToolRunContext(BaseModel):
     emitter: Emitter
 

--- a/backend/onyx/tools/tool_implementations/agent/__init__.py
+++ b/backend/onyx/tools/tool_implementations/agent/__init__.py
@@ -1,0 +1,1 @@
+# Agent tool implementation

--- a/backend/onyx/tools/tool_implementations/agent/agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/agent/agent_tool.py
@@ -128,8 +128,15 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
                 llm_facing_message=f"Maximum delegation depth reached"
             )
 
+        # Extract task from kwargs
+        task: str = kwargs.get("task", "")
+        if not task:
+            raise ToolCallException(
+                message="Missing required 'task' parameter",
+                llm_facing_message="Please provide a task to delegate"
+            )
+
         # Run sub-agent
-        task = "DUMMY TASK"
         result = self._run_sub_agent(
             task=task,
             placement=placement,

--- a/backend/onyx/tools/tool_implementations/agent/agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/agent/agent_tool.py
@@ -1,5 +1,3 @@
-"""Minimal AgentTool implementation - allows one persona to call another as a tool."""
-
 from collections.abc import Callable
 
 from sqlalchemy.orm import Session
@@ -192,7 +190,7 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
     ) -> AgentCallResult:
         """Run sub-agent LLM loop."""
 
-        # FIXME: Local import to avoid circular dependency through built_in_tools
+        # Local import to avoid circular dependency through built_in_tools
 
         from onyx.chat.llm_loop import construct_message_history
 

--- a/backend/onyx/tools/tool_implementations/agent/agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/agent/agent_tool.py
@@ -1,0 +1,307 @@
+"""Minimal AgentTool implementation - allows one persona to call another as a tool."""
+
+from collections.abc import Callable
+
+from sqlalchemy.orm import Session
+
+from onyx.chat.citation_processor import CitationMode, DynamicCitationProcessor
+from onyx.chat.citation_utils import update_citation_processor_from_tool_response
+from onyx.chat.emitter import Emitter
+from onyx.chat.llm_step import run_llm_step
+from onyx.chat.models import ChatMessageSimple
+from onyx.chat.prompt_utils import build_reminder_message, build_system_prompt
+from onyx.configs.constants import MessageType
+from onyx.context.search.models import BaseFilters
+from onyx.db.models import Persona, User
+from onyx.document_index.interfaces import DocumentIndex
+from onyx.llm.interfaces import LLM
+from onyx.llm.factory import get_llm_token_counter
+from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.factory import get_llm_for_persona
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CustomToolStart, Packet
+from onyx.tools.interface import Tool, ToolResponse
+from onyx.tools.models import AgentCallResult, AgentToolOverrideKwargs, SearchToolUsage, ToolCallException
+from onyx.tools.tool_constructor import construct_tools
+from onyx.tools.tool_runner import run_tool_calls
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+AGENT_CYCLE_CAP = 3
+
+
+class AgentTool(Tool[AgentToolOverrideKwargs | None]):
+    """Tool that calls another persona as a sub-agent."""
+
+    NAME = "call_agent"
+
+    def __init__(
+        self,
+        tool_id: int,
+        target_persona: Persona,
+        db_session: Session,
+        emitter: Emitter,
+        user: User | None,
+        llm: LLM,
+        document_index: DocumentIndex,
+        user_selected_filters: BaseFilters | None,
+        is_connected_fn: Callable[[], bool] | None = None,
+    ):
+        super().__init__(emitter=emitter)
+        self._id = tool_id
+        self.target_persona = target_persona
+        self.db_session = db_session
+        self.user = user
+        self.parent_llm = llm
+        self.document_index = document_index
+        self.user_selected_filters = user_selected_filters
+        self.is_connected_fn = is_connected_fn
+
+        self._display_name = f"Call {target_persona.name}"
+        self._tool_name = f"call_{target_persona.name.lower().replace(' ', '_')}"
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self._tool_name
+
+    @property
+    def display_name(self) -> str:
+        return self._display_name
+
+    @property
+    def description(self) -> str:
+        return f"Delegate a task to {self.target_persona.name}. {self.target_persona.description}"
+
+    def tool_definition(self) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "The specific task or question to delegate"
+                        }
+                    },
+                    "required": ["task"]
+                }
+            }
+        }
+
+    def emit_start(self, placement: Placement) -> None:
+        self.emitter.emit(
+            Packet(
+                placement=placement,
+                obj=CustomToolStart(tool_name=self.display_name),
+            )
+        )
+
+    def run(
+        self,
+        placement: Placement,
+        override_kwargs: AgentToolOverrideKwargs | None,
+        **kwargs,
+    ) -> ToolResponse:
+        """Execute sub-agent with the given task."""
+
+        if override_kwargs is None:
+            override_kwargs = AgentToolOverrideKwargs()
+
+        # Check recursion
+        if self.target_persona.id in override_kwargs.agent_call_stack:
+            raise ToolCallException(
+                message=f"Recursive call to {self.target_persona.name}",
+                llm_facing_message=f"Cannot call {self.target_persona.name} recursively"
+            )
+
+        if len(override_kwargs.agent_call_stack) >= override_kwargs.max_recursion_depth:
+            raise ToolCallException(
+                message=f"Max depth {override_kwargs.max_recursion_depth} exceeded",
+                llm_facing_message=f"Maximum delegation depth reached"
+            )
+
+        # Run sub-agent
+        task = "DUMMY TASK"
+        result = self._run_sub_agent(
+            task=task,
+            placement=placement,
+            agent_call_stack=override_kwargs.agent_call_stack + [self.target_persona.id],
+            starting_citation_num=override_kwargs.starting_citation_num,
+            parent_citation_mapping=override_kwargs.citation_mapping,
+        )
+
+        return ToolResponse(
+            rich_response=None,
+            llm_facing_response=result.answer,
+        )
+
+    def _run_sub_agent(
+        self,
+        task: str,
+        placement: Placement,
+        agent_call_stack: list[int],
+        starting_citation_num: int,
+        parent_citation_mapping: dict[int, str],
+    ) -> AgentCallResult:
+        """Run sub-agent LLM loop."""
+
+        # FIXME: Local import to avoid circular dependency through built_in_tools
+
+        from onyx.chat.llm_loop import construct_message_history
+
+        # Initialize sub-agent LLM
+        sub_agent_llm = get_llm_for_persona(
+            persona=self.target_persona,
+            user=self.user,
+            llm_override=None,
+        )
+
+        token_counter = get_llm_token_counter(sub_agent_llm)
+
+        # Fresh message history with task
+        initial_message = ChatMessageSimple(
+            message=task,
+            token_count=token_counter(task),
+            message_type=MessageType.USER,
+        )
+        msg_history: list[ChatMessageSimple] = [initial_message]
+
+        # Citation processor (KEEP_MARKERS mode)
+        citation_processor = DynamicCitationProcessor(
+            citation_mode=CitationMode.KEEP_MARKERS
+        )
+
+        # Construct tools for sub-agent
+        tools = construct_tools(
+            persona=self.target_persona,
+            db_session=self.db_session,
+            emitter=self.emitter,
+            user=self.user,
+            llm=sub_agent_llm,
+            search_tool_config=None,
+            custom_tool_config=None,
+            allowed_tool_ids=None,
+            search_usage_forcing_setting=SearchToolUsage.AUTO,
+        )
+
+        # Flatten tools and filter out agent tools to prevent deep nesting
+        all_tools = [tool for tool_list in tools.values() for tool in tool_list]
+        current_tools = [t for t in all_tools if not isinstance(t, AgentTool)]
+
+        # Build system prompt
+        system_prompt_str = build_system_prompt(
+            base_system_prompt=self.target_persona.system_prompt or "",
+            datetime_aware=self.target_persona.datetime_aware,
+            tools=current_tools,
+            should_cite_documents=True,
+        )
+
+        system_prompt = ChatMessageSimple(
+            message=system_prompt_str,
+            token_count=token_counter(system_prompt_str),
+            message_type=MessageType.SYSTEM,
+        )
+
+        # Run LLM cycles
+        final_answer = ""
+        next_citation_num = starting_citation_num
+        for cycle in range(AGENT_CYCLE_CAP + 1):
+            out_of_cycles = cycle == AGENT_CYCLE_CAP
+            cycle_tools = [] if out_of_cycles else current_tools
+
+            # Build reminder
+            reminder_text = build_reminder_message(
+                reminder_text=self.target_persona.task_prompt,
+                include_citation_reminder=True,
+                is_last_cycle=out_of_cycles,
+            ) or ""
+            reminder_msg = ChatMessageSimple(
+                message=reminder_text,
+                token_count=token_counter(reminder_text),
+                message_type=MessageType.USER,
+            )
+
+            # Construct full history
+            full_history = construct_message_history(
+                system_prompt=system_prompt,
+                custom_agent_prompt=None,
+                simple_chat_history=msg_history,
+                reminder_message=reminder_msg,
+                project_files=None,
+                available_tokens=sub_agent_llm.config.max_input_tokens,
+            )
+
+            # Call LLM
+            tool_defs = [t.tool_definition() for t in cycle_tools]
+            tool_choice = (
+                ToolChoiceOptions.AUTO if cycle_tools else ToolChoiceOptions.NONE
+            )
+
+            llm_result, _ = run_llm_step(
+                emitter=self.emitter,
+                history=full_history,
+                tool_definitions=tool_defs,
+                tool_choice=tool_choice,
+                llm=sub_agent_llm,
+                placement=Placement(
+                    turn_index=placement.turn_index,
+                    tab_index=placement.tab_index,
+                    sub_turn_index=cycle,
+                ),
+                citation_processor=citation_processor,
+                state_container=None,
+            )
+
+            if llm_result.answer:
+                final_answer = llm_result.answer
+                if not llm_result.tool_calls:
+                    break
+
+            # Execute tool calls
+            if llm_result.tool_calls:
+                tool_call_results = run_tool_calls(
+                    tool_calls=llm_result.tool_calls,
+                    tools=cycle_tools,
+                    message_history=full_history,
+                    memories=None,
+                    user_info=None,
+                    citation_mapping={},
+                    next_citation_num=next_citation_num,
+                    max_concurrent_tools=3,
+                )
+
+                # Add to history
+                for tool_result in tool_call_results.tool_responses:
+                    tool_call = tool_result.tool_call
+                    if tool_call is None:
+                        raise ValueError("Tool response missing tool_call reference")
+                    update_citation_processor_from_tool_response(
+                        tool_result, citation_processor
+                    )
+                    msg_history.append(ChatMessageSimple(
+                        message=tool_call.to_msg_str(),
+                        message_type=MessageType.TOOL_CALL,
+                        tool_call_id=tool_call.tool_call_id,
+                        token_count=token_counter(tool_call.to_msg_str()),
+                    ))
+                    msg_history.append(ChatMessageSimple(
+                        message=tool_result.llm_facing_response,
+                        message_type=MessageType.TOOL_CALL_RESPONSE,
+                        tool_call_id=tool_call.tool_call_id,
+                        token_count=token_counter(tool_result.llm_facing_response),
+                    ))
+                next_citation_num = citation_processor.get_next_citation_number()
+
+        return AgentCallResult(
+            answer=final_answer,
+            citation_mapping=citation_processor.get_seen_citations(),
+            token_count=token_counter(final_answer),
+        )

--- a/backend/onyx/tools/tool_implementations/agent/agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/agent/agent_tool.py
@@ -19,7 +19,12 @@ from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.models import ToolChoiceOptions
 from onyx.llm.factory import get_llm_for_persona
 from onyx.server.query_and_chat.placement import Placement
-from onyx.server.query_and_chat.streaming_models import CustomToolDelta, CustomToolStart, Packet
+from onyx.server.query_and_chat.streaming_models import (
+    AgentToolResult,
+    AgentToolStart,
+    AgentToolTask,
+    Packet,
+)
 from onyx.tools.interface import Tool, ToolResponse
 from onyx.tools.models import AgentCallResult, AgentToolOverrideKwargs, SearchToolUsage, ToolCallException
 from onyx.tools.tool_constructor import construct_tools
@@ -100,7 +105,10 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
         self.emitter.emit(
             Packet(
                 placement=placement,
-                obj=CustomToolStart(tool_name=self.display_name),
+                obj=AgentToolStart(
+                    tool_name=self.display_name,
+                    agent_name=self.target_persona.name,
+                ),
             )
         )
 
@@ -140,10 +148,9 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
         self.emitter.emit(
             Packet(
                 placement=placement,
-                obj=CustomToolDelta(
-                    tool_name=self.display_name,
-                    response_type="task",
-                    data={"task": task, "agent": self.target_persona.name},
+                obj=AgentToolTask(
+                    task=task,
+                    agent_name=self.target_persona.name,
                 ),
             )
         )
@@ -161,10 +168,9 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
         self.emitter.emit(
             Packet(
                 placement=placement,
-                obj=CustomToolDelta(
-                    tool_name=self.display_name,
-                    response_type="result",
-                    data={"answer": result.answer, "agent": self.target_persona.name},
+                obj=AgentToolResult(
+                    answer=result.answer,
+                    agent_name=self.target_persona.name,
                 ),
             )
         )

--- a/backend/onyx/tools/tool_implementations/agent/agent_tool.py
+++ b/backend/onyx/tools/tool_implementations/agent/agent_tool.py
@@ -225,7 +225,7 @@ class AgentTool(Tool[AgentToolOverrideKwargs | None]):
 
         # Flatten tools and filter out agent tools to prevent deep nesting
         all_tools = [tool for tool_list in tools.values() for tool in tool_list]
-        current_tools = [t for t in all_tools if not isinstance(t, AgentTool)]
+        current_tools = [t for t in all_tools if not (isinstance(t, AgentTool) and t.target_persona.id in agent_call_stack)]
 
         # Build system prompt
         system_prompt_str = build_system_prompt(

--- a/backend/tests/integration/tests/agent_tool/test_agent_tool.py
+++ b/backend/tests/integration/tests/agent_tool/test_agent_tool.py
@@ -1,0 +1,262 @@
+"""
+Integration tests for AgentTool functionality.
+
+Tests the ability for one persona to call another persona as a tool.
+"""
+
+import pytest
+
+from onyx.chat.emitter import get_default_emitter
+from onyx.document_index.factory import get_default_document_index
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
+from onyx.db.search_settings import get_active_search_settings
+from onyx.llm.factory import get_default_llm
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.models import AgentToolOverrideKwargs, ToolCallException
+from onyx.tools.tool_implementations.agent.agent_tool import AgentTool
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+
+@pytest.fixture
+def parent_persona_fixture(admin_user: DATestUser):
+    """Create parent persona for tests."""
+    return PersonaManager.create(
+        name="Parent Agent",
+        description="Parent agent that can delegate to other agents",
+        system_prompt="You are a parent agent that can delegate tasks",
+        task_prompt="Delegate complex tasks to specialists",
+        user_performing_action=admin_user,
+    )
+
+
+@pytest.fixture
+def sub_persona_fixture(admin_user: DATestUser):
+    """Create sub-agent persona for tests."""
+    return PersonaManager.create(
+        name="Sub Agent",
+        description="Specialized sub-agent for handling delegated tasks",
+        system_prompt="You are a specialized sub-agent",
+        task_prompt="Answer questions concisely",
+        user_performing_action=admin_user,
+    )
+
+
+def test_agent_tool_construction(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+):
+    """Test that AgentTool can be constructed properly."""
+
+    with get_session_with_current_tenant() as db_session:
+        active = get_active_search_settings(db_session)
+        # Get user from database
+        user = (
+            db_session.query(User).filter_by(email=admin_user.email).first()
+        )
+        assert user is not None, "Test user not found in database"
+
+        # Get personas from database
+        parent_persona = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        assert parent_persona is not None, "Parent persona not found"
+        assert sub_persona is not None, "Sub-agent persona not found"
+
+        # Create AgentTool
+        agent_tool = AgentTool(
+            tool_id=99999,
+            target_persona=sub_persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            document_index=get_default_document_index(active.primary, active.secondary),
+            user_selected_filters=None,
+        )
+
+        # Verify tool properties
+        assert agent_tool.id == 99999
+        assert agent_tool.name == f"call_{sub_persona.name.lower().replace(' ', '_')}"
+        assert agent_tool.display_name == f"Call {sub_persona.name}"
+        assert sub_persona.name in agent_tool.description
+
+        # Verify tool definition
+        tool_def = agent_tool.tool_definition()
+        assert tool_def["type"] == "function"
+        assert "task" in tool_def["function"]["parameters"]["properties"]
+        assert "task" in tool_def["function"]["parameters"]["required"]
+
+
+def test_agent_tool_execution(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+):
+    """Test that AgentTool can execute and call sub-agent."""
+
+    with get_session_with_current_tenant() as db_session:
+        active = get_active_search_settings(db_session)
+        # Get user from database
+        user = (
+            db_session.query(User).filter_by(email=admin_user.email).first()
+        )
+        assert user is not None
+
+        # Get personas
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Create tool
+        agent_tool = AgentTool(
+            tool_id=99999,
+            target_persona=sub_persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            document_index=get_default_document_index(active.primary, active.secondary),
+            user_selected_filters=None,
+        )
+
+        # Execute tool
+        result = agent_tool.run(
+            placement=Placement(turn_index=0, tab_index=0, sub_turn_index=None),
+            override_kwargs=AgentToolOverrideKwargs(
+                agent_call_stack=[],
+                max_recursion_depth=2,
+                starting_citation_num=1,
+                citation_mapping={},
+            ),
+            task="What are the main features of this application?",
+        )
+
+        # Verify result
+        assert result is not None
+        assert result.llm_facing_response is not None
+        assert len(result.llm_facing_response) > 0
+
+
+def test_recursion_prevention(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    sub_persona_fixture,
+):
+    """Test that AgentTool prevents recursive calls."""
+
+    with get_session_with_current_tenant() as db_session:
+        active = get_active_search_settings(db_session)
+        # Get user
+        user = (
+            db_session.query(User).filter_by(email=admin_user.email).first()
+        )
+        assert user is not None
+
+        # Get persona
+        persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Create tool
+        agent_tool = AgentTool(
+            tool_id=99999,
+            target_persona=persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            document_index=get_default_document_index(active.primary, active.secondary),
+            user_selected_filters=None,
+        )
+
+        # Attempt recursive call (persona already in call stack)
+        with pytest.raises(ToolCallException) as exc_info:
+            agent_tool.run(
+                placement=Placement(turn_index=0, tab_index=0, sub_turn_index=None),
+                override_kwargs=AgentToolOverrideKwargs(
+                    agent_call_stack=[persona.id],  # Already in stack!
+                    max_recursion_depth=2,
+                    starting_citation_num=1,
+                    citation_mapping={},
+                ),
+                task="Test recursion",
+            )
+
+        # Verify exception message
+        assert "recursively" in exc_info.value.llm_facing_message.lower()
+
+
+def test_depth_limiting(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    sub_persona_fixture,
+):
+    """Test that AgentTool enforces maximum recursion depth."""
+
+    with get_session_with_current_tenant() as db_session:
+        active = get_active_search_settings(db_session)
+        # Get user
+        user = (
+            db_session.query(User).filter_by(email=admin_user.email).first()
+        )
+        assert user is not None
+
+        # Get persona
+        persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Create tool
+        agent_tool = AgentTool(
+            tool_id=99999,
+            target_persona=persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            document_index=get_default_document_index(active.primary, active.secondary),
+            user_selected_filters=None,
+        )
+
+        # Attempt call at maximum depth
+        # Use high IDs that won't collide with actual persona IDs to avoid
+        # triggering the recursion check before the depth check
+        with pytest.raises(ToolCallException) as exc_info:
+            agent_tool.run(
+                placement=Placement(turn_index=0, tab_index=0, sub_turn_index=None),
+                override_kwargs=AgentToolOverrideKwargs(
+                    agent_call_stack=[999998, 999999],  # Already at depth 2
+                    max_recursion_depth=2,
+                    starting_citation_num=1,
+                    citation_mapping={},
+                ),
+                task="Test depth limit",
+            )
+
+        # Verify exception message
+        assert "depth" in exc_info.value.llm_facing_message.lower()

--- a/backend/tests/integration/tests/agent_tool/test_agent_tool.py
+++ b/backend/tests/integration/tests/agent_tool/test_agent_tool.py
@@ -9,12 +9,13 @@ import pytest
 from onyx.chat.emitter import get_default_emitter
 from onyx.document_index.factory import get_default_document_index
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.models import User
+from onyx.db.models import Persona__CallablePersona, User
 from onyx.db.persona import get_persona_by_id
 from onyx.db.search_settings import get_active_search_settings
 from onyx.llm.factory import get_default_llm
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import AgentToolOverrideKwargs, ToolCallException
+from onyx.tools.tool_constructor import AgentToolConfig, construct_tools
 from onyx.tools.tool_implementations.agent.agent_tool import AgentTool
 from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.test_models import DATestLLMProvider
@@ -260,3 +261,366 @@ def test_depth_limiting(
 
         # Verify exception message
         assert "depth" in exc_info.value.llm_facing_message.lower()
+
+
+def test_missing_task_parameter(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    sub_persona_fixture,
+):
+    """Test that AgentTool raises error when task parameter is missing."""
+
+    with get_session_with_current_tenant() as db_session:
+        active = get_active_search_settings(db_session)
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        agent_tool = AgentTool(
+            tool_id=99999,
+            target_persona=persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            document_index=get_default_document_index(active.primary, active.secondary),
+            user_selected_filters=None,
+        )
+
+        # Call without task parameter
+        with pytest.raises(ToolCallException) as exc_info:
+            agent_tool.run(
+                placement=Placement(turn_index=0, tab_index=0, sub_turn_index=None),
+                override_kwargs=AgentToolOverrideKwargs(),
+                # No task parameter provided
+            )
+
+        assert "task" in exc_info.value.llm_facing_message.lower()
+
+
+# =============================================================================
+# Integration tests for callable_personas relationship
+# =============================================================================
+
+
+@pytest.fixture
+def specialist_agent_fixture(admin_user: DATestUser):
+    """Create a specialist agent persona."""
+    return PersonaManager.create(
+        name="Specialist Agent",
+        description="A specialist agent for specific tasks",
+        system_prompt="You are a specialist",
+        task_prompt="Handle specialized requests",
+        user_performing_action=admin_user,
+    )
+
+
+@pytest.fixture
+def researcher_agent_fixture(admin_user: DATestUser):
+    """Create a researcher agent persona."""
+    return PersonaManager.create(
+        name="Researcher Agent",
+        description="A researcher agent for research tasks",
+        system_prompt="You are a researcher",
+        task_prompt="Conduct research",
+        user_performing_action=admin_user,
+    )
+
+
+def test_callable_personas_relationship(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+    specialist_agent_fixture,
+):
+    """Test that callable_personas relationship works correctly."""
+
+    with get_session_with_current_tenant() as db_session:
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        # Get personas
+        parent_persona = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        specialist = get_persona_by_id(
+            persona_id=specialist_agent_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Initially, no callable personas
+        assert len(parent_persona.callable_personas) == 0
+
+        # Add callable personas through the association table
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona.id,
+        ))
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=specialist.id,
+        ))
+        db_session.commit()
+
+        # Refresh the persona
+        db_session.refresh(parent_persona)
+
+        # Should now have two callable personas
+        assert len(parent_persona.callable_personas) == 2
+
+        callable_ids = {p.id for p in parent_persona.callable_personas}
+        assert sub_persona.id in callable_ids
+        assert specialist.id in callable_ids
+
+
+def test_construct_tools_creates_agent_tools_for_callable_personas(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+    specialist_agent_fixture,
+):
+    """Test that construct_tools creates AgentTools for each callable persona."""
+
+    with get_session_with_current_tenant() as db_session:
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        # Get personas
+        parent_persona = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        specialist = get_persona_by_id(
+            persona_id=specialist_agent_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Add callable personas
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona.id,
+        ))
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=specialist.id,
+        ))
+        db_session.commit()
+        db_session.refresh(parent_persona)
+
+        # Construct tools
+        tool_dict = construct_tools(
+            persona=parent_persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+            agent_tool_config=AgentToolConfig(),
+        )
+
+        # Should have AgentTools for each callable persona
+        # IDs are negative of target persona IDs
+        assert -sub_persona.id in tool_dict
+        assert -specialist.id in tool_dict
+
+        # Verify tools are AgentTool instances
+        sub_agent_tool = tool_dict[-sub_persona.id][0]
+        specialist_tool = tool_dict[-specialist.id][0]
+
+        assert isinstance(sub_agent_tool, AgentTool)
+        assert isinstance(specialist_tool, AgentTool)
+
+        # Verify tool names follow pattern
+        assert sub_agent_tool.name == "call_sub_agent"
+        assert specialist_tool.name == "call_specialist_agent"
+
+
+def test_agent_tool_execution_via_construct_tools(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+):
+    """Test that AgentTools created via construct_tools can execute."""
+
+    with get_session_with_current_tenant() as db_session:
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        # Get personas
+        parent_persona = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Add callable persona
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona.id,
+        ))
+        db_session.commit()
+        db_session.refresh(parent_persona)
+
+        # Construct tools
+        tool_dict = construct_tools(
+            persona=parent_persona,
+            db_session=db_session,
+            emitter=get_default_emitter(),
+            user=user,
+            llm=get_default_llm(),
+        )
+
+        # Get the agent tool
+        agent_tool = tool_dict[-sub_persona.id][0]
+
+        # Execute the tool
+        result = agent_tool.run(
+            placement=Placement(turn_index=0, tab_index=0, sub_turn_index=None),
+            override_kwargs=AgentToolOverrideKwargs(
+                agent_call_stack=[],
+                max_recursion_depth=2,
+                starting_citation_num=1,
+                citation_mapping={},
+            ),
+            task="Summarize your capabilities",
+        )
+
+        # Verify result
+        assert result is not None
+        assert result.llm_facing_response is not None
+
+
+def test_cascade_delete_callable_persona(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+):
+    """Test that deleting a persona cascades to callable_persona relationships."""
+
+    with get_session_with_current_tenant() as db_session:
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        # Get personas
+        parent_persona = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        sub_persona = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Add callable persona relationship
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona.id,
+        ))
+        db_session.commit()
+
+        # Verify relationship exists
+        relationship = db_session.query(Persona__CallablePersona).filter_by(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona.id,
+        ).first()
+        assert relationship is not None
+
+        # Delete the sub-persona (callee)
+        sub_persona_id = sub_persona.id
+        db_session.delete(sub_persona)
+        db_session.commit()
+
+        # Verify relationship was cascaded
+        relationship = db_session.query(Persona__CallablePersona).filter_by(
+            caller_persona_id=parent_persona.id,
+            callee_persona_id=sub_persona_id,
+        ).first()
+        assert relationship is None
+
+
+def test_multiple_callers_single_callee(
+    reset: None,
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,
+    parent_persona_fixture,
+    sub_persona_fixture,
+    researcher_agent_fixture,
+):
+    """Test that multiple personas can call the same target persona."""
+
+    with get_session_with_current_tenant() as db_session:
+        user = db_session.query(User).filter_by(email=admin_user.email).first()
+        assert user is not None
+
+        # Get personas
+        caller1 = get_persona_by_id(
+            persona_id=parent_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        caller2 = get_persona_by_id(
+            persona_id=researcher_agent_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+        target = get_persona_by_id(
+            persona_id=sub_persona_fixture.id,
+            db_session=db_session,
+            user=user,
+        )
+
+        # Both callers can call the same target
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=caller1.id,
+            callee_persona_id=target.id,
+        ))
+        db_session.add(Persona__CallablePersona(
+            caller_persona_id=caller2.id,
+            callee_persona_id=target.id,
+        ))
+        db_session.commit()
+
+        # Refresh
+        db_session.refresh(caller1)
+        db_session.refresh(caller2)
+
+        # Both should be able to call target
+        assert len(caller1.callable_personas) == 1
+        assert len(caller2.callable_personas) == 1
+        assert caller1.callable_personas[0].id == target.id
+        assert caller2.callable_personas[0].id == target.id

--- a/backend/tests/unit/onyx/tools/test_tool_constructor.py
+++ b/backend/tests/unit/onyx/tools/test_tool_constructor.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for tool_constructor.py.
+
+Tests the construction of tools for personas, including AgentTool creation.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onyx.tools.tool_constructor import (
+    AgentToolConfig,
+    construct_tools,
+)
+
+
+class MockPersona:
+    """Mock persona for testing."""
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        tools: list | None = None,
+        callable_personas: list | None = None,
+    ):
+        self.id = id
+        self.name = name
+        self.description = f"Description for {name}"
+        self.system_prompt = f"System prompt for {name}"
+        self.task_prompt = f"Task prompt for {name}"
+        self.tools = tools or []
+        self.callable_personas = callable_personas or []
+        self.datetime_aware = True
+
+
+class MockEmitter:
+    """Mock emitter for testing."""
+
+    def emit(self, packet):
+        pass
+
+
+class MockLLM:
+    """Mock LLM for testing."""
+
+    def __init__(self):
+        self.config = MagicMock()
+        self.config.max_input_tokens = 4096
+
+
+class MockDocumentIndex:
+    """Mock document index for testing."""
+
+    pass
+
+
+class TestAgentToolConfig:
+    """Tests for AgentToolConfig class."""
+
+    def test_default_values(self):
+        """Test that AgentToolConfig has correct defaults."""
+        config = AgentToolConfig()
+
+        assert config.user_selected_filters is None
+        assert config.is_connected_fn is None
+
+    def test_with_values(self):
+        """Test AgentToolConfig with provided values."""
+        from onyx.context.search.models import BaseFilters
+
+        mock_filters = BaseFilters()
+        mock_fn = lambda: True
+
+        config = AgentToolConfig(
+            user_selected_filters=mock_filters,
+            is_connected_fn=mock_fn,
+        )
+
+        assert config.user_selected_filters == mock_filters
+        assert config.is_connected_fn == mock_fn
+
+
+class TestConstructToolsWithCallablePersonas:
+    """Tests for construct_tools with callable personas."""
+
+    @pytest.fixture
+    def mock_db_session(self):
+        """Create a mock database session."""
+        session = MagicMock()
+        return session
+
+    @pytest.fixture
+    def mock_search_settings(self):
+        """Mock for search settings."""
+        settings = MagicMock()
+        settings.primary = MagicMock()
+        settings.secondary = None
+        return settings
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_no_callable_personas_returns_empty_agent_tools(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+        mock_db_session,
+        mock_search_settings,
+    ):
+        """Test that no AgentTools are created when no callable personas."""
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        # Persona with no callable personas
+        persona = MockPersona(
+            id=1,
+            name="Test Persona",
+            tools=[],
+            callable_personas=[],
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=mock_db_session,
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+        )
+
+        # Should have no tools
+        assert len(tool_dict) == 0
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_single_callable_persona_creates_agent_tool(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+        mock_db_session,
+        mock_search_settings,
+    ):
+        """Test that one AgentTool is created for one callable persona."""
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        # Target persona
+        target_persona = MockPersona(id=2, name="Research Agent")
+
+        # Main persona with one callable persona
+        persona = MockPersona(
+            id=1,
+            name="Main Persona",
+            tools=[],
+            callable_personas=[target_persona],
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=mock_db_session,
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+        )
+
+        # Should have one AgentTool with synthetic negative ID
+        assert len(tool_dict) == 1
+        assert -2 in tool_dict  # -target_persona.id
+
+        agent_tool = tool_dict[-2][0]
+        assert agent_tool.name == "call_research_agent"
+        assert agent_tool.target_persona == target_persona
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_multiple_callable_personas_creates_multiple_agent_tools(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+        mock_db_session,
+        mock_search_settings,
+    ):
+        """Test that multiple AgentTools are created for multiple callable personas."""
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        # Target personas
+        target_1 = MockPersona(id=10, name="Research Agent")
+        target_2 = MockPersona(id=20, name="Writing Agent")
+        target_3 = MockPersona(id=30, name="Code Agent")
+
+        # Main persona with multiple callable personas
+        persona = MockPersona(
+            id=1,
+            name="Orchestrator",
+            tools=[],
+            callable_personas=[target_1, target_2, target_3],
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=mock_db_session,
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+        )
+
+        # Should have three AgentTools
+        assert len(tool_dict) == 3
+
+        # Check each tool exists with correct synthetic ID
+        assert -10 in tool_dict
+        assert -20 in tool_dict
+        assert -30 in tool_dict
+
+        # Verify tool names
+        tool_names = {tool_dict[tid][0].name for tid in tool_dict}
+        assert "call_research_agent" in tool_names
+        assert "call_writing_agent" in tool_names
+        assert "call_code_agent" in tool_names
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_agent_tool_config_is_passed(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+        mock_db_session,
+        mock_search_settings,
+    ):
+        """Test that AgentToolConfig values are used when creating AgentTools."""
+        from onyx.context.search.models import BaseFilters
+
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        target_persona = MockPersona(id=5, name="Helper")
+
+        persona = MockPersona(
+            id=1,
+            name="Main",
+            tools=[],
+            callable_personas=[target_persona],
+        )
+
+        # Create config with real filter type
+        test_filters = BaseFilters()
+        agent_config = AgentToolConfig(
+            user_selected_filters=test_filters,
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=mock_db_session,
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+            agent_tool_config=agent_config,
+        )
+
+        # Verify config was passed
+        agent_tool = tool_dict[-5][0]
+        assert agent_tool.user_selected_filters == test_filters
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_synthetic_ids_are_unique_negative(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+        mock_db_session,
+        mock_search_settings,
+    ):
+        """Test that synthetic tool IDs are negative and unique per target."""
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        # Targets with different IDs
+        targets = [
+            MockPersona(id=100, name="Agent A"),
+            MockPersona(id=200, name="Agent B"),
+        ]
+
+        persona = MockPersona(
+            id=1,
+            name="Orchestrator",
+            tools=[],
+            callable_personas=targets,
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=mock_db_session,
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+        )
+
+        # All IDs should be negative
+        for tool_id in tool_dict.keys():
+            assert tool_id < 0, f"Expected negative ID, got {tool_id}"
+
+        # IDs should match -persona_id pattern
+        assert -100 in tool_dict
+        assert -200 in tool_dict
+
+
+class TestAgentToolDefinition:
+    """Tests for AgentTool tool_definition method via construct_tools."""
+
+    @patch("onyx.tools.tool_constructor.get_current_search_settings")
+    @patch("onyx.tools.tool_constructor.get_default_document_index")
+    def test_tool_definition_structure(
+        self,
+        mock_get_doc_index,
+        mock_get_search_settings,
+    ):
+        """Test that created AgentTool has correct tool definition structure."""
+        mock_search_settings = MagicMock()
+        mock_search_settings.primary = MagicMock()
+        mock_search_settings.secondary = None
+        mock_get_search_settings.return_value = mock_search_settings
+        mock_get_doc_index.return_value = MockDocumentIndex()
+
+        target = MockPersona(id=5, name="Specialist")
+
+        persona = MockPersona(
+            id=1,
+            name="Main",
+            tools=[],
+            callable_personas=[target],
+        )
+
+        tool_dict = construct_tools(
+            persona=persona,
+            db_session=MagicMock(),
+            emitter=MockEmitter(),
+            user=None,
+            llm=MockLLM(),
+        )
+
+        agent_tool = tool_dict[-5][0]
+        tool_def = agent_tool.tool_definition()
+
+        # Verify structure
+        assert tool_def["type"] == "function"
+        assert "function" in tool_def
+
+        func_def = tool_def["function"]
+        assert func_def["name"] == "call_specialist"
+        assert "parameters" in func_def
+        assert func_def["parameters"]["type"] == "object"
+        assert "task" in func_def["parameters"]["properties"]
+        assert "task" in func_def["parameters"]["required"]

--- a/web/src/app/admin/assistants/interfaces.ts
+++ b/web/src/app/admin/assistants/interfaces.ts
@@ -37,6 +37,8 @@ export interface Persona extends MinimalPersonaSnapshot {
   users: MinimalUserSnapshot[];
   groups: number[];
   num_chunks?: number;
+  // IDs of personas that this persona can call as sub-agents
+  callable_persona_ids: number[];
 
   // Embedded prompt fields on persona
   system_prompt: string | null;

--- a/web/src/app/admin/assistants/interfaces.ts
+++ b/web/src/app/admin/assistants/interfaces.ts
@@ -30,6 +30,9 @@ export interface MinimalPersonaSnapshot {
 
   labels?: PersonaLabel[];
   owner: MinimalUserSnapshot | null;
+
+  // IDs of personas that this persona can call as sub-agents
+  callable_persona_ids: number[];
 }
 
 export interface Persona extends MinimalPersonaSnapshot {

--- a/web/src/app/admin/assistants/lib.ts
+++ b/web/src/app/admin/assistants/lib.ts
@@ -22,6 +22,7 @@ interface PersonaUpsertRequest {
   users?: string[];
   groups: number[];
   tool_ids: number[];
+  callable_persona_ids: number[] | null;
   remove_image?: boolean;
   uploaded_image_id: string | null;
   icon_name: string | null;
@@ -50,6 +51,7 @@ export interface PersonaUpsertParameters {
   users?: string[];
   groups: number[];
   tool_ids: number[];
+  callable_persona_ids: number[];
   remove_image?: boolean;
   search_start_date: Date | null;
   uploaded_image_id: string | null;
@@ -71,6 +73,7 @@ function buildPersonaUpsertRequest({
   datetime_aware,
   users,
   tool_ids,
+  callable_persona_ids,
   remove_image,
   search_start_date,
   user_file_ids,
@@ -97,6 +100,7 @@ function buildPersonaUpsertRequest({
     groups,
     users,
     tool_ids,
+    callable_persona_ids: callable_persona_ids?.length ? callable_persona_ids : null,
     remove_image,
     search_start_date,
     datetime_aware,

--- a/web/src/app/chat/components/ChatPage.tsx
+++ b/web/src/app/chat/components/ChatPage.tsx
@@ -191,6 +191,11 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
     assistantId: selectedAssistant?.id,
   });
 
+  // State for runtime callable personas (sub-agents selected at chat time)
+  const [runtimeCallablePersonaIds, setRuntimeCallablePersonaIds] = useState<
+    number[]
+  >([]);
+
   const [presentingDocument, setPresentingDocument] =
     useState<MinimalOnyxDocument | null>(null);
 
@@ -451,6 +456,10 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
         message,
         currentMessageFiles: currentMessageFiles,
         deepResearch: deepResearchEnabled,
+        runtimeCallablePersonaIds:
+          runtimeCallablePersonaIds.length > 0
+            ? runtimeCallablePersonaIds
+            : undefined,
       });
       if (showOnboarding) {
         finishOnboarding();
@@ -460,6 +469,7 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
       onSubmit,
       currentMessageFiles,
       deepResearchEnabled,
+      runtimeCallablePersonaIds,
       showOnboarding,
       finishOnboarding,
     ]
@@ -777,6 +787,10 @@ export default function ChatPage({ firstMessage }: ChatPageProps) {
                     }
                     availableContextTokens={availableContextTokens}
                     selectedAssistant={selectedAssistant || liveAssistant}
+                    runtimeCallablePersonaIds={runtimeCallablePersonaIds}
+                    onRuntimeCallablePersonaIdsChange={
+                      setRuntimeCallablePersonaIds
+                    }
                     handleFileUpload={handleMessageSpecificFileUpload}
                     setPresentingDocument={setPresentingDocument}
                     disabled={

--- a/web/src/app/chat/components/input/ChatInputBar.tsx
+++ b/web/src/app/chat/components/input/ChatInputBar.tsx
@@ -32,6 +32,7 @@ import {
 import IconButton from "@/refresh-components/buttons/IconButton";
 import FilePickerPopover from "@/refresh-components/popovers/FilePickerPopover";
 import ActionsPopover from "@/refresh-components/popovers/ActionsPopover";
+import CallableAgentsPopover from "@/refresh-components/popovers/CallableAgentsPopover";
 import SelectButton from "@/refresh-components/buttons/SelectButton";
 import {
   getIconForAction,
@@ -112,6 +113,10 @@ export interface ChatInputBarProps {
   // assistants
   selectedAssistant: MinimalPersonaSnapshot | undefined;
 
+  // callable agents (sub-agents)
+  runtimeCallablePersonaIds: number[];
+  onRuntimeCallablePersonaIdsChange: (ids: number[]) => void;
+
   toggleDocumentSidebar: () => void;
   handleFileUpload: (files: File[]) => void;
   filterManager: FilterManager;
@@ -138,6 +143,9 @@ const ChatInputBar = React.memo(
     availableContextTokens,
     // assistants
     selectedAssistant,
+    // callable agents
+    runtimeCallablePersonaIds,
+    onRuntimeCallablePersonaIdsChange,
 
     handleFileUpload,
     llmManager,
@@ -626,6 +634,17 @@ const ChatInputBar = React.memo(
                   selectedAssistant={selectedAssistant}
                   filterManager={filterManager}
                   availableSources={memoizedAvailableSources}
+                  disabled={disabled}
+                />
+              )}
+              {selectedAssistant && (
+                <CallableAgentsPopover
+                  currentPersonaId={selectedAssistant.id}
+                  preConfiguredCallableIds={
+                    selectedAssistant.callable_persona_ids ?? []
+                  }
+                  runtimeSelectedIds={runtimeCallablePersonaIds}
+                  onRuntimeSelectionChange={onRuntimeCallablePersonaIdsChange}
                   disabled={disabled}
                 />
               )}

--- a/web/src/app/chat/hooks/useChatController.ts
+++ b/web/src/app/chat/hooks/useChatController.ts
@@ -85,6 +85,9 @@ export interface OnSubmitProps {
 
   deepResearch: boolean;
 
+  // Additional persona IDs to make callable as sub-agents at runtime
+  runtimeCallablePersonaIds?: number[];
+
   // optional params
   messageIdToResend?: number;
   queryOverride?: string;
@@ -350,6 +353,7 @@ export function useChatController({
       message,
       currentMessageFiles,
       deepResearch,
+      runtimeCallablePersonaIds,
       messageIdToResend,
       queryOverride,
       forceSearch,
@@ -712,6 +716,7 @@ export function useChatController({
                   .map((tool) => tool.id)
               : undefined,
           forcedToolId: effectiveForcedToolId,
+          runtimeCallablePersonaIds,
           origin: messageOrigin,
         });
 

--- a/web/src/app/chat/message/messageComponents/AIMessage.tsx
+++ b/web/src/app/chat/message/messageComponents/AIMessage.tsx
@@ -281,6 +281,7 @@ const AIMessage = React.memo(function AIMessage({
       PacketType.REASONING_START,
       PacketType.DEEP_RESEARCH_PLAN_START,
       PacketType.RESEARCH_AGENT_START,
+      PacketType.AGENT_TOOL_START,
     ];
     return packets.some((packet) =>
       contentPacketTypes.includes(packet.obj.type as PacketType)

--- a/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
+++ b/web/src/app/chat/message/messageComponents/renderMessageComponent.tsx
@@ -20,6 +20,7 @@ import CustomToolRenderer from "./renderers/CustomToolRenderer";
 import { FetchToolRenderer } from "./renderers/FetchToolRenderer";
 import { DeepResearchPlanRenderer } from "./renderers/DeepResearchPlanRenderer";
 import { ResearchAgentRenderer } from "./renderers/ResearchAgentRenderer";
+import { AgentToolRenderer } from "./renderers/AgentToolRenderer";
 import { SearchToolRenderer } from "./renderers/SearchToolRenderer";
 
 // Different types of chat packets using discriminated unions
@@ -81,6 +82,15 @@ function isResearchAgentPacket(packet: Packet) {
   );
 }
 
+function isAgentToolPacket(packet: Packet) {
+  // Check for any packet type that indicates an agent tool (sub-agent delegation) group
+  return (
+    packet.obj.type === PacketType.AGENT_TOOL_START ||
+    packet.obj.type === PacketType.AGENT_TOOL_TASK ||
+    packet.obj.type === PacketType.AGENT_TOOL_RESULT
+  );
+}
+
 export function findRenderer(
   groupedPackets: GroupedPackets
 ): MessageRenderer<any, any> | null {
@@ -98,6 +108,10 @@ export function findRenderer(
   }
   if (groupedPackets.packets.some((packet) => isResearchAgentPacket(packet))) {
     return ResearchAgentRenderer;
+  }
+  // Check for agent tool packets (sub-agent delegation) - priority over custom tools
+  if (groupedPackets.packets.some((packet) => isAgentToolPacket(packet))) {
+    return AgentToolRenderer;
   }
 
   // Standard tool checks

--- a/web/src/app/chat/message/messageComponents/renderers/AgentToolRenderer.tsx
+++ b/web/src/app/chat/message/messageComponents/renderers/AgentToolRenderer.tsx
@@ -1,0 +1,341 @@
+import React, { useEffect, useMemo, useState, useRef } from "react";
+import { FiCircle, FiTarget, FiMessageSquare } from "react-icons/fi";
+import { SvgChevronDown } from "@opal/icons";
+import { cn } from "@/lib/utils";
+import { FaRobot } from "react-icons/fa";
+
+import {
+  PacketType,
+  Packet,
+  AgentToolPacket,
+  AgentToolStart,
+  AgentToolTask,
+  AgentToolResult,
+} from "../../../services/streamingModels";
+import { MessageRenderer, FullChatState, RendererResult } from "../interfaces";
+import { RendererComponent } from "../renderMessageComponent";
+import { getToolName } from "../toolDisplayHelpers";
+import { STANDARD_TEXT_COLOR } from "../constants";
+import Text from "@/refresh-components/texts/Text";
+import { useMarkdownRenderer } from "../markdownUtils";
+
+interface NestedToolGroup {
+  sub_turn_index: number;
+  toolType: string;
+  status: string;
+  isComplete: boolean;
+  packets: Packet[];
+}
+
+/**
+ * Simple row component for rendering nested tool content
+ */
+function NestedToolItemRow({
+  icon,
+  content,
+  status,
+  isLastItem,
+  isLoading,
+  isCancelled,
+}: {
+  icon: ((props: { size: number }) => React.JSX.Element) | null;
+  content: React.JSX.Element | string;
+  status: string | React.JSX.Element | null;
+  isLastItem: boolean;
+  isLoading?: boolean;
+  isCancelled?: boolean;
+}) {
+  return (
+    <div className="relative">
+      {!isLastItem && (
+        <div
+          className="absolute w-px bg-background-tint-04 z-0"
+          style={{ left: "10px", top: "20px", bottom: "0" }}
+        />
+      )}
+      <div
+        className={cn(
+          "flex items-start gap-2",
+          STANDARD_TEXT_COLOR,
+          "relative z-10"
+        )}
+      >
+        <div className="flex flex-col items-center w-5">
+          <div className="flex-shrink-0 flex items-center justify-center w-5 h-5 bg-background rounded-full">
+            {icon ? (
+              <div className={cn(isLoading && "text-shimmer-base")}>
+                {icon({ size: 14 })}
+              </div>
+            ) : (
+              <FiCircle className="w-2 h-2 fill-current text-text-300" />
+            )}
+          </div>
+        </div>
+        <div
+          className={cn(
+            "flex-1 min-w-0 overflow-hidden",
+            !isLastItem && "pb-4"
+          )}
+        >
+          <Text
+            as="p"
+            text02
+            className={cn(
+              "text-sm mb-1",
+              isLoading && !isCancelled && "loading-text"
+            )}
+          >
+            {status}
+          </Text>
+          <div className="text-sm text-text-600 overflow-hidden">{content}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renderer for agent tool (sub-agent delegation) steps.
+ * Shows the delegated task, nested tool calls from the sub-agent, and the final answer.
+ */
+export const AgentToolRenderer: MessageRenderer<
+  AgentToolPacket,
+  FullChatState
+> = ({
+  packets,
+  state,
+  onComplete,
+  renderType,
+  animate,
+  stopPacketSeen,
+  children,
+}) => {
+  // Extract data from packets
+  const startPacket = packets.find(
+    (p) => p.obj.type === PacketType.AGENT_TOOL_START
+  );
+  const taskPacket = packets.find(
+    (p) => p.obj.type === PacketType.AGENT_TOOL_TASK
+  );
+  const resultPacket = packets.find(
+    (p) => p.obj.type === PacketType.AGENT_TOOL_RESULT
+  );
+
+  const agentName = startPacket
+    ? (startPacket.obj as AgentToolStart).agent_name
+    : taskPacket
+      ? (taskPacket.obj as AgentToolTask).agent_name
+      : "Agent";
+  const toolName = startPacket
+    ? (startPacket.obj as AgentToolStart).tool_name
+    : `Call ${agentName}`;
+  const task = taskPacket ? (taskPacket.obj as AgentToolTask).task : "";
+  const answer = resultPacket
+    ? (resultPacket.obj as AgentToolResult).answer
+    : "";
+
+  // Separate parent packets (no sub_turn_index) from nested tool packets
+  const { parentPackets, nestedToolGroups } = useMemo(() => {
+    const parent: Packet[] = [];
+    const nestedBySubTurn = new Map<number, Packet[]>();
+
+    packets.forEach((packet) => {
+      const subTurnIndex = packet.placement.sub_turn_index;
+      if (subTurnIndex === undefined || subTurnIndex === null) {
+        // Parent-level packet (agent tool start, task, result, etc.)
+        parent.push(packet);
+      } else {
+        // Nested tool packet from sub-agent
+        if (!nestedBySubTurn.has(subTurnIndex)) {
+          nestedBySubTurn.set(subTurnIndex, []);
+        }
+        nestedBySubTurn.get(subTurnIndex)!.push(packet);
+      }
+    });
+
+    // Convert nested packets to groups with metadata
+    const groups: NestedToolGroup[] = Array.from(nestedBySubTurn.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([subTurnIndex, toolPackets]) => {
+        const name = getToolName(toolPackets);
+        const isComplete = toolPackets.some(
+          (p) =>
+            p.obj.type === PacketType.SECTION_END ||
+            p.obj.type === PacketType.REASONING_DONE
+        );
+        return {
+          sub_turn_index: subTurnIndex,
+          toolType: name,
+          status: isComplete ? "Complete" : "Running",
+          isComplete,
+          packets: toolPackets,
+        };
+      });
+
+    return { parentPackets: parent, nestedToolGroups: groups };
+  }, [packets]);
+
+  // Check if complete - agent tool is complete when parent packets have SECTION_END
+  const isComplete = parentPackets.some(
+    (p) => p.obj.type === PacketType.SECTION_END
+  );
+  const hasAnswer = Boolean(answer);
+  const [isExpanded, toggleExpanded] = useState(true);
+  const hasCalledCompleteRef = useRef(false);
+
+  // Call onComplete when agent tool is complete
+  useEffect(() => {
+    if (isComplete && !hasCalledCompleteRef.current) {
+      hasCalledCompleteRef.current = true;
+      onComplete();
+    }
+  }, [isComplete, onComplete]);
+
+  // Use markdown renderer for the answer
+  const { renderedContent: renderedAnswer } = useMarkdownRenderer(
+    answer,
+    state,
+    "text-text-03 font-main-ui-body"
+  );
+
+  // Determine status text
+  let statusText: string;
+  if (isComplete) {
+    statusText = `${agentName} completed`;
+  } else if (hasAnswer) {
+    statusText = "Received response";
+  } else if (nestedToolGroups.length > 0) {
+    const activeTools = nestedToolGroups.filter((g) => !g.isComplete);
+    if (activeTools.length > 0) {
+      statusText =
+        activeTools[activeTools.length - 1]?.toolType ?? "Processing";
+    } else {
+      statusText = "Processing";
+    }
+  } else if (task) {
+    statusText = `Delegating to ${agentName}`;
+  } else {
+    statusText = `Calling ${agentName}`;
+  }
+
+  // Render nested tool using RendererComponent
+  const renderNestedTool = (
+    group: NestedToolGroup,
+    index: number,
+    totalGroups: number
+  ) => {
+    const isLastItem = index === totalGroups - 1 && !hasAnswer;
+    const isLoading = !stopPacketSeen && !group.isComplete && !isComplete;
+    const isCancelled = stopPacketSeen && !group.isComplete;
+
+    return (
+      <RendererComponent
+        key={group.sub_turn_index}
+        packets={group.packets}
+        chatState={state}
+        onComplete={() => {}}
+        animate={false}
+        stopPacketSeen={stopPacketSeen || false}
+        useShortRenderer={false}
+      >
+        {(result: RendererResult) => (
+          <NestedToolItemRow
+            icon={result.icon}
+            content={result.content}
+            status={result.status}
+            isLastItem={isLastItem}
+            isLoading={isLoading}
+            isCancelled={isCancelled}
+          />
+        )}
+      </RendererComponent>
+    );
+  };
+
+  // Total steps = task (1) + nested tool groups + answer (if present)
+  const stepCount = 1 + nestedToolGroups.length + (hasAnswer ? 1 : 0);
+
+  // Custom status element with toggle chevron
+  // Using span instead of div to allow nesting inside <p> tags
+  const statusElement = (
+    <span
+      className="flex items-center justify-between gap-2 cursor-pointer group w-full"
+      onClick={() => toggleExpanded(!isExpanded)}
+    >
+      <span>{statusText}</span>
+      <span className="flex items-center gap-2">
+        {stepCount > 0 && (
+          <span className="text-text-500 text-xs">{stepCount} Steps</span>
+        )}
+        <SvgChevronDown
+          className={cn(
+            "w-4 h-4 stroke-text-400 transition-transform duration-150 ease-in-out",
+            !isExpanded && "rotate-[-90deg]"
+          )}
+        />
+      </span>
+    </span>
+  );
+
+  const agentToolContent = (
+    <div className="text-text-600 text-sm overflow-hidden">
+      {/* Collapsible content */}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200 ease-in-out",
+          isExpanded ? "max-h-[2000px] opacity-100 mt-2" : "max-h-0 opacity-0"
+        )}
+      >
+        {/* First item: Delegated Task */}
+        {task && (
+          <div className="space-y-0.5 mb-1">
+            <NestedToolItemRow
+              icon={({ size }) => <FiTarget size={size} />}
+              content={
+                <div className="text-text-600 text-sm break-words whitespace-normal">
+                  {task}
+                </div>
+              }
+              status="Delegated Task"
+              isLastItem={nestedToolGroups.length === 0 && !hasAnswer}
+              isLoading={false}
+            />
+          </div>
+        )}
+
+        {/* Render nested tool calls from sub-agent */}
+        {nestedToolGroups.length > 0 && (
+          <div className="space-y-0.5">
+            {nestedToolGroups.map((group, index) =>
+              renderNestedTool(group, index, nestedToolGroups.length)
+            )}
+          </div>
+        )}
+
+        {/* Render final answer */}
+        {hasAnswer && (
+          <div className="space-y-0.5 mt-1">
+            <NestedToolItemRow
+              icon={({ size }) => <FiMessageSquare size={size} />}
+              content={
+                <div className="text-text-600 text-sm max-h-[9rem] overflow-y-auto">
+                  {renderedAnswer}
+                </div>
+              }
+              status={`${agentName} Response`}
+              isLastItem={true}
+              isLoading={false}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return children({
+    icon: FaRobot,
+    status: statusElement,
+    content: agentToolContent,
+    expandedText: agentToolContent,
+  });
+};

--- a/web/src/app/chat/message/messageComponents/timeline/hooks/packetProcessor.ts
+++ b/web/src/app/chat/message/messageComponents/timeline/hooks/packetProcessor.ts
@@ -10,6 +10,7 @@ import {
   Stop,
   SearchToolStart,
   CustomToolStart,
+  AgentToolStart,
 } from "@/app/chat/services/streamingModels";
 import { CitationMap } from "@/app/chat/interfaces";
 import { OnyxDocument } from "@/lib/search/interfaces";
@@ -139,6 +140,7 @@ const CONTENT_PACKET_TYPES_SET = new Set<PacketType>([
   PacketType.REASONING_START,
   PacketType.DEEP_RESEARCH_PLAN_START,
   PacketType.RESEARCH_AGENT_START,
+  PacketType.AGENT_TOOL_START,
 ]);
 
 function hasContentPackets(packets: Packet[]): boolean {
@@ -171,6 +173,10 @@ function getToolNameFromPacket(packet: Packet): string | null {
       return "Generate plan";
     case PacketType.RESEARCH_AGENT_START:
       return "Research agent";
+    case PacketType.AGENT_TOOL_START: {
+      const agentPacket = packet.obj as AgentToolStart;
+      return agentPacket.tool_name || `Call ${agentPacket.agent_name}`;
+    }
     case PacketType.REASONING_START:
       return "Thinking";
     default:

--- a/web/src/app/chat/message/messageComponents/timeline/hooks/useTimelineHeader.ts
+++ b/web/src/app/chat/message/messageComponents/timeline/hooks/useTimelineHeader.ts
@@ -5,6 +5,7 @@ import {
   SearchToolPacket,
   StopReason,
   CustomToolStart,
+  AgentToolStart,
 } from "@/app/chat/services/streamingModels";
 import { constructCurrentSearchState } from "@/app/chat/message/messageComponents/timeline/renderers/search/searchStateUtils";
 
@@ -90,6 +91,15 @@ export function useTimelineHeader(
 
     if (packetType === PacketType.RESEARCH_AGENT_START) {
       return { headerText: "Researching", hasPackets, userStopped };
+    }
+
+    if (packetType === PacketType.AGENT_TOOL_START) {
+      const agentName = (firstPacket.obj as AgentToolStart).agent_name;
+      return {
+        headerText: agentName ? `Consulting ${agentName}` : "Calling agent",
+        hasPackets,
+        userStopped,
+      };
     }
 
     return { headerText: "Thinking...", hasPackets, userStopped };

--- a/web/src/app/chat/message/messageComponents/timeline/packetHelpers.ts
+++ b/web/src/app/chat/message/messageComponents/timeline/packetHelpers.ts
@@ -6,11 +6,16 @@ export const COMPACT_SUPPORTED_PACKET_TYPES = new Set<PacketType>([
   PacketType.FETCH_TOOL_START,
   PacketType.PYTHON_TOOL_START,
   PacketType.CUSTOM_TOOL_START,
+  PacketType.AGENT_TOOL_START,
 ]);
 
 // Check if packets belong to a research agent (handles its own Done indicator)
 export const isResearchAgentPackets = (packets: Packet[]): boolean =>
   packets.some((p) => p.obj.type === PacketType.RESEARCH_AGENT_START);
+
+// Check if packets belong to an agent tool (handles its own Done indicator)
+export const isAgentToolPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => p.obj.type === PacketType.AGENT_TOOL_START);
 
 // Check if step supports compact rendering mode
 export const stepSupportsCompact = (packets: Packet[]): boolean =>

--- a/web/src/app/chat/services/lib.tsx
+++ b/web/src/app/chat/services/lib.tsx
@@ -120,6 +120,8 @@ export interface SendMessageParams {
   enabledToolIds?: number[];
   // Single forced tool ID (new API uses singular, not array)
   forcedToolId?: number | null;
+  // Additional persona IDs to make callable as sub-agents at runtime
+  runtimeCallablePersonaIds?: number[];
   // LLM override parameters
   modelProvider?: string;
   modelVersion?: string;
@@ -138,6 +140,7 @@ export async function* sendMessage({
   deepResearch,
   enabledToolIds,
   forcedToolId,
+  runtimeCallablePersonaIds,
   modelProvider,
   modelVersion,
   temperature,
@@ -153,6 +156,8 @@ export async function* sendMessage({
     deep_research: deepResearch ?? false,
     allowed_tool_ids: enabledToolIds,
     forced_tool_id: forcedToolId ?? null,
+    runtime_callable_persona_ids:
+      runtimeCallablePersonaIds?.length ? runtimeCallablePersonaIds : null,
     llm_override:
       temperature || modelVersion
         ? {
@@ -300,6 +305,11 @@ export function processRawChatHistory(
 ): Map<number, Message> {
   const messages: Map<number, Message> = new Map();
   const parentMessageChildrenMap: Map<number, number[]> = new Map();
+
+  // Handle undefined/null rawMessages gracefully
+  if (!rawMessages) {
+    return messages;
+  }
 
   let assistantMessageInd = 0;
 

--- a/web/src/app/chat/services/packetUtils.ts
+++ b/web/src/app/chat/services/packetUtils.ts
@@ -29,6 +29,10 @@ export function isToolPacket(
     PacketType.INTERMEDIATE_REPORT_START,
     PacketType.INTERMEDIATE_REPORT_DELTA,
     PacketType.INTERMEDIATE_REPORT_CITED_DOCS,
+    // Agent tool (sub-agent delegation) packets
+    PacketType.AGENT_TOOL_START,
+    PacketType.AGENT_TOOL_TASK,
+    PacketType.AGENT_TOOL_RESULT,
   ];
   if (includeSectionEnd) {
     toolPacketTypes.push(PacketType.SECTION_END);

--- a/web/src/app/chat/services/streamingModels.ts
+++ b/web/src/app/chat/services/streamingModels.ts
@@ -49,6 +49,11 @@ export enum PacketType {
   INTERMEDIATE_REPORT_START = "intermediate_report_start",
   INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta",
   INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs",
+
+  // Agent Tool (sub-agent delegation) packets
+  AGENT_TOOL_START = "agent_tool_start",
+  AGENT_TOOL_TASK = "agent_tool_task",
+  AGENT_TOOL_RESULT = "agent_tool_result",
 }
 
 // Basic Message Packets
@@ -228,6 +233,25 @@ export interface IntermediateReportCitedDocs extends BaseObj {
   cited_docs: OnyxDocument[] | null;
 }
 
+// Agent Tool (sub-agent delegation) packets
+export interface AgentToolStart extends BaseObj {
+  type: "agent_tool_start";
+  tool_name: string;
+  agent_name: string;
+}
+
+export interface AgentToolTask extends BaseObj {
+  type: "agent_tool_task";
+  task: string;
+  agent_name: string;
+}
+
+export interface AgentToolResult extends BaseObj {
+  type: "agent_tool_result";
+  answer: string;
+  agent_name: string;
+}
+
 export type ChatObj = MessageStart | MessageDelta | MessageEnd;
 
 export type StopObj = Stop;
@@ -298,6 +322,13 @@ export type ResearchAgentObj =
   | IntermediateReportCitedDocs
   | SectionEnd;
 
+export type AgentToolObj =
+  | AgentToolStart
+  | AgentToolTask
+  | AgentToolResult
+  | SectionEnd
+  | PacketError;
+
 // Union type for all possible streaming objects
 export type ObjTypes =
   | ChatObj
@@ -309,6 +340,7 @@ export type ObjTypes =
   | CitationObj
   | DeepResearchPlanObj
   | ResearchAgentObj
+  | AgentToolObj
   | PacketErrorObj
   | CitationObj;
 
@@ -389,4 +421,9 @@ export interface DeepResearchPlanPacket {
 export interface ResearchAgentPacket {
   placement: Placement;
   obj: ResearchAgentObj;
+}
+
+export interface AgentToolPacket {
+  placement: Placement;
+  obj: AgentToolObj;
 }

--- a/web/src/refresh-components/popovers/CallableAgentsPopover.tsx
+++ b/web/src/refresh-components/popovers/CallableAgentsPopover.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import Popover, { PopoverMenu } from "@/refresh-components/Popover";
+import { MinimalPersonaSnapshot } from "@/app/admin/assistants/interfaces";
+import { useAgents } from "@/hooks/useAgents";
+import SelectButton from "@/refresh-components/buttons/SelectButton";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import Text from "@/refresh-components/texts/Text";
+import Truncated from "@/refresh-components/texts/Truncated";
+import Switch from "@/refresh-components/inputs/Switch";
+import CustomAgentAvatar from "@/refresh-components/avatars/CustomAgentAvatar";
+import { SvgCheck, SvgOnyxOctagon } from "@opal/icons";
+import { Section } from "@/layouts/general-layouts";
+
+export interface CallableAgentsPopoverProps {
+  // The current agent/persona being used (to exclude from the list)
+  currentPersonaId: number | null;
+  // IDs of personas that are pre-configured as callable in the DB
+  preConfiguredCallableIds: number[];
+  // IDs of personas selected at runtime (controlled by parent)
+  runtimeSelectedIds: number[];
+  // Callback when runtime selection changes
+  onRuntimeSelectionChange: (ids: number[]) => void;
+  // Whether the popover trigger is disabled
+  disabled?: boolean;
+}
+
+export default function CallableAgentsPopover({
+  currentPersonaId,
+  preConfiguredCallableIds,
+  runtimeSelectedIds,
+  onRuntimeSelectionChange,
+  disabled = false,
+}: CallableAgentsPopoverProps) {
+  const { agents, isLoading } = useAgents();
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Filter agents to show only non-builtin, non-current agents
+  const availableAgents = useMemo(() => {
+    return agents.filter(
+      (agent) =>
+        !agent.builtin_persona &&
+        agent.id !== currentPersonaId &&
+        agent.id !== 0
+    );
+  }, [agents, currentPersonaId]);
+
+  // Filter by search query
+  const filteredAgents = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return availableAgents;
+    }
+    const query = searchQuery.toLowerCase();
+    return availableAgents.filter(
+      (agent) =>
+        agent.name.toLowerCase().includes(query) ||
+        agent.description?.toLowerCase().includes(query)
+    );
+  }, [availableAgents, searchQuery]);
+
+  // Count of selected agents (pre-configured + runtime)
+  const totalSelectedCount = useMemo(() => {
+    const preConfiguredSet = new Set(preConfiguredCallableIds);
+    const runtimeSet = new Set(runtimeSelectedIds);
+    // Merge and dedupe
+    const combined = new Set([...preConfiguredSet, ...runtimeSet]);
+    return combined.size;
+  }, [preConfiguredCallableIds, runtimeSelectedIds]);
+
+  // Handle toggle for runtime selection
+  const handleToggle = useCallback(
+    (agentId: number) => {
+      if (runtimeSelectedIds.includes(agentId)) {
+        onRuntimeSelectionChange(
+          runtimeSelectedIds.filter((id) => id !== agentId)
+        );
+      } else {
+        onRuntimeSelectionChange([...runtimeSelectedIds, agentId]);
+      }
+    },
+    [runtimeSelectedIds, onRuntimeSelectionChange]
+  );
+
+  // Reset search when popover closes
+  const handleOpenChange = useCallback((newOpen: boolean) => {
+    setOpen(newOpen);
+    if (!newOpen) {
+      setSearchQuery("");
+    }
+  }, []);
+
+  const renderAgentItem = (agent: MinimalPersonaSnapshot) => {
+    const isPreConfigured = preConfiguredCallableIds.includes(agent.id);
+    const isRuntimeSelected = runtimeSelectedIds.includes(agent.id);
+
+    return (
+      <div
+        key={agent.id}
+        className="flex flex-row w-full items-center p-2 rounded-08 gap-2 hover:bg-background-tint-02"
+      >
+        {/* Avatar */}
+        <div className="flex flex-col justify-center items-center h-[1rem] min-w-[1rem]">
+          <CustomAgentAvatar
+            size={20}
+            iconName={agent.icon_name ?? undefined}
+            src={
+              agent.uploaded_image_id
+                ? `/api/chat/file/${agent.uploaded_image_id}`
+                : undefined
+            }
+            name={agent.name}
+          />
+        </div>
+
+        {/* Name and description */}
+        <div className="flex-1 min-w-0">
+          <Truncated mainUiMuted className="text-left w-full">
+            {agent.name}
+          </Truncated>
+          {agent.description && (
+            <Truncated secondaryBody text03 className="text-left w-full">
+              {agent.description}
+            </Truncated>
+          )}
+        </div>
+
+        {/* Right control: checkmark or switch */}
+        <div className="shrink-0">
+          {isPreConfigured ? (
+            // Pre-configured: show grey checkmark (non-interactive)
+            <SvgCheck className="h-4 w-4 stroke-text-04" />
+          ) : (
+            // Runtime selectable: show switch
+            <Switch
+              checked={isRuntimeSelected}
+              onCheckedChange={() => handleToggle(agent.id)}
+              aria-label={`Toggle ${agent.name}`}
+            />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <Popover.Trigger asChild disabled={disabled}>
+        <div>
+          <SelectButton
+            leftIcon={SvgOnyxOctagon}
+            onClick={() => setOpen(true)}
+            transient={open}
+            rightChevronIcon
+            disabled={disabled}
+            badge={totalSelectedCount > 0 ? totalSelectedCount : undefined}
+          >
+            Sub-Agents
+          </SelectButton>
+        </div>
+      </Popover.Trigger>
+      <Popover.Content side="bottom" align="start" width="lg">
+        <Section gap={0.5}>
+          {/* Search Input */}
+          <InputTypeIn
+            leftSearchIcon
+            variant="internal"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search agents..."
+          />
+
+          {/* Agent List - constrained height to fit in viewport */}
+          <div className="flex flex-col gap-1 max-h-[12rem] overflow-y-auto">
+            {isLoading ? (
+              <div className="py-3">
+                <Text secondaryBody text03>
+                  Loading agents...
+                </Text>
+              </div>
+            ) : filteredAgents.length === 0 ? (
+              <div className="py-3">
+                <Text secondaryBody text03>
+                  {searchQuery ? "No agents found" : "No agents available"}
+                </Text>
+              </div>
+            ) : (
+              <>
+                {/* Show pre-configured agents first (with grey checkmark) */}
+                {filteredAgents
+                  .filter((a) => preConfiguredCallableIds.includes(a.id))
+                  .map(renderAgentItem)}
+                {/* Then show other agents (with switches) */}
+                {filteredAgents
+                  .filter((a) => !preConfiguredCallableIds.includes(a.id))
+                  .map(renderAgentItem)}
+              </>
+            )}
+          </div>
+
+          {/* Helper text */}
+          <div className="px-2 pb-1">
+            <Text text04 secondaryBody>
+              {preConfiguredCallableIds.length > 0
+                ? `${preConfiguredCallableIds.length} agent(s) pre-configured. Select more agents to call during this chat.`
+                : "Select agents this assistant can delegate tasks to."}
+            </Text>
+          </div>
+        </Section>
+      </Popover.Content>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Description

Allow Onyx agents (personas) to use other Onyx agents.

## How Has This Been Tested?

- Unit tests
- Integ tests
- E2E manual testing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multi-agent delegation so a persona can call other personas as sub-agents during a chat. Adds an AgentTool, a DB relationship to configure which personas are callable, runtime selection in chat, and guardrails to prevent loops and runaway delegation.

- New Features
  - AgentTool: delegate a task to a specific persona (task param). Uses the callee’s prompts and tools, supports multi-level delegation within a depth limit, blocks calling agents already in the agent_call_stack, keeps citations, and returns the sub-agent’s answer.
  - Safety: per-turn cap of 5 agent calls, recursion prevention with an agent_call_stack (blocks A → B → A), and depth limit (default 2).
  - Tool construction: AgentTools are created automatically for persona.callable_personas using synthetic negative IDs. AgentToolConfig supports runtime_callable_persona_ids (merged with DB) and optional filters/connectivity.
  - Chat and UI: stream “Call <Agent>” start/task/result; session replay reconstructs these calls; Agent editor lets you select callable personas; chat popover allows adding runtime sub-agents per chat; dedicated renderer shows the agent-call trace.
  - Prompting: adds an orchestrator reminder listing available sub-agents to encourage delegation.
  - Tests: unit and integration coverage for construction, execution, recursion/depth limits, relationship behavior, and cascade deletes.

- Migration
  - Run the new Alembic migration to create persona__callable_persona.
  - Configure callable personas for each persona (who can call whom). After configuration, the parent persona will expose “Call <Agent>” tools automatically.

<sup>Written for commit 925704602801aeef2f2cb91e6291cb061abd4295. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



