### PR TITLE
Fix/modal scroll medium variant

### DIFF
--- a/web/src/app/admin/configuration/llm/forms/components/FormWrapper.tsx
+++ b/web/src/app/admin/configuration/llm/forms/components/FormWrapper.tsx
@@ -115,7 +115,7 @@ export function ProviderFormEntrypointWrapper({
 
         {formIsVisible && (
           <Modal open onOpenChange={onClose}>
-            <Modal.Content>
+            <Modal.Content height="lg">
               <Modal.Header
                 icon={SvgSettings}
                 title={`Setup ${providerName}`}
@@ -197,7 +197,7 @@ export function ProviderFormEntrypointWrapper({
 
       {formIsVisible && (
         <Modal open onOpenChange={onClose}>
-          <Modal.Content>
+          <Modal.Content height="lg">
             <Modal.Header
               icon={SvgSettings}
               title={`${existingLlmProvider ? "Configure" : "Setup"} ${


### PR DESCRIPTION
## Summary

- Fixed scroll not working in medium-sized modals (e.g., LLM configuration modal)
- Changed medium variant from `h-fit` to `max-h-[calc(100dvh-4rem)]` to constrain height
- Added `medium` to the list of variants that get `overflow-auto` in `ModalBody`

## Problem

The `medium` modal variant was using `h-fit` which allowed content to grow beyond viewport bounds without enabling scroll. This caused modals like the LLM configuration form to be unusable when content exceeded the viewport height - users couldn't scroll to see or interact with form fields at the bottom.

## Test plan

- [ ] Open Admin → LLM Setup
- [ ] Click "Edit" on an existing provider or "Set up" on a new one
- [ ] Verify the modal scrolls properly when content exceeds viewport height
- [ ] Test on different screen sizes to ensure max-height constraint works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrolling in LLM provider modals by setting Modal.Content to the large height variant so content stays within the viewport and scrolls.

- **Bug Fixes**
  - LLM provider form: set Modal.Content height="lg" to constrain height and enable scrolling.

<sup>Written for commit bfc0108df774bb11ddbac9fa83c90bd4a3f4da9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

