### PR TITLE
fix: correct typos 'seperated', 'occured', and 'occurence'

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -125,7 +125,7 @@ SESSION_EXPIRE_TIME_SECONDS = int(
 # Default request timeout, mostly used by connectors
 REQUEST_TIMEOUT_SECONDS = int(os.environ.get("REQUEST_TIMEOUT_SECONDS") or 60)
 
-# set `VALID_EMAIL_DOMAINS` to a comma seperated list of domains in order to
+# set `VALID_EMAIL_DOMAINS` to a comma separated list of domains in order to
 # restrict access to Onyx to only users with emails from those domains.
 # E.g. `VALID_EMAIL_DOMAINS=example.com,example.org` will restrict Onyx
 # signups to users with either an @example.com or an @example.org email.

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -531,7 +531,7 @@ def run_deep_research_llm_loop(
                     )
 
                 if not tool_calls:
-                    # Basically hope that this is an infrequent occurence and hopefully multiple research
+                    # Basically hope that this is an infrequent occurrence and hopefully multiple research
                     # cycles have already ran
                     logger.warning("No tool calls found, this should not happen.")
                     report_turn_index = (

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -795,7 +795,7 @@ def index_doc_batch(
                     f"Updatable IDs: {updatable_ids}, "
                     f"Returned IDs: {all_returned_doc_ids}. "
                     "This should never happen."
-                    f"This occured for document index {document_index.__class__.__name__}"
+                    f"This occurred for document index {document_index.__class__.__name__}"
                 )
             # We treat the first document index we got as the primary one used
             # for reporting the state of indexing.

--- a/backend/tests/daily/connectors/salesforce/test_salesforce_connector.py
+++ b/backend/tests/daily/connectors/salesforce/test_salesforce_connector.py
@@ -83,7 +83,7 @@ def test_salesforce_connector_basic(salesforce_connector: SalesforceConnector) -
 
     # Set of received links
     received_links: set[str] = set()
-    # List of received text fields, which contain key-value pairs seperated by newlines
+    # List of received text fields, which contain key-value pairs separated by newlines
     received_text: list[str] = []
 
     # Iterate over the sections of the target test doc to extract the links and text


### PR DESCRIPTION
Fix spelling errors across 4 files:
- 'seperated' → 'separated' (2 occurrences)
- 'occured' → 'occurred' (1 occurrence)
- 'occurence' → 'occurrence' (1 occurrence)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected spelling errors in four files to improve readability and log clarity; no functional changes. Replaced "seperated"→"separated" (2), "occured"→"occurred" (1), and "occurence"→"occurrence" (1) across app_configs.py, dr_loop.py, indexing_pipeline.py (log message), and the Salesforce connector test.

<sup>Written for commit afec64a577523e249bffc18edf9a0b2a08a37f42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

