### PR TITLE
fix(helm): Proper PG CloudNative Support

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -23,11 +23,12 @@
 
 ## Test the entire cluster manually
 * cd charts/onyx
+* Optional: enable CloudNativePG cluster creation by setting `postgresql.cluster.enabled=true`.
 * helm install onyx . -n onyx --create-namespace --wait=false
-  * This chart installs operators (e.g. CloudNativePG) and their custom resources in one release.
-    On a fresh install, webhooks/operators may not be ready before dependent CRs are applied.
+  * If you enabled `postgresql.cluster.enabled=true`, CRDs/webhooks may not be discoverable/ready on first install.
+    In that case the Postgres Cluster CR will be created on the follow-up upgrade.
 * helm upgrade onyx . -n onyx --wait
-  * Running a second `upgrade --wait` once operators are up makes startup deterministic.
+  * Running a second `upgrade --wait` once operators are up makes CR creation deterministic.
 * kubectl -n onyx port-forward service/onyx-nginx 8080:80
   * this will forward the local port 8080 to the installed chart for you to run tests, etc.
 * When you are finished

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -23,9 +23,11 @@
 
 ## Test the entire cluster manually
 * cd charts/onyx
-* helm install onyx . -n onyx --set postgresql.primary.persistence.enabled=false
-  * the postgres flag is to keep the storage ephemeral for testing. You probably don't want to set that in prod.
-  * no flag for ephemeral vespa storage yet, might be good for testing
+* helm install onyx . -n onyx --create-namespace --wait=false
+  * This chart installs operators (e.g. CloudNativePG) and their custom resources in one release.
+    On a fresh install, webhooks/operators may not be ready before dependent CRs are applied.
+* helm upgrade onyx . -n onyx --wait
+  * Running a second `upgrade --wait` once operators are up makes startup deterministic.
 * kubectl -n onyx port-forward service/onyx-nginx 8080:80
   * this will forward the local port 8080 to the installed chart for you to run tests, etc.
 * When you are finished

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.25
+version: 0.4.26
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -161,7 +161,7 @@ Return the CloudNativePG Cluster name used by Onyx for POSTGRES_HOST and Cluster
 Deliberately independent from postgresql.nameOverride, which configures the operator chart.
 */}}
 {{- define "onyx.postgresql.clusterName" -}}
-{{- if and .Values.postgresql .Values.postgresql.cluster .Values.postgresql.cluster.name -}}
+{{- if and .Values.postgresql .Values.postgresql.cluster (not (empty .Values.postgresql.cluster.name)) -}}
 {{- .Values.postgresql.cluster.name -}}
 {{- else -}}
 {{- printf "%s-postgresql" .Release.Name -}}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -155,3 +155,15 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- $engine := default "hpa" .Values.autoscaling.engine -}}
 {{- $engine | lower -}}
 {{- end }}
+
+{{/*
+Return the CloudNativePG Cluster name used by Onyx for POSTGRES_HOST and Cluster CR naming.
+Deliberately independent from postgresql.nameOverride, which configures the operator chart.
+*/}}
+{{- define "onyx.postgresql.clusterName" -}}
+{{- if and .Values.postgresql .Values.postgresql.cluster .Values.postgresql.cluster.name -}}
+{{- .Values.postgresql.cluster.name -}}
+{{- else -}}
+{{- printf "%s-postgresql" .Release.Name -}}
+{{- end -}}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,7 +6,9 @@ metadata:
     {{- include "onyx.labels" . | nindent 4 }}
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
-  {{- if .Values.postgresql.enabled }}
+  {{- $cnpgClusterEnabled := and .Values.postgresql.cluster (eq (default false .Values.postgresql.cluster.enabled) true) }}
+  {{- $hasCustomPostgresHost := and .Values.configMap (not (empty .Values.configMap.POSTGRES_HOST)) }}
+  {{- if and .Values.postgresql.enabled $cnpgClusterEnabled (not $hasCustomPostgresHost) }}
   POSTGRES_HOST: {{ include "onyx.postgresql.clusterName" . }}-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -7,12 +7,7 @@ metadata:
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
-  {{- $postgresNameOverride := default "postgresql" .Values.postgresql.nameOverride }}
-  {{- $clusterName := printf "%s-%s" .Release.Name $postgresNameOverride }}
-  {{- if and .Values.postgresql.cluster .Values.postgresql.cluster.name }}
-  {{- $clusterName = .Values.postgresql.cluster.name }}
-  {{- end }}
-  POSTGRES_HOST: {{ $clusterName }}-rw
+  POSTGRES_HOST: {{ include "onyx.postgresql.clusterName" . }}-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}
   VESPA_HOST: {{ .Values.vespa.name }}.{{ .Values.vespa.service.name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -7,9 +7,11 @@ metadata:
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
-  {{- $postgresNameOverride := dig "postgresql" "nameOverride" "postgresql" .Values }}
-  {{- $clusterNameOverride := dig "postgresql" "cluster" "name" "" .Values }}
-  {{- $clusterName := default (printf "%s-%s" .Release.Name $postgresNameOverride) $clusterNameOverride }}
+  {{- $postgresNameOverride := default "postgresql" .Values.postgresql.nameOverride }}
+  {{- $clusterName := printf "%s-%s" .Release.Name $postgresNameOverride }}
+  {{- if and .Values.postgresql.cluster .Values.postgresql.cluster.name }}
+  {{- $clusterName = .Values.postgresql.cluster.name }}
+  {{- end }}
   POSTGRES_HOST: {{ $clusterName }}-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -7,7 +7,10 @@ metadata:
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
   {{- if .Values.postgresql.enabled }}
-  POSTGRES_HOST: {{ .Release.Name }}-{{ default "postgresql" .Values.postgresql.nameOverride }}-rw
+  {{- $postgresNameOverride := dig "postgresql" "nameOverride" "postgresql" .Values }}
+  {{- $clusterNameOverride := dig "postgresql" "cluster" "name" "" .Values }}
+  {{- $clusterName := default (printf "%s-%s" .Release.Name $postgresNameOverride) $clusterNameOverride }}
+  POSTGRES_HOST: {{ $clusterName }}-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}
   VESPA_HOST: {{ .Values.vespa.name }}.{{ .Values.vespa.service.name }}.{{ .Release.Namespace }}.svc.cluster.local

--- a/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
+++ b/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
@@ -1,6 +1,7 @@
-{{- $postgresEnabled := dig "postgresql" "enabled" false .Values -}}
-{{- $postgresNameOverride := dig "postgresql" "nameOverride" "postgresql" .Values -}}
-{{- $clusterConfig := dig "postgresql" "cluster" (dict) .Values -}}
+{{- $postgresConfig := .Values.postgresql | default dict -}}
+{{- $postgresEnabled := default false $postgresConfig.enabled -}}
+{{- $postgresNameOverride := default "postgresql" $postgresConfig.nameOverride -}}
+{{- $clusterConfig := $postgresConfig.cluster | default dict -}}
 {{- if and $postgresEnabled (ne (default true $clusterConfig.enabled) false) -}}
 {{- $clusterName := default (printf "%s-%s" .Release.Name $postgresNameOverride) $clusterConfig.name -}}
 {{- $storage := $clusterConfig.storage | default dict -}}

--- a/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
+++ b/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
@@ -1,0 +1,26 @@
+{{- $postgresEnabled := dig "postgresql" "enabled" false .Values -}}
+{{- $postgresNameOverride := dig "postgresql" "nameOverride" "postgresql" .Values -}}
+{{- $clusterConfig := dig "postgresql" "cluster" (dict) .Values -}}
+{{- if and $postgresEnabled (ne (default true $clusterConfig.enabled) false) -}}
+{{- $clusterName := default (printf "%s-%s" .Release.Name $postgresNameOverride) $clusterConfig.name -}}
+{{- $storage := $clusterConfig.storage | default dict -}}
+{{- $superuserSecret := $clusterConfig.superuserSecret | default dict -}}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ $clusterName }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+spec:
+  instances: {{ default 1 $clusterConfig.instances }}
+  storage:
+    size: {{ default "10Gi" $storage.size }}
+    {{- with $storage.storageClass }}
+    storageClass: {{ . }}
+    {{- end }}
+  {{- if (default true $clusterConfig.enableSuperuserAccess) }}
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: {{ default "onyx-postgresql" $superuserSecret.name }}
+  {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
+++ b/deployment/helm/charts/onyx/templates/postgresql-cluster.yaml
@@ -1,15 +1,14 @@
 {{- $postgresConfig := .Values.postgresql | default dict -}}
 {{- $postgresEnabled := default false $postgresConfig.enabled -}}
-{{- $postgresNameOverride := default "postgresql" $postgresConfig.nameOverride -}}
 {{- $clusterConfig := $postgresConfig.cluster | default dict -}}
-{{- if and $postgresEnabled (ne (default true $clusterConfig.enabled) false) -}}
-{{- $clusterName := default (printf "%s-%s" .Release.Name $postgresNameOverride) $clusterConfig.name -}}
+{{- $cnpgClusterApiAvailable := .Capabilities.APIVersions.Has "postgresql.cnpg.io/v1/Cluster" -}}
+{{- if and $postgresEnabled (eq (default false $clusterConfig.enabled) true) $cnpgClusterApiAvailable -}}
 {{- $storage := $clusterConfig.storage | default dict -}}
 {{- $superuserSecret := $clusterConfig.superuserSecret | default dict -}}
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: {{ $clusterName }}
+  name: {{ include "onyx.postgresql.clusterName" . }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -12,11 +12,18 @@ global:
 
 postgresql:
   enabled: true
+  # Note: if this chart is installing the operator and Cluster in the same release,
+  # a first install with `--wait=false` followed by `helm upgrade --wait` is recommended.
   # IMPORTANT: This nameOverride is required for the CloudNativePG operator to find itself.
   # The operator looks for a deployment with label app.kubernetes.io/name=cloudnative-pg,
   # but since the subchart is aliased as "postgresql", Helm defaults to that name.
   nameOverride: cloudnative-pg
+  # The subchart installs the CloudNativePG operator. The Onyx chart template below
+  # creates the actual Postgres Cluster CR.
   cluster:
+    enabled: true
+    # Defaults to "<release-name>-<postgresql.nameOverride>" when empty.
+    name: ""
     instances: 1
     storage:
       storageClass: ""

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -11,18 +11,17 @@ global:
   host: "0.0.0.0"
 
 postgresql:
+  # Set to false when connecting to an externally managed PostgreSQL instance.
   enabled: true
-  # Note: if this chart is installing the operator and Cluster in the same release,
-  # a first install with `--wait=false` followed by `helm upgrade --wait` is recommended.
+  # This controls installation of the CloudNativePG operator subchart.
   # IMPORTANT: This nameOverride is required for the CloudNativePG operator to find itself.
   # The operator looks for a deployment with label app.kubernetes.io/name=cloudnative-pg,
   # but since the subchart is aliased as "postgresql", Helm defaults to that name.
   nameOverride: cloudnative-pg
-  # The subchart installs the CloudNativePG operator. The Onyx chart template below
-  # creates the actual Postgres Cluster CR.
+  # Optional CloudNativePG Cluster CR managed by this chart.
   cluster:
-    enabled: true
-    # Defaults to "<release-name>-<postgresql.nameOverride>" when empty.
+    enabled: false
+    # Defaults to "<release-name>-postgresql" when empty.
     name: ""
     instances: 1
     storage:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -21,6 +21,7 @@ postgresql:
   # Optional CloudNativePG Cluster CR managed by this chart.
   cluster:
     enabled: false
+    # When false, set configMap.POSTGRES_HOST to your external database host.
     # Defaults to "<release-name>-postgresql" when empty.
     name: ""
     instances: 1


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Trying to properly support CloudNative PG setup in our helm charts

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Ran Helm Templates to ensure this is valid

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CloudNativePG support to the Helm chart by templating a Cluster CR and auto-setting POSTGRES_HOST to the cluster’s “-rw” service when a CNPG cluster is enabled. Updates docs for a deterministic two-step install and bumps the chart to 0.4.26.

- **New Features**
  - CloudNativePG Cluster template gated on CRD availability; configurable name (defaults to "<release-name>-postgresql"), instances, storage, enableSuperuserAccess, and superuserSecret (defaults to "onyx-postgresql").
  - New clusterName helper (independent of nameOverride); sets POSTGRES_HOST to "<cluster>-rw" only when the CNPG cluster is enabled and no custom configMap.POSTGRES_HOST is set.
  - values.yaml adds postgresql.cluster.enabled and name; supports external DBs via configMap.POSTGRES_HOST.

- **Migration**
  - Fresh installs: helm install ... --create-namespace --wait=false, then helm upgrade ... --wait.
  - Keep postgresql.nameOverride=cloudnative-pg.
  - To create a Cluster, set postgresql.cluster.enabled=true; for external DBs set postgresql.enabled=false and configMap.POSTGRES_HOST.

<sup>Written for commit bae76dae9469b82e7ae79a8f75d871ac72823c42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

