### PR TITLE
chore(posthog): Cleaning up Posthog callsites

### DIFF
--- a/backend/ee/onyx/configs/app_configs.py
+++ b/backend/ee/onyx/configs/app_configs.py
@@ -118,9 +118,8 @@ JWT_PUBLIC_KEY_URL: str | None = os.getenv("JWT_PUBLIC_KEY_URL", None)
 SUPER_USERS = json.loads(os.environ.get("SUPER_USERS", "[]"))
 SUPER_CLOUD_API_KEY = os.environ.get("SUPER_CLOUD_API_KEY", "api_key")
 
-# The posthog client does not accept empty API keys or hosts however it fails silently
-# when the capture is called. These defaults prevent Posthog issues from breaking the Onyx app
-POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY") or "FooBar"
+# When unset, PostHog integrations should be fully disabled and no client should be started.
+POSTHOG_API_KEY = os.environ.get("POSTHOG_API_KEY") or None
 POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"
 POSTHOG_DEBUG_LOGS_ENABLED = (
     os.environ.get("POSTHOG_DEBUG_LOGS_ENABLED", "").lower() == "true"

--- a/backend/ee/onyx/feature_flags/factory.py
+++ b/backend/ee/onyx/feature_flags/factory.py
@@ -1,5 +1,6 @@
-from ee.onyx.feature_flags.posthog_provider import PostHogFeatureFlagProvider
+from ee.onyx.configs.app_configs import POSTHOG_API_KEY
 from onyx.feature_flags.interface import FeatureFlagProvider
+from onyx.feature_flags.interface import NoOpFeatureFlagProvider
 
 
 def get_posthog_feature_flag_provider() -> FeatureFlagProvider:
@@ -12,4 +13,9 @@ def get_posthog_feature_flag_provider() -> FeatureFlagProvider:
     Returns:
         PostHogFeatureFlagProvider: The PostHog-based feature flag provider
     """
+    if not POSTHOG_API_KEY:
+        return NoOpFeatureFlagProvider()
+
+    from ee.onyx.feature_flags.posthog_provider import PostHogFeatureFlagProvider
+
     return PostHogFeatureFlagProvider()

--- a/backend/ee/onyx/feature_flags/posthog_provider.py
+++ b/backend/ee/onyx/feature_flags/posthog_provider.py
@@ -34,6 +34,9 @@ class PostHogFeatureFlagProvider(FeatureFlagProvider):
         Returns:
             True if the feature is enabled for the user, False otherwise.
         """
+        if not posthog:
+            return False
+
         try:
             posthog.set(
                 distinct_id=user_id,

--- a/backend/ee/onyx/utils/telemetry.py
+++ b/backend/ee/onyx/utils/telemetry.py
@@ -8,6 +8,9 @@ def event_telemetry(
     distinct_id: str, event: str, properties: dict | None = None
 ) -> None:
     """Capture and send an event to PostHog, flushing immediately."""
+    if not posthog:
+        return
+
     logger.info(f"Capturing PostHog event: {distinct_id} {event} {properties}")
     try:
         posthog.capture(distinct_id, event, properties)

--- a/backend/tests/unit/ee/onyx/feature_flags/test_posthog_provider.py
+++ b/backend/tests/unit/ee/onyx/feature_flags/test_posthog_provider.py
@@ -1,0 +1,31 @@
+from typing import Any
+from uuid import UUID
+
+from ee.onyx.feature_flags.factory import get_posthog_feature_flag_provider
+from ee.onyx.feature_flags.posthog_provider import PostHogFeatureFlagProvider
+from onyx.feature_flags.interface import NoOpFeatureFlagProvider
+
+
+def test_factory_returns_noop_provider_when_posthog_disabled(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr("ee.onyx.feature_flags.factory.POSTHOG_API_KEY", None)
+
+    provider = get_posthog_feature_flag_provider()
+    assert isinstance(provider, NoOpFeatureFlagProvider)
+
+
+def test_posthog_provider_returns_false_when_client_not_configured(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr("ee.onyx.feature_flags.posthog_provider.posthog", None)
+
+    provider = PostHogFeatureFlagProvider()
+    assert (
+        provider.feature_enabled(
+            flag_key="feature-test",
+            user_id=UUID("79a75f76-6b63-43ee-b04c-a0c6806900bd"),
+            user_properties={"tenant_id": "tenant_1"},
+        )
+        is False
+    )

--- a/backend/tests/unit/ee/onyx/utils/test_posthog_client.py
+++ b/backend/tests/unit/ee/onyx/utils/test_posthog_client.py
@@ -1,0 +1,104 @@
+import importlib
+from typing import Any
+from unittest.mock import Mock
+
+from ee.onyx.configs import app_configs as ee_app_configs
+from ee.onyx.utils import posthog_client
+from ee.onyx.utils import telemetry as ee_telemetry
+
+
+def test_posthog_api_key_defaults_to_none_when_unset(monkeypatch: Any) -> None:
+    with monkeypatch.context() as m:
+        m.delenv("POSTHOG_API_KEY", raising=False)
+        importlib.reload(ee_app_configs)
+        assert ee_app_configs.POSTHOG_API_KEY is None
+
+    importlib.reload(ee_app_configs)
+
+
+def test_primary_posthog_client_not_initialized_without_api_key(
+    monkeypatch: Any,
+) -> None:
+    class FakePosthog:
+        call_count = 0
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
+            type(self).call_count += 1
+
+    with monkeypatch.context() as m:
+        m.delenv("POSTHOG_API_KEY", raising=False)
+        m.delenv("MARKETING_POSTHOG_API_KEY", raising=False)
+        m.setattr("posthog.Posthog", FakePosthog)
+
+        importlib.reload(ee_app_configs)
+        importlib.reload(posthog_client)
+
+        assert posthog_client.posthog is None
+        assert posthog_client.marketing_posthog is None
+        assert FakePosthog.call_count == 0
+
+    importlib.reload(ee_app_configs)
+    importlib.reload(posthog_client)
+
+
+def test_primary_posthog_client_initialized_with_api_key(monkeypatch: Any) -> None:
+    class FakePosthog:
+        call_count = 0
+        last_kwargs: dict[str, Any] | None = None
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ARG002
+            type(self).call_count += 1
+            type(self).last_kwargs = kwargs
+
+    with monkeypatch.context() as m:
+        m.setenv("POSTHOG_API_KEY", "test-primary-key")
+        m.delenv("MARKETING_POSTHOG_API_KEY", raising=False)
+        m.setattr("posthog.Posthog", FakePosthog)
+
+        importlib.reload(ee_app_configs)
+        importlib.reload(posthog_client)
+
+        assert isinstance(posthog_client.posthog, FakePosthog)
+        assert posthog_client.marketing_posthog is None
+        assert FakePosthog.call_count == 1
+        assert FakePosthog.last_kwargs == {
+            "project_api_key": "test-primary-key",
+            "host": ee_app_configs.POSTHOG_HOST,
+            "debug": ee_app_configs.POSTHOG_DEBUG_LOGS_ENABLED,
+            "on_error": posthog_client.posthog_on_error,
+        }
+
+    importlib.reload(ee_app_configs)
+    importlib.reload(posthog_client)
+
+
+def test_capture_and_sync_skips_primary_identify_without_primary_client(
+    monkeypatch: Any,
+) -> None:
+    marketing_posthog = Mock()
+    monkeypatch.setattr(posthog_client, "marketing_posthog", marketing_posthog)
+    monkeypatch.setattr(posthog_client, "posthog", None)
+
+    posthog_client.capture_and_sync_with_alternate_posthog(
+        alternate_distinct_id="marketing-user-id",
+        event="signed_up",
+        properties={"onyx_cloud_user_id": "cloud-user-id", "plan": "trial"},
+    )
+
+    marketing_posthog.identify.assert_called_once()
+    marketing_posthog.capture.assert_called_once()
+    marketing_posthog.flush.assert_called_once()
+
+
+def test_event_telemetry_noops_when_posthog_disabled(monkeypatch: Any) -> None:
+    logger = Mock()
+    monkeypatch.setattr(ee_telemetry, "logger", logger)
+    monkeypatch.setattr(ee_telemetry, "posthog", None)
+
+    ee_telemetry.event_telemetry(
+        distinct_id="user@example.com",
+        event="message_sent",
+        properties={"source": "web"},
+    )
+
+    logger.info.assert_not_called()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Working on cleaning up Posthog usage since it seems to be used in a very non-intuitive way right now

Trying to cleanup from https://github.com/onyx-dot-app/onyx/pull/8268

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally with and without key

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up PostHog usage so it fully disables when no API key is set. This prevents silent failures and makes feature flags and telemetry safe no-ops.

- **Refactors**
  - Only initialize PostHog clients when API keys are provided; removed the "FooBar" default.
  - Feature flags: factory returns NoOp when PostHog is disabled; provider returns False if the client is missing.
  - Telemetry and cross-sync: added guards to no-op without a client; added unit tests to cover disabled behavior.

<sup>Written for commit 9bb6858ba3f10b6178d2d6c82c7d2c2e1674a5b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

