### PR TITLE
revert: "chore(tests): temporarily disable exa tests"

### DIFF
--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -41,7 +41,6 @@ class TestOnyxWebCrawler:
         assert "This domain is for use in" in content
         assert "documentation" in content or "illustrative" in content
 
-    @pytest.mark.skip(reason="Temporarily disabled")
     def test_fetches_multiple_urls(self, admin_user: DATestUser) -> None:
         """Test that the crawler can fetch multiple URLs in one request."""
         response = client.post(

--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -274,7 +274,6 @@ def _activate_exa_provider(admin_user: DATestUser) -> int:
 
 
 @pytestmark_exa
-@pytest.mark.skip(reason="Temporarily disabled")
 def test_web_search_endpoints_with_exa(
     admin_user: DATestUser,
 ) -> None:

--- a/web/tests/e2e/admin/web-search/web_search_providers.spec.ts
+++ b/web/tests/e2e/admin/web-search/web_search_providers.spec.ts
@@ -23,9 +23,7 @@ test.describe("Web Search Provider Configuration", () => {
 
     test.skip(!EXA_API_KEY, "EXA_API_KEY environment variable not set");
 
-    test.skip("should configure Exa as web search provider", async ({
-      page,
-    }) => {
+    test("should configure Exa as web search provider", async ({ page }) => {
       // Click Connect on the Exa card (or key icon if already configured)
       await openProviderModal(page, "Exa");
 

--- a/web/tests/e2e/chat/welcome_page.spec.ts
+++ b/web/tests/e2e/chat/welcome_page.spec.ts
@@ -83,7 +83,7 @@ for (const theme of THEMES) {
       await expect(newSessionBtn).toBeVisible({ timeout: 10000 });
     });
 
-    test.skip("send button is visible in the input bar", async ({ page }) => {
+    test("send button is visible in the input bar", async ({ page }) => {
       const sendButton = page.locator("#onyx-chat-input-send-button");
       await expect(sendButton).toBeVisible({ timeout: 10000 });
 

--- a/web/tests/e2e/chat/welcome_page.spec.ts
+++ b/web/tests/e2e/chat/welcome_page.spec.ts
@@ -83,7 +83,7 @@ for (const theme of THEMES) {
       await expect(newSessionBtn).toBeVisible({ timeout: 10000 });
     });
 
-    test("send button is visible in the input bar", async ({ page }) => {
+    test.skip("send button is visible in the input bar", async ({ page }) => {
       const sendButton = page.locator("#onyx-chat-input-send-button");
       await expect(sendButton).toBeVisible({ timeout: 10000 });
 


### PR DESCRIPTION
As promised, Reverts onyx-dot-app/onyx#8431

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted temporary skips to re-enable Exa backend tests, E2E provider configuration, and the multiple-URL fetch API test, restoring CI coverage. Exa tests only run when `EXA_API_KEY` is set.

<sup>Written for commit 60253a03810830aa43785097df24810a34ac3175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/8437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



