### PR TITLE
Add comprehensive Deep Research technical documentation

### DIFF
--- a/docs/deep_research/01_architecture_overview.md
+++ b/docs/deep_research/01_architecture_overview.md
@@ -1,0 +1,125 @@
+# Deep Research: Architecture Overview
+
+This document describes the high-level architecture of the Onyx Deep Research system.
+
+## System Design
+
+Deep Research is a multi-agent, multi-phase orchestration system that enables thorough, long-form research on user queries. It employs a hierarchical agent model:
+
+```
+                        +-----------------------+
+                        |   API Entry Point     |
+                        |  /send-chat-message   |
+                        |  (deep_research=true) |
+                        +-----------+-----------+
+                                    |
+                        +-----------v-----------+
+                        |   Orchestrator Loop   |
+                        |  (dr_loop.py)         |
+                        +-----------+-----------+
+                                    |
+              +---------------------+---------------------+
+              |                     |                     |
+     +--------v--------+  +--------v--------+  +--------v--------+
+     | Research Agent 1 |  | Research Agent 2 |  | Research Agent 3 |
+     | (parallel)       |  | (parallel)       |  | (parallel)       |
+     +--------+---------+  +--------+---------+  +--------+---------+
+              |                     |                     |
+        +-----+-----+        +-----+-----+        +-----+-----+
+        |  SearchTool |        | WebSearch |        | OpenURL   |
+        |  WebSearch  |        | OpenURL   |        | SearchTool|
+        |  OpenURL    |        | SearchTool|        | WebSearch |
+        +-------------+        +-----------+        +-----------+
+```
+
+## Execution Phases
+
+The system operates in four sequential phases:
+
+| Phase | Name | Purpose | Optional |
+|-------|------|---------|----------|
+| 1 | Clarification | Ask user for missing context | Yes |
+| 2 | Research Plan | Generate a structured 5-6 step plan | No |
+| 3 | Research Execution | Iterative orchestration of research agents | No |
+| 4 | Final Report | Synthesize all findings into a comprehensive answer | No |
+
+See [02_execution_phases.md](./02_execution_phases.md) for detailed phase descriptions.
+
+## Key Architectural Decisions
+
+### Hierarchical Agent Model
+
+The system uses a two-level agent hierarchy:
+
+- **Orchestrator** (top level): Decides which research tasks to delegate, when to think, and when to produce the final report. It does not perform research directly.
+- **Research Agents** (second level): Execute actual research using tools (search, URL reading). Each agent operates independently on a single research task and produces an intermediate report.
+
+### Mock Tools for Control Flow
+
+The orchestrator and research agents use "mock tools" -- tool definitions presented to the LLM that are not backed by real tool implementations. Instead, the system intercepts these tool calls to control execution flow:
+
+| Mock Tool | Used By | Purpose |
+|-----------|---------|---------|
+| `generate_plan` | Clarification LLM | Signals that clarification is not needed |
+| `research_agent` | Orchestrator | Delegates a research task |
+| `generate_report` | Orchestrator & Research Agent | Signals completion |
+| `think_tool` | Orchestrator & Research Agent | Chain-of-thought reasoning for non-reasoning models |
+
+See [05_mock_tools.md](./05_mock_tools.md) for details.
+
+### Parallel Research Agents
+
+The orchestrator can dispatch up to 3 research agents in parallel per cycle. Each agent runs in its own thread via `run_functions_tuples_in_parallel()`. Citations from parallel agents are renumbered and merged using `collapse_citations()`.
+
+### Reasoning Model Awareness
+
+The system detects whether the LLM is a reasoning model (e.g., o1, o3) and adapts:
+
+- **Non-reasoning models**: Use the `think_tool` for chain-of-thought, get 8 max orchestrator cycles
+- **Reasoning models**: Use native reasoning, get 4 max orchestrator cycles (since thinking is baked in), skip `think_tool`
+
+### Streaming Architecture
+
+All output is streamed as typed packets via an `Emitter` / `Queue` system. Each packet carries a `Placement` object that tells the frontend exactly where to render it in the timeline UI.
+
+See [06_streaming_and_packets.md](./06_streaming_and_packets.md) for the packet system.
+
+## File Organization
+
+```
+backend/onyx/
+  deep_research/
+    dr_loop.py               # Main orchestration loop
+    dr_mock_tools.py          # Mock tool definitions
+    models.py                 # Pydantic models
+    utils.py                  # Think tool processor, special tool detection
+  tools/fake_tools/
+    research_agent.py         # Research agent implementation
+  prompts/deep_research/
+    orchestration_layer.py    # Orchestrator & clarification prompts
+    research_agent.py         # Research agent & report prompts
+    dr_tool_prompts.py        # Tool description prompts
+
+web/src/
+  hooks/
+    useDeepResearchToggle.ts  # Toggle state management
+  app/app/
+    services/streamingModels.ts   # Packet type definitions
+    message/messageComponents/
+      timeline/renderers/deepresearch/
+        DeepResearchPlanRenderer.tsx   # Plan UI
+        ResearchAgentRenderer.tsx      # Research agent UI
+```
+
+## Related Documents
+
+- [02_execution_phases.md](./02_execution_phases.md) -- Detailed phase-by-phase execution flow
+- [03_orchestrator.md](./03_orchestrator.md) -- Orchestrator agent internals
+- [04_research_agent.md](./04_research_agent.md) -- Research agent internals
+- [05_mock_tools.md](./05_mock_tools.md) -- Mock tool definitions and control flow
+- [06_streaming_and_packets.md](./06_streaming_and_packets.md) -- Streaming packet system
+- [07_citation_system.md](./07_citation_system.md) -- Citation tracking and merging
+- [08_prompts.md](./08_prompts.md) -- All LLM prompts
+- [09_frontend.md](./09_frontend.md) -- Frontend integration
+- [10_configuration_and_constants.md](./10_configuration_and_constants.md) -- Configuration reference
+- [11_database_schema.md](./11_database_schema.md) -- Database models and migrations

--- a/docs/deep_research/02_execution_phases.md
+++ b/docs/deep_research/02_execution_phases.md
@@ -1,0 +1,130 @@
+# Deep Research: Execution Phases
+
+All phases are orchestrated by `run_deep_research_llm_loop()` in `backend/onyx/deep_research/dr_loop.py:188`.
+
+## Phase 1: Clarification (Optional)
+
+**Location**: `dr_loop.py:236-299`
+
+**Purpose**: Determine whether the user's query needs clarification before research begins.
+
+**Skip conditions** (any of these bypasses this phase):
+- `SKIP_DEEP_RESEARCH_CLARIFICATION` env var is `"true"` (see `backend/onyx/configs/chat_configs.py:64`)
+- `skip_clarification=True` is passed (happens when the user already answered a prior clarification)
+- The detection of `skip_clarification` is done via `is_last_assistant_message_clarification()` in `backend/onyx/chat/chat_utils.py`
+
+**Flow**:
+
+1. Construct system prompt using `CLARIFICATION_PROMPT` from `backend/onyx/prompts/deep_research/orchestration_layer.py:8`
+2. Build truncated message history with `construct_message_history()`, limited to last `MAX_USER_MESSAGES_FOR_CONTEXT=5` user messages
+3. Call `run_llm_step()` at `dr_loop.py:269` with:
+   - Tool definitions: `get_clarification_tool_definitions()` which returns only `[GENERATE_PLAN_TOOL_DESCRIPTION]`
+   - Tool choice: `AUTO` (LLM decides whether to call the tool or respond with text)
+   - Placement: `turn_index=0`
+4. **Decision point** (`dr_loop.py:286`):
+   - If the LLM **did not** call the `generate_plan` tool -> the LLM's text response is a clarification question. Mark the turn as clarification via `state_container.set_is_clarification(True)`, emit `OverallStop`, and return early. The user must respond before research continues.
+   - If the LLM **did** call `generate_plan` -> proceed to Phase 2.
+
+**Packets emitted**: Standard `AgentResponseStart`/`AgentResponseDelta` (if clarification), or nothing visible (if proceeding).
+
+## Phase 2: Research Plan Generation
+
+**Location**: `dr_loop.py:302-384`
+
+**Purpose**: Generate a numbered, 5-6 step research plan.
+
+**Flow**:
+
+1. Construct system prompt using `RESEARCH_PLAN_PROMPT` from `orchestration_layer.py:34`
+2. Append `RESEARCH_PLAN_REMINDER` (`orchestration_layer.py:55`) as a user-type message to reinforce plan-only output
+3. Build truncated history with `construct_message_history()`
+4. Call `run_llm_step_pkt_generator()` at `dr_loop.py:330` -- this is the streaming generator variant
+5. **Packet translation** (`dr_loop.py:346-364`):
+   - `AgentResponseStart` -> `DeepResearchPlanStart`
+   - `AgentResponseDelta` -> `DeepResearchPlanDelta` (carries `content` field with plan text chunks)
+   - Other packets (e.g., `ReasoningStart`, `ReasoningDelta`) pass through unchanged
+6. On `StopIteration`, emit a `SectionEnd` packet
+7. Extract the full plan text from `llm_step_result.answer` (`dr_loop.py:381`)
+
+**Output**: The plan is stored in the `research_plan` variable and used in Phase 3. If the plan is `None`, a `RuntimeError` is raised.
+
+**Packets emitted**: `DeepResearchPlanStart`, `DeepResearchPlanDelta` (streamed), `SectionEnd`
+
+## Phase 3: Research Execution
+
+**Location**: `dr_loop.py:386-764`
+
+**Purpose**: Iteratively dispatch research agents and accumulate findings.
+
+This is the core of deep research. The orchestrator LLM runs in a loop, deciding on each cycle whether to:
+- Dispatch research agent(s) via the `research_agent` mock tool
+- Reason about findings via the `think_tool` mock tool
+- Generate the final report via the `generate_report` mock tool
+
+### Orchestrator Loop
+
+**Loop bounds**: `dr_loop.py:426` -- iterates up to `MAX_ORCHESTRATOR_CYCLES` (8 for non-reasoning, 4 for reasoning models).
+
+**Per-cycle flow**:
+
+1. **Timeout/last-cycle check** (`dr_loop.py:429-456`): If elapsed time > `DEEP_RESEARCH_FORCE_REPORT_SECONDS` (30 min) or this is the last cycle, skip to `generate_final_report()`.
+
+2. **First cycle reminder** (`dr_loop.py:458-465`): On cycle 1, append `FIRST_CYCLE_REMINDER` to encourage thorough research.
+
+3. **Orchestrator LLM call** (`dr_loop.py:502-527`):
+   - System prompt: `ORCHESTRATOR_PROMPT` or `ORCHESTRATOR_PROMPT_REASONING` (from `orchestration_layer.py:62` / `orchestration_layer.py:156`)
+   - Tool definitions: `get_orchestrator_tools(include_think_tool=not is_reasoning_model)`
+   - Tool choice: `REQUIRED` (model must call a tool)
+   - Max tokens: 1024 (orchestrator output is just tool calls, never long)
+   - Custom token processor: `create_think_tool_token_processor()` for non-reasoning models
+
+4. **Tool call dispatch** (`dr_loop.py:562-764`):
+
+   The result is checked via `check_special_tool_calls()` (`deep_research/utils.py:203`):
+
+   - **`generate_report`** (`dr_loop.py:564-584`): Calls `generate_final_report()` and breaks the loop.
+   - **`think_tool`** (`dr_loop.py:585-624`): Processes the reasoning, appends think_tool call + response to chat history, continues loop.
+   - **`research_agent`** (`dr_loop.py:626-763`): Collects all `research_agent` tool calls, runs them in parallel via `run_research_agent_calls()`, merges results back into chat history with citations.
+
+### Research Agent Execution (within Phase 3)
+
+Each `research_agent` tool call triggers `run_research_agent_call()` in `backend/onyx/tools/fake_tools/research_agent.py:205`. Up to 3 run in parallel.
+
+See [04_research_agent.md](./04_research_agent.md) for the full research agent lifecycle.
+
+### Citation Merging
+
+After parallel research agents complete, `collapse_citations()` renumbers citations and merges mappings. See [07_citation_system.md](./07_citation_system.md).
+
+## Phase 4: Final Report Generation
+
+**Location**: `dr_loop.py:101-184` (`generate_final_report()`)
+
+**Purpose**: Produce a comprehensive, well-cited final answer using all research findings.
+
+**Flow**:
+
+1. Construct system prompt using `FINAL_REPORT_PROMPT` from `orchestration_layer.py:123`
+2. Construct a reminder using `USER_FINAL_REPORT_QUERY` (`orchestration_layer.py:140`) that includes the original research plan
+3. Build history via `construct_message_history()` -- this includes the full chat history with all intermediate reports and tool call responses
+4. Initialize `DynamicCitationProcessor` and populate it with the accumulated `citation_mapping` from all research agents
+5. Call `run_llm_step()` at `dr_loop.py:153` with:
+   - No tool definitions (empty list)
+   - Tool choice: `NONE`
+   - Max tokens: `MAX_FINAL_REPORT_TOKENS = 20000`
+   - Timeout: 300 seconds (5 min read timeout)
+   - `is_deep_research=True`
+6. Save citation mapping to `state_container` for DB persistence
+7. If saved reasoning from a prior `think_tool` call exists, attach it via `state_container.set_reasoning_tokens()`
+
+**Packets emitted**: `AgentResponseStart`, `AgentResponseDelta` (the final answer text, streamed)
+
+## Overall Stop
+
+After Phase 4 completes (or Phase 1 returns a clarification), the system emits:
+
+```python
+Packet(placement=Placement(turn_index=final_turn_index), obj=OverallStop(type="stop"))
+```
+
+This signals the frontend that the deep research session is complete (`dr_loop.py:765-770`).

--- a/docs/deep_research/03_orchestrator.md
+++ b/docs/deep_research/03_orchestrator.md
@@ -1,0 +1,129 @@
+# Deep Research: Orchestrator Agent
+
+The orchestrator is the top-level control agent in deep research. It does not perform research itself -- it delegates research tasks to research agents and decides when enough information has been gathered.
+
+## Entry Point
+
+**Function**: `run_deep_research_llm_loop()`
+**File**: `backend/onyx/deep_research/dr_loop.py:188`
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `emitter` | `Emitter` | Streaming packet emitter |
+| `state_container` | `ChatStateContainer` | Thread-safe state for the chat turn |
+| `simple_chat_history` | `list[ChatMessageSimple]` | Existing conversation history |
+| `tools` | `list[Tool]` | All available tools (filtered internally) |
+| `custom_agent_prompt` | `str \| None` | Custom persona prompt (currently unused, `noqa: ARG001`) |
+| `llm` | `LLM` | The LLM instance |
+| `token_counter` | `Callable[[str], int]` | Token counting function |
+| `db_session` | `Session` | SQLAlchemy session |
+| `skip_clarification` | `bool` | Whether to skip Phase 1 |
+| `user_identity` | `LLMUserIdentity \| None` | User identity for tracing |
+| `chat_session_id` | `str \| None` | Chat session ID for tracing |
+| `all_injected_file_metadata` | `dict[str, FileToolMetadata] \| None` | Injected file metadata |
+
+## LLM Requirements
+
+The orchestrator requires an LLM with at least 50,000 `max_input_tokens`. If this requirement is not met, a `RuntimeError` is raised at `dr_loop.py:215-218`.
+
+## Tool Filtering
+
+Before the orchestrator loop begins, the tool list is filtered to only allow:
+
+```python
+allowed_tool_names = {SearchTool.NAME, WebSearchTool.NAME, OpenURLTool.NAME}
+```
+
+**Reference**: `dr_loop.py:230`
+
+These filtered tools are passed to the research agents, not the orchestrator itself. The orchestrator only uses mock tools (`research_agent`, `generate_report`, `think_tool`).
+
+## Orchestrator Loop Mechanics
+
+**Loop**: `dr_loop.py:426-764`
+
+### Cycle Limits
+
+| Model Type | Max Cycles | Constant |
+|-----------|-----------|----------|
+| Non-reasoning | 8 | `MAX_ORCHESTRATOR_CYCLES` (`dr_loop.py:95`) |
+| Reasoning | 4 | `MAX_ORCHESTRATOR_CYCLES_REASONING` (`dr_loop.py:98`) |
+
+### Prompt Selection
+
+| Model Type | Prompt | Location |
+|-----------|--------|----------|
+| Non-reasoning | `ORCHESTRATOR_PROMPT` | `orchestration_layer.py:62` |
+| Reasoning | `ORCHESTRATOR_PROMPT_REASONING` | `orchestration_layer.py:156` |
+
+Both prompts are formatted with:
+- `{current_datetime}` -- current date/time
+- `{current_cycle_count}` -- current cycle number
+- `{max_cycles}` -- maximum cycles allowed
+- `{research_plan}` -- the plan generated in Phase 2
+- `{internal_search_research_task_guidance}` -- guidance for internal vs. web search (if applicable)
+
+### Per-Cycle Decision Tree
+
+```
+Orchestrator LLM call (tool_choice=REQUIRED)
+    |
+    +-- generate_report called?
+    |       YES -> generate_final_report() -> break
+    |
+    +-- think_tool called?
+    |       YES -> Save reasoning to history, continue loop
+    |
+    +-- research_agent called?
+    |       YES -> Collect all research_agent calls
+    |              If >1 call: emit TopLevelBranching packet
+    |              run_research_agent_calls() in parallel
+    |              Merge citations
+    |              Append results to chat history
+    |              Continue loop
+    |
+    +-- No tool calls?
+            Cycle 0: RuntimeError
+            Other cycles: Force generate_final_report() -> break
+```
+
+### Think Tool Processing (Non-Reasoning Models)
+
+When a `think_tool` call is detected (`dr_loop.py:585-624`):
+
+1. The reasoning text is available via `state_container.reasoning_tokens` (because the custom `create_think_tool_token_processor()` converts tool call arguments to reasoning content during streaming)
+2. An assistant message with the tool call is appended to `simple_chat_history`
+3. A tool response message (`"Acknowledged, please continue."`) is appended
+4. The loop continues without incrementing the cycle count (thinking is "free")
+
+### Research Agent Dispatch
+
+When `research_agent` tool calls are detected (`dr_loop.py:626-763`):
+
+1. Tool calls are collected into `research_agent_calls`
+2. If multiple parallel calls, a `TopLevelBranching` packet is emitted (`dr_loop.py:661-673`)
+3. `run_research_agent_calls()` is invoked (`research_agent.py:644`), which:
+   - Runs agents in parallel threads
+   - Returns `CombinedResearchAgentCallResult` with merged citations
+4. Results are stored as `ToolCallInfo` entries via `state_container.add_tool_call()`
+5. Intermediate reports are appended to `simple_chat_history` as `TOOL_CALL_RESPONSE` messages
+
+### Timeout Handling
+
+**Constant**: `DEEP_RESEARCH_FORCE_REPORT_SECONDS = 30 * 60` (30 minutes, `dr_loop.py:83`)
+
+At the start of each cycle (`dr_loop.py:429-430`), elapsed time is checked. If exceeded, the system logs a warning and immediately calls `generate_final_report()`.
+
+Note: The actual total runtime can exceed 30 minutes because a research cycle starting at minute 29 could run for up to another 30 minutes (the research agent has its own timeout).
+
+## Turn Index Tracking
+
+The orchestrator maintains `final_turn_index` to track the current position in the UI timeline:
+
+- Base: `orchestrator_start_turn_index` (1, or 2 if plan generation had reasoning)
+- Per cycle: `+cycle`
+- Per reasoning step: `+reasoning_cycles`
+
+This ensures packets are placed correctly in the frontend timeline.

--- a/docs/deep_research/04_research_agent.md
+++ b/docs/deep_research/04_research_agent.md
@@ -1,0 +1,150 @@
+# Deep Research: Research Agent
+
+The research agent is the workhorse of the deep research system. Each research agent receives a single research task and iteratively uses tools (search, URL reading) to gather information, then produces an intermediate report.
+
+## Key Functions
+
+| Function | File | Line | Purpose |
+|----------|------|------|---------|
+| `run_research_agent_call()` | `backend/onyx/tools/fake_tools/research_agent.py` | 205 | Single research agent execution |
+| `run_research_agent_calls()` | `backend/onyx/tools/fake_tools/research_agent.py` | 644 | Parallel execution coordinator |
+| `generate_intermediate_report()` | `backend/onyx/tools/fake_tools/research_agent.py` | 86 | Intermediate report generation |
+| `_on_research_agent_timeout()` | `backend/onyx/tools/fake_tools/research_agent.py` | 620 | Timeout handler callback |
+
+## Constants
+
+| Constant | Value | Location | Purpose |
+|----------|-------|----------|---------|
+| `RESEARCH_AGENT_TIMEOUT_SECONDS` | 1800 (30 min) | `research_agent.py:78` | Per-agent timeout |
+| `RESEARCH_AGENT_FORCE_REPORT_SECONDS` | 720 (12 min) | `research_agent.py:81` | Force report generation after this |
+| `MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS` | 10000 | `research_agent.py:83` | Max tokens for intermediate report |
+| `MAX_RESEARCH_CYCLES` | 8 | `prompts/deep_research/research_agent.py:5` | Max tool-calling cycles per agent |
+
+## Single Agent Lifecycle (`run_research_agent_call`)
+
+### Initialization (Lines 220-253)
+
+1. Start timer for timeout tracking
+2. Create `DynamicCitationProcessor` with `CitationMode.KEEP_MARKERS` -- this preserves original `[1]`, `[2]` markers in text while tracking which documents were cited
+3. Extract `research_topic` from `tool_args["task"]`
+4. Emit `ResearchAgentStart` packet with the research task text
+5. Create initial message history with the research topic as a user message
+
+### Research Loop (Lines 257-587)
+
+The agent loops up to `MAX_RESEARCH_CYCLES` (8) times:
+
+```
+for each cycle:
+    Check time limit (12 min) -> break if exceeded
+    Check cycle limit -> break if last cycle
+
+    Build system prompt with tool descriptions
+    Call LLM with tool_choice=REQUIRED
+
+    Check tool calls:
+      generate_report -> generate_intermediate_report() -> return result
+      think_tool -> append reasoning to history, continue
+      real tools -> execute via run_tool_calls(), append results to history
+```
+
+### System Prompt Construction (Lines 272-312)
+
+The system prompt is assembled dynamically:
+
+1. **Base template**: `RESEARCH_AGENT_PROMPT` or `RESEARCH_AGENT_PROMPT_REASONING` from `prompts/deep_research/research_agent.py:8` / `research_agent.py:75`
+2. **Tool descriptions**: Generated via `generate_tools_description(current_tools)` from `tools/utils.py`
+3. **Conditional guidance injected**:
+   - `INTERNAL_SEARCH_GUIDANCE` -- if `SearchTool` is available
+   - `WEB_SEARCH_TOOL_DESCRIPTION` -- if `WebSearchTool` is available (`prompts/deep_research/dr_tool_prompts.py:17`)
+   - `OPEN_URLS_TOOL_DESCRIPTION` -- if `OpenURLTool` is available (`dr_tool_prompts.py:26`)
+   - For reasoning models, `OPEN_URLS_TOOL_DESCRIPTION_REASONING` is used instead (`dr_tool_prompts.py:34`)
+4. **Template variables**: `{available_tools}`, `{current_datetime}`, `{current_cycle_count}`, plus the optional tool descriptions
+
+### Tool Definitions Passed to LLM (Lines 332-347)
+
+The research agent receives:
+- Real tool definitions: `[tool.tool_definition() for tool in current_tools]` (search, web_search, open_url)
+- Mock tool definitions: `get_research_agent_additional_tool_definitions(include_think_tool=not is_reasoning_model)` -- this includes `generate_report` and optionally `think_tool`
+
+### LLM Call Configuration (Lines 343-368)
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `tool_choice` | `REQUIRED` | Agent must call a tool |
+| `reasoning_effort` | `LOW` | Faster inference for iterative steps |
+| `max_tokens` | 1000 | Safety limit to avoid infinite loops |
+| `use_existing_tab_index` | `True` | Packets stay on the agent's tab |
+| `is_deep_research` | `True` | Signals special deep research handling |
+
+### Real Tool Execution (Lines 444-587)
+
+When the agent calls real tools (search, web_search, open_url):
+
+1. Tool calls are filtered to a single tool type per turn (`research_agent.py:380-384`) -- this is a current limitation due to the Placement system
+2. `run_tool_calls()` executes the tools with `max_concurrent_tools=1`
+3. For each tool response:
+   - If it's a `SearchDocsResponse`, search docs are extracted and added to `state_container`
+   - If it was a `WebSearchTool` call with results, set `just_ran_web_search = True` to trigger the `OPEN_URL_REMINDER_RESEARCH_AGENT` on the next cycle
+   - `update_citation_processor_from_tool_response()` updates the citation processor with new documents
+   - A `ToolCallInfo` is created and added to `state_container`
+   - A `TOOL_CALL_RESPONSE` message is appended to the agent's local history
+
+### Web Search -> Open URL Flow
+
+After a web search returns results, the agent is nudged to open promising URLs:
+
+- `just_ran_web_search` flag is set (`research_agent.py:542`)
+- On the next cycle, `OPEN_URL_REMINDER_RESEARCH_AGENT` (`prompts/deep_research/research_agent.py:96`) is injected as a reminder message
+
+## Intermediate Report Generation (`generate_intermediate_report`)
+
+**Location**: `research_agent.py:86-202`
+
+Called when the agent triggers `generate_report` or when cycles/time run out.
+
+**Flow**:
+
+1. Construct system prompt from `RESEARCH_REPORT_PROMPT` (`prompts/deep_research/research_agent.py:38`)
+2. Construct reminder from `USER_REPORT_QUERY` (`research_agent.py:60`) with the original research topic
+3. Build message history from the agent's local history
+4. Call `run_llm_step_pkt_generator()` with:
+   - `reasoning_effort=LOW`
+   - `max_tokens=MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS` (10000)
+   - `timeout_override=300` (5 min)
+5. Translate packets:
+   - `AgentResponseStart` -> `IntermediateReportStart`
+   - `AgentResponseDelta` -> `IntermediateReportDelta`
+6. On completion, emit `IntermediateReportCitedDocs` with the cited documents, then `SectionEnd`
+7. Return the full report text
+
+## Parallel Execution (`run_research_agent_calls`)
+
+**Location**: `research_agent.py:644-708`
+
+Coordinates multiple research agents running in parallel.
+
+**Mechanism**: `run_functions_tuples_in_parallel()` from `onyx/utils/threadpool_concurrency.py`
+
+**Configuration**:
+- `allow_failures=False`
+- `timeout=RESEARCH_AGENT_TIMEOUT_SECONDS` (30 min)
+- `timeout_callback=_on_research_agent_timeout` -- returns a result with `RESEARCH_AGENT_TIMEOUT_MESSAGE` instead of crashing
+
+**Post-processing** (Lines 687-708):
+For each agent result:
+1. If `None` (failure), append `None` to reports list
+2. Otherwise, call `collapse_citations()` to renumber citations and merge into the combined mapping
+
+Returns `CombinedResearchAgentCallResult` with all intermediate reports and the merged citation mapping.
+
+## Error Handling
+
+Individual research agent errors are caught at `research_agent.py:609-617`:
+- Error is logged
+- A `PacketException` is emitted
+- `None` is returned (the orchestrator skips failed agents)
+
+## Test Script
+
+`research_agent.py:711-797` contains a `__main__` block for standalone testing of a single research agent call. It sets up the required infrastructure (LLM, tools, emitter, state container) and runs a single research agent with a configurable prompt.

--- a/docs/deep_research/05_mock_tools.md
+++ b/docs/deep_research/05_mock_tools.md
@@ -1,0 +1,148 @@
+# Deep Research: Mock Tools
+
+Mock tools are tool definitions presented to the LLM that are intercepted by the system rather than executed by real tool implementations. They provide structured control flow between the system and the LLM.
+
+## Definitions
+
+All mock tool definitions are in `backend/onyx/deep_research/dr_mock_tools.py`.
+
+Tool name constants are also duplicated in `backend/onyx/prompts/deep_research/dr_tool_prompts.py:1-11` (used for prompt template references).
+
+### `generate_plan`
+
+**Name constant**: `GENERATE_PLAN_TOOL_NAME = "generate_plan"` (`dr_mock_tools.py:1`)
+**Definition**: `dr_mock_tools.py:13-24`
+
+```json
+{
+  "name": "generate_plan",
+  "description": "No clarification needed, generate a research plan for the user's query.",
+  "parameters": { "properties": {}, "required": [] }
+}
+```
+
+**Used by**: Clarification phase
+**Purpose**: The LLM calls this tool to signal that the user's query is clear enough -- no clarification questions needed. If the LLM responds with text instead of calling this tool, that text is treated as a clarification question.
+**No parameters**.
+
+### `research_agent`
+
+**Name constant**: `RESEARCH_AGENT_TOOL_NAME = "research_agent"` (`dr_mock_tools.py:4`)
+**Task key constant**: `RESEARCH_AGENT_TASK_KEY = "task"` (`dr_mock_tools.py:5`)
+**Definition**: `dr_mock_tools.py:27-43`
+
+```json
+{
+  "name": "research_agent",
+  "description": "Conduct research on a specific topic.",
+  "parameters": {
+    "properties": {
+      "task": {
+        "type": "string",
+        "description": "The research task to investigate, should be 1-2 descriptive sentences..."
+      }
+    },
+    "required": ["task"]
+  }
+}
+```
+
+**Used by**: Orchestrator
+**Purpose**: Delegates a research task to a research agent. The `task` argument becomes the agent's research topic.
+**Parameters**: `task` (string, required) -- 1-2 descriptive sentences.
+
+### `generate_report`
+
+**Name constant**: `GENERATE_REPORT_TOOL_NAME = "generate_report"` (`dr_mock_tools.py:7`)
+**Definitions**:
+- Orchestrator version: `dr_mock_tools.py:46-57`
+- Research agent version: `RESEARCH_AGENT_GENERATE_REPORT_TOOL_DESCRIPTION` (`dr_mock_tools.py:98-109`)
+
+```json
+{
+  "name": "generate_report",
+  "description": "Generate the final research report from all of the findings...",
+  "parameters": { "properties": {}, "required": [] }
+}
+```
+
+**Used by**: Both orchestrator and research agents
+**Purpose**:
+- In the **orchestrator**: Signals that research is complete, triggers `generate_final_report()`
+- In the **research agent**: Signals that the agent has gathered enough information, triggers `generate_intermediate_report()`
+**No parameters**.
+
+### `think_tool`
+
+**Name constant**: `THINK_TOOL_NAME = "think_tool"` (`dr_mock_tools.py:9`)
+**Definitions**:
+- Orchestrator version: `THINK_TOOL_DESCRIPTION` (`dr_mock_tools.py:60-76`)
+- Research agent version: `RESEARCH_AGENT_THINK_TOOL_DESCRIPTION` (`dr_mock_tools.py:79-95`)
+
+```json
+{
+  "name": "think_tool",
+  "description": "Use this for reasoning between research_agent calls...",
+  "parameters": {
+    "properties": {
+      "reasoning": {
+        "type": "string",
+        "description": "Your chain of thought reasoning, use paragraph format, no lists."
+      }
+    },
+    "required": ["reasoning"]
+  }
+}
+```
+
+**Used by**: Both orchestrator and research agents (only for non-reasoning models)
+**Purpose**: Enables chain-of-thought reasoning for models that don't have native reasoning. The `reasoning` argument text is converted into reasoning tokens for the UI via `create_think_tool_token_processor()`.
+**Parameters**: `reasoning` (string, required)
+
+The orchestrator version description says "Use this for reasoning between research_agent calls and before calling generate_report." The research agent version says "Use this for reasoning between research steps."
+
+## Accessor Functions
+
+| Function | Location | Returns | Used By |
+|----------|----------|---------|---------|
+| `get_clarification_tool_definitions()` | `dr_mock_tools.py:116` | `[GENERATE_PLAN_TOOL_DESCRIPTION]` | Phase 1 |
+| `get_orchestrator_tools(include_think_tool)` | `dr_mock_tools.py:120` | `[research_agent, generate_report, (think_tool)]` | Phase 3 orchestrator |
+| `get_research_agent_additional_tool_definitions(include_think_tool)` | `dr_mock_tools.py:130` | `[generate_report, (think_tool)]` | Research agent |
+
+## Constants
+
+| Constant | Value | Location | Purpose |
+|----------|-------|----------|---------|
+| `THINK_TOOL_RESPONSE_MESSAGE` | `"Acknowledged, please continue."` | `dr_mock_tools.py:112` | Response injected into chat history after think_tool |
+| `THINK_TOOL_RESPONSE_TOKEN_COUNT` | `10` | `dr_mock_tools.py:113` | Approximate token count for the response |
+| `RESEARCH_AGENT_IN_CODE_ID` | `"ResearchAgent"` | `dr_mock_tools.py:3` | Used for DB tool lookup |
+
+## Detection Logic
+
+Mock tool calls are detected by `check_special_tool_calls()` in `backend/onyx/deep_research/utils.py:203-216`:
+
+```python
+def check_special_tool_calls(tool_calls: list[ToolCallKickoff]) -> SpecialToolCalls:
+    # Scans tool_calls for think_tool and generate_report
+    # Returns SpecialToolCalls with the detected calls (or None)
+```
+
+This returns a `SpecialToolCalls` model (`deep_research/models.py:7-9`) with optional `think_tool_call` and `generate_report_tool_call` fields.
+
+## Think Tool Token Processor
+
+For non-reasoning models, the `think_tool` arguments are streamed as reasoning content in the UI. This is handled by `create_think_tool_token_processor()` in `backend/onyx/deep_research/utils.py:121-200`.
+
+The processor:
+1. Detects think_tool calls in streaming deltas
+2. Strips the JSON wrapper (`{"reasoning": "...content..."}`)
+3. Unescapes JSON string escape sequences
+4. Converts the content to `Delta(reasoning_content=chunk)` for the UI
+5. On flush, returns the complete tool call for proper chat history
+
+**State class**: `ThinkToolProcessorState` (`utils.py:21-32`)
+
+**JSON parsing details**:
+- Looks for prefixes: `'{"reasoning": "'` or `'{"reasoning":"'`
+- Holds back 3 characters to avoid splitting escape sequences or emitting the closing `"}`
+- Uses `_unescape_json_string()` (`utils.py:35-60`) for `\n`, `\r`, `\t`, `\"`, `\\`

--- a/docs/deep_research/06_streaming_and_packets.md
+++ b/docs/deep_research/06_streaming_and_packets.md
@@ -1,0 +1,186 @@
+# Deep Research: Streaming and Packets
+
+Deep research streams all output to the frontend as typed packets. This document describes the packet system and how packets are emitted and consumed.
+
+## Packet Infrastructure
+
+### Placement
+
+**File**: `backend/onyx/server/query_and_chat/placement.py:4`
+
+```python
+class Placement(BaseModel):
+    turn_index: int        # Which iterative block in the UI
+    tab_index: int = 0     # For parallel tool calls (0-2 for research agents)
+    sub_turn_index: int | None = None  # For nested tool calls within agents
+```
+
+The `Placement` object encodes the position of a packet in the UI timeline:
+- `turn_index`: Sequential position in the overall timeline (plan=0, orchestrator cycles increment)
+- `tab_index`: Parallel branch identifier (0, 1, 2 for up to 3 parallel research agents)
+- `sub_turn_index`: Depth within a research agent's tool calls
+
+### Packet
+
+**File**: `backend/onyx/server/query_and_chat/streaming_models.py`
+
+```python
+class Packet(BaseModel):
+    placement: Placement
+    obj: PacketObj  # Discriminated union of all packet types
+```
+
+### Emitter
+
+The `Emitter` class wraps a `Queue[Packet]` and provides `emit(packet)`. Packets are consumed by the API streaming response.
+
+## Deep Research Packet Types
+
+All defined in `backend/onyx/server/query_and_chat/streaming_models.py`.
+
+### Plan Packets
+
+| Packet | StreamingType Enum | Fields | Emitted By |
+|--------|-------------------|--------|------------|
+| `DeepResearchPlanStart` | `DEEP_RESEARCH_PLAN_START` | `type` | Plan generation (`dr_loop.py:349-353`) |
+| `DeepResearchPlanDelta` | `DEEP_RESEARCH_PLAN_DELTA` | `type`, `content: str` | Plan generation (`dr_loop.py:355-361`) |
+
+### Research Agent Packets
+
+| Packet | StreamingType Enum | Fields | Emitted By |
+|--------|-------------------|--------|------------|
+| `ResearchAgentStart` | `RESEARCH_AGENT_START` | `type`, `research_task: str` | Agent start (`research_agent.py:241-246`) |
+| `IntermediateReportStart` | `INTERMEDIATE_REPORT_START` | `type` | Report gen (`research_agent.py:150-155`) |
+| `IntermediateReportDelta` | `INTERMEDIATE_REPORT_DELTA` | `type`, `content: str` | Report gen (`research_agent.py:156-161`) |
+| `IntermediateReportCitedDocs` | `INTERMEDIATE_REPORT_CITED_DOCS` | `type`, `cited_docs: list[SearchDoc] \| None` | Report complete (`research_agent.py:175-184`) |
+
+### Control Packets
+
+| Packet | StreamingType Enum | Fields | Emitted By |
+|--------|-------------------|--------|------------|
+| `SectionEnd` | `SECTION_END` | `type` | Phase/section completion |
+| `OverallStop` | `STOP` | `type` | Deep research complete (`dr_loop.py:765-770`) |
+| `TopLevelBranching` | `TOP_LEVEL_BRANCHING` | `type`, `num_parallel_branches: int` | Before parallel agents (`dr_loop.py:662-673`) |
+| `PacketException` | `ERROR` | `type`, `exception` | Error handling (`research_agent.py:611-616`) |
+
+### Shared Packets (Also Used by Deep Research)
+
+| Packet | Purpose |
+|--------|---------|
+| `AgentResponseStart` | Start of final report text |
+| `AgentResponseDelta` | Final report text chunks |
+| `ReasoningStart` | Start of reasoning content |
+| `ReasoningDelta` | Reasoning content chunks |
+| `ReasoningDone` | Reasoning complete |
+
+## Packet Flow by Phase
+
+### Phase 1: Clarification
+
+```
+If clarification needed:
+  AgentResponseStart (turn_index=0)
+  AgentResponseDelta (content chunks)
+  OverallStop (turn_index=0)
+
+If no clarification:
+  (no deep-research-specific packets)
+```
+
+### Phase 2: Plan
+
+```
+DeepResearchPlanStart (turn_index=0)
+DeepResearchPlanDelta (content chunks, multiple)
+[optional: ReasoningStart, ReasoningDelta, ReasoningDone]
+SectionEnd (turn_index=0 or 1)
+```
+
+### Phase 3: Research Execution
+
+```
+Per orchestrator cycle:
+  [optional: ReasoningStart/Delta/Done for think_tool]
+
+  TopLevelBranching (if >1 parallel agents)
+
+  Per research agent (tab_index=0,1,2):
+    ResearchAgentStart (research_task="...")
+
+    Per tool call (sub_turn_index=0,1,...):
+      [tool-specific packets: SearchToolStart, OpenUrlStart, etc.]
+
+    IntermediateReportStart
+    IntermediateReportDelta (content chunks)
+    IntermediateReportCitedDocs (cited_docs=[...])
+    SectionEnd
+```
+
+### Phase 4: Final Report
+
+```
+[optional: ReasoningStart/Delta/Done]
+AgentResponseStart (turn_index=N)
+AgentResponseDelta (content chunks)
+```
+
+### Termination
+
+```
+OverallStop (turn_index=final_turn_index)
+```
+
+## Packet Translation
+
+Deep research reuses the generic `run_llm_step` / `run_llm_step_pkt_generator` infrastructure but translates the generic packets to deep-research-specific ones:
+
+| Source Packet | Translated To | Context |
+|--------------|---------------|---------|
+| `AgentResponseStart` | `DeepResearchPlanStart` | Plan phase (`dr_loop.py:348-353`) |
+| `AgentResponseDelta` | `DeepResearchPlanDelta` | Plan phase (`dr_loop.py:355-361`) |
+| `AgentResponseStart` | `IntermediateReportStart` | Intermediate report (`research_agent.py:149-155`) |
+| `AgentResponseDelta` | `IntermediateReportDelta` | Intermediate report (`research_agent.py:156-161`) |
+
+The final report does **not** translate packets -- `AgentResponseStart`/`AgentResponseDelta` are emitted directly.
+
+## Frontend Packet Consumption
+
+### TypeScript Packet Types
+
+**File**: `web/src/app/app/services/streamingModels.ts`
+
+The TypeScript enum mirrors the Python `StreamingType`:
+
+```typescript
+enum PacketType {
+    DEEP_RESEARCH_PLAN_START = "deep_research_plan_start",   // line 54
+    DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta",   // line 55
+    RESEARCH_AGENT_START = "research_agent_start",           // line 56
+    INTERMEDIATE_REPORT_START = "intermediate_report_start", // line 57
+    INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta", // line 58
+    INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs", // line 59
+}
+```
+
+### Renderer Selection
+
+**File**: `web/src/app/app/message/messageComponents/renderMessageComponent.tsx:89-123`
+
+Packets are routed to renderers by type detection:
+
+```typescript
+isDeepResearchPlanPacket(packet)  -> DeepResearchPlanRenderer
+isResearchAgentPacket(packet)     -> ResearchAgentRenderer
+```
+
+Detection functions (`renderMessageComponent.tsx:89-104`):
+- `isDeepResearchPlanPacket()`: checks for `DEEP_RESEARCH_PLAN_START` or `DEEP_RESEARCH_PLAN_DELTA`
+- `isResearchAgentPacket()`: checks for `RESEARCH_AGENT_START`, `INTERMEDIATE_REPORT_START`, `INTERMEDIATE_REPORT_DELTA`, or `INTERMEDIATE_REPORT_CITED_DOCS`
+
+### Packet Helpers
+
+**File**: `web/src/app/app/message/messageComponents/timeline/packetHelpers.ts`
+
+- `COLLAPSED_STREAMING_PACKET_TYPES` (line 4): Set of packet types that can be collapsed in the timeline, includes `RESEARCH_AGENT_START` and `DEEP_RESEARCH_PLAN_START`
+- `isDeepResearchPlanPackets()` (line 107): Checks if a group of packets contains deep research plan data
+- `stepHasCollapsedStreamingContent()` (line 38): Determines if a step has content that should show in collapsed mode

--- a/docs/deep_research/07_citation_system.md
+++ b/docs/deep_research/07_citation_system.md
@@ -1,0 +1,131 @@
+# Deep Research: Citation System
+
+Citations in deep research flow through multiple stages: tool responses -> research agent reports -> final report. This document traces how citations are tracked, preserved, renumbered, and merged.
+
+## Citation Mode: KEEP_MARKERS
+
+Each research agent creates its citation processor in `KEEP_MARKERS` mode:
+
+```python
+citation_processor = DynamicCitationProcessor(
+    citation_mode=CitationMode.KEEP_MARKERS
+)
+```
+
+**Reference**: `backend/onyx/tools/fake_tools/research_agent.py:228-230`
+
+In `KEEP_MARKERS` mode, the processor:
+- Preserves original citation markers like `[1]`, `[2]` in the text unchanged
+- Tracks which documents were cited via an internal mapping (`get_seen_citations()`)
+- Does NOT renumber citations during the agent's execution
+
+This is important because each parallel research agent maintains its own independent citation numbering (starting from `[1]`), which must be reconciled later.
+
+## Citation Flow
+
+### Stage 1: Tool Responses -> Citation Processor
+
+When a research agent calls a tool (search, web_search, open_url), the tool response contains documents with citation numbers.
+
+`update_citation_processor_from_tool_response()` (`backend/onyx/chat/citation_utils.py`) updates the citation processor with all possible docs and citation numbers from the tool response.
+
+**Reference**: `research_agent.py:546-549`
+
+### Stage 2: Intermediate Report Generation
+
+When the research agent generates its intermediate report:
+- The LLM uses inline citations `[1]`, `[2]` etc. based on the documents it has seen
+- These markers are preserved in the report text (KEEP_MARKERS mode)
+- On completion, `citation_processor.get_seen_citations()` returns the mapping of citation numbers to `SearchDoc` objects
+
+The intermediate report is returned as `ResearchAgentCallResult`:
+
+```python
+class ResearchAgentCallResult(BaseModel):
+    intermediate_report: str          # Report text with [1], [2] markers
+    citation_mapping: CitationMapping # {citation_num: SearchDoc}
+```
+
+**Reference**: `backend/onyx/deep_research/models.py:12-14`
+
+### Stage 3: Citation Merging Across Agents
+
+After parallel research agents complete, `run_research_agent_calls()` merges citations using `collapse_citations()`:
+
+```python
+updated_answer, updated_citation_mapping = collapse_citations(
+    answer_text=result.intermediate_report,
+    existing_citation_mapping=updated_citation_mapping,
+    new_citation_mapping=result.citation_mapping,
+)
+```
+
+**Reference**: `research_agent.py:698-702`
+
+`collapse_citations()` (from `backend/onyx/chat/citation_utils.py`):
+- Takes the report text and both the existing (accumulated) and new citation mappings
+- Renumbers citations in the new report to avoid conflicts with existing ones
+- Merges the mappings into a single combined mapping
+- Returns the updated text and merged mapping
+
+Example:
+- Agent 1 report uses `[1]`, `[2]`, `[3]` (3 documents)
+- Agent 2 report uses `[1]`, `[2]` (2 documents)
+- After collapsing: Agent 2's `[1]` -> `[4]`, `[2]` -> `[5]`
+- Combined mapping: `{1: doc_a, 2: doc_b, 3: doc_c, 4: doc_d, 5: doc_e}`
+
+### Stage 4: Final Report
+
+The accumulated `citation_mapping` from all cycles and agents is passed to `generate_final_report()`:
+
+```python
+citation_processor = DynamicCitationProcessor()
+citation_processor.update_citation_mapping(citation_mapping)
+```
+
+**Reference**: `dr_loop.py:147-148`
+
+The final report LLM is instructed to use inline citations `[1]`, `[2]`, etc. based on the citations included by the research agents. The `DynamicCitationProcessor` resolves these to the correct documents.
+
+After generation, the mapping is saved for persistence:
+
+```python
+state_container.set_citation_mapping(citation_processor.citation_to_doc)
+```
+
+**Reference**: `dr_loop.py:171`
+
+## Key Types
+
+| Type | File | Description |
+|------|------|-------------|
+| `CitationMapping` | `backend/onyx/chat/citation_processor.py` | Type alias: `dict[int, SearchDoc]` -- maps citation number to document |
+| `DynamicCitationProcessor` | `backend/onyx/chat/citation_processor.py` | Main citation processing class |
+| `CitationMode` | `backend/onyx/chat/citation_processor.py` | Enum: `KEEP_MARKERS`, `REPLACE`, etc. |
+
+## Key Functions
+
+| Function | File | Purpose |
+|----------|------|---------|
+| `collapse_citations()` | `backend/onyx/chat/citation_utils.py` | Renumber citations and merge mappings |
+| `update_citation_processor_from_tool_response()` | `backend/onyx/chat/citation_utils.py` | Update processor from tool response |
+| `DynamicCitationProcessor.get_seen_citations()` | `backend/onyx/chat/citation_processor.py` | Get mapping of seen citation numbers to docs |
+| `DynamicCitationProcessor.update_citation_mapping()` | `backend/onyx/chat/citation_processor.py` | Add citations from an existing mapping |
+| `DynamicCitationProcessor.get_next_citation_number()` | `backend/onyx/chat/citation_processor.py` | Get the next available citation number |
+
+## Frontend Citation Display
+
+The `IntermediateReportCitedDocs` packet carries the final cited documents for each research agent to the frontend:
+
+```python
+emitter.emit(Packet(
+    placement=placement,
+    obj=IntermediateReportCitedDocs(
+        cited_docs=list(citation_processor.get_seen_citations().values())
+    ),
+))
+```
+
+**Reference**: `research_agent.py:175-184`
+
+The frontend's `ResearchAgentRenderer` processes this packet to display cited sources alongside the intermediate report.

--- a/docs/deep_research/08_prompts.md
+++ b/docs/deep_research/08_prompts.md
@@ -1,0 +1,212 @@
+# Deep Research: Prompts Reference
+
+All prompts used by the deep research system, organized by phase and agent.
+
+## Prompt Files
+
+| File | Purpose |
+|------|---------|
+| `backend/onyx/prompts/deep_research/orchestration_layer.py` | Orchestrator, clarification, and final report prompts |
+| `backend/onyx/prompts/deep_research/research_agent.py` | Research agent and intermediate report prompts |
+| `backend/onyx/prompts/deep_research/dr_tool_prompts.py` | Tool description text injected into agent prompts |
+
+## Phase 1: Clarification
+
+### `CLARIFICATION_PROMPT`
+
+**Location**: `orchestration_layer.py:8-25`
+**Used at**: `dr_loop.py:245`
+**Template variables**: `{current_datetime}`, `{internal_search_clarification_guidance}`
+
+**Key instructions**:
+- Never directly answer the user's query
+- If query is already detailed (>3 sentences), call `generate_plan` tool instead
+- Max 5 questions if clarification is needed
+- Numbered list format
+- Same language as user's query
+
+### `INTERNAL_SEARCH_CLARIFICATION_GUIDANCE`
+
+**Location**: `orchestration_layer.py:28-30`
+**Injected when**: `SearchTool` is in the allowed tools
+**Content**: Instructs to ask whether internal or web search is more appropriate.
+
+## Phase 2: Research Plan
+
+### `RESEARCH_PLAN_PROMPT`
+
+**Location**: `orchestration_layer.py:34-50`
+**Used at**: `dr_loop.py:306`
+**Template variables**: `{current_datetime}`
+
+**Key instructions**:
+- Break query into main concepts and areas of exploration
+- Stay on topic, avoid duplicates
+- Emphasize up-to-date information
+- MUST only output the plan (not respond to the user)
+- 6 or fewer steps
+- Numbered list, same language as query
+
+### `RESEARCH_PLAN_REMINDER`
+
+**Location**: `orchestration_layer.py:55-59`
+**Used at**: `dr_loop.py:315`
+**Type**: Appended as a `USER` message
+
+**Purpose**: Reinforces that the model should only output the numbered list of steps.
+
+## Phase 3: Orchestrator
+
+### `ORCHESTRATOR_PROMPT` (Non-Reasoning Models)
+
+**Location**: `orchestration_layer.py:62-106`
+**Used at**: `dr_loop.py:401`
+**Template variables**: `{current_datetime}`, `{current_cycle_count}`, `{max_cycles}`, `{research_plan}`, `{internal_search_research_task_guidance}`
+
+**Key instructions**:
+- Conduct research by calling `research_agent` with high-level tasks
+- NEVER output normal response tokens, only call tools
+- Research agent tasks should be 1-2 descriptive sentences
+- CRITICAL: research_agent has NO context about the query/plan -- all context must be in the task argument
+- Call research_agent MANY times before completing
+- Max 3 parallel research_agent calls
+- CRITICAL: Use `think_tool` between every research_agent call and before generate_report
+- Never use think_tool in parallel with other tools
+- Conditions for calling generate_report: all topics researched, enough info gathered, last cycle yielded minimal new info
+
+### `ORCHESTRATOR_PROMPT_REASONING` (Reasoning Models)
+
+**Location**: `orchestration_layer.py:156-193`
+**Used at**: `dr_loop.py:403`
+**Template variables**: Same as above
+
+**Differences from non-reasoning version**:
+- No `think_tool` section (reasoning models think natively)
+- Instructions to "think deeply on what to do next" between calls
+- Otherwise structurally identical
+
+### `FIRST_CYCLE_REMINDER`
+
+**Location**: `orchestration_layer.py:206-208`
+**Used at**: `dr_loop.py:458-465`
+**Injected on**: Cycle 1 only
+
+**Content**: "Make sure all parts of the user question and the plan have been thoroughly explored before calling generate_report."
+
+### `INTERNAL_SEARCH_RESEARCH_TASK_GUIDANCE`
+
+**Location**: `orchestration_layer.py:109-113`
+**Injected when**: `SearchTool` is available
+
+**Content**: Guidance to clarify if research agent should focus on internal, web, or both search types.
+
+## Phase 3: Research Agent
+
+### `RESEARCH_AGENT_PROMPT` (Non-Reasoning Models)
+
+**Location**: `prompts/deep_research/research_agent.py:8-35`
+**Used at**: `research_agent.py:297`
+**Template variables**: `{available_tools}`, `{current_datetime}`, `{current_cycle_count}`, `{optional_internal_search_tool_description}`, `{optional_web_search_tool_description}`, `{optional_open_url_tool_description}`
+
+**Key instructions**:
+- Thorough research over being helpful; curious but on-topic
+- Iteratively call tools until done, then call `generate_report`
+- NEVER output normal response tokens
+- CRITICAL: Use `think_tool` after every set of searches+reads
+- MUST use think_tool before web_search (except first call)
+- Use think_tool before generate_report
+- Reflect on key findings, reason about gaps
+
+### `RESEARCH_AGENT_PROMPT_REASONING` (Reasoning Models)
+
+**Location**: `prompts/deep_research/research_agent.py:75-93`
+**Used at**: `research_agent.py:295`
+**Template variables**: Same as above
+
+**Differences**: No think_tool section; instructions to think between calls natively.
+
+### `OPEN_URL_REMINDER_RESEARCH_AGENT`
+
+**Location**: `prompts/deep_research/research_agent.py:96-99`
+**Injected when**: The previous cycle used `web_search` successfully
+**Used at**: `research_agent.py:316`
+
+**Content**: Reminds to open promising pages after web_search.
+
+## Intermediate Report
+
+### `RESEARCH_REPORT_PROMPT`
+
+**Location**: `prompts/deep_research/research_agent.py:38-57`
+**Used at**: `research_agent.py:106`
+**No template variables**
+
+**Key instructions**:
+- Organize findings from research
+- Report seen by another agent, not user -- focus on facts only
+- No title, no sections, no conclusions/analysis
+- EXTREMELY thorough and comprehensive -- several pages long
+- Remove irrelevant/duplicative information
+- Flag untrustworthy or contradictory statements
+- Same language as the task
+- Cite ALL sources inline as `[1]`, `[2]`, etc.
+
+### `USER_REPORT_QUERY`
+
+**Location**: `prompts/deep_research/research_agent.py:60-71`
+**Used at**: `research_agent.py:111`
+**Template variables**: `{research_topic}`
+
+**Purpose**: Reminder message for the intermediate report, restates the original topic.
+
+## Phase 4: Final Report
+
+### `FINAL_REPORT_PROMPT`
+
+**Location**: `orchestration_layer.py:123-137`
+**Used at**: `dr_loop.py:123`
+**Template variables**: `{current_datetime}`
+
+**Key instructions**:
+- Thorough, balanced, and comprehensive answer
+- Get straight to the point, no title, avoid lengthy intros
+- Users expect long and detailed answer (several pages)
+- Structure logically into relevant sections
+- Use different text styles and formatting
+- Markdown rarely when necessary
+- Inline citations `[1]`, `[2]`, `[3]`
+
+### `USER_FINAL_REPORT_QUERY`
+
+**Location**: `orchestration_layer.py:140-152`
+**Used at**: `dr_loop.py:131`
+**Template variables**: `{research_plan}`
+
+**Key instructions**:
+- Includes the original research plan as reference
+- CRITICAL: be extremely thorough
+- Ignore format styles of intermediate reports
+- Inline citations as `[1]`, `[2]` -- just a number in a bracket
+
+## Tool Description Prompts
+
+### `WEB_SEARCH_TOOL_DESCRIPTION`
+
+**Location**: `dr_tool_prompts.py:17-23`
+**Injected into**: Research agent system prompt
+
+**Content**: Guidance for using web_search -- concise queries, max 3 parallel queries, avoid redundant queries.
+
+### `OPEN_URLS_TOOL_DESCRIPTION`
+
+**Location**: `dr_tool_prompts.py:26-32`
+**Injected into**: Research agent system prompt (non-reasoning models)
+
+**Content**: Guidance for using open_urls -- open promising pages, can open many at once, prioritize reputable sources, almost always use after web_search.
+
+### `OPEN_URLS_TOOL_DESCRIPTION_REASONING`
+
+**Location**: `dr_tool_prompts.py:34-40`
+**Injected into**: Research agent system prompt (reasoning models)
+
+**Difference from non-reasoning version**: Removes the reference to the `think_tool` for when to use open_urls.

--- a/docs/deep_research/09_frontend.md
+++ b/docs/deep_research/09_frontend.md
@@ -1,0 +1,212 @@
+# Deep Research: Frontend Integration
+
+This document covers the frontend implementation for deep research, including state management, UI rendering, and API integration.
+
+## Toggle State Management
+
+### `useDeepResearchToggle` Hook
+
+**File**: `web/src/hooks/useDeepResearchToggle.ts` (lines 1-55)
+
+**Props**:
+```typescript
+interface UseDeepResearchToggleProps {
+    chatSessionId: string | null;
+    assistantId: number | undefined;
+}
+```
+
+**Returns**: `{ deepResearchEnabled: boolean, toggleDeepResearch: () => void }`
+
+**Behavior**:
+- Defaults to `false`
+- Resets to `false` when switching between chat sessions (not on first session creation from `null`)
+- Resets to `false` when assistant changes
+- Uses `useRef` to track previous session ID for transition detection
+
+### Input Bar Button
+
+**File**: `web/src/sections/input/AppInputBar.tsx`
+
+**Visibility logic** (lines 386-398):
+```typescript
+const showDeepResearch = useMemo(() => {
+    const deepResearchGloballyEnabled =
+        combinedSettings?.settings?.deep_research_enabled ?? true;
+    return (
+        deepResearchGloballyEnabled &&
+        hasSearchToolsAvailable(selectedAssistant?.tools || [])
+    );
+}, [...]);
+```
+
+The button is shown only when:
+1. Global setting `deep_research_enabled` is `true` (defaults to `true`)
+2. The selected assistant has search tools available (internal or web)
+
+**Button rendering** (lines 706-717):
+- Icon: `SvgHourglass`
+- Variant: `"select"`
+- Selected state when `deepResearchEnabled` is `true`
+- Foldable when not selected
+
+## API Integration
+
+### Send Message Request
+
+**File**: `web/src/app/app/services/lib.tsx`
+
+**Interface** (lines 112-129):
+```typescript
+interface SendMessageParams {
+    deepResearch?: boolean;
+    // ... other params
+}
+```
+
+**Payload construction** (line 153):
+```typescript
+const payload = {
+    deep_research: deepResearch ?? false,
+    // ... other fields
+};
+```
+
+**Endpoint**: `POST /api/chat/send-chat-message`
+
+### Chat Controller
+
+**File**: `web/src/hooks/useChatController.ts`
+
+**Submit props** (lines 77-92):
+```typescript
+interface OnSubmitProps {
+    message: string;
+    deepResearch: boolean;
+    // ... other props
+}
+```
+
+## Renderers
+
+### Deep Research Plan Renderer
+
+**File**: `web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/DeepResearchPlanRenderer.tsx` (lines 1-75)
+
+**Type**: `MessageRenderer<DeepResearchPlanPacket, FullChatState>`
+
+**Behavior**:
+1. Aggregates `DEEP_RESEARCH_PLAN_DELTA` content via `useMemo` (line 27-40)
+2. Determines status: "Generated plan" or "Generating plan" (line 42)
+3. Renders via `ExpandableTextDisplay` component with `MinimalMarkdown`
+4. Icon: `SvgCircle`
+5. Title: "Research Plan"
+
+### Research Agent Renderer
+
+**File**: `web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx` (lines 1-385)
+
+**Type**: `MessageRenderer<ResearchAgentPacket, FullChatState>`
+
+This is the most complex renderer. It handles the full lifecycle of a research agent, including nested tool calls and intermediate reports.
+
+**Render modes** (lines 43-52):
+| Mode | Description | Usage |
+|------|-------------|-------|
+| `FULL` | Shows all nested tool groups, research task, and report | Expanded step in timeline |
+| `COMPACT` | Shows only latest active item (tool or report) | Collapsed step |
+| `HIGHLIGHT` | Shows only latest active item with header embedded | Parallel streaming preview |
+
+**Data processing**:
+1. **Extract start packet** (lines 68-73): Gets `RESEARCH_AGENT_START` to extract `research_task`
+2. **Separate packets** (lines 76-112): Splits into `parentPackets` (no sub_turn_index) and `nestedToolGroups` (grouped by sub_turn_index)
+
+**NestedToolGroup interface** (lines 32-38):
+```typescript
+interface NestedToolGroup {
+    sub_turn_index: number;
+    toolType: string;
+    status: string;    // "Complete" | "Running"
+    isComplete: boolean;
+    packets: Packet[];
+}
+```
+
+**Rendering logic**:
+- **HIGHLIGHT mode** (lines 189-287): Shows streaming report or running tool or research task text
+- **FULL/COMPACT mode** (lines 289-384):
+  - Research task in `StepContainer`
+  - Nested tools via `TimelineRendererComponent` + `TimelineStepComposer`
+  - Intermediate report in `StepContainer` with `SvgBookOpen` icon and `ExpandableTextDisplay`
+
+### Renderer Selection
+
+**File**: `web/src/app/app/message/messageComponents/renderMessageComponent.tsx` (lines 89-123)
+
+Deep research packets are checked early (before other tool types):
+
+```typescript
+if (groupedPackets.packets.some(isDeepResearchPlanPacket)) {
+    return DeepResearchPlanRenderer;
+}
+if (groupedPackets.packets.some(isResearchAgentPacket)) {
+    return ResearchAgentRenderer;
+}
+```
+
+## Page Integration
+
+### AppPage
+
+**File**: `web/src/refresh-pages/AppPage.tsx`
+
+- Import: `useDeepResearchToggle` (line 39)
+- Initialize toggle (line 124): `const { deepResearchEnabled, toggleDeepResearch } = useDeepResearchToggle({...})`
+- Pass to submit handler (line 193): `deepResearch: deepResearchEnabled`
+
+### NRFPage
+
+**File**: `web/src/app/app/nrf/NRFPage.tsx`
+
+- Same pattern as AppPage
+- Uses `useDeepResearchToggle` hook (line 21)
+- Passes props to `ChatUI` and `AppInputBar`
+
+## Global Settings
+
+### Settings Interface
+
+**File**: `web/src/app/admin/settings/interfaces.ts`
+
+```typescript
+interface Settings {
+    deep_research_enabled?: boolean;  // line 27
+    // ... other settings
+}
+```
+
+### Default Value
+
+**File**: `web/src/components/settings/lib.ts` (lines 116-118)
+
+```typescript
+if (settings.deep_research_enabled == null) {
+    settings.deep_research_enabled = true;
+}
+```
+
+## Data Flow Summary
+
+```
+User clicks Deep Research button
+    -> useDeepResearchToggle sets deepResearchEnabled=true
+User submits message
+    -> onSubmit({ message, deepResearch: true, ... })
+    -> useChatController -> sendMessage({ deep_research: true })
+    -> POST /api/chat/send-chat-message { deep_research: true }
+Backend streams packets via SSE
+    -> Packet grouper sorts by placement
+    -> renderMessageComponent detects packet types
+    -> DeepResearchPlanRenderer / ResearchAgentRenderer
+    -> Rendered in chat timeline
+```

--- a/docs/deep_research/10_configuration_and_constants.md
+++ b/docs/deep_research/10_configuration_and_constants.md
@@ -1,0 +1,113 @@
+# Deep Research: Configuration and Constants
+
+## Environment Variables
+
+| Variable | Default | Location | Description |
+|----------|---------|----------|-------------|
+| `SKIP_DEEP_RESEARCH_CLARIFICATION` | `"false"` | `backend/onyx/configs/chat_configs.py:64-65` | Skip the clarification phase entirely |
+
+## Backend Constants
+
+### Orchestrator Constants (`dr_loop.py`)
+
+| Constant | Value | Line | Description |
+|----------|-------|------|-------------|
+| `MAX_USER_MESSAGES_FOR_CONTEXT` | 5 | 77 | Max user messages included in truncated history |
+| `MAX_FINAL_REPORT_TOKENS` | 20000 | 78 | Max tokens for the final report output |
+| `DEEP_RESEARCH_FORCE_REPORT_SECONDS` | 1800 (30 min) | 83 | Timeout before forcing final report |
+| `MAX_ORCHESTRATOR_CYCLES` | 8 | 95 | Max orchestrator iterations (non-reasoning) |
+| `MAX_ORCHESTRATOR_CYCLES_REASONING` | 4 | 98 | Max orchestrator iterations (reasoning models) |
+
+### Research Agent Constants (`research_agent.py`)
+
+| Constant | Value | Line | Description |
+|----------|-------|------|-------------|
+| `RESEARCH_AGENT_TIMEOUT_SECONDS` | 1800 (30 min) | 78 | Per-agent timeout in parallel execution |
+| `RESEARCH_AGENT_TIMEOUT_MESSAGE` | `"Research Agent timed out after 30 minutes"` | 79 | Message returned on timeout |
+| `RESEARCH_AGENT_FORCE_REPORT_SECONDS` | 720 (12 min) | 81 | Timeout before forcing intermediate report |
+| `MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS` | 10000 | 83 | Max tokens for intermediate report |
+| `MAX_RESEARCH_CYCLES` | 8 | `prompts/deep_research/research_agent.py:5` | Max tool-calling cycles per agent |
+
+### Mock Tool Constants (`dr_mock_tools.py`)
+
+| Constant | Value | Line | Description |
+|----------|-------|------|-------------|
+| `GENERATE_PLAN_TOOL_NAME` | `"generate_plan"` | 1 | Clarification tool name |
+| `RESEARCH_AGENT_IN_CODE_ID` | `"ResearchAgent"` | 3 | DB tool identifier |
+| `RESEARCH_AGENT_TOOL_NAME` | `"research_agent"` | 4 | Orchestrator tool name |
+| `RESEARCH_AGENT_TASK_KEY` | `"task"` | 5 | Key for research task argument |
+| `GENERATE_REPORT_TOOL_NAME` | `"generate_report"` | 7 | Report generation tool name |
+| `THINK_TOOL_NAME` | `"think_tool"` | 9 | Think/reasoning tool name |
+| `THINK_TOOL_RESPONSE_MESSAGE` | `"Acknowledged, please continue."` | 112 | Response after think_tool call |
+| `THINK_TOOL_RESPONSE_TOKEN_COUNT` | 10 | 113 | Approx tokens for think response |
+
+### Prompt Constants (`orchestration_layer.py`)
+
+| Constant | Value | Line | Description |
+|----------|-------|------|-------------|
+| `FIRST_CYCLE_REMINDER_TOKENS` | 100 | 205 | Approx tokens for first cycle reminder |
+
+## LLM Call Configuration
+
+### Orchestrator LLM Calls
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `tool_choice` | `REQUIRED` | Must call a tool |
+| `max_tokens` | 1024 | Short output (just tool calls) |
+| `custom_token_processor` | `create_think_tool_token_processor()` | Non-reasoning models only |
+
+### Research Agent LLM Calls
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `tool_choice` | `REQUIRED` | Must call a tool |
+| `reasoning_effort` | `LOW` | Faster iterations |
+| `max_tokens` | 1000 | Safety limit |
+| `use_existing_tab_index` | `True` | Stay on agent's tab |
+
+### Intermediate Report LLM Calls
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `tool_choice` | `NONE` | No tools available |
+| `reasoning_effort` | `LOW` | Faster generation |
+| `max_tokens` | 10000 | `MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS` |
+| `timeout_override` | 300 (5 min) | Long reports need more time |
+
+### Final Report LLM Calls
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `tool_choice` | `NONE` | No tools available |
+| `max_tokens` | 20000 | `MAX_FINAL_REPORT_TOKENS` |
+| `timeout_override` | 300 (5 min) | Long reports need more time |
+
+## Parallelism Limits
+
+| Limit | Value | Enforced By |
+|-------|-------|-------------|
+| Max parallel research agents | 3 | Prompt instruction (not code-enforced) |
+| Max concurrent tool calls per agent | 1 | `run_tool_calls(max_concurrent_tools=1)` at `research_agent.py:455` |
+| Max parallel web search queries | 3 | Prompt instruction |
+
+## Frontend Configuration
+
+| Setting | Default | Location |
+|---------|---------|----------|
+| `deep_research_enabled` | `true` | `web/src/components/settings/lib.ts:116-118` |
+| Toggle resets on session change | Yes | `web/src/hooks/useDeepResearchToggle.ts` |
+| Toggle resets on assistant change | Yes | `web/src/hooks/useDeepResearchToggle.ts` |
+
+## LLM Requirements
+
+| Requirement | Value | Enforced At |
+|-------------|-------|-------------|
+| Min `max_input_tokens` | 50000 | `dr_loop.py:215-218` |
+
+## Restrictions
+
+| Restriction | Enforced At |
+|-------------|-------------|
+| Cannot use with projects | `process_message.py:870-871` |
+| Only search/web_search/open_url tools allowed | `dr_loop.py:230` |

--- a/docs/deep_research/11_database_schema.md
+++ b/docs/deep_research/11_database_schema.md
@@ -1,0 +1,130 @@
+# Deep Research: Database Schema
+
+## Migrations
+
+Deep research introduced several database changes via Alembic migrations.
+
+### Main Migration
+
+**File**: `backend/alembic/versions/5ae8240accb3_add_research_agent_database_tables_and_.py`
+
+This migration creates the core tables for persisting deep research state.
+
+### Chat Message Extensions
+
+New columns added to the `chat_message` table:
+
+| Column | Type | Nullable | Purpose |
+|--------|------|----------|---------|
+| `research_type` | `VARCHAR` | Yes | Type of research (e.g., "LEGACY_AGENTIC") |
+| `research_plan` | `JSONB` | Yes | The research plan generated in Phase 2 |
+| `is_clarification` | `BOOLEAN` | No | `True` if message is a clarification question |
+
+**Model reference**: `backend/onyx/db/models.py:2549` -- `is_clarification: Mapped[bool]`
+
+### `research_agent_iteration` Table
+
+Stores each orchestrator cycle's metadata.
+
+| Column | Type | Nullable | Constraints | Purpose |
+|--------|------|----------|-------------|---------|
+| `id` | `INTEGER` | No | PK, autoincrement | Row identifier |
+| `primary_question_id` | `INTEGER` | No | FK -> `chat_message.id`, CASCADE | Links to the user's original message |
+| `iteration_nr` | `INTEGER` | No | | Orchestrator cycle number |
+| `created_at` | `DATETIME(tz)` | No | | Timestamp |
+| `purpose` | `VARCHAR` | Yes | | Purpose/description of the iteration |
+| `reasoning` | `VARCHAR` | Yes | | Reasoning content (from think_tool or native reasoning) |
+
+**Unique constraint**: `(primary_question_id, iteration_nr)`
+
+### `research_agent_iteration_sub_step` Table
+
+Stores each individual tool call within a research agent's execution.
+
+| Column | Type | Nullable | Constraints | Purpose |
+|--------|------|----------|-------------|---------|
+| `id` | `INTEGER` | No | PK, autoincrement | Row identifier |
+| `primary_question_id` | `INTEGER` | No | FK -> `chat_message.id`, CASCADE | Links to original message |
+| `iteration_nr` | `INTEGER` | No | | Parent orchestrator cycle |
+| `iteration_sub_step_nr` | `INTEGER` | No | | Step number within the agent |
+| `created_at` | `DATETIME(tz)` | No | | Timestamp |
+| `sub_step_instructions` | `VARCHAR` | Yes | | The research task given to the agent |
+| `sub_step_tool_id` | `INTEGER` | Yes | FK -> `tool.id` | Which tool was used |
+| `reasoning` | `VARCHAR` | Yes | | Agent's reasoning for this step |
+| `sub_answer` | `VARCHAR` | Yes | | Tool response / agent's findings |
+| `cited_doc_results` | `JSONB` | Yes | | Cited documents from this step |
+| `claims` | `JSONB` | Yes | | Claims extracted from results |
+| `generated_images` | `JSONB` | Yes | | Any generated images |
+| `additional_data` | `JSONB` | Yes | | Extensible metadata |
+
+**Composite FK**: `(primary_question_id, iteration_nr)` -> `research_agent_iteration`
+
+### Tool Registration
+
+**File**: `backend/alembic/versions/c1d2e3f4a5b6_add_deep_research_tool.py`
+
+Inserts a tool record for the research agent:
+
+| Field | Value |
+|-------|-------|
+| `name` | `"ResearchAgent"` |
+| `display_name` | `"Research Agent"` |
+| `in_code_tool_id` | `"ResearchAgent"` |
+| `enabled` | `false` |
+
+This tool ID is referenced at runtime via `get_tool_by_name(tool_name=RESEARCH_AGENT_TOOL_NAME, db_session=db_session)` at `dr_loop.py:740-743`.
+
+### Additional Migrations
+
+| File | Purpose |
+|------|---------|
+| `f8a9b2c3d4e5_*.py` | Adds `research_answer_purpose` column to `chat_message` |
+| `f9b8c7d6e5a4_*.py` | Updates `parent_question_id` foreign key in `research_agent_iteration` |
+| `bd7c3bf8beba_*.py` | Migrates legacy agent responses to `research_agent_iteration` format |
+
+## State Persistence
+
+During deep research execution, the `ChatStateContainer` accumulates state:
+
+| Method | What It Stores | Persisted To |
+|--------|---------------|-------------|
+| `add_tool_call(tool_call_info)` | Tool call details (args, response, docs) | `research_agent_iteration_sub_step` |
+| `set_citation_mapping(mapping)` | Citation number -> document mapping | `chat_message` (via completion callback) |
+| `set_is_clarification(True)` | Mark turn as clarification | `chat_message.is_clarification` |
+| `set_reasoning_tokens(reasoning)` | Think tool / native reasoning text | `research_agent_iteration.reasoning` |
+
+The `llm_loop_completion_callback` (referenced in `process_message.py:877-879`) handles persisting the accumulated state to the database after the deep research loop completes.
+
+## Pydantic Models
+
+**File**: `backend/onyx/deep_research/models.py`
+
+```python
+class SpecialToolCalls(BaseModel):          # line 7
+    think_tool_call: ToolCallKickoff | None = None
+    generate_report_tool_call: ToolCallKickoff | None = None
+
+class ResearchAgentCallResult(BaseModel):   # line 12
+    intermediate_report: str
+    citation_mapping: CitationMapping
+
+class CombinedResearchAgentCallResult(BaseModel):  # line 17
+    intermediate_reports: list[str | None]
+    citation_mapping: CitationMapping
+```
+
+## Chat State Container
+
+**File**: `backend/onyx/chat/chat_state.py`
+
+Deep-research-relevant fields and methods:
+
+| Member | Type | Line | Purpose |
+|--------|------|------|---------|
+| `is_clarification` | `bool` | 47 | Whether this turn is a clarification |
+| `set_reasoning_tokens()` | method | 61 | Save reasoning text |
+| `set_is_clarification()` | method | 76 | Set clarification flag (thread-safe) |
+| `get_is_clarification()` | method | 101 | Get clarification flag (thread-safe) |
+| `set_citation_mapping()` | method | -- | Save final citation mapping |
+| `add_tool_call()` | method | -- | Add a tool call info record |
+| `add_search_docs()` | method | -- | Add search documents |

--- a/docs/deep_research/README.md
+++ b/docs/deep_research/README.md
@@ -1,0 +1,136 @@
+# Onyx Deep Research -- Technical Documentation
+
+This document set provides a comprehensive reference for the Onyx Deep Research system. It is intended to serve as a resource for understanding, evaluating, and improving the deep research implementation.
+
+## What is Deep Research?
+
+Deep Research is a multi-agent, multi-phase system within Onyx that conducts thorough, long-form research on user queries. Rather than producing a single LLM response, it:
+
+1. Optionally asks the user for clarification
+2. Generates a structured research plan (5-6 steps)
+3. Iteratively dispatches parallel research agents that use search and URL reading tools
+4. Synthesizes all findings into a comprehensive, cited final report
+
+A single deep research session can involve dozens of LLM calls, multiple parallel research agents, and hundreds of documents -- producing a final report that is several pages long with inline citations.
+
+## System at a Glance
+
+```
+User Query
+    |
+    v
+[Phase 1] Clarification (optional) ------> Ask user questions, wait for response
+    |
+    v
+[Phase 2] Plan Generation ----------------> 5-6 step numbered research plan
+    |
+    v
+[Phase 3] Research Execution Loop --------> Up to 8 orchestrator cycles
+    |                                           |
+    |   +-----------------------------------+   |
+    |   | Orchestrator decides:             |   |
+    |   |   - research_agent (1-3 parallel) |   |
+    |   |   - think_tool (reasoning)        |   |
+    |   |   - generate_report (done)        |   |
+    |   +-----------------------------------+   |
+    |       |                                   |
+    |       v                                   |
+    |   Research Agent (per task):              |
+    |     - web_search / search / open_url     |
+    |     - think_tool (reasoning)             |
+    |     - generate_report -> intermediate    |
+    |                          report          |
+    |                                           |
+    v
+[Phase 4] Final Report --------------------> Comprehensive cited answer
+```
+
+## Key Implementation Files
+
+### Backend Core
+
+| File | Purpose | Key Function |
+|------|---------|--------------|
+| `backend/onyx/deep_research/dr_loop.py` | Main orchestration loop | `run_deep_research_llm_loop()` (line 188) |
+| `backend/onyx/tools/fake_tools/research_agent.py` | Research agent execution | `run_research_agent_call()` (line 205) |
+| `backend/onyx/deep_research/dr_mock_tools.py` | Mock tool definitions | `get_orchestrator_tools()` (line 120) |
+| `backend/onyx/deep_research/models.py` | Data models | `ResearchAgentCallResult` (line 12) |
+| `backend/onyx/deep_research/utils.py` | Utilities | `create_think_tool_token_processor()` (line 121) |
+
+### Prompts
+
+| File | Purpose |
+|------|---------|
+| `backend/onyx/prompts/deep_research/orchestration_layer.py` | Clarification, plan, orchestrator, and final report prompts |
+| `backend/onyx/prompts/deep_research/research_agent.py` | Research agent and intermediate report prompts |
+| `backend/onyx/prompts/deep_research/dr_tool_prompts.py` | Tool-specific description text |
+
+### API Layer
+
+| File | Purpose | Key Reference |
+|------|---------|---------------|
+| `backend/onyx/chat/process_message.py` | Routes to deep research | Lines 869-893 |
+| `backend/onyx/server/query_and_chat/models.py` | Request model | `SendMessageRequest.deep_research` (line 99) |
+| `backend/onyx/server/query_and_chat/streaming_models.py` | Packet types | Lines 49-54 (enum), 302-341 (classes) |
+| `backend/onyx/server/query_and_chat/placement.py` | UI positioning | `Placement` class (line 4) |
+
+### Frontend
+
+| File | Purpose |
+|------|---------|
+| `web/src/hooks/useDeepResearchToggle.ts` | Toggle state management |
+| `web/src/sections/input/AppInputBar.tsx` | Deep Research button (lines 386-398, 706-717) |
+| `web/src/app/app/services/streamingModels.ts` | TypeScript packet types (lines 54-59) |
+| `web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/DeepResearchPlanRenderer.tsx` | Plan renderer |
+| `web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx` | Research agent renderer (385 lines) |
+| `web/src/app/app/message/messageComponents/renderMessageComponent.tsx` | Renderer dispatch (lines 89-123) |
+
+## Key Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| Max orchestrator cycles | 8 (non-reasoning) / 4 (reasoning) | How many times the orchestrator can loop |
+| Max research cycles per agent | 8 | Tool-calling cycles within a single agent |
+| Max parallel agents | 3 | Parallel research agents per orchestrator cycle |
+| Orchestrator timeout | 30 minutes | Forces final report generation |
+| Agent forced report timeout | 12 minutes | Forces intermediate report within an agent |
+| Agent hard timeout | 30 minutes | Thread-level timeout for parallel execution |
+| Final report max tokens | 20,000 | Output token limit for the final report |
+| Intermediate report max tokens | 10,000 | Output token limit per intermediate report |
+| Min LLM input tokens | 50,000 | LLM must support at least this context window |
+
+## Documents
+
+| # | Document | Description |
+|---|----------|-------------|
+| 01 | [Architecture Overview](./01_architecture_overview.md) | High-level system design, agent hierarchy, key decisions |
+| 02 | [Execution Phases](./02_execution_phases.md) | Phase-by-phase execution flow with code references |
+| 03 | [Orchestrator Agent](./03_orchestrator.md) | Orchestrator loop mechanics, decision tree, timeout handling |
+| 04 | [Research Agent](./04_research_agent.md) | Research agent lifecycle, tool execution, intermediate reports |
+| 05 | [Mock Tools](./05_mock_tools.md) | Mock tool definitions, detection logic, think tool processor |
+| 06 | [Streaming and Packets](./06_streaming_and_packets.md) | Packet types, flow by phase, translation, frontend consumption |
+| 07 | [Citation System](./07_citation_system.md) | KEEP_MARKERS mode, citation flow, merging across agents |
+| 08 | [Prompts Reference](./08_prompts.md) | Every prompt with location, template variables, key instructions |
+| 09 | [Frontend Integration](./09_frontend.md) | Toggle hook, renderers, API integration, data flow |
+| 10 | [Configuration and Constants](./10_configuration_and_constants.md) | All constants, env vars, LLM call config, limits |
+| 11 | [Database Schema](./11_database_schema.md) | Migrations, tables, state persistence, Pydantic models |
+
+## Quick Reference: Function Call Chain
+
+```
+POST /api/chat/send-chat-message { deep_research: true }
+  -> process_message.py:869 (detect deep_research flag)
+    -> run_deep_research_llm_loop()                          [dr_loop.py:188]
+      -> Phase 1: run_llm_step() with clarification prompt   [dr_loop.py:269]
+      -> Phase 2: run_llm_step_pkt_generator() for plan      [dr_loop.py:330]
+      -> Phase 3: orchestrator loop                           [dr_loop.py:426]
+        -> run_llm_step() for orchestrator decisions          [dr_loop.py:502]
+        -> run_research_agent_calls()                         [research_agent.py:644]
+          -> run_research_agent_call() x N (parallel)         [research_agent.py:205]
+            -> run_llm_step() per research cycle              [research_agent.py:343]
+            -> run_tool_calls() for real tools                [research_agent.py:445]
+            -> generate_intermediate_report()                 [research_agent.py:86]
+        -> collapse_citations()                               [research_agent.py:698]
+      -> Phase 4: generate_final_report()                     [dr_loop.py:101]
+        -> run_llm_step() for final answer                    [dr_loop.py:153]
+```

--- a/docs/deep_research/extraction-agent-prompt-architecture.md
+++ b/docs/deep_research/extraction-agent-prompt-architecture.md
@@ -1,0 +1,452 @@
+# Data Extraction Agent — Prompt Architecture
+
+A complete reference for the system prompt, user message structure, answer tool schema, and result type definitions.
+
+---
+
+## 1. Answer Tool Schema
+
+Universal schema — same for every answer type. The `answer` field shape is controlled by the prompt, not the schema, so it can vary per type without needing multiple tool definitions.
+
+```json
+{
+  "name": "<answerToolName>",
+  "description": "Submit your final extracted answer. This completes the task.",
+  "parameters": {
+    "type": "object",
+    "required": ["answer", "reasoning", "confidence"],
+    "properties": {
+      "answer": {
+        "description": "The extracted value. Shape depends on the answer type specified in the task."
+      },
+      "reasoning": {
+        "type": "string",
+        "description": "Explanation of how the answer was derived, with citations."
+      },
+      "confidence": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Confidence score from 0 to 1."
+      }
+    }
+  }
+}
+```
+
+**Why these three fields:**
+
+| Field | Role | Consumer |
+|-------|------|----------|
+| `answer` | Machine-readable extracted value | Downstream system / UI |
+| `reasoning` | Human-readable justification with citations | Reviewer / audit trail |
+| `confidence` | Calibrated certainty signal | Routing logic (flag low-confidence for human review) |
+
+---
+
+## 2. System Prompt (static, cacheable)
+
+Everything below is identical across all requests. Cache it.
+
+```
+You are a data extraction agent for legal documents.
+
+## CRITICAL RULE
+You MUST only communicate through tool calls. NEVER output plain text responses.
+Every turn must end with exactly one tool call. Your final turn MUST be a call to the answer tool specified in your task.
+
+## ANSWER STRUCTURE
+Every answer you submit has three required fields:
+
+**answer** — The extracted value. Shape depends on the answer type specified in your task.
+
+**reasoning** — A brief explanation covering:
+- How you arrived at the answer (which sections, which clauses)
+- Relevant context that doesn't fit in the answer itself (conditions, exceptions, related provisions)
+- Why you chose this answer over alternatives if ambiguity existed
+- Cite references here too: [ref-xxxxxxxx]
+
+**confidence** — A number from 0 to 1 reflecting how certain you are:
+- 0.9 – 1.0: Explicitly stated, unambiguous, directly answers the question
+- 0.7 – 0.9: Clearly supported but requires minor interpretation (e.g. combining two clauses)
+- 0.4 – 0.7: Inferable but not directly stated, or the document is partially ambiguous
+- 0.1 – 0.4: Weak evidence, answer is a best guess based on limited context
+- 0.0 – 0.1: Document does not appear to contain this information
+
+Do NOT default to high confidence. If you had to infer, say so in reasoning and lower the score.
+
+## WORKFLOW (follow in order)
+
+### Step 1: Locate
+Use **search_document** to find relevant keywords.
+Use **get_document_structure** if you need section/page orientation first.
+
+### Step 2: Read Full Context
+⚠️ NEVER extract from search snippets alone.
+Use **get_text** with offset = (order - 50), limit = 100 to read full surrounding context.
+Look for: definitions, conditions, exceptions, cross-references.
+Use **get_text_context** for pinpoint expansion around a specific order position.
+
+### Step 3: Verify Completeness
+Before finishing, confirm:
+- You satisfy ALL requirements listed under EXPECTED RESULT in your task
+- You have read the FULL relevant sections (not just snippets)
+- Every claim has a citation with an EXACT ref value from tool output
+- You can justify your confidence score
+
+If anything is missing, repeat Steps 1-2 for the gap. Otherwise proceed to Step 4.
+
+### Step 4: Submit Answer
+Call the answer tool with answer, reasoning, and confidence.
+Match the answer format described in EXPECTED RESULT exactly.
+This is the ONLY way to complete your task. Do NOT continue after this call.
+
+## TOOLS
+
+**Search & Structure:**
+- **get_document_structure** - Document outline with sections and page numbers
+- **search_document** - Keyword search → order numbers and pages
+
+**Reading:**
+- **get_text** - Read text by page OR offset/limit (primary reading tool)
+- **get_text_context** - Surrounding lines around a specific order position
+
+**Metadata:**
+- **get_document_assets** - List images, charts, signatures
+- **get_document_parties** - List people and companies mentioned
+
+**Vision (use sparingly):**
+- **ask_page_question** - Analyze page screenshots (tables, charts, handwriting only)
+
+## CITATION FORMAT
+Tools return: <line ref="ref-a1b2c3d4">text here</line>
+You cite: text here [ref-xxxxxxxx]
+NEVER fabricate reference IDs. Use EXACT ref values from tool outputs.
+
+## REMINDER
+You have a LIMITED number of turns. Once you satisfy the EXPECTED RESULT requirements, call the answer tool immediately.
+```
+
+---
+
+## 3. User Message (dynamic, per-request)
+
+```
+## TASK
+Extract: "<question>"
+
+## DOCUMENT
+<document description or 'No description available.'>
+
+## EXPECTED RESULT
+<result type instructions — see section 4>
+
+## ANSWER TOOL
+Call **`<answerToolName>`** to submit your answer. This is the only way to complete the task.
+```
+
+---
+
+## 4. Result Type Definitions
+
+### Template
+
+Every result type follows this skeleton. Four sections, same order:
+
+```
+**Answer Type: TYPE_NAME**
+One-line description of what the final output looks like.
+
+**Research focus:**
+What to prioritize DURING search and reading.
+Shapes Steps 1-2 behavior — the model searches differently per type.
+
+**Answer field format:**
+Exact structure of the `answer` field passed to the answer tool.
+This is the only section that varies structurally between types.
+
+**Reasoning field focus:**
+What the `reasoning` field should emphasize for this type.
+Short nudge, not a constraint — the model fills in the rest.
+```
+
+---
+
+### TEXT
+
+```
+**Answer Type: TEXT**
+A comprehensive, well-structured natural language answer.
+
+**Research focus:**
+- Read complete paragraphs, not just matching lines
+- Follow cross-references to other sections/clauses
+- Capture conditions, exceptions, and qualifiers — these change meaning
+- Preserve legal terminology exactly as written in the document
+
+**Answer field format:**
+A markdown-formatted string containing the full extracted information.
+- Use headings to separate distinct aspects if covering multiple topics
+- Bold key terms and defined terms
+- Cite every factual statement inline: "The term expires after 24 months [ref-a1b2c3d4]"
+- Write in the document's primary language unless the question specifies otherwise
+- Include all relevant context, conditions, and exceptions in the answer itself
+
+**Reasoning field focus:**
+Cross-references checked, sections consulted, how you determined completeness.
+```
+
+**Example output:**
+
+```json
+{
+  "answer": "## Termination Rights\n\nEither party may terminate the agreement with **90 days written notice** [ref-b3c4d5e6], provided that all outstanding obligations under Section 7 have been fulfilled [ref-f7g8h9i0].\n\n## Exceptions\n\nImmediate termination is permitted in cases of **material breach** as defined in Section 2.1(d) [ref-a1b2c3d4], subject to a 30-day cure period [ref-j1k2l3m4].",
+  "reasoning": "Found termination provisions in Section 14 [ref-b3c4d5e6]. Cross-referenced Section 7 for outstanding obligations [ref-f7g8h9i0] and Section 2.1(d) for the material breach definition [ref-a1b2c3d4]. Also checked Sections 15-16 for additional termination triggers — none found. Cure period in Section 14.3 [ref-j1k2l3m4].",
+  "confidence": 0.95
+}
+```
+
+---
+
+### DATE
+
+```
+**Answer Type: DATE**
+A specific date or date range extracted from the document.
+
+**Research focus:**
+- Look for explicit dates, effective dates, deadlines, expiration dates
+- Check for conditions that modify the date ("unless extended", "subject to renewal")
+- Verify the date applies to what was asked — documents often contain multiple dates
+
+**Answer field format:**
+A JSON object:
+{
+  "date": "YYYY-MM-DD",
+  "original_text": "the exact date string as written in the document",
+  "conditions": ["condition 1 [ref-xxxxxxxx]", "condition 2 [ref-xxxxxxxx]"]
+}
+- Use ISO 8601 for the date value
+- If a date range: { "start": "YYYY-MM-DD", "end": "YYYY-MM-DD", ... }
+- If exact day unknown, use partial: "2024-03" or "2024"
+- conditions: empty array if none
+
+**Reasoning field focus:**
+Why this date and not others found in the document. Any ambiguity in date interpretation.
+```
+
+**Example output:**
+
+```json
+{
+  "answer": {
+    "date": "2025-06-30",
+    "original_text": "30 June 2025",
+    "conditions": [
+      "Automatically extends for successive 1-year periods unless either party provides 60 days notice [ref-c8d91e3f]"
+    ]
+  },
+  "reasoning": "The initial term expiration is stated in Section 3.1 [ref-e4f7a2b1]. Document also contains a signing date (2020-07-01) and an amendment date (2023-01-15) — neither answers the question about expiration. Auto-renewal clause in Section 3.2 [ref-c8d91e3f] means the effective expiration depends on notice.",
+  "confidence": 0.88
+}
+```
+
+---
+
+### CURRENCY
+
+```
+**Answer Type: CURRENCY**
+A monetary value with its currency denomination.
+
+**Research focus:**
+- Locate the specific amount tied to the question (not just any monetary figure)
+- Check for adjustments: escalation clauses, caps, floors, indexation
+- Look for related amounts: taxes, fees, penalties that modify the base figure
+
+**Answer field format:**
+A JSON object:
+{
+  "amount": 150000.00,
+  "currency": "EUR",
+  "original_text": "€150,000 (one hundred and fifty thousand euros)",
+  "adjustments": ["adjustment description [ref-xxxxxxxx]"]
+}
+- Use numeric amount (no formatting, no thousands separators)
+- Use ISO 4217 currency code
+- Do NOT convert currencies or calculate unless explicitly asked
+- If a range: { "min": 100000, "max": 200000, ... }
+- adjustments: empty array if none
+
+**Reasoning field focus:**
+How you confirmed this is the right amount. Related figures found and why they were excluded.
+```
+
+**Example output:**
+
+```json
+{
+  "answer": {
+    "amount": 250000.00,
+    "currency": "EUR",
+    "original_text": "€250,000 (two hundred and fifty thousand euros) per annum",
+    "adjustments": [
+      "CPI-indexed annually per Section 4.3 [ref-d5e6f7g8]",
+      "Capped at 3% annual increase per Section 4.3(b) [ref-h9i0j1k2]"
+    ]
+  },
+  "reasoning": "Base rent found in Section 4.1 [ref-a1b2c3d4]. Service charges (€35,000) in Section 4.2 are separate and excluded as the question asks specifically about rent. Escalation mechanism in Section 4.3 [ref-d5e6f7g8] with cap [ref-h9i0j1k2]. No other rent-related amounts found in Schedules.",
+  "confidence": 0.94
+}
+```
+
+---
+
+### BOOLEAN
+
+```
+**Answer Type: BOOLEAN**
+A yes/no determination based on document content.
+
+**Research focus:**
+- Find the clause or section that directly answers the question
+- Check for exceptions, carve-outs, or conditions that flip the answer
+- Look for defined terms — "Permitted" may have a specific contractual meaning
+
+**Answer field format:**
+A JSON object:
+{
+  "value": true,
+  "clause": "Section 8.2(a) [ref-xxxxxxxx]",
+  "exceptions": ["exception description [ref-xxxxxxxx]"]
+}
+- value: true = yes, false = no, null = document is silent or ambiguous
+- clause: the primary clause supporting the determination
+- exceptions: anything that could conditionally flip the answer, empty array if none
+
+**Reasoning field focus:**
+The logic chain from clause to determination. If null, explain what you searched and why it was inconclusive.
+```
+
+**Example output:**
+
+```json
+{
+  "answer": {
+    "value": true,
+    "clause": "Section 12.1 - The Tenant may assign the lease with prior written consent of the Landlord [ref-e4f7a2b1]",
+    "exceptions": [
+      "Assignment to affiliates does not require consent per Section 12.3 [ref-c8d91e3f]",
+      "Landlord may withhold consent if assignee net worth is below €1M per Section 12.1(b) [ref-a2b3c4d5]"
+    ]
+  },
+  "reasoning": "Section 12.1 explicitly permits assignment subject to landlord consent [ref-e4f7a2b1]. Searched 'assign', 'transfer', 'sublease' across the full document. Found the affiliate carve-out in 12.3 [ref-c8d91e3f] and the financial condition in 12.1(b) [ref-a2b3c4d5]. No other restrictions in Sections 13-15 (General Provisions).",
+  "confidence": 0.92
+}
+```
+
+---
+
+### LIST
+
+```
+**Answer Type: LIST**
+A collection of items extracted from the document.
+
+**Research focus:**
+- Find ALL items, not just the first match
+- Check for items defined elsewhere via cross-reference ("including those in Schedule A")
+- Verify exhaustiveness — look for "including but not limited to" vs. closed lists
+
+**Answer field format:**
+A JSON object:
+{
+  "items": [
+    { "value": "item text [ref-xxxxxxxx]" },
+    { "value": "item text [ref-xxxxxxxx]" }
+  ],
+  "exhaustive": true
+}
+- exhaustive: true if the document defines a closed list, false if open-ended
+- Each item cited individually
+
+**Reasoning field focus:**
+Where items were found (single list vs. aggregated from multiple sections). Whether the list appears complete.
+```
+
+**Example output:**
+
+```json
+{
+  "answer": {
+    "items": [
+      { "value": "Fire insurance [ref-a1b2c3d4]" },
+      { "value": "Public liability insurance [ref-a1b2c3d4]" },
+      { "value": "Business interruption insurance [ref-e5f6g7h8]" },
+      { "value": "Employer's liability insurance [ref-e5f6g7h8]" }
+    ],
+    "exhaustive": false
+  },
+  "reasoning": "Primary insurance obligations listed in Section 9.1 [ref-a1b2c3d4] (fire, public liability). Additional requirements in Schedule D [ref-e5f6g7h8] (business interruption, employer's liability). Section 9.1 uses 'including but not limited to', so the list is non-exhaustive — landlord may require additional coverage. Searched 'insurance', 'coverage', 'policy' for completeness.",
+  "confidence": 0.82
+}
+```
+
+---
+
+## 5. API Call Assembly
+
+```typescript
+function getResultTypeInstructions(answerType: string): string {
+  switch (answerType) {
+    case 'TEXT':     return TEXT_INSTRUCTIONS;
+    case 'DATE':     return DATE_INSTRUCTIONS;
+    case 'CURRENCY': return CURRENCY_INSTRUCTIONS;
+    case 'BOOLEAN':  return BOOLEAN_INSTRUCTIONS;
+    case 'LIST':     return LIST_INSTRUCTIONS;
+    default:         return TEXT_INSTRUCTIONS;
+  }
+}
+
+function buildTaskMessage(
+  question: string,
+  description: string | null,
+  answerToolName: string,
+  resultTypeInstructions: string
+): string {
+  return [
+    `## TASK`,
+    `Extract: "${question}"`,
+    ``,
+    `## DOCUMENT`,
+    description ?? 'No description available.',
+    ``,
+    `## EXPECTED RESULT`,
+    resultTypeInstructions,
+    ``,
+    `## ANSWER TOOL`,
+    `Call **\`${answerToolName}\`** to submit your answer. This is the only way to complete the task.`,
+  ].join('\n');
+}
+
+// Assembly
+const messages = [
+  { role: 'system', content: SYSTEM_PROMPT },   // ← cached
+  { role: 'user', content: buildTaskMessage(...) }, // ← per-request
+];
+```
+
+---
+
+## 6. Design Decisions Summary
+
+| Decision | Rationale |
+|----------|-----------|
+| reasoning + confidence on ALL types | Even a "simple" DATE extraction can be ambiguous. The reviewer always needs to know why. |
+| Confidence scale is anchored | Without anchors, models default to 0.8-0.9 on everything. The scale descriptions calibrate output. |
+| "Do NOT default to high confidence" | Explicit anti-pattern instruction. Models are sycophantic — they must be told it's OK to be uncertain. |
+| JSON for structured types, markdown for TEXT | TEXT is human-consumed directly. DATE/CURRENCY/BOOLEAN/LIST are machine-parsed first. Match format to consumer. |
+| Reasoning includes citations | Reasoning without citations is just the model's opinion. Citations make it auditable. |
+| "Reasoning field focus" per type | Nudges type-appropriate context without over-constraining. A DATE reasoning should explain "why this date not others." |
+| System prompt says "answer tool" generically | Keeps it cacheable. The concrete tool name resolves in the user message. |
+| Step 3 includes "can you justify your confidence" | Forces the model to assess certainty BEFORE calling the tool, not as an afterthought during the call. |

--- a/docs/deep_research/reference-implementation.md
+++ b/docs/deep_research/reference-implementation.md
@@ -1,0 +1,409 @@
+# Deep Research: Reference Implementation Analysis
+
+A conceptual analysis of the Onyx deep research system's design patterns, structural decisions, and trade-offs. Intended as a reference for building or improving deep research systems, regardless of domain.
+
+---
+
+## 1. Multi-Phase Pipeline
+
+The system decomposes research into four sequential phases with distinct responsibilities. Each phase produces a well-defined artifact that feeds the next.
+
+### Phase Sequence
+
+```
+Clarification -> Plan -> Execution -> Synthesis
+```
+
+### Why Four Phases (Not Fewer)
+
+**Clarification as a gate.** Separating clarification from planning prevents the planner from making assumptions about ambiguous queries. The clarification agent is instructed to *never answer the query* -- it either asks questions or signals readiness. This hard separation prevents a common failure mode where the model starts "helping" prematurely.
+
+The clarification phase uses a clever signaling mechanism: a no-parameter tool (`generate_plan`) that the LLM calls when it believes the query is clear. If the LLM responds with text instead of calling this tool, that text is treated as clarification questions. This avoids parsing LLM output to determine intent -- the tool call IS the signal.
+
+**Plan as a contract.** The research plan serves as a shared reference between the orchestrator and the final report generator. The orchestrator uses it to decide what to research; the report generator uses it to structure the answer. Without an explicit plan, the orchestrator tends to drift or fixate on subtopics.
+
+The plan is deliberately capped at 5-6 steps. This is a prompt engineering decision to prevent over-decomposition, which leads to shallow, scattered research.
+
+**Execution separated from synthesis.** The system never asks the model to research and synthesize simultaneously. Research agents produce fact-dense, unstructured intermediate reports ("no title, no sections, no conclusions"). The final report generator then operates on this raw material with a different prompt optimized for structure, readability, and comprehensiveness. This separation prevents the common failure mode where a model prematurely commits to a narrative structure before it has all the facts.
+
+### Phase Communication
+
+Phases communicate through minimal interfaces:
+
+| From | To | What passes through |
+|------|----|-------------------|
+| Clarification | Plan | Nothing (implicit: query was clear enough) |
+| Plan | Execution | Plan text (string) |
+| Execution | Synthesis | Chat history containing intermediate reports + citation mapping |
+
+Each boundary is a compression point. The plan compresses understanding of the query into steps. Intermediate reports compress raw tool outputs into findings. The final report compresses everything into a user-facing answer.
+
+---
+
+## 2. Hierarchical Agent Model
+
+### Two-Level Hierarchy
+
+```
+Orchestrator (strategic)
+    |
+    +-- Research Agent 1 (tactical)
+    +-- Research Agent 2 (tactical)
+    +-- Research Agent 3 (tactical)
+```
+
+The orchestrator operates at the **strategic level**: what topics to research, whether enough information has been gathered, when to stop. It never touches tools directly.
+
+Research agents operate at the **tactical level**: what queries to run, which pages to open, how to interpret results. They never see the big picture.
+
+### Why Not Flat?
+
+A single agent doing everything (planning + searching + synthesizing) degrades badly on complex queries because:
+
+1. **Context pollution.** Raw search results and page contents fill the context window, pushing the original query and research direction out of view.
+2. **Mode confusion.** The model oscillates between "researcher" and "writer" modes, often producing half-baked reports mid-research.
+3. **No parallelism.** A single agent is sequential by nature.
+
+The hierarchy solves these by giving each level a clean, focused context.
+
+### The Isolation Trade-off
+
+Research agents are **fully isolated** from each other and from the orchestrator's context. Each agent receives only a task string and has no knowledge of:
+- The original user query
+- The research plan
+- What other agents have found
+- What the orchestrator is thinking
+
+This is a deliberate design choice with clear trade-offs:
+
+**Benefits:**
+- Clean context windows (no cross-contamination)
+- Parallelizable (no shared mutable state beyond citation bookkeeping)
+- Predictable behavior (same task string = similar research)
+
+**Costs:**
+- Redundant work across agents on related topics
+- No ability to "continue" a prior agent's research
+- The orchestrator must front-load all context into the task string, which the LLM may do poorly
+
+### The Continuation Gap
+
+This is the most significant structural limitation. When the orchestrator receives an insufficient result from an agent and wants to dig deeper, it must dispatch an entirely new agent with a fresh context. The new agent:
+
+- Cannot see what was already searched
+- Cannot see what pages were already read
+- Cannot see what was already found
+- Will likely repeat some of the same work
+
+The system relies on the orchestrator LLM to formulate a sufficiently different task to avoid redundancy, but provides no structural mechanism to enforce this. Possible mitigations not currently implemented:
+
+- **Append prior findings to the task string.** Simple but bloats the task parameter.
+- **Pass a "negative context" of searches to avoid.** Requires the agent to understand and respect exclusions.
+- **Stateful agents with resumable sessions.** Most complex but most powerful.
+- **A shared knowledge base tool** that agents can read from and write to.
+
+---
+
+## 3. Control Flow via Mock Tools
+
+### The Pattern
+
+Instead of building explicit state machines, the system uses LLM tool calling as a control flow mechanism. "Mock tools" are tool definitions presented to the LLM that are not backed by real implementations -- the system intercepts the tool call and routes execution accordingly.
+
+```
+LLM decides to call "generate_report"
+    -> System intercepts this
+    -> System runs report generation logic
+    -> Report text is injected as tool response
+```
+
+### Mock Tool Inventory
+
+| Tool | Signal Meaning | Called By |
+|------|---------------|-----------|
+| `generate_plan` | "Query is clear, proceed" | Clarification LLM |
+| `research_agent` | "Research this topic" | Orchestrator |
+| `generate_report` | "I'm done, synthesize" | Orchestrator, Research Agent |
+| `think_tool` | "I need to reason" | Orchestrator, Research Agent |
+
+### Why Mock Tools Instead of Structured Output
+
+1. **Natural decision points.** The LLM decides when it has enough information by calling `generate_report`, rather than being asked "do you have enough?" in a structured output schema. This produces better calibration.
+2. **Parallel dispatch for free.** The LLM can call `research_agent` multiple times in one turn, and the system interprets these as parallel dispatches. No special prompting for parallelism needed.
+3. **Unified interface.** Mock tools and real tools share the same calling convention. The LLM doesn't distinguish between them, simplifying the prompt.
+4. **Type-safe arguments.** The `research_agent` tool's `task` parameter has a schema, which constrains the LLM's output format naturally.
+
+### The Think Tool: Simulated Reasoning
+
+For non-reasoning models, the system provides a `think_tool` that simulates chain-of-thought reasoning. The LLM calls `think_tool(reasoning="I notice that...")`, and the system:
+
+1. Strips the JSON wrapper from the arguments
+2. Converts the content into reasoning display tokens for the UI
+3. Injects a minimal acknowledgment ("Acknowledged, please continue.") as the tool response
+4. Continues the loop
+
+This achieves two things:
+- Forces the model to reason between actions (the prompt makes `think_tool` mandatory between research cycles)
+- Makes reasoning visible in the UI alongside reasoning-model output
+
+For reasoning models, the `think_tool` is omitted entirely -- the model reasons natively, and the system detects reasoning tokens from the model's output.
+
+The duality (think_tool for standard models, native reasoning for reasoning models) also drives structural differences:
+- Standard models get 8 orchestrator cycles (because thinking takes a cycle)
+- Reasoning models get 4 cycles (thinking is folded into each cycle)
+
+---
+
+## 4. Parallel Execution Model
+
+### Dispatch Pattern
+
+The orchestrator can call `research_agent` up to 3 times in a single LLM turn. These are executed in parallel threads.
+
+```
+Orchestrator turn N:
+    research_agent(task="Topic A")  -> Thread 1
+    research_agent(task="Topic B")  -> Thread 2
+    research_agent(task="Topic C")  -> Thread 3
+                                          |
+                              All complete |
+                                          v
+                                    Merge results
+                                          |
+                                          v
+                              Orchestrator turn N+1
+```
+
+### Parallelism Constraints
+
+- **Max 3 agents per cycle** -- enforced by prompt, not code. A soft limit that could be violated by the LLM.
+- **Max 1 tool call per agent turn** -- enforced by code. Within a research agent, tool calls of the same type are batched, but different tool types cannot execute in the same turn due to the placement system's inability to differentiate parallel sub-tool calls.
+- **Shared state container** -- agents share a mutable `state_container` across threads. This is safe for additive operations (adding tool calls, adding search docs) but could cause issues with non-idempotent operations. Currently only used for writes plus one read (URL dedup map).
+
+### Post-Parallel Merging
+
+After parallel agents complete, their results must be reconciled:
+
+1. **Citation renumbering.** Each agent independently numbers citations from `[1]`. After completion, `collapse_citations()` renumbers them to create a globally consistent scheme.
+2. **Report concatenation.** Intermediate reports are appended to the orchestrator's chat history as separate tool responses.
+3. **Failure handling.** If an agent returns `None` (failure/timeout), it's skipped. The orchestrator's next cycle sees no result for that task and may retry or move on.
+
+---
+
+## 5. Citation Architecture
+
+### The KEEP_MARKERS Strategy
+
+The system uses a two-pass citation approach:
+
+**Pass 1 (During Research):** Citations are tracked but markers are preserved as-is. Each research agent numbers citations independently starting from `[1]`. The citation processor records which document each number refers to but doesn't modify the text.
+
+**Pass 2 (After Research):** `collapse_citations()` renumbers citations to create a global, non-conflicting scheme across all agents and cycles.
+
+### Why Not Renumber During Research?
+
+If citations were renumbered in real-time, streaming intermediate reports to the UI would show unstable citation numbers (a `[3]` could become `[7]` mid-stream). KEEP_MARKERS ensures that what's streamed is what's stored, and renumbering happens only in the final merged history.
+
+### Citation Flow
+
+```
+Agent 1: [1]=DocA, [2]=DocB    Agent 2: [1]=DocC, [2]=DocD
+    |                               |
+    v                               v
+Intermediate Report 1:         Intermediate Report 2:
+"...found X [1]..."            "...found Y [1]..."
+    |                               |
+    +--- collapse_citations() ------+
+    |
+    v
+Merged history:
+Report 1: "...found X [1]..."  (unchanged)
+Report 2: "...found Y [3]..."  (renumbered)
+Mapping: {1:DocA, 2:DocB, 3:DocC, 4:DocD}
+    |
+    v
+Final report LLM sees the merged history
+and produces: "...X [1]...Y [3]..."
+```
+
+### What Passes to the Final Report
+
+Only cited documents are passed to the final report generator, not all search results. This is a context management decision -- passing every search result would bloat the context. The trade-off is that the final report cannot cite documents that weren't explicitly cited in intermediate reports, even if they appeared in search results.
+
+---
+
+## 6. Timeout Cascade
+
+The system implements a multi-level timeout strategy that degrades gracefully rather than failing hard.
+
+### Timeout Hierarchy
+
+```
+Level 0: Research Agent Force Report    12 minutes
+Level 1: Research Agent Hard Timeout    30 minutes
+Level 2: Orchestrator Force Report      30 minutes
+```
+
+### Cascade Behavior
+
+**Level 0 -- Agent force report (12 min).** If a research agent has been running for 12 minutes without calling `generate_report`, the system breaks the agent's research loop and forces intermediate report generation from whatever has been gathered so far. The agent doesn't fail -- it just stops researching and summarizes.
+
+**Level 1 -- Agent hard timeout (30 min).** If the entire agent execution (including report generation) exceeds 30 minutes, the thread-level timeout fires. A callback returns a stub result with a timeout message. The orchestrator sees this as a low-quality result and may dispatch another agent or proceed to the final report.
+
+**Level 2 -- Orchestrator force report (30 min).** If the overall deep research session exceeds 30 minutes (measured from the start of the orchestration loop), the system skips the LLM call entirely and jumps to `generate_final_report()`. This ensures the user always gets an answer.
+
+### Important: These Are Not Cumulative
+
+The total runtime can exceed any single timeout because:
+- A research cycle starting at minute 29 can run for up to 30 more minutes
+- The final report itself has a 5-minute timeout
+- Multiple orchestrator cycles can each trigger their own research agents
+
+Worst case: ~65 minutes (29 min orchestration + 30 min agent + 5 min report + overhead). This is acknowledged in the codebase but not explicitly bounded.
+
+### Design Principle
+
+Each timeout triggers a **graceful degradation** rather than a failure:
+- Agent force report: partial results summarized
+- Agent hard timeout: timeout message returned as result
+- Orchestrator force report: final report from whatever was gathered
+
+The user always gets something, even if research was incomplete.
+
+---
+
+## 7. Prompt Engineering Patterns
+
+### Pattern: Tool-Only Output
+
+Both the orchestrator and research agent prompts contain:
+
+> "NEVER output normal response tokens, you must only call tools."
+
+Combined with `tool_choice=REQUIRED`, this creates a hard constraint: the LLM must call a tool on every turn. This prevents the model from "chatting" or producing unsolicited commentary between research steps.
+
+The max_tokens limit is set low (1024 for orchestrator, 1000 for agent) as a safety net -- if the model somehow bypasses tool_choice and starts generating text, it's cut short quickly.
+
+### Pattern: Context Injection Through Task Strings
+
+Since research agents have no context beyond their task string, the orchestrator prompt explicitly warns:
+
+> "CRITICAL - the research_agent only receives the task and has no additional context about the user's query, research plan, other research agents, or message history. You absolutely must provide all of the context needed to complete the task in the argument."
+
+This is a key architectural constraint enforced purely through prompting. The system doesn't validate that the task string contains sufficient context -- it trusts the LLM.
+
+### Pattern: Combating Model Caution
+
+The plan generation prompt contains:
+
+> "CRITICAL - You MUST only output the research plan... Do not worry about the feasibility of the plan or access to data or tools, a different deep research flow will handle that."
+
+This combats a known failure mode where models refuse to plan research because they're uncertain about their ability to execute it. By explicitly decoupling planning from execution concerns, the system gets bolder, more comprehensive plans.
+
+### Pattern: Report Style Differentiation
+
+Intermediate reports and the final report have deliberately different style instructions:
+
+- **Intermediate reports:** "No title, no sections, no conclusions. Facts only. No formatting." These are agent-to-agent communication -- optimized for information density, not readability.
+- **Final report:** "Structure logically into relevant sections. Use different text styles and formatting." This is agent-to-user communication -- optimized for comprehension.
+
+The final report prompt even warns:
+
+> "Ignore the format styles of the intermediate research_agent reports, those are not end user facing and different from your task."
+
+This prevents the final report from inheriting the flat, unformatted style of intermediate reports.
+
+### Pattern: Progressive Encouragement
+
+On the second orchestrator cycle, a reminder is injected:
+
+> "Make sure all parts of the user question and the plan have been thoroughly explored before calling generate_report."
+
+This combats early termination -- models tend to call `generate_report` too early, especially after a single successful research cycle. The reminder is only injected once (cycle 1) to avoid repetitive nagging.
+
+### Pattern: Nudging Tool Sequences
+
+After a web search, the system injects a reminder to open promising URLs:
+
+> "Remember that after using web_search, you are encouraged to open some pages to get more context unless the query is completely answered by the snippets."
+
+This addresses a common failure mode where the model treats search snippets as sufficient and never reads full pages. The nudge is conditional (only after web_search) and soft (says "encouraged", not "must").
+
+---
+
+## 8. Streaming Architecture
+
+### Placement as UI Coordinates
+
+Every packet carries a `Placement` that acts as a coordinate system for the UI:
+
+```
+placement:
+    turn_index:     Which vertical block (sequential position)
+    tab_index:      Which horizontal tab (parallel branch: 0, 1, 2)
+    sub_turn_index: Nesting depth within a branch
+```
+
+This allows the frontend to render a complex, nested, parallel timeline without any knowledge of the research logic. The backend simply tags each packet with where it belongs.
+
+### Packet Translation
+
+The system reuses a generic LLM step infrastructure (`run_llm_step_pkt_generator`) for all phases. Deep-research-specific packet types are created by translating generic packets:
+
+```
+Generic:  AgentResponseStart  ->  DeepResearchPlanStart   (plan phase)
+Generic:  AgentResponseDelta  ->  IntermediateReportDelta  (agent report phase)
+Generic:  (unchanged)         ->  AgentResponseDelta       (final report)
+```
+
+This means the final report uses the SAME packet types as normal chat, so the frontend's standard message renderer handles it automatically. Only the plan and intermediate reports need custom renderers.
+
+### Branching Signal
+
+Before parallel agents start, a `TopLevelBranching(num_parallel_branches=N)` packet tells the frontend to prepare N parallel lanes. Without this signal, the frontend wouldn't know how to lay out incoming packets from different `tab_index` values.
+
+---
+
+## 9. Error Handling Philosophy
+
+### Agent-Level: Isolate and Continue
+
+Research agent failures are caught, logged, and the agent returns `None`. The orchestrator sees a missing result and can decide to:
+- Retry with a different task
+- Proceed with whatever other agents returned
+- Generate the final report from partial data
+
+No single agent failure kills the session.
+
+### Orchestrator-Level: Degrade to Report
+
+If the orchestrator LLM fails to produce tool calls (which shouldn't happen with `tool_choice=REQUIRED` but can in edge cases), the system falls through to `generate_final_report()` with whatever has been gathered so far. On cycle 0 (no data gathered), this raises an error. On later cycles, it produces a partial report.
+
+### Token Loop Protection
+
+Both the orchestrator and research agent set low `max_tokens` limits (1024 and 1000 respectively). This prevents a failure mode where the model enters an infinite loop of null or garbage tokens, which can happen with long contexts. The low limit means a degenerate response is cheap and the system can attempt recovery on the next cycle.
+
+---
+
+## 10. Known Limitations and Open Questions
+
+### Agent Memory / Continuation
+As discussed, there is no mechanism for agents to build on prior agents' work. Each dispatch is stateless. This leads to redundant searches and wasted cycles when iterating on a topic.
+
+### Parallelism Limit is Prompt-Based
+The "max 3 parallel agents" constraint is enforced by prompt instruction, not by code. The LLM could call `research_agent` 5 times in one turn and the system would execute all 5. This is fragile.
+
+### No Search Query Deduplication
+While URL fetching has deduplication (via `url_snippet_map`), search queries do not. Two agents researching related topics will likely submit similar queries and get overlapping results.
+
+### Intermediate Report Compression
+Intermediate reports are capped at 10,000 tokens, but the information loss from this compression is uncontrolled. Important details from raw search results may be dropped during summarization, and there's no mechanism to detect or recover from this.
+
+### Single-Turn Tool Type Restriction
+Within a research agent, only one tool type can execute per turn (e.g., can't do a search AND open a URL in the same turn). This is a limitation of the placement/UI system, not a research logic constraint, and forces extra cycles.
+
+### No Evaluation Loop
+There is no mechanism to evaluate the quality of intermediate reports or the final report. The system cannot detect when a report is shallow, contains hallucinations, or misses key aspects of the query. Quality is entirely dependent on the LLM's judgment and the prompt engineering.
+
+### Total Runtime is Unbounded in Practice
+While individual components have timeouts, the cascade of timeouts means total runtime is not strictly bounded. A more robust approach would impose a global wall-clock deadline.


### PR DESCRIPTION
## Description

This PR adds a complete technical documentation suite for the Onyx Deep Research system. The documentation provides a comprehensive reference for understanding, evaluating, and improving the deep research implementation.

### Documentation Added

**11 new markdown files** covering all aspects of the system:

1. **README.md** - Overview and quick reference guide to the documentation set
2. **01_architecture_overview.md** - High-level system design and key architectural decisions
3. **02_execution_phases.md** - Detailed breakdown of all four execution phases (Clarification, Plan, Execution, Synthesis)
4. **03_orchestrator.md** - Orchestrator agent mechanics, cycle limits, and decision trees
5. **04_research_agent.md** - Research agent lifecycle, tool calling loops, and intermediate report generation
6. **05_mock_tools.md** - Mock tool definitions and control flow mechanisms
7. **06_streaming_and_packets.md** - Packet infrastructure, types, and streaming flow by phase
8. **07_citation_system.md** - Citation tracking, merging, and renumbering across agents
9. **08_prompts.md** - Complete prompt reference organized by phase and agent
10. **09_frontend.md** - Frontend integration including state management, API integration, and renderers
11. **10_configuration_and_constants.md** - All environment variables, constants, and configuration options
12. **11_database_schema.md** - Database migrations and schema for persisting deep research state
13. **reference-implementation.md** - Conceptual analysis of design patterns, structural decisions, and trade-offs

### Content Highlights

- **Architecture diagrams** showing the hierarchical agent model and execution flow
- **Detailed phase descriptions** with code references and packet flows
- **Mock tool inventory** explaining control flow mechanisms
- **Citation system walkthrough** showing how citations flow through multiple stages
- **Frontend integration guide** with component references and state management patterns
- **Database schema documentation** with migration references and table descriptions
- **Prompt reference** with template variables and injection points
- **Configuration reference** with all constants and their purposes

### Purpose

This documentation serves as:
- A reference for developers building or improving deep research systems
- A guide for understanding the current implementation's design decisions
- A resource for evaluating trade-offs and limitations
- A foundation for future enhancements and optimizations

## How Has This Been Tested?

Documentation review only - no code changes or tests required. The documentation references existing code and is intended as a reference guide.

## Additional Options

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch.
  - This is documentation only and does not require cherry-picking.
- [ ] [Optional] Override Linear Check

https://claude.ai/code/session_01ThybJgRtu7tccupStQerR6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete technical documentation suite for the Onyx Deep Research system, now including the data extraction agent prompt architecture. This improves onboarding and makes the feature easier to debug and extend.

- **New Documentation**
  - New markdown docs covering: architecture, execution phases, orchestrator and research agents, mock tools, streaming/packets, citation system, prompts, frontend integration, configuration/constants, database schema, and reference implementation analysis. Docs include code references, diagrams, and packet flows.
  - Added data extraction agent prompt architecture: cacheable system prompt, dynamic user message structure, universal answer tool schema (answer + reasoning + confidence), and five result types (TEXT, DATE, CURRENCY, BOOLEAN, LIST) with a calibrated confidence scale and examples.
  - No code changes.

<sup>Written for commit 7326fa6cd0934cbd9e56bc90dd60db3f7bce6018. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

