### PR TITLE
feat: add LLMAPI.ai as first-class LLM provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -20,6 +20,7 @@ class LlmProviderNames(str, Enum):
     BEDROCK_CONVERSE = "bedrock_converse"
     VERTEX_AI = "vertex_ai"
     OPENROUTER = "openrouter"
+    LLMAPI = "llmapi"
     AZURE = "azure"
     OLLAMA_CHAT = "ollama_chat"
     MISTRAL = "mistral"
@@ -39,6 +40,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.VERTEX_AI,
     LlmProviderNames.BEDROCK,
     LlmProviderNames.OPENROUTER,
+    LlmProviderNames.LLMAPI,
     LlmProviderNames.AZURE,
     LlmProviderNames.OLLAMA_CHAT,
 ]
@@ -53,6 +55,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.BEDROCK_CONVERSE: "Bedrock",
     LlmProviderNames.VERTEX_AI: "Vertex AI",
     LlmProviderNames.OPENROUTER: "OpenRouter",
+    LlmProviderNames.LLMAPI: "LLM API",
     LlmProviderNames.AZURE: "Azure",
     "ollama": "Ollama",
     LlmProviderNames.OLLAMA_CHAT: "Ollama",
@@ -102,6 +105,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.BEDROCK,
     LlmProviderNames.BEDROCK_CONVERSE,
     LlmProviderNames.OPENROUTER,
+    LlmProviderNames.LLMAPI,
     LlmProviderNames.OLLAMA_CHAT,
     LlmProviderNames.VERTEX_AI,
     LlmProviderNames.AZURE,

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -48,6 +48,12 @@ def _build_provider_extra_headers(
             "X-Title": "Onyx",
         }
 
+    elif provider == LlmProviderNames.LLMAPI:
+        return {
+            "HTTP-Referer": "https://onyx.app",
+            "X-Title": "Onyx",
+        }
+
     return {}
 
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -292,11 +292,16 @@ class LitellmLLM(LLM):
         optional_kwargs: dict[str, Any] = {}
 
         # Model name
-        model_provider = (
-            f"{self.config.model_provider}/responses"
-            if is_openai_model  # Uses litellm's completions -> responses bridge
-            else self.config.model_provider
-        )
+        # LLMAPI is an OpenAI-compatible aggregator; route through LiteLLM's
+        # openai handler with a custom base_url.
+        is_llmapi = self._model_provider == LlmProviderNames.LLMAPI
+        if is_llmapi:
+            effective_provider = "openai"
+        elif is_openai_model:
+            effective_provider = f"{self.config.model_provider}/responses"
+        else:
+            effective_provider = self.config.model_provider
+        model_provider = effective_provider
         model = (
             f"{model_provider}/{self.config.deployment_name or self.config.model_name}"
         )

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -38,6 +38,9 @@ OLLAMA_API_KEY_CONFIG_KEY = "OLLAMA_API_KEY"
 # OpenRouter
 OPENROUTER_PROVIDER_NAME = "openrouter"
 
+# LLM API
+LLMAPI_PROVIDER_NAME = "llmapi"
+
 ANTHROPIC_PROVIDER_NAME = "anthropic"
 
 # Curated list of Anthropic models to show by default in the UI

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -15,6 +15,7 @@ from onyx.llm.well_known_providers.constants import AZURE_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OLLAMA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import LLMAPI_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENROUTER_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import VERTEXAI_PROVIDER_NAME
 from onyx.llm.well_known_providers.models import WellKnownLLMProviderDescriptor
@@ -38,6 +39,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         VERTEXAI_PROVIDER_NAME: get_vertexai_model_names(),
         OLLAMA_PROVIDER_NAME: [],  # Dynamic - fetched from Ollama API
         OPENROUTER_PROVIDER_NAME: [],  # Dynamic - fetched from OpenRouter API
+        LLMAPI_PROVIDER_NAME: [],  # Dynamic - fetched from LLM API
     }
 
 
@@ -300,6 +302,7 @@ def get_provider_display_name(provider_name: str) -> str:
         BEDROCK_PROVIDER_NAME: "Amazon Bedrock",
         VERTEXAI_PROVIDER_NAME: "Google Vertex AI",
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
+        LLMAPI_PROVIDER_NAME: "LLM API",
     }
 
     if provider_name in _ONYX_PROVIDER_DISPLAY_NAMES:

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -421,3 +421,32 @@ class OpenRouterFinalModelResponse(BaseModel):
         int | None
     )  # From OpenRouter API context_length (may be missing for some models)
     supports_image_input: bool
+
+
+# LLM API dynamic models fetch
+class LLMAPIModelsRequest(BaseModel):
+    api_base: str
+    api_key: str
+    provider_name: str | None = None  # Optional: to save models to existing provider
+
+
+class LLMAPIModelDetails(BaseModel):
+    """Response model for LLM API /v1/models endpoint (OpenAI-compatible)"""
+
+    model_config = {"extra": "ignore"}
+
+    id: str
+
+    @property
+    def display_name(self) -> str:
+        """Generate display name from model ID by stripping vendor prefix."""
+        if "/" in self.id:
+            return self.id.split("/", 1)[1]
+        return self.id
+
+
+class LLMAPIFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g., "anthropic/claude-sonnet-4-5")
+    display_name: str  # Human-readable name derived from model ID
+    max_input_tokens: int | None  # Not available from /models; None
+    supports_image_input: bool

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -21,6 +21,7 @@ from onyx.llm.constants import PROVIDER_DISPLAY_NAMES
 DYNAMIC_LLM_PROVIDERS = frozenset(
     {
         LlmProviderNames.OPENROUTER,
+        LlmProviderNames.LLMAPI,
         LlmProviderNames.BEDROCK,
         LlmProviderNames.OLLAMA_CHAT,
     }
@@ -320,7 +321,7 @@ def extract_vendor_from_model_name(model_name: str, provider: str) -> str | None
         - Ollama: "llama3:70b" → "Meta"
         - Ollama: "qwen2.5:7b" → "Alibaba"
     """
-    if provider == LlmProviderNames.OPENROUTER:
+    if provider in (LlmProviderNames.OPENROUTER, LlmProviderNames.LLMAPI):
         # Format: "vendor/model-name" e.g., "anthropic/claude-3-5-sonnet"
         if "/" in model_name:
             vendor_key = model_name.split("/")[0].lower()

--- a/web/src/app/admin/configuration/llm/LLMConfiguration.tsx
+++ b/web/src/app/admin/configuration/llm/LLMConfiguration.tsx
@@ -15,6 +15,7 @@ import { AzureForm } from "./forms/AzureForm";
 import { BedrockForm } from "./forms/BedrockForm";
 import { VertexAIForm } from "./forms/VertexAIForm";
 import { OpenRouterForm } from "./forms/OpenRouterForm";
+import { LLMAPIForm } from "./forms/LLMAPIForm";
 import { getFormForExistingProvider } from "./forms/getForm";
 import { CustomForm } from "./forms/CustomForm";
 
@@ -76,6 +77,7 @@ export function LLMConfiguration() {
         <BedrockForm shouldMarkAsDefault={isFirstProvider} />
         <VertexAIForm shouldMarkAsDefault={isFirstProvider} />
         <OpenRouterForm shouldMarkAsDefault={isFirstProvider} />
+        <LLMAPIForm shouldMarkAsDefault={isFirstProvider} />
 
         <CustomForm shouldMarkAsDefault={isFirstProvider} />
       </div>

--- a/web/src/app/admin/configuration/llm/forms/LLMAPIForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/LLMAPIForm.tsx
@@ -1,0 +1,230 @@
+import Separator from "@/refresh-components/Separator";
+import { Form, Formik } from "formik";
+import { TextFormField } from "@/components/Field";
+import {
+  LLMProviderFormProps,
+  ModelConfiguration,
+  LLMAPIModelResponse,
+} from "../interfaces";
+import * as Yup from "yup";
+import {
+  ProviderFormEntrypointWrapper,
+  ProviderFormContext,
+} from "./components/FormWrapper";
+import { DisplayNameField } from "./components/DisplayNameField";
+import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
+import { FormActionButtons } from "./components/FormActionButtons";
+import {
+  buildDefaultInitialValues,
+  buildDefaultValidationSchema,
+  buildAvailableModelConfigurations,
+  submitLLMProvider,
+  BaseLLMFormValues,
+  LLM_FORM_CLASS_NAME,
+} from "./formUtils";
+import { AdvancedOptions } from "./components/AdvancedOptions";
+import { DisplayModels } from "./components/DisplayModels";
+import { FetchModelsButton } from "./components/FetchModelsButton";
+import { useState } from "react";
+
+export const LLMAPI_PROVIDER_NAME = "llmapi";
+const LLMAPI_DISPLAY_NAME = "LLM API";
+const DEFAULT_API_BASE = "https://api.llmapi.ai/v1";
+const LLMAPI_MODELS_API_URL = "/api/admin/llm/llmapi/available-models";
+
+interface LLMAPIFormValues extends BaseLLMFormValues {
+  api_key: string;
+  api_base: string;
+}
+
+async function fetchLLMAPIModels(params: {
+  apiBase: string;
+  apiKey: string;
+  providerName?: string;
+}): Promise<{ models: ModelConfiguration[]; error?: string }> {
+  if (!params.apiBase || !params.apiKey) {
+    return {
+      models: [],
+      error: "API Base and API Key are required to fetch models",
+    };
+  }
+
+  try {
+    const response = await fetch(LLMAPI_MODELS_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_base: params.apiBase,
+        api_key: params.apiKey,
+        provider_name: params.providerName,
+      }),
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorMessage;
+      } catch {
+        // ignore JSON parsing errors
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: LLMAPIModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+}
+
+export function LLMAPIForm({
+  existingLlmProvider,
+  shouldMarkAsDefault,
+}: LLMProviderFormProps) {
+  const [fetchedModels, setFetchedModels] = useState<ModelConfiguration[]>([]);
+
+  return (
+    <ProviderFormEntrypointWrapper
+      providerName={LLMAPI_DISPLAY_NAME}
+      providerEndpoint={LLMAPI_PROVIDER_NAME}
+      existingLlmProvider={existingLlmProvider}
+    >
+      {({
+        onClose,
+        mutate,
+        isTesting,
+        setIsTesting,
+        testError,
+        setTestError,
+        wellKnownLLMProvider,
+      }: ProviderFormContext) => {
+        const modelConfigurations = buildAvailableModelConfigurations(
+          existingLlmProvider,
+          wellKnownLLMProvider
+        );
+        const initialValues: LLMAPIFormValues = {
+          ...buildDefaultInitialValues(
+            existingLlmProvider,
+            modelConfigurations
+          ),
+          api_key: existingLlmProvider?.api_key ?? "",
+          api_base: existingLlmProvider?.api_base ?? DEFAULT_API_BASE,
+        };
+
+        const validationSchema = buildDefaultValidationSchema().shape({
+          api_key: Yup.string().required("API Key is required"),
+          api_base: Yup.string().required("API Base URL is required"),
+        });
+
+        return (
+          <Formik
+            initialValues={initialValues}
+            validationSchema={validationSchema}
+            validateOnMount={true}
+            onSubmit={async (values, { setSubmitting }) => {
+              await submitLLMProvider({
+                providerName: LLMAPI_PROVIDER_NAME,
+                values,
+                initialValues,
+                modelConfigurations:
+                  fetchedModels.length > 0
+                    ? fetchedModels
+                    : modelConfigurations,
+                existingLlmProvider,
+                shouldMarkAsDefault,
+                setIsTesting,
+                setTestError,
+                mutate,
+                onClose,
+                setSubmitting,
+              });
+            }}
+          >
+            {(formikProps) => {
+              const currentModels =
+                fetchedModels.length > 0
+                  ? fetchedModels
+                  : existingLlmProvider?.model_configurations ||
+                    modelConfigurations;
+
+              const isFetchDisabled =
+                !formikProps.values.api_base || !formikProps.values.api_key;
+
+              return (
+                <Form className={LLM_FORM_CLASS_NAME}>
+                  <DisplayNameField disabled={!!existingLlmProvider} />
+
+                  <PasswordInputTypeInField name="api_key" label="API Key" />
+
+                  <TextFormField
+                    name="api_base"
+                    label="API Base URL"
+                    subtext="The base URL for LLM API."
+                    placeholder={DEFAULT_API_BASE}
+                  />
+
+                  <FetchModelsButton
+                    onFetch={() =>
+                      fetchLLMAPIModels({
+                        apiBase: formikProps.values.api_base,
+                        apiKey: formikProps.values.api_key,
+                        providerName: existingLlmProvider?.name,
+                      })
+                    }
+                    isDisabled={isFetchDisabled}
+                    disabledHint={
+                      !formikProps.values.api_key
+                        ? "Enter your API key first."
+                        : !formikProps.values.api_base
+                          ? "Enter the API base URL."
+                          : undefined
+                    }
+                    onModelsFetched={setFetchedModels}
+                    autoFetchOnInitialLoad={!!existingLlmProvider}
+                  />
+
+                  <Separator />
+
+                  <DisplayModels
+                    modelConfigurations={currentModels}
+                    formikProps={formikProps}
+                    noModelConfigurationsMessage={
+                      "Fetch available models first, then you'll be able to select " +
+                      "the models you want to make available in Onyx."
+                    }
+                    recommendedDefaultModel={null}
+                    shouldShowAutoUpdateToggle={false}
+                  />
+
+                  <AdvancedOptions formikProps={formikProps} />
+
+                  <FormActionButtons
+                    isTesting={isTesting}
+                    testError={testError}
+                    existingLlmProvider={existingLlmProvider}
+                    mutate={mutate}
+                    onClose={onClose}
+                    isFormValid={formikProps.isValid}
+                  />
+                </Form>
+              );
+            }}
+          </Formik>
+        );
+      }}
+    </ProviderFormEntrypointWrapper>
+  );
+}

--- a/web/src/app/admin/configuration/llm/forms/getForm.tsx
+++ b/web/src/app/admin/configuration/llm/forms/getForm.tsx
@@ -5,6 +5,7 @@ import { OllamaForm } from "./OllamaForm";
 import { AzureForm } from "./AzureForm";
 import { VertexAIForm } from "./VertexAIForm";
 import { OpenRouterForm } from "./OpenRouterForm";
+import { LLMAPIForm } from "./LLMAPIForm";
 import { CustomForm } from "./CustomForm";
 import { BedrockForm } from "./BedrockForm";
 
@@ -38,6 +39,8 @@ export const getFormForExistingProvider = (provider: LLMProviderView) => {
       return <BedrockForm existingLlmProvider={provider} />;
     case LLMProviderName.OPENROUTER:
       return <OpenRouterForm existingLlmProvider={provider} />;
+    case LLMProviderName.LLMAPI:
+      return <LLMAPIForm existingLlmProvider={provider} />;
     default:
       return <CustomForm existingLlmProvider={provider} />;
   }

--- a/web/src/app/admin/configuration/llm/interfaces.ts
+++ b/web/src/app/admin/configuration/llm/interfaces.ts
@@ -4,6 +4,7 @@ export enum LLMProviderName {
   OLLAMA_CHAT = "ollama_chat",
   AZURE = "azure",
   OPENROUTER = "openrouter",
+  LLMAPI = "llmapi",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
   CUSTOM = "custom",
@@ -127,6 +128,19 @@ export interface OpenRouterFetchParams {
   provider_name?: string;
 }
 
+export interface LLMAPIModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+}
+
+export interface LLMAPIFetchParams {
+  api_base?: string;
+  api_key?: string;
+  provider_name?: string;
+}
+
 export interface VertexAIFetchParams {
   model_configurations?: ModelConfiguration[];
 }
@@ -135,4 +149,5 @@ export type FetchModelsParams =
   | BedrockFetchParams
   | OllamaFetchParams
   | OpenRouterFetchParams
+  | LLMAPIFetchParams
   | VertexAIFetchParams;


### PR DESCRIPTION
## Summary
- Adds [LLMAPI.ai](https://llmapi.ai) as a well-known LLM provider in Onyx
- LLMAPI is an OpenAI-compatible LLM gateway that routes to 100+ models from multiple vendors (Anthropic, OpenAI, Google, Meta, Mistral, etc.)
- Follows the existing OpenRouter aggregator pattern exactly: dynamic model fetching, vendor grouping, LiteLLM routing via openai/ prefix with custom api_base

### Backend changes (8 files)
- Register llmapi in LlmProviderNames enum, WELL_KNOWN_PROVIDER_NAMES, PROVIDER_DISPLAY_NAMES, and AGGREGATOR_PROVIDERS
- Add LLMAPI_PROVIDER_NAME constant in well-known providers
- Map LLMAPI to LiteLLM openai handler with custom api_base in multi_llm.py
- Add POST /admin/llm/llmapi/available-models endpoint for dynamic model fetching
- Add LLMAPI to DYNAMIC_LLM_PROVIDERS and vendor extraction logic

### Frontend changes (5 files, 1 new)
- Add LLMAPI to LLMProviderName enum and TypeScript interfaces
- Create LLMAPIForm.tsx component (based on OpenRouterForm pattern)
- Wire up form in getForm.tsx and LLMConfiguration.tsx
- Add fetchLLMAPIModels utility, provider icon mapping, and aggregator registration

## Test plan
- [ ] Verify LLMAPI appears in the admin LLM provider configuration page
- [ ] Enter API key and base URL, click Fetch Models, verify model list populates
- [ ] Select models, save provider, verify it appears in the enabled providers list
- [ ] Send a chat message through an LLMAPI-configured model, verify streaming response

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LLMAPI.ai as a first-class LLM provider with dynamic model fetching and OpenAI-compatible routing, following the OpenRouter aggregator pattern. This lets admins configure LLMAPI and route to 100+ models via LiteLLM using a custom base URL.

- **New Features**
  - Backend: register llmapi in well-known providers; route through LiteLLM’s openai handler with custom api_base; add POST /admin/llm/llmapi/available-models to parse OpenAI-compatible /v1/models; include vendor extraction and DYNAMIC_LLM_PROVIDERS updates.
  - Frontend: add LLMAPI to enums and aggregator providers; add LLMAPIForm with API key/base fields and Fetch Models; add fetchLLMAPIModels utility and provider icon mapping; wire into admin configuration flows.

- **Migration**
  - In Admin → LLM Providers, select LLM API.
  - Enter API key and API base (e.g., https://api.llmapi.ai/v1).
  - Click Fetch Models, select desired models, and save.
  - Send a chat with a selected model to confirm streaming works.

<sup>Written for commit 4f6bcf409f0b5cc5c97bce7e5a3dbfc56ae68a02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

