### PR TITLE
fix(actions): persist source selection when toggling search tool in ActionsPopover

### DIFF
--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -816,18 +816,18 @@ export default function ActionsPopover({
 
     if (toolId === searchToolId) {
       if (wasDisabled) {
-        // Enabling - restore previous sources or enable all (no persistence)
+        // Enabling - restore previous sources or enable all (persisted to localStorage)
         const previous = previouslyEnabledSourcesRef.current;
         if (previous.length > 0) {
-          setSelectedSources(previous);
+          enableSources(previous);
         } else {
-          setSelectedSources(configuredSources);
+          enableSources(configuredSources);
         }
         previouslyEnabledSourcesRef.current = [];
       } else {
-        // Disabling - store current sources then disable all (no persistence)
+        // Disabling - store current sources then disable all (persisted to localStorage)
         previouslyEnabledSourcesRef.current = [...selectedSources];
-        setSelectedSources([]);
+        baseDisableAllSources();
       }
     }
   };


### PR DESCRIPTION
## Description
- Fixed source selection not persisting to localStorage when toggling the search tool on/off in the ActionsPopover

## How Has This Been Tested?
Tested by first disabling all the sources; at that point, the internal search tool was disabled. When I enabled the tool and refreshed the page, it stays enabled. Previously, it went back to a disabled state again.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist source selection when toggling the search tool in ActionsPopover, so the tool’s state and selected sources survive page reloads. Fixes the regression where the search tool reverted to disabled after refresh.

- **Bug Fixes**
  - Use enableSources(...) and baseDisableAllSources(...) to write changes to localStorage.
  - On enable: restore previous sources or enable all; on disable: save current sources, then disable all.

<sup>Written for commit 07b366285af0a24638c8861254249940042b785a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

