### PR TITLE
fix(auth): force IdP re-authentication after OIDC/SAML logout

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1718,6 +1718,14 @@ def get_oauth_router(
                 authorization_url, {"access_type": "offline", "prompt": "consent"}
             )
 
+        # After explicit logout, force the IdP to show a login screen
+        if oauth_client.name == "openid":
+            force_reauth = request.cookies.get("onyx_force_reauth")
+            if force_reauth:
+                authorization_url = add_url_params(
+                    authorization_url, {"prompt": "login"}
+                )
+
         if redirect:
             redirect_response = RedirectResponse(authorization_url, status_code=302)
             redirect_response.set_cookie(

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -195,7 +195,9 @@ async def saml_login(request: Request) -> SAMLAuthorizeResponse:
     req = await prepare_from_fastapi_request(request)
     auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_CONF_DIR)
     return_to = _sanitize_relay_state(request.query_params.get("next"))
-    callback_url = auth.login(return_to=return_to)
+    # After explicit logout, force the IdP to show a login screen
+    force_reauth = request.cookies.get("onyx_force_reauth")
+    callback_url = auth.login(return_to=return_to, force_authn=bool(force_reauth))
     return SAMLAuthorizeResponse(authorization_url=callback_url)
 
 

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -18,7 +18,6 @@ export interface PageProps {
 
 export default async function Page(props: PageProps) {
   const searchParams = await props.searchParams;
-  const autoRedirectDisabled = searchParams?.disableAutoRedirect === "true";
   const autoRedirectToSignupDisabled =
     searchParams?.autoRedirectToSignup === "false";
   const nextUrl: string | null = Array.isArray(searchParams?.next)
@@ -87,7 +86,7 @@ export default async function Page(props: PageProps) {
     }
   }
 
-  if (authTypeMetadata?.autoRedirect && authUrl && !autoRedirectDisabled) {
+  if (authTypeMetadata?.autoRedirect && authUrl) {
     return redirect(authUrl as Route);
   }
 

--- a/web/src/app/auth/logout/route.ts
+++ b/web/src/app/auth/logout/route.ts
@@ -35,6 +35,15 @@ export const POST = async (request: NextRequest) => {
     );
   });
 
+  // Set a short-lived cookie so the next OIDC/SAML auth request forces the
+  // IdP to show a login screen instead of silently re-authenticating.
+  headers.append(
+    "Set-Cookie",
+    `onyx_force_reauth=true; Max-Age=600; ${Object.entries(cookieOptions)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("; ")}`
+  );
+
   return new Response(null, {
     status: 204,
     headers: headers,

--- a/web/src/app/auth/oidc/callback/route.ts
+++ b/web/src/app/auth/oidc/callback/route.ts
@@ -34,5 +34,6 @@ export const GET = async (request: NextRequest) => {
   );
 
   redirectResponse.headers.set("set-cookie", setCookieHeader);
+  redirectResponse.cookies.delete("onyx_force_reauth");
   return redirectResponse;
 };

--- a/web/src/app/auth/saml/callback/route.ts
+++ b/web/src/app/auth/saml/callback/route.ts
@@ -66,6 +66,7 @@ async function handleSamlCallback(
     SEE_OTHER_REDIRECT_STATUS
   );
   redirectResponse.headers.set("set-cookie", setCookieHeader);
+  redirectResponse.cookies.delete("onyx_force_reauth");
   return redirectResponse;
 }
 

--- a/web/src/sections/sidebar/UserAvatarPopover.tsx
+++ b/web/src/sections/sidebar/UserAvatarPopover.tsx
@@ -87,9 +87,7 @@ function SettingsPopover({
 
         const encodedRedirect = encodeURIComponent(currentUrl);
 
-        router.push(
-          `/auth/login?disableAutoRedirect=true&next=${encodedRedirect}`
-        );
+        router.push(`/auth/login?next=${encodedRedirect}`);
       })
 
       .catch(() => {


### PR DESCRIPTION
## Summary
- After explicit logout, sets a short-lived `onyx_force_reauth` cookie (10 min TTL) that forces the IdP to prompt for credentials on the next auth request (`prompt=login` for OIDC, `ForceAuthn=true` for SAML)
- Clears the cookie after successful auth callback so subsequent logins get seamless SSO
- Removes the `disableAutoRedirect` workaround which only worked on the login page and was bypassed by navigating to any protected route

## Test plan
- [ ] Log in via OIDC, log out, verify `onyx_force_reauth` cookie is set and IdP shows login screen (not silent re-auth)
- [ ] After re-authenticating, verify cookie is cleared and subsequent navigations use seamless SSO
- [ ] Repeat for SAML flow
- [ ] Verify auto-redirect on login page still works for fresh visits (no force-reauth cookie)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
After logout, users now see the IdP login screen instead of being silently signed back in. We set a short‑lived cookie to force re‑auth for OIDC and SAML and remove the old auto‑redirect workaround.

- **Bug Fixes**
  - Set onyx_force_reauth cookie (10 min) on logout to require credentials.
  - Send prompt=login (OIDC) and ForceAuthn=true (SAML) when cookie is present.
  - Clear the cookie on successful OIDC/SAML callbacks.
  - Remove disableAutoRedirect param/logic; login auto-redirect still works when enabled.

<sup>Written for commit 5f456b8a2017ed1c3463f4ec7dec38c43514eeca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

