### PR TITLE
chore(helm): Update from ingress nginx to nginx ingress

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Add required Helm repositories
         run: |
-          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add nginx-stable https://helm.nginx.com/stable
           helm repo add onyx-vespa https://onyx-dot-app.github.io/vespa-helm-charts
           helm repo add opensearch https://opensearch-project.github.io/helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -85,7 +85,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           echo "=== Adding Helm repositories ==="
-          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add nginx-stable https://helm.nginx.com/stable
           helm repo add vespa https://onyx-dot-app.github.io/vespa-helm-charts
           helm repo add opensearch https://opensearch-project.github.io/helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -8,7 +8,7 @@ chart-dirs:
 chart-repos:
   - vespa=https://onyx-dot-app.github.io/vespa-helm-charts
   - opensearch=https://opensearch-project.github.io/helm-charts
-  - ingress-nginx=https://kubernetes.github.io/ingress-nginx
+  - nginx-stable=https://helm.nginx.com/stable
   - postgresql=https://cloudnative-pg.github.io/charts
   - redis=https://ot-container-kit.github.io/helm-charts
   - minio=https://charts.min.io/

--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -8,9 +8,9 @@ dependencies:
 - name: opensearch
   repository: https://opensearch-project.github.io/helm-charts
   version: 3.4.0
-- name: ingress-nginx
-  repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.13.3
+- name: nginx-ingress
+  repository: https://helm.nginx.com/stable
+  version: 2.4.4
 - name: redis
   repository: https://ot-container-kit.github.io/helm-charts
   version: 0.16.6
@@ -20,5 +20,5 @@ dependencies:
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
   version: 0.3.0
-digest: sha256:cf8f01906d46034962c6ce894770621ee183ac761e6942951118aeb48540eddd
-generated: "2026-02-24T10:59:38.78318-08:00"
+digest: sha256:49a672417fbbdf36db8571862d896cbb99d33bf94deab4f6f0726a01d8ef0b99
+generated: "2026-02-26T15:10:12.656557-08:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.32
+version: 0.5.0
 appVersion: latest
 annotations:
   category: Productivity
@@ -31,9 +31,9 @@ dependencies:
     version: 3.4.0
     repository: https://opensearch-project.github.io/helm-charts
     condition: opensearch.enabled
-  - name: ingress-nginx
-    version: 4.13.3
-    repository: https://kubernetes.github.io/ingress-nginx
+  - name: nginx-ingress
+    version: 2.4.4
+    repository: https://helm.nginx.com/stable
     condition: nginx.enabled
     alias: nginx
   - name: redis

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.org/rewrite-target: /$2
+    nginx.org/path-regex: "case_sensitive"
     cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
 spec:
   {{- if .Values.ingress.className }}

--- a/deployment/helm/charts/onyx/templates/ingress-api.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-api.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     {{- end }}
     nginx.org/rewrite-target: /$2
-    nginx.org/path-regex: "case_sensitive"
+    nginx.org/path-regex: "case_insensitive"
     cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
 spec:
   {{- if .Values.ingress.className }}

--- a/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- if not .Values.ingress.className }}
     kubernetes.io/ingress.class: nginx
     {{- end }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.org/rewrite-target: /$2
+    nginx.org/path-regex: "case_sensitive"
     cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
 spec:
   {{- if .Values.ingress.className }}

--- a/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
+++ b/deployment/helm/charts/onyx/templates/ingress-mcp.yaml
@@ -8,7 +8,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     {{- end }}
     nginx.org/rewrite-target: /$2
-    nginx.org/path-regex: "case_sensitive"
+    nginx.org/path-regex: "case_insensitive"
     cert-manager.io/cluster-issuer: {{ include "onyx.fullname" . }}-letsencrypt
 spec:
   {{- if .Values.ingress.className }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -274,40 +274,41 @@ nginx:
       http: 1024
 
     # NOTE: When onyx-nginx-conf changes, nginx pods need to restart.
-    # The ingress-nginx subchart doesn't auto-detect our custom ConfigMap changes.
+    # The F5/NGINX Ingress Controller subchart doesn't auto-detect our custom ConfigMap changes.
     # Workaround: Helm upgrade will restart if the following annotation value changes.
-    podAnnotations:
-      onyx.app/nginx-config-version: "1"
+    pod:
+      annotations:
+        onyx.app/nginx-config-version: "1"
 
     # Propagate DOMAIN into nginx so server_name continues to use the same env var
-    extraEnvs:
+    env:
       - name: DOMAIN
         value: localhost
 
     config:
-      # Expose DOMAIN to the nginx config and pull in our custom snippets
-      main-snippet: |
-        env DOMAIN;
-      http-snippet: |
-        include /etc/nginx/custom-snippets/upstreams.conf;
-        include /etc/nginx/custom-snippets/server.conf;
+      entries:
+        # Expose DOMAIN to the nginx config and pull in our custom snippets
+        main-snippets: |
+          env DOMAIN;
+        http-snippets: |
+          include /etc/nginx/custom-snippets/upstreams.conf;
+          include /etc/nginx/custom-snippets/server.conf;
 
     # Mount the existing nginx ConfigMap that holds the upstream and server snippets
-    extraVolumes:
+    volumes:
       - name: nginx-config
         configMap:
           name: onyx-nginx-conf
-    extraVolumeMounts:
+    volumeMounts:
       - name: nginx-config
         mountPath: /etc/nginx/custom-snippets
         readOnly: true
 
     service:
       type: LoadBalancer
-      ports:
-        http: 80
-      targetPorts:
-        http: http
+      httpPort:
+        port: 80
+        targetPort: 1024
 
 webserver:
   replicaCount: 1


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

We have had to move off of ingress-nginx since it's getting retired: 

https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/

This means that we needed to find an alternative and we landed on https://docs.nginx.com/nginx-ingress-controller/ given how similar it is to the existing setup

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
