### PR TITLE
fix(helm): remove incorrect -master suffix from REDIS_HOST

### DIFF
--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
   ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX: "false"
   {{- end }}
   {{- if .Values.redis.enabled }}
-  REDIS_HOST: {{ .Values.redis.redisStandalone.name | default .Release.Name }}-master
+  REDIS_HOST: {{ .Values.redis.redisStandalone.name | default .Release.Name }}
   {{- end }}
   MODEL_SERVER_HOST: "{{ include "onyx.fullname" . }}-inference-model-service"
   {{- if .Values.vectorDB.enabled }}


### PR DESCRIPTION
## Description

The helm chart in this repo uses ot-container-kit for Redis deployment. The ot-container-kit Redis standalone chart names its service `{{ redisStandalone.name | default .Release.Name }}` with no suffix. The `-master` suffix is a Bitnami Redis convention and does not apply here.

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

 helm install onyx-test onyx/deployment/helm/charts/onyx -n onyx

<!--- Describe the tests you ran to verify your changes --->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the incorrect “-master” suffix from REDIS_HOST in the Helm chart to match the ot-container-kit Redis standalone service name. This fixes Redis connection issues when deploying with the standalone chart.

<sup>Written for commit dccc30da83b42370ebc265925ac17b4cc479b26e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

