### PR TITLE
feat(helm): add external PostgreSQL support

### DIFF
--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -6,7 +6,17 @@ metadata:
     {{- include "onyx.labels" . | nindent 4 }}
 data:
   INTERNAL_URL: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort | default 8080 }}"
-  {{- if .Values.postgresql.enabled }}
+  {{- if and .Values.externalPostgresql.enabled .Values.postgresql.enabled }}
+  {{- fail "Cannot enable both externalPostgresql and postgresql. Set postgresql.enabled=false when using an external database." }}
+  {{- end }}
+  {{- if .Values.externalPostgresql.enabled }}
+  {{- if not .Values.externalPostgresql.host }}
+  {{- fail "externalPostgresql.host must be set when externalPostgresql.enabled is true" }}
+  {{- end }}
+  POSTGRES_HOST: {{ .Values.externalPostgresql.host | quote }}
+  POSTGRES_PORT: {{ .Values.externalPostgresql.port | default "5432" | quote }}
+  POSTGRES_DB: {{ .Values.externalPostgresql.database | default "postgres" | quote }}
+  {{- else if .Values.postgresql.enabled }}
   POSTGRES_HOST: {{ .Release.Name }}-{{ default "postgresql" .Values.postgresql.nameOverride }}-rw
   {{- end }}
   {{- if .Values.vespa.enabled }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1062,6 +1062,19 @@ letsencrypt:
   enabled: false
   email: "abc@abc.com"
 
+# -- External PostgreSQL configuration. Use this when connecting to a pre-existing
+# PostgreSQL instance (e.g., AWS RDS, GCP Cloud SQL, Azure Database for PostgreSQL).
+# When enabled, set postgresql.enabled=false to skip deploying the bundled CloudNativePG cluster.
+externalPostgresql:
+  enabled: false
+  # -- Hostname or Kubernetes service name of the external PostgreSQL instance.
+  # Required when enabled=true.
+  host: ""
+  # -- Port for the external PostgreSQL instance.
+  port: "5432"
+  # -- Name of the database to connect to.
+  database: "postgres"
+
 # -- Governs all Secrets created or used by this chart. Values set by this chart will be base64 encoded in the k8s cluster.
 auth:
   postgresql:
@@ -1069,11 +1082,15 @@ auth:
     enabled: true
     # -- Overwrite the default secret name, ignored if existingSecret is defined
     secretName: 'onyx-postgresql'
-    # -- Use a secret specified elsewhere
+    # -- Use a secret specified elsewhere.
+    # When connecting to an external PostgreSQL instance, set this to the name of a pre-existing
+    # K8s Secret that contains the database credentials. Also update secretKeys below to match
+    # the key names used in that secret (they may differ from the CloudNativePG defaults).
     existingSecret: ""
-    # -- This defines the env var to secret map, key is always upper-cased as an env var
+    # -- This defines the env var to secret map, key is always upper-cased as an env var.
+    # CloudNativePG uses `username` and `password` as key names (the defaults below).
+    # For external secrets, update these values to match your secret's actual key names.
     secretKeys:
-      # CloudNativePG requires `username` and `password` keys for the superuser secret.
       POSTGRES_USER: username
       POSTGRES_PASSWORD: password
     # -- Secrets values IF existingSecret is empty. Key here must match the value in secretKeys to be used. Values will be base64 encoded in the k8s cluster.


### PR DESCRIPTION
## Description
Currently, when deploying with helm, the only option for the database is bundled CloudNative-NG Postgresql. This PR allow user to leverage existing Postgresql database or other database operator. 
 
It Adds an `externalPostgresql` block to values.yaml so users can point the chart at an existing Postgres instance (RDS, Cloud SQL, etc.) without deploying the bundled CloudNativePG subchart.

- Injects POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB into the shared ConfigMap when externalPostgresql.enabled=true
- Guards against enabling both externalPostgresql and postgresql simultaneously (hard fail)
- Guards against missing host when externalPostgresql is enabled
- Updates auth.postgresql comments to explain existingSecret/secretKeys usage for external credentials

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
```
postgresql:
  enabled: false

externalPostgresql:
   enabled: true
   host: "onyx-test-pg"
   port: "5432"
   database: "onyx"

auth:
  postgresql:
    existingSecret: "existing-postgres-secret-for-onyx"
    secretKeys:
      POSTGRES_USER: username
      POSTGRES_PASSWORD: password
```

`helm install -f values.yaml -n onyx onyx-test onyx/deployment/helm/charts/onyx`
 
<!--- Describe the tests you ran to verify your changes --->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds external PostgreSQL support to the Helm chart so you can connect to an existing Postgres (RDS, Cloud SQL, etc.) without deploying CloudNativePG. Improves safety with clear validation and simpler credential wiring.

- **New Features**
  - New externalPostgresql values (enabled, host, port, database).
  - Sets POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB in the shared ConfigMap when enabled.
  - Fails fast if both externalPostgresql and postgresql are enabled.
  - Fails if host is missing when externalPostgresql is enabled.
  - Clarifies auth.postgresql docs for using existingSecret and custom secretKeys.

- **Migration**
  - Set postgresql.enabled=false.
  - Set externalPostgresql.enabled=true and define host/port/database.
  - Provide credentials via auth.postgresql.existingSecret and map keys with auth.postgresql.secretKeys.

<sup>Written for commit becdb61baccde0038d11da609fc9ec9ea705b779. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

