### PR TITLE
fix(email): support unauthenticated SMTP relays

### DIFF
--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -290,8 +290,10 @@ def send_email_with_smtplib(
         msg.attach(html_part)
 
     with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as s:
-        s.starttls()
-        s.login(SMTP_USER, SMTP_PASS)
+        if SMTP_PORT != 25:
+            s.starttls()
+        if SMTP_USER and SMTP_PASS:
+            s.login(SMTP_USER, SMTP_PASS)
         s.send_message(msg)
 
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -217,7 +217,7 @@ SMTP_PASS = os.environ.get("SMTP_PASS") or ""
 EMAIL_FROM = os.environ.get("EMAIL_FROM") or SMTP_USER
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY") or ""
-EMAIL_CONFIGURED = all([SMTP_SERVER, SMTP_USER, SMTP_PASS]) or SENDGRID_API_KEY
+EMAIL_CONFIGURED = bool(SMTP_SERVER) or bool(SENDGRID_API_KEY)
 
 # If set, Onyx will listen to the `expires_at` returned by the identity
 # provider (e.g. Okta, Google, etc.) and force the user to re-authenticate


### PR DESCRIPTION
## Description

- Skip starttls() when SMTP_PORT is 25 (plaintext relay)
- Skip login() when SMTP_USER/SMTP_PASS are not set
- Mark EMAIL_CONFIGURED as true when SMTP_SERVER is set, regardless of credentials

This allows Onyx to send emails via internal SMTP relays that don't require authentication, which is common in enterprise environments.

This PR also addresses the issue: https://github.com/onyx-dot-app/onyx/issues/8306
<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
Setup a plaintext smtp relay:
```
configMap:
  SMTP_SERVER: "smtp.mail-relay.ubc.ca"
  SMTP_PORT: "25"
  SMTP_USER: ""
  SMTP_PASS: ""
```
```
helm install -f values.yaml -n onyx onyx-test onyx/deployment/helm/charts/onyx
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for unauthenticated SMTP relays so Onyx can send email via internal enterprise mail relays. Skips TLS and login when not needed and treats email as configured with just an SMTP server.

- **Bug Fixes**
  - Skip STARTTLS when SMTP_PORT is 25.
  - Skip login when SMTP_USER or SMTP_PASS is not set.
  - Set EMAIL_CONFIGURED to true if SMTP_SERVER or SENDGRID_API_KEY is present.

<sup>Written for commit 234b8ec32331a27f01eed6be4e55da1d7cfb5bdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

