### PR TITLE
feat: Improve code-int error display

### DIFF
--- a/backend/onyx/server/manage/code_interpreter/api.py
+++ b/backend/onyx/server/manage/code_interpreter/api.py
@@ -23,9 +23,13 @@ def get_code_interpreter_health(
 ) -> CodeInterpreterServerHealth:
     try:
         client = CodeInterpreterClient()
-        return CodeInterpreterServerHealth(healthy=client.health().healthy)
-    except ValueError:
-        return CodeInterpreterServerHealth(healthy=False)
+        result = client.health()
+        return CodeInterpreterServerHealth(
+            connected=result.connected,
+            error=result.error,
+        )
+    except ValueError as e:
+        return CodeInterpreterServerHealth(connected=False, error=str(e))
 
 
 @admin_router.get("")

--- a/backend/onyx/server/manage/code_interpreter/models.py
+++ b/backend/onyx/server/manage/code_interpreter/models.py
@@ -6,4 +6,5 @@ class CodeInterpreterServer(BaseModel):
 
 
 class CodeInterpreterServerHealth(BaseModel):
-    healthy: bool
+    connected: bool
+    error: str = ""

--- a/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
+++ b/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
@@ -112,10 +112,21 @@ def _min_version_for(method: Callable[..., object]) -> str:
 
 
 class HealthResponse(BaseModel):
-    """Result of a Code Interpreter health check"""
+    """Result of a Code Interpreter health check.
 
-    healthy: bool
+    ``connected`` reflects whether the service was reachable at all; a
+    reachable-but-erroring service is ``connected=True`` with a non-empty
+    ``error``. ``error`` is empty when the service is healthy.
+    """
+
+    connected: bool
+    error: str = ""
     version: str = _DEFAULT_SERVER_VERSION
+
+    @property
+    def healthy(self) -> bool:
+        """True only when the service is reachable and reporting no error."""
+        return self.connected and not self.error
 
 
 class FileInput(TypedDict):
@@ -237,10 +248,16 @@ class CodeInterpreterClient:
     def health(self, use_cache: bool = False) -> HealthResponse:
         """Check if the Code Interpreter service is healthy
 
-        Returns a ``HealthResponse`` containing both the health status and the
-        server version (defaults to ``"0.0.0"`` when the server is unhealthy
-        or the response does not include a version field — e.g. older
-        code-interpreter releases that pre-date version reporting).
+        Returns a ``HealthResponse`` describing connectivity, any error
+        message, and the server version (defaults to ``"0.0.0"`` when the
+        response omits a version field — e.g. older code-interpreter releases
+        that pre-date version reporting).
+
+        An HTTP error status (4xx/5xx) means the service was reachable but
+        unhealthy, so it is reported as ``connected=True`` with an ``error``.
+        A network-level failure is reported as ``connected=False``. Error
+        strings are sanitized so raw exception text (which may embed the
+        request URL) is never surfaced to callers.
 
         Args:
             use_cache: When True, return a cached result if available and
@@ -261,10 +278,28 @@ class CodeInterpreterClient:
             body = response.json()
             healthy = body.get("status") == "ok"
             version = body.get("version") or _DEFAULT_SERVER_VERSION
-            result = HealthResponse(healthy=healthy, version=version)
+            result = HealthResponse(
+                connected=True,
+                error="" if healthy else (body.get("message") or "Unknown error"),
+                version=version,
+            )
+        except requests.HTTPError as e:
+            status_code = (
+                e.response.status_code if e.response is not None else "unknown"
+            )
+            logger.warning(
+                "Code Interpreter health check returned HTTP %s", status_code
+            )
+            result = HealthResponse(
+                connected=True,
+                error=f"Code Interpreter service returned HTTP {status_code}",
+            )
         except Exception as e:
             logger.warning("Exception caught when checking health, e=%s", e)
-            result = HealthResponse(healthy=False, version=_DEFAULT_SERVER_VERSION)
+            result = HealthResponse(
+                connected=False,
+                error="Unable to reach the Code Interpreter service",
+            )
 
         _health_cache[self.base_url] = (time.monotonic(), result)
         return result

--- a/backend/tests/integration/tests/code_interpreter/test_code_interpreter_api.py
+++ b/backend/tests/integration/tests/code_interpreter/test_code_interpreter_api.py
@@ -9,15 +9,17 @@ CODE_INTERPRETER_HEALTH_URL = f"{CODE_INTERPRETER_URL}/health"
 def test_get_code_interpreter_health_as_admin(
     admin_user: DATestUser,
 ) -> None:
-    """Health endpoint should return a JSON object with a 'healthy' boolean."""
+    """Health endpoint should return a JSON object with 'connected' and 'error'."""
     response = client.get(
         CODE_INTERPRETER_HEALTH_URL,
         headers=admin_user.headers,
     )
     assert response.status_code == 200
     data = response.json()
-    assert "healthy" in data
-    assert isinstance(data["healthy"], bool)
+    assert "connected" in data
+    assert isinstance(data["connected"], bool)
+    assert "error" in data
+    assert isinstance(data["error"], str)
 
 
 def test_get_code_interpreter_status_as_admin(

--- a/backend/tests/unit/onyx/tools/test_python_tool_availability.py
+++ b/backend/tests/unit/onyx/tools/test_python_tool_availability.py
@@ -90,7 +90,7 @@ def test_python_tool_available_when_health_check_passes(
     )
 
     mock_client = MagicMock()
-    mock_client.health.return_value = HealthResponse(healthy=True, version="1.0.0")
+    mock_client.health.return_value = HealthResponse(connected=True, version="1.0.0")
     mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
     mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -117,7 +117,7 @@ def test_python_tool_unavailable_when_health_check_fails(
     )
 
     mock_client = MagicMock()
-    mock_client.health.return_value = HealthResponse(healthy=False)
+    mock_client.health.return_value = HealthResponse(connected=False)
     mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
     mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 

--- a/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
@@ -426,7 +426,7 @@ def _is_available_env(
 
         mock_client = MagicMock()
         mock_client.health.return_value = HealthResponse(
-            healthy=healthy, version=server_version
+            connected=healthy, version=server_version
         )
         mock_client.supports.return_value = supports_return
 

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+import requests
 
 from onyx.tools.tool_implementations.python import code_interpreter_client as cic
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
@@ -45,7 +46,7 @@ def _prime_health(base_url: str, version: str) -> None:
     the network."""
     cic._health_cache[base_url] = (
         time.monotonic(),
-        HealthResponse(healthy=True, version=version),
+        HealthResponse(connected=True, version=version),
     )
 
 
@@ -621,3 +622,72 @@ def test_min_version_for_decorated_method_returns_declared_value() -> None:
     assert cic._min_version_for(client.create_session) == "0.4.0"
     assert cic._min_version_for(client.delete_session) == "0.4.0"
     assert cic._min_version_for(client.execute_bash_in_session) == "0.4.0"
+
+
+def _make_health_response(status: str = "ok", version: str = "1.2.3") -> MagicMock:
+    """Build a mock ``requests.Response`` for the /health endpoint."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"status": status, "version": version}
+    return resp
+
+
+def test_health_ok_reports_connected() -> None:
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+
+    with patch.object(client.session, "get", return_value=_make_health_response()):
+        result = client.health()
+
+    assert result.connected is True
+    assert result.error == ""
+    assert result.version == "1.2.3"
+
+
+def test_health_non_ok_status_reports_connected_with_error() -> None:
+    """A reachable service reporting a non-ok status is connected but unhealthy."""
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+    resp = _make_health_response(status="error")
+    resp.json.return_value = {"status": "error", "message": "sandbox crashed"}
+
+    with patch.object(client.session, "get", return_value=resp):
+        result = client.health()
+
+    assert result.connected is True
+    assert result.error == "sandbox crashed"
+
+
+def test_health_http_error_reports_connected() -> None:
+    """4xx/5xx means the service was reachable, so ``connected`` stays True and
+    the raw exception text (which may embed the request URL) is not surfaced."""
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+
+    resp = MagicMock()
+    error_response = MagicMock()
+    error_response.status_code = 503
+    http_error = requests.HTTPError("503 Server Error for url: http://fake:9000/health")
+    http_error.response = error_response
+    resp.raise_for_status.side_effect = http_error
+
+    with patch.object(client.session, "get", return_value=resp):
+        result = client.health()
+
+    assert result.connected is True
+    assert "503" in result.error
+    assert client.base_url not in result.error
+
+
+def test_health_network_error_reports_not_connected() -> None:
+    """A network-level failure is reported as disconnected with a sanitized error."""
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+
+    with patch.object(
+        client.session,
+        "get",
+        side_effect=requests.ConnectionError("failed to connect to http://fake:9000"),
+    ):
+        result = client.health()
+
+    assert result.connected is False
+    assert result.error == "Unable to reach the Code Interpreter service"
+    assert client.base_url not in result.error

--- a/web/src/hooks/useCodeInterpreter.ts
+++ b/web/src/hooks/useCodeInterpreter.ts
@@ -4,8 +4,14 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 const HEALTH_ENDPOINT = "/api/admin/code-interpreter/health";
 const STATUS_ENDPOINT = "/api/admin/code-interpreter";
 
+export type CodeInterpreterHealthStatus =
+  | "healthy"
+  | "unhealthy"
+  | "connection_lost";
+
 interface CodeInterpreterHealth {
-  healthy: boolean;
+  connected: boolean;
+  error: string;
 }
 
 interface CodeInterpreterStatus {
@@ -15,7 +21,7 @@ interface CodeInterpreterStatus {
 export default function useCodeInterpreter() {
   const {
     data: healthData,
-    error: healthError,
+    error: healthFetchError,
     isLoading: isHealthLoading,
     mutate: refetchHealth,
   } = useSWR<CodeInterpreterHealth>(HEALTH_ENDPOINT, errorHandlingFetcher, {
@@ -34,11 +40,22 @@ export default function useCodeInterpreter() {
     refetchStatus();
   }
 
+  const status: CodeInterpreterHealthStatus = healthFetchError
+    ? "connection_lost"
+    : !healthData?.connected
+      ? "connection_lost"
+      : healthData.error
+        ? "unhealthy"
+        : "healthy";
+
+  const error = healthFetchError?.message || healthData?.error || undefined;
+
   return {
-    isHealthy: healthData?.healthy ?? false,
+    status: isHealthLoading || isStatusLoading ? undefined : status,
+    error,
     isEnabled: statusData?.enabled ?? false,
     isLoading: isHealthLoading || isStatusLoading,
-    error: healthError || statusError,
+    fetchError: healthFetchError || statusError,
     refetch,
   };
 }

--- a/web/src/views/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/views/admin/CodeInterpreterPage/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SettingsLayouts } from "@opal/layouts";
 import {
   SvgArrowExchange,
@@ -18,12 +18,35 @@ import { Card, Content, ContentAction } from "@opal/layouts";
 import { Disabled, Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
-import useCodeInterpreter from "@/hooks/useCodeInterpreter";
+import useCodeInterpreter, {
+  type CodeInterpreterHealthStatus,
+} from "@/hooks/useCodeInterpreter";
 import { updateCodeInterpreter } from "@/views/admin/CodeInterpreterPage/svc";
 import { toast } from "@/hooks/useToast";
 import { cn } from "@opal/utils";
 
 const route = ADMIN_ROUTES.CODE_INTERPRETER;
+
+const STATUS_CONFIG: Record<
+  CodeInterpreterHealthStatus,
+  { label: string; icon: typeof SvgCheckCircle; iconColor: string }
+> = {
+  healthy: {
+    label: "Connected",
+    icon: SvgCheckCircle,
+    iconColor: "text-status-success-05!",
+  },
+  unhealthy: {
+    label: "Unhealthy",
+    icon: SvgXOctagon,
+    iconColor: "text-status-error-05!",
+  },
+  connection_lost: {
+    label: "Connection Lost",
+    icon: SvgXOctagon,
+    iconColor: "text-status-error-05!",
+  },
+};
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -47,34 +70,42 @@ function CheckingStatus() {
 }
 
 interface ConnectionStatusProps {
-  healthy: boolean;
+  status: CodeInterpreterHealthStatus | undefined;
   isLoading: boolean;
+  onIconHover: (hovered: boolean) => void;
 }
 
-function ConnectionStatus({ healthy, isLoading }: ConnectionStatusProps) {
-  if (isLoading) {
+function ConnectionStatus({
+  status,
+  isLoading,
+  onIconHover,
+}: ConnectionStatusProps) {
+  if (isLoading || !status) {
     return <CheckingStatus />;
   }
 
-  const label = healthy ? "Connected" : "Connection Lost";
-  const Icon = healthy ? SvgCheckCircle : SvgXOctagon;
-  const iconColor = healthy
-    ? "text-status-success-05!"
-    : "text-status-error-05!";
+  const { label, icon: Icon, iconColor } = STATUS_CONFIG[status];
+  const hasError = status !== "healthy";
 
   return (
-    <div className="p-2">
-      <Content
-        title={label}
-        icon={(props) => (
-          <Icon {...props} className={cn(props.className, iconColor)} />
-        )}
-        sizePreset="main-ui"
-        variant="body"
-        orientation="reverse"
-        color="muted"
-      />
-    </div>
+    <Section
+      flexDirection="row"
+      justifyContent="end"
+      alignItems="center"
+      gap={0.25}
+      padding={0.5}
+    >
+      <Text mainUiAction text03>
+        {label}
+      </Text>
+      <div
+        onMouseEnter={() => hasError && onIconHover(true)}
+        onMouseLeave={() => onIconHover(false)}
+        className={cn(hasError && "cursor-pointer")}
+      >
+        <Icon size={16} className={iconColor} />
+      </div>
+    </Section>
   );
 }
 
@@ -83,9 +114,27 @@ function ConnectionStatus({ healthy, isLoading }: ConnectionStatusProps) {
 // ---------------------------------------------------------------------------
 
 export default function CodeInterpreterPage() {
-  const { isHealthy, isEnabled, isLoading, refetch } = useCodeInterpreter();
+  const { status, error, isEnabled, isLoading, refetch } = useCodeInterpreter();
+  const isHealthy = status === "healthy";
   const [showDisconnectModal, setShowDisconnectModal] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [showErrorMenu, setShowErrorMenu] = useState(false);
+  const fadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function handleErrorHover(hovered: boolean) {
+    if (fadeTimeoutRef.current) {
+      clearTimeout(fadeTimeoutRef.current);
+      fadeTimeoutRef.current = null;
+    }
+    if (hovered) {
+      setShowErrorMenu(true);
+    } else {
+      fadeTimeoutRef.current = setTimeout(() => {
+        setShowErrorMenu(false);
+        fadeTimeoutRef.current = null;
+      }, 1000);
+    }
+  }
 
   async function handleToggle(enabled: boolean) {
     const action = enabled ? "reconnect" : "disconnect";
@@ -102,6 +151,14 @@ export default function CodeInterpreterPage() {
       setIsReconnecting(false);
     }
   }
+
+  useEffect(() => {
+    return () => {
+      if (fadeTimeoutRef.current) {
+        clearTimeout(fadeTimeoutRef.current);
+      }
+    };
+  }, []);
 
   return (
     <SettingsLayouts.Root>
@@ -130,8 +187,9 @@ export default function CodeInterpreterPage() {
                   rightChildren={
                     <Section alignItems="end" gap={0}>
                       <ConnectionStatus
-                        healthy={isHealthy}
+                        status={status}
                         isLoading={isLoading}
+                        onIconHover={handleErrorHover}
                       />
                       <div className="px-1 pb-1">
                         <Section
@@ -198,6 +256,35 @@ export default function CodeInterpreterPage() {
               }
             />
           </SelectCard>
+        )}
+        {showErrorMenu && !isHealthy && (
+          <Section
+            flexDirection="row"
+            justifyContent="end"
+            onMouseEnter={() => handleErrorHover(true)}
+            onMouseLeave={() => handleErrorHover(false)}
+          >
+            <div className="w-[15rem]">
+              <SelectCard state="filled" padding="sm" rounding="lg">
+                <Content
+                  icon={(props) => (
+                    <SvgXOctagon
+                      {...props}
+                      className={cn(props.className, "text-status-error-05!")}
+                    />
+                  )}
+                  title={
+                    status === "connection_lost"
+                      ? "Connection Lost Error"
+                      : "Code Interpreter Error"
+                  }
+                  description={error}
+                  variant="section"
+                  sizePreset="main-ui"
+                />
+              </SelectCard>
+            </div>
+          </Section>
         )}
       </SettingsLayouts.Body>
 

--- a/web/tests/e2e/admin/code-interpreter/code_interpreter.spec.ts
+++ b/web/tests/e2e/admin/code-interpreter/code_interpreter.spec.ts
@@ -19,7 +19,12 @@ const API_HEALTH_URL = "**/api/admin/code-interpreter/health";
  */
 async function mockCodeInterpreterApi(
   page: Page,
-  opts: { enabled: boolean; healthy: boolean; putStatus?: number }
+  opts: {
+    enabled: boolean;
+    connected: boolean;
+    error?: string;
+    putStatus?: number;
+  }
 ) {
   const putStatus = opts.putStatus ?? 200;
 
@@ -27,7 +32,10 @@ async function mockCodeInterpreterApi(
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ healthy: opts.healthy }),
+      body: JSON.stringify({
+        connected: opts.connected,
+        error: opts.error ?? "",
+      }),
     });
   });
 
@@ -77,7 +85,7 @@ test.describe("Code Interpreter Admin Page", () => {
   });
 
   test("page loads with header and description", async ({ page }) => {
-    await mockCodeInterpreterApi(page, { enabled: true, healthy: true });
+    await mockCodeInterpreterApi(page, { enabled: true, connected: true });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.locator('[aria-label="admin-page-title"]')).toHaveText(
@@ -89,14 +97,14 @@ test.describe("Code Interpreter Admin Page", () => {
   });
 
   test("shows Connected status when enabled and healthy", async ({ page }) => {
-    await mockCodeInterpreterApi(page, { enabled: true, healthy: true });
+    await mockCodeInterpreterApi(page, { enabled: true, connected: true });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByText("Connected")).toBeVisible({ timeout: 10000 });
   });
 
   test("shows Connection Lost when enabled but unhealthy", async ({ page }) => {
-    await mockCodeInterpreterApi(page, { enabled: true, healthy: false });
+    await mockCodeInterpreterApi(page, { enabled: true, connected: false });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByText("Connection Lost")).toBeVisible({
@@ -105,7 +113,7 @@ test.describe("Code Interpreter Admin Page", () => {
   });
 
   test("shows Reconnect button when disabled", async ({ page }) => {
-    await mockCodeInterpreterApi(page, { enabled: false, healthy: false });
+    await mockCodeInterpreterApi(page, { enabled: false, connected: false });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByRole("button", { name: "Reconnect" })).toBeVisible({
@@ -117,7 +125,7 @@ test.describe("Code Interpreter Admin Page", () => {
   test("disconnect flow opens modal and sends PUT request", async ({
     page,
   }) => {
-    await mockCodeInterpreterApi(page, { enabled: true, healthy: true });
+    await mockCodeInterpreterApi(page, { enabled: true, connected: true });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByText("Connected")).toBeVisible({ timeout: 10000 });
@@ -144,7 +152,7 @@ test.describe("Code Interpreter Admin Page", () => {
   test("disconnect modal can be closed without disconnecting", async ({
     page,
   }) => {
-    await mockCodeInterpreterApi(page, { enabled: true, healthy: true });
+    await mockCodeInterpreterApi(page, { enabled: true, connected: true });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByText("Connected")).toBeVisible({ timeout: 10000 });
@@ -165,7 +173,7 @@ test.describe("Code Interpreter Admin Page", () => {
   });
 
   test("reconnect flow sends PUT with enabled=true", async ({ page }) => {
-    await mockCodeInterpreterApi(page, { enabled: false, healthy: false });
+    await mockCodeInterpreterApi(page, { enabled: false, connected: false });
     await page.goto(CODE_INTERPRETER_URL);
 
     await expect(page.getByRole("button", { name: "Reconnect" })).toBeVisible({
@@ -191,7 +199,7 @@ test.describe("Code Interpreter Admin Page", () => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({ healthy: false }),
+        body: JSON.stringify({ connected: false, error: "" }),
       });
     });
 
@@ -227,7 +235,7 @@ test.describe("Code Interpreter Admin Page", () => {
   test("shows error toast when disconnect fails", async ({ page }) => {
     await mockCodeInterpreterApi(page, {
       enabled: true,
-      healthy: true,
+      connected: true,
       putStatus: 500,
     });
     await page.goto(CODE_INTERPRETER_URL);
@@ -248,7 +256,7 @@ test.describe("Code Interpreter Admin Page", () => {
   test("shows error toast when reconnect fails", async ({ page }) => {
     await mockCodeInterpreterApi(page, {
       enabled: false,
-      healthy: false,
+      connected: false,
       putStatus: 500,
     });
     await page.goto(CODE_INTERPRETER_URL);
@@ -268,5 +276,90 @@ test.describe("Code Interpreter Admin Page", () => {
     await expect(page.getByRole("button", { name: "Reconnect" })).toBeVisible({
       timeout: 5000,
     });
+  });
+
+  test("shows error popover on hover over unhealthy status icon", async ({
+    page,
+  }) => {
+    const errorMessage = "Sandbox runtime crashed unexpectedly";
+    await mockCodeInterpreterApi(page, {
+      enabled: true,
+      connected: true,
+      error: errorMessage,
+    });
+    await page.goto(CODE_INTERPRETER_URL);
+
+    // Wait for the Unhealthy status to render
+    const statusText = page.getByText("Unhealthy");
+    await expect(statusText).toBeVisible({ timeout: 10000 });
+
+    // Error popover should not be visible initially
+    await expect(page.getByText("Code Interpreter Error")).not.toBeVisible();
+
+    // Hover over the status icon — sibling of the status label
+    const statusIcon = statusText.locator("..").locator(".cursor-pointer");
+    await statusIcon.hover();
+
+    // Error popover should appear with the title and error description
+    await expect(page.getByText("Code Interpreter Error")).toBeVisible({
+      timeout: 3000,
+    });
+    await expect(page.getByText(errorMessage)).toBeVisible();
+
+    // Move mouse away — error popover should disappear
+    await page.mouse.move(0, 0);
+    await expect(page.getByText("Code Interpreter Error")).not.toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test("shows error popover on hover over connection lost status icon", async ({
+    page,
+  }) => {
+    const errorMessage = "Failed to reach code interpreter service";
+    await mockCodeInterpreterApi(page, {
+      enabled: true,
+      connected: false,
+      error: errorMessage,
+    });
+    await page.goto(CODE_INTERPRETER_URL);
+
+    // Wait for the Connection Lost status to render
+    const statusText = page.getByText("Connection Lost");
+    await expect(statusText).toBeVisible({ timeout: 10000 });
+
+    // Hover over the status icon — sibling of the status label
+    const statusIcon = statusText.locator("..").locator(".cursor-pointer");
+    await statusIcon.hover();
+
+    // Error popover should show the connection lost title and error
+    await expect(page.getByText("Connection Lost Error")).toBeVisible({
+      timeout: 3000,
+    });
+    await expect(page.getByText(errorMessage)).toBeVisible();
+
+    // Move mouse away — error popover should disappear
+    await page.mouse.move(0, 0);
+    await expect(page.getByText("Connection Lost Error")).not.toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test("does not show error popover on hover when healthy", async ({
+    page,
+  }) => {
+    await mockCodeInterpreterApi(page, {
+      enabled: true,
+      connected: true,
+    });
+    await page.goto(CODE_INTERPRETER_URL);
+
+    const statusText = page.getByText("Connected");
+    await expect(statusText).toBeVisible({ timeout: 10000 });
+
+    // The status icon wrapper should not have cursor-pointer when healthy
+    await expect(
+      statusText.locator("..").locator(".cursor-pointer")
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Description
Currently there is no display of the errors. We want to make the errors display inline with mocks.

Mock: https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=2954-27049&m=dev

Note: Only shows on hover of the icon
<img width="1916" height="986" alt="Screenshot 2026-03-02 at 11 09 01 AM" src="https://github.com/user-attachments/assets/568e5287-96c9-458c-995f-83379151f9d3" />

<img width="1908" height="976" alt="Screenshot 2026-03-02 at 11 10 12 AM" src="https://github.com/user-attachments/assets/bd81e939-7631-469e-a99c-ec579ced463b" />


## How Has This Been Tested?
Visual / Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Code Interpreter health errors inline on the Admin page with a tri-state status (Connected, Unhealthy, Connection Lost) and a hover error popover that auto-fades.

- **New Features**
  - Backend/API: Switch from `healthy: boolean` to `{ connected: boolean, error: string }`. `health()` reports HTTP 4xx/5xx as connected with a sanitized error, and network failures as not connected.
  - Frontend: `useCodeInterpreter` exposes `status` (`healthy` | `unhealthy` | `connection_lost`, `undefined` while loading), `error`, `fetchError`, `isEnabled`, `isLoading`, `refetch`. Admin status icon is interactive only when not healthy; popover shows state-based titles and cleans up the fade timer on unmount.
  - Tests: Integration and unit tests updated for the new schema and health classification; e2e covers the hover popover’s show/hide behavior.

<sup>Written for commit 7da6a16b5c4d309d59c9dbcab35b767e515b2cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/8916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

