### PR TITLE
feat(teams): add Microsoft Teams bot integration

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_teams_bot_tables.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_teams_bot_tables.py
@@ -36,6 +36,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("id = 'SINGLETON'", name="ck_teams_bot_config_singleton"),
     )
 
     op.create_table(

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_teams_bot_tables.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_teams_bot_tables.py
@@ -1,0 +1,104 @@
+"""add teams bot tables
+
+Revision ID: a1b2c3d4e5f6
+Revises: 6b3b4083c5aa
+Create Date: 2026-03-02 12:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "6b3b4083c5aa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "teams_bot_config",
+        sa.Column(
+            "id",
+            sa.String(),
+            server_default=sa.text("'SINGLETON'"),
+            nullable=False,
+        ),
+        sa.Column("app_id", sa.String(), nullable=False),
+        sa.Column("app_secret", sa.LargeBinary(), nullable=False),
+        sa.Column("azure_tenant_id", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "teams_team_config",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("team_id", sa.String(), nullable=True),
+        sa.Column("team_name", sa.String(length=256), nullable=True),
+        sa.Column("registration_key", sa.String(), nullable=False),
+        sa.Column("registered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("default_persona_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["default_persona_id"],
+            ["persona.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("team_id"),
+        sa.UniqueConstraint("registration_key"),
+    )
+
+    op.create_table(
+        "teams_channel_config",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("team_config_id", sa.Integer(), nullable=False),
+        sa.Column("channel_id", sa.String(), nullable=False),
+        sa.Column("channel_name", sa.String(), nullable=False),
+        sa.Column(
+            "require_bot_mention",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column("persona_override_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_config_id"],
+            ["teams_team_config.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["persona_override_id"],
+            ["persona.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "team_config_id", "channel_id", name="uq_teams_channel_team_channel"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("teams_channel_config")
+    op.drop_table("teams_team_config")
+    op.drop_table("teams_bot_config")

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1123,6 +1123,13 @@ DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN")
 DISCORD_BOT_INVOKE_CHAR = os.environ.get("DISCORD_BOT_INVOKE_CHAR", "!")
 
 
+## Teams Bot Configuration
+TEAMS_BOT_APP_ID = os.environ.get("TEAMS_BOT_APP_ID")
+TEAMS_BOT_APP_SECRET = os.environ.get("TEAMS_BOT_APP_SECRET")
+TEAMS_BOT_AZURE_TENANT_ID = os.environ.get("TEAMS_BOT_AZURE_TENANT_ID")
+TEAMS_BOT_PORT = int(os.environ.get("TEAMS_BOT_PORT", "3978"))
+
+
 ## Stripe Configuration
 # URL to fetch the Stripe publishable key from a public S3 bucket.
 # Publishable keys are safe to expose publicly - they can only initialize

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1127,7 +1127,7 @@ DISCORD_BOT_INVOKE_CHAR = os.environ.get("DISCORD_BOT_INVOKE_CHAR", "!")
 TEAMS_BOT_APP_ID = os.environ.get("TEAMS_BOT_APP_ID")
 TEAMS_BOT_APP_SECRET = os.environ.get("TEAMS_BOT_APP_SECRET")
 TEAMS_BOT_AZURE_TENANT_ID = os.environ.get("TEAMS_BOT_AZURE_TENANT_ID")
-TEAMS_BOT_PORT = int(os.environ.get("TEAMS_BOT_PORT", "3978"))
+TEAMS_BOT_PORT = int(os.environ.get("TEAMS_BOT_PORT") or "3978")
 
 
 ## Stripe Configuration

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -99,6 +99,7 @@ DANSWER_API_KEY_PREFIX = "API_KEY__"
 DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN = "onyxapikey.ai"
 UNNAMED_KEY_PLACEHOLDER = "Unnamed"
 DISCORD_SERVICE_API_KEY_NAME = "discord-bot-service"
+TEAMS_SERVICE_API_KEY_NAME = "teams-bot-service"
 
 # Key-Value store keys
 KV_REINDEX_KEY = "needs_reindexing"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3668,6 +3668,112 @@ class DiscordChannelConfig(Base):
     )
 
 
+class TeamsBotConfig(Base):
+    """Global Teams bot configuration (one per tenant).
+
+    Stores the Azure Bot Service credentials when not provided via env vars.
+    Uses a fixed ID with check constraint to enforce only one row per tenant.
+    """
+
+    __tablename__ = "teams_bot_config"
+
+    id: Mapped[str] = mapped_column(
+        String, primary_key=True, server_default=text("'SINGLETON'")
+    )
+    app_id: Mapped[str] = mapped_column(String, nullable=False)
+    app_secret: Mapped[SensitiveValue[str] | None] = mapped_column(
+        EncryptedString(), nullable=False
+    )
+    azure_tenant_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class TeamsTeamConfig(Base):
+    """Configuration for a Teams team connected to this tenant.
+
+    registration_key is a one-time key used to link a Teams team to this tenant.
+    Format: teams_<tenant_id>.<random_token>
+    team_id is NULL until the Teams admin runs @bot register with the key.
+    """
+
+    __tablename__ = "teams_team_config"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # Teams team ID (GUID string) - NULL until registered via command in Teams
+    team_id: Mapped[str | None] = mapped_column(String, nullable=True, unique=True)
+    team_name: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    # One-time registration key: teams_<tenant_id>.<random_token>
+    registration_key: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+
+    registered_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Configuration
+    default_persona_id: Mapped[int | None] = mapped_column(
+        ForeignKey("persona.id", ondelete="SET NULL"), nullable=True
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, server_default=text("true"), nullable=False
+    )
+
+    # Relationships
+    default_persona: Mapped["Persona | None"] = relationship(
+        "Persona", foreign_keys=[default_persona_id]
+    )
+    channels: Mapped[list["TeamsChannelConfig"]] = relationship(
+        back_populates="team_config", cascade="all, delete-orphan"
+    )
+
+
+class TeamsChannelConfig(Base):
+    """Per-channel configuration for Teams bot behavior.
+
+    Used to whitelist specific channels and configure per-channel behavior.
+    """
+
+    __tablename__ = "teams_channel_config"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    team_config_id: Mapped[int] = mapped_column(
+        ForeignKey("teams_team_config.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # Teams channel ID (string)
+    channel_id: Mapped[str] = mapped_column(String, nullable=False)
+    channel_name: Mapped[str] = mapped_column(String(), nullable=False)
+
+    # If true (default), bot only responds when @mentioned
+    # If false, bot responds to ALL messages in this channel
+    require_bot_mention: Mapped[bool] = mapped_column(
+        Boolean, server_default=text("true"), nullable=False
+    )
+
+    # Override the team's default persona for this channel
+    persona_override_id: Mapped[int | None] = mapped_column(
+        ForeignKey("persona.id", ondelete="SET NULL"), nullable=True
+    )
+
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, server_default=text("false"), nullable=False
+    )
+
+    # Relationships
+    team_config: Mapped["TeamsTeamConfig"] = relationship(back_populates="channels")
+    persona_override: Mapped["Persona | None"] = relationship()
+
+    # Constraints
+    __table_args__ = (
+        UniqueConstraint(
+            "team_config_id", "channel_id", name="uq_teams_channel_team_channel"
+        ),
+    )
+
+
 class Milestone(Base):
     # This table is used to track significant events for a deployment towards finding value
     # The table is currently not used for features but it may be used in the future to inform

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -20,6 +20,7 @@ from fastapi_users_db_sqlalchemy import SQLAlchemyBaseUserTableUUID
 from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyBaseAccessTokenTableUUID
 from fastapi_users_db_sqlalchemy.generics import TIMESTAMPAware
 from sqlalchemy import Boolean
+from sqlalchemy import CheckConstraint
 from sqlalchemy import DateTime
 from sqlalchemy import desc
 from sqlalchemy import Enum
@@ -3676,6 +3677,9 @@ class TeamsBotConfig(Base):
     """
 
     __tablename__ = "teams_bot_config"
+    __table_args__ = (
+        CheckConstraint("id = 'SINGLETON'", name="ck_teams_bot_config_singleton"),
+    )
 
     id: Mapped[str] = mapped_column(
         String, primary_key=True, server_default=text("'SINGLETON'")

--- a/backend/onyx/db/teams_bot.py
+++ b/backend/onyx/db/teams_bot.py
@@ -1,0 +1,324 @@
+"""CRUD operations for Teams bot models."""
+
+from datetime import datetime
+from datetime import timezone
+
+from sqlalchemy import delete
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import Session
+
+from onyx.auth.api_key import build_displayable_api_key
+from onyx.auth.api_key import generate_api_key
+from onyx.auth.api_key import hash_api_key
+from onyx.auth.schemas import UserRole
+from onyx.configs.constants import TEAMS_SERVICE_API_KEY_NAME
+from onyx.db.api_key import insert_api_key
+from onyx.db.models import ApiKey
+from onyx.db.models import TeamsBotConfig
+from onyx.db.models import TeamsChannelConfig
+from onyx.db.models import TeamsTeamConfig
+from onyx.db.models import User
+from onyx.server.api_key.models import APIKeyArgs
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# === TeamsBotConfig ===
+
+
+def get_teams_bot_config(db_session: Session) -> TeamsBotConfig | None:
+    """Get the Teams bot config for this tenant (at most one)."""
+    return db_session.scalar(select(TeamsBotConfig).limit(1))
+
+
+def create_teams_bot_config(
+    db_session: Session,
+    app_id: str,
+    app_secret: str,
+    azure_tenant_id: str | None = None,
+) -> TeamsBotConfig:
+    """Create the Teams bot config. Raises ValueError if already exists.
+
+    The check constraint on id='SINGLETON' ensures only one config per tenant.
+    """
+    existing = get_teams_bot_config(db_session)
+    if existing:
+        raise ValueError("Teams bot config already exists")
+
+    config = TeamsBotConfig(
+        app_id=app_id,
+        app_secret=app_secret,
+        azure_tenant_id=azure_tenant_id,
+    )
+    db_session.add(config)
+    try:
+        db_session.flush()
+    except IntegrityError:
+        db_session.rollback()
+        raise ValueError("Teams bot config already exists")
+    return config
+
+
+def delete_teams_bot_config(db_session: Session) -> bool:
+    """Delete the Teams bot config. Returns True if deleted."""
+    result = db_session.execute(delete(TeamsBotConfig))
+    db_session.flush()
+    return result.rowcount > 0  # type: ignore[attr-defined]
+
+
+# === Teams Service API Key ===
+
+
+def get_teams_service_api_key(db_session: Session) -> ApiKey | None:
+    """Get the Teams service API key if it exists."""
+    return db_session.scalar(
+        select(ApiKey).where(ApiKey.name == TEAMS_SERVICE_API_KEY_NAME)
+    )
+
+
+def get_or_create_teams_service_api_key(
+    db_session: Session,
+    tenant_id: str,
+) -> str:
+    """Get existing Teams service API key or create one.
+
+    The API key is used by the Teams bot to authenticate with the
+    Onyx API pods when sending chat requests.
+
+    Returns:
+        The raw API key string (not hashed).
+    """
+    existing = get_teams_service_api_key(db_session)
+    if existing:
+        # Database only stores the hash, so we must regenerate to get the raw key.
+        logger.debug(
+            f"Found existing Teams service API key for tenant {tenant_id} that isn't in cache, "
+            "regenerating to update cache"
+        )
+        new_api_key = generate_api_key(tenant_id)
+        existing.hashed_api_key = hash_api_key(new_api_key)
+        existing.api_key_display = build_displayable_api_key(new_api_key)
+        db_session.flush()
+        return new_api_key
+
+    logger.info(f"Creating Teams service API key for tenant {tenant_id}")
+    api_key_args = APIKeyArgs(
+        name=TEAMS_SERVICE_API_KEY_NAME,
+        role=UserRole.LIMITED,
+    )
+    api_key_descriptor = insert_api_key(
+        db_session=db_session,
+        api_key_args=api_key_args,
+        user_id=None,
+    )
+
+    if not api_key_descriptor.api_key:
+        raise RuntimeError(
+            f"Failed to create Teams service API key for tenant {tenant_id}"
+        )
+
+    return api_key_descriptor.api_key
+
+
+def delete_teams_service_api_key(db_session: Session) -> bool:
+    """Delete the Teams service API key for a tenant.
+
+    Called when:
+    - Bot config is deleted (self-hosted)
+    - All team configs are deleted (Cloud)
+    """
+    existing_key = get_teams_service_api_key(db_session)
+    if not existing_key:
+        return False
+
+    api_key_user = db_session.scalar(
+        select(User).where(User.id == existing_key.user_id)  # type: ignore[arg-type]
+    )
+
+    db_session.delete(existing_key)
+    if api_key_user:
+        db_session.delete(api_key_user)
+
+    db_session.flush()
+    logger.info("Deleted Teams service API key")
+    return True
+
+
+# === TeamsTeamConfig ===
+
+
+def get_team_configs(
+    db_session: Session,
+    include_channels: bool = False,
+) -> list[TeamsTeamConfig]:
+    """Get all team configs for this tenant."""
+    stmt = select(TeamsTeamConfig)
+    if include_channels:
+        stmt = stmt.options(joinedload(TeamsTeamConfig.channels))
+    return list(db_session.scalars(stmt).unique().all())
+
+
+def get_team_config_by_internal_id(
+    db_session: Session,
+    internal_id: int,
+) -> TeamsTeamConfig | None:
+    """Get a specific team config by its ID."""
+    return db_session.scalar(
+        select(TeamsTeamConfig).where(TeamsTeamConfig.id == internal_id)
+    )
+
+
+def get_team_config_by_teams_id(
+    db_session: Session,
+    team_id: str,
+) -> TeamsTeamConfig | None:
+    """Get a team config by Teams team ID."""
+    return db_session.scalar(
+        select(TeamsTeamConfig).where(TeamsTeamConfig.team_id == team_id)
+    )
+
+
+def get_team_config_by_registration_key(
+    db_session: Session,
+    registration_key: str,
+) -> TeamsTeamConfig | None:
+    """Get a team config by its registration key."""
+    return db_session.scalar(
+        select(TeamsTeamConfig).where(
+            TeamsTeamConfig.registration_key == registration_key
+        )
+    )
+
+
+def create_team_config(
+    db_session: Session,
+    registration_key: str,
+) -> TeamsTeamConfig:
+    """Create a new team config with a registration key (team_id=NULL)."""
+    config = TeamsTeamConfig(registration_key=registration_key)
+    db_session.add(config)
+    db_session.flush()
+    return config
+
+
+def register_team(
+    db_session: Session,
+    config: TeamsTeamConfig,
+    team_id: str,
+    team_name: str,
+) -> TeamsTeamConfig:
+    """Complete registration by setting team_id and team_name."""
+    config.team_id = team_id
+    config.team_name = team_name
+    config.registered_at = datetime.now(timezone.utc)
+    db_session.flush()
+    return config
+
+
+def update_team_config(
+    db_session: Session,
+    config: TeamsTeamConfig,
+    enabled: bool,
+    default_persona_id: int | None = None,
+) -> TeamsTeamConfig:
+    """Update team config fields."""
+    config.enabled = enabled
+    config.default_persona_id = default_persona_id
+    db_session.flush()
+    return config
+
+
+def delete_team_config(
+    db_session: Session,
+    internal_id: int,
+) -> bool:
+    """Delete team config (cascades to channel configs). Returns True if deleted."""
+    result = db_session.execute(
+        delete(TeamsTeamConfig).where(TeamsTeamConfig.id == internal_id)
+    )
+    db_session.flush()
+    return result.rowcount > 0  # type: ignore[attr-defined]
+
+
+# === TeamsChannelConfig ===
+
+
+def get_channel_configs(
+    db_session: Session,
+    team_config_id: int,
+) -> list[TeamsChannelConfig]:
+    """Get all channel configs for a team."""
+    return list(
+        db_session.scalars(
+            select(TeamsChannelConfig).where(
+                TeamsChannelConfig.team_config_id == team_config_id
+            )
+        ).all()
+    )
+
+
+def get_channel_config_by_teams_ids(
+    db_session: Session,
+    team_id: str,
+    channel_id: str,
+) -> TeamsChannelConfig | None:
+    """Get a specific channel config by team_id and channel_id."""
+    return db_session.scalar(
+        select(TeamsChannelConfig)
+        .join(TeamsTeamConfig)
+        .where(
+            TeamsTeamConfig.team_id == team_id,
+            TeamsChannelConfig.channel_id == channel_id,
+        )
+    )
+
+
+def get_channel_config_by_internal_ids(
+    db_session: Session,
+    team_config_id: int,
+    channel_config_id: int,
+) -> TeamsChannelConfig | None:
+    """Get a specific channel config by team_config_id and channel_config_id."""
+    return db_session.scalar(
+        select(TeamsChannelConfig).where(
+            TeamsChannelConfig.team_config_id == team_config_id,
+            TeamsChannelConfig.id == channel_config_id,
+        )
+    )
+
+
+def update_teams_channel_config(
+    db_session: Session,
+    config: TeamsChannelConfig,
+    channel_name: str,
+    require_bot_mention: bool,
+    enabled: bool,
+    persona_override_id: int | None = None,
+) -> TeamsChannelConfig:
+    """Update channel config fields."""
+    config.channel_name = channel_name
+    config.require_bot_mention = require_bot_mention
+    config.persona_override_id = persona_override_id
+    config.enabled = enabled
+    db_session.flush()
+    return config
+
+
+def create_channel_config(
+    db_session: Session,
+    team_config_id: int,
+    channel_id: str,
+    channel_name: str,
+) -> TeamsChannelConfig:
+    """Create a new channel config with default settings (disabled by default)."""
+    config = TeamsChannelConfig(
+        team_config_id=team_config_id,
+        channel_id=channel_id,
+        channel_name=channel_name,
+    )
+    db_session.add(config)
+    db_session.flush()
+    return config

--- a/backend/onyx/db/teams_bot.py
+++ b/backend/onyx/db/teams_bot.py
@@ -79,24 +79,25 @@ def get_teams_service_api_key(db_session: Session) -> ApiKey | None:
     )
 
 
-def get_or_create_teams_service_api_key(
+def provision_teams_service_api_key(
     db_session: Session,
     tenant_id: str,
 ) -> str:
-    """Get existing Teams service API key or create one.
+    """Create or regenerate the Teams service API key, returning the raw key.
 
-    The API key is used by the Teams bot to authenticate with the
-    Onyx API pods when sending chat requests.
+    The database only stores the hashed key. When the cache is cold
+    (e.g. after a pod restart), the raw key is unrecoverable, so we
+    regenerate a new one and update the stored hash. This is safe because
+    the bot is the sole consumer of this key.
 
-    Returns:
-        The raw API key string (not hashed).
+    This function is **not** idempotent — it mutates the stored hash on
+    every call when a key already exists. Only call it on cache miss.
     """
     existing = get_teams_service_api_key(db_session)
     if existing:
-        # Database only stores the hash, so we must regenerate to get the raw key.
         logger.debug(
-            f"Found existing Teams service API key for tenant {tenant_id} that isn't in cache, "
-            "regenerating to update cache"
+            f"Regenerating Teams service API key for tenant {tenant_id} "
+            "(raw key unrecoverable from hash)"
         )
         new_api_key = generate_api_key(tenant_id)
         existing.hashed_api_key = hash_api_key(new_api_key)
@@ -184,13 +185,19 @@ def get_team_config_by_teams_id(
 def get_team_config_by_registration_key(
     db_session: Session,
     registration_key: str,
+    for_update: bool = False,
 ) -> TeamsTeamConfig | None:
-    """Get a team config by its registration key."""
-    return db_session.scalar(
-        select(TeamsTeamConfig).where(
-            TeamsTeamConfig.registration_key == registration_key
-        )
+    """Get a team config by its registration key.
+
+    Use ``for_update=True`` to acquire a row-level lock, preventing
+    concurrent registration races.
+    """
+    stmt = select(TeamsTeamConfig).where(
+        TeamsTeamConfig.registration_key == registration_key
     )
+    if for_update:
+        stmt = stmt.with_for_update()
+    return db_session.scalar(stmt)
 
 
 def create_team_config(

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -115,6 +115,7 @@ from onyx.server.manage.opensearch_migration.api import (
 )
 from onyx.server.manage.search_settings import router as search_settings_router
 from onyx.server.manage.slack_bot import router as slack_bot_management_router
+from onyx.server.manage.teams_bot.api import router as teams_bot_router
 from onyx.server.manage.users import router as user_router
 from onyx.server.manage.web_search.api import (
     admin_router as web_search_admin_router,
@@ -449,6 +450,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         application, slack_bot_management_router
     )
     include_router_with_global_prefix_prepended(application, discord_bot_router)
+    include_router_with_global_prefix_prepended(application, teams_bot_router)
     include_router_with_global_prefix_prepended(application, persona_router)
     include_router_with_global_prefix_prepended(application, admin_persona_router)
     include_router_with_global_prefix_prepended(application, agents_router)

--- a/backend/onyx/onyxbot/api_client.py
+++ b/backend/onyx/onyxbot/api_client.py
@@ -1,12 +1,12 @@
-"""Async HTTP client for communicating with Onyx API pods."""
+"""Shared async HTTP client for communicating with Onyx API pods."""
 
 import aiohttp
 
 from onyx.chat.models import ChatFullResponse
-from onyx.onyxbot.discord.constants import API_REQUEST_TIMEOUT
-from onyx.onyxbot.discord.exceptions import APIConnectionError
-from onyx.onyxbot.discord.exceptions import APIResponseError
-from onyx.onyxbot.discord.exceptions import APITimeoutError
+from onyx.onyxbot.constants import API_REQUEST_TIMEOUT
+from onyx.onyxbot.exceptions import APIConnectionError
+from onyx.onyxbot.exceptions import APIResponseError
+from onyx.onyxbot.exceptions import APITimeoutError
 from onyx.server.query_and_chat.models import ChatSessionCreationRequest
 from onyx.server.query_and_chat.models import MessageOrigin
 from onyx.server.query_and_chat.models import SendMessageRequest
@@ -19,36 +19,17 @@ logger = setup_logger()
 class OnyxAPIClient:
     """Async HTTP client for sending chat requests to Onyx API pods.
 
-    This client manages an aiohttp session for making non-blocking HTTP
-    requests to the Onyx API server. It handles authentication with per-tenant
-    API keys and multi-tenant routing.
-
-    Usage:
-        client = OnyxAPIClient()
-        await client.initialize()
-        try:
-            response = await client.send_chat_message(
-                message="What is our deployment process?",
-                tenant_id="tenant_123",
-                api_key="dn_xxx...",
-                persona_id=1,
-            )
-            print(response.answer)
-        finally:
-            await client.close()
+    Used by both Discord and Teams bots. The ``origin`` parameter controls
+    which ``MessageOrigin`` value is attached to outgoing requests for
+    telemetry tracking.
     """
 
     def __init__(
         self,
+        origin: MessageOrigin,
         timeout: int = API_REQUEST_TIMEOUT,
     ) -> None:
-        """Initialize the API client.
-
-        Args:
-            timeout: Request timeout in seconds.
-        """
-        # Helm chart uses API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS to set the base URL
-        # TODO: Ideally, this override is only used when someone is launching an Onyx service independently
+        self._origin = origin
         self._base_url = build_api_server_url_for_http_requests(
             respect_env_override_if_set=True
         ).rstrip("/")
@@ -56,28 +37,20 @@ class OnyxAPIClient:
         self._session: aiohttp.ClientSession | None = None
 
     async def initialize(self) -> None:
-        """Create the aiohttp session.
-
-        Must be called before making any requests. The session is created
-        with a total timeout and connection timeout.
-        """
+        """Create the aiohttp session."""
         if self._session is not None:
             logger.warning("API client session already initialized")
             return
 
         timeout = aiohttp.ClientTimeout(
             total=self._timeout,
-            connect=30,  # 30 seconds to establish connection
+            connect=30,
         )
         self._session = aiohttp.ClientSession(timeout=timeout)
         logger.info(f"API client initialized with base URL: {self._base_url}")
 
     async def close(self) -> None:
-        """Close the aiohttp session.
-
-        Should be called when shutting down the bot to properly release
-        resources.
-        """
+        """Close the aiohttp session."""
         if self._session is not None:
             await self._session.close()
             self._session = None
@@ -85,7 +58,6 @@ class OnyxAPIClient:
 
     @property
     def is_initialized(self) -> bool:
-        """Check if the session is initialized."""
         return self._session is not None
 
     async def send_chat_message(
@@ -94,24 +66,7 @@ class OnyxAPIClient:
         api_key: str,
         persona_id: int | None = None,
     ) -> ChatFullResponse:
-        """Send a chat message to the Onyx API server and get a response.
-
-        This method sends a non-streaming chat request to the API server. The response
-        contains the complete answer with any citations and metadata.
-
-        Args:
-            message: The user's message to process.
-            api_key: The API key for authentication.
-            persona_id: Optional persona ID to use for the response.
-
-        Returns:
-            ChatFullResponse containing the answer, citations, and metadata.
-
-        Raises:
-            APIConnectionError: If unable to connect to the API.
-            APITimeoutError: If the request times out.
-            APIResponseError: If the API returns an error response.
-        """
+        """Send a chat message to the Onyx API server and get a response."""
         if self._session is None:
             raise APIConnectionError(
                 "API client not initialized. Call initialize() first."
@@ -119,17 +74,15 @@ class OnyxAPIClient:
 
         url = f"{self._base_url}/chat/send-chat-message"
 
-        # Build request payload
         request = SendMessageRequest(
             message=message,
             stream=False,
-            origin=MessageOrigin.DISCORDBOT,
+            origin=self._origin,
             chat_session_info=ChatSessionCreationRequest(
                 persona_id=persona_id if persona_id is not None else 0,
             ),
         )
 
-        # Build headers
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {api_key}",
@@ -169,7 +122,6 @@ class OnyxAPIClient:
                         status_code=response.status,
                     )
 
-                # Parse successful response
                 data = await response.json()
                 response_obj = ChatFullResponse.model_validate(data)
 
@@ -195,11 +147,7 @@ class OnyxAPIClient:
             raise APIConnectionError(f"HTTP client error: {e}") from e
 
     async def health_check(self) -> bool:
-        """Check if the API server is healthy.
-
-        Returns:
-            True if the API server is reachable and healthy, False otherwise.
-        """
+        """Check if the API server is healthy."""
         if self._session is None:
             logger.warning("API client not initialized. Call initialize() first.")
             return False

--- a/backend/onyx/onyxbot/cache.py
+++ b/backend/onyx/onyxbot/cache.py
@@ -1,0 +1,185 @@
+"""Shared multi-tenant cache for bot entity-tenant mappings and API keys.
+
+Subclass ``BotCacheManager`` and implement the three abstract helpers to
+create a platform-specific cache (e.g. Discord guilds, Teams teams).
+"""
+
+import asyncio
+from abc import ABC
+from abc import abstractmethod
+from typing import Generic
+from typing import TypeVar
+
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.engine.tenant_utils import get_all_tenant_ids
+from onyx.onyxbot.exceptions import CacheError
+from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+logger = setup_logger()
+
+EntityIdT = TypeVar("EntityIdT")
+
+
+class BotCacheManager(ABC, Generic[EntityIdT]):
+    """Caches entity->tenant mappings and tenant->API key mappings.
+
+    ``EntityIdT`` is ``int`` for Discord guilds, ``str`` for Teams teams.
+    """
+
+    def __init__(self, entity_name: str) -> None:
+        self._entity_name = entity_name
+        self._entity_tenants: dict[EntityIdT, str] = {}
+        self._api_keys: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Abstract hooks — platform-specific DB access
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _get_entity_ids(self, db: Session) -> list[EntityIdT]:
+        """Return active entity IDs from DB configs."""
+
+    @abstractmethod
+    def _get_or_create_api_key(self, db: Session, tenant_id: str) -> str:
+        """Provision (or retrieve) a service API key for *tenant_id*."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    async def refresh_all(self) -> None:
+        """Full cache refresh from all tenants."""
+        async with self._lock:
+            logger.info(f"Starting {self._entity_name} cache refresh")
+
+            new_entity_tenants: dict[EntityIdT, str] = {}
+            new_api_keys: dict[str, str] = {}
+
+            try:
+                gated = fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.product_gating",
+                    "get_gated_tenants",
+                    set(),
+                )()
+
+                tenant_ids = await asyncio.to_thread(get_all_tenant_ids)
+                for tenant_id in tenant_ids:
+                    if tenant_id in gated:
+                        continue
+
+                    context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+                    try:
+                        entity_ids, api_key = await self._load_tenant_data(tenant_id)
+                        if not entity_ids:
+                            logger.debug(
+                                f"No {self._entity_name} found for tenant "
+                                f"{tenant_id}"
+                            )
+                            continue
+
+                        if not api_key:
+                            logger.warning(
+                                f"Service API key missing for tenant that has "
+                                f"registered {self._entity_name}. {tenant_id} "
+                                f"will not be handled in this refresh cycle."
+                            )
+                            continue
+
+                        for entity_id in entity_ids:
+                            new_entity_tenants[entity_id] = tenant_id
+
+                        new_api_keys[tenant_id] = api_key
+                    except Exception as e:
+                        logger.warning(f"Failed to refresh tenant {tenant_id}: {e}")
+                    finally:
+                        CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
+
+                self._entity_tenants = new_entity_tenants
+                self._api_keys = new_api_keys
+                self._initialized = True
+
+                logger.info(
+                    f"Cache refresh complete: "
+                    f"{len(new_entity_tenants)} {self._entity_name}, "
+                    f"{len(new_api_keys)} tenants"
+                )
+
+            except Exception as e:
+                logger.error(f"Cache refresh failed: {e}")
+                raise CacheError(f"Failed to refresh cache: {e}") from e
+
+    async def refresh_entity(self, entity_id: EntityIdT, tenant_id: str) -> None:
+        """Add a single entity to cache after registration."""
+        async with self._lock:
+            logger.info(
+                f"Refreshing cache for {self._entity_name} entity "
+                f"{entity_id} (tenant: {tenant_id})"
+            )
+
+            entity_ids, api_key = await self._load_tenant_data(tenant_id)
+
+            if entity_id in entity_ids:
+                self._entity_tenants[entity_id] = tenant_id
+                if api_key:
+                    self._api_keys[tenant_id] = api_key
+                logger.info(f"Cache updated for entity {entity_id}")
+            else:
+                logger.warning(f"Entity {entity_id} not found or disabled")
+
+    def get_tenant(self, entity_id: EntityIdT) -> str | None:
+        """Get tenant ID for an entity."""
+        return self._entity_tenants.get(entity_id)
+
+    def get_api_key(self, tenant_id: str) -> str | None:
+        """Get API key for a tenant."""
+        return self._api_keys.get(tenant_id)
+
+    def remove_entity(self, entity_id: EntityIdT) -> None:
+        """Remove an entity from cache."""
+        self._entity_tenants.pop(entity_id, None)
+
+    def get_all_entity_ids(self) -> list[EntityIdT]:
+        """Get all cached entity IDs."""
+        return list(self._entity_tenants.keys())
+
+    def clear(self) -> None:
+        """Clear all caches."""
+        self._entity_tenants.clear()
+        self._api_keys.clear()
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _load_tenant_data(
+        self, tenant_id: str
+    ) -> tuple[list[EntityIdT], str | None]:
+        """Load entity IDs and provision API key if needed."""
+        cached_key = self._api_keys.get(tenant_id)
+
+        def _sync() -> tuple[list[EntityIdT], str | None]:
+            with get_session_with_tenant(tenant_id=tenant_id) as db:
+                entity_ids = self._get_entity_ids(db)
+
+                if not entity_ids:
+                    return [], None
+
+                if not cached_key:
+                    new_key = self._get_or_create_api_key(db, tenant_id)
+                    db.commit()
+                    return entity_ids, new_key
+
+                return entity_ids, cached_key
+
+        return await asyncio.to_thread(_sync)

--- a/backend/onyx/onyxbot/cache.py
+++ b/backend/onyx/onyxbot/cache.py
@@ -10,6 +10,7 @@ from abc import abstractmethod
 from typing import Generic
 from typing import TypeVar
 
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
@@ -58,76 +59,85 @@ class BotCacheManager(ABC, Generic[EntityIdT]):
         return self._initialized
 
     async def refresh_all(self) -> None:
-        """Full cache refresh from all tenants."""
-        async with self._lock:
-            logger.info(f"Starting {self._entity_name} cache refresh")
+        """Full cache refresh from all tenants.
 
-            new_entity_tenants: dict[EntityIdT, str] = {}
-            new_api_keys: dict[str, str] = {}
+        Data is loaded outside the lock; the lock is only held for the
+        atomic swap of the cache dicts so that ``refresh_entity`` and
+        read operations are not blocked during I/O.
+        """
+        logger.info(f"Starting {self._entity_name} cache refresh")
 
-            try:
-                gated = fetch_ee_implementation_or_noop(
-                    "onyx.server.tenants.product_gating",
-                    "get_gated_tenants",
-                    set(),
-                )()
+        new_entity_tenants: dict[EntityIdT, str] = {}
+        new_api_keys: dict[str, str] = {}
 
-                tenant_ids = await asyncio.to_thread(get_all_tenant_ids)
-                for tenant_id in tenant_ids:
-                    if tenant_id in gated:
+        try:
+            gated = fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.product_gating",
+                "get_gated_tenants",
+                set(),
+            )()
+
+            tenant_ids = await asyncio.to_thread(get_all_tenant_ids)
+            for tenant_id in tenant_ids:
+                if tenant_id in gated:
+                    continue
+
+                context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+                try:
+                    entity_ids, api_key = await self._load_tenant_data(tenant_id)
+                    if not entity_ids:
+                        logger.debug(
+                            f"No {self._entity_name} found for tenant " f"{tenant_id}"
+                        )
                         continue
 
-                    context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
-                    try:
-                        entity_ids, api_key = await self._load_tenant_data(tenant_id)
-                        if not entity_ids:
-                            logger.debug(
-                                f"No {self._entity_name} found for tenant "
-                                f"{tenant_id}"
-                            )
-                            continue
+                    if not api_key:
+                        logger.warning(
+                            f"Service API key missing for tenant that has "
+                            f"registered {self._entity_name}. {tenant_id} "
+                            f"will not be handled in this refresh cycle."
+                        )
+                        continue
 
-                        if not api_key:
-                            logger.warning(
-                                f"Service API key missing for tenant that has "
-                                f"registered {self._entity_name}. {tenant_id} "
-                                f"will not be handled in this refresh cycle."
-                            )
-                            continue
+                    for entity_id in entity_ids:
+                        new_entity_tenants[entity_id] = tenant_id
 
-                        for entity_id in entity_ids:
-                            new_entity_tenants[entity_id] = tenant_id
+                    new_api_keys[tenant_id] = api_key
+                except (OperationalError, ConnectionError, OSError) as e:
+                    logger.warning(f"Failed to refresh tenant {tenant_id}: {e}")
+                finally:
+                    CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
 
-                        new_api_keys[tenant_id] = api_key
-                    except Exception as e:
-                        logger.warning(f"Failed to refresh tenant {tenant_id}: {e}")
-                    finally:
-                        CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
-
+            # Atomic swap under lock
+            async with self._lock:
                 self._entity_tenants = new_entity_tenants
                 self._api_keys = new_api_keys
                 self._initialized = True
 
-                logger.info(
-                    f"Cache refresh complete: "
-                    f"{len(new_entity_tenants)} {self._entity_name}, "
-                    f"{len(new_api_keys)} tenants"
-                )
+            logger.info(
+                f"Cache refresh complete: "
+                f"{len(new_entity_tenants)} {self._entity_name}, "
+                f"{len(new_api_keys)} tenants"
+            )
 
-            except Exception as e:
-                logger.error(f"Cache refresh failed: {e}")
-                raise CacheError(f"Failed to refresh cache: {e}") from e
+        except (OperationalError, ConnectionError, OSError) as e:
+            logger.error(f"Cache refresh failed: {e}")
+            raise CacheError(f"Failed to refresh cache: {e}") from e
 
     async def refresh_entity(self, entity_id: EntityIdT, tenant_id: str) -> None:
         """Add a single entity to cache after registration."""
-        async with self._lock:
-            logger.info(
-                f"Refreshing cache for {self._entity_name} entity "
-                f"{entity_id} (tenant: {tenant_id})"
-            )
+        logger.info(
+            f"Refreshing cache for {self._entity_name} entity "
+            f"{entity_id} (tenant: {tenant_id})"
+        )
 
+        context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+        try:
             entity_ids, api_key = await self._load_tenant_data(tenant_id)
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
 
+        async with self._lock:
             if entity_id in entity_ids:
                 self._entity_tenants[entity_id] = tenant_id
                 if api_key:

--- a/backend/onyx/onyxbot/constants.py
+++ b/backend/onyx/onyxbot/constants.py
@@ -1,0 +1,10 @@
+"""Shared constants for Onyx bot integrations (Discord, Teams, etc.)."""
+
+# API settings
+API_REQUEST_TIMEOUT: int = 3 * 60  # 3 minutes
+
+# Cache settings
+CACHE_REFRESH_INTERVAL: int = 60  # 1 minute
+
+# Registration
+REGISTER_COMMAND: str = "register"

--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -1,154 +1,35 @@
 """Multi-tenant cache for Discord bot guild-tenant mappings and API keys."""
 
-import asyncio
+from sqlalchemy.orm import Session
 
 from onyx.db.discord_bot import get_guild_configs
 from onyx.db.discord_bot import get_or_create_discord_service_api_key
-from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.engine.tenant_utils import get_all_tenant_ids
-from onyx.onyxbot.discord.exceptions import CacheError
-from onyx.utils.logger import setup_logger
-from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
-from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-
-logger = setup_logger()
+from onyx.onyxbot.cache import BotCacheManager
 
 
-class DiscordCacheManager:
-    """Caches guild->tenant mappings and tenant->API key mappings.
-
-    Refreshed on startup, periodically (every 60s), and when guilds register.
-    """
+class DiscordCacheManager(BotCacheManager[int]):
+    """Caches guild->tenant mappings and tenant->API key mappings."""
 
     def __init__(self) -> None:
-        self._guild_tenants: dict[int, str] = {}  # guild_id -> tenant_id
-        self._api_keys: dict[str, str] = {}  # tenant_id -> api_key
-        self._lock = asyncio.Lock()
-        self._initialized = False
+        super().__init__(entity_name="guilds")
 
-    @property
-    def is_initialized(self) -> bool:
-        return self._initialized
+    def _get_entity_ids(self, db: Session) -> list[int]:
+        configs = get_guild_configs(db)
+        return [
+            config.guild_id
+            for config in configs
+            if config.enabled and config.guild_id is not None
+        ]
 
-    async def refresh_all(self) -> None:
-        """Full cache refresh from all tenants."""
-        async with self._lock:
-            logger.info("Starting Discord cache refresh")
+    def _get_or_create_api_key(self, db: Session, tenant_id: str) -> str:
+        return get_or_create_discord_service_api_key(db, tenant_id)
 
-            new_guild_tenants: dict[int, str] = {}
-            new_api_keys: dict[str, str] = {}
-
-            try:
-                gated = fetch_ee_implementation_or_noop(
-                    "onyx.server.tenants.product_gating",
-                    "get_gated_tenants",
-                    set(),
-                )()
-
-                tenant_ids = await asyncio.to_thread(get_all_tenant_ids)
-                for tenant_id in tenant_ids:
-                    if tenant_id in gated:
-                        continue
-
-                    context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
-                    try:
-                        guild_ids, api_key = await self._load_tenant_data(tenant_id)
-                        if not guild_ids:
-                            logger.debug(f"No guilds found for tenant {tenant_id}")
-                            continue
-
-                        if not api_key:
-                            logger.warning(
-                                "Discord service API key missing for tenant that has registered guilds. "
-                                f"{tenant_id} will not be handled in this refresh cycle."
-                            )
-                            continue
-
-                        for guild_id in guild_ids:
-                            new_guild_tenants[guild_id] = tenant_id
-
-                        new_api_keys[tenant_id] = api_key
-                    except Exception as e:
-                        logger.warning(f"Failed to refresh tenant {tenant_id}: {e}")
-                    finally:
-                        CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
-
-                self._guild_tenants = new_guild_tenants
-                self._api_keys = new_api_keys
-                self._initialized = True
-
-                logger.info(
-                    f"Cache refresh complete: {len(new_guild_tenants)} guilds, "
-                    f"{len(new_api_keys)} tenants"
-                )
-
-            except Exception as e:
-                logger.error(f"Cache refresh failed: {e}")
-                raise CacheError(f"Failed to refresh cache: {e}") from e
-
+    # Convenience aliases for backward compatibility with callers
     async def refresh_guild(self, guild_id: int, tenant_id: str) -> None:
-        """Add a single guild to cache after registration."""
-        async with self._lock:
-            logger.info(f"Refreshing cache for guild {guild_id} (tenant: {tenant_id})")
-
-            guild_ids, api_key = await self._load_tenant_data(tenant_id)
-
-            if guild_id in guild_ids:
-                self._guild_tenants[guild_id] = tenant_id
-                if api_key:
-                    self._api_keys[tenant_id] = api_key
-                logger.info(f"Cache updated for guild {guild_id}")
-            else:
-                logger.warning(f"Guild {guild_id} not found or disabled")
-
-    async def _load_tenant_data(self, tenant_id: str) -> tuple[list[int], str | None]:
-        """Load guild IDs and provision API key if needed.
-
-        Returns:
-            (active_guild_ids, api_key) - api_key is the cached key if available,
-            otherwise a newly created key. Returns None if no guilds found.
-        """
-        cached_key = self._api_keys.get(tenant_id)
-
-        def _sync() -> tuple[list[int], str | None]:
-            with get_session_with_tenant(tenant_id=tenant_id) as db:
-                configs = get_guild_configs(db)
-                guild_ids = [
-                    config.guild_id
-                    for config in configs
-                    if config.enabled and config.guild_id is not None
-                ]
-
-                if not guild_ids:
-                    return [], None
-
-                if not cached_key:
-                    new_key = get_or_create_discord_service_api_key(db, tenant_id)
-                    db.commit()
-                    return guild_ids, new_key
-
-                return guild_ids, cached_key
-
-        return await asyncio.to_thread(_sync)
-
-    def get_tenant(self, guild_id: int) -> str | None:
-        """Get tenant ID for a guild."""
-        return self._guild_tenants.get(guild_id)
-
-    def get_api_key(self, tenant_id: str) -> str | None:
-        """Get API key for a tenant."""
-        return self._api_keys.get(tenant_id)
+        await self.refresh_entity(guild_id, tenant_id)
 
     def remove_guild(self, guild_id: int) -> None:
-        """Remove a guild from cache."""
-        self._guild_tenants.pop(guild_id, None)
+        self.remove_entity(guild_id)
 
     def get_all_guild_ids(self) -> list[int]:
-        """Get all cached guild IDs."""
-        return list(self._guild_tenants.keys())
-
-    def clear(self) -> None:
-        """Clear all caches."""
-        self._guild_tenants.clear()
-        self._api_keys.clear()
-        self._initialized = False
+        return self.get_all_entity_ids()

--- a/backend/onyx/onyxbot/discord/client.py
+++ b/backend/onyx/onyxbot/discord/client.py
@@ -7,15 +7,16 @@ import discord
 from discord.ext import commands
 
 from onyx.configs.app_configs import DISCORD_BOT_INVOKE_CHAR
-from onyx.onyxbot.discord.api_client import OnyxAPIClient
+from onyx.onyxbot.api_client import OnyxAPIClient
+from onyx.onyxbot.constants import CACHE_REFRESH_INTERVAL
 from onyx.onyxbot.discord.cache import DiscordCacheManager
-from onyx.onyxbot.discord.constants import CACHE_REFRESH_INTERVAL
 from onyx.onyxbot.discord.handle_commands import handle_dm
 from onyx.onyxbot.discord.handle_commands import handle_registration_command
 from onyx.onyxbot.discord.handle_commands import handle_sync_channels_command
 from onyx.onyxbot.discord.handle_message import process_chat_message
 from onyx.onyxbot.discord.handle_message import should_respond
 from onyx.onyxbot.discord.utils import get_bot_token
+from onyx.server.query_and_chat.models import MessageOrigin
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -40,7 +41,7 @@ class OnyxDiscordClient(commands.Bot):
 
         self.ready = False
         self.cache = DiscordCacheManager()
-        self.api_client = OnyxAPIClient()
+        self.api_client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
         self._cache_refresh_task: asyncio.Task | None = None
 
     # -------------------------------------------------------------------------

--- a/backend/onyx/onyxbot/discord/constants.py
+++ b/backend/onyx/onyxbot/discord/constants.py
@@ -1,19 +1,16 @@
-"""Discord bot constants."""
+"""Discord-specific bot constants.
 
-# API settings
-API_REQUEST_TIMEOUT: int = 3 * 60  # 3 minutes
-
-# Cache settings
-CACHE_REFRESH_INTERVAL: int = 60  # 1 minute
+Shared constants (API_REQUEST_TIMEOUT, CACHE_REFRESH_INTERVAL,
+REGISTER_COMMAND) live in ``onyx.onyxbot.constants``.
+"""
 
 # Message settings
 MAX_MESSAGE_LENGTH: int = 2000  # Discord's character limit
 MAX_CONTEXT_MESSAGES: int = 10  # Max messages to include in conversation context
 # Note: Discord.py's add_reaction() requires unicode emoji, not :name: format
-THINKING_EMOJI: str = "🤔"  # U+1F914 - Thinking Face
-SUCCESS_EMOJI: str = "✅"  # U+2705 - White Heavy Check Mark
-ERROR_EMOJI: str = "❌"  # U+274C - Cross Mark
+THINKING_EMOJI: str = "\U0001f914"  # U+1F914 - Thinking Face
+SUCCESS_EMOJI: str = "\u2705"  # U+2705 - White Heavy Check Mark
+ERROR_EMOJI: str = "\u274c"  # U+274C - Cross Mark
 
-# Command prefix
-REGISTER_COMMAND: str = "register"
+# Discord-specific commands
 SYNC_CHANNELS_COMMAND: str = "sync-channels"

--- a/backend/onyx/onyxbot/discord/exceptions.py
+++ b/backend/onyx/onyxbot/discord/exceptions.py
@@ -1,37 +1,7 @@
-"""Custom exception classes for Discord bot."""
+"""Discord-specific exception classes."""
+
+from onyx.onyxbot.exceptions import OnyxBotError
 
 
-class DiscordBotError(Exception):
-    """Base exception for Discord bot errors."""
-
-
-class RegistrationError(DiscordBotError):
-    """Error during guild registration."""
-
-
-class SyncChannelsError(DiscordBotError):
+class SyncChannelsError(OnyxBotError):
     """Error during channel sync."""
-
-
-class APIError(DiscordBotError):
-    """Base API error."""
-
-
-class CacheError(DiscordBotError):
-    """Error during cache operations."""
-
-
-class APIConnectionError(APIError):
-    """Failed to connect to API."""
-
-
-class APITimeoutError(APIError):
-    """Request timed out."""
-
-
-class APIResponseError(APIError):
-    """API returned an error response."""
-
-    def __init__(self, message: str, status_code: int | None = None):
-        super().__init__(message)
-        self.status_code = status_code

--- a/backend/onyx/onyxbot/discord/handle_commands.py
+++ b/backend/onyx/onyxbot/discord/handle_commands.py
@@ -15,11 +15,11 @@ from onyx.db.discord_bot import get_guild_config_by_registration_key
 from onyx.db.discord_bot import sync_channel_configs
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.utils import DiscordChannelView
+from onyx.onyxbot.constants import REGISTER_COMMAND
 from onyx.onyxbot.discord.cache import DiscordCacheManager
-from onyx.onyxbot.discord.constants import REGISTER_COMMAND
 from onyx.onyxbot.discord.constants import SYNC_CHANNELS_COMMAND
-from onyx.onyxbot.discord.exceptions import RegistrationError
 from onyx.onyxbot.discord.exceptions import SyncChannelsError
+from onyx.onyxbot.exceptions import RegistrationError
 from onyx.server.manage.discord_bot.utils import parse_discord_registration_key
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR

--- a/backend/onyx/onyxbot/discord/handle_message.py
+++ b/backend/onyx/onyxbot/discord/handle_message.py
@@ -11,11 +11,11 @@ from onyx.db.discord_bot import get_guild_config_by_discord_id
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import DiscordChannelConfig
 from onyx.db.models import DiscordGuildConfig
-from onyx.onyxbot.discord.api_client import OnyxAPIClient
+from onyx.onyxbot.api_client import OnyxAPIClient
 from onyx.onyxbot.discord.constants import MAX_CONTEXT_MESSAGES
 from onyx.onyxbot.discord.constants import MAX_MESSAGE_LENGTH
 from onyx.onyxbot.discord.constants import THINKING_EMOJI
-from onyx.onyxbot.discord.exceptions import APIError
+from onyx.onyxbot.exceptions import APIError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/onyxbot/exceptions.py
+++ b/backend/onyx/onyxbot/exceptions.py
@@ -1,0 +1,33 @@
+"""Shared exception classes for Onyx bot integrations (Discord, Teams, etc.)."""
+
+
+class OnyxBotError(Exception):
+    """Base exception for all Onyx bot errors."""
+
+
+class RegistrationError(OnyxBotError):
+    """Error during bot registration."""
+
+
+class APIError(OnyxBotError):
+    """Base API error."""
+
+
+class CacheError(OnyxBotError):
+    """Error during cache operations."""
+
+
+class APIConnectionError(APIError):
+    """Failed to connect to API."""
+
+
+class APITimeoutError(APIError):
+    """Request timed out."""
+
+
+class APIResponseError(APIError):
+    """API returned an error response."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code

--- a/backend/onyx/onyxbot/registration.py
+++ b/backend/onyx/onyxbot/registration.py
@@ -1,0 +1,42 @@
+"""Shared registration key generation and parsing for bot integrations."""
+
+import secrets
+from urllib.parse import quote
+from urllib.parse import unquote
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def generate_registration_key(prefix: str, tenant_id: str) -> str:
+    """Generate a one-time registration key with embedded tenant_id.
+
+    Format: <prefix>_<url_encoded_tenant_id>.<random_token>
+    """
+    encoded_tenant = quote(tenant_id)
+    random_token = secrets.token_urlsafe(16)
+
+    logger.info(f"Generated {prefix} registration key for tenant {tenant_id}")
+    return f"{prefix}_{encoded_tenant}.{random_token}"
+
+
+def parse_registration_key(prefix: str, key: str) -> str | None:
+    """Parse registration key to extract tenant_id.
+
+    Returns tenant_id or None if invalid format.
+    """
+    full_prefix = f"{prefix}_"
+    if not key.startswith(full_prefix):
+        return None
+
+    try:
+        key_body = key.removeprefix(full_prefix)
+        parts = key_body.split(".", 1)
+        if len(parts) != 2:
+            return None
+
+        encoded_tenant = parts[0]
+        return unquote(encoded_tenant)
+    except Exception:
+        return None

--- a/backend/onyx/onyxbot/teams/bot.py
+++ b/backend/onyx/onyxbot/teams/bot.py
@@ -96,8 +96,9 @@ class OnyxTeamsBot(ActivityHandler):
                 logger.debug(f"No tenant found for team {team_id}")
                 return
         else:
-            # DM — not in a team context, we can't determine tenant
-            # TODO: Could support DM registration or use a default tenant
+            # DM — not in a team context, so we can't determine tenant.
+            # TODO(nik): support DM registration or default tenant lookup
+            logger.debug("Ignoring DM (no team context to resolve tenant)")
             return
 
         # Check if bot should respond

--- a/backend/onyx/onyxbot/teams/bot.py
+++ b/backend/onyx/onyxbot/teams/bot.py
@@ -1,0 +1,185 @@
+"""Teams bot Activity handler using Bot Framework SDK."""
+
+import asyncio
+
+from botbuilder.core import ActivityHandler  # type: ignore[import-untyped]
+from botbuilder.core import TurnContext
+from botbuilder.schema import Activity  # type: ignore[import-untyped]
+from botbuilder.schema import ActivityTypes
+from botbuilder.schema import Attachment
+from botbuilder.schema import ChannelAccount
+
+from onyx.onyxbot.api_client import OnyxAPIClient
+from onyx.onyxbot.constants import CACHE_REFRESH_INTERVAL
+from onyx.onyxbot.exceptions import RegistrationError
+from onyx.onyxbot.teams.cache import TeamsCacheManager
+from onyx.onyxbot.teams.handle_commands import handle_registration_command
+from onyx.onyxbot.teams.handle_commands import is_registration_command
+from onyx.onyxbot.teams.handle_message import process_chat_message
+from onyx.onyxbot.teams.handle_message import should_respond
+from onyx.onyxbot.teams.utils import extract_channel_id
+from onyx.onyxbot.teams.utils import extract_team_id
+from onyx.server.query_and_chat.models import MessageOrigin
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class OnyxTeamsBot(ActivityHandler):
+    """Activity handler for Teams bot.
+
+    Handles incoming message activities, member additions, and routes
+    messages to the appropriate handler (registration, chat).
+    """
+
+    def __init__(self) -> None:
+        self.cache = TeamsCacheManager()
+        self.api_client = OnyxAPIClient(origin=MessageOrigin.TEAMSBOT)
+        self._cache_refresh_task: asyncio.Task[None] | None = None
+        self._bot_id: str | None = None
+        self._bot_name: str = "Onyx"
+
+    async def initialize(self) -> None:
+        """Initialize the bot: API client, cache, and background tasks."""
+        await self.api_client.initialize()
+        await self.cache.refresh_all()
+        self._cache_refresh_task = asyncio.create_task(self._periodic_cache_refresh())
+        logger.info("Teams bot initialized")
+
+    async def shutdown(self) -> None:
+        """Gracefully shut down the bot."""
+        if self._cache_refresh_task:
+            self._cache_refresh_task.cancel()
+            try:
+                await self._cache_refresh_task
+            except asyncio.CancelledError:
+                pass
+
+        await self.api_client.close()
+        self.cache.clear()
+        logger.info("Teams bot shut down")
+
+    async def _periodic_cache_refresh(self) -> None:
+        """Background task to refresh cache periodically."""
+        while True:
+            await asyncio.sleep(CACHE_REFRESH_INTERVAL)
+            try:
+                await self.cache.refresh_all()
+            except Exception as e:
+                logger.error(f"Periodic cache refresh failed: {e}")
+
+    async def on_message_activity(self, turn_context: TurnContext) -> None:
+        """Handle incoming message activities."""
+        activity = turn_context.activity
+        if not activity.text:
+            return
+
+        # Capture bot identity on first message
+        if not self._bot_id and activity.recipient:
+            self._bot_id = activity.recipient.id
+            self._bot_name = activity.recipient.name or "Onyx"
+
+        activity_dict = activity.as_dict() if hasattr(activity, "as_dict") else {}
+        team_id = extract_team_id(activity_dict)
+        channel_id = extract_channel_id(activity_dict)
+
+        # Check for registration command
+        if is_registration_command(activity.text, self._bot_name):
+            await self._handle_registration(turn_context, activity_dict)
+            return
+
+        # Resolve tenant from team cache
+        tenant_id: str | None = None
+        if team_id:
+            tenant_id = self.cache.get_tenant(team_id)
+            if not tenant_id:
+                logger.debug(f"No tenant found for team {team_id}")
+                return
+        else:
+            # DM — not in a team context, we can't determine tenant
+            # TODO: Could support DM registration or use a default tenant
+            return
+
+        # Check if bot should respond
+        context = await asyncio.to_thread(
+            should_respond,
+            activity_dict,
+            team_id,
+            channel_id,
+            tenant_id,
+            self._bot_id or "",
+        )
+
+        if not context.should_respond:
+            return
+
+        api_key = self.cache.get_api_key(tenant_id)
+        if not api_key:
+            logger.warning(f"No API key for tenant {tenant_id}")
+            return
+
+        # Send typing indicator
+        await turn_context.send_activity(Activity(type=ActivityTypes.typing))
+
+        # Process message and send response
+        card = await process_chat_message(
+            text=activity.text,
+            api_key=api_key,
+            persona_id=context.persona_id,
+            api_client=self.api_client,
+            bot_name=self._bot_name,
+        )
+
+        # Send as Adaptive Card
+        attachment = Attachment(
+            content_type="application/vnd.microsoft.card.adaptive",
+            content=card,
+        )
+        response = Activity(
+            type=ActivityTypes.message,
+            attachments=[attachment],
+        )
+        await turn_context.send_activity(response)
+
+    async def _handle_registration(
+        self,
+        turn_context: TurnContext,
+        activity_dict: dict,
+    ) -> None:
+        """Handle registration command."""
+        try:
+            result = await handle_registration_command(
+                text=turn_context.activity.text or "",
+                activity_dict=activity_dict,
+                bot_name=self._bot_name,
+                cache=self.cache,
+            )
+            await turn_context.send_activity(result)
+        except RegistrationError as e:
+            await turn_context.send_activity(f"Registration failed: {e}")
+        except Exception as e:
+            logger.exception(f"Registration error: {e}")
+            await turn_context.send_activity(
+                "An unexpected error occurred during registration."
+            )
+
+    async def on_members_added_activity(
+        self,
+        members_added: list[ChannelAccount],
+        turn_context: TurnContext,
+    ) -> None:
+        """Handle when the bot is added to a team or conversation."""
+        for member in members_added:
+            # Only send welcome when the bot itself is added
+            if member.id == turn_context.activity.recipient.id:
+                from onyx.onyxbot.teams.cards import build_welcome_card
+
+                attachment = Attachment(
+                    content_type="application/vnd.microsoft.card.adaptive",
+                    content=build_welcome_card(),
+                )
+                response = Activity(
+                    type=ActivityTypes.message,
+                    attachments=[attachment],
+                )
+                await turn_context.send_activity(response)

--- a/backend/onyx/onyxbot/teams/cache.py
+++ b/backend/onyx/onyxbot/teams/cache.py
@@ -1,0 +1,35 @@
+"""Multi-tenant cache for Teams bot team-tenant mappings and API keys."""
+
+from sqlalchemy.orm import Session
+
+from onyx.db.teams_bot import get_or_create_teams_service_api_key
+from onyx.db.teams_bot import get_team_configs
+from onyx.onyxbot.cache import BotCacheManager
+
+
+class TeamsCacheManager(BotCacheManager[str]):
+    """Caches team->tenant mappings and tenant->API key mappings."""
+
+    def __init__(self) -> None:
+        super().__init__(entity_name="teams")
+
+    def _get_entity_ids(self, db: Session) -> list[str]:
+        configs = get_team_configs(db)
+        return [
+            config.team_id
+            for config in configs
+            if config.enabled and config.team_id is not None
+        ]
+
+    def _get_or_create_api_key(self, db: Session, tenant_id: str) -> str:
+        return get_or_create_teams_service_api_key(db, tenant_id)
+
+    # Convenience aliases for caller clarity
+    async def refresh_team(self, team_id: str, tenant_id: str) -> None:
+        await self.refresh_entity(team_id, tenant_id)
+
+    def remove_team(self, team_id: str) -> None:
+        self.remove_entity(team_id)
+
+    def get_all_team_ids(self) -> list[str]:
+        return self.get_all_entity_ids()

--- a/backend/onyx/onyxbot/teams/cache.py
+++ b/backend/onyx/onyxbot/teams/cache.py
@@ -2,8 +2,8 @@
 
 from sqlalchemy.orm import Session
 
-from onyx.db.teams_bot import get_or_create_teams_service_api_key
 from onyx.db.teams_bot import get_team_configs
+from onyx.db.teams_bot import provision_teams_service_api_key
 from onyx.onyxbot.cache import BotCacheManager
 
 
@@ -22,7 +22,7 @@ class TeamsCacheManager(BotCacheManager[str]):
         ]
 
     def _get_or_create_api_key(self, db: Session, tenant_id: str) -> str:
-        return get_or_create_teams_service_api_key(db, tenant_id)
+        return provision_teams_service_api_key(db, tenant_id)
 
     # Convenience aliases for caller clarity
     async def refresh_team(self, team_id: str, tenant_id: str) -> None:

--- a/backend/onyx/onyxbot/teams/cards.py
+++ b/backend/onyx/onyxbot/teams/cards.py
@@ -1,0 +1,136 @@
+"""Adaptive Card builders for Teams bot responses."""
+
+from onyx.chat.models import ChatFullResponse
+from onyx.onyxbot.teams.constants import ADAPTIVE_CARD_SCHEMA
+from onyx.onyxbot.teams.constants import ADAPTIVE_CARD_VERSION
+from onyx.onyxbot.teams.constants import MAX_CITATIONS
+
+
+def build_answer_card(
+    answer: str,
+    response: ChatFullResponse | None = None,
+) -> dict:
+    """Build an Adaptive Card for a chat answer with optional citations.
+
+    Target Adaptive Card schema version 1.3 for mobile compatibility.
+    """
+    body: list[dict] = [
+        {
+            "type": "TextBlock",
+            "text": answer,
+            "wrap": True,
+        }
+    ]
+
+    # Add citations if present
+    citations = _extract_citations(response) if response else []
+    if citations:
+        body.append(
+            {
+                "type": "TextBlock",
+                "text": "**Sources:**",
+                "wrap": True,
+                "spacing": "Medium",
+            }
+        )
+        for num, name, link in citations:
+            if link:
+                body.append(
+                    {
+                        "type": "TextBlock",
+                        "text": f"{num}. [{name}]({link})",
+                        "wrap": True,
+                        "spacing": "None",
+                    }
+                )
+            else:
+                body.append(
+                    {
+                        "type": "TextBlock",
+                        "text": f"{num}. {name}",
+                        "wrap": True,
+                        "spacing": "None",
+                    }
+                )
+
+    return {
+        "$schema": ADAPTIVE_CARD_SCHEMA,
+        "type": "AdaptiveCard",
+        "version": ADAPTIVE_CARD_VERSION,
+        "body": body,
+    }
+
+
+def build_error_card(message: str) -> dict:
+    """Build an Adaptive Card for error messages."""
+    return {
+        "$schema": ADAPTIVE_CARD_SCHEMA,
+        "type": "AdaptiveCard",
+        "version": ADAPTIVE_CARD_VERSION,
+        "body": [
+            {
+                "type": "TextBlock",
+                "text": message,
+                "wrap": True,
+                "color": "Attention",
+            }
+        ],
+    }
+
+
+def build_welcome_card() -> dict:
+    """Build an Adaptive Card for the welcome message when bot is added."""
+    return {
+        "$schema": ADAPTIVE_CARD_SCHEMA,
+        "type": "AdaptiveCard",
+        "version": ADAPTIVE_CARD_VERSION,
+        "body": [
+            {
+                "type": "TextBlock",
+                "text": "Welcome to Onyx!",
+                "weight": "Bolder",
+                "size": "Medium",
+            },
+            {
+                "type": "TextBlock",
+                "text": (
+                    "I'm the Onyx bot. I can help you search your company's knowledge base "
+                    "and answer questions.\n\n"
+                    "To get started, an admin needs to register this team. "
+                    "Send me a direct message with:\n\n"
+                    "`@Onyx register <registration_key>`"
+                ),
+                "wrap": True,
+            },
+        ],
+    }
+
+
+def _extract_citations(
+    response: ChatFullResponse,
+) -> list[tuple[int, str, str | None]]:
+    """Extract citation information from a chat response."""
+    if not response.citation_info or not response.top_documents:
+        return []
+
+    cited_docs: list[tuple[int, str, str | None]] = []
+    for citation in response.citation_info:
+        doc = next(
+            (
+                d
+                for d in response.top_documents
+                if d.document_id == citation.document_id
+            ),
+            None,
+        )
+        if doc:
+            cited_docs.append(
+                (
+                    citation.citation_number,
+                    doc.semantic_identifier or "Source",
+                    doc.link,
+                )
+            )
+
+    cited_docs.sort(key=lambda x: x[0])
+    return cited_docs[:MAX_CITATIONS]

--- a/backend/onyx/onyxbot/teams/constants.py
+++ b/backend/onyx/onyxbot/teams/constants.py
@@ -1,0 +1,14 @@
+"""Teams-specific bot constants.
+
+Shared constants (API_REQUEST_TIMEOUT, CACHE_REFRESH_INTERVAL,
+REGISTER_COMMAND) live in ``onyx.onyxbot.constants``.
+"""
+
+# Bot Framework settings
+BOT_MESSAGES_ENDPOINT: str = "/api/messages"
+BOT_HEALTH_ENDPOINT: str = "/health"
+
+# Adaptive Card settings
+ADAPTIVE_CARD_SCHEMA: str = "http://adaptivecards.io/schemas/adaptive-card.json"
+ADAPTIVE_CARD_VERSION: str = "1.3"  # Compatible with mobile clients
+MAX_CITATIONS: int = 5

--- a/backend/onyx/onyxbot/teams/handle_commands.py
+++ b/backend/onyx/onyxbot/teams/handle_commands.py
@@ -1,0 +1,78 @@
+"""Teams bot command handlers (e.g., registration)."""
+
+import asyncio
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.teams_bot import get_team_config_by_registration_key
+from onyx.db.teams_bot import register_team
+from onyx.onyxbot.constants import REGISTER_COMMAND
+from onyx.onyxbot.exceptions import RegistrationError
+from onyx.onyxbot.teams.cache import TeamsCacheManager
+from onyx.onyxbot.teams.utils import extract_team_id
+from onyx.onyxbot.teams.utils import extract_team_name
+from onyx.onyxbot.teams.utils import strip_bot_mention
+from onyx.server.manage.teams_bot.utils import parse_teams_registration_key
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+async def handle_registration_command(
+    text: str,
+    activity_dict: dict,
+    bot_name: str,
+    cache: TeamsCacheManager,
+) -> str:
+    """Handle the 'register <key>' command.
+
+    Returns a human-readable response message.
+    """
+    clean_text = strip_bot_mention(text, bot_name).strip()
+
+    # Parse "register <key>"
+    parts = clean_text.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != REGISTER_COMMAND:
+        raise RegistrationError(
+            f"Invalid registration command. Usage: @{bot_name} register <registration_key>"
+        )
+
+    registration_key = parts[1].strip()
+
+    # Parse tenant_id from registration key
+    tenant_id = parse_teams_registration_key(registration_key)
+    if not tenant_id:
+        raise RegistrationError("Invalid registration key format.")
+
+    team_id = extract_team_id(activity_dict)
+    team_name = extract_team_name(activity_dict) or "Unknown Team"
+
+    if not team_id:
+        raise RegistrationError(
+            "Registration must be done from a Teams channel, not a DM."
+        )
+
+    def _register() -> str:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
+            config = get_team_config_by_registration_key(db, registration_key)
+            if not config:
+                raise RegistrationError("Registration key not found or already used.")
+
+            if config.team_id is not None:
+                raise RegistrationError("This registration key has already been used.")
+
+            register_team(db, config, team_id, team_name)
+            db.commit()
+            return tenant_id
+
+    registered_tenant_id = await asyncio.to_thread(_register)
+    await cache.refresh_team(team_id, registered_tenant_id)
+
+    logger.info(f"Team {team_id} ({team_name}) registered for tenant {tenant_id}")
+    return f"Team **{team_name}** has been registered with Onyx. You can now configure channels in the admin panel."
+
+
+def is_registration_command(text: str, bot_name: str) -> bool:
+    """Check if a message is a registration command."""
+    clean_text = strip_bot_mention(text, bot_name).strip()
+    parts = clean_text.split(None, 1)
+    return len(parts) >= 1 and parts[0].lower() == REGISTER_COMMAND

--- a/backend/onyx/onyxbot/teams/handle_commands.py
+++ b/backend/onyx/onyxbot/teams/handle_commands.py
@@ -53,7 +53,10 @@ async def handle_registration_command(
 
     def _register() -> str:
         with get_session_with_tenant(tenant_id=tenant_id) as db:
-            config = get_team_config_by_registration_key(db, registration_key)
+            # Lock the row to prevent concurrent registration with the same key
+            config = get_team_config_by_registration_key(
+                db, registration_key, for_update=True
+            )
             if not config:
                 raise RegistrationError("Registration key not found or already used.")
 

--- a/backend/onyx/onyxbot/teams/handle_message.py
+++ b/backend/onyx/onyxbot/teams/handle_message.py
@@ -1,0 +1,109 @@
+"""Teams bot message handling and response logic."""
+
+from pydantic import BaseModel
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.models import TeamsChannelConfig
+from onyx.db.models import TeamsTeamConfig
+from onyx.db.teams_bot import get_channel_config_by_teams_ids
+from onyx.db.teams_bot import get_team_config_by_teams_id
+from onyx.onyxbot.api_client import OnyxAPIClient
+from onyx.onyxbot.exceptions import APIError
+from onyx.onyxbot.teams.cards import build_answer_card
+from onyx.onyxbot.teams.cards import build_error_card
+from onyx.onyxbot.teams.utils import is_bot_mentioned
+from onyx.onyxbot.teams.utils import strip_bot_mention
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class ShouldRespondContext(BaseModel):
+    """Context for whether the bot should respond to a message."""
+
+    should_respond: bool
+    persona_id: int | None
+    tenant_id: str | None = None
+    api_key: str | None = None
+
+
+def should_respond(
+    activity_dict: dict,
+    team_id: str | None,
+    channel_id: str | None,
+    tenant_id: str,
+    bot_id: str,
+) -> ShouldRespondContext:
+    """Determine if bot should respond and which persona to use.
+
+    This is a synchronous function that performs DB lookups.
+    """
+    no_response = ShouldRespondContext(should_respond=False, persona_id=None)
+
+    if not team_id or not channel_id:
+        # DM or group chat — respond if we have a tenant
+        return ShouldRespondContext(should_respond=True, persona_id=None)
+
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
+        team_config: TeamsTeamConfig | None = get_team_config_by_teams_id(db, team_id)
+        if not team_config or not team_config.enabled:
+            return no_response
+
+        channel_config: TeamsChannelConfig | None = get_channel_config_by_teams_ids(
+            db, team_id, channel_id
+        )
+        if not channel_config or not channel_config.enabled:
+            return no_response
+
+        # Determine persona (channel override or team default)
+        persona_id = (
+            channel_config.persona_override_id or team_config.default_persona_id
+        )
+
+        # Check mention requirement
+        if channel_config.require_bot_mention:
+            if not is_bot_mentioned(activity_dict, bot_id):
+                return no_response
+
+        return ShouldRespondContext(should_respond=True, persona_id=persona_id)
+
+
+async def process_chat_message(
+    text: str,
+    api_key: str,
+    persona_id: int | None,
+    api_client: OnyxAPIClient,
+    bot_name: str,
+) -> dict:
+    """Process a message and return an Adaptive Card response.
+
+    Returns:
+        Adaptive Card dict for the response.
+    """
+    try:
+        # Strip bot mention from the message
+        clean_text = strip_bot_mention(text, bot_name)
+        if not clean_text:
+            return build_error_card("Please include a message after the @mention.")
+
+        # Send to Onyx API
+        response = await api_client.send_chat_message(
+            message=clean_text,
+            api_key=api_key,
+            persona_id=persona_id,
+        )
+
+        answer = response.answer or "I couldn't generate a response."
+        return build_answer_card(answer, response)
+
+    except APIError as e:
+        logger.error(f"API error processing Teams message: {e}")
+        return build_error_card(
+            "Sorry, I encountered an error processing your message. "
+            "Please try again later."
+        )
+    except Exception as e:
+        logger.exception(f"Error processing Teams chat message: {e}")
+        return build_error_card(
+            "Sorry, an unexpected error occurred. Please try again later."
+        )

--- a/backend/onyx/onyxbot/teams/handle_message.py
+++ b/backend/onyx/onyxbot/teams/handle_message.py
@@ -1,6 +1,7 @@
 """Teams bot message handling and response logic."""
 
-from pydantic import BaseModel
+from dataclasses import dataclass
+from dataclasses import field
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import TeamsChannelConfig
@@ -18,13 +19,14 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
-class ShouldRespondContext(BaseModel):
+@dataclass
+class ShouldRespondContext:
     """Context for whether the bot should respond to a message."""
 
     should_respond: bool
     persona_id: int | None
-    tenant_id: str | None = None
-    api_key: str | None = None
+    tenant_id: str | None = field(default=None)
+    api_key: str | None = field(default=None)
 
 
 def should_respond(

--- a/backend/onyx/onyxbot/teams/server.py
+++ b/backend/onyx/onyxbot/teams/server.py
@@ -66,7 +66,18 @@ async def _handle_messages(request: web.Request) -> web.Response:
         await bot.on_turn(turn_context)
 
     try:
-        await adapter.process_activity(activity, auth_header, _turn_callback)
+        invoke_response = await adapter.process_activity(
+            activity, auth_header, _turn_callback
+        )
+        # For invoke activities (messaging extensions, task modules),
+        # process_activity returns an InvokeResponse with status/body
+        # that must be forwarded to the Bot Framework.
+        if invoke_response:
+            return web.Response(
+                status=invoke_response.status,
+                body=invoke_response.body,
+                content_type="application/json",
+            )
         return web.Response(status=200)
     except Exception as e:
         logger.exception(f"Error processing activity: {e}")

--- a/backend/onyx/onyxbot/teams/server.py
+++ b/backend/onyx/onyxbot/teams/server.py
@@ -1,0 +1,144 @@
+"""HTTP server for Teams bot using aiohttp + Bot Framework adapter."""
+
+import sys
+
+from aiohttp import web
+from botbuilder.core import BotFrameworkAdapter  # type: ignore[import-untyped]
+from botbuilder.core import BotFrameworkAdapterSettings
+from botbuilder.core import TurnContext
+from botbuilder.schema import Activity  # type: ignore[import-untyped]
+
+from onyx.configs.app_configs import TEAMS_BOT_PORT
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.teams_bot import get_teams_bot_config
+from onyx.onyxbot.teams.bot import OnyxTeamsBot
+from onyx.onyxbot.teams.constants import BOT_HEALTH_ENDPOINT
+from onyx.onyxbot.teams.constants import BOT_MESSAGES_ENDPOINT
+from onyx.onyxbot.teams.utils import get_bot_credentials_from_env
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def _get_credentials() -> tuple[str, str, str | None] | None:
+    """Get bot credentials from env vars or database.
+
+    Env vars take priority. Falls back to DB config for self-hosted
+    deployments that configure via admin UI.
+    """
+    env_creds = get_bot_credentials_from_env()
+    if env_creds:
+        return env_creds
+
+    # Try database (for self-hosted deployments)
+    try:
+        from onyx.db.engine.tenant_utils import get_all_tenant_ids
+
+        tenant_ids = get_all_tenant_ids()
+        for tenant_id in tenant_ids:
+            with get_session_with_tenant(tenant_id=tenant_id) as db:
+                config = get_teams_bot_config(db)
+                if config:
+                    # Access the decrypted value
+                    app_secret = config.app_secret
+                    if isinstance(app_secret, str):
+                        return config.app_id, app_secret, config.azure_tenant_id
+    except Exception as e:
+        logger.warning(f"Failed to load Teams bot config from DB: {e}")
+
+    return None
+
+
+async def _handle_messages(request: web.Request) -> web.Response:
+    """Handle incoming Bot Framework Activities at POST /api/messages."""
+    bot: OnyxTeamsBot = request.app["bot"]
+    adapter: BotFrameworkAdapter = request.app["adapter"]
+
+    if request.content_type != "application/json":
+        return web.Response(status=415, text="Unsupported media type")
+
+    body = await request.json()
+    activity = Activity().deserialize(body)
+
+    auth_header = request.headers.get("Authorization", "")
+
+    async def _turn_callback(turn_context: TurnContext) -> None:
+        await bot.on_turn(turn_context)
+
+    try:
+        await adapter.process_activity(activity, auth_header, _turn_callback)
+        return web.Response(status=200)
+    except Exception as e:
+        logger.exception(f"Error processing activity: {e}")
+        return web.Response(status=500, text="Internal server error")
+
+
+async def _handle_health(request: web.Request) -> web.Response:
+    """Health check endpoint."""
+    bot: OnyxTeamsBot = request.app["bot"]
+    healthy = bot.api_client.is_initialized and bot.cache.is_initialized
+    if healthy:
+        return web.Response(status=200, text="OK")
+    return web.Response(status=503, text="Not ready")
+
+
+async def _on_startup(app: web.Application) -> None:
+    """Initialize bot on server startup."""
+    bot: OnyxTeamsBot = app["bot"]
+    await bot.initialize()
+    logger.info("Teams bot server started")
+
+
+async def _on_shutdown(app: web.Application) -> None:
+    """Shut down bot on server shutdown."""
+    bot: OnyxTeamsBot = app["bot"]
+    await bot.shutdown()
+    logger.info("Teams bot server stopped")
+
+
+def create_app(
+    app_id: str,
+    app_secret: str,
+) -> web.Application:
+    """Create the aiohttp web application for the Teams bot."""
+    settings = BotFrameworkAdapterSettings(
+        app_id=app_id,
+        app_password=app_secret,
+    )
+    adapter = BotFrameworkAdapter(settings)
+
+    bot = OnyxTeamsBot()
+
+    app = web.Application()
+    app["bot"] = bot
+    app["adapter"] = adapter
+    app.router.add_post(BOT_MESSAGES_ENDPOINT, _handle_messages)
+    app.router.add_get(BOT_HEALTH_ENDPOINT, _handle_health)
+    app.on_startup.append(_on_startup)
+    app.on_shutdown.append(_on_shutdown)
+
+    return app
+
+
+def main() -> None:
+    """Entry point for the Teams bot process."""
+    logger.info("Starting Teams bot...")
+
+    credentials = _get_credentials()
+    if not credentials:
+        logger.error(
+            "Teams bot credentials not configured. "
+            "Set TEAMS_BOT_APP_ID and TEAMS_BOT_APP_SECRET environment variables, "
+            "or configure via the admin panel."
+        )
+        sys.exit(1)
+
+    app_id, app_secret, _azure_tenant_id = credentials
+    logger.info(f"Teams bot starting with App ID: {app_id}")
+
+    app = create_app(app_id, app_secret)
+    web.run_app(app, host="0.0.0.0", port=TEAMS_BOT_PORT)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/onyx/onyxbot/teams/utils.py
+++ b/backend/onyx/onyxbot/teams/utils.py
@@ -1,0 +1,83 @@
+"""Utility functions for Teams bot."""
+
+from onyx.configs.app_configs import TEAMS_BOT_APP_ID
+from onyx.configs.app_configs import TEAMS_BOT_APP_SECRET
+from onyx.configs.app_configs import TEAMS_BOT_AZURE_TENANT_ID
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def get_bot_credentials_from_env() -> tuple[str, str, str | None] | None:
+    """Get bot credentials from environment variables.
+
+    Returns:
+        (app_id, app_secret, azure_tenant_id) or None if not configured.
+    """
+    if not TEAMS_BOT_APP_ID or not TEAMS_BOT_APP_SECRET:
+        return None
+    return TEAMS_BOT_APP_ID, TEAMS_BOT_APP_SECRET, TEAMS_BOT_AZURE_TENANT_ID
+
+
+def extract_team_id(activity: dict) -> str | None:
+    """Extract the Teams team ID from an Activity's channelData.
+
+    Teams Activities include channelData.team.id for messages in team channels.
+    For 1:1 or group chats, this will be None.
+    """
+    channel_data = activity.get("channelData", {})
+    team = channel_data.get("team")
+    if team:
+        return team.get("id")
+    return None
+
+
+def extract_channel_id(activity: dict) -> str | None:
+    """Extract the Teams channel ID from an Activity's channelData."""
+    channel_data = activity.get("channelData", {})
+    channel = channel_data.get("channel")
+    if channel:
+        return channel.get("id")
+    return None
+
+
+def extract_team_name(activity: dict) -> str | None:
+    """Extract the Teams team name from an Activity's channelData."""
+    channel_data = activity.get("channelData", {})
+    team = channel_data.get("team")
+    if team:
+        return team.get("name")
+    return None
+
+
+def strip_bot_mention(text: str, bot_name: str) -> str:
+    """Remove the bot @mention from the message text.
+
+    Teams includes the @mention in the message text as <at>BotName</at>.
+    """
+    import re
+
+    # Remove <at>BotName</at> tags
+    cleaned = re.sub(
+        rf"<at>{re.escape(bot_name)}</at>",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    )
+    # Also try without the specific name (some clients send generic)
+    cleaned = re.sub(r"<at>[^<]*</at>", "", cleaned)
+    return cleaned.strip()
+
+
+def is_bot_mentioned(activity: dict, bot_id: str) -> bool:
+    """Check if the bot is mentioned in the activity.
+
+    Teams includes mentions in the activity entities array.
+    """
+    entities = activity.get("entities", [])
+    for entity in entities:
+        if entity.get("type") == "mention":
+            mentioned = entity.get("mentioned", {})
+            if mentioned.get("id") == bot_id:
+                return True
+    return False

--- a/backend/onyx/server/manage/teams_bot/api.py
+++ b/backend/onyx/server/manage/teams_bot/api.py
@@ -1,0 +1,279 @@
+"""Teams bot admin API endpoints."""
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import current_admin_user
+from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.app_configs import TEAMS_BOT_APP_ID
+from onyx.configs.constants import AuthType
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import User
+from onyx.db.teams_bot import create_team_config
+from onyx.db.teams_bot import create_teams_bot_config
+from onyx.db.teams_bot import delete_team_config
+from onyx.db.teams_bot import delete_teams_bot_config
+from onyx.db.teams_bot import delete_teams_service_api_key
+from onyx.db.teams_bot import get_channel_config_by_internal_ids
+from onyx.db.teams_bot import get_channel_configs
+from onyx.db.teams_bot import get_team_config_by_internal_id
+from onyx.db.teams_bot import get_team_configs
+from onyx.db.teams_bot import get_teams_bot_config
+from onyx.db.teams_bot import update_team_config
+from onyx.db.teams_bot import update_teams_channel_config
+from onyx.server.manage.teams_bot.models import TeamsBotConfigCreateRequest
+from onyx.server.manage.teams_bot.models import TeamsBotConfigResponse
+from onyx.server.manage.teams_bot.models import TeamsChannelConfigResponse
+from onyx.server.manage.teams_bot.models import TeamsChannelConfigUpdateRequest
+from onyx.server.manage.teams_bot.models import TeamsTeamConfigCreateResponse
+from onyx.server.manage.teams_bot.models import TeamsTeamConfigResponse
+from onyx.server.manage.teams_bot.models import TeamsTeamConfigUpdateRequest
+from onyx.server.manage.teams_bot.utils import generate_teams_registration_key
+from shared_configs.contextvars import get_current_tenant_id
+
+router = APIRouter(prefix="/manage/admin/teams-bot")
+
+
+def _check_bot_config_api_access() -> None:
+    """Raise 403 if bot config cannot be managed via API.
+
+    Bot config endpoints are disabled:
+    - On Cloud (managed by Onyx)
+    - When TEAMS_BOT_APP_ID env var is set (managed via env)
+    """
+    if AUTH_TYPE == AuthType.CLOUD:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Teams bot configuration is managed by Onyx on Cloud.",
+        )
+    if TEAMS_BOT_APP_ID:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Teams bot is configured via environment variables. API access disabled.",
+        )
+
+
+# === Bot Config ===
+
+
+@router.get("/config")
+def get_bot_config(
+    _: None = Depends(_check_bot_config_api_access),
+    __: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsBotConfigResponse:
+    """Get Teams bot config. Returns 403 on Cloud or if env vars set."""
+    config = get_teams_bot_config(db_session)
+    if not config:
+        return TeamsBotConfigResponse(configured=False)
+
+    return TeamsBotConfigResponse(
+        configured=True,
+        created_at=config.created_at,
+    )
+
+
+@router.post("/config")
+def create_bot_request(
+    request: TeamsBotConfigCreateRequest,
+    _: None = Depends(_check_bot_config_api_access),
+    __: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsBotConfigResponse:
+    """Create Teams bot config. Returns 403 on Cloud or if env vars set."""
+    try:
+        config = create_teams_bot_config(
+            db_session,
+            app_id=request.app_id,
+            app_secret=request.app_secret,
+            azure_tenant_id=request.azure_tenant_id,
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Teams bot config already exists. Delete it first to create a new one.",
+        )
+
+    db_session.commit()
+
+    return TeamsBotConfigResponse(
+        configured=True,
+        created_at=config.created_at,
+    )
+
+
+@router.delete("/config")
+def delete_bot_config_endpoint(
+    _: None = Depends(_check_bot_config_api_access),
+    __: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> dict:
+    """Delete Teams bot config.
+
+    Also deletes the Teams service API key since the bot is being removed.
+    """
+    deleted = delete_teams_bot_config(db_session)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Bot config not found")
+
+    delete_teams_service_api_key(db_session)
+
+    db_session.commit()
+    return {"deleted": True}
+
+
+# === Service API Key ===
+
+
+@router.delete("/service-api-key")
+def delete_service_api_key_endpoint(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> dict:
+    """Delete the Teams service API key."""
+    deleted = delete_teams_service_api_key(db_session)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Service API key not found")
+    db_session.commit()
+    return {"deleted": True}
+
+
+# === Team Config ===
+
+
+@router.get("/teams")
+def list_team_configs(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> list[TeamsTeamConfigResponse]:
+    """List all team configs (pending and registered)."""
+    configs = get_team_configs(db_session)
+    return [TeamsTeamConfigResponse.model_validate(c) for c in configs]
+
+
+@router.post("/teams")
+def create_team_request(
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsTeamConfigCreateResponse:
+    """Create new team config with registration key. Key shown once."""
+    tenant_id = get_current_tenant_id()
+    registration_key = generate_teams_registration_key(tenant_id)
+
+    config = create_team_config(db_session, registration_key)
+    db_session.commit()
+
+    return TeamsTeamConfigCreateResponse(
+        id=config.id,
+        registration_key=registration_key,
+    )
+
+
+@router.get("/teams/{config_id}")
+def get_team_config(
+    config_id: int,
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsTeamConfigResponse:
+    """Get specific team config."""
+    config = get_team_config_by_internal_id(db_session, internal_id=config_id)
+    if not config:
+        raise HTTPException(status_code=404, detail="Team config not found")
+    return TeamsTeamConfigResponse.model_validate(config)
+
+
+@router.patch("/teams/{config_id}")
+def update_team_request(
+    config_id: int,
+    request: TeamsTeamConfigUpdateRequest,
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsTeamConfigResponse:
+    """Update team config."""
+    config = get_team_config_by_internal_id(db_session, internal_id=config_id)
+    if not config:
+        raise HTTPException(status_code=404, detail="Team config not found")
+
+    config = update_team_config(
+        db_session,
+        config,
+        enabled=request.enabled,
+        default_persona_id=request.default_persona_id,
+    )
+    db_session.commit()
+
+    return TeamsTeamConfigResponse.model_validate(config)
+
+
+@router.delete("/teams/{config_id}")
+def delete_team_request(
+    config_id: int,
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> dict:
+    """Delete team config (invalidates registration key).
+
+    On Cloud, if this was the last team config, also deletes the service API key.
+    """
+    deleted = delete_team_config(db_session, config_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Team config not found")
+
+    if AUTH_TYPE == AuthType.CLOUD:
+        remaining_teams = get_team_configs(db_session)
+        if not remaining_teams:
+            delete_teams_service_api_key(db_session)
+
+    db_session.commit()
+    return {"deleted": True}
+
+
+# === Channel Config ===
+
+
+@router.get("/teams/{config_id}/channels")
+def list_channel_configs(
+    config_id: int,
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> list[TeamsChannelConfigResponse]:
+    """List whitelisted channels for a team."""
+    team_config = get_team_config_by_internal_id(db_session, internal_id=config_id)
+    if not team_config:
+        raise HTTPException(status_code=404, detail="Team config not found")
+    if not team_config.team_id:
+        raise HTTPException(status_code=400, detail="Team not yet registered")
+
+    configs = get_channel_configs(db_session, config_id)
+    return [TeamsChannelConfigResponse.model_validate(c) for c in configs]
+
+
+@router.patch("/teams/{team_config_id}/channels/{channel_config_id}")
+def update_channel_request(
+    team_config_id: int,
+    channel_config_id: int,
+    request: TeamsChannelConfigUpdateRequest,
+    _: User = Depends(current_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TeamsChannelConfigResponse:
+    """Update channel config."""
+    config = get_channel_config_by_internal_ids(
+        db_session, team_config_id, channel_config_id
+    )
+    if not config:
+        raise HTTPException(status_code=404, detail="Channel config not found")
+
+    config = update_teams_channel_config(
+        db_session,
+        config,
+        channel_name=config.channel_name,  # Keep existing name
+        require_bot_mention=request.require_bot_mention,
+        persona_override_id=request.persona_override_id,
+        enabled=request.enabled,
+    )
+    db_session.commit()
+
+    return TeamsChannelConfigResponse.model_validate(config)

--- a/backend/onyx/server/manage/teams_bot/models.py
+++ b/backend/onyx/server/manage/teams_bot/models.py
@@ -1,0 +1,69 @@
+"""Pydantic models for Teams bot API."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+# === Bot Config ===
+
+
+class TeamsBotConfigResponse(BaseModel):
+    configured: bool
+    created_at: datetime | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class TeamsBotConfigCreateRequest(BaseModel):
+    app_id: str
+    app_secret: str
+    azure_tenant_id: str | None = None
+
+
+# === Team Config ===
+
+
+class TeamsTeamConfigResponse(BaseModel):
+    id: int
+    team_id: str | None
+    team_name: str | None
+    registered_at: datetime | None
+    default_persona_id: int | None
+    enabled: bool
+
+    class Config:
+        from_attributes = True
+
+
+class TeamsTeamConfigCreateResponse(BaseModel):
+    id: int
+    registration_key: str  # Shown once!
+
+
+class TeamsTeamConfigUpdateRequest(BaseModel):
+    enabled: bool
+    default_persona_id: int | None
+
+
+# === Channel Config ===
+
+
+class TeamsChannelConfigResponse(BaseModel):
+    id: int
+    team_config_id: int
+    channel_id: str
+    channel_name: str
+    require_bot_mention: bool
+    persona_override_id: int | None
+    enabled: bool
+
+    class Config:
+        from_attributes = True
+
+
+class TeamsChannelConfigUpdateRequest(BaseModel):
+    require_bot_mention: bool
+    persona_override_id: int | None
+    enabled: bool

--- a/backend/onyx/server/manage/teams_bot/utils.py
+++ b/backend/onyx/server/manage/teams_bot/utils.py
@@ -1,16 +1,16 @@
-"""Discord registration key generation and parsing."""
+"""Teams registration key generation and parsing."""
 
 from onyx.onyxbot.registration import generate_registration_key
 from onyx.onyxbot.registration import parse_registration_key
 
-REGISTRATION_KEY_PREFIX: str = "discord"
+REGISTRATION_KEY_PREFIX: str = "teams"
 
 
-def generate_discord_registration_key(tenant_id: str) -> str:
+def generate_teams_registration_key(tenant_id: str) -> str:
     """Generate a one-time registration key with embedded tenant_id."""
     return generate_registration_key(REGISTRATION_KEY_PREFIX, tenant_id)
 
 
-def parse_discord_registration_key(key: str) -> str | None:
+def parse_teams_registration_key(key: str) -> str | None:
     """Parse registration key to extract tenant_id."""
     return parse_registration_key(REGISTRATION_KEY_PREFIX, key)

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -32,6 +32,7 @@ class MessageOrigin(str, Enum):
     SLACKBOT = "slackbot"
     WIDGET = "widget"
     DISCORDBOT = "discordbot"
+    TEAMSBOT = "teamsbot"
     UNKNOWN = "unknown"
     UNSET = "unset"
 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -17,6 +17,7 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.13.3
     # via
     #   aiobotocore
+    #   botbuilder-integration-aiohttp
     #   discord-py
     #   litellm
     #   onyx
@@ -67,6 +68,8 @@ attrs==25.4.0
     #   zeep
 authlib==1.6.6
     # via fastmcp
+azure-core==1.38.2
+    # via msrest
 babel==2.17.0
     # via courlan
 backoff==2.2.1
@@ -88,6 +91,25 @@ beautifulsoup4==4.12.3
     #   unstructured
 billiard==4.2.3
     # via celery
+botbuilder-core==4.17.1
+    # via
+    #   botbuilder-integration-aiohttp
+    #   onyx
+botbuilder-integration-aiohttp==4.17.1
+    # via onyx
+botbuilder-schema==4.17.1
+    # via
+    #   botbuilder-core
+    #   botbuilder-integration-aiohttp
+    #   botframework-connector
+    #   botframework-streaming
+botframework-connector==4.17.1
+    # via
+    #   botbuilder-core
+    #   botbuilder-integration-aiohttp
+    #   botframework-streaming
+botframework-streaming==4.17.1
+    # via botbuilder-core
 boto3==1.39.11
     # via
     #   aiobotocore
@@ -123,6 +145,7 @@ certifi==2025.11.12
     #   httpx
     #   hubspot-api-client
     #   kubernetes
+    #   msrest
     #   opensearch-py
     #   requests
     #   sentry-sdk
@@ -444,6 +467,7 @@ iniconfig==2.3.0
     # via pytest
 isodate==0.7.2
     # via
+    #   msrest
     #   python3-saml
     #   zeep
 jaraco-classes==3.4.0
@@ -474,6 +498,8 @@ joblib==1.5.2
     # via nltk
 jsonpatch==1.33
     # via langchain-core
+jsonpickle==3.4.2
+    # via botbuilder-core
 jsonpointer==3.0.0
     # via jsonpatch
 jsonref==1.1.0
@@ -573,12 +599,17 @@ mpmath==1.3.0
     # via sympy
 msal==1.34.0
     # via
+    #   botframework-connector
     #   office365-rest-python-client
     #   onyx
 msgpack==1.1.2
     # via distributed
 msoffcrypto-tool==5.4.2
     # via onyx
+msrest==0.7.1
+    # via
+    #   botbuilder-schema
+    #   botframework-connector
 multidict==6.7.0
     # via
     #   aiobotocore
@@ -796,6 +827,7 @@ pygments==2.19.2
     # via rich
 pyjwt==2.11.0
     # via
+    #   botframework-connector
     #   fastapi-users
     #   mcp
     #   msal
@@ -922,6 +954,7 @@ regex==2025.11.3
 requests==2.32.5
     # via
     #   atlassian-python-api
+    #   azure-core
     #   braintrust
     #   cohere
     #   dropbox
@@ -940,6 +973,7 @@ requests==2.32.5
     #   markitdown
     #   matrix-client
     #   msal
+    #   msrest
     #   office365-rest-python-client
     #   onyx
     #   opensearch-py
@@ -967,6 +1001,7 @@ requests-oauthlib==1.3.1
     #   google-auth-oauthlib
     #   jira
     #   kubernetes
+    #   msrest
     #   onyx
 requests-toolbelt==1.0.0
     # via
@@ -1111,6 +1146,7 @@ typing-extensions==4.15.0
     #   aiosignal
     #   alembic
     #   anyio
+    #   azure-core
     #   boto3-stubs
     #   braintrust
     #   cohere
@@ -1177,6 +1213,7 @@ uritemplate==4.2.0
 urllib3==2.6.3
     # via
     #   asana
+    #   botbuilder-schema
     #   botocore
     #   courlan
     #   distributed
@@ -1239,7 +1276,9 @@ xmlsec==1.3.14
 xmltodict==1.0.2
     # via ddtrace
 yarl==1.22.0
-    # via aiohttp
+    # via
+    #   aiohttp
+    #   botbuilder-integration-aiohttp
 zeep==4.3.2
     # via simple-salesforce
 zict==3.0.0

--- a/backend/tests/unit/onyx/onyxbot/discord/test_api_client.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_api_client.py
@@ -12,11 +12,12 @@ import aiohttp
 import pytest
 
 from onyx.chat.models import ChatFullResponse
-from onyx.onyxbot.discord.api_client import OnyxAPIClient
-from onyx.onyxbot.discord.constants import API_REQUEST_TIMEOUT
-from onyx.onyxbot.discord.exceptions import APIConnectionError
-from onyx.onyxbot.discord.exceptions import APIResponseError
-from onyx.onyxbot.discord.exceptions import APITimeoutError
+from onyx.onyxbot.api_client import OnyxAPIClient
+from onyx.onyxbot.constants import API_REQUEST_TIMEOUT
+from onyx.onyxbot.exceptions import APIConnectionError
+from onyx.onyxbot.exceptions import APIResponseError
+from onyx.onyxbot.exceptions import APITimeoutError
+from onyx.server.query_and_chat.models import MessageOrigin
 
 
 class MockAsyncContextManager:
@@ -43,7 +44,7 @@ class TestClientLifecycle:
     @pytest.mark.asyncio
     async def test_initialize_creates_session(self) -> None:
         """initialize() creates aiohttp session."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
         assert client._session is None
 
         with patch("aiohttp.ClientSession") as mock_session_class:
@@ -57,13 +58,13 @@ class TestClientLifecycle:
 
     def test_is_initialized_before_init(self) -> None:
         """is_initialized returns False before initialize()."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
         assert client.is_initialized is False
 
     @pytest.mark.asyncio
     async def test_is_initialized_after_init(self) -> None:
         """is_initialized returns True after initialize()."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         with patch("aiohttp.ClientSession"):
             await client.initialize()
@@ -73,7 +74,7 @@ class TestClientLifecycle:
     @pytest.mark.asyncio
     async def test_close_closes_session(self) -> None:
         """close() closes session and resets is_initialized."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_session = AsyncMock()
         with patch("aiohttp.ClientSession", return_value=mock_session):
@@ -88,7 +89,7 @@ class TestClientLifecycle:
     @pytest.mark.asyncio
     async def test_send_message_not_initialized(self) -> None:
         """send_chat_message() before initialize() raises APIConnectionError."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         with pytest.raises(APIConnectionError) as exc_info:
             await client.send_chat_message("test", "api_key")
@@ -102,7 +103,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_success(self) -> None:
         """Valid request returns ChatFullResponse."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         response_data = {
             "answer": "Test response",
@@ -133,7 +134,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_with_persona(self) -> None:
         """persona_id is passed to API."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         response_data = {"answer": "Response", "citations": [], "error_msg": None}
 
@@ -164,7 +165,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_401_error(self) -> None:
         """Invalid API key returns APIResponseError with 401."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 401
@@ -184,7 +185,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_403_error(self) -> None:
         """Persona not accessible returns APIResponseError with 403."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 403
@@ -204,7 +205,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_timeout(self) -> None:
         """Request timeout raises APITimeoutError."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(
@@ -221,7 +222,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_connection_error(self) -> None:
         """Network failure raises APIConnectionError."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_session = MagicMock()
         mock_session.post = MagicMock(
@@ -240,7 +241,7 @@ class TestSendChatMessage:
     @pytest.mark.asyncio
     async def test_send_message_server_error(self) -> None:
         """500 response raises APIResponseError with 500."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 500
@@ -265,7 +266,7 @@ class TestHealthCheck:
     @pytest.mark.asyncio
     async def test_health_check_success(self) -> None:
         """Server healthy returns True."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 200
@@ -283,7 +284,7 @@ class TestHealthCheck:
     @pytest.mark.asyncio
     async def test_health_check_failure(self) -> None:
         """Server unhealthy returns False."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 503
@@ -301,7 +302,7 @@ class TestHealthCheck:
     @pytest.mark.asyncio
     async def test_health_check_timeout(self) -> None:
         """Request times out returns False."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_session = MagicMock()
         mock_session.get = MagicMock(
@@ -318,7 +319,7 @@ class TestHealthCheck:
     @pytest.mark.asyncio
     async def test_health_check_not_initialized(self) -> None:
         """Health check before initialize returns False."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         result = await client.health_check()
         assert result is False
@@ -330,7 +331,7 @@ class TestResponseParsing:
     @pytest.mark.asyncio
     async def test_response_malformed_json(self) -> None:
         """API returns invalid JSON raises exception."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         mock_response = MagicMock()
         mock_response.status = 200
@@ -349,7 +350,7 @@ class TestResponseParsing:
     @pytest.mark.asyncio
     async def test_response_with_error_msg(self) -> None:
         """200 status but error_msg present - warning logged, response returned."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         response_data = {
             "answer": "Partial response",
@@ -381,7 +382,7 @@ class TestResponseParsing:
     @pytest.mark.asyncio
     async def test_response_empty_answer(self) -> None:
         """answer field is empty string - handled gracefully."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         response_data = {
             "answer": "",
@@ -416,18 +417,18 @@ class TestClientConfiguration:
 
     def test_default_timeout(self) -> None:
         """Client uses API_REQUEST_TIMEOUT by default."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
         assert client._timeout == API_REQUEST_TIMEOUT
 
     def test_custom_timeout(self) -> None:
         """Client accepts custom timeout."""
-        client = OnyxAPIClient(timeout=60)
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT, timeout=60)
         assert client._timeout == 60
 
     @pytest.mark.asyncio
     async def test_double_initialize_warning(self) -> None:
         """Calling initialize() twice logs warning but doesn't error."""
-        client = OnyxAPIClient()
+        client = OnyxAPIClient(origin=MessageOrigin.DISCORDBOT)
 
         with patch("aiohttp.ClientSession") as mock_session_class:
             mock_session = MagicMock()

--- a/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
@@ -239,7 +239,7 @@ class TestThreadSafety:
 
         call_count = 0
 
-        async def slow_refresh() -> tuple[list[int], str]:
+        async def slow_refresh(_tenant_id: str) -> tuple[list[int], str]:
             nonlocal call_count
             call_count += 1
             # Simulate slow operation
@@ -499,7 +499,7 @@ class TestCacheErrorHandling:
             nonlocal call_count
             call_count += 1
             if tenant_id == "tenant1":
-                raise Exception("Tenant 1 error")
+                raise ConnectionError("Tenant 1 connection failed")
             return ([222222], "api_key")
 
         with (

--- a/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
@@ -18,7 +18,7 @@ class TestCacheInitialization:
     def test_cache_starts_empty(self) -> None:
         """New cache manager has empty caches."""
         cache = DiscordCacheManager()
-        assert cache._guild_tenants == {}
+        assert cache._entity_tenants == {}
         assert cache._api_keys == {}
         assert cache.is_initialized is False
 
@@ -37,14 +37,14 @@ class TestCacheInitialization:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config1, mock_config2],
@@ -61,10 +61,10 @@ class TestCacheInitialization:
             await cache.refresh_all()
 
         assert cache.is_initialized is True
-        assert 111111 in cache._guild_tenants
-        assert 222222 in cache._guild_tenants
-        assert cache._guild_tenants[111111] == "tenant1"
-        assert cache._guild_tenants[222222] == "tenant1"
+        assert 111111 in cache._entity_tenants
+        assert 222222 in cache._entity_tenants
+        assert cache._entity_tenants[111111] == "tenant1"
+        assert cache._entity_tenants[222222] == "tenant1"
 
     @pytest.mark.asyncio
     async def test_cache_refresh_provisions_api_key(self) -> None:
@@ -77,14 +77,14 @@ class TestCacheInitialization:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -110,7 +110,7 @@ class TestCacheLookups:
     def test_get_tenant_returns_correct(self) -> None:
         """Lookup registered guild returns correct tenant ID."""
         cache = DiscordCacheManager()
-        cache._guild_tenants[123456] = "tenant1"
+        cache._entity_tenants[123456] = "tenant1"
 
         result = cache.get_tenant(123456)
         assert result == "tenant1"
@@ -140,7 +140,7 @@ class TestCacheLookups:
     def test_get_all_guild_ids(self) -> None:
         """After loading returns all cached guild IDs."""
         cache = DiscordCacheManager()
-        cache._guild_tenants = {111: "t1", 222: "t2", 333: "t1"}
+        cache._entity_tenants = {111: "t1", 222: "t2", 333: "t1"}
 
         result = cache.get_all_guild_ids()
         assert set(result) == {111, 222, 333}
@@ -159,7 +159,7 @@ class TestCacheUpdates:
         mock_config.enabled = True
 
         with (
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -187,7 +187,7 @@ class TestCacheUpdates:
         mock_config.enabled = False  # Disabled!
 
         with (
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -205,7 +205,7 @@ class TestCacheUpdates:
     def test_remove_guild(self) -> None:
         """remove_guild() removes guild from cache."""
         cache = DiscordCacheManager()
-        cache._guild_tenants[111111] = "tenant1"
+        cache._entity_tenants[111111] = "tenant1"
 
         cache.remove_guild(111111)
 
@@ -214,13 +214,13 @@ class TestCacheUpdates:
     def test_clear_removes_all(self) -> None:
         """clear() empties all caches."""
         cache = DiscordCacheManager()
-        cache._guild_tenants = {111: "t1", 222: "t2"}
+        cache._entity_tenants = {111: "t1", 222: "t2"}
         cache._api_keys = {"t1": "key1", "t2": "key2"}
         cache._initialized = True
 
         cache.clear()
 
-        assert cache._guild_tenants == {}
+        assert cache._entity_tenants == {}
         assert cache._api_keys == {}
         assert cache.is_initialized is False
 
@@ -248,11 +248,11 @@ class TestThreadSafety:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
             patch.object(cache, "_load_tenant_data", side_effect=slow_refresh),
@@ -271,7 +271,7 @@ class TestThreadSafety:
     async def test_concurrent_read_write(self) -> None:
         """Read during refresh doesn't cause exceptions."""
         cache = DiscordCacheManager()
-        cache._guild_tenants[111111] = "tenant1"
+        cache._entity_tenants[111111] = "tenant1"
 
         async def read_loop() -> None:
             for _ in range(10):
@@ -280,7 +280,7 @@ class TestThreadSafety:
 
         async def write_loop() -> None:
             for i in range(10):
-                cache._guild_tenants[200000 + i] = f"tenant{i}"
+                cache._entity_tenants[200000 + i] = f"tenant{i}"
                 await asyncio.sleep(0.001)
 
         # Should not raise any exceptions
@@ -301,14 +301,14 @@ class TestAPIKeyProvisioning:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -339,14 +339,14 @@ class TestAPIKeyProvisioning:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -392,14 +392,14 @@ class TestGatedTenantHandling:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1", "tenant2"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: gated_tenants,
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 side_effect=mock_get_configs,
@@ -416,9 +416,9 @@ class TestGatedTenantHandling:
             await cache.refresh_all()
 
         # Only tenant1 should be loaded (tenant2 is gated)
-        assert "tenant1" in cache._api_keys and 111111 in cache._guild_tenants
+        assert "tenant1" in cache._api_keys and 111111 in cache._entity_tenants
         # tenant2's guilds should NOT be in cache
-        assert "tenant2" not in cache._api_keys and 222222 not in cache._guild_tenants
+        assert "tenant2" not in cache._api_keys and 222222 not in cache._entity_tenants
 
     @pytest.mark.asyncio
     async def test_gated_check_calls_ee_function(self) -> None:
@@ -427,14 +427,14 @@ class TestGatedTenantHandling:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ) as mock_ee,
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[],
@@ -459,14 +459,14 @@ class TestGatedTenantHandling:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),  # No gated tenants
             ),
-            patch("onyx.onyxbot.discord.cache.get_session_with_tenant") as mock_session,
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.cache.get_guild_configs",
                 return_value=[mock_config],
@@ -504,11 +504,11 @@ class TestCacheErrorHandling:
 
         with (
             patch(
-                "onyx.onyxbot.discord.cache.get_all_tenant_ids",
+                "onyx.onyxbot.cache.get_all_tenant_ids",
                 return_value=["tenant1", "tenant2"],
             ),
             patch(
-                "onyx.onyxbot.discord.cache.fetch_ee_implementation_or_noop",
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
                 return_value=lambda: set(),
             ),
             patch.object(cache, "_load_tenant_data", side_effect=mock_load),

--- a/backend/tests/unit/onyx/onyxbot/teams/conftest.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/conftest.py
@@ -1,0 +1,105 @@
+"""Fixtures for Teams bot unit tests."""
+
+import random
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mock_team_config_enabled() -> MagicMock:
+    """Team config that is enabled."""
+    config = MagicMock()
+    config.id = 1
+    config.team_id = "team-abc-123"
+    config.enabled = True
+    config.default_persona_id = 1
+    return config
+
+
+@pytest.fixture
+def mock_team_config_disabled() -> MagicMock:
+    """Team config that is disabled."""
+    config = MagicMock()
+    config.id = 2
+    config.team_id = "team-abc-123"
+    config.enabled = False
+    config.default_persona_id = None
+    return config
+
+
+@pytest.fixture
+def mock_channel_config_factory() -> Callable[..., MagicMock]:
+    """Factory fixture for creating channel configs with various settings."""
+
+    def _make_config(
+        enabled: bool = True,
+        require_bot_mention: bool = True,
+        persona_override_id: int | None = None,
+    ) -> MagicMock:
+        config = MagicMock()
+        config.id = random.randint(1, 1000)
+        config.channel_id = "19:channel-xyz@thread.tacv2"
+        config.enabled = enabled
+        config.require_bot_mention = require_bot_mention
+        config.persona_override_id = persona_override_id
+        return config
+
+    return _make_config
+
+
+@pytest.fixture
+def sample_activity_dict() -> dict:
+    """Sample Teams Activity as a dict."""
+    return {
+        "type": "message",
+        "text": "<at>Onyx</at> What is our deployment process?",
+        "from": {
+            "id": "29:user-id-123",
+            "name": "Test User",
+        },
+        "recipient": {
+            "id": "28:bot-id-456",
+            "name": "Onyx",
+        },
+        "channelData": {
+            "team": {
+                "id": "team-abc-123",
+                "name": "Engineering",
+            },
+            "channel": {
+                "id": "19:channel-xyz@thread.tacv2",
+                "name": "general",
+            },
+        },
+        "entities": [
+            {
+                "type": "mention",
+                "mentioned": {
+                    "id": "28:bot-id-456",
+                    "name": "Onyx",
+                },
+                "text": "<at>Onyx</at>",
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def sample_dm_activity_dict() -> dict:
+    """Sample Teams DM Activity (no team context)."""
+    return {
+        "type": "message",
+        "text": "Hello bot",
+        "from": {
+            "id": "29:user-id-123",
+            "name": "Test User",
+        },
+        "recipient": {
+            "id": "28:bot-id-456",
+            "name": "Onyx",
+        },
+        "channelData": {},
+        "entities": [],
+    }

--- a/backend/tests/unit/onyx/onyxbot/teams/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/test_cache_manager.py
@@ -44,7 +44,7 @@ class TestCacheInitialization:
                 return_value=[mock_config1, mock_config2],
             ),
             patch(
-                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                "onyx.onyxbot.teams.cache.provision_teams_service_api_key",
                 return_value="test_api_key",
             ),
         ):
@@ -82,7 +82,7 @@ class TestCacheInitialization:
                 return_value=[mock_config],
             ),
             patch(
-                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                "onyx.onyxbot.teams.cache.provision_teams_service_api_key",
                 return_value="new_api_key",
             ) as mock_provision,
         ):
@@ -142,7 +142,7 @@ class TestCacheUpdates:
                 return_value=[mock_config],
             ),
             patch(
-                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                "onyx.onyxbot.teams.cache.provision_teams_service_api_key",
                 return_value="api_key",
             ),
         ):
@@ -200,7 +200,7 @@ class TestGatedTenantHandling:
                 return_value=[mock_config],
             ),
             patch(
-                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                "onyx.onyxbot.teams.cache.provision_teams_service_api_key",
                 return_value="api_key",
             ),
         ):

--- a/backend/tests/unit/onyx/onyxbot/teams/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/test_cache_manager.py
@@ -1,0 +1,214 @@
+"""Unit tests for Teams bot cache manager."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.onyxbot.teams.cache import TeamsCacheManager
+
+
+class TestCacheInitialization:
+    """Tests for cache initialization."""
+
+    def test_cache_starts_empty(self) -> None:
+        cache = TeamsCacheManager()
+        assert cache._entity_tenants == {}
+        assert cache._api_keys == {}
+        assert cache.is_initialized is False
+
+    @pytest.mark.asyncio
+    async def test_cache_refresh_all_loads_teams(self) -> None:
+        cache = TeamsCacheManager()
+
+        mock_config1 = MagicMock()
+        mock_config1.team_id = "team-111"
+        mock_config1.enabled = True
+
+        mock_config2 = MagicMock()
+        mock_config2.team_id = "team-222"
+        mock_config2.enabled = True
+
+        with (
+            patch(
+                "onyx.onyxbot.cache.get_all_tenant_ids",
+                return_value=["tenant1"],
+            ),
+            patch(
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
+                return_value=lambda: set(),
+            ),
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
+            patch(
+                "onyx.onyxbot.teams.cache.get_team_configs",
+                return_value=[mock_config1, mock_config2],
+            ),
+            patch(
+                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                return_value="test_api_key",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            await cache.refresh_all()
+
+        assert cache.is_initialized is True
+        assert "team-111" in cache._entity_tenants
+        assert "team-222" in cache._entity_tenants
+        assert cache._entity_tenants["team-111"] == "tenant1"
+
+    @pytest.mark.asyncio
+    async def test_cache_refresh_provisions_api_key(self) -> None:
+        cache = TeamsCacheManager()
+
+        mock_config = MagicMock()
+        mock_config.team_id = "team-111"
+        mock_config.enabled = True
+
+        with (
+            patch(
+                "onyx.onyxbot.cache.get_all_tenant_ids",
+                return_value=["tenant1"],
+            ),
+            patch(
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
+                return_value=lambda: set(),
+            ),
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
+            patch(
+                "onyx.onyxbot.teams.cache.get_team_configs",
+                return_value=[mock_config],
+            ),
+            patch(
+                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                return_value="new_api_key",
+            ) as mock_provision,
+        ):
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            await cache.refresh_all()
+
+        assert cache._api_keys.get("tenant1") == "new_api_key"
+        mock_provision.assert_called()
+
+
+class TestCacheLookups:
+    """Tests for cache lookup operations."""
+
+    def test_get_tenant_returns_correct(self) -> None:
+        cache = TeamsCacheManager()
+        cache._entity_tenants["team-123"] = "tenant1"
+        assert cache.get_tenant("team-123") == "tenant1"
+
+    def test_get_tenant_returns_none_unknown(self) -> None:
+        cache = TeamsCacheManager()
+        assert cache.get_tenant("unknown-team") is None
+
+    def test_get_api_key_returns_correct(self) -> None:
+        cache = TeamsCacheManager()
+        cache._api_keys["tenant1"] = "api_key_123"
+        assert cache.get_api_key("tenant1") == "api_key_123"
+
+    def test_get_api_key_returns_none_unknown(self) -> None:
+        cache = TeamsCacheManager()
+        assert cache.get_api_key("unknown_tenant") is None
+
+    def test_get_all_team_ids(self) -> None:
+        cache = TeamsCacheManager()
+        cache._entity_tenants = {"t1": "tenant1", "t2": "tenant2", "t3": "tenant1"}
+        result = cache.get_all_team_ids()
+        assert set(result) == {"t1", "t2", "t3"}
+
+
+class TestCacheUpdates:
+    """Tests for cache update operations."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_team_adds_new(self) -> None:
+        cache = TeamsCacheManager()
+
+        mock_config = MagicMock()
+        mock_config.team_id = "team-111"
+        mock_config.enabled = True
+
+        with (
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
+            patch(
+                "onyx.onyxbot.teams.cache.get_team_configs",
+                return_value=[mock_config],
+            ),
+            patch(
+                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                return_value="api_key",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            await cache.refresh_team("team-111", "tenant1")
+
+        assert cache.get_tenant("team-111") == "tenant1"
+
+    def test_remove_team(self) -> None:
+        cache = TeamsCacheManager()
+        cache._entity_tenants["team-111"] = "tenant1"
+        cache.remove_team("team-111")
+        assert cache.get_tenant("team-111") is None
+
+    def test_clear_removes_all(self) -> None:
+        cache = TeamsCacheManager()
+        cache._entity_tenants = {"t1": "tenant1", "t2": "tenant2"}
+        cache._api_keys = {"tenant1": "key1", "tenant2": "key2"}
+        cache._initialized = True
+
+        cache.clear()
+
+        assert cache._entity_tenants == {}
+        assert cache._api_keys == {}
+        assert cache.is_initialized is False
+
+
+class TestGatedTenantHandling:
+    """Tests for gated tenant filtering."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_skips_gated_tenants(self) -> None:
+        cache = TeamsCacheManager()
+        gated_tenants = {"tenant2"}
+
+        mock_config = MagicMock()
+        mock_config.team_id = "team-111"
+        mock_config.enabled = True
+
+        with (
+            patch(
+                "onyx.onyxbot.cache.get_all_tenant_ids",
+                return_value=["tenant1", "tenant2"],
+            ),
+            patch(
+                "onyx.onyxbot.cache.fetch_ee_implementation_or_noop",
+                return_value=lambda: gated_tenants,
+            ),
+            patch("onyx.onyxbot.cache.get_session_with_tenant") as mock_session,
+            patch(
+                "onyx.onyxbot.teams.cache.get_team_configs",
+                return_value=[mock_config],
+            ),
+            patch(
+                "onyx.onyxbot.teams.cache.get_or_create_teams_service_api_key",
+                return_value="api_key",
+            ),
+        ):
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            await cache.refresh_all()
+
+        assert "tenant1" in cache._api_keys
+        assert "tenant2" not in cache._api_keys

--- a/backend/tests/unit/onyx/onyxbot/teams/test_cards.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/test_cards.py
@@ -1,0 +1,86 @@
+"""Unit tests for Teams bot Adaptive Card builders."""
+
+from unittest.mock import MagicMock
+
+from onyx.onyxbot.teams.cards import build_answer_card
+from onyx.onyxbot.teams.cards import build_error_card
+from onyx.onyxbot.teams.cards import build_welcome_card
+
+
+class TestBuildAnswerCard:
+    """Tests for answer card generation."""
+
+    def test_basic_answer(self) -> None:
+        card = build_answer_card("Hello world")
+        assert card["type"] == "AdaptiveCard"
+        assert card["version"] == "1.3"
+        assert len(card["body"]) == 1
+        assert card["body"][0]["text"] == "Hello world"
+
+    def test_answer_with_citations(self) -> None:
+        mock_response = MagicMock()
+        mock_citation = MagicMock()
+        mock_citation.citation_number = 1
+        mock_citation.document_id = "doc1"
+
+        mock_doc = MagicMock()
+        mock_doc.document_id = "doc1"
+        mock_doc.semantic_identifier = "Design Doc"
+        mock_doc.link = "https://example.com/doc1"
+
+        mock_response.citation_info = [mock_citation]
+        mock_response.top_documents = [mock_doc]
+
+        card = build_answer_card("Answer text", mock_response)
+        # Body should have: answer + "Sources:" header + citation
+        assert len(card["body"]) == 3
+        assert "Sources" in card["body"][1]["text"]
+        assert "Design Doc" in card["body"][2]["text"]
+
+    def test_answer_no_citations(self) -> None:
+        mock_response = MagicMock()
+        mock_response.citation_info = []
+        mock_response.top_documents = []
+
+        card = build_answer_card("Answer text", mock_response)
+        assert len(card["body"]) == 1
+
+    def test_answer_citation_without_link(self) -> None:
+        mock_response = MagicMock()
+        mock_citation = MagicMock()
+        mock_citation.citation_number = 1
+        mock_citation.document_id = "doc1"
+
+        mock_doc = MagicMock()
+        mock_doc.document_id = "doc1"
+        mock_doc.semantic_identifier = "Internal Doc"
+        mock_doc.link = None
+
+        mock_response.citation_info = [mock_citation]
+        mock_response.top_documents = [mock_doc]
+
+        card = build_answer_card("Answer text", mock_response)
+        assert "Internal Doc" in card["body"][2]["text"]
+        # Should not contain markdown link since link is None
+        assert "http" not in card["body"][2]["text"]
+
+
+class TestBuildErrorCard:
+    """Tests for error card generation."""
+
+    def test_error_card(self) -> None:
+        card = build_error_card("Something went wrong")
+        assert card["type"] == "AdaptiveCard"
+        assert card["body"][0]["text"] == "Something went wrong"
+        assert card["body"][0]["color"] == "Attention"
+
+
+class TestBuildWelcomeCard:
+    """Tests for welcome card generation."""
+
+    def test_welcome_card(self) -> None:
+        card = build_welcome_card()
+        assert card["type"] == "AdaptiveCard"
+        assert len(card["body"]) == 2
+        assert "Welcome" in card["body"][0]["text"]
+        assert "register" in card["body"][1]["text"]

--- a/backend/tests/unit/onyx/onyxbot/teams/test_should_respond.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/test_should_respond.py
@@ -1,0 +1,272 @@
+"""Unit tests for Teams bot should_respond logic."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.onyxbot.teams.handle_message import should_respond
+
+
+class TestBasicShouldRespond:
+    """Tests for basic should_respond decision logic."""
+
+    def test_team_disabled_returns_false(self) -> None:
+        """Team config enabled=false returns False."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = False
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with patch(
+                "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                return_value=mock_team_config,
+            ):
+                result = should_respond(
+                    activity_dict={},
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is False
+
+    def test_team_enabled_channel_enabled_no_mention_required(self) -> None:
+        """Team + channel enabled, require_bot_mention=false returns True."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+        mock_team_config.default_persona_id = 2
+
+        mock_channel_config = MagicMock()
+        mock_channel_config.enabled = True
+        mock_channel_config.require_bot_mention = False
+        mock_channel_config.persona_override_id = None
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=mock_channel_config,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict={},
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is True
+        assert result.persona_id == 2
+
+    def test_channel_disabled_returns_false(self) -> None:
+        """Channel config enabled=false returns False."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+
+        mock_channel_config = MagicMock()
+        mock_channel_config.enabled = False
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=mock_channel_config,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict={},
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is False
+
+    def test_channel_not_found_returns_false(self) -> None:
+        """No channel config returns False (not whitelisted)."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=None,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict={},
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is False
+
+    def test_require_mention_true_with_mention(
+        self, sample_activity_dict: dict
+    ) -> None:
+        """require_bot_mention=true with @mention returns True."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+        mock_team_config.default_persona_id = 1
+
+        mock_channel_config = MagicMock()
+        mock_channel_config.enabled = True
+        mock_channel_config.require_bot_mention = True
+        mock_channel_config.persona_override_id = None
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=mock_channel_config,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict=sample_activity_dict,
+                    team_id="team-abc-123",
+                    channel_id="19:channel-xyz@thread.tacv2",
+                    tenant_id="tenant1",
+                    bot_id="28:bot-id-456",
+                )
+
+        assert result.should_respond is True
+
+    def test_require_mention_true_no_mention(self) -> None:
+        """require_bot_mention=true without @mention returns False."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+        mock_team_config.default_persona_id = 1
+
+        mock_channel_config = MagicMock()
+        mock_channel_config.enabled = True
+        mock_channel_config.require_bot_mention = True
+        mock_channel_config.persona_override_id = None
+
+        activity_no_mention = {"entities": []}
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=mock_channel_config,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict=activity_no_mention,
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is False
+
+    def test_dm_no_team_returns_true(self) -> None:
+        """DM (no team_id or channel_id) returns True."""
+        result = should_respond(
+            activity_dict={},
+            team_id=None,
+            channel_id=None,
+            tenant_id="tenant1",
+            bot_id="bot-id",
+        )
+        assert result.should_respond is True
+
+    def test_persona_override_takes_priority(self) -> None:
+        """Channel persona override takes priority over team default."""
+        mock_team_config = MagicMock()
+        mock_team_config.enabled = True
+        mock_team_config.default_persona_id = 1
+
+        mock_channel_config = MagicMock()
+        mock_channel_config.enabled = True
+        mock_channel_config.require_bot_mention = False
+        mock_channel_config.persona_override_id = 5
+
+        with patch(
+            "onyx.onyxbot.teams.handle_message.get_session_with_tenant"
+        ) as mock_session:
+            mock_db = MagicMock()
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_session.return_value.__exit__ = MagicMock()
+
+            with (
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_team_config_by_teams_id",
+                    return_value=mock_team_config,
+                ),
+                patch(
+                    "onyx.onyxbot.teams.handle_message.get_channel_config_by_teams_ids",
+                    return_value=mock_channel_config,
+                ),
+            ):
+                result = should_respond(
+                    activity_dict={},
+                    team_id="team-123",
+                    channel_id="channel-456",
+                    tenant_id="tenant1",
+                    bot_id="bot-id",
+                )
+
+        assert result.should_respond is True
+        assert result.persona_id == 5

--- a/backend/tests/unit/onyx/onyxbot/teams/test_utils.py
+++ b/backend/tests/unit/onyx/onyxbot/teams/test_utils.py
@@ -1,0 +1,104 @@
+"""Unit tests for Teams bot utility functions."""
+
+from onyx.onyxbot.teams.utils import extract_channel_id
+from onyx.onyxbot.teams.utils import extract_team_id
+from onyx.onyxbot.teams.utils import extract_team_name
+from onyx.onyxbot.teams.utils import is_bot_mentioned
+from onyx.onyxbot.teams.utils import strip_bot_mention
+from onyx.server.manage.teams_bot.utils import generate_teams_registration_key
+from onyx.server.manage.teams_bot.utils import parse_teams_registration_key
+
+
+class TestExtractIds:
+    """Tests for ID extraction from Activity dicts."""
+
+    def test_extract_team_id_present(self, sample_activity_dict: dict) -> None:
+        assert extract_team_id(sample_activity_dict) == "team-abc-123"
+
+    def test_extract_team_id_missing(self, sample_dm_activity_dict: dict) -> None:
+        assert extract_team_id(sample_dm_activity_dict) is None
+
+    def test_extract_channel_id_present(self, sample_activity_dict: dict) -> None:
+        assert extract_channel_id(sample_activity_dict) == "19:channel-xyz@thread.tacv2"
+
+    def test_extract_channel_id_missing(self, sample_dm_activity_dict: dict) -> None:
+        assert extract_channel_id(sample_dm_activity_dict) is None
+
+    def test_extract_team_name(self, sample_activity_dict: dict) -> None:
+        assert extract_team_name(sample_activity_dict) == "Engineering"
+
+    def test_extract_team_name_missing(self, sample_dm_activity_dict: dict) -> None:
+        assert extract_team_name(sample_dm_activity_dict) is None
+
+
+class TestStripBotMention:
+    """Tests for bot mention stripping."""
+
+    def test_strip_named_mention(self) -> None:
+        text = "<at>Onyx</at> What is our process?"
+        assert strip_bot_mention(text, "Onyx") == "What is our process?"
+
+    def test_strip_case_insensitive(self) -> None:
+        text = "<at>onyx</at> Hello"
+        assert strip_bot_mention(text, "Onyx") == "Hello"
+
+    def test_strip_no_mention(self) -> None:
+        text = "Just a normal message"
+        assert strip_bot_mention(text, "Onyx") == "Just a normal message"
+
+    def test_strip_multiple_mentions(self) -> None:
+        text = "<at>Onyx</at> hello <at>Onyx</at>"
+        assert strip_bot_mention(text, "Onyx") == "hello"
+
+    def test_strip_empty_result(self) -> None:
+        text = "<at>Onyx</at>"
+        assert strip_bot_mention(text, "Onyx") == ""
+
+
+class TestIsBotMentioned:
+    """Tests for bot mention detection."""
+
+    def test_bot_mentioned(self, sample_activity_dict: dict) -> None:
+        assert is_bot_mentioned(sample_activity_dict, "28:bot-id-456") is True
+
+    def test_bot_not_mentioned(self, sample_dm_activity_dict: dict) -> None:
+        assert is_bot_mentioned(sample_dm_activity_dict, "28:bot-id-456") is False
+
+    def test_different_bot_mentioned(self, sample_activity_dict: dict) -> None:
+        assert is_bot_mentioned(sample_activity_dict, "other-bot-id") is False
+
+    def test_no_entities(self) -> None:
+        activity = {"entities": []}
+        assert is_bot_mentioned(activity, "any-id") is False
+
+
+class TestRegistrationKeys:
+    """Tests for registration key generation and parsing."""
+
+    def test_generate_and_parse_roundtrip(self) -> None:
+        key = generate_teams_registration_key("tenant1")
+        parsed = parse_teams_registration_key(key)
+        assert parsed == "tenant1"
+
+    def test_generate_has_correct_prefix(self) -> None:
+        key = generate_teams_registration_key("tenant1")
+        assert key.startswith("teams_")
+
+    def test_parse_invalid_prefix(self) -> None:
+        assert parse_teams_registration_key("discord_tenant1.token") is None
+
+    def test_parse_no_separator(self) -> None:
+        assert parse_teams_registration_key("teams_noseparator") is None
+
+    def test_parse_empty_string(self) -> None:
+        assert parse_teams_registration_key("") is None
+
+    def test_generate_url_encodes_tenant(self) -> None:
+        key = generate_teams_registration_key("tenant with spaces")
+        parsed = parse_teams_registration_key(key)
+        assert parsed == "tenant with spaces"
+
+    def test_generate_unique_keys(self) -> None:
+        key1 = generate_teams_registration_key("tenant1")
+        key2 = generate_teams_registration_key("tenant1")
+        assert key1 != key2

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -65,7 +65,10 @@ services:
       - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
+      - TEAMS_BOT_APP_ID=${TEAMS_BOT_APP_ID:-}
+      - TEAMS_BOT_APP_SECRET=${TEAMS_BOT_APP_SECRET:-}
+      - TEAMS_BOT_AZURE_TENANT_ID=${TEAMS_BOT_AZURE_TENANT_ID:-}
+      # API Server connection for Discord/Teams bot message processing
       - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
       - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
     env_file:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -87,7 +87,10 @@ services:
       - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
+      - TEAMS_BOT_APP_ID=${TEAMS_BOT_APP_ID:-}
+      - TEAMS_BOT_APP_SECRET=${TEAMS_BOT_APP_SECRET:-}
+      - TEAMS_BOT_AZURE_TENANT_ID=${TEAMS_BOT_AZURE_TENANT_ID:-}
+      # API Server connection for Discord/Teams bot message processing
       - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
       - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
       - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -161,7 +161,10 @@ services:
       - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
       - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
+      - TEAMS_BOT_APP_ID=${TEAMS_BOT_APP_ID:-}
+      - TEAMS_BOT_APP_SECRET=${TEAMS_BOT_APP_SECRET:-}
+      - TEAMS_BOT_AZURE_TENANT_ID=${TEAMS_BOT_AZURE_TENANT_ID:-}
+      # API Server connection for Discord/Teams bot message processing
       - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
       - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
       # Onyx Craft configuration (set up automatically on container startup)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -103,6 +103,14 @@ MINIO_ROOT_PASSWORD=minioadmin
 ## Command prefix for bot commands (default: "!")
 # DISCORD_BOT_INVOKE_CHAR=!
 
+## Teams Bot Configuration
+## The Teams bot allows users to interact with Onyx from Microsoft Teams
+## App ID and Secret from Azure Bot Service registration
+# TEAMS_BOT_APP_ID=
+# TEAMS_BOT_APP_SECRET=
+## Azure tenant ID (optional, for single-tenant bots)
+# TEAMS_BOT_AZURE_TENANT_ID=
+
 ## Celery Configuration
 # CELERY_BROKER_POOL_LIMIT=
 # CELERY_WORKER_DOCFETCHING_CONCURRENCY=

--- a/deployment/helm/charts/onyx/templates/teamsbot-service.yaml
+++ b/deployment/helm/charts/onyx/templates/teamsbot-service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.teamsbot.enabled }}
+# Service to expose the Teams bot /api/messages endpoint.
+# Unlike Discord (outbound WebSocket only), Teams requires an inbound HTTP endpoint
+# that Azure Bot Service can POST Activities to.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "onyx.fullname" . }}-teamsbot
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.teamsbot.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.teamsbot.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.teamsbot.service.port | default 80 }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "onyx.selectorLabels" . | nindent 4 }}
+    {{- if .Values.teamsbot.deploymentLabels }}
+    {{- toYaml .Values.teamsbot.deploymentLabels | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/teamsbot.yaml
+++ b/deployment/helm/charts/onyx/templates/teamsbot.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.teamsbot.enabled }}
+# Teams bot receives webhooks via HTTP POST - supports multiple replicas behind a load balancer.
+# Unlike Discord (WebSocket, single replica), Teams is horizontally scalable.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "onyx.fullname" . }}-teamsbot
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    {{- with .Values.teamsbot.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.teamsbot.replicaCount | default 1 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "onyx.selectorLabels" . | nindent 6 }}
+      {{- if .Values.teamsbot.deploymentLabels }}
+      {{- toYaml .Values.teamsbot.deploymentLabels | nindent 6 }}
+      {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.teamsbot.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "onyx.labels" . | nindent 8 }}
+        {{- with .Values.teamsbot.deploymentLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.teamsbot.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "onyx.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.teamsbot.podSecurityContext | nindent 8 }}
+      {{- with .Values.teamsbot.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.teamsbot.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.teamsbot.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: teamsbot
+          securityContext:
+            {{- toYaml .Values.teamsbot.securityContext | nindent 12 }}
+          image: "{{ .Values.teamsbot.image.repository }}:{{ .Values.teamsbot.image.tag | default .Values.global.version }}"
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
+          command: ["python", "onyx/onyxbot/teams/server.py"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.teamsbot.port | default 3978 }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.teamsbot.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.config.envConfigMapName }}
+          env:
+            {{- include "onyx.envSecrets" . | nindent 12}}
+            # Teams bot App ID
+            {{- if .Values.teamsbot.appId }}
+            - name: TEAMS_BOT_APP_ID
+              value: {{ .Values.teamsbot.appId | quote }}
+            {{- end }}
+            {{- if .Values.teamsbot.appIdSecretName }}
+            - name: TEAMS_BOT_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.teamsbot.appIdSecretName }}
+                  key: {{ .Values.teamsbot.appIdSecretKey | default "app-id" }}
+            {{- end }}
+            # Teams bot App Secret
+            {{- if .Values.teamsbot.appSecret }}
+            - name: TEAMS_BOT_APP_SECRET
+              value: {{ .Values.teamsbot.appSecret | quote }}
+            {{- end }}
+            {{- if .Values.teamsbot.appSecretSecretName }}
+            - name: TEAMS_BOT_APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.teamsbot.appSecretSecretName }}
+                  key: {{ .Values.teamsbot.appSecretSecretKey | default "app-secret" }}
+            {{- end }}
+            # Azure tenant ID (optional, for single-tenant bots)
+            {{- if .Values.teamsbot.azureTenantId }}
+            - name: TEAMS_BOT_AZURE_TENANT_ID
+              value: {{ .Values.teamsbot.azureTenantId | quote }}
+            {{- end }}
+            # Bot port
+            - name: TEAMS_BOT_PORT
+              value: {{ .Values.teamsbot.port | default 3978 | quote }}
+          {{- with .Values.teamsbot.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.teamsbot.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -783,6 +783,49 @@ discordbot:
   tolerations: []
   affinity: {}
 
+teamsbot:
+  enabled: false  # Disabled by default - requires Azure Bot Service credentials
+  replicaCount: 1  # Can scale horizontally (HTTP webhook, not WebSocket)
+  # Bot credentials can be provided directly or via Kubernetes secrets
+  # Option 1: Direct values (not recommended for production)
+  appId: ""
+  appSecret: ""
+  azureTenantId: ""  # Optional - for single-tenant bots
+  # Option 2: Reference Kubernetes secrets (recommended)
+  appIdSecretName: ""
+  appIdSecretKey: "app-id"
+  appSecretSecretName: ""
+  appSecretSecretKey: "app-secret"
+  # Bot HTTP port
+  port: 3978
+  image:
+    repository: onyxdotapp/onyx-backend
+    tag: ""  # Overrides the image tag whose default is the chart appVersion.
+  service:
+    type: ClusterIP
+    port: 80
+  podAnnotations: {}
+  podLabels:
+    scope: onyx-backend
+  deploymentLabels:
+    app: teams-bot
+  podSecurityContext:
+    {}
+  securityContext:
+    {}
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 slackbot:
   enabled: true
   replicaCount: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ backend = [
     "asyncpg==0.30.0",
     "atlassian-python-api==3.41.16",
     "beautifulsoup4==4.12.3",
+    "botbuilder-core>=4.17.0,<5.0.0",
+    "botbuilder-integration-aiohttp>=4.17.0,<5.0.0",
     "boto3==1.39.11",
     "boto3-stubs[s3]==1.39.11",
     "celery==5.5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -464,6 +464,19 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.38.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/fe/5c7710bc611a4070d06ba801de9a935cc87c3d4b689c644958047bdf2cba/azure_core-1.38.2.tar.gz", hash = "sha256:67562857cb979217e48dc60980243b61ea115b77326fa93d83b729e7ff0482e7", size = 363734, upload-time = "2026-02-18T19:33:05.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/23/6371a551800d3812d6019cd813acd985f9fac0fedc1290129211a73da4ae/azure_core-1.38.2-py3-none-any.whl", hash = "sha256:074806c75cf239ea284a33a66827695ef7aeddac0b4e19dda266a93e4665ead9", size = 217957, upload-time = "2026-02-18T19:33:07.696Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -600,6 +613,73 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/ee/adda3d46d4a9120772fae6de454c8495603c37c4c3b9c60f25b1ab6401fe/black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171", size = 1782926, upload-time = "2025-01-29T04:18:58.564Z" },
     { url = "https://files.pythonhosted.org/packages/cc/64/94eb5f45dcb997d2082f097a3944cfc7fe87e071907f677e80788a2d7b7a/black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18", size = 1442613, upload-time = "2025-01-29T04:19:27.63Z" },
     { url = "https://files.pythonhosted.org/packages/09/71/54e999902aed72baf26bca0d50781b01838251a462612966e9fc4891eadd/black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717", size = 207646, upload-time = "2025-01-29T04:15:38.082Z" },
+]
+
+[[package]]
+name = "botbuilder-core"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+    { name = "botframework-streaming" },
+    { name = "jsonpickle" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/11/cd231b48525e6b34a11cf211db110a95e901204f141c1633bdcbfe1866f1/botbuilder_core-4.17.1-py3-none-any.whl", hash = "sha256:b0a5eea6ce9759dba0847adeed0587fec83ce069f3b4938eb348bb44becde8d7", size = 116145, upload-time = "2026-01-05T19:49:41.946Z" },
+]
+
+[[package]]
+name = "botbuilder-integration-aiohttp"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "botbuilder-core" },
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+    { name = "yarl" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0f/19ebe8cfaf7181940e6a31c98a116c9549a8e23b74965be445954ce803db/botbuilder_integration_aiohttp-4.17.1-py3-none-any.whl", hash = "sha256:3b66245e2ba76b2aeeb680ac0a97915f36385bc98361984a7a0d48389d86b524", size = 19030, upload-time = "2026-01-05T19:49:44.017Z" },
+]
+
+[[package]]
+name = "botbuilder-schema"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msrest" },
+    { name = "urllib3" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/44/abac81a80ed8aea977afbf8c40c22dec11610bbc1e4bd5bff4a7d7386b94/botbuilder_schema-4.17.1-py2.py3-none-any.whl", hash = "sha256:34da28d721b0635fc41bbe3b368225b9883f527d6f17337f858efe80f74656eb", size = 38196, upload-time = "2026-01-05T19:49:45.501Z" },
+]
+
+[[package]]
+name = "botframework-connector"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "msal" },
+    { name = "msrest" },
+    { name = "pyjwt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/37/6c325f4e6441cba2b3184e6c9a15c3ddc00b5e5aa47966398c3d9836b598/botframework_connector-4.17.1-py2.py3-none-any.whl", hash = "sha256:929d242a242f16c7c637eec7c239a84fd7f5f5bb7f95968407d3a9aa9d7bdf8d", size = 100883, upload-time = "2026-01-05T19:49:48.285Z" },
+]
+
+[[package]]
+name = "botframework-streaming"
+version = "4.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botbuilder-schema" },
+    { name = "botframework-connector" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/67/16b1a40b9bdc6288d90f17a464fca457e1e50cc36f1c25bc6265bcdffefe/botframework_streaming-4.17.1-py3-none-any.whl", hash = "sha256:66ad1cfe24c8c6b1fde8f95131e39e01197158e7e0bab797dfa709b4f905deb3", size = 41951, upload-time = "2026-01-05T19:49:50.245Z" },
 ]
 
 [[package]]
@@ -2998,6 +3078,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpickle"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/d9/05365407d3312653498001adcebe64a14024f7189691b728610209991c46/jsonpickle-3.4.2.tar.gz", hash = "sha256:2efa2778859b6397d5804b0a98d52cd2a7d9a70fcb873bc5a3ca5acca8f499ba", size = 314339, upload-time = "2024-11-06T07:48:25.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/a3/e610ae0feba3e7374da08ab6cc9bb76c8bfa84b4e502aa357bda0ef6dcae/jsonpickle-3.4.2-py3-none-any.whl", hash = "sha256:fd6c273278a02b3b66e3405db3dd2f4dbc8f4a4a3123bfcab3045177c6feb9c3", size = 46256, upload-time = "2024-11-06T07:48:22.923Z" },
+]
+
+[[package]]
 name = "jsonpointer"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3889,6 +3978,22 @@ wheels = [
 ]
 
 [[package]]
+name = "msrest"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "certifi" },
+    { name = "isodate" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/cf/f2966a2638144491f8696c27320d5219f48a072715075d168b31d3237720/msrest-0.7.1-py3-none-any.whl", hash = "sha256:21120a810e1233e5e6cc7fe40b474eeb4ec6f757a15d7cf86702c369f9567c32", size = 85384, upload-time = "2022-06-13T22:41:22.42Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4439,6 +4544,8 @@ backend = [
     { name = "asyncpg" },
     { name = "atlassian-python-api" },
     { name = "beautifulsoup4" },
+    { name = "botbuilder-core" },
+    { name = "botbuilder-integration-aiohttp" },
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "braintrust" },
@@ -4594,6 +4701,8 @@ requires-dist = [
     { name = "atlassian-python-api", marker = "extra == 'backend'", specifier = "==3.41.16" },
     { name = "beautifulsoup4", marker = "extra == 'backend'", specifier = "==4.12.3" },
     { name = "black", marker = "extra == 'dev'", specifier = "==25.1.0" },
+    { name = "botbuilder-core", marker = "extra == 'backend'", specifier = ">=4.17.0,<5.0.0" },
+    { name = "botbuilder-integration-aiohttp", marker = "extra == 'backend'", specifier = ">=4.17.0,<5.0.0" },
     { name = "boto3", marker = "extra == 'backend'", specifier = "==1.39.11" },
     { name = "boto3-stubs", extras = ["s3"], marker = "extra == 'backend'", specifier = "==1.39.11" },
     { name = "braintrust", marker = "extra == 'backend'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Description

Add a full Microsoft Teams bot integration using the `botbuilder-core` SDK v4, following existing Discord bot patterns. This enables Onyx to respond to @mentions and DMs in Teams channels with AI-powered answers.

**What's included:**
- **DB layer**: 3 new tables (`teams_bot_config`, `teams_team_config`, `teams_channel_config`) + CRUD operations + Alembic migration
- **Bot core**: HTTP webhook server (`POST /api/messages`), `BotFrameworkAdapter` for auth, `TeamsCacheManager` for multi-tenant team→tenant→API key resolution
- **Chat integration**: Adaptive Card responses with citations, `should_respond()` logic with per-channel mention requirements and persona overrides
- **Admin API**: REST endpoints at `/manage/admin/teams-bot` for config, team, and channel management
- **Deployment**: Helm chart (Deployment + Service), Docker Compose env vars
- **Shared utilities**: Extracted `OnyxAPIClient`, `BotCacheManager[T]`, exceptions, registration keys, and constants into `onyx/onyxbot/` to eliminate ~450 lines of duplication between Discord and Teams bots
- **Tests**: 48 new unit tests; all 124 existing Discord tests pass unchanged

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a full Microsoft Teams bot so Onyx can answer @mentions and DMs in Teams using Adaptive Cards with citations, and extract shared bot utilities to reduce duplication. Also includes fixes for correct Bot Framework responses, faster cache refreshes, and race-safe team registration.

- **New Features**
  - DB: new Teams tables (bot, team, channel) with CRUD and Alembic migration; singleton bot config enforced via CheckConstraint.
  - Bot server: aiohttp webhook at /api/messages with Bot Framework auth; forwards InvokeResponse for invoke activities; multi-tenant cache for team→tenant→API key.
  - Cache: shared BotCacheManager; builds outside lock and swaps atomically; sets tenant context for per-entity refresh; narrower exception handling.
  - Chat: should_respond per channel (mention requirements, persona overrides); Adaptive Card replies with sources.
  - Admin API: manage bot/team/channel configs and registration (SELECT FOR UPDATE to prevent registration races); service API keys per tenant.
  - Deployment: Helm Deployment + Service and Docker env vars; configurable port (3978) with safe empty-env handling.
  - Tests/Deps: 48 new unit tests; added MessageOrigin=TEAMSBOT; added botbuilder packages.

- **Migration**
  - Run DB migration.
  - Configure Azure Bot Service (App ID/Secret, optional tenant) and set messages endpoint to https://<host>/api/messages.
  - Provide credentials via env or Helm values; expose port 3978 through service/ingress.
  - Generate a one-time registration key via the admin API and run “register <key>” in Teams to link a team.
  - No changes required for Discord; existing tests pass.

<sup>Written for commit 32766066b41e9c919510bf0e1a16139c9e153338. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

