### PR TITLE
fix(notion): gracefully skip multi-source databases

### DIFF
--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -275,7 +275,10 @@ class NotionConnector(LoadConnector, PollConnector):
             # new data sources endpoint to handle that case correctly.
             if code == "object_not_found" or (
                 code == "validation_error"
-                and "does not contain any data sources" in json_data.get("message", "")
+                and (
+                    "does not contain any data sources" in json_data.get("message", "")
+                    or "multiple data sources are not supported" in json_data.get("message", "")
+                )
             ):
                 # this happens when a database is not shared with the integration
                 # in this case, we should just ignore the database


### PR DESCRIPTION
## Problem
Notion connector crashes with `400 Bad Request` when encountering databases with multiple data sources (introduced in Notion API version 2025-09-03).

Error: `"Databases with multiple data sources are not supported in this API version."`

## Fix
Added the multi-source error message to the existing validation_error check in `_fetch_database`, so these databases are gracefully skipped (logged as warning, returns empty results) rather than crashing the indexing run.

This is a minimal fix. Full multi-source database support will require upgrading to Notion API 2025-09-03 and using the new `/v1/data_sources` endpoints (as noted in the existing TODO).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Notion connector from crashing on multi-source databases by skipping them and logging a warning. Extends validation_error handling to include the "Databases with multiple data sources are not supported in this API version" message.

- **Bug Fixes**
  - Treat 400 validation_error for multi-source databases as unsupported.
  - Skip indexing (return empty results) and warn instead of failing the run.

<sup>Written for commit 463124f77719d00c1d1b5f9c5c98d2236fea11b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

