### PR TITLE
chore: Remove deprecated provider columns from orm

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2822,17 +2822,8 @@ class LLMProvider(Base):
         postgresql.JSONB(), nullable=True
     )
 
-    # Deprecated: use LLMModelFlow with CHAT flow type instead
-    default_model_name: Mapped[str | None] = mapped_column(String, nullable=True)
-
     deployment_name: Mapped[str | None] = mapped_column(String, nullable=True)
 
-    # Deprecated: use LLMModelFlow.is_default with CHAT flow type instead
-    is_default_provider: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-    # Deprecated: use LLMModelFlow.is_default with VISION flow type instead
-    is_default_vision_provider: Mapped[bool | None] = mapped_column(Boolean)
-    # Deprecated: use LLMModelFlow with VISION flow type instead
-    default_vision_model: Mapped[str | None] = mapped_column(String, nullable=True)
     # EE only
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     # Auto mode: models, visibility, and defaults are managed by GitHub config


### PR DESCRIPTION
## Description
Drop the deprecated columns from the LLMProvider ORM

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hid deprecated fields on LLMProvider in the ORM to prevent new reads/writes and guide usage to LLMModelFlow. No database schema changes.

- **Refactors**
  - Unmapped deprecated columns: default_model_name, is_default_provider, is_default_vision_provider, default_vision_model.
  - Use LLMModelFlow (CHAT/VISION) and is_default instead.

<sup>Written for commit c9155a87673f72de6ff36f976f92e15a32d82c25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

