### PR TITLE
chore: Remove deprecated models columns

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -865,7 +865,6 @@ def insert_new_model_configuration__no_commit(
             is_visible=is_visible,
             max_input_tokens=max_input_tokens,
             display_name=display_name,
-            supports_image_input=LLMModelFlowType.VISION in supported_flows,
         )
         .on_conflict_do_nothing()
         .returning(ModelConfiguration.id)
@@ -900,7 +899,6 @@ def update_model_configuration__no_commit(
             is_visible=is_visible,
             max_input_tokens=max_input_tokens,
             display_name=display_name,
-            supports_image_input=LLMModelFlowType.VISION in supported_flows,
         )
         .where(ModelConfiguration.id == model_configuration_id)
         .returning(ModelConfiguration)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2882,9 +2882,6 @@ class ModelConfiguration(Base):
     # - The end-user is configuring a model and chooses not to set a max-input-tokens limit.
     max_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    # Deprecated: use LLMModelFlow with VISION flow type instead
-    supports_image_input: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
-
     # Human-readable display name for the model.
     # For dynamic providers (OpenRouter, Bedrock, Ollama), this comes from the source API.
     # For static providers (OpenAI, Anthropic), this may be null and will fall back to LiteLLM.

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -168,19 +168,6 @@ class ModelConfigurationUpsertRequest(BaseModel):
     supports_image_input: bool | None = None
     display_name: str | None = None  # For dynamic providers, from source API
 
-    @classmethod
-    def from_model(
-        cls, model_configuration_model: "ModelConfigurationModel"
-    ) -> "ModelConfigurationUpsertRequest":
-        return cls(
-            name=model_configuration_model.name,
-            is_visible=model_configuration_model.is_visible,
-            max_input_tokens=model_configuration_model.max_input_tokens,
-            supports_image_input=LLMModelFlowType.VISION
-            in model_configuration_model.llm_model_flow_types,
-            display_name=model_configuration_model.display_name,
-        )
-
 
 class ModelConfigurationView(BaseModel):
     name: str

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -176,7 +176,8 @@ class ModelConfigurationUpsertRequest(BaseModel):
             name=model_configuration_model.name,
             is_visible=model_configuration_model.is_visible,
             max_input_tokens=model_configuration_model.max_input_tokens,
-            supports_image_input=model_configuration_model.supports_image_input,
+            supports_image_input=LLMModelFlowType.VISION
+            in model_configuration_model.llm_model_flow_types,
             display_name=model_configuration_model.display_name,
         )
 


### PR DESCRIPTION
## Description
Stop using deprecated supports_image_input on the ModelConfiguration table at the ORM level

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated supports_image_input column from ModelConfiguration and removed all references, including insert/update logic and the ModelConfigurationUpsertRequest.from_model helper. Image support is now determined solely by LLMModelFlowType.VISION.

<sup>Written for commit 21ca9715ddcea43f370393f302a18455b23bc20f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

