### PR TITLE
feat(metrics): add Redis connection pool metrics

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -125,6 +125,7 @@ from onyx.server.manage.web_search.api import (
 from onyx.server.metrics.postgres_connection_pool import (
     setup_postgres_connection_pool_metrics,
 )
+from onyx.server.metrics.prometheus_setup import setup_app_observability
 from onyx.server.metrics.prometheus_setup import setup_prometheus_metrics
 from onyx.server.middleware.latency_logging import add_latency_logging_middleware
 from onyx.server.middleware.rate_limiting import close_auth_limiter
@@ -640,6 +641,11 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    # App-scoped observability (memory delta middleware, etc.).
+    # Must be called after all routers — memory delta builds its route map
+    # at registration time.
+    setup_app_observability(application)
+
     if LOG_ENDPOINT_LATENCY:
         add_latency_logging_middleware(application, logger)
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -127,6 +127,7 @@ from onyx.server.metrics.postgres_connection_pool import (
 )
 from onyx.server.metrics.prometheus_setup import setup_app_observability
 from onyx.server.metrics.prometheus_setup import setup_prometheus_metrics
+from onyx.server.metrics.prometheus_setup import start_observability
 from onyx.server.middleware.latency_logging import add_latency_logging_middleware
 from onyx.server.middleware.rate_limiting import close_auth_limiter
 from onyx.server.middleware.rate_limiting import get_auth_rate_limiters
@@ -334,6 +335,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
             "readonly": SqlEngine.get_readonly_engine(),
         },
     )
+
+    # Lifespan-scoped observability (redis pool, etc.).
+    # All probes/collectors are orchestrated through prometheus_setup.
+    start_observability()
 
     verify_auth = fetch_versioned_implementation(
         "onyx.auth.users", "verify_auth_setting"

--- a/backend/onyx/server/metrics/memory_delta.py
+++ b/backend/onyx/server/metrics/memory_delta.py
@@ -15,6 +15,7 @@ Metrics:
 - onyx_api_process_rss_bytes: Gauge of current process RSS
 """
 
+import os
 import re
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -55,7 +56,25 @@ _PROCESS_RSS: Gauge = Gauge(
     "Current process RSS in bytes",
 )
 
-_process: psutil.Process = psutil.Process()
+
+def _get_process() -> psutil.Process:
+    """Return a psutil.Process for the *current* PID.
+
+    We lazily create the Process object and cache it, but invalidate the
+    cache when the PID changes (e.g. after Uvicorn forks workers).
+    Module-level ``psutil.Process()`` would capture the *parent's* PID
+    and report that child's RSS from the wrong process.
+    """
+    global _process, _process_pid
+    pid = os.getpid()
+    if _process is None or _process_pid != pid:
+        _process = psutil.Process(pid)
+        _process_pid = pid
+    return _process
+
+
+_process: psutil.Process | None = None
+_process_pid: int | None = None
 
 
 def _build_route_map(app: FastAPI) -> list[tuple[re.Pattern[str], str]]:
@@ -93,14 +112,14 @@ def add_memory_delta_middleware(app: FastAPI) -> None:
     ) -> Response:
         handler = _match_route(route_map, request.url.path) or "unmatched"
         try:
-            rss_before = _process.memory_info().rss
+            rss_before = _get_process().memory_info().rss
         except (psutil.Error, OSError):
             return await call_next(request)
 
         response = await call_next(request)
 
         try:
-            rss_after = _process.memory_info().rss
+            rss_after = _get_process().memory_info().rss
             delta = rss_after - rss_before
             _RSS_DELTA.labels(handler=handler).observe(abs(delta))
             if delta < 0:

--- a/backend/onyx/server/metrics/memory_delta.py
+++ b/backend/onyx/server/metrics/memory_delta.py
@@ -1,0 +1,106 @@
+"""Per-endpoint memory delta middleware.
+
+Measures RSS change before and after each HTTP request, attributing
+memory growth to specific route handlers. Uses psutil for a single
+syscall per request (sub-microsecond overhead).
+
+Note: RSS is process-wide, so on a server handling concurrent requests
+the delta for one request may include allocations from other requests.
+This is inherent to the approach — the metric is most useful for
+identifying endpoints that *consistently* cause large deltas.
+
+Metrics:
+- onyx_api_request_rss_delta_bytes: Histogram of RSS change per request
+- onyx_api_process_rss_bytes: Gauge of current process RSS
+"""
+
+import re
+from collections.abc import Awaitable
+from collections.abc import Callable
+
+import psutil
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi.routing import APIRoute
+from prometheus_client import Gauge
+from prometheus_client import Histogram
+from starlette.responses import Response
+
+_RSS_DELTA: Histogram = Histogram(
+    "onyx_api_request_rss_delta_bytes",
+    "RSS change in bytes during a single request",
+    ["handler"],
+    buckets=(
+        -16777216,
+        -1048576,
+        -65536,
+        0,
+        1024,
+        4096,
+        16384,
+        65536,
+        262144,
+        1048576,
+        4194304,
+        16777216,
+    ),
+)
+
+_PROCESS_RSS: Gauge = Gauge(
+    "onyx_api_process_rss_bytes",
+    "Current process RSS in bytes",
+)
+
+_process: psutil.Process = psutil.Process()
+
+
+def _build_route_map(app: FastAPI) -> list[tuple[re.Pattern[str], str]]:
+    route_map: list[tuple[re.Pattern[str], str]] = []
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route_map.append((route.path_regex, route.path))
+    return route_map
+
+
+def _match_route(route_map: list[tuple[re.Pattern[str], str]], path: str) -> str | None:
+    for pattern, template in route_map:
+        if pattern.match(path):
+            return template
+    return None
+
+
+def add_memory_delta_middleware(app: FastAPI) -> None:
+    """Register middleware that tracks per-endpoint RSS deltas.
+
+    Idempotent — safe to call multiple times (e.g. Uvicorn hot-reload).
+    Builds its own route map to avoid contextvar ordering issues
+    with the endpoint context middleware.
+    """
+    if getattr(app.state, "_memory_delta_registered", False):
+        return
+    app.state._memory_delta_registered = True
+
+    route_map = _build_route_map(app)
+
+    @app.middleware("http")
+    async def memory_delta_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        handler = _match_route(route_map, request.url.path) or "unmatched"
+        try:
+            rss_before = _process.memory_info().rss
+        except (psutil.Error, OSError):
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        try:
+            rss_after = _process.memory_info().rss
+            delta = rss_after - rss_before
+            _RSS_DELTA.labels(handler=handler).observe(delta)
+            _PROCESS_RSS.set(rss_after)
+        except (psutil.Error, OSError):
+            pass
+
+        return response

--- a/backend/onyx/server/metrics/memory_delta.py
+++ b/backend/onyx/server/metrics/memory_delta.py
@@ -57,6 +57,10 @@ _PROCESS_RSS: Gauge = Gauge(
 )
 
 
+_process: psutil.Process | None = None
+_process_pid: int | None = None
+
+
 def _get_process() -> psutil.Process:
     """Return a psutil.Process for the *current* PID.
 
@@ -71,10 +75,6 @@ def _get_process() -> psutil.Process:
         _process = psutil.Process(pid)
         _process_pid = pid
     return _process
-
-
-_process: psutil.Process | None = None
-_process_pid: int | None = None
 
 
 def _build_route_map(app: FastAPI) -> list[tuple[re.Pattern[str], str]]:

--- a/backend/onyx/server/metrics/memory_delta.py
+++ b/backend/onyx/server/metrics/memory_delta.py
@@ -10,7 +10,8 @@ This is inherent to the approach — the metric is most useful for
 identifying endpoints that *consistently* cause large deltas.
 
 Metrics:
-- onyx_api_request_rss_delta_bytes: Histogram of RSS change per request
+- onyx_api_request_rss_delta_bytes: Histogram of abs(RSS change) per request
+- onyx_api_request_rss_shrink_total: Counter of requests where RSS decreased
 - onyx_api_process_rss_bytes: Gauge of current process RSS
 """
 
@@ -22,19 +23,16 @@ import psutil
 from fastapi import FastAPI
 from fastapi import Request
 from fastapi.routing import APIRoute
+from prometheus_client import Counter
 from prometheus_client import Gauge
 from prometheus_client import Histogram
 from starlette.responses import Response
 
 _RSS_DELTA: Histogram = Histogram(
     "onyx_api_request_rss_delta_bytes",
-    "RSS change in bytes during a single request",
+    "Absolute RSS change in bytes during a single request",
     ["handler"],
     buckets=(
-        -16777216,
-        -1048576,
-        -65536,
-        0,
         1024,
         4096,
         16384,
@@ -44,6 +42,12 @@ _RSS_DELTA: Histogram = Histogram(
         4194304,
         16777216,
     ),
+)
+
+_RSS_SHRINK: Counter = Counter(
+    "onyx_api_request_rss_shrink_total",
+    "Requests where RSS decreased (pages freed)",
+    ["handler"],
 )
 
 _PROCESS_RSS: Gauge = Gauge(
@@ -98,7 +102,9 @@ def add_memory_delta_middleware(app: FastAPI) -> None:
         try:
             rss_after = _process.memory_info().rss
             delta = rss_after - rss_before
-            _RSS_DELTA.labels(handler=handler).observe(delta)
+            _RSS_DELTA.labels(handler=handler).observe(abs(delta))
+            if delta < 0:
+                _RSS_SHRINK.labels(handler=handler).inc()
             _PROCESS_RSS.set(rss_after)
         except (psutil.Error, OSError):
             pass

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -1,15 +1,23 @@
 """Prometheus metrics setup for the Onyx API server.
 
-Orchestrates HTTP request instrumentation via ``prometheus-fastapi-instrumentator``:
-- Request count, latency histograms, in-progress gauges
-- Pool checkout timeout exception handler
-- Custom metric callbacks (e.g. slow request counting)
+Central orchestration point for ALL metrics and observability.
+
+Functions:
+- ``setup_prometheus_metrics(app)`` — HTTP request instrumentation (middleware).
+  Called from ``get_application()``.
+- ``setup_app_observability(app)`` — app-scoped observability (middleware that
+  must be registered after all routers). Called from ``get_application()``.
+- ``start_observability()`` — lifespan-scoped observability (collectors and
+  probes). Called from ``lifespan()``.
+- ``stop_observability()`` — async shutdown for lifespan-scoped probes.
+  Called from ``lifespan()`` after yield.
 
 SQLAlchemy connection pool metrics are registered separately via
 ``setup_postgres_connection_pool_metrics`` during application lifespan
-(after engines are created).
+(after engines are created, before ``start_observability``).
 """
 
+from fastapi import FastAPI
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import default as default_metrics
 from sqlalchemy.exc import TimeoutError as SATimeoutError
@@ -73,3 +81,17 @@ def setup_prometheus_metrics(app: Starlette) -> None:
     instrumentator.add(per_tenant_request_callback)
 
     instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(app)
+
+
+def setup_app_observability(app: FastAPI) -> None:
+    """Register app-scoped observability components.
+
+    Must be called in ``get_application()`` AFTER all routers are registered
+    (memory delta middleware builds its route map at registration time).
+
+    Args:
+        app: The FastAPI application.
+    """
+    from onyx.server.metrics.memory_delta import add_memory_delta_middleware
+
+    add_memory_delta_middleware(app)

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -91,3 +91,15 @@ def setup_app_observability(app: FastAPI) -> None:
     from onyx.server.metrics.memory_delta import add_memory_delta_middleware
 
     add_memory_delta_middleware(app)
+
+
+def start_observability() -> None:
+    """Start lifespan-scoped observability probes and collectors.
+
+    Called from ``lifespan()`` after engines/pools are ready.
+    """
+    from onyx.server.metrics.redis_connection_pool import (
+        setup_redis_connection_pool_metrics,
+    )
+
+    setup_redis_connection_pool_metrics()

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -7,14 +7,10 @@ Functions:
   Called from ``get_application()``.
 - ``setup_app_observability(app)`` — app-scoped observability (middleware that
   must be registered after all routers). Called from ``get_application()``.
-- ``start_observability()`` — lifespan-scoped observability (collectors and
-  probes). Called from ``lifespan()``.
-- ``stop_observability()`` — async shutdown for lifespan-scoped probes.
-  Called from ``lifespan()`` after yield.
 
 SQLAlchemy connection pool metrics are registered separately via
 ``setup_postgres_connection_pool_metrics`` during application lifespan
-(after engines are created, before ``start_observability``).
+(after engines are created).
 """
 
 from fastapi import FastAPI

--- a/backend/onyx/server/metrics/redis_connection_pool.py
+++ b/backend/onyx/server/metrics/redis_connection_pool.py
@@ -1,0 +1,111 @@
+"""Redis connection pool Prometheus collector.
+
+Reads pool internals from redis.BlockingConnectionPool on each
+Prometheus scrape to report utilization metrics.
+
+Metrics:
+- onyx_redis_pool_in_use: Currently checked-out connections
+- onyx_redis_pool_available: Idle connections in the pool
+- onyx_redis_pool_max: Configured max_connections
+- onyx_redis_pool_created: Lifetime connections created
+"""
+
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector
+from prometheus_client.registry import REGISTRY
+from redis import BlockingConnectionPool
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class RedisPoolCollector(Collector):
+    """Custom collector that reads BlockingConnectionPool internals on scrape.
+
+    NOTE: Uses private redis-py attributes (_in_use_connections,
+    _available_connections, _created_connections) because there is no
+    public API for pool statistics. Wrapped in try/except so a redis-py
+    upgrade changing internals degrades gracefully (metrics go to 0)
+    instead of crashing every scrape.
+    """
+
+    def __init__(self) -> None:
+        self._pools: list[tuple[str, BlockingConnectionPool]] = []
+
+    def add_pool(self, label: str, pool: BlockingConnectionPool) -> None:
+        self._pools.append((label, pool))
+
+    def collect(self) -> list[GaugeMetricFamily]:
+        in_use = GaugeMetricFamily(
+            "onyx_redis_pool_in_use",
+            "Currently checked-out Redis connections",
+            labels=["pool"],
+        )
+        available = GaugeMetricFamily(
+            "onyx_redis_pool_available",
+            "Idle Redis connections in the pool",
+            labels=["pool"],
+        )
+        max_conns = GaugeMetricFamily(
+            "onyx_redis_pool_max",
+            "Configured max Redis connections",
+            labels=["pool"],
+        )
+        created = GaugeMetricFamily(
+            "onyx_redis_pool_created",
+            "Lifetime Redis connections created",
+            labels=["pool"],
+        )
+
+        for label, pool in self._pools:
+            try:
+                in_use.add_metric([label], len(pool._in_use_connections))
+                available.add_metric([label], len(pool._available_connections))
+                max_conns.add_metric([label], pool.max_connections)
+                created.add_metric([label], pool._created_connections)
+            except (AttributeError, TypeError):
+                # Degrade to zeros so the time series stays visible
+                # instead of disappearing when internals change.
+                in_use.add_metric([label], 0)
+                available.add_metric([label], 0)
+                max_conns.add_metric([label], 0)
+                created.add_metric([label], 0)
+                logger.warning(
+                    "Redis pool %s: falling back to zero metrics — "
+                    "redis-py internals may have changed",
+                    label,
+                    exc_info=True,
+                )
+
+        return [in_use, available, max_conns, created]
+
+    def describe(self) -> list[GaugeMetricFamily]:
+        return []
+
+
+_redis_collector: RedisPoolCollector | None = None
+
+
+def setup_redis_connection_pool_metrics() -> None:
+    """Register Redis pool metrics using the RedisPool singleton.
+
+    Idempotent — safe to call multiple times (e.g. Uvicorn hot-reload).
+    """
+    global _redis_collector
+    if _redis_collector is not None:
+        return
+
+    from onyx.redis.redis_pool import RedisPool
+
+    pool_instance = RedisPool()
+    collector = RedisPoolCollector()
+    collector.add_pool("primary", pool_instance._pool)
+    # Replica pool always exists (defaults to same host as primary when
+    # REDIS_REPLICA_HOST is not set). Still worth monitoring separately
+    # since it maintains an independent connection pool.
+    collector.add_pool("replica", pool_instance._replica_pool)
+
+    REGISTRY.register(collector)
+    _redis_collector = collector
+    logger.info("Registered Redis connection pool metrics")

--- a/backend/onyx/server/metrics/redis_connection_pool.py
+++ b/backend/onyx/server/metrics/redis_connection_pool.py
@@ -81,6 +81,9 @@ class RedisPoolCollector(Collector):
         return [in_use, available, max_conns, created]
 
     def describe(self) -> list[GaugeMetricFamily]:
+        # Return empty to mark this as an "unchecked" collector.
+        # Prometheus checks describe() vs collect() for consistency;
+        # returning empty opts out since our metrics are dynamic.
         return []
 
 
@@ -91,6 +94,10 @@ def setup_redis_connection_pool_metrics() -> None:
     """Register Redis pool metrics using the RedisPool singleton.
 
     Idempotent — safe to call multiple times (e.g. Uvicorn hot-reload).
+    On hot-reload, the module re-imports and ``_redis_collector`` resets
+    to ``None``, but the REGISTRY still holds the old collector.
+    We catch the ``ValueError`` from duplicate registration and update
+    the module-level reference to the existing collector.
     """
     global _redis_collector
     if _redis_collector is not None:
@@ -106,6 +113,11 @@ def setup_redis_connection_pool_metrics() -> None:
     # since it maintains an independent connection pool.
     collector.add_pool("replica", pool_instance._replica_pool)
 
-    REGISTRY.register(collector)
+    try:
+        REGISTRY.register(collector)
+    except ValueError:
+        # Already registered from a previous module load (Uvicorn reload).
+        # The old collector still works — just update our reference.
+        logger.debug("Redis pool collector already registered, skipping")
     _redis_collector = collector
     logger.info("Registered Redis connection pool metrics")

--- a/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
+++ b/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
@@ -1,0 +1,90 @@
+"""Unit tests for per-endpoint memory delta middleware."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from onyx.server.metrics.memory_delta import _build_route_map
+from onyx.server.metrics.memory_delta import _match_route
+from onyx.server.metrics.memory_delta import add_memory_delta_middleware
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/chat/{chat_id}")
+    def get_chat(chat_id: str) -> dict[str, str]:
+        return {"id": chat_id}
+
+    @app.get("/api/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def test_build_route_map_extracts_api_routes() -> None:
+    app = _make_app()
+    route_map = _build_route_map(app)
+    templates = [template for _, template in route_map]
+    assert "/api/chat/{chat_id}" in templates
+    assert "/api/health" in templates
+
+
+def test_match_route_returns_template() -> None:
+    app = _make_app()
+    route_map = _build_route_map(app)
+    assert _match_route(route_map, "/api/chat/abc-123") == "/api/chat/{chat_id}"
+    assert _match_route(route_map, "/api/health") == "/api/health"
+    assert _match_route(route_map, "/nonexistent") is None
+
+
+@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._RSS_DELTA")
+@patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
+def test_middleware_observes_rss_delta(
+    mock_rss_gauge: MagicMock,
+    mock_histogram: MagicMock,
+    mock_process: MagicMock,
+) -> None:
+    """Verify the middleware measures RSS before/after and records the delta."""
+    mem_before = MagicMock()
+    mem_before.rss = 100_000_000
+    mem_after = MagicMock()
+    mem_after.rss = 100_065_536
+
+    mock_process.memory_info.side_effect = [mem_before, mem_after]
+
+    app = _make_app()
+    add_memory_delta_middleware(app)
+
+    client = TestClient(app)
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    mock_histogram.labels.assert_called_with(handler="/api/health")
+    mock_histogram.labels().observe.assert_called_once_with(65_536)
+    mock_rss_gauge.set.assert_called_once_with(100_065_536)
+
+
+@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._RSS_DELTA")
+@patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
+def test_middleware_uses_unmatched_for_unknown_paths(
+    mock_rss_gauge: MagicMock,  # noqa: ARG001
+    mock_histogram: MagicMock,
+    mock_process: MagicMock,
+) -> None:
+    mem_info = MagicMock()
+    mem_info.rss = 50_000_000
+    mock_process.memory_info.return_value = mem_info
+
+    app = _make_app()
+    add_memory_delta_middleware(app)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/totally-unknown")
+
+    mock_histogram.labels.assert_called_with(handler="unmatched")

--- a/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
+++ b/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
@@ -42,14 +42,16 @@ def test_match_route_returns_template() -> None:
 
 
 @patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._RSS_SHRINK")
 @patch("onyx.server.metrics.memory_delta._RSS_DELTA")
 @patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
 def test_middleware_observes_rss_delta(
     mock_rss_gauge: MagicMock,
     mock_histogram: MagicMock,
+    mock_shrink: MagicMock,
     mock_process: MagicMock,
 ) -> None:
-    """Verify the middleware measures RSS before/after and records the delta."""
+    """Verify the middleware measures RSS before/after and records abs(delta)."""
     mem_before = MagicMock()
     mem_before.rss = 100_000_000
     mem_after = MagicMock()
@@ -66,7 +68,37 @@ def test_middleware_observes_rss_delta(
     assert response.status_code == 200
     mock_histogram.labels.assert_called_with(handler="/api/health")
     mock_histogram.labels().observe.assert_called_once_with(65_536)
+    mock_shrink.labels().inc.assert_not_called()
     mock_rss_gauge.set.assert_called_once_with(100_065_536)
+
+
+@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._RSS_SHRINK")
+@patch("onyx.server.metrics.memory_delta._RSS_DELTA")
+@patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
+def test_middleware_tracks_rss_shrink(
+    mock_rss_gauge: MagicMock,  # noqa: ARG001
+    mock_histogram: MagicMock,
+    mock_shrink: MagicMock,
+    mock_process: MagicMock,
+) -> None:
+    """When RSS decreases, observe abs(delta) and increment shrink counter."""
+    mem_before = MagicMock()
+    mem_before.rss = 100_065_536
+    mem_after = MagicMock()
+    mem_after.rss = 100_000_000
+
+    mock_process.memory_info.side_effect = [mem_before, mem_after]
+
+    app = _make_app()
+    add_memory_delta_middleware(app)
+
+    client = TestClient(app)
+    client.get("/api/health")
+
+    mock_histogram.labels().observe.assert_called_once_with(65_536)
+    mock_shrink.labels.assert_called_with(handler="/api/health")
+    mock_shrink.labels().inc.assert_called_once()
 
 
 @patch("onyx.server.metrics.memory_delta._process")

--- a/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
+++ b/backend/tests/unit/onyx/server/test_memory_delta_metrics.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import psutil
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
@@ -41,7 +42,7 @@ def test_match_route_returns_template() -> None:
     assert _match_route(route_map, "/nonexistent") is None
 
 
-@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._get_process")
 @patch("onyx.server.metrics.memory_delta._RSS_SHRINK")
 @patch("onyx.server.metrics.memory_delta._RSS_DELTA")
 @patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
@@ -49,7 +50,7 @@ def test_middleware_observes_rss_delta(
     mock_rss_gauge: MagicMock,
     mock_histogram: MagicMock,
     mock_shrink: MagicMock,
-    mock_process: MagicMock,
+    mock_get_process: MagicMock,
 ) -> None:
     """Verify the middleware measures RSS before/after and records abs(delta)."""
     mem_before = MagicMock()
@@ -57,7 +58,9 @@ def test_middleware_observes_rss_delta(
     mem_after = MagicMock()
     mem_after.rss = 100_065_536
 
-    mock_process.memory_info.side_effect = [mem_before, mem_after]
+    mock_proc = MagicMock()
+    mock_proc.memory_info.side_effect = [mem_before, mem_after]
+    mock_get_process.return_value = mock_proc
 
     app = _make_app()
     add_memory_delta_middleware(app)
@@ -72,7 +75,7 @@ def test_middleware_observes_rss_delta(
     mock_rss_gauge.set.assert_called_once_with(100_065_536)
 
 
-@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._get_process")
 @patch("onyx.server.metrics.memory_delta._RSS_SHRINK")
 @patch("onyx.server.metrics.memory_delta._RSS_DELTA")
 @patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
@@ -80,7 +83,7 @@ def test_middleware_tracks_rss_shrink(
     mock_rss_gauge: MagicMock,  # noqa: ARG001
     mock_histogram: MagicMock,
     mock_shrink: MagicMock,
-    mock_process: MagicMock,
+    mock_get_process: MagicMock,
 ) -> None:
     """When RSS decreases, observe abs(delta) and increment shrink counter."""
     mem_before = MagicMock()
@@ -88,7 +91,9 @@ def test_middleware_tracks_rss_shrink(
     mem_after = MagicMock()
     mem_after.rss = 100_000_000
 
-    mock_process.memory_info.side_effect = [mem_before, mem_after]
+    mock_proc = MagicMock()
+    mock_proc.memory_info.side_effect = [mem_before, mem_after]
+    mock_get_process.return_value = mock_proc
 
     app = _make_app()
     add_memory_delta_middleware(app)
@@ -101,17 +106,19 @@ def test_middleware_tracks_rss_shrink(
     mock_shrink.labels().inc.assert_called_once()
 
 
-@patch("onyx.server.metrics.memory_delta._process")
+@patch("onyx.server.metrics.memory_delta._get_process")
 @patch("onyx.server.metrics.memory_delta._RSS_DELTA")
 @patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
 def test_middleware_uses_unmatched_for_unknown_paths(
     mock_rss_gauge: MagicMock,  # noqa: ARG001
     mock_histogram: MagicMock,
-    mock_process: MagicMock,
+    mock_get_process: MagicMock,
 ) -> None:
     mem_info = MagicMock()
     mem_info.rss = 50_000_000
-    mock_process.memory_info.return_value = mem_info
+    mock_proc = MagicMock()
+    mock_proc.memory_info.return_value = mem_info
+    mock_get_process.return_value = mock_proc
 
     app = _make_app()
     add_memory_delta_middleware(app)
@@ -120,3 +127,26 @@ def test_middleware_uses_unmatched_for_unknown_paths(
     client.get("/totally-unknown")
 
     mock_histogram.labels.assert_called_with(handler="unmatched")
+
+
+@patch("onyx.server.metrics.memory_delta._get_process")
+@patch("onyx.server.metrics.memory_delta._RSS_DELTA")
+@patch("onyx.server.metrics.memory_delta._PROCESS_RSS")
+def test_middleware_skips_metrics_on_psutil_error(
+    mock_rss_gauge: MagicMock,  # noqa: ARG001
+    mock_histogram: MagicMock,
+    mock_get_process: MagicMock,
+) -> None:
+    """When psutil raises on the initial memory_info call, middleware skips metrics."""
+    mock_proc = MagicMock()
+    mock_proc.memory_info.side_effect = psutil.Error("no such process")
+    mock_get_process.return_value = mock_proc
+
+    app = _make_app()
+    add_memory_delta_middleware(app)
+
+    client = TestClient(app)
+    response = client.get("/api/health")
+
+    assert response.status_code == 200
+    mock_histogram.labels.assert_not_called()

--- a/backend/tests/unit/onyx/server/test_redis_pool_metrics.py
+++ b/backend/tests/unit/onyx/server/test_redis_pool_metrics.py
@@ -1,0 +1,86 @@
+"""Unit tests for Redis connection pool metrics collector."""
+
+from unittest.mock import MagicMock
+
+from onyx.server.metrics.redis_connection_pool import RedisPoolCollector
+
+
+def test_redis_pool_collector_reports_metrics() -> None:
+    """Verify the collector reads pool internals correctly."""
+    mock_pool = MagicMock()
+    mock_pool._in_use_connections = {"conn1", "conn2", "conn3"}
+    mock_pool._available_connections = ["conn4", "conn5"]
+    mock_pool.max_connections = 128
+    mock_pool._created_connections = 5
+
+    collector = RedisPoolCollector()
+    collector.add_pool("primary", mock_pool)
+
+    families = collector.collect()
+    assert len(families) == 4
+
+    metrics: dict[str, float] = {}
+    for family in families:
+        for sample in family.samples:
+            metrics[f"{sample.name}:{sample.labels['pool']}"] = sample.value
+
+    assert metrics["onyx_redis_pool_in_use:primary"] == 3
+    assert metrics["onyx_redis_pool_available:primary"] == 2
+    assert metrics["onyx_redis_pool_max:primary"] == 128
+    assert metrics["onyx_redis_pool_created:primary"] == 5
+
+
+def test_redis_pool_collector_handles_multiple_pools() -> None:
+    """Verify the collector supports primary + replica pools."""
+    primary = MagicMock()
+    primary._in_use_connections = {"a"}
+    primary._available_connections = ["b", "c"]
+    primary.max_connections = 128
+    primary._created_connections = 3
+
+    replica = MagicMock()
+    replica._in_use_connections = set()
+    replica._available_connections = ["d"]
+    replica.max_connections = 64
+    replica._created_connections = 1
+
+    collector = RedisPoolCollector()
+    collector.add_pool("primary", primary)
+    collector.add_pool("replica", replica)
+
+    families = collector.collect()
+    metrics: dict[str, float] = {}
+    for family in families:
+        for sample in family.samples:
+            metrics[f"{sample.name}:{sample.labels['pool']}"] = sample.value
+
+    assert metrics["onyx_redis_pool_in_use:primary"] == 1
+    assert metrics["onyx_redis_pool_in_use:replica"] == 0
+    assert metrics["onyx_redis_pool_max:replica"] == 64
+
+
+def test_redis_pool_collector_falls_back_to_zeros_on_attribute_error() -> None:
+    """Verify collector degrades gracefully when redis-py internals change."""
+    mock_pool = MagicMock(spec=[])  # empty spec — no attributes at all
+    collector = RedisPoolCollector()
+    collector.add_pool("primary", mock_pool)
+
+    families = collector.collect()
+    assert len(families) == 4
+
+    metrics: dict[str, float] = {}
+    for family in families:
+        for sample in family.samples:
+            metrics[f"{sample.name}:{sample.labels['pool']}"] = sample.value
+
+    # All metrics should fall back to zero
+    assert metrics["onyx_redis_pool_in_use:primary"] == 0
+    assert metrics["onyx_redis_pool_available:primary"] == 0
+    assert metrics["onyx_redis_pool_max:primary"] == 0
+    assert metrics["onyx_redis_pool_created:primary"] == 0
+
+
+def test_redis_pool_collector_describe_returns_empty() -> None:
+    """Unchecked collector pattern — describe() returns empty."""
+    collector = RedisPoolCollector()
+    assert collector.describe() == []

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -65,8 +65,8 @@ For metrics that attach to engines, pools, or background systems, add a setup fu
 |----------|-------------|---------|
 | `setup_prometheus_metrics(app)` | `get_application()` | HTTP request instrumentation (middleware) |
 | `setup_app_observability(app)` | `get_application()` | App-scoped components (middleware registered after routers) |
-| `start_observability()` | `lifespan()` startup | Lifespan-scoped probes and collectors |
-| `stop_observability()` | `lifespan()` shutdown | Async cleanup for probes |
+
+For lifespan-scoped metrics (probes, collectors that need engines/pools ready), add a setup function and call it from `start_observability()` in `metrics/prometheus_setup.py`:
 
 ```python
 # metrics/my_metric.py
@@ -79,9 +79,7 @@ def setup_my_metrics(resource: SomeResource) -> None:
 # metrics/prometheus_setup.py — inside start_observability()
 from onyx.server.metrics.my_metric import setup_my_metrics
 
-def start_observability() -> None:
-    setup_my_metrics(resource)  # Add your call here
-    ...
+setup_my_metrics(resource)
 ```
 
 All metrics initialization is funneled through `metrics/prometheus_setup.py`. Do not add separate setup calls to `main.py`.

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -198,6 +198,24 @@ topk(5, avg by (handler)(
 topk(5, rate(onyx_api_request_rss_shrink_total[5m]))
 ```
 
+## Redis Pool Metrics
+
+Always-on, read from `BlockingConnectionPool` internals on each `/metrics` scrape.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `onyx_redis_pool_in_use` | Gauge | `pool` | Checked-out connections |
+| `onyx_redis_pool_available` | Gauge | `pool` | Idle connections |
+| `onyx_redis_pool_max` | Gauge | `pool` | Configured max |
+| `onyx_redis_pool_created` | Gauge | `pool` | Lifetime connections created |
+
+Pool label values: `primary`, `replica`.
+
+```promql
+# Redis pool utilization (alert if > 80%)
+onyx_redis_pool_in_use{pool="primary"} / onyx_redis_pool_max{pool="primary"}
+```
+
 ## Example PromQL Queries
 
 ### Which endpoints are saturated right now?

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -182,15 +182,22 @@ Always-on, sub-microsecond overhead per request (single `psutil` syscall).
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `onyx_api_request_rss_delta_bytes` | Histogram | `handler` | RSS change in bytes during a request |
+| `onyx_api_request_rss_delta_bytes` | Histogram | `handler` | Absolute RSS change in bytes during a request |
+| `onyx_api_request_rss_shrink_total` | Counter | `handler` | Requests where RSS decreased (pages freed) |
 | `onyx_api_process_rss_bytes` | Gauge | — | Current process RSS |
 
+The histogram tracks `abs(delta)` so `histogram_quantile()` works correctly.
+Use the shrink counter to distinguish growth from reclamation.
+
 ```promql
-# Top 5 endpoints by average memory delta per request
+# Top 5 endpoints by average memory impact per request
 topk(5, avg by (handler)(
   rate(onyx_api_request_rss_delta_bytes_sum[5m])
   / rate(onyx_api_request_rss_delta_bytes_count[5m])
 ))
+
+# Endpoints with frequent RSS shrinkage (GC/mmap release)
+topk(5, rate(onyx_api_request_rss_shrink_total[5m]))
 ```
 
 ## Example PromQL Queries

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -57,9 +57,16 @@ from onyx.server.metrics.my_metric import my_metric_callback
 instrumentator.add(my_metric_callback)
 ```
 
-### 4. Wire it into setup_prometheus_metrics (if infrastructure-scoped)
+### 4. Wire it into the orchestration layer (if infrastructure-scoped)
 
-For metrics that attach to engines, pools, or background systems, add a setup function and call it from `setup_prometheus_metrics()` in `metrics/prometheus_setup.py`:
+For metrics that attach to engines, pools, or background systems, add a setup function and call it from the appropriate orchestration function in `metrics/prometheus_setup.py`:
+
+| Function | Called from | Purpose |
+|----------|-------------|---------|
+| `setup_prometheus_metrics(app)` | `get_application()` | HTTP request instrumentation (middleware) |
+| `setup_app_observability(app)` | `get_application()` | App-scoped components (middleware registered after routers) |
+| `start_observability()` | `lifespan()` startup | Lifespan-scoped probes and collectors |
+| `stop_observability()` | `lifespan()` shutdown | Async cleanup for probes |
 
 ```python
 # metrics/my_metric.py
@@ -69,15 +76,15 @@ def setup_my_metrics(resource: SomeResource) -> None:
 ```
 
 ```python
-# metrics/prometheus_setup.py — inside setup_prometheus_metrics()
+# metrics/prometheus_setup.py — inside start_observability()
 from onyx.server.metrics.my_metric import setup_my_metrics
 
-def setup_prometheus_metrics(app, engines=None) -> None:
+def start_observability() -> None:
     setup_my_metrics(resource)  # Add your call here
     ...
 ```
 
-All metrics initialization is funneled through the single `setup_prometheus_metrics()` call in `onyx/main.py:lifespan()`. Do not add separate setup calls to `main.py`.
+All metrics initialization is funneled through `metrics/prometheus_setup.py`. Do not add separate setup calls to `main.py`.
 
 ### 5. Write tests
 
@@ -168,6 +175,23 @@ These metrics provide visibility into SQLAlchemy connection pool state across al
 Engine label values: `sync` (main read-write), `async` (async sessions), `readonly` (read-only user).
 
 Connections from background tasks (Celery) or boot-time warmup appear as `handler="unknown"`.
+
+## Memory Metrics
+
+Always-on, sub-microsecond overhead per request (single `psutil` syscall).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `onyx_api_request_rss_delta_bytes` | Histogram | `handler` | RSS change in bytes during a request |
+| `onyx_api_process_rss_bytes` | Gauge | — | Current process RSS |
+
+```promql
+# Top 5 endpoints by average memory delta per request
+topk(5, avg by (handler)(
+  rate(onyx_api_request_rss_delta_bytes_sum[5m])
+  / rate(onyx_api_request_rss_delta_bytes_count[5m])
+))
+```
 
 ## Example PromQL Queries
 


### PR DESCRIPTION
## Description

Add always-on Redis pool collector that reports pool state on each Prometheus scrape via `BlockingConnectionPool` internals.

New metrics:
- `onyx_redis_pool_in_use` — Gauge by `pool`. Checked-out connections.
- `onyx_redis_pool_available` — Gauge by `pool`. Idle connections.
- `onyx_redis_pool_max` — Gauge by `pool`. Configured max.
- `onyx_redis_pool_created` — Gauge by `pool`. Lifetime connections created.

Pool label values: `primary`, `replica`.

Adds `start_observability()` to `prometheus_setup.py` for lifespan-scoped collector registration.

Part 2 of 6 in the API server observability series. Stacks on #9083.

## How Has This Been Tested?

- Unit tests for collector output, multiple pools, attribute error fallback, and describe (4 tests)
- mypy clean
- Pre-commit hooks pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check