### PR TITLE
feat(metrics): add thread pool instrumentation

### DIFF
--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -102,8 +102,10 @@ def start_observability() -> None:
     from onyx.server.metrics.redis_connection_pool import (
         setup_redis_connection_pool_metrics,
     )
+    from onyx.server.metrics.threadpool import setup_threadpool_metrics
 
     setup_redis_connection_pool_metrics()
+    setup_threadpool_metrics()
     start_event_loop_lag_probe()
 
 

--- a/backend/onyx/server/metrics/threadpool.py
+++ b/backend/onyx/server/metrics/threadpool.py
@@ -46,10 +46,17 @@ _TASK_DURATION: Histogram = Histogram(
 )
 
 
+_process: psutil.Process | None = None
+_process_pid: int | None = None
+
+
 def _get_process() -> psutil.Process:
     """Return a psutil.Process for the *current* PID.
 
     Lazily created and invalidated when PID changes (fork).
+    Not locked — worst case on a benign race is creating two Process
+    objects for the same PID; one gets discarded. The default
+    CollectorRegistry serializes collect() calls anyway.
     """
     global _process, _process_pid
     pid = os.getpid()
@@ -57,10 +64,6 @@ def _get_process() -> psutil.Process:
         _process = psutil.Process(pid)
         _process_pid = pid
     return _process
-
-
-_process: psutil.Process | None = None
-_process_pid: int | None = None
 
 
 class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):

--- a/backend/onyx/server/metrics/threadpool.py
+++ b/backend/onyx/server/metrics/threadpool.py
@@ -11,6 +11,7 @@ Metrics:
 - onyx_process_thread_count: Gauge of total process threads (via psutil)
 """
 
+import os
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
@@ -44,7 +45,22 @@ _TASK_DURATION: Histogram = Histogram(
     "Thread pool task execution duration in seconds",
 )
 
-_process: psutil.Process = psutil.Process()
+
+def _get_process() -> psutil.Process:
+    """Return a psutil.Process for the *current* PID.
+
+    Lazily created and invalidated when PID changes (fork).
+    """
+    global _process, _process_pid
+    pid = os.getpid()
+    if _process is None or _process_pid != pid:
+        _process = psutil.Process(pid)
+        _process_pid = pid
+    return _process
+
+
+_process: psutil.Process | None = None
+_process_pid: int | None = None
 
 
 class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):
@@ -69,6 +85,8 @@ class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):
                 _TASKS_ACTIVE.dec()
                 _TASK_DURATION.observe(time.monotonic() - start)
 
+        # Increment *after* super().submit() so we don't count tasks
+        # that fail to submit (e.g. pool already shut down).
         future = super().submit(_wrapped)
         _TASKS_SUBMITTED.inc()
         return future
@@ -83,13 +101,16 @@ class ThreadCountCollector(Collector):
             "Total OS threads in the process",
         )
         try:
-            family.add_metric([], _process.num_threads())
+            family.add_metric([], _get_process().num_threads())
         except (psutil.Error, OSError):
             logger.warning("Failed to read process thread count", exc_info=True)
             family.add_metric([], 0)
         return [family]
 
     def describe(self) -> list[GaugeMetricFamily]:
+        # Return empty to mark this as an "unchecked" collector.
+        # Prometheus checks describe() vs collect() for consistency;
+        # returning empty opts out since our metrics are dynamic.
         return []
 
 
@@ -100,6 +121,9 @@ def setup_threadpool_metrics() -> None:
     """Register the process thread count collector and enable instrumentation.
 
     Idempotent — safe to call multiple times (e.g. Uvicorn hot-reload).
+    Uses try/except on REGISTRY.register() to handle the case where the
+    module is reimported (guard resets) but REGISTRY still holds the old
+    collector.
     """
     global _thread_collector
     if _thread_collector is not None:
@@ -109,5 +133,8 @@ def setup_threadpool_metrics() -> None:
 
     enable_threadpool_instrumentation()
     collector = ThreadCountCollector()
-    REGISTRY.register(collector)
+    try:
+        REGISTRY.register(collector)
+    except ValueError:
+        logger.debug("Thread count collector already registered, skipping")
     _thread_collector = collector

--- a/backend/onyx/server/metrics/threadpool.py
+++ b/backend/onyx/server/metrics/threadpool.py
@@ -1,0 +1,113 @@
+"""Thread pool instrumentation.
+
+Provides an InstrumentedThreadPoolExecutor that wraps submit() to
+track task submission, active count, and duration. Also exports a
+custom Collector for process-wide thread count.
+
+Metrics:
+- onyx_threadpool_tasks_submitted_total: Counter of submitted tasks
+- onyx_threadpool_tasks_active: Gauge of currently executing tasks
+- onyx_threadpool_task_duration_seconds: Histogram of task execution time
+- onyx_process_thread_count: Gauge of total process threads (via psutil)
+"""
+
+import time
+from collections.abc import Callable
+from concurrent.futures import Future
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import psutil
+from prometheus_client import Counter
+from prometheus_client import Gauge
+from prometheus_client import Histogram
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector
+from prometheus_client.registry import REGISTRY
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_TASKS_SUBMITTED: Counter = Counter(
+    "onyx_threadpool_tasks_submitted_total",
+    "Total tasks submitted to thread pools",
+)
+
+_TASKS_ACTIVE: Gauge = Gauge(
+    "onyx_threadpool_tasks_active",
+    "Currently executing thread pool tasks",
+)
+
+_TASK_DURATION: Histogram = Histogram(
+    "onyx_threadpool_task_duration_seconds",
+    "Thread pool task execution duration in seconds",
+)
+
+_process: psutil.Process = psutil.Process()
+
+
+class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):
+    """ThreadPoolExecutor subclass that records Prometheus metrics."""
+
+    def submit(
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Future[Any]:
+        def _wrapped() -> Any:
+            # _wrapped runs inside the thread pool worker, so both the
+            # active gauge and the duration timer reflect *execution* time
+            # only — queue wait time is excluded.
+            _TASKS_ACTIVE.inc()
+            start = time.monotonic()
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                _TASKS_ACTIVE.dec()
+                _TASK_DURATION.observe(time.monotonic() - start)
+
+        future = super().submit(_wrapped)
+        _TASKS_SUBMITTED.inc()
+        return future
+
+
+class ThreadCountCollector(Collector):
+    """Reports the process-wide thread count on each Prometheus scrape."""
+
+    def collect(self) -> list[GaugeMetricFamily]:
+        family = GaugeMetricFamily(
+            "onyx_process_thread_count",
+            "Total OS threads in the process",
+        )
+        try:
+            family.add_metric([], _process.num_threads())
+        except (psutil.Error, OSError):
+            logger.warning("Failed to read process thread count", exc_info=True)
+            family.add_metric([], 0)
+        return [family]
+
+    def describe(self) -> list[GaugeMetricFamily]:
+        return []
+
+
+_thread_collector: ThreadCountCollector | None = None
+
+
+def setup_threadpool_metrics() -> None:
+    """Register the process thread count collector and enable instrumentation.
+
+    Idempotent — safe to call multiple times (e.g. Uvicorn hot-reload).
+    """
+    global _thread_collector
+    if _thread_collector is not None:
+        return
+
+    from onyx.utils.threadpool_concurrency import enable_threadpool_instrumentation
+
+    enable_threadpool_instrumentation()
+    collector = ThreadCountCollector()
+    REGISTRY.register(collector)
+    _thread_collector = collector

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -30,6 +30,32 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+
+_threadpool_instrumentation_enabled: bool = False
+
+
+def _get_executor_class() -> type[ThreadPoolExecutor]:
+    """Return InstrumentedThreadPoolExecutor when running in the API server.
+
+    Non-server contexts (Celery workers, CLI scripts) get vanilla
+    ThreadPoolExecutor because enable_threadpool_instrumentation() is
+    never called there. The flag lives here (not in the metrics module)
+    to avoid importing prometheus_client as a side effect of every
+    parallel operation.
+    """
+    if _threadpool_instrumentation_enabled:
+        from onyx.server.metrics.threadpool import InstrumentedThreadPoolExecutor
+
+        return InstrumentedThreadPoolExecutor
+    return ThreadPoolExecutor
+
+
+def enable_threadpool_instrumentation() -> None:
+    """Called by setup_threadpool_metrics() during API server startup."""
+    global _threadpool_instrumentation_enabled
+    _threadpool_instrumentation_enabled = True
+
+
 R = TypeVar("R")
 KT = TypeVar("KT")  # Key type
 VT = TypeVar("VT")  # Value type
@@ -323,7 +349,8 @@ def run_functions_tuples_in_parallel(
         return []
 
     results: list[tuple[int, Any]] = []
-    executor = ThreadPoolExecutor(max_workers=workers)
+    executor_cls = _get_executor_class()
+    executor = executor_cls(max_workers=workers)
 
     try:
         # The primary reason for propagating contextvars is to allow acquiring a db session
@@ -421,7 +448,8 @@ def run_functions_in_parallel(
     if len(function_calls) == 0:
         return results
 
-    with ThreadPoolExecutor(max_workers=len(function_calls)) as executor:
+    executor_cls = _get_executor_class()
+    with executor_cls(max_workers=len(function_calls)) as executor:
         future_to_id = {
             executor.submit(
                 contextvars.copy_context().run, func_call.execute
@@ -543,7 +571,8 @@ def parallel_yield(gens: list[Iterator[R]], max_workers: int = 10) -> Iterator[R
     if you are consuming all elements from the generators OR it is acceptable
     for some extra generator code to run and not have the result(s) yielded.
     """
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    executor_cls = _get_executor_class()
+    with executor_cls(max_workers=max_workers) as executor:
         future_to_index: dict[Future[tuple[int, R | None]], int] = {
             executor.submit(_next_or_none, ind, gen): ind
             for ind, gen in enumerate(gens)

--- a/backend/tests/unit/onyx/server/test_threadpool_metrics.py
+++ b/backend/tests/unit/onyx/server/test_threadpool_metrics.py
@@ -1,0 +1,70 @@
+"""Unit tests for thread pool instrumentation."""
+
+from unittest.mock import patch
+
+import pytest
+
+from onyx.server.metrics.threadpool import InstrumentedThreadPoolExecutor
+from onyx.server.metrics.threadpool import ThreadCountCollector
+
+
+def test_instrumented_executor_tracks_submissions() -> None:
+    """Verify counter increments and gauge tracks active tasks."""
+    with (
+        patch("onyx.server.metrics.threadpool._TASKS_SUBMITTED") as mock_submitted,
+        patch("onyx.server.metrics.threadpool._TASKS_ACTIVE") as mock_active,
+        patch("onyx.server.metrics.threadpool._TASK_DURATION") as mock_duration,
+    ):
+
+        with InstrumentedThreadPoolExecutor(max_workers=2) as executor:
+            future = executor.submit(lambda: 42)
+            result = future.result(timeout=5)
+
+        assert result == 42
+        mock_submitted.inc.assert_called_once()
+        mock_active.inc.assert_called_once()
+        mock_active.dec.assert_called_once()
+        mock_duration.observe.assert_called_once()
+
+        # Duration should be non-negative
+        observed_duration = mock_duration.observe.call_args[0][0]
+        assert observed_duration >= 0
+
+
+def test_instrumented_executor_handles_exceptions() -> None:
+    """Verify metrics still fire when the task raises."""
+    with (
+        patch("onyx.server.metrics.threadpool._TASKS_SUBMITTED") as mock_submitted,
+        patch("onyx.server.metrics.threadpool._TASKS_ACTIVE") as mock_active,
+        patch("onyx.server.metrics.threadpool._TASK_DURATION") as mock_duration,
+    ):
+
+        with InstrumentedThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(lambda: 1 / 0)
+            with pytest.raises(ZeroDivisionError):
+                future.result(timeout=5)
+
+        # Metrics should still be recorded even on failure
+        mock_submitted.inc.assert_called_once()
+        mock_active.inc.assert_called_once()
+        mock_active.dec.assert_called_once()
+        mock_duration.observe.assert_called_once()
+
+
+def test_thread_count_collector_reports_threads() -> None:
+    """Verify the collector returns the process thread count."""
+    with patch("onyx.server.metrics.threadpool._process") as mock_process:
+        mock_process.num_threads.return_value = 15
+
+        collector = ThreadCountCollector()
+        families = collector.collect()
+
+        assert len(families) == 1
+        samples = families[0].samples
+        assert len(samples) == 1
+        assert samples[0].value == 15
+
+
+def test_thread_count_collector_describe_returns_empty() -> None:
+    collector = ThreadCountCollector()
+    assert collector.describe() == []

--- a/backend/tests/unit/onyx/server/test_threadpool_metrics.py
+++ b/backend/tests/unit/onyx/server/test_threadpool_metrics.py
@@ -53,8 +53,8 @@ def test_instrumented_executor_handles_exceptions() -> None:
 
 def test_thread_count_collector_reports_threads() -> None:
     """Verify the collector returns the process thread count."""
-    with patch("onyx.server.metrics.threadpool._process") as mock_process:
-        mock_process.num_threads.return_value = 15
+    with patch("onyx.server.metrics.threadpool._get_process") as mock_get_process:
+        mock_get_process.return_value.num_threads.return_value = 15
 
         collector = ThreadCountCollector()
         families = collector.collect()

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -232,6 +232,22 @@ Configurable via `EVENT_LOOP_LAG_PROBE_INTERVAL_SECONDS` (default `2.0`).
 onyx_api_event_loop_lag_seconds > 0.1
 ```
 
+## Thread Pool Metrics
+
+Always-on via `InstrumentedThreadPoolExecutor` (wraps all `ThreadPoolExecutor` usage).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `onyx_threadpool_tasks_submitted_total` | Counter | — | Total tasks submitted |
+| `onyx_threadpool_tasks_active` | Gauge | — | Currently executing tasks |
+| `onyx_threadpool_task_duration_seconds` | Histogram | — | Task execution duration |
+| `onyx_process_thread_count` | Gauge | — | OS threads in the process |
+
+```promql
+# Rising thread count = potential leak
+onyx_process_thread_count
+```
+
 ## Example PromQL Queries
 
 ### Which endpoints are saturated right now?

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -234,7 +234,7 @@ onyx_api_event_loop_lag_seconds > 0.1
 
 ## Thread Pool Metrics
 
-Always-on via `InstrumentedThreadPoolExecutor` (wraps all `ThreadPoolExecutor` usage).
+Collected via `InstrumentedThreadPoolExecutor` (wraps `ThreadPoolExecutor` usage in `threadpool_concurrency.py`).
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|


### PR DESCRIPTION
## Description

Add `InstrumentedThreadPoolExecutor` that wraps `submit()` to track task submission, active count, and duration. Also adds a custom `Collector` for process-wide thread count via `psutil`.

New metrics:
- `onyx_threadpool_tasks_submitted_total` — Counter. Total tasks submitted.
- `onyx_threadpool_tasks_active` — Gauge. Currently executing tasks.
- `onyx_threadpool_task_duration_seconds` — Histogram. Task execution duration.
- `onyx_process_thread_count` — Gauge. OS threads in the process.

Modifies `threadpool_concurrency.py` to use the instrumented executor via `enable_threadpool_instrumentation()`.

Part 4 of 6 in the API server observability series. Stacks on #9089.

## How Has This Been Tested?

- Unit tests for submission tracking, exception handling, thread count collector, and describe (4 tests)
- mypy clean
- Pre-commit hooks pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check