### PR TITLE
fix: universal think tag parsing and buffer newlines before toolcalls

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1085,6 +1085,13 @@ def run_llm_step_pkt_generator(
                 )
                 reasoning_start = False
 
+        # Buffer whitespace-only content until we see real text.  Open-weight
+        # models (e.g. Qwen 3.5 via LM Studio) frequently emit "\n\n" before
+        # tool calls.  If we emit AgentResponseStart for that whitespace, the
+        # frontend thinks the final answer has started and renders incorrectly
+        # when tool packets follow.
+        pending_whitespace = ""
+
         def _emit_content_chunk(content_chunk: str) -> Generator[Packet, None, None]:
             nonlocal accumulated_answer
             nonlocal accumulated_reasoning
@@ -1092,6 +1099,7 @@ def run_llm_step_pkt_generator(
             nonlocal reasoning_start
             nonlocal turn_index
             nonlocal sub_turn_index
+            nonlocal pending_whitespace
 
             # When tool_choice is REQUIRED, content before tool calls is reasoning/thinking
             # about which tool to call, not an actual answer to the user.
@@ -1113,6 +1121,18 @@ def run_llm_step_pkt_generator(
                 return
 
             # Normal flow for AUTO or NONE tool choice
+
+            # Buffer whitespace-only content so we don't prematurely emit
+            # AgentResponseStart before tool calls arrive.
+            if not answer_start and content_chunk.strip() == "":
+                pending_whitespace += content_chunk
+                return
+
+            # Flush any buffered whitespace now that real content has arrived.
+            if pending_whitespace:
+                content_chunk = pending_whitespace + content_chunk
+                pending_whitespace = ""
+
             yield from _close_reasoning_if_active()
 
             if not answer_start:
@@ -1221,6 +1241,10 @@ def run_llm_step_pkt_generator(
                     yield from _emit_content_chunk(filtered_content)
 
             if delta.tool_calls:
+                # Discard any buffered whitespace — it was junk before tool calls,
+                # not part of the actual answer.
+                pending_whitespace = ""
+
                 yield from _close_reasoning_if_active()
 
                 for tool_call_delta in delta.tool_calls:

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -9,8 +9,9 @@ Status checked against LiteLLM v1.81.6-nightly (2026-02-02):
    - LiteLLM's chunk_parser doesn't properly handle reasoning content in streaming
      responses from Ollama
    - Processes native "thinking" field from Ollama responses
-   - Also handles <think>...</think> tags in content for models that use that format
    - Tracks reasoning state to properly separate thinking from regular content
+   - NOTE: <think>...</think> tag parsing is handled universally for ALL providers
+     by make_think_tag_processor in model_response.py
    STATUS: STILL NEEDED - LiteLLM has a bug where it only yields thinking content on
            the first two chunks, then stops (lines 504-510). Our patch correctly yields
            ALL thinking chunks. The upstream logic sets finished_reasoning_content=True
@@ -162,35 +163,23 @@ def _patch_ollama_chunk_parser() -> None:
                 reasoning_content = thinking_content
                 if self.started_reasoning_content is False:
                     self.started_reasoning_content = True
-            if chunk["message"].get("content") is not None:
-                message_content = chunk["message"].get("content")
-                # Track whether we are inside <think>...</think> tagged content.
-                in_think_tag_block = bool(getattr(self, "_in_think_tag_block", False))
-                if "<think>" in message_content:
-                    message_content = message_content.replace("<think>", "")
-                    self.started_reasoning_content = True
-                    self.finished_reasoning_content = False
-                    in_think_tag_block = True
-                if "</think>" in message_content and self.started_reasoning_content:
-                    message_content = message_content.replace("</think>", "")
-                    self.finished_reasoning_content = True
-                    in_think_tag_block = False
 
-                # For native Ollama "thinking" streams, content without active
-                # think tags indicates a transition into regular assistant output.
+            message_content = chunk["message"].get("content")
+            if message_content is not None:
+                # For native Ollama "thinking" streams, content arriving
+                # after thinking chunks (without the thinking field)
+                # indicates a transition into regular assistant output.
                 if (
                     self.started_reasoning_content
                     and not self.finished_reasoning_content
-                    and not in_think_tag_block
                     and not thinking_content
                 ):
                     self.finished_reasoning_content = True
 
-                self._in_think_tag_block = in_think_tag_block
-
-                # When Ollama returns both "thinking" and "content" in the same
-                # chunk, preserve both instead of classifying content as reasoning.
-                if thinking_content and not in_think_tag_block:
+                # When Ollama returns both "thinking" and "content" in the
+                # same chunk, preserve both.  Otherwise, if we're still in
+                # the reasoning phase, route content as reasoning.
+                if thinking_content:
                     content = message_content
                 elif (
                     self.started_reasoning_content

--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 from typing import List
 from typing import TYPE_CHECKING
@@ -174,6 +175,79 @@ def _usage_from_usage_data(usage_data: dict[str, Any]) -> Usage:
         )
         or 0,
     )
+
+
+def make_think_tag_processor() -> Callable[[ModelResponseStream], ModelResponseStream]:
+    """Return a stateful function that extracts ``<think>``/``</think>`` tags
+    from streaming content and routes the enclosed text to
+    ``reasoning_content``.
+
+    Works universally across all providers.  When ``reasoning_content`` is
+    already populated on a chunk (e.g. Ollama with our monkey-patch, or
+    providers that natively support structured reasoning), the chunk is
+    returned unchanged so there is no double-processing.
+    """
+    in_think_block = False
+
+    def _process(response: ModelResponseStream) -> ModelResponseStream:
+        nonlocal in_think_block
+        delta = response.choice.delta
+
+        # Provider already supplies structured reasoning — leave it alone.
+        if delta.reasoning_content is not None:
+            return response
+
+        content = delta.content
+        if not content:
+            return response
+
+        reasoning_text = ""
+        content_text = ""
+
+        i = 0
+        while i < len(content):
+            if not in_think_block:
+                tag_start = content.find("<think>", i)
+                if tag_start == -1:
+                    content_text += content[i:]
+                    break
+                content_text += content[i:tag_start]
+                in_think_block = True
+                i = tag_start + len("<think>")
+            else:
+                tag_end = content.find("</think>", i)
+                if tag_end == -1:
+                    reasoning_text += content[i:]
+                    break
+                reasoning_text += content[i:tag_end]
+                in_think_block = False
+                i = tag_end + len("</think>")
+
+        new_content = content_text or None
+        new_reasoning = reasoning_text or None
+
+        # Fast path: nothing changed.
+        if new_content == delta.content and new_reasoning is None:
+            return response
+
+        new_delta = Delta(
+            content=new_content,
+            reasoning_content=new_reasoning,
+            tool_calls=delta.tool_calls,
+        )
+        new_choice = StreamingChoice(
+            finish_reason=response.choice.finish_reason,
+            index=response.choice.index,
+            delta=new_delta,
+        )
+        return ModelResponseStream(
+            id=response.id,
+            created=response.created,
+            choice=new_choice,
+            usage=response.usage,
+        )
+
+    return _process
 
 
 def from_litellm_model_response_stream(

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -683,6 +683,7 @@ class LitellmLLM(LLM):
         from litellm import HTTPHandler
 
         from onyx.llm.model_response import from_litellm_model_response_stream
+        from onyx.llm.model_response import make_think_tag_processor
 
         # HTTPHandler Threading & Connection Pool Notes:
         # =============================================
@@ -735,8 +736,11 @@ class LitellmLLM(LLM):
                 ),
             )
 
+            process_think_tags = make_think_tag_processor()
             for chunk in response:
-                model_response = from_litellm_model_response_stream(chunk)
+                model_response = process_think_tags(
+                    from_litellm_model_response_stream(chunk)
+                )
 
                 # Track LLM cost when usage info is available (typically in the last chunk)
                 if model_response.usage:

--- a/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
+++ b/backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py
@@ -52,41 +52,6 @@ def test_ollama_chunk_parser_transitions_from_native_thinking_to_content() -> No
     assert iterator.finished_reasoning_content is True
 
 
-def test_ollama_chunk_parser_keeps_tagged_thinking_until_close_tag() -> None:
-    iterator = _create_iterator()
-
-    start_chunk = _build_chunk(content="<think>step 1")
-    middle_chunk = _build_chunk(content="step 2")
-    close_chunk = _build_chunk(content="final</think>")
-
-    start_response = iterator.chunk_parser(start_chunk)
-    middle_response = iterator.chunk_parser(middle_chunk)
-    close_response = iterator.chunk_parser(close_chunk)
-
-    assert start_response.choices[0].delta.reasoning_content == "step 1"
-    assert start_response.choices[0].delta.content is None
-
-    assert middle_response.choices[0].delta.reasoning_content == "step 2"
-    assert middle_response.choices[0].delta.content is None
-
-    assert getattr(close_response.choices[0].delta, "reasoning_content", None) is None
-    assert close_response.choices[0].delta.content == "final"
-    assert iterator.finished_reasoning_content is True
-
-
-def test_ollama_chunk_parser_handles_think_tag_after_native_thinking() -> None:
-    iterator = _create_iterator()
-
-    native_thinking_chunk = _build_chunk(thinking="native reasoning")
-    tagged_thinking_chunk = _build_chunk(content="<think>tagged reasoning")
-
-    iterator.chunk_parser(native_thinking_chunk)
-    tagged_response = iterator.chunk_parser(tagged_thinking_chunk)
-
-    assert tagged_response.choices[0].delta.reasoning_content == "tagged reasoning"
-    assert tagged_response.choices[0].delta.content is None
-
-
 def test_ollama_chunk_parser_preserves_content_when_thinking_and_content_coexist() -> (
     None
 ):

--- a/backend/tests/unit/onyx/llm/test_model_response.py
+++ b/backend/tests/unit/onyx/llm/test_model_response.py
@@ -6,11 +6,14 @@ from typing import TYPE_CHECKING
 import pytest
 
 from onyx.llm.model_response import ChatCompletionDeltaToolCall
+from onyx.llm.model_response import Delta
 from onyx.llm.model_response import from_litellm_model_response
 from onyx.llm.model_response import from_litellm_model_response_stream
 from onyx.llm.model_response import FunctionCall
+from onyx.llm.model_response import make_think_tag_processor
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.model_response import ModelResponseStream
+from onyx.llm.model_response import StreamingChoice
 
 if TYPE_CHECKING:
     from litellm.types.utils import (
@@ -295,6 +298,104 @@ def test_from_litellm_model_response_stream_parses_multiple_tool_calls() -> None
             name="web_search",
         ),
     )
+
+
+def _make_model_response_stream(
+    content: str | None = None,
+    reasoning_content: str | None = None,
+) -> ModelResponseStream:
+    """Helper to build a ModelResponseStream for ThinkTagStreamProcessor tests."""
+    return ModelResponseStream(
+        id="test-id",
+        created="123",
+        choice=StreamingChoice(
+            delta=Delta(
+                content=content,
+                reasoning_content=reasoning_content,
+            ),
+        ),
+    )
+
+
+class TestThinkTagProcessor:
+    def test_no_think_tags_passes_through(self) -> None:
+        process = make_think_tag_processor()
+        resp = _make_model_response_stream(content="hello world")
+        result = process(resp)
+        assert result.choice.delta.content == "hello world"
+        assert result.choice.delta.reasoning_content is None
+
+    def test_existing_reasoning_content_not_modified(self) -> None:
+        process = make_think_tag_processor()
+        resp = _make_model_response_stream(
+            content="some content", reasoning_content="already set"
+        )
+        result = process(resp)
+        assert result.choice.delta.content == "some content"
+        assert result.choice.delta.reasoning_content == "already set"
+
+    def test_think_tag_in_single_chunk(self) -> None:
+        process = make_think_tag_processor()
+        resp = _make_model_response_stream(
+            content="<think>reasoning here</think>answer"
+        )
+        result = process(resp)
+        assert result.choice.delta.reasoning_content == "reasoning here"
+        assert result.choice.delta.content == "answer"
+
+    def test_think_tags_across_multiple_chunks(self) -> None:
+        process = make_think_tag_processor()
+
+        r1 = process(_make_model_response_stream(content="<think>start"))
+        assert r1.choice.delta.reasoning_content == "start"
+        assert r1.choice.delta.content is None
+
+        r2 = process(_make_model_response_stream(content=" middle"))
+        assert r2.choice.delta.reasoning_content == " middle"
+        assert r2.choice.delta.content is None
+
+        r3 = process(_make_model_response_stream(content="</think>the answer"))
+        assert r3.choice.delta.reasoning_content is None
+        assert r3.choice.delta.content == "the answer"
+
+    def test_empty_content_passes_through(self) -> None:
+        process = make_think_tag_processor()
+        resp = _make_model_response_stream(content=None)
+        result = process(resp)
+        assert result is resp  # Same object, untouched
+
+    def test_closing_tag_with_trailing_reasoning_and_content(self) -> None:
+        """Mirrors the old Ollama test: content="final</think>" yields
+        reasoning='final' then subsequent content is regular."""
+        process = make_think_tag_processor()
+
+        process(_make_model_response_stream(content="<think>step 1"))
+        r2 = process(_make_model_response_stream(content="step 2"))
+        assert r2.choice.delta.reasoning_content == "step 2"
+        assert r2.choice.delta.content is None
+
+        r3 = process(_make_model_response_stream(content="final</think>"))
+        assert r3.choice.delta.reasoning_content == "final"
+        assert r3.choice.delta.content is None
+
+        r4 = process(_make_model_response_stream(content="visible answer"))
+        assert r4.choice.delta.content == "visible answer"
+        assert r4.choice.delta.reasoning_content is None
+
+    def test_think_only_no_content_after(self) -> None:
+        process = make_think_tag_processor()
+
+        r1 = process(_make_model_response_stream(content="<think>"))
+        assert r1.choice.delta.reasoning_content is None
+        assert r1.choice.delta.content is None
+
+        r2 = process(_make_model_response_stream(content="reasoning"))
+        assert r2.choice.delta.reasoning_content == "reasoning"
+        assert r2.choice.delta.content is None
+
+        r3 = process(_make_model_response_stream(content="</think>"))
+        assert r3.choice.delta.reasoning_content is None
+        assert r3.choice.delta.content is None
 
 
 def test_from_litellm_model_response_parses_basic_message() -> None:


### PR DESCRIPTION
## Description

- Moved ollama <think> tag parsing to run universally (so models that output this style--Qwen--will work no matter the provider)
- Added a buffer for packets that only contain new lines (mirrors dr) --> Qwen 3.5 will sometimes output new lines before tool calls and our FE thinks that this means the final answer is coming

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
