### PR TITLE
refactor: replace HTTPException with OnyxError in model_server

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -4,10 +4,11 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
-from fastapi import HTTPException
 from fastapi import Request
 
 from model_server.utils import simple_log_function_time
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from shared_configs.enums import EmbedTextType
 from shared_configs.model_server_models import Embedding
@@ -188,7 +189,7 @@ async def process_embed_request(
         )
 
     if not embed_request.texts:
-        raise HTTPException(status_code=400, detail="No texts to be embedded")
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, "No texts to be embedded")
 
     if not all(embed_request.texts):
         raise ValueError("Empty strings are not allowed for embedding.")
@@ -211,14 +212,12 @@ async def process_embed_request(
         )
         return EmbedResponse(embeddings=embeddings)
     except RateLimitError as e:
-        raise HTTPException(
-            status_code=429,
-            detail=str(e),
-        )
+        raise OnyxError(OnyxErrorCode.RATE_LIMITED, str(e))
     except Exception as e:
         logger.exception(
             f"Error during embedding process: provider={embed_request.provider_type} model={embed_request.model_name}"
         )
-        raise HTTPException(
-            status_code=500, detail=f"Error during embedding process: {e}"
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            f"Error during embedding process: {e}",
         )

--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -18,6 +18,7 @@ from model_server.encoders import router as encoders_router
 from model_server.management_endpoints import router as management_router
 from model_server.utils import get_gpu_type
 from onyx import __version__
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.utils.logger import setup_logger
 from onyx.utils.logger import setup_uvicorn_logger
 from onyx.utils.middleware import add_onyx_request_id_middleware
@@ -107,6 +108,8 @@ def get_model_app() -> FastAPI:
 
     application.include_router(management_router)
     application.include_router(encoders_router)
+
+    register_onyx_exception_handlers(application)
 
     request_id_prefix = "INF"
     if INDEXING_ONLY:


### PR DESCRIPTION
## Description

Converts the last 3 `HTTPException` usages in the non-test, non-infrastructure backend code to `OnyxError`:
- `model_server/encoders.py` — validation error, rate limit, and internal error during embedding

Note: `model_server/legacy/reranker.py` has `HTTPException` in commented-out dead code, so no conversion needed there.

This is the final conversion PR in the HTTPException → OnyxError standardization effort.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check