### PR TITLE
Update access.py

### DIFF
--- a/backend/onyx/connectors/jira/access.py
+++ b/backend/onyx/connectors/jira/access.py
@@ -8,6 +8,7 @@ from typing import cast
 from jira import JIRA
 
 from onyx.access.models import ExternalAccess
+from onyx.configs.constants import DocumentSource
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from onyx.utils.variable_functionality import global_version
 
@@ -16,6 +17,7 @@ def get_project_permissions(
     jira_client: JIRA,
     jira_project: str,
     add_prefix: bool = False,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> ExternalAccess | None:
     """
     Fetch the project + issue level permissions / access-control.
@@ -27,6 +29,8 @@ def get_project_permissions(
         add_prefix: When True, prefix group IDs with source type (for indexing path).
                    When False (default), leave unprefixed (for permission sync path
                    where upsert_document_external_perms handles prefixing).
+        source: The DocumentSource to use when prefixing group IDs.
+                Defaults to JIRA; JSM connector passes JIRA_SERVICE_MANAGEMENT.
 
     Returns:
         ExternalAccess object for the page. None if EE is not enabled or no restrictions found.
@@ -38,7 +42,7 @@ def get_project_permissions(
 
     ee_get_project_permissions = cast(
         Callable[
-            [JIRA, str, bool],
+            [JIRA, str, bool, DocumentSource],
             ExternalAccess | None,
         ],
         fetch_versioned_implementation(
@@ -50,4 +54,5 @@ def get_project_permissions(
         jira_client,
         jira_project,
         add_prefix,
+        source,
     )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `source` parameter to Jira project permission fetching to choose the correct `DocumentSource` for group ID prefixing. This enables JSM to pass `JIRA_SERVICE_MANAGEMENT` while keeping `JIRA` as the default.

- **New Features**
  - Added `source: DocumentSource = DocumentSource.JIRA` to `get_project_permissions`.
  - Forwarded `source` to the versioned implementation and use it when `add_prefix` is true.

<sup>Written for commit e9f7948cf58fb6b2dc0d5807cfd0532dc7793890. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

