### PR TITLE
fix(chat): prevent submitting empty or whitespace-only messages (#7700)

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -5,10 +5,11 @@ import { FileDescriptor } from "@/app/app/interfaces";
 import "katex/dist/katex.min.css";
 import MessageSwitcher from "@/app/app/message/MessageSwitcher";
 import Text from "@/refresh-components/texts/Text";
-import { cn } from "@/lib/utils";
+import { cn, isValidMessage } from "@/lib/utils";
 import useScreenSize from "@/hooks/useScreenSize";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Button } from "@opal/components";
+import { Disabled } from "@opal/core";
 import { SvgEdit } from "@opal/icons";
 import FileDisplay from "./FileDisplay";
 
@@ -34,8 +35,12 @@ function MessageEditing({
     textareaRef.current.select();
   }, []);
 
+  const isEditedContentValid = isValidMessage(editedContent);
+
   function handleSubmit() {
-    onSubmitEdit(editedContent);
+    if (isEditedContentValid) {
+      onSubmitEdit(editedContent);
+    }
   }
 
   function handleCancel() {
@@ -70,11 +75,16 @@ function MessageEditing({
               handleCancel();
             }
             // Submit edit if "Command Enter" is pressed, like in ChatGPT
-            if (e.key === "Enter" && e.metaKey) handleSubmit();
+            if (e.key === "Enter" && e.metaKey && isEditedContentValid) {
+              e.preventDefault();
+              handleSubmit();
+            }
           }}
         />
         <div className="flex justify-end gap-1">
-          <Button onClick={handleSubmit}>Submit</Button>
+          <Disabled disabled={!isEditedContentValid}>
+            <Button onClick={handleSubmit}>Submit</Button>
+          </Disabled>
           <Button prominence="secondary" onClick={handleCancel}>
             Cancel
           </Button>
@@ -203,6 +213,10 @@ const HumanMessage = React.memo(function HumanMessage({
             // Don't update UI for edits that can't be persisted
             if (messageId === undefined || messageId === null) {
               setIsEditing(false);
+              return;
+            }
+            // Validate edited content before submitting
+            if (!isValidMessage(editedContent)) {
               return;
             }
             onEdit?.(editedContent, messageId);

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -290,3 +290,12 @@ export function mergeRefs<T>(
     });
   };
 }
+
+/**
+ * Checks if a message string contains at least one non-whitespace character.
+ * Returns false for empty strings, strings with only spaces, tabs, newlines, etc.
+ */
+export function isValidMessage(message: string | null | undefined): boolean {
+  if (!message) return false;
+  return message.trim().length > 0;
+}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -21,7 +21,7 @@ import { ChatState } from "@/app/app/interfaces";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import { useAppMode } from "@/providers/AppModeProvider";
 import useAppFocus from "@/hooks/useAppFocus";
-import { cn, isImageFile } from "@/lib/utils";
+import { cn, isImageFile, isValidMessage } from "@/lib/utils";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
 import {
@@ -361,6 +361,12 @@ const AppInputBar = React.memo(
       [currentMessageFiles]
     );
 
+    // Memoize validation result since it's used multiple times per render
+    const isMessageValid = useMemo(
+      () => isValidMessage(message),
+      [message]
+    );
+
     // Check if the agent has search tools available (internal search or web search)
     // AND if deep research is globally enabled in admin settings
     const showDeepResearch = useMemo(() => {
@@ -560,7 +566,7 @@ const AppInputBar = React.memo(
           </div>
           <Disabled
             disabled={
-              (chatState === "input" && !message) ||
+              (chatState === "input" && !isMessageValid) ||
               hasUploadingFiles ||
               isClassifying
             }
@@ -577,7 +583,7 @@ const AppInputBar = React.memo(
               onClick={() => {
                 if (chatState == "streaming") {
                   stopGenerating();
-                } else if (message) {
+                } else if (isMessageValid) {
                   onSubmit(message);
                 }
               }}
@@ -671,7 +677,7 @@ const AppInputBar = React.memo(
                       ) {
                         event.preventDefault();
                         if (
-                          message &&
+                          isMessageValid &&
                           !disabled &&
                           !isClassifying &&
                           !hasUploadingFiles
@@ -726,7 +732,7 @@ const AppInputBar = React.memo(
 
             {isSearchMode && (
               <Section flexDirection="row" width="fit" gap={0}>
-                <Disabled disabled={!message || isClassifying}>
+                <Disabled disabled={!isMessageValid || isClassifying}>
                   <Button
                     icon={SvgX}
                     onClick={() => setMessage("")}
@@ -734,7 +740,7 @@ const AppInputBar = React.memo(
                   />
                 </Disabled>
                 <Disabled
-                  disabled={!message || isClassifying || hasUploadingFiles}
+                  disabled={!isMessageValid || isClassifying || hasUploadingFiles}
                 >
                   <Button
                     id="onyx-chat-input-send-button"
@@ -742,7 +748,7 @@ const AppInputBar = React.memo(
                     onClick={() => {
                       if (chatState == "streaming") {
                         stopGenerating();
-                      } else if (message) {
+                      } else if (isMessageValid) {
                         onSubmit(message);
                       }
                     }}


### PR DESCRIPTION
## Summary
Fixes #7700 by preventing empty or whitespace-only chat messages from being submitted.

## Problem
Users could submit messages containing only whitespace characters (spaces, tabs, newlines) by clicking the send button or pressing Enter. This resulted in empty or meaningless messages being sent or errors with some models:

<img width="1899" height="880" alt="image" src="https://github.com/user-attachments/assets/c5a319dd-0adb-48b8-97b3-edfd5b73e6dd" />

## Solution
Added validation to check that messages contain at least one non-whitespace character before allowing submission:

1. **New utility function** (`isValidMessage` in `utils.ts`):
   - Checks if a message string has at least one non-whitespace character
   - Returns false for empty strings or strings with only whitespace

2. **Main input bar** (`AppInputBar.tsx`):
   - Send button is disabled when message is invalid
   - Enter key is blocked when message is invalid
   - Works in both chat and search modes

3. **Message editing** (`HumanMessage.tsx`):
   - Submit button is disabled when edited content is invalid
   - Cmd+Enter is blocked when edited content is invalid
   - Visual feedback shows disabled state

## Testing
- Empty string input → send button disabled
- Whitespace-only input → send button disabled  
- Valid input → send button enabled
- Enter key blocked for invalid input
- Message editing validation works correctly
- Buttons visually appear disabled when invalid

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents submitting empty or whitespace-only messages across chat input and edit flows. Fixes #7700 by disabling send actions and keyboard submits unless the text contains at least one non-whitespace character.

- **Bug Fixes**
  - Added `isValidMessage` in `web/src/lib/utils.ts`.
  - `AppInputBar.tsx`: disable send and block Enter when invalid in chat and search modes.
  - `HumanMessage.tsx`: disable Submit, block Cmd+Enter, and validate before saving edits (uses `@opal/core` `Disabled` for visual state).

<sup>Written for commit 677a6d674e9905196debf82f73e481f243af63cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

