### PR TITLE
feat: add persona-scoped prompt shortcuts for assistants

### DIFF
--- a/backend/alembic/versions/c2f6a1d9e4b7_add_persona_scoped_input_prompts.py
+++ b/backend/alembic/versions/c2f6a1d9e4b7_add_persona_scoped_input_prompts.py
@@ -1,0 +1,79 @@
+"""add persona scoped input prompts
+
+Revision ID: c2f6a1d9e4b7
+Revises: b5c4d7e8f9a1
+Create Date: 2026-03-10 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c2f6a1d9e4b7"
+down_revision = "b5c4d7e8f9a1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("inputprompt", sa.Column("persona_id", sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        "fk_inputprompt_persona_id_persona",
+        "inputprompt",
+        "persona",
+        ["persona_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    op.create_unique_constraint(
+        "uq_inputprompt_prompt_persona_id",
+        "inputprompt",
+        ["prompt", "persona_id"],
+    )
+
+    op.drop_index("uq_inputprompt_prompt_public", table_name="inputprompt")
+    op.create_index(
+        "uq_inputprompt_prompt_public",
+        "inputprompt",
+        ["prompt"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_public = TRUE AND user_id IS NULL AND persona_id IS NULL"
+        ),
+    )
+
+    op.create_check_constraint(
+        "ck_inputprompt_only_one_owner",
+        "inputprompt",
+        "(user_id IS NULL) OR (persona_id IS NULL)",
+    )
+    op.create_check_constraint(
+        "ck_inputprompt_public_has_no_owner",
+        "inputprompt",
+        "(is_public = FALSE) OR (user_id IS NULL AND persona_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_inputprompt_public_has_no_owner", "inputprompt")
+    op.drop_constraint("ck_inputprompt_only_one_owner", "inputprompt")
+
+    op.drop_index("uq_inputprompt_prompt_public", table_name="inputprompt")
+    op.create_index(
+        "uq_inputprompt_prompt_public",
+        "inputprompt",
+        ["prompt"],
+        unique=True,
+        postgresql_where=sa.text("user_id IS NULL"),
+    )
+
+    op.drop_constraint(
+        "uq_inputprompt_prompt_persona_id", "inputprompt", type_="unique"
+    )
+    op.drop_constraint(
+        "fk_inputprompt_persona_id_persona", "inputprompt", type_="foreignkey"
+    )
+    op.drop_column("inputprompt", "persona_id")

--- a/backend/alembic/versions/c2f6a1d9e4b7_add_persona_scoped_input_prompts.py
+++ b/backend/alembic/versions/c2f6a1d9e4b7_add_persona_scoped_input_prompts.py
@@ -61,6 +61,11 @@ def downgrade() -> None:
     op.drop_constraint("ck_inputprompt_public_has_no_owner", "inputprompt")
     op.drop_constraint("ck_inputprompt_only_one_owner", "inputprompt")
 
+    # Persona-scoped prompts are not representable in the pre-migration schema.
+    # Remove them before restoring legacy uniqueness on prompt where user_id IS NULL,
+    # otherwise rollback can fail when different personas share shortcut names.
+    op.execute("DELETE FROM inputprompt WHERE persona_id IS NOT NULL")
+
     op.drop_index("uq_inputprompt_prompt_public", table_name="inputprompt")
     op.create_index(
         "uq_inputprompt_prompt_public",

--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -1,8 +1,11 @@
+from collections.abc import Sequence
 from uuid import UUID
 
 from fastapi import HTTPException
+from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import aliased
@@ -11,7 +14,9 @@ from sqlalchemy.orm import Session
 from onyx.db.models import InputPrompt
 from onyx.db.models import InputPrompt__User
 from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
 from onyx.server.features.input_prompt.models import InputPromptSnapshot
+from onyx.server.features.input_prompt.models import SyncPersonaInputPromptItem
 from onyx.server.manage.models import UserInfo
 from onyx.utils.logger import setup_logger
 
@@ -23,6 +28,7 @@ def insert_input_prompt(
     content: str,
     is_public: bool,
     user: User | None,
+    persona_id: int | None,
     db_session: Session,
 ) -> InputPrompt:
     user_id = user.id if user else None
@@ -35,17 +41,24 @@ def insert_input_prompt(
         active=True,
         is_public=is_public,
         user_id=user_id,
+        persona_id=persona_id,
     )
 
     # Use the appropriate constraint based on whether this is a user-owned or public prompt
     if user_id is not None:
         stmt = stmt.on_conflict_do_nothing(constraint="uq_inputprompt_prompt_user_id")
+    elif persona_id is not None:
+        stmt = stmt.on_conflict_do_nothing(
+            constraint="uq_inputprompt_prompt_persona_id"
+        )
     else:
         # Partial unique indexes cannot be targeted by constraint name;
         # must use index_elements + index_where
         stmt = stmt.on_conflict_do_nothing(
             index_elements=[InputPrompt.prompt],
-            index_where=InputPrompt.user_id.is_(None),
+            index_where=text(
+                "is_public = TRUE AND user_id IS NULL AND persona_id IS NULL"
+            ),
         )
 
     stmt = stmt.returning(InputPrompt)
@@ -100,7 +113,7 @@ def validate_user_prompt_authorization(user: User, input_prompt: InputPrompt) ->
     prompt = InputPromptSnapshot.from_model(input_prompt=input_prompt)
 
     # Public prompts cannot be modified via the user API (only admins via admin endpoints)
-    if prompt.is_public or prompt.user_id is None:
+    if prompt.is_public or prompt.user_id is None or prompt.persona_id is not None:
         return False
 
     # Anonymous users cannot modify user-owned prompts
@@ -184,6 +197,7 @@ def fetch_input_prompts_by_user(
     user_id: UUID | None,
     active: bool | None = None,
     include_public: bool = False,
+    persona_id: int | None = None,
 ) -> list[InputPrompt]:
     """
     Returns all prompts belonging to the user or public prompts,
@@ -205,16 +219,23 @@ def fetch_input_prompts_by_user(
         query = query.where(or_(IPU.disabled.is_(None), IPU.disabled.is_(False)))
 
         if include_public:
-            # Return both user-owned and public prompts
-            query = query.where(
-                or_(
-                    InputPrompt.user_id == user_id,
-                    InputPrompt.is_public,
-                )
-            )
+            # Return user-owned and public prompts
+            ownership_filters = [
+                InputPrompt.user_id == user_id,
+                and_(
+                    InputPrompt.is_public.is_(True),
+                    InputPrompt.user_id.is_(None),
+                    InputPrompt.persona_id.is_(None),
+                ),
+            ]
         else:
-            # Return only user-owned prompts
-            query = query.where(InputPrompt.user_id == user_id)
+            # Return only user-owned prompts by default
+            ownership_filters = [InputPrompt.user_id == user_id]
+
+        if persona_id is not None:
+            ownership_filters.append(InputPrompt.persona_id == persona_id)
+
+        query = query.where(or_(*ownership_filters))
 
     else:
         # user_id is None - anonymous usage
@@ -227,6 +248,7 @@ def fetch_input_prompts_by_user(
     if active is not None:
         query = query.where(InputPrompt.active == active)
 
+    query = query.order_by(InputPrompt.id.asc())
     return list(db_session.scalars(query).all())
 
 
@@ -256,3 +278,180 @@ def disable_input_prompt_for_user(
         ipu.disabled = True
 
     db_session.commit()
+
+
+def fetch_input_prompts_by_persona(
+    db_session: Session,
+    persona_id: int,
+    active: bool | None = None,
+) -> list[InputPrompt]:
+    query = select(InputPrompt).where(
+        InputPrompt.persona_id == persona_id,
+        InputPrompt.is_public.is_(False),
+    )
+    if active is not None:
+        query = query.where(InputPrompt.active == active)
+    query = query.order_by(InputPrompt.id.asc())
+    return list(db_session.scalars(query).all())
+
+
+def insert_input_prompt_for_persona(
+    prompt: str,
+    content: str,
+    active: bool,
+    persona_id: int,
+    user: User,
+    db_session: Session,
+) -> InputPrompt:
+    _validate_persona_access(
+        persona_id=persona_id, user=user, db_session=db_session, is_for_edit=True
+    )
+    input_prompt = insert_input_prompt(
+        prompt=prompt,
+        content=content,
+        is_public=False,
+        user=None,
+        persona_id=persona_id,
+        db_session=db_session,
+    )
+    if not active:
+        input_prompt.active = False
+        db_session.commit()
+    return input_prompt
+
+
+def sync_input_prompts_for_persona(
+    user: User,
+    persona_id: int,
+    prompts: Sequence[SyncPersonaInputPromptItem],
+    db_session: Session,
+) -> list[InputPrompt]:
+    _validate_persona_access(
+        persona_id=persona_id, user=user, db_session=db_session, is_for_edit=True
+    )
+    existing_prompts = list(
+        db_session.scalars(
+            select(InputPrompt).where(
+                InputPrompt.persona_id == persona_id,
+                InputPrompt.is_public.is_(False),
+            )
+        ).all()
+    )
+    existing_by_id = {prompt.id: prompt for prompt in existing_prompts}
+    incoming_ids: set[int] = set()
+
+    try:
+        for prompt in prompts:
+            if prompt.id is None:
+                db_session.add(
+                    InputPrompt(
+                        prompt=prompt.prompt,
+                        content=prompt.content,
+                        active=prompt.active,
+                        is_public=False,
+                        user_id=None,
+                        persona_id=persona_id,
+                    )
+                )
+                continue
+
+            existing_prompt = existing_by_id.get(prompt.id)
+            if existing_prompt is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Prompt id {prompt.id} does not belong to persona {persona_id}",
+                )
+            incoming_ids.add(prompt.id)
+            existing_prompt.prompt = prompt.prompt
+            existing_prompt.content = prompt.content
+            existing_prompt.active = prompt.active
+
+        for existing_prompt in existing_prompts:
+            if existing_prompt.id not in incoming_ids:
+                db_session.delete(existing_prompt)
+
+        db_session.commit()
+    except IntegrityError:
+        db_session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="One or more prompt shortcut names already exist for this assistant",
+        )
+
+    return fetch_input_prompts_by_persona(
+        db_session=db_session,
+        persona_id=persona_id,
+    )
+
+
+def update_input_prompt_for_persona(
+    user: User,
+    persona_id: int,
+    input_prompt_id: int,
+    prompt: str,
+    content: str,
+    active: bool,
+    db_session: Session,
+) -> InputPrompt:
+    _validate_persona_access(
+        persona_id=persona_id, user=user, db_session=db_session, is_for_edit=True
+    )
+    input_prompt = db_session.scalar(
+        select(InputPrompt).where(
+            InputPrompt.id == input_prompt_id,
+            InputPrompt.persona_id == persona_id,
+        )
+    )
+    if input_prompt is None:
+        raise ValueError(f"No persona input prompt with id {input_prompt_id}")
+
+    input_prompt.prompt = prompt
+    input_prompt.content = content
+    input_prompt.active = active
+
+    try:
+        db_session.commit()
+    except IntegrityError:
+        db_session.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=f"A prompt shortcut with the name '{prompt}' already exists",
+        )
+
+    return input_prompt
+
+
+def remove_input_prompt_for_persona(
+    user: User,
+    persona_id: int,
+    input_prompt_id: int,
+    db_session: Session,
+) -> None:
+    _validate_persona_access(
+        persona_id=persona_id, user=user, db_session=db_session, is_for_edit=True
+    )
+    input_prompt = db_session.scalar(
+        select(InputPrompt).where(
+            InputPrompt.id == input_prompt_id,
+            InputPrompt.persona_id == persona_id,
+        )
+    )
+    if input_prompt is None:
+        raise ValueError(f"No persona input prompt with id {input_prompt_id}")
+
+    db_session.delete(input_prompt)
+    db_session.commit()
+
+
+def _validate_persona_access(
+    persona_id: int, user: User, db_session: Session, is_for_edit: bool
+) -> None:
+    try:
+        get_persona_by_id(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            is_for_edit=is_for_edit,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e))

--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -15,6 +15,8 @@ from onyx.db.models import InputPrompt
 from onyx.db.models import InputPrompt__User
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.input_prompt.models import InputPromptSnapshot
 from onyx.server.features.input_prompt.models import SyncPersonaInputPromptItem
 from onyx.server.manage.models import UserInfo
@@ -30,6 +32,7 @@ def insert_input_prompt(
     user: User | None,
     persona_id: int | None,
     db_session: Session,
+    active: bool = True,
 ) -> InputPrompt:
     user_id = user.id if user else None
 
@@ -38,7 +41,7 @@ def insert_input_prompt(
     stmt = pg_insert(InputPrompt).values(
         prompt=prompt,
         content=content,
-        active=True,
+        active=active,
         is_public=is_public,
         user_id=user_id,
         persona_id=persona_id,
@@ -313,10 +316,8 @@ def insert_input_prompt_for_persona(
         user=None,
         persona_id=persona_id,
         db_session=db_session,
+        active=active,
     )
-    if not active:
-        input_prompt.active = False
-        db_session.commit()
     return input_prompt
 
 
@@ -357,9 +358,9 @@ def sync_input_prompts_for_persona(
 
             existing_prompt = existing_by_id.get(prompt.id)
             if existing_prompt is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Prompt id {prompt.id} does not belong to persona {persona_id}",
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Prompt id {prompt.id} does not belong to persona {persona_id}",
                 )
             incoming_ids.add(prompt.id)
             existing_prompt.prompt = prompt.prompt
@@ -373,9 +374,9 @@ def sync_input_prompts_for_persona(
         db_session.commit()
     except IntegrityError:
         db_session.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail="One or more prompt shortcut names already exist for this assistant",
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "One or more prompt shortcut names already exist for this assistant",
         )
 
     return fetch_input_prompts_by_persona(
@@ -413,9 +414,9 @@ def update_input_prompt_for_persona(
         db_session.commit()
     except IntegrityError:
         db_session.rollback()
-        raise HTTPException(
-            status_code=409,
-            detail=f"A prompt shortcut with the name '{prompt}' already exists",
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            f"A prompt shortcut with the name '{prompt}' already exists",
         )
 
     return input_prompt
@@ -454,4 +455,4 @@ def _validate_persona_access(
             is_for_edit=is_for_edit,
         )
     except ValueError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+        raise OnyxError(OnyxErrorCode.UNAUTHORIZED, str(e))

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -26,6 +26,7 @@ from sqlalchemy import Enum
 from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import ForeignKeyConstraint
+from sqlalchemy import CheckConstraint
 from sqlalchemy import func
 from sqlalchemy import Index
 from sqlalchemy import Integer
@@ -3414,6 +3415,9 @@ class Persona(Base):
         secondary=Persona__Tool.__table__,
         back_populates="personas",
     )
+    input_prompts: Mapped[list["InputPrompt"]] = relationship(
+        "InputPrompt", back_populates="persona"
+    )
     # Owner
     user: Mapped[User | None] = relationship("User", back_populates="personas")
     # Other users with access
@@ -4238,20 +4242,40 @@ class InputPrompt(Base):
     content: Mapped[str] = mapped_column(String)
     active: Mapped[bool] = mapped_column(Boolean)
     user: Mapped[User | None] = relationship("User", back_populates="input_prompts")
+    persona: Mapped[Persona | None] = relationship(
+        "Persona", back_populates="input_prompts"
+    )
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     user_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("user.id", ondelete="CASCADE"), nullable=True
+    )
+    persona_id: Mapped[int | None] = mapped_column(
+        ForeignKey("persona.id", ondelete="CASCADE"), nullable=True
     )
 
     __table_args__ = (
         # Unique constraint on (prompt, user_id) for user-owned prompts
         UniqueConstraint("prompt", "user_id", name="uq_inputprompt_prompt_user_id"),
+        # Unique constraint on (prompt, persona_id) for persona-owned prompts
+        UniqueConstraint(
+            "prompt", "persona_id", name="uq_inputprompt_prompt_persona_id"
+        ),
         # Partial unique index for public prompts (user_id IS NULL)
         Index(
             "uq_inputprompt_prompt_public",
             "prompt",
             unique=True,
-            postgresql_where=text("user_id IS NULL"),
+            postgresql_where=text(
+                "is_public = TRUE AND user_id IS NULL AND persona_id IS NULL"
+            ),
+        ),
+        CheckConstraint(
+            "(user_id IS NULL) OR (persona_id IS NULL)",
+            name="ck_inputprompt_only_one_owner",
+        ),
+        CheckConstraint(
+            "(is_public = FALSE) OR (user_id IS NULL AND persona_id IS NULL)",
+            name="ck_inputprompt_public_has_no_owner",
         ),
     )
 

--- a/backend/onyx/server/features/input_prompt/api.py
+++ b/backend/onyx/server/features/input_prompt/api.py
@@ -15,6 +15,7 @@ from onyx.db.input_prompt import remove_public_input_prompt
 from onyx.db.input_prompt import update_input_prompt
 from onyx.db.models import InputPrompt__User
 from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
 from onyx.server.features.input_prompt.models import CreateInputPromptRequest
 from onyx.server.features.input_prompt.models import InputPromptSnapshot
 from onyx.server.features.input_prompt.models import UpdateInputPromptRequest
@@ -30,12 +31,25 @@ admin_router = APIRouter(prefix="/admin/input_prompt")
 def list_input_prompts(
     user: User = Depends(current_user),
     include_public: bool = True,
+    persona_id: int | None = None,
     db_session: Session = Depends(get_session),
 ) -> list[InputPromptSnapshot]:
+    if persona_id is not None:
+        try:
+            get_persona_by_id(
+                persona_id=persona_id,
+                user=user,
+                db_session=db_session,
+                is_for_edit=False,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=403, detail=str(e))
+
     user_prompts = fetch_input_prompts_by_user(
         user_id=user.id,
         db_session=db_session,
         include_public=include_public,
+        persona_id=persona_id,
     )
     return [InputPromptSnapshot.from_model(prompt) for prompt in user_prompts]
 
@@ -66,6 +80,7 @@ def create_input_prompt(
         content=create_input_prompt_request.content,
         is_public=False,
         user=user,
+        persona_id=None,
         db_session=db_session,
     )
 

--- a/backend/onyx/server/features/input_prompt/models.py
+++ b/backend/onyx/server/features/input_prompt/models.py
@@ -20,6 +20,29 @@ class UpdateInputPromptRequest(BaseModel):
     active: bool
 
 
+class CreatePersonaInputPromptRequest(BaseModel):
+    prompt: str
+    content: str
+    active: bool = True
+
+
+class UpdatePersonaInputPromptRequest(BaseModel):
+    prompt: str
+    content: str
+    active: bool
+
+
+class SyncPersonaInputPromptItem(BaseModel):
+    id: int | None = None
+    prompt: str
+    content: str
+    active: bool
+
+
+class SyncPersonaInputPromptsRequest(BaseModel):
+    prompts: list[SyncPersonaInputPromptItem]
+
+
 class InputPromptResponse(BaseModel):
     id: int
     prompt: str
@@ -33,6 +56,7 @@ class InputPromptSnapshot(BaseModel):
     content: str
     active: bool
     user_id: UUID | None
+    persona_id: int | None
     is_public: bool
 
     @classmethod
@@ -43,5 +67,6 @@ class InputPromptSnapshot(BaseModel):
             content=input_prompt.content,
             active=input_prompt.active,
             user_id=input_prompt.user_id,
+            persona_id=input_prompt.persona_id,
             is_public=input_prompt.is_public,
         )

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -19,6 +19,11 @@ from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.input_prompt import fetch_input_prompts_by_persona
+from onyx.db.input_prompt import insert_input_prompt_for_persona
+from onyx.db.input_prompt import remove_input_prompt_for_persona
+from onyx.db.input_prompt import sync_input_prompts_for_persona
+from onyx.db.input_prompt import update_input_prompt_for_persona
 from onyx.db.models import User
 from onyx.db.persona import create_assistant_label
 from onyx.db.persona import create_update_persona
@@ -41,6 +46,10 @@ from onyx.db.persona import update_personas_display_priority
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType
 from onyx.server.documents.models import PaginatedReturn
+from onyx.server.features.input_prompt.models import CreatePersonaInputPromptRequest
+from onyx.server.features.input_prompt.models import InputPromptSnapshot
+from onyx.server.features.input_prompt.models import SyncPersonaInputPromptsRequest
+from onyx.server.features.input_prompt.models import UpdatePersonaInputPromptRequest
 from onyx.server.features.persona.constants import ADMIN_AGENTS_RESOURCE
 from onyx.server.features.persona.constants import AGENTS_RESOURCE
 from onyx.server.features.persona.models import FullPersonaSnapshot
@@ -540,3 +549,95 @@ def get_persona(
             db_session.commit()
 
     return FullPersonaSnapshot.from_model(persona)
+
+
+@basic_router.get("/{persona_id}/input_prompt")
+def list_persona_input_prompts(
+    persona_id: int,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> list[InputPromptSnapshot]:
+    # Access check: users who can use the assistant can view/use its shortcuts
+    try:
+        get_persona_by_id(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            is_for_edit=False,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e))
+    input_prompts = fetch_input_prompts_by_persona(
+        db_session=db_session,
+        persona_id=persona_id,
+    )
+    return [InputPromptSnapshot.from_model(prompt) for prompt in input_prompts]
+
+
+@basic_router.post("/{persona_id}/input_prompt")
+def create_persona_input_prompt(
+    persona_id: int,
+    request: CreatePersonaInputPromptRequest,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> InputPromptSnapshot:
+    input_prompt = insert_input_prompt_for_persona(
+        prompt=request.prompt,
+        content=request.content,
+        active=request.active,
+        persona_id=persona_id,
+        user=user,
+        db_session=db_session,
+    )
+    return InputPromptSnapshot.from_model(input_prompt)
+
+
+@basic_router.patch("/{persona_id}/input_prompt/{input_prompt_id}")
+def patch_persona_input_prompt(
+    persona_id: int,
+    input_prompt_id: int,
+    request: UpdatePersonaInputPromptRequest,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> InputPromptSnapshot:
+    updated_prompt = update_input_prompt_for_persona(
+        user=user,
+        persona_id=persona_id,
+        input_prompt_id=input_prompt_id,
+        prompt=request.prompt,
+        content=request.content,
+        active=request.active,
+        db_session=db_session,
+    )
+    return InputPromptSnapshot.from_model(updated_prompt)
+
+
+@basic_router.delete("/{persona_id}/input_prompt/{input_prompt_id}")
+def delete_persona_input_prompt(
+    persona_id: int,
+    input_prompt_id: int,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> None:
+    remove_input_prompt_for_persona(
+        user=user,
+        persona_id=persona_id,
+        input_prompt_id=input_prompt_id,
+        db_session=db_session,
+    )
+
+
+@basic_router.put("/{persona_id}/input_prompt")
+def sync_persona_input_prompts(
+    persona_id: int,
+    request: SyncPersonaInputPromptsRequest,
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
+) -> list[InputPromptSnapshot]:
+    synced_prompts = sync_input_prompts_for_persona(
+        user=user,
+        persona_id=persona_id,
+        prompts=request.prompts,
+        db_session=db_session,
+    )
+    return [InputPromptSnapshot.from_model(prompt) for prompt in synced_prompts]

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -43,6 +43,8 @@ from onyx.db.persona import update_persona_public_status
 from onyx.db.persona import update_persona_shared
 from onyx.db.persona import update_persona_visibility
 from onyx.db.persona import update_personas_display_priority
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType
 from onyx.server.documents.models import PaginatedReturn
@@ -566,7 +568,7 @@ def list_persona_input_prompts(
             is_for_edit=False,
         )
     except ValueError as e:
-        raise HTTPException(status_code=403, detail=str(e))
+        raise OnyxError(OnyxErrorCode.UNAUTHORIZED, str(e))
     input_prompts = fetch_input_prompts_by_persona(
         db_session=db_session,
         persona_id=persona_id,

--- a/backend/tests/external_dependency_unit/db/test_input_prompt_persona_scope.py
+++ b/backend/tests/external_dependency_unit/db/test_input_prompt_persona_scope.py
@@ -1,0 +1,257 @@
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from onyx.db.input_prompt import fetch_input_prompts_by_user
+from onyx.db.input_prompt import insert_input_prompt
+from onyx.db.input_prompt import insert_input_prompt_for_persona
+from onyx.db.input_prompt import sync_input_prompts_for_persona
+from onyx.db.input_prompt import update_input_prompt_for_persona
+from onyx.db.models import Persona
+from onyx.server.features.input_prompt.models import SyncPersonaInputPromptItem
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _create_persona(db_session: Session, owner_id: UUID, name: str) -> Persona:
+    persona = Persona(
+        id=int(uuid4().int % 1000000),
+        user_id=owner_id,
+        name=name,
+        description=f"{name} description",
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=True,
+        is_public=True,
+        is_visible=True,
+        featured=False,
+        builtin_persona=False,
+        deleted=False,
+    )
+    db_session.add(persona)
+    db_session.commit()
+    db_session.refresh(persona)
+    return persona
+
+
+def test_fetch_input_prompts_by_user_includes_persona_shortcuts(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "prompt_scope_user")
+    persona = _create_persona(db_session, user.id, "prompt_scope_persona")
+
+    user_prompt = insert_input_prompt(
+        prompt="user_cmd",
+        content="user content",
+        is_public=False,
+        user=user,
+        persona_id=None,
+        db_session=db_session,
+    )
+    public_prompt = insert_input_prompt(
+        prompt="public_cmd",
+        content="public content",
+        is_public=True,
+        user=None,
+        persona_id=None,
+        db_session=db_session,
+    )
+    persona_prompt = insert_input_prompt_for_persona(
+        prompt="persona_cmd",
+        content="persona content",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    prompts = fetch_input_prompts_by_user(
+        db_session=db_session,
+        user_id=user.id,
+        include_public=True,
+        persona_id=persona.id,
+    )
+    prompt_ids = {prompt.id for prompt in prompts}
+
+    assert user_prompt.id in prompt_ids
+    assert public_prompt.id in prompt_ids
+    assert persona_prompt.id in prompt_ids
+
+
+def test_persona_prompt_and_public_prompt_can_share_name(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "prompt_scope_user2")
+    persona = _create_persona(db_session, user.id, "prompt_scope_persona2")
+
+    public_prompt = insert_input_prompt(
+        prompt="shared_name",
+        content="public content",
+        is_public=True,
+        user=None,
+        persona_id=None,
+        db_session=db_session,
+    )
+    persona_prompt = insert_input_prompt_for_persona(
+        prompt="shared_name",
+        content="persona content",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert public_prompt.id is not None
+    assert persona_prompt.id is not None
+    assert public_prompt.id != persona_prompt.id
+
+
+def test_insert_input_prompt_for_persona_enforces_unique_name_per_persona(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "prompt_scope_user3")
+    persona = _create_persona(db_session, user.id, "prompt_scope_persona3")
+
+    insert_input_prompt_for_persona(
+        prompt="dupe_name",
+        content="first",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        insert_input_prompt_for_persona(
+            prompt="dupe_name",
+            content="second",
+            active=True,
+            persona_id=persona.id,
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+def test_update_input_prompt_for_persona_requires_editor_access(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "prompt_scope_owner")
+    other_user = create_test_user(db_session, "prompt_scope_other")
+    persona = _create_persona(db_session, owner.id, "prompt_scope_persona4")
+
+    prompt = insert_input_prompt_for_persona(
+        prompt="editable_name",
+        content="editable content",
+        active=True,
+        persona_id=persona.id,
+        user=owner,
+        db_session=db_session,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_input_prompt_for_persona(
+            user=other_user,
+            persona_id=persona.id,
+            input_prompt_id=prompt.id,
+            prompt="updated_name",
+            content="updated_content",
+            active=True,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_sync_input_prompts_for_persona_updates_creates_and_deletes(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "prompt_scope_user4")
+    persona = _create_persona(db_session, user.id, "prompt_scope_persona5")
+
+    keep_prompt = insert_input_prompt_for_persona(
+        prompt="keep_name",
+        content="keep_content",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+    remove_prompt = insert_input_prompt_for_persona(
+        prompt="remove_name",
+        content="remove_content",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    synced = sync_input_prompts_for_persona(
+        user=user,
+        persona_id=persona.id,
+        prompts=[
+            SyncPersonaInputPromptItem(
+                id=keep_prompt.id,
+                prompt="keep_name_updated",
+                content="keep_content_updated",
+                active=False,
+            ),
+            SyncPersonaInputPromptItem(
+                prompt="new_name",
+                content="new_content",
+                active=True,
+            ),
+        ],
+        db_session=db_session,
+    )
+
+    prompt_names = [prompt.prompt for prompt in synced]
+    assert prompt_names == ["keep_name_updated", "new_name"]
+    assert all(prompt.id != remove_prompt.id for prompt in synced)
+    updated = next(prompt for prompt in synced if prompt.id == keep_prompt.id)
+    assert updated.content == "keep_content_updated"
+    assert updated.active is False
+
+
+def test_sync_input_prompts_for_persona_rejects_foreign_prompt_id(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "prompt_scope_user5")
+    other = create_test_user(db_session, "prompt_scope_user6")
+    persona = _create_persona(db_session, user.id, "prompt_scope_persona6")
+    other_persona = _create_persona(db_session, other.id, "prompt_scope_persona7")
+
+    other_persona_prompt = insert_input_prompt_for_persona(
+        prompt="foreign_name",
+        content="foreign_content",
+        active=True,
+        persona_id=other_persona.id,
+        user=other,
+        db_session=db_session,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        sync_input_prompts_for_persona(
+            user=user,
+            persona_id=persona.id,
+            prompts=[
+                SyncPersonaInputPromptItem(
+                    id=other_persona_prompt.id,
+                    prompt="invalid",
+                    content="invalid",
+                    active=True,
+                )
+            ],
+            db_session=db_session,
+        )
+
+    assert exc_info.value.status_code == 400

--- a/backend/tests/external_dependency_unit/server/test_persona_input_prompt_api.py
+++ b/backend/tests/external_dependency_unit/server/test_persona_input_prompt_api.py
@@ -1,0 +1,144 @@
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from onyx.db.input_prompt import insert_input_prompt
+from onyx.db.input_prompt import insert_input_prompt_for_persona
+from onyx.db.models import Persona
+from onyx.server.features.input_prompt.api import list_input_prompts
+from onyx.server.features.input_prompt.models import SyncPersonaInputPromptItem
+from onyx.server.features.input_prompt.models import SyncPersonaInputPromptsRequest
+from onyx.server.features.persona.api import sync_persona_input_prompts
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _create_persona(
+    db_session: Session, owner_id: UUID, name: str, is_public: bool
+) -> Persona:
+    persona = Persona(
+        id=int(uuid4().int % 1000000),
+        user_id=owner_id,
+        name=name,
+        description=f"{name} description",
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=True,
+        is_public=is_public,
+        is_visible=True,
+        featured=False,
+        builtin_persona=False,
+        deleted=False,
+    )
+    db_session.add(persona)
+    db_session.commit()
+    db_session.refresh(persona)
+    return persona
+
+
+def test_list_input_prompts_with_persona_id_returns_composed_results(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "persona_prompt_api_user")
+    persona = _create_persona(
+        db_session=db_session,
+        owner_id=user.id,
+        name="persona_prompt_api_assistant",
+        is_public=True,
+    )
+
+    user_prompt = insert_input_prompt(
+        prompt="api_user",
+        content="api user content",
+        is_public=False,
+        user=user,
+        persona_id=None,
+        db_session=db_session,
+    )
+    public_prompt = insert_input_prompt(
+        prompt="api_public",
+        content="api public content",
+        is_public=True,
+        user=None,
+        persona_id=None,
+        db_session=db_session,
+    )
+    persona_prompt = insert_input_prompt_for_persona(
+        prompt="api_persona",
+        content="api persona content",
+        active=True,
+        persona_id=persona.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    prompts = list_input_prompts(
+        user=user,
+        include_public=True,
+        persona_id=persona.id,
+        db_session=db_session,
+    )
+    prompt_ids = {prompt.id for prompt in prompts}
+
+    assert user_prompt.id in prompt_ids
+    assert public_prompt.id in prompt_ids
+    assert persona_prompt.id in prompt_ids
+
+
+def test_list_input_prompts_with_inaccessible_persona_raises_403(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "persona_prompt_api_owner")
+    other = create_test_user(db_session, "persona_prompt_api_other")
+    private_persona = _create_persona(
+        db_session=db_session,
+        owner_id=owner.id,
+        name="persona_prompt_private_assistant",
+        is_public=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        list_input_prompts(
+            user=other,
+            include_public=True,
+            persona_id=private_persona.id,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_sync_persona_input_prompts_requires_editor_access(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    owner = create_test_user(db_session, "persona_prompt_sync_owner")
+    other = create_test_user(db_session, "persona_prompt_sync_other")
+    persona = _create_persona(
+        db_session=db_session,
+        owner_id=owner.id,
+        name="persona_prompt_sync_assistant",
+        is_public=True,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        sync_persona_input_prompts(
+            persona_id=persona.id,
+            request=SyncPersonaInputPromptsRequest(
+                prompts=[
+                    SyncPersonaInputPromptItem(
+                        prompt="new_sync_prompt",
+                        content="new_sync_content",
+                        active=True,
+                    )
+                ]
+            ),
+            user=other,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.status_code == 403

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -267,6 +267,7 @@ export interface InputPrompt {
   content: string;
   active: boolean;
   is_public: boolean;
+  persona_id?: number | null;
 }
 
 export interface EditPromptModalProps {

--- a/web/src/hooks/usePromptShortcuts.ts
+++ b/web/src/hooks/usePromptShortcuts.ts
@@ -4,9 +4,10 @@ import useSWR from "swr";
 import { InputPrompt } from "@/app/app/interfaces";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 
-export default function usePromptShortcuts() {
+export default function usePromptShortcuts(personaId?: number) {
+  const query = personaId !== undefined ? `?persona_id=${personaId}` : "";
   const { data, error, isLoading, mutate } = useSWR<InputPrompt[]>(
-    "/api/input_prompt",
+    `/api/input_prompt${query}`,
     errorHandlingFetcher
   );
 

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -582,9 +582,26 @@ export default function AgentEditorPage({
     fallback: string
   ): Promise<string> {
     const errorData = (await response.json().catch(() => ({}))) as {
-      detail?: string;
+      detail?: unknown;
     };
-    return errorData.detail || fallback;
+    const { detail } = errorData;
+    if (typeof detail === "string") {
+      return detail || fallback;
+    }
+    if (Array.isArray(detail)) {
+      const messages = detail
+        .map((item) =>
+          typeof item === "object" && item !== null && "msg" in item
+            ? String((item as Record<string, unknown>).msg)
+            : String(item)
+        )
+        .filter(Boolean);
+      return messages.length > 0 ? messages.join("; ") : fallback;
+    }
+    if (typeof detail === "object" && detail !== null && "msg" in detail) {
+      return String((detail as Record<string, unknown>).msg) || fallback;
+    }
+    return fallback;
   }
 
   useEffect(() => {

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -100,6 +100,7 @@ import { useVectorDbEnabled } from "@/providers/SettingsProvider";
 import { useUser } from "@/providers/UserProvider";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
+import { InputPrompt } from "@/app/app/interfaces";
 
 interface AgentIconEditorProps {
   existingAgent?: FullPersona | null;
@@ -574,6 +575,17 @@ export default function AgentEditorPage({
   >([]);
   const [initialPromptShortcutsEnabled, setInitialPromptShortcutsEnabled] =
     useState(true);
+  const [createdAgentId, setCreatedAgentId] = useState<number | null>(null);
+
+  async function getApiErrorDetail(
+    response: Response,
+    fallback: string
+  ): Promise<string> {
+    const errorData = (await response.json().catch(() => ({}))) as {
+      detail?: string;
+    };
+    return errorData.detail || fallback;
+  }
 
   useEffect(() => {
     async function loadPromptShortcuts() {
@@ -595,7 +607,7 @@ export default function AgentEditorPage({
 
       const shortcuts = await response.json();
       const mapped: LocalPromptShortcut[] = shortcuts
-        .map((shortcut: any) => ({
+        .map((shortcut: InputPrompt) => ({
           id: shortcut.id,
           key: shortcut.id,
           prompt: shortcut.prompt,
@@ -648,7 +660,11 @@ export default function AgentEditorPage({
     });
 
     if (!syncResponse.ok) {
-      throw new Error("Failed to sync prompt shortcuts");
+      const detail = await getApiErrorDetail(
+        syncResponse,
+        "Failed to sync prompt shortcuts"
+      );
+      throw new Error(`Failed to sync prompt shortcuts: ${detail}`);
     }
 
     const syncedShortcuts = await syncResponse.json();
@@ -1039,9 +1055,11 @@ export default function AgentEditorPage({
       };
 
       // Call API
+      const isUpdateOperation = !!existingAgent || createdAgentId !== null;
+      const targetAgentId = existingAgent?.id ?? createdAgentId;
       let personaResponse;
-      if (!!existingAgent) {
-        personaResponse = await updatePersona(existingAgent.id, submissionData);
+      if (isUpdateOperation && targetAgentId !== null) {
+        personaResponse = await updatePersona(targetAgentId, submissionData);
       } else {
         personaResponse = await createPersona(submissionData);
       }
@@ -1049,20 +1067,25 @@ export default function AgentEditorPage({
       // Handle response
       if (!personaResponse || !personaResponse.ok) {
         const error = personaResponse
-          ? await personaResponse.text()
+          ? await getApiErrorDetail(personaResponse, "Unknown server error")
           : "No response received";
         toast.error(
-          `Failed to ${existingAgent ? "update" : "create"} agent - ${error}`
+          `Failed to ${
+            isUpdateOperation ? "update" : "create"
+          } agent - ${error}`
         );
         return;
       }
 
       // Success
       const agent = await personaResponse.json();
+      if (!isUpdateOperation) {
+        setCreatedAgentId(agent.id);
+      }
       await syncPromptShortcuts(agent.id);
       toast.success(
         `Agent "${agent.name}" ${
-          existingAgent ? "updated" : "created"
+          isUpdateOperation ? "updated" : "created"
         } successfully`
       );
 
@@ -1076,7 +1099,9 @@ export default function AgentEditorPage({
       appRouter({ agentId: agent.id });
     } catch (error) {
       console.error("Submit error:", error);
-      toast.error(`An error occurred: ${error}`);
+      toast.error(
+        error instanceof Error ? error.message : `An error occurred: ${error}`
+      );
     }
   }
 

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -60,6 +60,8 @@ import {
   SvgSliders,
   SvgUsers,
   SvgTrash,
+  SvgPlus,
+  SvgMinusCircle,
 } from "@opal/icons";
 import CustomAgentAvatar, {
   agentAvatarIconMap,
@@ -80,6 +82,8 @@ import * as ExpandableCard from "@/layouts/expandable-card-layouts";
 import { getActionIcon } from "@/lib/tools/mcpUtils";
 import { MCPServer, MCPTool, ToolSnapshot } from "@/lib/tools/interfaces";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import InputTextArea from "@/refresh-components/inputs/InputTextArea";
+import Switch from "@/refresh-components/inputs/Switch";
 import useFilter from "@/hooks/useFilter";
 import EnabledCount from "@/refresh-components/EnabledCount";
 import { useAppRouter } from "@/hooks/appNavigation";
@@ -99,6 +103,21 @@ import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidE
 
 interface AgentIconEditorProps {
   existingAgent?: FullPersona | null;
+}
+
+interface LocalPromptShortcut {
+  id?: number;
+  key: number;
+  prompt: string;
+  content: string;
+  active: boolean;
+}
+
+interface PersistedPromptShortcut {
+  id: number;
+  prompt: string;
+  content: string;
+  active: boolean;
 }
 
 function FormWarningsEffect() {
@@ -441,6 +460,93 @@ function StarterMessages() {
   );
 }
 
+function PromptShortcutsEditor({
+  shortcuts,
+  onChange,
+}: {
+  shortcuts: LocalPromptShortcut[];
+  onChange: (shortcuts: LocalPromptShortcut[]) => void;
+}) {
+  const canRemoveShortcut = shortcuts.length > 1;
+
+  function updateShortcut(
+    key: number,
+    updates: Partial<Pick<LocalPromptShortcut, "prompt" | "content" | "active">>
+  ) {
+    onChange(
+      shortcuts.map((shortcut) =>
+        shortcut.key === key ? { ...shortcut, ...updates } : shortcut
+      )
+    );
+  }
+
+  function removeShortcut(key: number) {
+    const next = shortcuts.filter((shortcut) => shortcut.key !== key);
+    onChange(
+      next.length > 0
+        ? next
+        : [{ key: Date.now(), prompt: "", content: "", active: true }]
+    );
+  }
+
+  return (
+    <GeneralLayouts.Section gap={0.75}>
+      {shortcuts.map((shortcut) => {
+        const isEmpty =
+          !shortcut.prompt.trim().length && !shortcut.content.trim().length;
+
+        return (
+          <div
+            key={shortcut.key}
+            className="w-full grid grid-cols-[1fr_min-content] gap-x-1 gap-y-1"
+          >
+            <InputTypeIn
+              prefixText="/"
+              placeholder="Summarize"
+              value={shortcut.prompt}
+              onChange={(e) =>
+                updateShortcut(shortcut.key, { prompt: e.target.value })
+              }
+            />
+            <GeneralLayouts.Section>
+              <Disabled disabled={!canRemoveShortcut && isEmpty}>
+                <OpalButton
+                  icon={SvgMinusCircle}
+                  onClick={() => removeShortcut(shortcut.key)}
+                  prominence="tertiary"
+                  aria-label="Remove shortcut"
+                />
+              </Disabled>
+            </GeneralLayouts.Section>
+            <InputTextArea
+              placeholder="Provide a concise 1–2 sentence summary of the following:"
+              value={shortcut.content}
+              onChange={(e) =>
+                updateShortcut(shortcut.key, { content: e.target.value })
+              }
+              rows={3}
+            />
+          </div>
+        );
+      })}
+      <div>
+        <OpalButton
+          prominence="secondary"
+          icon={SvgPlus}
+          onClick={() =>
+            onChange([
+              ...shortcuts,
+              { key: Date.now(), prompt: "", content: "", active: true },
+            ])
+          }
+        >
+          Add Shortcut
+        </OpalButton>
+      </div>
+    </GeneralLayouts.Section>
+  );
+}
+
 export interface AgentEditorPageProps {
   agent?: FullPersona;
   refreshAgent?: () => void;
@@ -459,6 +565,117 @@ export default function AgentEditorPage({
   const canUpdateFeaturedStatus = isAdmin || isCurator;
   const vectorDbEnabled = useVectorDbEnabled();
   const isPaidEnterpriseFeaturesEnabled = usePaidEnterpriseFeaturesEnabled();
+  const [promptShortcutsEnabled, setPromptShortcutsEnabled] = useState(true);
+  const [promptShortcuts, setPromptShortcuts] = useState<LocalPromptShortcut[]>(
+    [{ key: Date.now(), prompt: "", content: "", active: true }]
+  );
+  const [initialPromptShortcuts, setInitialPromptShortcuts] = useState<
+    PersistedPromptShortcut[]
+  >([]);
+  const [initialPromptShortcutsEnabled, setInitialPromptShortcutsEnabled] =
+    useState(true);
+
+  useEffect(() => {
+    async function loadPromptShortcuts() {
+      if (!existingAgent) {
+        setPromptShortcuts([
+          { key: Date.now(), prompt: "", content: "", active: true },
+        ]);
+        setPromptShortcutsEnabled(true);
+        return;
+      }
+
+      const response = await fetch(
+        `/api/persona/${existingAgent.id}/input_prompt`
+      );
+      if (!response.ok) {
+        toast.error("Failed to load agent shortcuts");
+        return;
+      }
+
+      const shortcuts = await response.json();
+      const mapped: LocalPromptShortcut[] = shortcuts
+        .map((shortcut: any) => ({
+          id: shortcut.id,
+          key: shortcut.id,
+          prompt: shortcut.prompt,
+          content: shortcut.content,
+          active: shortcut.active,
+        }))
+        .sort((a: LocalPromptShortcut, b: LocalPromptShortcut) =>
+          (a.id ?? 0) > (b.id ?? 0) ? 1 : -1
+        );
+
+      const persistedMapped: PersistedPromptShortcut[] = mapped.map(
+        (shortcut) => ({
+          id: shortcut.id ?? 0,
+          prompt: shortcut.prompt,
+          content: shortcut.content,
+          active: shortcut.active,
+        })
+      );
+      const enabled = persistedMapped.some((s) => s.active);
+
+      setInitialPromptShortcuts(persistedMapped);
+      setInitialPromptShortcutsEnabled(enabled);
+      setPromptShortcutsEnabled(enabled);
+      setPromptShortcuts(
+        mapped.length > 0
+          ? mapped
+          : [{ key: Date.now(), prompt: "", content: "", active: true }]
+      );
+    }
+
+    loadPromptShortcuts();
+  }, [existingAgent?.id]);
+
+  async function syncPromptShortcuts(personaId: number) {
+    const validShortcuts = promptShortcuts
+      .filter((shortcut) => shortcut.prompt.trim() && shortcut.content.trim())
+      .map((shortcut) => ({
+        id: shortcut.id,
+        prompt: shortcut.prompt.trim(),
+        content: shortcut.content.trim(),
+        active: promptShortcutsEnabled ? shortcut.active : false,
+      }));
+
+    const syncResponse = await fetch(`/api/persona/${personaId}/input_prompt`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompts: validShortcuts,
+      }),
+    });
+
+    if (!syncResponse.ok) {
+      throw new Error("Failed to sync prompt shortcuts");
+    }
+
+    const syncedShortcuts = await syncResponse.json();
+    const normalizedShortcuts: PersistedPromptShortcut[] = syncedShortcuts
+      .map((shortcut: any) => ({
+        id: shortcut.id,
+        prompt: shortcut.prompt,
+        content: shortcut.content,
+        active: shortcut.active,
+      }))
+      .sort((a: PersistedPromptShortcut, b: PersistedPromptShortcut) =>
+        a.id > b.id ? 1 : -1
+      );
+
+    setInitialPromptShortcuts(normalizedShortcuts);
+    const enabled = normalizedShortcuts.some((s) => s.active);
+    setInitialPromptShortcutsEnabled(enabled);
+    setPromptShortcutsEnabled(enabled);
+    setPromptShortcuts(
+      normalizedShortcuts.length > 0
+        ? normalizedShortcuts.map((shortcut) => ({
+            ...shortcut,
+            key: shortcut.id,
+          }))
+        : [{ key: Date.now(), prompt: "", content: "", active: true }]
+    );
+  }
 
   // LLM Model Selection
   const getCurrentLlm = useCallback(
@@ -842,6 +1059,7 @@ export default function AgentEditorPage({
 
       // Success
       const agent = await personaResponse.json();
+      await syncPromptShortcuts(agent.id);
       toast.success(
         `Agent "${agent.name}" ${
           existingAgent ? "updated" : "created"
@@ -952,6 +1170,33 @@ export default function AgentEditorPage({
   if (isToolsLoading || isMcpLoading || isOpenApiLoading) {
     return null;
   }
+
+  const normalizedCurrentShortcuts = promptShortcuts
+    .filter((shortcut) => shortcut.prompt.trim() && shortcut.content.trim())
+    .map((shortcut) => ({
+      id: shortcut.id ?? null,
+      prompt: shortcut.prompt.trim(),
+      content: shortcut.content.trim(),
+      active: promptShortcutsEnabled ? shortcut.active : false,
+    }))
+    .sort(
+      (a, b) =>
+        (a.id ?? Number.MAX_SAFE_INTEGER) - (b.id ?? Number.MAX_SAFE_INTEGER)
+    );
+
+  const normalizedInitialShortcuts = initialPromptShortcuts
+    .map((shortcut) => ({
+      id: shortcut.id,
+      prompt: shortcut.prompt.trim(),
+      content: shortcut.content.trim(),
+      active: initialPromptShortcutsEnabled ? shortcut.active : false,
+    }))
+    .sort((a, b) => a.id - b.id);
+
+  const promptShortcutsDirty =
+    promptShortcutsEnabled !== initialPromptShortcutsEnabled ||
+    JSON.stringify(normalizedCurrentShortcuts) !==
+      JSON.stringify(normalizedInitialShortcuts);
 
   return (
     <>
@@ -1205,7 +1450,7 @@ export default function AgentEditorPage({
                             disabled={
                               isSubmitting ||
                               !isValid ||
-                              !dirty ||
+                              (!dirty && !promptShortcutsDirty) ||
                               hasUploadingFiles
                             }
                           >
@@ -1278,6 +1523,36 @@ export default function AgentEditorPage({
                           optional
                         >
                           <StarterMessages />
+                        </InputLayouts.Vertical>
+                        <InputLayouts.Vertical
+                          name="prompt_shortcuts"
+                          title="Prompt Shortcuts"
+                          description="Shortcuts available in chat when this agent is selected. Type / in chat to use them."
+                          optional
+                        >
+                          <Card>
+                            <InputLayouts.Horizontal
+                              title="Use Prompt Shortcuts"
+                              description="Enable shortcuts to quickly insert common prompts."
+                            >
+                              <Switch
+                                checked={promptShortcutsEnabled}
+                                onCheckedChange={(checked) => {
+                                  setPromptShortcutsEnabled(checked);
+                                  setPromptShortcuts((prev) =>
+                                    prev.map((s) => ({ ...s, active: checked }))
+                                  );
+                                }}
+                              />
+                            </InputLayouts.Horizontal>
+
+                            {promptShortcutsEnabled && (
+                              <PromptShortcutsEditor
+                                shortcuts={promptShortcuts}
+                                onChange={setPromptShortcuts}
+                              />
+                            )}
+                          </Card>
                         </InputLayouts.Vertical>
                       </GeneralLayouts.Section>
 

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -53,6 +53,7 @@ import {
 import { Button, SelectButton } from "@opal/components";
 import Popover from "@/refresh-components/Popover";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
+import Text from "@/refresh-components/texts/Text";
 import { useQueryController } from "@/providers/QueryControllerProvider";
 import { Section } from "@/layouts/general-layouts";
 import Spacer from "@/refresh-components/Spacer";
@@ -257,7 +258,7 @@ const AppInputBar = React.memo(
       [setCurrentMessageFiles]
     );
 
-    const { activePromptShortcuts } = usePromptShortcuts();
+    const { activePromptShortcuts } = usePromptShortcuts(selectedAgent?.id);
     const vectorDbEnabled = useVectorDbEnabled();
     const { ccPairs, isLoading: ccPairsLoading } = useCCPairs(vectorDbEnabled);
     const { data: federatedConnectorsData, isLoading: federatedLoading } =
@@ -302,6 +303,28 @@ const AppInputBar = React.memo(
     const sortedFilteredPrompts = useMemo(
       () => [...filteredPrompts].sort((a, b) => a.id - b.id),
       [filteredPrompts]
+    );
+    const filteredAgentPrompts = useMemo(
+      () =>
+        sortedFilteredPrompts.filter(
+          (prompt) =>
+            selectedAgent?.id !== undefined &&
+            prompt.persona_id === selectedAgent.id
+        ),
+      [sortedFilteredPrompts, selectedAgent?.id]
+    );
+    const filteredUserPrompts = useMemo(
+      () =>
+        sortedFilteredPrompts.filter(
+          (prompt) =>
+            prompt.persona_id === undefined || prompt.persona_id === null
+        ),
+      [sortedFilteredPrompts]
+    );
+
+    const displayedPrompts = useMemo(
+      () => [...filteredAgentPrompts, ...filteredUserPrompts],
+      [filteredAgentPrompts, filteredUserPrompts]
     );
 
     // Reset tabbingIconIndex when filtered prompts change to avoid out-of-bounds
@@ -388,11 +411,11 @@ const AppInputBar = React.memo(
 
       if (e.key === "Enter") {
         e.preventDefault();
-        if (tabbingIconIndex === sortedFilteredPrompts.length) {
+        if (tabbingIconIndex === displayedPrompts.length) {
           // "Create a new prompt" is selected
           window.open("/app/settings/chat-preferences", "_self");
         } else {
-          const selectedPrompt = sortedFilteredPrompts[tabbingIconIndex];
+          const selectedPrompt = displayedPrompts[tabbingIconIndex];
           if (selectedPrompt) {
             updateInputPrompt(selectedPrompt);
           }
@@ -405,12 +428,12 @@ const AppInputBar = React.memo(
         // Tab: cycle forward
         e.preventDefault();
         setTabbingIconIndex((prev) =>
-          Math.min(prev + 1, sortedFilteredPrompts.length)
+          Math.min(prev + 1, displayedPrompts.length)
         );
       } else if (e.key === "ArrowDown") {
         e.preventDefault();
         setTabbingIconIndex((prev) =>
-          Math.min(prev + 1, sortedFilteredPrompts.length)
+          Math.min(prev + 1, displayedPrompts.length)
         );
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
@@ -693,33 +716,63 @@ const AppInputBar = React.memo(
                 width="xl"
               >
                 <Popover.Menu>
-                  {[
-                    ...sortedFilteredPrompts.map((prompt, index) => (
-                      <LineItem
-                        key={prompt.id}
-                        selected={tabbingIconIndex === index}
-                        emphasized={tabbingIconIndex === index}
-                        description={prompt.content?.trim()}
-                        onClick={() => updateInputPrompt(prompt)}
-                      >
-                        {prompt.prompt}
-                      </LineItem>
-                    )),
-                    sortedFilteredPrompts.length > 0 ? null : undefined,
-                    <LineItem
-                      key="create-new"
-                      href="/app/settings/chat-preferences"
-                      icon={SvgPlus}
-                      selected={
-                        tabbingIconIndex === sortedFilteredPrompts.length
-                      }
-                      emphasized={
-                        tabbingIconIndex === sortedFilteredPrompts.length
-                      }
-                    >
-                      Create New Prompt
-                    </LineItem>,
-                  ]}
+                  {filteredAgentPrompts.length > 0 && (
+                    <>
+                      <div className="px-2 py-1">
+                        <Text text03>Agent Shortcuts</Text>
+                      </div>
+                      {filteredAgentPrompts.map((prompt) => {
+                        const flatIndex = displayedPrompts.findIndex(
+                          (p) => p.id === prompt.id
+                        );
+                        return (
+                          <LineItem
+                            key={prompt.id}
+                            selected={tabbingIconIndex === flatIndex}
+                            emphasized={tabbingIconIndex === flatIndex}
+                            description={prompt.content?.trim()}
+                            onClick={() => updateInputPrompt(prompt)}
+                          >
+                            {prompt.prompt}
+                          </LineItem>
+                        );
+                      })}
+                    </>
+                  )}
+
+                  {filteredUserPrompts.length > 0 && (
+                    <>
+                      <div className="px-2 py-1">
+                        <Text text03>Your Shortcuts</Text>
+                      </div>
+                      {filteredUserPrompts.map((prompt) => {
+                        const flatIndex = displayedPrompts.findIndex(
+                          (p) => p.id === prompt.id
+                        );
+                        return (
+                          <LineItem
+                            key={prompt.id}
+                            selected={tabbingIconIndex === flatIndex}
+                            emphasized={tabbingIconIndex === flatIndex}
+                            description={prompt.content?.trim()}
+                            onClick={() => updateInputPrompt(prompt)}
+                          >
+                            {prompt.prompt}
+                          </LineItem>
+                        );
+                      })}
+                    </>
+                  )}
+
+                  <LineItem
+                    key="create-new"
+                    href="/app/settings/chat-preferences"
+                    icon={SvgPlus}
+                    selected={tabbingIconIndex === displayedPrompts.length}
+                    emphasized={tabbingIconIndex === displayedPrompts.length}
+                  >
+                    Create New Prompt
+                  </LineItem>
                 </Popover.Menu>
               </Popover.Content>
             </Popover>

--- a/web/tests/e2e/chat/assistant_prompt_shortcuts.spec.ts
+++ b/web/tests/e2e/chat/assistant_prompt_shortcuts.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+
+test.describe("Assistant prompt shortcuts", () => {
+  test("shows grouped shortcuts and keyboard selection follows visual order", async ({
+    page,
+  }, testInfo) => {
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+
+    const onyxApiClient = new OnyxApiClient(page.request);
+
+    const createAgentResponse = await page.request.post("/api/persona", {
+      data: {
+        name: `Shortcut Agent ${Date.now()}`,
+        description: "E2E assistant prompt shortcut test",
+        document_set_ids: [],
+        is_public: true,
+        llm_model_provider_override: null,
+        llm_model_version_override: null,
+        starter_messages: null,
+        users: [],
+        groups: [],
+        tool_ids: [],
+        remove_image: false,
+        uploaded_image_id: null,
+        icon_name: null,
+        search_start_date: null,
+        label_ids: null,
+        featured: false,
+        display_priority: null,
+        user_file_ids: [],
+        hierarchy_node_ids: [],
+        document_ids: [],
+        system_prompt: "",
+        replace_base_system_prompt: false,
+        task_prompt: "",
+        datetime_aware: false,
+      },
+    });
+    expect(createAgentResponse.ok()).toBeTruthy();
+    const agent = await createAgentResponse.json();
+    const shortcutCommand = `collision_${Date.now()}`;
+
+    try {
+      const createUserShortcut = await page.request.post("/api/input_prompt", {
+        data: {
+          prompt: shortcutCommand,
+          content: "user shortcut content",
+          active: true,
+          is_public: false,
+        },
+      });
+      expect(createUserShortcut.ok()).toBeTruthy();
+
+      const createAgentShortcut = await page.request.post(
+        `/api/persona/${agent.id}/input_prompt`,
+        {
+          data: {
+            prompt: shortcutCommand,
+            content: "agent shortcut content",
+            active: true,
+          },
+        }
+      );
+      expect(createAgentShortcut.ok()).toBeTruthy();
+
+      const createInactiveAgentShortcut = await page.request.post(
+        `/api/persona/${agent.id}/input_prompt`,
+        {
+          data: {
+            prompt: `inactive_${Date.now()}`,
+            content: "should not show",
+            active: false,
+          },
+        }
+      );
+      expect(createInactiveAgentShortcut.ok()).toBeTruthy();
+
+      await page.goto(`/app?agentId=${agent.id}`);
+      await page.waitForSelector("#onyx-chat-input-textarea");
+
+      const input = page.locator("#onyx-chat-input-textarea");
+      await input.fill(`/${shortcutCommand}`);
+
+      await expect(page.getByText("Agent Shortcuts")).toBeVisible();
+      await expect(page.getByText("Your Shortcuts")).toBeVisible();
+      await expect(page.getByText(shortcutCommand)).toHaveCount(2);
+      await expect(page.getByText("should not show")).toHaveCount(0);
+
+      await input.fill(`/${shortcutCommand}`);
+      await input.press("Enter");
+      await expect(input).toHaveValue("agent shortcut content");
+    } finally {
+      await onyxApiClient.deleteAgent(agent.id);
+    }
+  });
+});


### PR DESCRIPTION


https://github.com/user-attachments/assets/1bc5719f-7f00-4331-8410-4ec3ed3dd223



## Description

This PR adds assistant-level (persona-scoped) prompt shortcuts so shortcuts can be tied to a specific assistant and shown in chat only when that assistant is selected.

### What changed

- add persona-scoped shortcut data model support (including migration/index updates)
- add persona shortcut CRUD + bulk sync APIs with access checks
- update chat shortcut picker to include assistant-scoped shortcuts and grouped display
- update agent editor flow to manage assistant shortcuts with global enable/disable
- add backend tests for scope, auth, and list composition behavior
- add e2e coverage for assistant shortcut visibility and picker interaction

### Behavior summary

- `/` shortcut picker now supports assistant-specific shortcuts in addition to existing user/public shortcuts.
- assistant shortcuts appear under an **Agent Shortcuts** section when that assistant is active.
- user/public shortcuts appear under **Your Shortcuts**.
- shortcut save flow in the agent editor uses bulk sync semantics to avoid destructive delete/recreate behavior.
- global enable/disable behavior for assistant shortcuts remains supported in the editor.

You can attach your demo video in the PR to showcase:
- creating/editing shortcuts in assistant editor
- switching assistants and seeing scoped shortcut changes
- `/` picker grouped display and insertion behavior

---

## How Has This Been Tested?

### Backend

- Added/updated external dependency unit tests covering:
  - persona-scoped shortcut fetch composition
  - duplicate/constraint behavior
  - persona access enforcement for update/sync paths
  - sync behavior (create/update/delete in one operation)
  - rejection of foreign prompt IDs in persona sync requests

### API-level coverage

- Added tests for:
  - `GET /api/input_prompt?persona_id=<id>` composition behavior
  - inaccessible persona handling (`403`)
  - persona sync endpoint auth requirements

### Frontend / E2E

- Updated Playwright test to validate:
  - grouped shortcut sections in chat picker
  - assistant-scoped visibility behavior
  - inactive shortcut non-visibility
  - keyboard selection behavior in grouped picker

### Notes

- If your local/external dependency test DB has not applied the latest migration, tests may fail due to missing `persona_id` column on `inputprompt`. Running the migration first resolves this.


Fix #9226 