### PR TITLE
feat(security): Secrets from Files

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -215,21 +215,15 @@ DISPOSABLE_EMAIL_DOMAINS_URL = os.environ.get(
 
 # OAuth Login Flow
 # Used for both Google OAuth2 and OIDC flows
-OAUTH_CLIENT_ID = (
-    get_secret_env(
-        "OAUTH_CLIENT_ID",
-        fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_ID"],
-        default="",
-    )
-    or ""
+OAUTH_CLIENT_ID = get_secret_env(
+    "OAUTH_CLIENT_ID",
+    fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_ID"],
+    default="",
 )
-OAUTH_CLIENT_SECRET = (
-    get_secret_env(
-        "OAUTH_CLIENT_SECRET",
-        fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_SECRET"],
-        default="",
-    )
-    or ""
+OAUTH_CLIENT_SECRET = get_secret_env(
+    "OAUTH_CLIENT_SECRET",
+    fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_SECRET"],
+    default="",
 )
 
 # Whether Google OAuth is enabled (requires both client ID and secret)
@@ -279,7 +273,7 @@ REQUIRE_EMAIL_VERIFICATION = (
 SMTP_SERVER = os.environ.get("SMTP_SERVER") or ""
 SMTP_PORT = int(os.environ.get("SMTP_PORT") or "587")
 SMTP_USER = os.environ.get("SMTP_USER") or ""
-SMTP_PASS = get_secret_env("SMTP_PASS", default="") or ""
+SMTP_PASS = get_secret_env("SMTP_PASS", default="")
 EMAIL_FROM = os.environ.get("EMAIL_FROM") or SMTP_USER
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY") or ""

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -312,13 +312,8 @@ DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S = int(
 DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S = int(
     os.environ.get("DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S") or 50
 )
-OPENSEARCH_ADMIN_USERNAME = (
-    get_secret_env("OPENSEARCH_ADMIN_USERNAME", default="admin") or "admin"
-)
-OPENSEARCH_ADMIN_PASSWORD = (
-    get_secret_env("OPENSEARCH_ADMIN_PASSWORD", default="StrongPassword123!")
-    or "StrongPassword123!"
-)
+OPENSEARCH_ADMIN_USERNAME = get_secret_env("OPENSEARCH_ADMIN_USERNAME") or ""
+OPENSEARCH_ADMIN_PASSWORD = get_secret_env("OPENSEARCH_ADMIN_PASSWORD") or ""
 USING_AWS_MANAGED_OPENSEARCH = (
     os.environ.get("USING_AWS_MANAGED_OPENSEARCH", "").lower() == "true"
 )
@@ -395,10 +390,13 @@ MAX_DRIVE_WORKERS = int(os.environ.get("MAX_DRIVE_WORKERS", 4))
 # Below are intended to match the env variables names used by the official postgres docker image
 # https://hub.docker.com/_/postgres
 POSTGRES_USER = get_secret_env("POSTGRES_USER", default="postgres") or "postgres"
+_POSTGRES_PASSWORD = get_secret_env("POSTGRES_PASSWORD")
+if _POSTGRES_PASSWORD is None and os.getenv("USE_IAM_AUTH", "False").lower() != "true":
+    raise RuntimeError(
+        "POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE must be set when USE_IAM_AUTH is false."
+    )
 # URL-encode the password for asyncpg to avoid issues with special characters on some machines.
-POSTGRES_PASSWORD = urllib.parse.quote_plus(
-    get_secret_env("POSTGRES_PASSWORD", default="password") or "password"
-)
+POSTGRES_PASSWORD = urllib.parse.quote_plus(_POSTGRES_PASSWORD or "")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST") or "127.0.0.1"
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT") or "5432"
 POSTGRES_DB = os.environ.get("POSTGRES_DB") or "postgres"
@@ -1143,7 +1141,7 @@ DB_READONLY_USER: str = (
     get_secret_env("DB_READONLY_USER", default="db_readonly_user") or "db_readonly_user"
 )
 DB_READONLY_PASSWORD: str = urllib.parse.quote_plus(
-    get_secret_env("DB_READONLY_PASSWORD", default="password") or "password"
+    get_secret_env("DB_READONLY_PASSWORD") or ""
 )
 
 # File Store Configuration

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -4,6 +4,7 @@ import urllib.parse
 from datetime import datetime
 from datetime import timezone
 from typing import cast
+from typing import overload
 
 from onyx.auth.schemas import AuthBackend
 from onyx.cache.interface import CacheBackendType
@@ -27,6 +28,24 @@ def _read_secret_from_file(file_path: str, file_env_var_name: str) -> str:
         ) from e
 
 
+@overload
+def get_secret_env(
+    env_var_name: str,
+    *,
+    default: str,
+    fallback_env_var_names: list[str] | None = None,
+) -> str: ...
+
+
+@overload
+def get_secret_env(
+    env_var_name: str,
+    *,
+    default: None = None,
+    fallback_env_var_names: list[str] | None = None,
+) -> str | None: ...
+
+
 def get_secret_env(
     env_var_name: str,
     *,
@@ -44,7 +63,14 @@ def get_secret_env(
 
         file_env_var = f"{current_env_var}_FILE"
         file_path = os.environ.get(file_env_var)
-        if file_path:
+        if file_path is not None:
+            if not file_path:
+                logger.warning(
+                    "%s is set to an empty string; skipping file lookup.",
+                    file_env_var,
+                )
+                continue
+
             file_value = _read_secret_from_file(
                 file_path=file_path, file_env_var_name=file_env_var
             )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -392,9 +392,11 @@ MAX_DRIVE_WORKERS = int(os.environ.get("MAX_DRIVE_WORKERS", 4))
 POSTGRES_USER = get_secret_env("POSTGRES_USER", default="postgres") or "postgres"
 _POSTGRES_PASSWORD = get_secret_env("POSTGRES_PASSWORD")
 if _POSTGRES_PASSWORD is None and os.getenv("USE_IAM_AUTH", "False").lower() != "true":
-    raise RuntimeError(
-        "POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE must be set when USE_IAM_AUTH is false."
+    logger.warning(
+        "POSTGRES_PASSWORD is not set. Falling back to legacy default password. "
+        "Set POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE in production."
     )
+    _POSTGRES_PASSWORD = "password"
 # URL-encode the password for asyncpg to avoid issues with special characters on some machines.
 POSTGRES_PASSWORD = urllib.parse.quote_plus(_POSTGRES_PASSWORD or "")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST") or "127.0.0.1"
@@ -1141,7 +1143,7 @@ DB_READONLY_USER: str = (
     get_secret_env("DB_READONLY_USER", default="db_readonly_user") or "db_readonly_user"
 )
 DB_READONLY_PASSWORD: str = urllib.parse.quote_plus(
-    get_secret_env("DB_READONLY_PASSWORD") or ""
+    get_secret_env("DB_READONLY_PASSWORD", default="password") or "password"
 )
 
 # File Store Configuration

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -50,6 +50,11 @@ def get_secret_env(
             )
             if file_value:
                 return file_value
+            logger.warning(
+                "Secret file at '%s' (from %s) is empty; falling back to next source.",
+                file_path,
+                file_env_var,
+            )
 
     return default
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -20,7 +20,7 @@ logger = setup_logger()
 def _read_secret_from_file(file_path: str, file_env_var_name: str) -> str:
     try:
         with open(file_path, encoding="utf-8") as file:
-            return file.read().rstrip()
+            return file.read().strip()
     except OSError as e:
         raise RuntimeError(
             f"Unable to read secret file '{file_path}' from {file_env_var_name}"

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -39,7 +39,7 @@ def get_secret_env(
 
     for current_env_var in env_var_names:
         env_value = os.environ.get(current_env_var)
-        if env_value:
+        if env_value is not None:
             return env_value
 
         file_env_var = f"{current_env_var}_FILE"
@@ -312,8 +312,24 @@ DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S = int(
 DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S = int(
     os.environ.get("DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S") or 50
 )
-OPENSEARCH_ADMIN_USERNAME = get_secret_env("OPENSEARCH_ADMIN_USERNAME") or ""
-OPENSEARCH_ADMIN_PASSWORD = get_secret_env("OPENSEARCH_ADMIN_PASSWORD") or ""
+_OPENSEARCH_ADMIN_USERNAME = get_secret_env("OPENSEARCH_ADMIN_USERNAME")
+if _OPENSEARCH_ADMIN_USERNAME is None:
+    logger.warning(
+        "OPENSEARCH_ADMIN_USERNAME is not set. Falling back to legacy default username "
+        "'admin'. Set OPENSEARCH_ADMIN_USERNAME or OPENSEARCH_ADMIN_USERNAME_FILE in "
+        "production."
+    )
+    _OPENSEARCH_ADMIN_USERNAME = "admin"
+OPENSEARCH_ADMIN_USERNAME = _OPENSEARCH_ADMIN_USERNAME
+
+_OPENSEARCH_ADMIN_PASSWORD = get_secret_env("OPENSEARCH_ADMIN_PASSWORD")
+if _OPENSEARCH_ADMIN_PASSWORD is None:
+    logger.warning(
+        "OPENSEARCH_ADMIN_PASSWORD is not set. Falling back to legacy default password. "
+        "Set OPENSEARCH_ADMIN_PASSWORD or OPENSEARCH_ADMIN_PASSWORD_FILE in production."
+    )
+    _OPENSEARCH_ADMIN_PASSWORD = "StrongPassword123!"
+OPENSEARCH_ADMIN_PASSWORD = _OPENSEARCH_ADMIN_PASSWORD
 USING_AWS_MANAGED_OPENSEARCH = (
     os.environ.get("USING_AWS_MANAGED_OPENSEARCH", "").lower() == "true"
 )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -20,7 +20,7 @@ logger = setup_logger()
 def _read_secret_from_file(file_path: str, file_env_var_name: str) -> str:
     try:
         with open(file_path, encoding="utf-8") as file:
-            return file.read().rstrip("\r\n")
+            return file.read().rstrip()
     except OSError as e:
         raise RuntimeError(
             f"Unable to read secret file '{file_path}' from {file_env_var_name}"
@@ -57,6 +57,10 @@ def get_secret_env(
             )
 
     return default
+
+
+def _use_iam_auth() -> bool:
+    return os.getenv("USE_IAM_AUTH", "False").lower() == "true"
 
 
 #####
@@ -407,7 +411,7 @@ MAX_DRIVE_WORKERS = int(os.environ.get("MAX_DRIVE_WORKERS", 4))
 # https://hub.docker.com/_/postgres
 POSTGRES_USER = get_secret_env("POSTGRES_USER", default="postgres") or "postgres"
 _POSTGRES_PASSWORD = get_secret_env("POSTGRES_PASSWORD")
-if _POSTGRES_PASSWORD is None and os.getenv("USE_IAM_AUTH", "False").lower() != "true":
+if _POSTGRES_PASSWORD is None and not _use_iam_auth():
     logger.warning(
         "POSTGRES_PASSWORD is not set. Falling back to legacy default password. "
         "Set POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE in production."
@@ -451,7 +455,7 @@ except ValueError:
     POSTGRES_POOL_RECYCLE = POSTGRES_POOL_RECYCLE_DEFAULT
 
 # RDS IAM authentication - enables IAM-based authentication for PostgreSQL
-USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
+USE_IAM_AUTH = _use_iam_auth()
 
 # Redis IAM authentication - enables IAM-based authentication for Redis ElastiCache
 # Note: This is separate from RDS IAM auth as they use different authentication mechanisms

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -16,6 +16,44 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+
+def _read_secret_from_file(file_path: str, file_env_var_name: str) -> str:
+    try:
+        with open(file_path, encoding="utf-8") as file:
+            return file.read().rstrip("\r\n")
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to read secret file '{file_path}' from {file_env_var_name}"
+        ) from e
+
+
+def get_secret_env(
+    env_var_name: str,
+    *,
+    default: str | None = None,
+    fallback_env_var_names: list[str] | None = None,
+) -> str | None:
+    env_var_names = [env_var_name]
+    if fallback_env_var_names:
+        env_var_names.extend(fallback_env_var_names)
+
+    for current_env_var in env_var_names:
+        env_value = os.environ.get(current_env_var)
+        if env_value:
+            return env_value
+
+        file_env_var = f"{current_env_var}_FILE"
+        file_path = os.environ.get(file_env_var)
+        if file_path:
+            file_value = _read_secret_from_file(
+                file_path=file_path, file_env_var_name=file_env_var
+            )
+            if file_value:
+                return file_value
+
+    return default
+
+
 #####
 # App Configs
 #####
@@ -169,10 +207,19 @@ DISPOSABLE_EMAIL_DOMAINS_URL = os.environ.get(
 # OAuth Login Flow
 # Used for both Google OAuth2 and OIDC flows
 OAUTH_CLIENT_ID = (
-    os.environ.get("OAUTH_CLIENT_ID", os.environ.get("GOOGLE_OAUTH_CLIENT_ID")) or ""
+    get_secret_env(
+        "OAUTH_CLIENT_ID",
+        fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_ID"],
+        default="",
+    )
+    or ""
 )
 OAUTH_CLIENT_SECRET = (
-    os.environ.get("OAUTH_CLIENT_SECRET", os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET"))
+    get_secret_env(
+        "OAUTH_CLIENT_SECRET",
+        fallback_env_var_names=["GOOGLE_OAUTH_CLIENT_SECRET"],
+        default="",
+    )
     or ""
 )
 
@@ -223,7 +270,7 @@ REQUIRE_EMAIL_VERIFICATION = (
 SMTP_SERVER = os.environ.get("SMTP_SERVER") or ""
 SMTP_PORT = int(os.environ.get("SMTP_PORT") or "587")
 SMTP_USER = os.environ.get("SMTP_USER") or ""
-SMTP_PASS = os.environ.get("SMTP_PASS") or ""
+SMTP_PASS = get_secret_env("SMTP_PASS", default="") or ""
 EMAIL_FROM = os.environ.get("EMAIL_FROM") or SMTP_USER
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY") or ""
@@ -260,9 +307,12 @@ DEFAULT_OPENSEARCH_CLIENT_TIMEOUT_S = int(
 DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S = int(
     os.environ.get("DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S") or 50
 )
-OPENSEARCH_ADMIN_USERNAME = os.environ.get("OPENSEARCH_ADMIN_USERNAME", "admin")
-OPENSEARCH_ADMIN_PASSWORD = os.environ.get(
-    "OPENSEARCH_ADMIN_PASSWORD", "StrongPassword123!"
+OPENSEARCH_ADMIN_USERNAME = (
+    get_secret_env("OPENSEARCH_ADMIN_USERNAME", default="admin") or "admin"
+)
+OPENSEARCH_ADMIN_PASSWORD = (
+    get_secret_env("OPENSEARCH_ADMIN_PASSWORD", default="StrongPassword123!")
+    or "StrongPassword123!"
 )
 USING_AWS_MANAGED_OPENSEARCH = (
     os.environ.get("USING_AWS_MANAGED_OPENSEARCH", "").lower() == "true"
@@ -339,10 +389,10 @@ MAX_DRIVE_WORKERS = int(os.environ.get("MAX_DRIVE_WORKERS", 4))
 
 # Below are intended to match the env variables names used by the official postgres docker image
 # https://hub.docker.com/_/postgres
-POSTGRES_USER = os.environ.get("POSTGRES_USER") or "postgres"
+POSTGRES_USER = get_secret_env("POSTGRES_USER", default="postgres") or "postgres"
 # URL-encode the password for asyncpg to avoid issues with special characters on some machines.
 POSTGRES_PASSWORD = urllib.parse.quote_plus(
-    os.environ.get("POSTGRES_PASSWORD") or "password"
+    get_secret_env("POSTGRES_PASSWORD", default="password") or "password"
 )
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST") or "127.0.0.1"
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT") or "5432"
@@ -388,7 +438,7 @@ USE_REDIS_IAM_AUTH = os.getenv("USE_REDIS_IAM_AUTH", "False").lower() == "true"
 REDIS_SSL = os.getenv("REDIS_SSL", "").lower() == "true"
 REDIS_HOST = os.environ.get("REDIS_HOST") or "localhost"
 REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
-REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD") or ""
+REDIS_PASSWORD = get_secret_env("REDIS_PASSWORD", default="") or ""
 
 # this assumes that other redis settings remain the same as the primary
 REDIS_REPLICA_HOST = os.environ.get("REDIS_REPLICA_HOST") or REDIS_HOST
@@ -1084,9 +1134,11 @@ IMAGE_SUMMARIZATION_USER_PROMPT = os.environ.get(
 )
 
 # Knowledge Graph Read Only User Configuration
-DB_READONLY_USER: str = os.environ.get("DB_READONLY_USER", "db_readonly_user")
+DB_READONLY_USER: str = (
+    get_secret_env("DB_READONLY_USER", default="db_readonly_user") or "db_readonly_user"
+)
 DB_READONLY_PASSWORD: str = urllib.parse.quote_plus(
-    os.environ.get("DB_READONLY_PASSWORD") or "password"
+    get_secret_env("DB_READONLY_PASSWORD", default="password") or "password"
 )
 
 # File Store Configuration
@@ -1102,8 +1154,8 @@ S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL")
 S3_VERIFY_SSL = os.environ.get("S3_VERIFY_SSL", "").lower() == "true"
 
 # S3/MinIO Access Keys
-S3_AWS_ACCESS_KEY_ID = os.environ.get("S3_AWS_ACCESS_KEY_ID")
-S3_AWS_SECRET_ACCESS_KEY = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
+S3_AWS_ACCESS_KEY_ID = get_secret_env("S3_AWS_ACCESS_KEY_ID")
+S3_AWS_SECRET_ACCESS_KEY = get_secret_env("S3_AWS_SECRET_ACCESS_KEY")
 
 # Should we force S3 local checksumming
 S3_GENERATE_LOCAL_CHECKSUM = (

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -52,6 +52,19 @@ By default, some onyx containers run as root. If you'd like to explicitly run th
       runAsUser: 1000
     ```
 
+## Mount secrets as files
+By default, this chart injects configured auth secrets as env vars.
+
+To mount those secrets as files and pass only `*_FILE` env vars instead:
+
+```yaml
+secretsAsFiles:
+  enabled: true
+  mountPath: /etc/onyx-secrets # optional, defaults to this path
+```
+
+When enabled, Onyx will read secret-backed config values from `VAR_FILE` paths (while preserving existing `VAR` env support for backwards compatibility).
+
 ## Resourcing
 In the helm charts, we have resource suggestions for all Onyx-owned components. 
 These are simply initial suggestions, and may need to be tuned for your specific use case.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.33
+version: 0.4.34
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -72,8 +72,8 @@ Set secret name
 Create env vars from secrets
 */}}
 {{- define "onyx.envSecrets" -}}
-    {{- $secretFilesEnabled := .Values.secretsAsFiles.enabled | default false }}
-    {{- $secretFilesMountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
+    {{- $secretFilesEnabled := include "onyx.secretsAsFiles.enabled" . }}
+    {{- $secretFilesMountPath := dig "secretsAsFiles" "mountPath" "/etc/onyx-secrets" .Values }}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
     {{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
     {{- range $name, $key := $secretContent.secretKeys }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Create env vars from secrets
     {{- $secretFilesEnabled := .Values.secretsAsFiles.enabled | default false }}
     {{- $secretFilesMountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
-    {{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
+    {{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
     {{- range $name, $key := $secretContent.secretKeys }}
     {{- $envVarName := $name | upper | replace "-" "_" }}
     {{- $secretKey := default $name $key }}
@@ -105,7 +105,7 @@ Secret file mounting helpers.
 {{- if (include "onyx.secretsAsFiles.enabled" .) }}
 {{- $mountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
 {{- range $secretSuffix, $secretContent := .Values.auth }}
-{{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
+{{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
 - name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
   mountPath: {{ printf "%s/%s" $mountPath $secretSuffix | quote }}
   readOnly: true
@@ -117,7 +117,7 @@ Secret file mounting helpers.
 {{- define "onyx.secretsAsFiles.volumes" -}}
 {{- if (include "onyx.secretsAsFiles.enabled" .) }}
 {{- range $secretSuffix, $secretContent := .Values.auth }}
-{{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
+{{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
 - name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
   secret:
     secretName: {{ include "onyx.secretName" $secretContent }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -69,6 +69,17 @@ Set secret name
 {{- end }}
 
 {{/*
+Validate path segments used for projected secret file paths.
+*/}}
+{{- define "onyx.secretPathSegment" -}}
+{{- $segment := . | toString -}}
+{{- if or (contains "/" $segment) (contains "\\" $segment) (contains ".." $segment) -}}
+{{- fail (printf "Invalid secret path segment %q: must not contain '/', '\\\\', or '..'" $segment) -}}
+{{- end -}}
+{{- $segment -}}
+{{- end }}
+
+{{/*
 Create env vars from secrets
 */}}
 {{- define "onyx.envSecrets" -}}
@@ -79,9 +90,11 @@ Create env vars from secrets
     {{- range $name, $key := $secretContent.secretKeys }}
     {{- $envVarName := $name | upper | replace "-" "_" }}
     {{- $secretKey := default $name $key }}
+    {{- $safeSecretSuffix := include "onyx.secretPathSegment" $secretSuffix }}
+    {{- $safeSecretKey := include "onyx.secretPathSegment" $secretKey }}
     {{- if $secretFilesEnabled }}
 - name: {{ printf "%s_FILE" $envVarName | quote }}
-  value: {{ printf "%s/%s/%s" $secretFilesMountPath $secretSuffix $secretKey | quote }}
+  value: {{ printf "%s/%s/%s" $secretFilesMountPath $safeSecretSuffix $safeSecretKey | quote }}
     {{- else }}
 - name: {{ $envVarName | quote }}
   valueFrom:
@@ -114,8 +127,9 @@ Secret file mounting helpers.
 {{- $mountPath := include "onyx.secretsAsFiles.mountPath" . }}
 {{- range $secretSuffix, $secretContent := .Values.auth }}
 {{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
+{{- $safeSecretSuffix := include "onyx.secretPathSegment" $secretSuffix }}
 - name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
-  mountPath: {{ printf "%s/%s" $mountPath $secretSuffix | quote }}
+  mountPath: {{ printf "%s/%s" $mountPath $safeSecretSuffix | quote }}
   readOnly: true
 {{- end }}
 {{- end }}
@@ -131,8 +145,9 @@ Secret file mounting helpers.
     secretName: {{ include "onyx.secretName" $secretContent }}
     items:
     {{- range $name, $key := $secretContent.secretKeys }}
+    {{- $safeSecretKey := include "onyx.secretPathSegment" (default $name $key) }}
       - key: {{ default $name $key }}
-        path: {{ default $name $key }}
+        path: {{ $safeSecretKey }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -121,6 +121,11 @@ Secret file mounting helpers.
 - name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
   secret:
     secretName: {{ include "onyx.secretName" $secretContent }}
+    items:
+    {{- range $name, $key := $secretContent.secretKeys }}
+      - key: {{ default $name $key }}
+        path: {{ default $name $key }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -73,7 +73,7 @@ Create env vars from secrets
 */}}
 {{- define "onyx.envSecrets" -}}
     {{- $secretFilesEnabled := include "onyx.secretsAsFiles.enabled" . }}
-    {{- $secretFilesMountPath := dig "secretsAsFiles" "mountPath" "/etc/onyx-secrets" .Values }}
+    {{- $secretFilesMountPath := include "onyx.secretsAsFiles.mountPath" . }}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
     {{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
     {{- range $name, $key := $secretContent.secretKeys }}
@@ -101,9 +101,17 @@ Secret file mounting helpers.
 {{- if and .Values.secretsAsFiles .Values.secretsAsFiles.enabled }}true{{- end }}
 {{- end }}
 
+{{- define "onyx.secretsAsFiles.mountPath" -}}
+{{- if and .Values.secretsAsFiles .Values.secretsAsFiles.mountPath -}}
+{{- .Values.secretsAsFiles.mountPath -}}
+{{- else -}}
+/etc/onyx-secrets
+{{- end }}
+{{- end }}
+
 {{- define "onyx.secretsAsFiles.volumeMounts" -}}
 {{- if (include "onyx.secretsAsFiles.enabled" .) }}
-{{- $mountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
+{{- $mountPath := include "onyx.secretsAsFiles.mountPath" . }}
 {{- range $secretSuffix, $secretContent := .Values.auth }}
 {{- if and (kindIs "map" $secretContent) (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
 - name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -73,8 +73,8 @@ Validate path segments used for projected secret file paths.
 */}}
 {{- define "onyx.secretPathSegment" -}}
 {{- $segment := . | toString -}}
-{{- if or (contains "/" $segment) (contains "\\" $segment) (contains ".." $segment) -}}
-{{- fail (printf "Invalid secret path segment %q: must not contain '/', '\\\\', or '..'" $segment) -}}
+{{- if or (contains "/" $segment) (contains "\\" $segment) (eq $segment "..") -}}
+{{- fail (printf "Invalid secret path segment %q: must not contain '/', '\\\\', or equal '..'" $segment) -}}
 {{- end -}}
 {{- $segment -}}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -72,17 +72,58 @@ Set secret name
 Create env vars from secrets
 */}}
 {{- define "onyx.envSecrets" -}}
+    {{- $secretFilesEnabled := .Values.secretsAsFiles.enabled | default false }}
+    {{- $secretFilesMountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
-    {{- if and (ne $secretContent.enabled false) ($secretContent.secretKeys) }}
+    {{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
     {{- range $name, $key := $secretContent.secretKeys }}
-- name: {{ $name | upper | replace "-" "_" | quote }}
+    {{- $envVarName := $name | upper | replace "-" "_" }}
+    {{- $secretKey := default $name $key }}
+    {{- if $secretFilesEnabled }}
+- name: {{ printf "%s_FILE" $envVarName | quote }}
+  value: {{ printf "%s/%s/%s" $secretFilesMountPath $secretSuffix $secretKey | quote }}
+    {{- else }}
+- name: {{ $envVarName | quote }}
   valueFrom:
     secretKeyRef:
       name: {{ include "onyx.secretName" $secretContent }}
-      key: {{ default $name $key }}
+      key: {{ $secretKey }}
     {{- end }}
     {{- end }}
     {{- end }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Secret file mounting helpers.
+*/}}
+{{- define "onyx.secretsAsFiles.enabled" -}}
+{{- if and .Values.secretsAsFiles .Values.secretsAsFiles.enabled }}true{{- end }}
+{{- end }}
+
+{{- define "onyx.secretsAsFiles.volumeMounts" -}}
+{{- if (include "onyx.secretsAsFiles.enabled" .) }}
+{{- $mountPath := .Values.secretsAsFiles.mountPath | default "/etc/onyx-secrets" }}
+{{- range $secretSuffix, $secretContent := .Values.auth }}
+{{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
+- name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
+  mountPath: {{ printf "%s/%s" $mountPath $secretSuffix | quote }}
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "onyx.secretsAsFiles.volumes" -}}
+{{- if (include "onyx.secretsAsFiles.enabled" .) }}
+{{- range $secretSuffix, $secretContent := .Values.auth }}
+{{- if and (kindIs "map" $secretContent) (ne ($secretContent.enabled | default true) false) ($secretContent.secretKeys) }}
+- name: {{ printf "auth-secret-%s" ($secretSuffix | lower | replace "_" "-") }}
+  secret:
+    secretName: {{ include "onyx.secretName" $secretContent }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -122,11 +163,15 @@ checksum/pginto: {{ include (print $.Template.BasePath "/tooling-pginto-configma
 
 {{- define "onyx.renderVolumeMounts" -}}
 {{- $pginto := include "onyx.pgInto.volumeMount" .ctx -}}
+{{- $secretFiles := include "onyx.secretsAsFiles.volumeMounts" .ctx -}}
 {{- $existing := .volumeMounts -}}
-{{- if or $pginto $existing -}}
+{{- if or $pginto $secretFiles $existing -}}
 volumeMounts:
 {{- if $pginto }}
 {{ $pginto | nindent 2 }}
+{{- end }}
+{{- if $secretFiles }}
+{{ $secretFiles | nindent 2 }}
 {{- end }}
 {{- if $existing }}
 {{ toYaml $existing | nindent 2 }}
@@ -136,11 +181,15 @@ volumeMounts:
 
 {{- define "onyx.renderVolumes" -}}
 {{- $pginto := include "onyx.pgInto.volume" .ctx -}}
+{{- $secretFiles := include "onyx.secretsAsFiles.volumes" .ctx -}}
 {{- $existing := .volumes -}}
-{{- if or $pginto $existing -}}
+{{- if or $pginto $secretFiles $existing -}}
 volumes:
 {{- if $pginto }}
 {{ $pginto | nindent 2 }}
+{{- end }}
+{{- if $secretFiles }}
+{{ $secretFiles | nindent 2 }}
 {{- end }}
 {{- if $existing }}
 {{ toYaml $existing | nindent 2 }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -72,9 +72,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_beat.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryBeatVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_beat.volumeMounts) }}
+          {{- if $celeryBeatVolumeMounts }}
+          {{- $celeryBeatVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -98,8 +98,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_beat_liveness.txt
-      {{- with .Values.celery_beat.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryBeatVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_beat.volumes) }}
+      {{- if $celeryBeatVolumes }}
+      {{- $celeryBeatVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -80,9 +80,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_docfetching.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryDocfetchingVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_docfetching.volumeMounts) }}
+          {{- if $celeryDocfetchingVolumeMounts }}
+          {{- $celeryDocfetchingVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -106,8 +106,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_docfetching_liveness.txt
-      {{- with .Values.celery_worker_docfetching.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryDocfetchingVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_docfetching.volumes) }}
+      {{- if $celeryDocfetchingVolumes }}
+      {{- $celeryDocfetchingVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -82,9 +82,9 @@ spec:
             - name: ENABLE_MULTIPASS_INDEXING
               value: "{{ .Values.celery_worker_docprocessing.enableMiniChunk }}"
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_docprocessing.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryDocprocessingVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_docprocessing.volumeMounts) }}
+          {{- if $celeryDocprocessingVolumeMounts }}
+          {{- $celeryDocprocessingVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -108,8 +108,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_docprocessing_liveness.txt
-      {{- with .Values.celery_worker_docprocessing.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryDocprocessingVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_docprocessing.volumes) }}
+      {{- if $celeryDocprocessingVolumes }}
+      {{- $celeryDocprocessingVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -77,9 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_heavy.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryHeavyVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_heavy.volumeMounts) }}
+          {{- if $celeryHeavyVolumeMounts }}
+          {{- $celeryHeavyVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -103,8 +103,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_heavy_liveness.txt
-      {{- with .Values.celery_worker_heavy.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryHeavyVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_heavy.volumes) }}
+      {{- if $celeryHeavyVolumes }}
+      {{- $celeryHeavyVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -77,9 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_light.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryLightVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_light.volumeMounts) }}
+          {{- if $celeryLightVolumeMounts }}
+          {{- $celeryLightVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -103,8 +103,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_light_liveness.txt
-      {{- with .Values.celery_worker_light.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryLightVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_light.volumes) }}
+      {{- if $celeryLightVolumes }}
+      {{- $celeryLightVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -77,9 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_monitoring.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryMonitoringVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_monitoring.volumeMounts) }}
+          {{- if $celeryMonitoringVolumeMounts }}
+          {{- $celeryMonitoringVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -103,8 +103,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_monitoring_liveness.txt
-      {{- with .Values.celery_worker_monitoring.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryMonitoringVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_monitoring.volumes) }}
+      {{- if $celeryMonitoringVolumes }}
+      {{- $celeryMonitoringVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -77,9 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_primary.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryPrimaryVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_primary.volumeMounts) }}
+          {{- if $celeryPrimaryVolumeMounts }}
+          {{- $celeryPrimaryVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -103,8 +103,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_primary_liveness.txt
-      {{- with .Values.celery_worker_primary.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryPrimaryVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_primary.volumes) }}
+      {{- if $celeryPrimaryVolumes }}
+      {{- $celeryPrimaryVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -77,9 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.celery_worker_user_file_processing.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $celeryUserFileProcessingVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.celery_worker_user_file_processing.volumeMounts) }}
+          {{- if $celeryUserFileProcessingVolumeMounts }}
+          {{- $celeryUserFileProcessingVolumeMounts | nindent 10 }}
           {{- end }}
           startupProbe:
             {{ .Values.celery_shared.startupProbe | toYaml | nindent 12}}
@@ -103,8 +103,8 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_userfileprocessing_liveness.txt
-      {{- with .Values.celery_worker_user_file_processing.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $celeryUserFileProcessingVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.celery_worker_user_file_processing.volumes) }}
+      {{- if $celeryUserFileProcessingVolumes }}
+      {{- $celeryUserFileProcessingVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/discordbot.yaml
+++ b/deployment/helm/charts/onyx/templates/discordbot.yaml
@@ -87,12 +87,12 @@ spec:
             - name: DISCORD_BOT_INVOKE_CHAR
               value: {{ .Values.discordbot.invokeChar | quote }}
             {{- end }}
-          {{- with .Values.discordbot.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $discordbotVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.discordbot.volumeMounts) }}
+          {{- if $discordbotVolumeMounts }}
+          {{- $discordbotVolumeMounts | nindent 10 }}
           {{- end }}
-      {{- with .Values.discordbot.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $discordbotVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.discordbot.volumes) }}
+      {{- if $discordbotVolumes }}
+      {{- $discordbotVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -68,6 +68,10 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx.envSecrets" . | nindent 10}}
+        {{- $indexVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.indexCapability.volumeMounts) }}
+        {{- if $indexVolumeMounts }}
+        {{- $indexVolumeMounts | nindent 8 }}
+        {{- end }}
         {{- if .Values.indexCapability.securityContext }}
         securityContext:
           {{- toYaml .Values.indexCapability.securityContext | nindent 10 }}
@@ -88,4 +92,8 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- $indexVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.indexCapability.volumes) }}
+      {{- if $indexVolumes }}
+      {{- $indexVolumes | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -57,6 +57,10 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx.envSecrets" . | nindent 12}}
+        {{- $inferenceVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.inferenceCapability.volumeMounts) }}
+        {{- if $inferenceVolumeMounts }}
+        {{- $inferenceVolumeMounts | nindent 8 }}
+        {{- end }}
         {{- if .Values.inferenceCapability.securityContext }}
         securityContext:
           {{- toYaml .Values.inferenceCapability.securityContext | nindent 10 }}
@@ -77,4 +81,8 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- $inferenceVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.inferenceCapability.volumes) }}
+      {{- if $inferenceVolumes }}
+      {{- $inferenceVolumes | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -99,13 +99,12 @@ spec:
             - name: API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
               value: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }}"
             {{- include "onyx.envSecrets" . | nindent 12 }}
-          {{- with .Values.mcpServer.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $mcpServerVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.mcpServer.volumeMounts) }}
+          {{- if $mcpServerVolumeMounts }}
+          {{- $mcpServerVolumeMounts | nindent 10 }}
           {{- end }}
-      {{- with .Values.mcpServer.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $mcpServerVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.mcpServer.volumes) }}
+      {{- if $mcpServerVolumes }}
+      {{- $mcpServerVolumes | nindent 6 }}
       {{- end }}
 {{- end }}
-

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -64,12 +64,12 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.slackbot.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $slackbotVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.slackbot.volumeMounts) }}
+          {{- if $slackbotVolumeMounts }}
+          {{- $slackbotVolumeMounts | nindent 10 }}
           {{- end }}
-      {{- with .Values.slackbot.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $slackbotVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.slackbot.volumes) }}
+      {{- if $slackbotVolumes }}
+      {{- $slackbotVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -12,7 +12,16 @@ data:
 
     HOST="${POSTGRES_HOST:-localhost}"
     PORT="${POSTGRES_PORT:-5432}"
-    USER="${POSTGRES_USER:-postgres}"
+    POSTGRES_USER_VALUE="${POSTGRES_USER:-}"
+    if [ -z "${POSTGRES_USER_VALUE}" ] && [ -n "${POSTGRES_USER_FILE:-}" ]; then
+      if [ -r "${POSTGRES_USER_FILE}" ]; then
+        POSTGRES_USER_VALUE="$(cat "${POSTGRES_USER_FILE}")"
+      else
+        echo "POSTGRES_USER_FILE is set but not readable: ${POSTGRES_USER_FILE}" >&2
+        exit 1
+      fi
+    fi
+    USER="${POSTGRES_USER_VALUE:-postgres}"
     DB="${POSTGRES_DB:-postgres}"
     PSQL_BIN="${PGINTO_PSQL_BIN:-{{ default "psql" .Values.tooling.pgInto.psqlBinary }}}"
     USE_IAM="$(printf '%s' "${USE_IAM_AUTH:-false}" | tr '[:upper:]' '[:lower:]')"
@@ -48,6 +57,16 @@ data:
     else
       if [ -z "${PGPASSWORD:-}" ] && [ -n "${POSTGRES_PASSWORD:-}" ]; then
         export PGPASSWORD="${POSTGRES_PASSWORD}"
+      fi
+
+      if [ -z "${PGPASSWORD:-}" ] && [ -n "${POSTGRES_PASSWORD_FILE:-}" ]; then
+        if [ -r "${POSTGRES_PASSWORD_FILE}" ]; then
+          PGPASSWORD="$(cat "${POSTGRES_PASSWORD_FILE}")"
+          export PGPASSWORD
+        else
+          echo "POSTGRES_PASSWORD_FILE is set but not readable: ${POSTGRES_PASSWORD_FILE}" >&2
+          exit 1
+        fi
       fi
 
       if [ -z "${PGPASSWORD:-}" ]; then

--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -12,10 +12,13 @@ data:
 
     HOST="${POSTGRES_HOST:-localhost}"
     PORT="${POSTGRES_PORT:-5432}"
+    trim_file_secret() {
+      sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$1"
+    }
     POSTGRES_USER_VALUE="${POSTGRES_USER:-}"
     if [ -z "${POSTGRES_USER_VALUE}" ] && [ -n "${POSTGRES_USER_FILE:-}" ]; then
       if [ -r "${POSTGRES_USER_FILE}" ]; then
-        POSTGRES_USER_VALUE="$(cat "${POSTGRES_USER_FILE}")"
+        POSTGRES_USER_VALUE="$(trim_file_secret "${POSTGRES_USER_FILE}")"
         if [ -z "${POSTGRES_USER_VALUE}" ]; then
           echo "POSTGRES_USER_FILE is set but empty: ${POSTGRES_USER_FILE}" >&2
           exit 1
@@ -65,7 +68,7 @@ data:
 
       if [ -z "${PGPASSWORD:-}" ] && [ -n "${POSTGRES_PASSWORD_FILE:-}" ]; then
         if [ -r "${POSTGRES_PASSWORD_FILE}" ]; then
-          PGPASSWORD="$(cat "${POSTGRES_PASSWORD_FILE}")"
+          PGPASSWORD="$(trim_file_secret "${POSTGRES_PASSWORD_FILE}")"
           if [ -z "${PGPASSWORD}" ]; then
             echo "POSTGRES_PASSWORD_FILE is set but empty: ${POSTGRES_PASSWORD_FILE}" >&2
             exit 1

--- a/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/tooling-pginto-configmap.yaml
@@ -16,6 +16,10 @@ data:
     if [ -z "${POSTGRES_USER_VALUE}" ] && [ -n "${POSTGRES_USER_FILE:-}" ]; then
       if [ -r "${POSTGRES_USER_FILE}" ]; then
         POSTGRES_USER_VALUE="$(cat "${POSTGRES_USER_FILE}")"
+        if [ -z "${POSTGRES_USER_VALUE}" ]; then
+          echo "POSTGRES_USER_FILE is set but empty: ${POSTGRES_USER_FILE}" >&2
+          exit 1
+        fi
       else
         echo "POSTGRES_USER_FILE is set but not readable: ${POSTGRES_USER_FILE}" >&2
         exit 1
@@ -62,6 +66,10 @@ data:
       if [ -z "${PGPASSWORD:-}" ] && [ -n "${POSTGRES_PASSWORD_FILE:-}" ]; then
         if [ -r "${POSTGRES_PASSWORD_FILE}" ]; then
           PGPASSWORD="$(cat "${POSTGRES_PASSWORD_FILE}")"
+          if [ -z "${PGPASSWORD}" ]; then
+            echo "POSTGRES_PASSWORD_FILE is set but empty: ${POSTGRES_PASSWORD_FILE}" >&2
+            exit 1
+          fi
           export PGPASSWORD
         else
           echo "POSTGRES_PASSWORD_FILE is set but not readable: ${POSTGRES_PASSWORD_FILE}" >&2

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -82,12 +82,12 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
-          {{- with .Values.webserver.volumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- $webserverVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.webserver.volumeMounts) }}
+          {{- if $webserverVolumeMounts }}
+          {{- $webserverVolumeMounts | nindent 10 }}
           {{- end }}
-      {{- with .Values.webserver.volumes }}
-      volumes:
-        {{- toYaml . | nindent 8 }}
+      {{- $webserverVolumes := include "onyx.renderVolumes" (dict "ctx" . "volumes" .Values.webserver.volumes) }}
+      {{- if $webserverVolumes }}
+      {{- $webserverVolumes | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -180,6 +180,10 @@ inferenceCapability:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Additional volumes on the output Deployment definition.
+  volumes: []
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts: []
   # Deployment strategy - use Recreate or RollingUpdate with maxSurge: 0 to terminate old pod first
   # This prevents pending pods when cluster resources are constrained
   strategy: {}
@@ -235,6 +239,10 @@ indexCapability:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Additional volumes on the output Deployment definition.
+  volumes: []
+  # Additional volumeMounts on the output Deployment definition.
+  volumeMounts: []
   # Deployment strategy - use Recreate or RollingUpdate with maxSurge: 0 to terminate old pod first
   # This prevents pending pods when cluster resources are constrained
   strategy: {}
@@ -1066,6 +1074,11 @@ ingress:
 letsencrypt:
   enabled: false
   email: "abc@abc.com"
+
+# -- Optional: expose auth secrets as mounted files + *_FILE env vars instead of secret-backed env vars.
+secretsAsFiles:
+  enabled: false
+  mountPath: /etc/onyx-secrets
 
 # -- Governs all Secrets created or used by this chart. Values set by this chart will be base64 encoded in the k8s cluster.
 auth:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This introduces a workflow that allows users to inject secrets into the k8s services through a file rather than other means. We have historically only cared about the Env Variables but this change allows us to avoid all of that and only get secrets from files as long as the file is properly mounted.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Deployed to testing cluster to validate that services were still in tact with this updated workflow. 

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in support for secrets from mounted files across the app and Helm chart, enabling both `VAR` and `VAR_FILE` envs. Also improves Helm helpers so env/volume injection is safe when some auth blocks are unset.

- **New Features**
  - Backend reads secrets via `get_secret_env` from `VAR` or `VAR_FILE` (with fallback envs where relevant). Applied to OAuth client ID/secret (with `GOOGLE_*` fallback), `SMTP_PASS`, OpenSearch admin user/pass (warning fallback to legacy defaults), Postgres user/pass (warning fallback when IAM auth is off), Redis password, DB read-only user/pass, and S3 keys.
  - Helm: new `secretsAsFiles.enabled` mounts auth secrets under `/etc/onyx-secrets` and sets `VAR_FILE` envs; validates secret path segments; shared helpers inject volumes/volumeMounts into all pods and handle missing/disabled auth blocks safely. Index and inference charts accept extra `volumes`/`volumeMounts`.
  - `pgInto` supports `POSTGRES_USER_FILE` and `POSTGRES_PASSWORD_FILE`.
  - Chart version bumped to `0.4.34`.

- **Migration**
  - No action if you use env vars today.
  - Postgres: if IAM auth is off, set `POSTGRES_PASSWORD` or `POSTGRES_PASSWORD_FILE`. If missing, a warning is logged and a legacy default is used. If IAM auth is on, an unset password is fine.
  - OpenSearch: set `OPENSEARCH_ADMIN_USERNAME`/`OPENSEARCH_ADMIN_PASSWORD` or their `*_FILE` variants in production; otherwise a warning is logged and legacy defaults are used.
  - To adopt file-based secrets: set `secretsAsFiles.enabled: true` (optional `mountPath`) and ensure `auth.*.secretKeys` are defined.

<sup>Written for commit acfb47f7b344a8ae952f45de766098ef4a601271. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

