### PR TITLE
fix(slackbot): close code fences when splitting long messages

### DIFF
--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -1,3 +1,5 @@
+import re
+from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 
@@ -76,39 +78,69 @@ def get_feedback_reminder_blocks(thread_link: str, include_followup: bool) -> Bl
     return SectionBlock(text=text)
 
 
-def _find_unclosed_fence(text: str) -> tuple[bool, int, str]:
-    """Scan *text* line-by-line to determine code-fence state.
+@dataclass
+class CodeSnippet:
+    """A code block extracted from the answer to be uploaded as a Slack file."""
 
-    Returns (is_open, fence_line_start, lang) where:
-      - *is_open* is True when the text ends inside an unclosed code fence
-      - *fence_line_start* is the char offset of the opening fence line
-        (only meaningful when *is_open* is True)
-      - *lang* is the language specifier on the opening fence (e.g. "python")
+    code: str
+    language: str
+    filename: str
+
+
+# Matches fenced code blocks: ```lang\n...\n```
+_CODE_FENCE_RE = re.compile(
+    r"^```(\w*)\n(.*?)^```",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _extract_code_snippets(
+    text: str, limit: int = 3000
+) -> tuple[str, list[CodeSnippet]]:
+    """Extract code blocks that would push the text over *limit*.
+
+    Returns (cleaned_text, snippets) where *cleaned_text* has large code
+    blocks replaced with a placeholder and *snippets* contains the extracted
+    code to be uploaded as Slack file snippets.
     """
-    in_fence = False
-    fence_start = 0
-    lang = ""
-    offset = 0
-    for line in text.splitlines(True):  # keep line endings
-        # Slack only treats ``` as a fence when it starts at column 0.
-        # Indented backticks (e.g. inside a heredoc) are content, not fences.
-        if line.startswith("```"):
-            if not in_fence:
-                in_fence = True
-                fence_start = offset
-                lang = line[3:].strip()
-            else:
-                in_fence = False
-                lang = ""
-        offset += len(line)
-    return in_fence, fence_start, lang
+    if len(text) <= limit:
+        return text, []
+
+    snippets: list[CodeSnippet] = []
+    counter = 0
+
+    def _replace_if_needed(match: re.Match[str]) -> str:
+        nonlocal counter
+        lang = match.group(1) or ""
+        code = match.group(2)
+        full_block = match.group(0)
+
+        # Only extract if removing this block would help us stay under limit
+        text_without = text[: match.start()] + text[match.end() :]
+        if len(text_without) <= limit or len(full_block) > limit // 2:
+            counter += 1
+            ext = lang if lang else "txt"
+            snippets.append(
+                CodeSnippet(
+                    code=code.strip(),
+                    language=lang or "text",
+                    filename=f"code_{counter}.{ext}",
+                )
+            )
+            return ""
+        return full_block
+
+    cleaned = _CODE_FENCE_RE.sub(_replace_if_needed, text)
+    # Clean up any double blank lines left by extraction
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned, snippets
 
 
 def _split_text(text: str, limit: int = 3000) -> list[str]:
     if len(text) <= limit:
         return [text]
 
-    chunks: list[str] = []
+    chunks = []
     while text:
         if len(text) <= limit:
             chunks.append(text)
@@ -120,37 +152,8 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
             split_at = limit
 
         chunk = text[:split_at]
-
-        # Check whether the chunk ends inside an unclosed code fence.
-        is_open, fence_start, lang = _find_unclosed_fence(chunk)
-        if is_open:
-            # Tier 1: try to back up to before the opening fence so the
-            # entire code block stays in the next chunk.
-            split_before = text.rfind("\n", 0, fence_start)
-            if split_before > 0 and text[:split_before].strip():
-                chunk = text[:split_before]
-                remainder = text[split_before:]
-                # Strip only the leading newline to preserve blank lines
-                # and formatting before the code fence.
-                if remainder and remainder[0] == "\n":
-                    remainder = remainder[1:]
-                text = remainder
-            else:
-                # Tier 2: the code block itself exceeds the limit — split
-                # inside it. Close the fence here, reopen in the next.
-                chunk += "\n```"
-                remainder = text[split_at:]
-                # Strip only the single boundary character (space/newline)
-                # to avoid eating meaningful indentation inside code.
-                if remainder and remainder[0] in " \n":
-                    remainder = remainder[1:]
-                text = f"```{lang}\n" + remainder
-        else:
-            # No unclosed fence — plain prose split. Leading whitespace
-            # is cosmetic in Slack mrkdwn, so lstrip() is safe here.
-            text = text[split_at:].lstrip()
-
         chunks.append(chunk)
+        text = text[split_at:].lstrip()  # Remove leading spaces from the next chunk
 
     return chunks
 
@@ -474,7 +477,7 @@ def _build_citations_blocks(
 
 def _build_main_response_blocks(
     answer: ChatBasicResponse,
-) -> list[Block]:
+) -> tuple[list[Block], list[CodeSnippet]]:
     # TODO: add back in later when auto-filtering is implemented
     # if (
     #     retrieval_info.applied_time_cutoff
@@ -505,9 +508,13 @@ def _build_main_response_blocks(
     # replaces markdown links with slack format links
     formatted_answer = format_slack_message(answer.answer)
     answer_processed = decode_escapes(remove_slack_text_interactions(formatted_answer))
-    answer_blocks = [SectionBlock(text=text) for text in _split_text(answer_processed)]
 
-    return cast(list[Block], answer_blocks)
+    # Extract large code blocks as snippets to upload separately,
+    # avoiding broken code fences when splitting across SectionBlocks.
+    cleaned_text, code_snippets = _extract_code_snippets(answer_processed)
+    answer_blocks = [SectionBlock(text=text) for text in _split_text(cleaned_text)]
+
+    return cast(list[Block], answer_blocks), code_snippets
 
 
 def _build_continue_in_web_ui_block(
@@ -588,10 +595,13 @@ def build_slack_response_blocks(
     skip_ai_feedback: bool = False,
     offer_ephemeral_publication: bool = False,
     skip_restated_question: bool = False,
-) -> list[Block]:
+) -> tuple[list[Block], list[CodeSnippet]]:
     """
     This function is a top level function that builds all the blocks for the Slack response.
     It also handles combining all the blocks together.
+
+    Returns (blocks, code_snippets) where code_snippets should be uploaded
+    as Slack file snippets in the same thread.
     """
     # If called with the OnyxBot slash command, the question is lost so we have to reshow it
     if not skip_restated_question:
@@ -601,7 +611,7 @@ def build_slack_response_blocks(
     else:
         restate_question_block = []
 
-    answer_blocks = _build_main_response_blocks(answer)
+    answer_blocks, code_snippets = _build_main_response_blocks(answer)
 
     web_follow_up_block = []
     if channel_conf and channel_conf.get("show_continue_in_web_ui"):
@@ -667,4 +677,4 @@ def build_slack_response_blocks(
         + follow_up_block
     )
 
-    return all_blocks
+    return all_blocks, code_snippets

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -128,7 +128,12 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
             split_before = text.rfind("\n", 0, fence_start)
             if split_before > 0 and text[:split_before].strip():
                 chunk = text[:split_before]
-                text = text[split_before:].lstrip()
+                remainder = text[split_before:]
+                # Strip only the leading newline to preserve blank lines
+                # and formatting before the code fence.
+                if remainder and remainder[0] == "\n":
+                    remainder = remainder[1:]
+                text = remainder
             else:
                 # Tier 2: the code block itself exceeds the limit — split
                 # inside it. Close the fence here, reopen in the next.

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -92,8 +92,27 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
             split_at = limit
 
         chunk = text[:split_at]
+
+        # If splitting inside an unclosed code fence, try to back up and
+        # split before the opening ``` so the code block stays in one piece.
+        open_fences = chunk.count("```")
+        if open_fences % 2 == 1:
+            last_fence = chunk.rfind("```")
+            # Find a newline before the fence to get a clean break
+            split_before = text.rfind("\n", 0, last_fence)
+            if split_before > 0:
+                # Back up to before the code block
+                chunk = text[:split_before]
+                text = text[split_before:].lstrip()
+            else:
+                # Code block itself exceeds the limit — no choice but to
+                # split inside it. Close the fence here, reopen in the next.
+                chunk += "\n```"
+                text = "```\n" + text[split_at:].lstrip()
+        else:
+            text = text[split_at:].lstrip()
+
         chunks.append(chunk)
-        text = text[split_at:].lstrip()  # Remove leading spaces from the next chunk
 
     return chunks
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -48,6 +49,8 @@ from onyx.onyxbot.slack.utils import remove_slack_text_interactions
 from onyx.onyxbot.slack.utils import translate_vespa_highlight_to_slack
 from onyx.utils.text_processing import decode_escapes
 
+logger = logging.getLogger(__name__)
+
 _MAX_BLURB_LEN = 45
 
 
@@ -87,15 +90,21 @@ class CodeSnippet:
     filename: str
 
 
+_SECTION_BLOCK_LIMIT = 3000
+
 # Matches fenced code blocks: ```lang\n...\n```
+# The opening fence must start at the beginning of a line (^), may have an
+# optional language specifier (\w*), followed by a newline. The closing fence
+# is ``` at the beginning of a line. We also handle an optional trailing
+# newline on the closing fence line to be robust against different formatting.
 _CODE_FENCE_RE = re.compile(
-    r"^```(\w*)\n(.*?)^```",
+    r"^```(\w*)\n(.*?)^```\s*$",
     re.MULTILINE | re.DOTALL,
 )
 
 
 def _extract_code_snippets(
-    text: str, limit: int = 3000
+    text: str, limit: int = _SECTION_BLOCK_LIMIT
 ) -> tuple[str, list[CodeSnippet]]:
     """Extract code blocks that would push the text over *limit*.
 
@@ -106,8 +115,10 @@ def _extract_code_snippets(
     Uses a two-pass approach: first collect all matches, then decide which
     to extract based on cumulative removal so each decision accounts for
     previously extracted blocks.
+
+    Pass *limit=0* to force-extract ALL code blocks unconditionally.
     """
-    if len(text) <= limit:
+    if limit > 0 and len(text) <= limit:
         return text, []
 
     # Pass 1: collect all code-fence matches
@@ -117,17 +128,22 @@ def _extract_code_snippets(
 
     # Pass 2: decide which blocks to extract, accounting for cumulative removal.
     # Only extract if the text is still over the limit OR the block is very large.
+    # With limit=0, extract everything unconditionally.
     extract_indices: set[int] = set()
     removed_chars = 0
     for i, match in enumerate(matches):
         full_block = match.group(0)
-        current_len = len(text) - removed_chars
-        if current_len > limit and current_len - len(full_block) <= limit:
+        if limit == 0:
             extract_indices.add(i)
             removed_chars += len(full_block)
-        elif len(full_block) > limit // 2:
-            extract_indices.add(i)
-            removed_chars += len(full_block)
+        else:
+            current_len = len(text) - removed_chars
+            if current_len > limit and current_len - len(full_block) <= limit:
+                extract_indices.add(i)
+                removed_chars += len(full_block)
+            elif len(full_block) > limit // 2:
+                extract_indices.add(i)
+                removed_chars += len(full_block)
 
     if not extract_indices:
         return text, []
@@ -534,7 +550,39 @@ def _build_main_response_blocks(
     # Extract large code blocks as snippets to upload separately,
     # avoiding broken code fences when splitting across SectionBlocks.
     cleaned_text, code_snippets = _extract_code_snippets(answer_processed)
-    answer_blocks = [SectionBlock(text=text) for text in _split_text(cleaned_text)]
+    logger.info(
+        "Code extraction: input=%d chars, cleaned=%d chars, snippets=%d",
+        len(answer_processed),
+        len(cleaned_text),
+        len(code_snippets),
+    )
+
+    if len(cleaned_text) <= _SECTION_BLOCK_LIMIT:
+        answer_blocks = [SectionBlock(text=cleaned_text)]
+    elif "```" not in cleaned_text:
+        # No code fences — safe to split at word boundaries.
+        answer_blocks = [
+            SectionBlock(text=text)
+            for text in _split_text(cleaned_text, limit=_SECTION_BLOCK_LIMIT)
+        ]
+    else:
+        # Text still has code fences after extraction and exceeds the
+        # SectionBlock limit. Splitting would break the fences, so fall
+        # back to uploading the entire remaining code as another snippet
+        # and keeping only the prose in the blocks.
+        logger.warning(
+            "Cleaned text still has code fences (%d chars); "
+            "force-extracting remaining code blocks",
+            len(cleaned_text),
+        )
+        remaining_cleaned, remaining_snippets = _extract_code_snippets(
+            cleaned_text, limit=0
+        )
+        code_snippets.extend(remaining_snippets)
+        answer_blocks = [
+            SectionBlock(text=text)
+            for text in _split_text(remaining_cleaned, limit=_SECTION_BLOCK_LIMIT)
+        ]
 
     return cast(list[Block], answer_blocks), code_snippets
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -90,12 +90,13 @@ def _find_unclosed_fence(text: str) -> tuple[bool, int, str]:
     lang = ""
     offset = 0
     for line in text.splitlines(True):  # keep line endings
-        stripped = line.lstrip()
-        if stripped.startswith("```"):
+        # Slack only treats ``` as a fence when it starts at column 0.
+        # Indented backticks (e.g. inside a heredoc) are content, not fences.
+        if line.startswith("```"):
             if not in_fence:
                 in_fence = True
                 fence_start = offset
-                lang = stripped[3:].strip()
+                lang = line[3:].strip()
             else:
                 in_fence = False
                 lang = ""
@@ -145,6 +146,8 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
                     remainder = remainder[1:]
                 text = f"```{lang}\n" + remainder
         else:
+            # No unclosed fence — plain prose split. Leading whitespace
+            # is cosmetic in Slack mrkdwn, so lstrip() is safe here.
             text = text[split_at:].lstrip()
 
         chunks.append(chunk)

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -76,11 +76,38 @@ def get_feedback_reminder_blocks(thread_link: str, include_followup: bool) -> Bl
     return SectionBlock(text=text)
 
 
+def _find_unclosed_fence(text: str) -> tuple[bool, int, str]:
+    """Scan *text* line-by-line to determine code-fence state.
+
+    Returns (is_open, fence_line_start, lang) where:
+      - *is_open* is True when the text ends inside an unclosed code fence
+      - *fence_line_start* is the char offset of the opening fence line
+        (only meaningful when *is_open* is True)
+      - *lang* is the language specifier on the opening fence (e.g. "python")
+    """
+    in_fence = False
+    fence_start = 0
+    lang = ""
+    offset = 0
+    for line in text.splitlines(True):  # keep line endings
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            if not in_fence:
+                in_fence = True
+                fence_start = offset
+                lang = stripped[3:].strip()
+            else:
+                in_fence = False
+                lang = ""
+        offset += len(line)
+    return in_fence, fence_start, lang
+
+
 def _split_text(text: str, limit: int = 3000) -> list[str]:
     if len(text) <= limit:
         return [text]
 
-    chunks = []
+    chunks: list[str] = []
     while text:
         if len(text) <= limit:
             chunks.append(text)
@@ -93,22 +120,25 @@ def _split_text(text: str, limit: int = 3000) -> list[str]:
 
         chunk = text[:split_at]
 
-        # If splitting inside an unclosed code fence, try to back up and
-        # split before the opening ``` so the code block stays in one piece.
-        open_fences = chunk.count("```")
-        if open_fences % 2 == 1:
-            last_fence = chunk.rfind("```")
-            # Find a newline before the fence to get a clean break
-            split_before = text.rfind("\n", 0, last_fence)
-            if split_before > 0:
-                # Back up to before the code block
+        # Check whether the chunk ends inside an unclosed code fence.
+        is_open, fence_start, lang = _find_unclosed_fence(chunk)
+        if is_open:
+            # Tier 1: try to back up to before the opening fence so the
+            # entire code block stays in the next chunk.
+            split_before = text.rfind("\n", 0, fence_start)
+            if split_before > 0 and text[:split_before].strip():
                 chunk = text[:split_before]
                 text = text[split_before:].lstrip()
             else:
-                # Code block itself exceeds the limit — no choice but to
-                # split inside it. Close the fence here, reopen in the next.
+                # Tier 2: the code block itself exceeds the limit — split
+                # inside it. Close the fence here, reopen in the next.
                 chunk += "\n```"
-                text = "```\n" + text[split_at:].lstrip()
+                remainder = text[split_at:]
+                # Strip only the single boundary character (space/newline)
+                # to avoid eating meaningful indentation inside code.
+                if remainder and remainder[0] in " \n":
+                    remainder = remainder[1:]
+                text = f"```{lang}\n" + remainder
         else:
             text = text[split_at:].lstrip()
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -115,13 +115,17 @@ def _extract_code_snippets(
     if not matches:
         return text, []
 
-    # Pass 2: decide which blocks to extract, accounting for cumulative removal
+    # Pass 2: decide which blocks to extract, accounting for cumulative removal.
+    # Only extract if the text is still over the limit OR the block is very large.
     extract_indices: set[int] = set()
     removed_chars = 0
     for i, match in enumerate(matches):
         full_block = match.group(0)
-        text_len_without = len(text) - removed_chars - len(full_block)
-        if text_len_without <= limit or len(full_block) > limit // 2:
+        current_len = len(text) - removed_chars
+        if current_len > limit and current_len - len(full_block) <= limit:
+            extract_indices.add(i)
+            removed_chars += len(full_block)
+        elif len(full_block) > limit // 2:
             extract_indices.add(i)
             removed_chars += len(full_block)
 

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -102,36 +102,54 @@ def _extract_code_snippets(
     Returns (cleaned_text, snippets) where *cleaned_text* has large code
     blocks replaced with a placeholder and *snippets* contains the extracted
     code to be uploaded as Slack file snippets.
+
+    Uses a two-pass approach: first collect all matches, then decide which
+    to extract based on cumulative removal so each decision accounts for
+    previously extracted blocks.
     """
     if len(text) <= limit:
         return text, []
 
-    snippets: list[CodeSnippet] = []
-    counter = 0
+    # Pass 1: collect all code-fence matches
+    matches = list(_CODE_FENCE_RE.finditer(text))
+    if not matches:
+        return text, []
 
-    def _replace_if_needed(match: re.Match[str]) -> str:
-        nonlocal counter
+    # Pass 2: decide which blocks to extract, accounting for cumulative removal
+    extract_indices: set[int] = set()
+    removed_chars = 0
+    for i, match in enumerate(matches):
+        full_block = match.group(0)
+        text_len_without = len(text) - removed_chars - len(full_block)
+        if text_len_without <= limit or len(full_block) > limit // 2:
+            extract_indices.add(i)
+            removed_chars += len(full_block)
+
+    if not extract_indices:
+        return text, []
+
+    # Build cleaned text and snippets by processing matches in reverse
+    # so character offsets remain valid.
+    snippets: list[CodeSnippet] = []
+    cleaned = text
+    for i in sorted(extract_indices, reverse=True):
+        match = matches[i]
         lang = match.group(1) or ""
         code = match.group(2)
-        full_block = match.group(0)
-
-        # Only extract if removing this block would help us stay under limit
-        text_without = text[: match.start()] + text[match.end() :]
-        if len(text_without) <= limit or len(full_block) > limit // 2:
-            counter += 1
-            ext = lang if lang else "txt"
-            snippets.append(
-                CodeSnippet(
-                    code=code.strip(),
-                    language=lang or "text",
-                    filename=f"code_{counter}.{ext}",
-                )
+        ext = lang if lang else "txt"
+        snippets.append(
+            CodeSnippet(
+                code=code.strip(),
+                language=lang or "text",
+                filename=f"code_{len(extract_indices) - len(snippets)}.{ext}",
             )
-            return ""
-        return full_block
+        )
+        cleaned = cleaned[: match.start()] + cleaned[match.end() :]
 
-    cleaned = _CODE_FENCE_RE.sub(_replace_if_needed, text)
-    # Clean up any double blank lines left by extraction
+    # Snippets were appended in reverse order — flip to match document order
+    snippets.reverse()
+
+    # Clean up any triple+ blank lines left by extraction
     cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
     return cleaned, snippets
 

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -282,7 +282,7 @@ def handle_publish_ephemeral_message_button(
             logger.error(f"Failed to send webhook: {e}")
 
         # remove handling of empheremal block and add AI feedback.
-        all_blocks = build_slack_response_blocks(
+        all_blocks, _ = build_slack_response_blocks(
             answer=onyx_bot_answer,
             message_info=slack_message_info,
             channel_conf=channel_conf,
@@ -311,7 +311,7 @@ def handle_publish_ephemeral_message_button(
     elif action_id == KEEP_TO_YOURSELF_ACTION_ID:
         # Keep as ephemeral message in channel or thread, but remove the publish button and add feedback button
 
-        changed_blocks = build_slack_response_blocks(
+        changed_blocks, _ = build_slack_response_blocks(
             answer=onyx_bot_answer,
             message_info=slack_message_info,
             channel_conf=channel_conf,

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -163,6 +163,8 @@ def _upload_code_snippets(
     thread_ts: str,
     snippets: list[CodeSnippet],
     logger: OnyxLoggingAdapter,
+    receiver_ids: list[str] | None = None,
+    send_as_ephemeral: bool | None = None,
 ) -> None:
     """Upload extracted code blocks as Slack file snippets in the thread."""
     for snippet in snippets:
@@ -180,12 +182,15 @@ def _upload_code_snippets(
                 f"Failed to upload code snippet {snippet.filename}, "
                 "falling back to inline code block"
             )
-            # Fall back to posting as a regular message with code fences
+            # Fall back to posting as a regular message with code fences,
+            # preserving the same visibility as the primary response.
             respond_in_thread_or_channel(
                 client=client,
                 channel=channel,
+                receiver_ids=receiver_ids,
                 text=f"```{snippet.language}\n{snippet.code}\n```",
                 thread_ts=thread_ts,
+                send_as_ephemeral=send_as_ephemeral,
             )
 
 
@@ -471,13 +476,16 @@ def handle_regular_answer(
 
         # Upload extracted code blocks as Slack file snippets so they
         # render as collapsible, syntax-highlighted blocks in the thread.
-        if code_snippets and target_thread_ts:
+        snippet_thread_ts = target_thread_ts or message_ts_to_respond_to
+        if code_snippets and snippet_thread_ts:
             _upload_code_snippets(
                 client=client,
                 channel=channel,
-                thread_ts=target_thread_ts,
+                thread_ts=snippet_thread_ts,
                 snippets=code_snippets,
                 logger=logger,
+                receiver_ids=target_receiver_ids,
+                send_as_ephemeral=send_as_ephemeral,
             )
 
         # For DM (ephemeral message), we need to create a thread via a normal message so the user can see

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -25,6 +25,7 @@ from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
 from onyx.db.users import get_user_by_email
 from onyx.onyxbot.slack.blocks import build_slack_response_blocks
+from onyx.onyxbot.slack.blocks import CodeSnippet
 from onyx.onyxbot.slack.constants import SLACK_CHANNEL_REF_PATTERN
 from onyx.onyxbot.slack.handlers.utils import send_team_member_message
 from onyx.onyxbot.slack.models import SlackMessageInfo
@@ -132,6 +133,37 @@ def build_slack_context_str(
         message_strs.append(message_text)
 
     return slack_context_str + "\n\n".join(message_strs)
+
+
+def _upload_code_snippets(
+    client: WebClient,
+    channel: str,
+    thread_ts: str,
+    snippets: list[CodeSnippet],
+    logger: OnyxLoggingAdapter,
+) -> None:
+    """Upload extracted code blocks as Slack file snippets in the thread."""
+    for snippet in snippets:
+        try:
+            client.files_upload_v2(
+                channel=channel,
+                thread_ts=thread_ts,
+                content=snippet.code,
+                filename=snippet.filename,
+                snippet_type=snippet.language,
+            )
+        except Exception:
+            logger.warning(
+                f"Failed to upload code snippet {snippet.filename}, "
+                "falling back to inline code block"
+            )
+            # Fall back to posting as a regular message with code fences
+            respond_in_thread_or_channel(
+                client=client,
+                channel=channel,
+                text=f"```{snippet.language}\n{snippet.code}\n```",
+                thread_ts=thread_ts,
+            )
 
 
 def handle_regular_answer(
@@ -387,7 +419,7 @@ def handle_regular_answer(
         offer_ephemeral_publication = False
         skip_ai_feedback = False
 
-    all_blocks = build_slack_response_blocks(
+    all_blocks, code_snippets = build_slack_response_blocks(
         message_info=message_info,
         answer=answer,
         channel_conf=channel_conf,
@@ -413,6 +445,17 @@ def handle_regular_answer(
             unfurl=False,
             send_as_ephemeral=send_as_ephemeral,
         )
+
+        # Upload extracted code blocks as Slack file snippets so they
+        # render as collapsible, syntax-highlighted blocks in the thread.
+        if code_snippets and target_thread_ts:
+            _upload_code_snippets(
+                client=client,
+                channel=channel,
+                thread_ts=target_thread_ts,
+                snippets=code_snippets,
+                logger=logger,
+            )
 
         # For DM (ephemeral message), we need to create a thread via a normal message so the user can see
         # the ephemeral message. This also will give the user a notification which ephemeral message does not.

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -135,6 +135,28 @@ def build_slack_context_str(
     return slack_context_str + "\n\n".join(message_strs)
 
 
+# Normalize common LLM language aliases to Slack's expected snippet_type values.
+# Slack silently falls back to plain text for unrecognized types, so this map
+# only needs to cover the most common mismatches.
+_SNIPPET_TYPE_MAP: dict[str, str] = {
+    "py": "python",
+    "js": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "jsx": "javascript",
+    "sh": "shell",
+    "bash": "shell",
+    "zsh": "shell",
+    "yml": "yaml",
+    "rb": "ruby",
+    "rs": "rust",
+    "cs": "csharp",
+    "md": "markdown",
+    "txt": "text",
+    "text": "plain_text",
+}
+
+
 def _upload_code_snippets(
     client: WebClient,
     channel: str,
@@ -145,12 +167,13 @@ def _upload_code_snippets(
     """Upload extracted code blocks as Slack file snippets in the thread."""
     for snippet in snippets:
         try:
+            snippet_type = _SNIPPET_TYPE_MAP.get(snippet.language, snippet.language)
             client.files_upload_v2(
                 channel=channel,
                 thread_ts=thread_ts,
                 content=snippet.code,
                 filename=snippet.filename,
-                snippet_type=snippet.language,
+                snippet_type=snippet_type,
             )
         except Exception:
             logger.warning(

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -7,7 +7,7 @@ import timeago  # type: ignore
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import SavedSearchDoc
 from onyx.onyxbot.slack.blocks import _build_documents_blocks
-from onyx.onyxbot.slack.blocks import _find_unclosed_fence
+from onyx.onyxbot.slack.blocks import _extract_code_snippets
 from onyx.onyxbot.slack.blocks import _split_text
 
 
@@ -88,137 +88,76 @@ class TestSplitText:
         result = _split_text(text, limit=8)
         assert len(result) >= 2
 
-    def test_code_block_not_split_when_fits(self) -> None:
-        # Text fits within limit — exercises the early-return path,
-        # not the fence-aware splitting logic.
-        text = "before ```code here``` after"
-        result = _split_text(text, limit=100)
-        assert result == [text]
-
-    def test_code_block_split_backs_up_before_fence(self) -> None:
-        # Build text where the split point falls inside a code block,
-        # but the code block itself fits within the limit. The split
-        # should back up to before the opening ``` so the block stays intact.
-        before = "some intro text here " * 5 + "\n"  # ~105 chars
-        code_content = "x " * 20  # ~40 chars of code
-        text = f"{before}```\n{code_content}\n```\nafter"
-        # limit=120 means the initial split lands inside the code block
-        # but the code block (~50 chars) fits in the next chunk
-        result = _split_text(text, limit=120)
-
-        assert len(result) >= 2
-        # Every chunk must have balanced code fences
-        for chunk in result:
-            is_open, _, _ = _find_unclosed_fence(chunk)
-            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
-        # The code block should be fully contained in one chunk
-        code_chunks = [c for c in result if "```" in c]
-        assert len(code_chunks) == 1, "Code block should not be split across chunks"
-
     def test_no_code_fences_splits_normally(self) -> None:
         text = "word " * 100  # 500 chars
         result = _split_text(text, limit=100)
         assert len(result) >= 5
         for chunk in result:
-            fence_count = chunk.count("```")
-            assert fence_count == 0
-
-    def test_code_block_exceeding_limit_falls_back_to_close_reopen(self) -> None:
-        # When the code block itself is bigger than the limit, we can't
-        # avoid splitting inside it — verify fences are still balanced.
-        code_content = "x " * 100  # ~200 chars
-        text = f"```\n{code_content}\n```"
-        result = _split_text(text, limit=80)
-
-        assert len(result) >= 2
-        for chunk in result:
-            is_open, _, _ = _find_unclosed_fence(chunk)
-            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
-
-    def test_code_block_exceeding_limit_no_spaces(self) -> None:
-        # When code has no spaces, split_at is forced to limit.
-        # Fences should still be balanced.
-        code_content = "x" * 200
-        text = f"```\n{code_content}\n```"
-        result = _split_text(text, limit=80)
-
-        assert len(result) >= 2
-        for chunk in result:
-            is_open, _, _ = _find_unclosed_fence(chunk)
-            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
-
-    def test_all_content_preserved_after_split(self) -> None:
-        text = "intro paragraph and more text here\n```\nprint('hello')\n```\nconclusion here"
-        result = _split_text(text, limit=50)
-
-        # Key content should appear somewhere across the chunks
-        joined = " ".join(result)
-        assert "intro" in joined
-        assert "print('hello')" in joined
-        assert "conclusion" in joined
-
-    def test_language_specifier_preserved_on_reopen(self) -> None:
-        # When a ```python block exceeds the limit and must be split,
-        # the continuation chunk should reopen with ```python, not ```.
-        code_content = "x " * 100  # ~200 chars
-        text = f"```python\n{code_content}\n```"
-        result = _split_text(text, limit=80)
-
-        assert len(result) >= 2
-        for chunk in result[1:]:
-            stripped = chunk.lstrip()
-            if stripped.startswith("```"):
-                assert stripped.startswith(
-                    "```python"
-                ), f"Language specifier lost in continuation: {chunk[:40]}"
-
-    def test_inline_backticks_inside_code_block_ignored(self) -> None:
-        # Triple backticks appearing mid-line inside a code block should
-        # not be mistaken for fence boundaries.
-        before = "some text here " * 6 + "\n"  # ~90 chars
-        text = f"{before}```bash\necho '```'\necho done\n```\nafter"
-        result = _split_text(text, limit=110)
-
-        assert len(result) >= 2
-        for chunk in result:
-            is_open, _, _ = _find_unclosed_fence(chunk)
-            assert not is_open, f"Chunk has unclosed fence: {chunk[:80]}..."
+            assert "```" not in chunk
 
 
 # ---------------------------------------------------------------------------
-# _find_unclosed_fence tests
+# _extract_code_snippets tests
 # ---------------------------------------------------------------------------
 
 
-class TestFindUnclosedFence:
-    def test_no_fences(self) -> None:
-        is_open, _, _ = _find_unclosed_fence("just plain text")
-        assert not is_open
+class TestExtractCodeSnippets:
+    def test_short_text_no_extraction(self) -> None:
+        text = "short answer with ```python\nprint('hi')\n``` inline"
+        cleaned, snippets = _extract_code_snippets(text, limit=3000)
+        assert cleaned == text
+        assert snippets == []
 
-    def test_balanced_fences(self) -> None:
-        is_open, _, _ = _find_unclosed_fence("```\ncode\n```")
-        assert not is_open
+    def test_large_code_block_extracted(self) -> None:
+        code = "x = 1\n" * 200  # ~1200 chars of code
+        text = f"Here is the solution:\n```python\n{code}```\nHope that helps!"
+        cleaned, snippets = _extract_code_snippets(text, limit=200)
 
-    def test_unclosed_fence(self) -> None:
-        is_open, start, lang = _find_unclosed_fence("before\n```\ncode here")
-        assert is_open
-        assert start == len("before\n")
-        assert lang == ""
+        assert len(snippets) == 1
+        assert snippets[0].language == "python"
+        assert snippets[0].filename == "code_1.python"
+        assert "x = 1" in snippets[0].code
+        # Code block should be removed from cleaned text
+        assert "```" not in cleaned
+        assert "Here is the solution" in cleaned
+        assert "Hope that helps!" in cleaned
 
-    def test_unclosed_fence_with_lang(self) -> None:
-        is_open, _, lang = _find_unclosed_fence("intro\n```python\ncode")
-        assert is_open
-        assert lang == "python"
+    def test_multiple_code_blocks_only_large_ones_extracted(self) -> None:
+        small_code = "print('hi')"
+        large_code = "x = 1\n" * 300
+        text = (
+            f"First:\n```python\n{small_code}\n```\n"
+            f"Second:\n```javascript\n{large_code}\n```\n"
+            "Done!"
+        )
+        cleaned, snippets = _extract_code_snippets(text, limit=500)
 
-    def test_inline_backticks_not_counted(self) -> None:
-        # Backticks mid-line should not toggle fence state
-        text = "```bash\necho '```'\necho done\n```"
-        is_open, _, _ = _find_unclosed_fence(text)
-        assert not is_open
+        # The large block should be extracted
+        assert len(snippets) >= 1
+        langs = [s.language for s in snippets]
+        assert "javascript" in langs
 
-    def test_indented_backticks_not_counted_as_fence(self) -> None:
-        # Slack only treats ``` at column 0 as a fence delimiter.
-        # Indented backticks inside a code block are content, not fences.
-        text = "```bash\ncat <<'EOF'\n    ```\nEOF\n```"
-        is_open, _, _ = _find_unclosed_fence(text)
-        assert not is_open
+    def test_language_specifier_captured(self) -> None:
+        code = "fn main() {}\n" * 100
+        text = f"```rust\n{code}```"
+        _, snippets = _extract_code_snippets(text, limit=100)
+
+        assert len(snippets) == 1
+        assert snippets[0].language == "rust"
+        assert snippets[0].filename == "code_1.rust"
+
+    def test_no_language_defaults_to_text(self) -> None:
+        code = "some output\n" * 100
+        text = f"```\n{code}```"
+        _, snippets = _extract_code_snippets(text, limit=100)
+
+        assert len(snippets) == 1
+        assert snippets[0].language == "text"
+        assert snippets[0].filename == "code_1.txt"
+
+    def test_cleaned_text_has_no_triple_blank_lines(self) -> None:
+        code = "x = 1\n" * 200
+        text = f"Before\n\n```python\n{code}```\n\nAfter"
+        cleaned, _ = _extract_code_snippets(text, limit=100)
+
+        assert "\n\n\n" not in cleaned

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -7,6 +7,7 @@ import timeago  # type: ignore
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import SavedSearchDoc
 from onyx.onyxbot.slack.blocks import _build_documents_blocks
+from onyx.onyxbot.slack.blocks import _split_text
 
 
 def _make_saved_doc(updated_at: datetime | None) -> SavedSearchDoc:
@@ -69,3 +70,78 @@ def test_build_documents_blocks_formats_naive_timestamp(
     formatted_timestamp: datetime = captured["doc"]
     expected_timestamp: datetime = naive_timestamp.replace(tzinfo=pytz.utc)
     assert formatted_timestamp == expected_timestamp
+
+
+# ---------------------------------------------------------------------------
+# _split_text tests
+# ---------------------------------------------------------------------------
+
+
+class TestSplitText:
+    def test_short_text_returns_single_chunk(self) -> None:
+        result = _split_text("hello world", limit=100)
+        assert result == ["hello world"]
+
+    def test_splits_at_space_boundary(self) -> None:
+        text = "aaa bbb ccc ddd"
+        result = _split_text(text, limit=8)
+        assert len(result) >= 2
+
+    def test_code_block_not_split_when_fits(self) -> None:
+        text = "before ```code here``` after"
+        result = _split_text(text, limit=100)
+        assert result == [text]
+
+    def test_code_block_split_backs_up_before_fence(self) -> None:
+        # Build text where the split point falls inside a code block,
+        # but the code block itself fits within the limit. The split
+        # should back up to before the opening ``` so the block stays intact.
+        before = "some intro text here " * 5 + "\n"  # ~105 chars
+        code_content = "x " * 20  # ~40 chars of code
+        text = f"{before}```\n{code_content}\n```\nafter"
+        # limit=120 means the initial split lands inside the code block
+        # but the code block (~50 chars) fits in the next chunk
+        result = _split_text(text, limit=120)
+
+        assert len(result) >= 2
+        # Every chunk must have balanced code fences (0 or 2)
+        for chunk in result:
+            fence_count = chunk.count("```")
+            assert (
+                fence_count % 2 == 0
+            ), f"Unbalanced code fences in chunk: {chunk[:80]}..."
+        # The code block should be fully contained in one chunk
+        code_chunks = [c for c in result if "```" in c]
+        assert len(code_chunks) == 1, "Code block should not be split across chunks"
+
+    def test_no_code_fences_splits_normally(self) -> None:
+        text = "word " * 100  # 500 chars
+        result = _split_text(text, limit=100)
+        assert len(result) >= 5
+        for chunk in result:
+            fence_count = chunk.count("```")
+            assert fence_count == 0
+
+    def test_code_block_exceeding_limit_falls_back_to_close_reopen(self) -> None:
+        # When the code block itself is bigger than the limit, we can't
+        # avoid splitting inside it — verify fences are still balanced.
+        code_content = "x " * 100  # ~200 chars
+        text = f"```\n{code_content}\n```"
+        result = _split_text(text, limit=80)
+
+        assert len(result) >= 2
+        for chunk in result:
+            fence_count = chunk.count("```")
+            assert (
+                fence_count % 2 == 0
+            ), f"Unbalanced code fences in chunk: {chunk[:80]}..."
+
+    def test_all_content_preserved_after_split(self) -> None:
+        text = "intro paragraph and more text here\n```\nprint('hello')\n```\nconclusion here"
+        result = _split_text(text, limit=50)
+
+        # Key content should appear somewhere across the chunks
+        joined = " ".join(result)
+        assert "intro" in joined
+        assert "print('hello')" in joined
+        assert "conclusion" in joined

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -7,6 +7,7 @@ import timeago  # type: ignore
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import SavedSearchDoc
 from onyx.onyxbot.slack.blocks import _build_documents_blocks
+from onyx.onyxbot.slack.blocks import _find_unclosed_fence
 from onyx.onyxbot.slack.blocks import _split_text
 
 
@@ -145,3 +146,62 @@ class TestSplitText:
         assert "intro" in joined
         assert "print('hello')" in joined
         assert "conclusion" in joined
+
+    def test_language_specifier_preserved_on_reopen(self) -> None:
+        # When a ```python block exceeds the limit and must be split,
+        # the continuation chunk should reopen with ```python, not ```.
+        code_content = "x " * 100  # ~200 chars
+        text = f"```python\n{code_content}\n```"
+        result = _split_text(text, limit=80)
+
+        assert len(result) >= 2
+        for chunk in result[1:]:
+            stripped = chunk.lstrip()
+            if stripped.startswith("```"):
+                assert stripped.startswith(
+                    "```python"
+                ), f"Language specifier lost in continuation: {chunk[:40]}"
+
+    def test_inline_backticks_inside_code_block_ignored(self) -> None:
+        # Triple backticks appearing mid-line inside a code block should
+        # not be mistaken for fence boundaries.
+        before = "some text here " * 6 + "\n"  # ~90 chars
+        text = f"{before}```bash\necho '```'\necho done\n```\nafter"
+        result = _split_text(text, limit=110)
+
+        assert len(result) >= 2
+        for chunk in result:
+            is_open, _, _ = _find_unclosed_fence(chunk)
+            assert not is_open, f"Chunk has unclosed fence: {chunk[:80]}..."
+
+
+# ---------------------------------------------------------------------------
+# _find_unclosed_fence tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnclosedFence:
+    def test_no_fences(self) -> None:
+        is_open, _, _ = _find_unclosed_fence("just plain text")
+        assert not is_open
+
+    def test_balanced_fences(self) -> None:
+        is_open, _, _ = _find_unclosed_fence("```\ncode\n```")
+        assert not is_open
+
+    def test_unclosed_fence(self) -> None:
+        is_open, start, lang = _find_unclosed_fence("before\n```\ncode here")
+        assert is_open
+        assert start == len("before\n")
+        assert lang == ""
+
+    def test_unclosed_fence_with_lang(self) -> None:
+        is_open, _, lang = _find_unclosed_fence("intro\n```python\ncode")
+        assert is_open
+        assert lang == "python"
+
+    def test_inline_backticks_not_counted(self) -> None:
+        # Backticks mid-line should not toggle fence state
+        text = "```bash\necho '```'\necho done\n```"
+        is_open, _, _ = _find_unclosed_fence(text)
+        assert not is_open

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -89,6 +89,8 @@ class TestSplitText:
         assert len(result) >= 2
 
     def test_code_block_not_split_when_fits(self) -> None:
+        # Text fits within limit — exercises the early-return path,
+        # not the fence-aware splitting logic.
         text = "before ```code here``` after"
         result = _split_text(text, limit=100)
         assert result == [text]
@@ -125,6 +127,18 @@ class TestSplitText:
         # When the code block itself is bigger than the limit, we can't
         # avoid splitting inside it — verify fences are still balanced.
         code_content = "x " * 100  # ~200 chars
+        text = f"```\n{code_content}\n```"
+        result = _split_text(text, limit=80)
+
+        assert len(result) >= 2
+        for chunk in result:
+            is_open, _, _ = _find_unclosed_fence(chunk)
+            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
+
+    def test_code_block_exceeding_limit_no_spaces(self) -> None:
+        # When code has no spaces, split_at is forced to limit.
+        # Fences should still be balanced.
+        code_content = "x" * 200
         text = f"```\n{code_content}\n```"
         result = _split_text(text, limit=80)
 
@@ -199,5 +213,12 @@ class TestFindUnclosedFence:
     def test_inline_backticks_not_counted(self) -> None:
         # Backticks mid-line should not toggle fence state
         text = "```bash\necho '```'\necho done\n```"
+        is_open, _, _ = _find_unclosed_fence(text)
+        assert not is_open
+
+    def test_indented_backticks_not_counted_as_fence(self) -> None:
+        # Slack only treats ``` at column 0 as a fence delimiter.
+        # Indented backticks inside a code block are content, not fences.
+        text = "```bash\ncat <<'EOF'\n    ```\nEOF\n```"
         is_open, _, _ = _find_unclosed_fence(text)
         assert not is_open

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -165,18 +165,26 @@ class TestExtractCodeSnippets:
 
     def test_multiple_blocks_cumulative_removal(self) -> None:
         """When multiple code blocks exist, extraction decisions should
-        account for previously extracted blocks (two-pass logic)."""
-        block_a = "a = 1\n" * 60  # ~360 chars
-        block_b = "b = 2\n" * 60  # ~360 chars
-        # Total text is ~760 chars. With limit=400, removing block_a alone
-        # brings us to ~400 chars, so block_b should NOT be extracted.
-        text = f"Intro\n```python\n{block_a}```\nMiddle\n```python\n{block_b}```\nEnd"
-        cleaned, snippets = _extract_code_snippets(text, limit=400)
+        account for previously extracted blocks (two-pass logic).
+        Blocks must be smaller than limit//2 so the 'very large block'
+        override doesn't trigger — we're testing the cumulative logic only."""
+        # Each fenced block is ~103 chars (```python\n + 15*6 + ```)
+        block_a = "a = 1\n" * 15  # 90 chars of code
+        block_b = "b = 2\n" * 15  # 90 chars of code
+        prose = "x" * 200
+        # Total: ~200 + 103 + 103 + overhead ≈ 420 chars
+        # limit=300, limit//2=150. Each block (~103) < 150, so only
+        # the cumulative check applies. Removing block_a (~103 chars)
+        # brings us to ~317 > 300, so block_b should also be extracted.
+        # But with limit=350: removing block_a → ~317 ≤ 350, stop.
+        text = f"{prose}\n```python\n{block_a}```\n```python\n{block_b}```\nEnd"
+        cleaned, snippets = _extract_code_snippets(text, limit=350)
 
-        # At least one block extracted
-        assert len(snippets) >= 1
-        # Snippet filenames should be numbered sequentially from 1
+        # After extracting block_a the text is ≤ 350, so block_b stays.
+        assert len(snippets) == 1
         assert snippets[0].filename == "code_1.python"
+        # block_b should still be in the cleaned text
+        assert "b = 2" in cleaned
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -105,12 +105,10 @@ class TestSplitText:
         result = _split_text(text, limit=120)
 
         assert len(result) >= 2
-        # Every chunk must have balanced code fences (0 or 2)
+        # Every chunk must have balanced code fences
         for chunk in result:
-            fence_count = chunk.count("```")
-            assert (
-                fence_count % 2 == 0
-            ), f"Unbalanced code fences in chunk: {chunk[:80]}..."
+            is_open, _, _ = _find_unclosed_fence(chunk)
+            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
         # The code block should be fully contained in one chunk
         code_chunks = [c for c in result if "```" in c]
         assert len(code_chunks) == 1, "Code block should not be split across chunks"
@@ -132,10 +130,8 @@ class TestSplitText:
 
         assert len(result) >= 2
         for chunk in result:
-            fence_count = chunk.count("```")
-            assert (
-                fence_count % 2 == 0
-            ), f"Unbalanced code fences in chunk: {chunk[:80]}..."
+            is_open, _, _ = _find_unclosed_fence(chunk)
+            assert not is_open, f"Unclosed fence in chunk: {chunk[:80]}..."
 
     def test_all_content_preserved_after_split(self) -> None:
         text = "intro paragraph and more text here\n```\nprint('hello')\n```\nconclusion here"

--- a/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_blocks.py
@@ -9,6 +9,7 @@ from onyx.context.search.models import SavedSearchDoc
 from onyx.onyxbot.slack.blocks import _build_documents_blocks
 from onyx.onyxbot.slack.blocks import _extract_code_snippets
 from onyx.onyxbot.slack.blocks import _split_text
+from onyx.onyxbot.slack.handlers.handle_regular_answer import _SNIPPET_TYPE_MAP
 
 
 def _make_saved_doc(updated_at: datetime | None) -> SavedSearchDoc:
@@ -161,3 +162,50 @@ class TestExtractCodeSnippets:
         cleaned, _ = _extract_code_snippets(text, limit=100)
 
         assert "\n\n\n" not in cleaned
+
+    def test_multiple_blocks_cumulative_removal(self) -> None:
+        """When multiple code blocks exist, extraction decisions should
+        account for previously extracted blocks (two-pass logic)."""
+        block_a = "a = 1\n" * 60  # ~360 chars
+        block_b = "b = 2\n" * 60  # ~360 chars
+        # Total text is ~760 chars. With limit=400, removing block_a alone
+        # brings us to ~400 chars, so block_b should NOT be extracted.
+        text = f"Intro\n```python\n{block_a}```\nMiddle\n```python\n{block_b}```\nEnd"
+        cleaned, snippets = _extract_code_snippets(text, limit=400)
+
+        # At least one block extracted
+        assert len(snippets) >= 1
+        # Snippet filenames should be numbered sequentially from 1
+        assert snippets[0].filename == "code_1.python"
+
+
+# ---------------------------------------------------------------------------
+# _SNIPPET_TYPE_MAP tests
+# ---------------------------------------------------------------------------
+
+
+class TestSnippetTypeMap:
+    @pytest.mark.parametrize(
+        "alias,expected",
+        [
+            ("py", "python"),
+            ("js", "javascript"),
+            ("ts", "typescript"),
+            ("tsx", "typescript"),
+            ("jsx", "javascript"),
+            ("sh", "shell"),
+            ("bash", "shell"),
+            ("yml", "yaml"),
+            ("rb", "ruby"),
+            ("rs", "rust"),
+            ("cs", "csharp"),
+            ("md", "markdown"),
+            ("text", "plain_text"),
+        ],
+    )
+    def test_common_aliases_normalized(self, alias: str, expected: str) -> None:
+        assert _SNIPPET_TYPE_MAP[alias] == expected
+
+    def test_unknown_language_passes_through(self) -> None:
+        unknown = "haskell"
+        assert _SNIPPET_TYPE_MAP.get(unknown, unknown) == "haskell"


### PR DESCRIPTION
## Description

When a Slack bot response exceeds 3000 chars, `_split_text` splits it into multiple `SectionBlock`s. If the split point lands inside a code fence, the opening ``` ends up in one block and the closing ``` in the next, causing Slack to render everything after the cut as raw code.

This adds code-fence-aware splitting to `_split_text`:
- **Tier 1**: If splitting inside an unclosed code fence, back up to before the opening ``` so the entire code block stays in one chunk
- **Tier 2 (fallback)**: If the code block itself exceeds the 3000 char limit and can't fit in a single chunk, close the fence at the split point and reopen it in the next chunk

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check