### PR TITLE
feat(gitlab): add Include Code Files checkbox to connector UI

### DIFF
--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -320,6 +320,14 @@ export const connectorConfigs: Record<
         description: "Index issues from repositories",
         default: true,
       },
+      {
+        type: "checkbox",
+        query: "Include code files?",
+        label: "Include Code Files",
+        name: "include_code_files",
+        description: "Index repository files (code, documentation, configs)",
+        default: false,
+      },
     ],
   },
   bitbucket: {
@@ -1896,6 +1904,7 @@ export interface GitlabConfig {
   project_name: string;
   include_mrs: boolean;
   include_issues: boolean;
+  include_code_files: boolean;
 }
 
 export interface BitbucketConfig {


### PR DESCRIPTION
## Summary

Closes #9305

The GitLab backend connector already supports the `include_code_files` parameter
([connector.py](https://github.com/onyx-dot-app/onyx/blob/main/backend/onyx/connectors/gitlab/connector.py#L42)), which enables indexing of
repository files (code, documentation, configs) via tree traversal. However, the frontend UI has no corresponding checkbox, so users can only enable
this feature through the API.

This PR adds:
- **Checkbox** "Include Code Files" to the GitLab connector's Advanced Options section (default: `false`, matching the backend default)
- **TypeScript interface** update — `include_code_files: boolean` added to `GitlabConfig`

## Changes

- `web/src/lib/connectors/connectors.tsx` — 2 additions:
  1. New checkbox entry in `advanced_values` for the `gitlab` connector
  2. New field in `GitlabConfig` interface

## Test plan

- [x] Create a new GitLab connector in Admin UI — verify "Include Code Files" checkbox appears under Advanced Options
- [x] Checkbox defaults to unchecked (off)
- [x] Create connector with checkbox enabled — verify `include_code_files: true` is sent in the API payload
- [ ] Verify indexed documents include repository files when enabled
- [ ] Verify existing connectors without the field continue to work (backend defaults to `false`)