### PR TITLE
fix(favicon): add cache headers to favicon fetching

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -159,7 +159,7 @@ def fetch_logo_helper(request: Request) -> Response:
             detail="No logo file found",
         )
 
-    etag_value = f'"{hashlib.md5(onyx_file.data).hexdigest()}"'
+    etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
     if request.headers.get("if-none-match") == etag_value:
         return Response(
             status_code=304,
@@ -171,7 +171,7 @@ def fetch_logo_helper(request: Request) -> Response:
         media_type=onyx_file.mime_type,
         headers={
             "ETag": etag_value,
-            "Cache-Control": "public, max-age=3600, must-revalidate",
+            "Cache-Control": "private, max-age=3600, must-revalidate",
         },
     )
 
@@ -183,12 +183,13 @@ def fetch_logotype_helper(request: Request) -> Response:
         if not onyx_file:
             raise ValueError("get_onyx_file returned None!")
     except Exception:
+        logger.exception("Failed to fetch logotype file")
         raise HTTPException(
             status_code=404,
             detail="No logotype file found",
         )
 
-    etag_value = f'"{hashlib.md5(onyx_file.data).hexdigest()}"'
+    etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
     if request.headers.get("if-none-match") == etag_value:
         return Response(
             status_code=304,
@@ -200,7 +201,7 @@ def fetch_logotype_helper(request: Request) -> Response:
         media_type=onyx_file.mime_type,
         headers={
             "ETag": etag_value,
-            "Cache-Control": "public, max-age=3600, must-revalidate",
+            "Cache-Control": "private, max-age=3600, must-revalidate",
         },
     )
 

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -162,7 +162,11 @@ def _fetch_image_helper(request: Request, filename: str, label: str) -> Response
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
     if_none_match = request.headers.get("if-none-match", "")
     # Strip W/ prefix for weak comparison per RFC 9110 §13.1.2
-    client_etags = [tag.strip().removeprefix("W/") for tag in if_none_match.split(",")]
+    client_etags = [
+        tag.strip().removeprefix("W/")
+        for tag in if_none_match.split(",")
+        if tag.strip()
+    ]
     normalized_etag = etag_value.removeprefix("W/")
     cache_headers = {
         "ETag": etag_value,

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -6,6 +7,7 @@ import httpx
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi import Response
 from fastapi import status
 from fastapi import UploadFile
@@ -144,23 +146,37 @@ def put_logo(
     upload_logo(file=file, is_logotype=is_logotype)
 
 
-def fetch_logo_helper(db_session: Session) -> Response:  # noqa: ARG001
+def fetch_logo_helper(request: Request) -> Response:
     try:
         file_store = get_default_file_store()
         onyx_file = file_store.get_file_with_mime_type(get_logo_filename())
         if not onyx_file:
             raise ValueError("get_onyx_file returned None!")
     except Exception:
-        logger.exception("Faield to fetch logo file")
+        logger.exception("Failed to fetch logo file")
         raise HTTPException(
             status_code=404,
             detail="No logo file found",
         )
-    else:
-        return Response(content=onyx_file.data, media_type=onyx_file.mime_type)
+
+    etag_value = f'"{hashlib.md5(onyx_file.data).hexdigest()}"'
+    if request.headers.get("if-none-match") == etag_value:
+        return Response(
+            status_code=304,
+            headers={"ETag": etag_value},
+        )
+
+    return Response(
+        content=onyx_file.data,
+        media_type=onyx_file.mime_type,
+        headers={
+            "ETag": etag_value,
+            "Cache-Control": "public, max-age=3600, must-revalidate",
+        },
+    )
 
 
-def fetch_logotype_helper(db_session: Session) -> Response:  # noqa: ARG001
+def fetch_logotype_helper(request: Request) -> Response:
     try:
         file_store = get_default_file_store()
         onyx_file = file_store.get_file_with_mime_type(get_logotype_filename())
@@ -171,23 +187,38 @@ def fetch_logotype_helper(db_session: Session) -> Response:  # noqa: ARG001
             status_code=404,
             detail="No logotype file found",
         )
-    else:
-        return Response(content=onyx_file.data, media_type=onyx_file.mime_type)
+
+    etag_value = f'"{hashlib.md5(onyx_file.data).hexdigest()}"'
+    if request.headers.get("if-none-match") == etag_value:
+        return Response(
+            status_code=304,
+            headers={"ETag": etag_value},
+        )
+
+    return Response(
+        content=onyx_file.data,
+        media_type=onyx_file.mime_type,
+        headers={
+            "ETag": etag_value,
+            "Cache-Control": "public, max-age=3600, must-revalidate",
+        },
+    )
 
 
 @basic_router.get("/logotype")
-def fetch_logotype(db_session: Session = Depends(get_session)) -> Response:
-    return fetch_logotype_helper(db_session)
+def fetch_logotype(request: Request) -> Response:
+    return fetch_logotype_helper(request)
 
 
 @basic_router.get("/logo")
 def fetch_logo(
-    is_logotype: bool = False, db_session: Session = Depends(get_session)
+    request: Request,
+    is_logotype: bool = False,
 ) -> Response:
     if is_logotype:
-        return fetch_logotype_helper(db_session)
+        return fetch_logotype_helper(request)
 
-    return fetch_logo_helper(db_session)
+    return fetch_logo_helper(request)
 
 
 @admin_router.put("/custom-analytics-script")

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -152,10 +152,11 @@ def _fetch_image_helper(request: Request, filename: str, label: str) -> Response
     try:
         file_store = get_default_file_store()
         onyx_file = file_store.get_file_with_mime_type(filename)
-        if not onyx_file:
-            raise ValueError(f"get_onyx_file returned None for {label}!")
     except Exception:
         logger.exception("Failed to fetch %s file", label)
+        raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, f"Failed to fetch {label} file")
+
+    if not onyx_file:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, f"No {label} file found")
 
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -160,19 +160,20 @@ def fetch_logo_helper(request: Request) -> Response:
         )
 
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
-    if request.headers.get("if-none-match") == etag_value:
-        return Response(
-            status_code=304,
-            headers={"ETag": etag_value},
-        )
+    client_etags = [
+        tag.strip() for tag in request.headers.get("if-none-match", "").split(",")
+    ]
+    cache_headers = {
+        "ETag": etag_value,
+        "Cache-Control": "private, max-age=3600, must-revalidate",
+    }
+    if etag_value in client_etags:
+        return Response(status_code=304, headers=cache_headers)
 
     return Response(
         content=onyx_file.data,
         media_type=onyx_file.mime_type,
-        headers={
-            "ETag": etag_value,
-            "Cache-Control": "private, max-age=3600, must-revalidate",
-        },
+        headers=cache_headers,
     )
 
 
@@ -190,19 +191,20 @@ def fetch_logotype_helper(request: Request) -> Response:
         )
 
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
-    if request.headers.get("if-none-match") == etag_value:
-        return Response(
-            status_code=304,
-            headers={"ETag": etag_value},
-        )
+    client_etags = [
+        tag.strip() for tag in request.headers.get("if-none-match", "").split(",")
+    ]
+    cache_headers = {
+        "ETag": etag_value,
+        "Cache-Control": "private, max-age=3600, must-revalidate",
+    }
+    if etag_value in client_etags:
+        return Response(status_code=304, headers=cache_headers)
 
     return Response(
         content=onyx_file.data,
         media_type=onyx_file.mime_type,
-        headers={
-            "ETag": etag_value,
-            "Cache-Control": "private, max-age=3600, must-revalidate",
-        },
+        headers=cache_headers,
     )
 
 

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -35,6 +35,8 @@ from onyx.auth.users import get_user_manager
 from onyx.auth.users import UserManager
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
@@ -146,28 +148,24 @@ def put_logo(
     upload_logo(file=file, is_logotype=is_logotype)
 
 
-def fetch_logo_helper(request: Request) -> Response:
+def _fetch_image_helper(request: Request, filename: str, label: str) -> Response:
     try:
         file_store = get_default_file_store()
-        onyx_file = file_store.get_file_with_mime_type(get_logo_filename())
+        onyx_file = file_store.get_file_with_mime_type(filename)
         if not onyx_file:
-            raise ValueError("get_onyx_file returned None!")
+            raise ValueError(f"get_onyx_file returned None for {label}!")
     except Exception:
-        logger.exception("Failed to fetch logo file")
-        raise HTTPException(
-            status_code=404,
-            detail="No logo file found",
-        )
+        logger.exception("Failed to fetch %s file", label)
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, f"No {label} file found")
 
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
-    client_etags = [
-        tag.strip() for tag in request.headers.get("if-none-match", "").split(",")
-    ]
+    if_none_match = request.headers.get("if-none-match", "")
+    client_etags = [tag.strip() for tag in if_none_match.split(",")]
     cache_headers = {
         "ETag": etag_value,
         "Cache-Control": "private, max-age=3600, must-revalidate",
     }
-    if etag_value in client_etags:
+    if "*" in client_etags or etag_value in client_etags:
         return Response(status_code=304, headers=cache_headers)
 
     return Response(
@@ -175,37 +173,14 @@ def fetch_logo_helper(request: Request) -> Response:
         media_type=onyx_file.mime_type,
         headers=cache_headers,
     )
+
+
+def fetch_logo_helper(request: Request) -> Response:
+    return _fetch_image_helper(request, get_logo_filename(), "logo")
 
 
 def fetch_logotype_helper(request: Request) -> Response:
-    try:
-        file_store = get_default_file_store()
-        onyx_file = file_store.get_file_with_mime_type(get_logotype_filename())
-        if not onyx_file:
-            raise ValueError("get_onyx_file returned None!")
-    except Exception:
-        logger.exception("Failed to fetch logotype file")
-        raise HTTPException(
-            status_code=404,
-            detail="No logotype file found",
-        )
-
-    etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
-    client_etags = [
-        tag.strip() for tag in request.headers.get("if-none-match", "").split(",")
-    ]
-    cache_headers = {
-        "ETag": etag_value,
-        "Cache-Control": "private, max-age=3600, must-revalidate",
-    }
-    if etag_value in client_etags:
-        return Response(status_code=304, headers=cache_headers)
-
-    return Response(
-        content=onyx_file.data,
-        media_type=onyx_file.mime_type,
-        headers=cache_headers,
-    )
+    return _fetch_image_helper(request, get_logotype_filename(), "logotype")
 
 
 @basic_router.get("/logotype")

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -167,12 +167,11 @@ def _fetch_image_helper(request: Request, filename: str, label: str) -> Response
         for tag in if_none_match.split(",")
         if tag.strip()
     ]
-    normalized_etag = etag_value.removeprefix("W/")
     cache_headers = {
         "ETag": etag_value,
         "Cache-Control": "private, max-age=3600, must-revalidate",
     }
-    if "*" in client_etags or normalized_etag in client_etags:
+    if "*" in client_etags or etag_value in client_etags:
         return Response(status_code=304, headers=cache_headers)
 
     return Response(

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -160,12 +160,14 @@ def _fetch_image_helper(request: Request, filename: str, label: str) -> Response
 
     etag_value = f'"{hashlib.md5(onyx_file.data, usedforsecurity=False).hexdigest()}"'
     if_none_match = request.headers.get("if-none-match", "")
-    client_etags = [tag.strip() for tag in if_none_match.split(",")]
+    # Strip W/ prefix for weak comparison per RFC 9110 §13.1.2
+    client_etags = [tag.strip().removeprefix("W/") for tag in if_none_match.split(",")]
+    normalized_etag = etag_value.removeprefix("W/")
     cache_headers = {
         "ETag": etag_value,
         "Cache-Control": "private, max-age=3600, must-revalidate",
     }
-    if "*" in client_etags or etag_value in client_etags:
+    if "*" in client_etags or normalized_etag in client_etags:
         return Response(status_code=304, headers=cache_headers)
 
     return Response(


### PR DESCRIPTION
## Description



## How Has This Been Tested?

TBD

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ETag and Cache-Control headers to the logo and logotype endpoints to enable browser caching and return 304 when unchanged. Also differentiate 404 (missing file) from 500 (infrastructure errors) for cleaner responses.

- **Bug Fixes**
  - Generate strong ETag from file bytes; honor `If-None-Match` (wildcard and weak ETags), filter empty tokens, and return 304 with cache headers when unchanged.
  - Add `Cache-Control: private, max-age=3600, must-revalidate`.
  - Replace `HTTPException` with `OnyxError`; return 404 without a stack trace when the file is missing, and 500 with logging for infrastructure failures.
  - Consolidate fetch logic into `_fetch_image_helper`; endpoints now take `Request` and drop the unused `Session`.
  - Remove no-op ETag normalization variable; server always emits strong ETags.

<sup>Written for commit 6bf64fa0b7965a4e706355003a15bf084d2a4212. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

