### PR TITLE
chore: small touchups in UI

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -957,7 +957,7 @@ ENTERPRISE_EDITION_ENABLED = (
 #####
 # Image Generation Configuration (DEPRECATED)
 # These environment variables will be deprecated soon.
-# To configure image generation, please visit the Image Generation page in the Admin Panel.
+# To configure image generation, please visit the Image Generation page in the Admin Settings.
 #####
 # Azure Image Configurations
 AZURE_IMAGE_API_VERSION = os.environ.get("AZURE_IMAGE_API_VERSION") or os.environ.get(

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18181,22 +18181,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18181,6 +18181,22 @@
         }
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",

--- a/web/src/app/admin/configuration/voice/page.tsx
+++ b/web/src/app/admin/configuration/voice/page.tsx
@@ -464,7 +464,7 @@ export default function VoiceConfigurationPage() {
     return (
       <>
         <AdminPageTitle
-          title="Voice"
+          title="Voice Mode"
           icon={SvgMicrophone}
           includeDivider={false}
         />
@@ -484,7 +484,7 @@ export default function VoiceConfigurationPage() {
     return (
       <>
         <AdminPageTitle
-          title="Voice"
+          title="Voice Mode"
           icon={SvgMicrophone}
           includeDivider={false}
         />
@@ -497,7 +497,7 @@ export default function VoiceConfigurationPage() {
 
   return (
     <>
-      <AdminPageTitle icon={SvgAudio} title="Voice" />
+      <AdminPageTitle icon={SvgAudio} title="Voice Mode" />
       <div className="pt-4 pb-4">
         <Text as="p" secondaryBody text03>
           Speech to text (STT) and text to speech (TTS) capabilities.

--- a/web/src/app/craft/v1/configure/page.tsx
+++ b/web/src/app/craft/v1/configure/page.tsx
@@ -79,7 +79,7 @@ interface SelectedConnectorState {
 }
 
 /**
- * Build Admin Panel - Connector configuration page
+ * Build Admin Settings - Connector configuration page
  *
  * Renders in the center panel area (replacing ChatPanel + OutputPanel).
  * Uses SettingsLayouts like AgentEditorPage does.

--- a/web/src/components/modals/NoAgentModal.tsx
+++ b/web/src/components/modals/NoAgentModal.tsx
@@ -22,10 +22,10 @@ export default function NoAgentModal() {
             <>
               <Text as="p">
                 As an administrator, you can create a new agent by visiting the
-                admin panel.
+                admin settings.
               </Text>
               <Button width="full" href="/admin/agents">
-                Go to Admin Panel
+                Go to Admin Settings
               </Button>
             </>
           ) : (

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -766,6 +766,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                     {(appFocus.isNewSession() || appFocus.isAgent()) &&
                       (state.phase === "idle" ||
                         state.phase === "classifying") &&
+                      !isLoadingOnboarding &&
                       (showOnboarding || !user?.personalization?.name) &&
                       !onboardingDismissed && (
                         <OnboardingFlow

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -977,7 +977,7 @@ function ChatPreferencesSettings() {
 
       <Section gap={0.75}>
         <Content
-          title="Voice"
+          title="Voice Mode"
           sizePreset="main-content"
           variant="section"
           widthVariant="full"

--- a/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
+++ b/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
@@ -92,7 +92,7 @@ export default function ChatDocumentDisplay({
         ) : (
           <SourceIcon sourceType={document.source_type} iconSize={18} />
         )}
-        <Truncated className="line-clamp-2" side="left">
+        <Truncated className="line-clamp-2" side="left" disable>
           {title}
         </Truncated>
       </div>

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -135,6 +135,23 @@ const DocumentsSidebar = memo(
       return { citedDocumentIds, citationOrder };
     }, [idOfMessageToDisplay, selectedMessage?.packets.length]);
 
+    const sidebarRef = useRef<HTMLDivElement>(null);
+    const moreSentinelRef = useRef<HTMLDivElement>(null);
+    const [isMoreStuck, setIsMoreStuck] = useState(false);
+
+    useEffect(() => {
+      const sentinel = moreSentinelRef.current;
+      const root = sidebarRef.current;
+      if (!sentinel || !root) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => setIsMoreStuck(!entries[0]?.isIntersecting),
+        { root, threshold: 0 }
+      );
+      observer.observe(sentinel);
+      return () => observer.disconnect();
+    }, []);
+
     // if these are missing for some reason, then nothing we can do. Just
     // don't render.
     // TODO: improve this display
@@ -171,23 +188,6 @@ const DocumentsSidebar = memo(
     );
     const hasCited = citedDocuments.length > 0;
     const hasOther = otherDocuments.length > 0;
-
-    const sidebarRef = useRef<HTMLDivElement>(null);
-    const moreSentinelRef = useRef<HTMLDivElement>(null);
-    const [isMoreStuck, setIsMoreStuck] = useState(false);
-
-    useEffect(() => {
-      const sentinel = moreSentinelRef.current;
-      const root = sidebarRef.current;
-      if (!sentinel || !root) return;
-
-      const observer = new IntersectionObserver(
-        (entries) => setIsMoreStuck(!entries[0]?.isIntersecting),
-        { root, threshold: 0 }
-      );
-      observer.observe(sentinel);
-      return () => observer.disconnect();
-    }, [hasCited, hasOther]);
 
     return (
       <div

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -3,7 +3,15 @@
 import { MinimalOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
 import ChatDocumentDisplay from "@/sections/document-sidebar/ChatDocumentDisplay";
 import { removeDuplicateDocs } from "@/lib/documentUtils";
-import { Dispatch, SetStateAction, useMemo, memo } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useMemo,
+  memo,
+  useRef,
+  useState,
+  useEffect,
+} from "react";
 import { getCitations } from "@/app/app/services/packetUtils";
 import {
   useCurrentMessageTree,
@@ -40,25 +48,30 @@ const buildOnyxDocumentFromFile = (
 
 interface HeaderProps {
   children: string;
-  onClose: () => void;
+  onClose?: () => void;
+  isTop?: boolean;
 }
 
-function Header({ children, onClose }: HeaderProps) {
+function Header({ children, onClose, isTop }: HeaderProps) {
   return (
     <div className="sticky top-0 z-sticky bg-background-tint-01">
       <div className="flex flex-row w-full items-center justify-between gap-2 py-3">
         <div className="flex items-center gap-2 w-full px-3">
-          <SvgSearchMenu className="w-[1.3rem] h-[1.3rem] stroke-text-03" />
+          {isTop && (
+            <SvgSearchMenu className="w-[1.3rem] h-[1.3rem] stroke-text-03" />
+          )}
           <Text as="p" headingH3 text03>
             {children}
           </Text>
         </div>
-        <Button
-          icon={SvgX}
-          prominence="tertiary"
-          onClick={onClose}
-          tooltip="Close Sidebar"
-        />
+        {onClose && (
+          <Button
+            icon={SvgX}
+            prominence="tertiary"
+            onClick={onClose}
+            tooltip="Close Sidebar"
+          />
+        )}
       </div>
       <Separator noPadding />
     </div>
@@ -159,15 +172,35 @@ const DocumentsSidebar = memo(
     const hasCited = citedDocuments.length > 0;
     const hasOther = otherDocuments.length > 0;
 
+    const sidebarRef = useRef<HTMLDivElement>(null);
+    const moreSentinelRef = useRef<HTMLDivElement>(null);
+    const [isMoreStuck, setIsMoreStuck] = useState(false);
+
+    useEffect(() => {
+      const sentinel = moreSentinelRef.current;
+      const root = sidebarRef.current;
+      if (!sentinel || !root) return;
+
+      const observer = new IntersectionObserver(
+        (entries) => setIsMoreStuck(!entries[0]?.isIntersecting),
+        { root, threshold: 0 }
+      );
+      observer.observe(sentinel);
+      return () => observer.disconnect();
+    }, [hasCited, hasOther]);
+
     return (
       <div
+        ref={sidebarRef}
         id="onyx-chat-sidebar"
         className="bg-background-tint-01 overflow-y-scroll h-full w-full border-l"
       >
         <div className="flex flex-col px-3 gap-6">
           {hasCited && (
             <div>
-              <Header onClose={closeSidebar}>Cited Sources</Header>
+              <Header isTop onClose={closeSidebar}>
+                Cited Sources
+              </Header>
               <ChatDocumentDisplayWrapper>
                 {citedDocuments.map((document) => (
                   <ChatDocumentDisplay
@@ -186,7 +219,11 @@ const DocumentsSidebar = memo(
 
           {hasOther && (
             <div>
-              <Header onClose={closeSidebar}>
+              <div ref={moreSentinelRef} className="h-0" />
+              <Header
+                isTop={!hasCited || isMoreStuck}
+                onClose={!hasCited || isMoreStuck ? closeSidebar : undefined}
+              >
                 {citedDocuments.length > 0 ? "More" : "Found Sources"}
               </Header>
               <ChatDocumentDisplayWrapper>
@@ -207,7 +244,12 @@ const DocumentsSidebar = memo(
 
           {humanFileDescriptors && humanFileDescriptors.length > 0 && (
             <div>
-              <Header onClose={closeSidebar}>User Files</Header>
+              <Header
+                isTop={!hasCited && !hasOther}
+                onClose={!hasCited && !hasOther ? closeSidebar : undefined}
+              >
+                User Files
+              </Header>
               <ChatDocumentDisplayWrapper>
                 {humanFileDescriptors.map((file) => (
                   <ChatDocumentDisplay

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -10,7 +10,7 @@ import {
   memo,
   useRef,
   useState,
-  useEffect,
+  useCallback,
 } from "react";
 import { getCitations } from "@/app/app/services/packetUtils";
 import {
@@ -135,21 +135,24 @@ const DocumentsSidebar = memo(
       return { citedDocumentIds, citationOrder };
     }, [idOfMessageToDisplay, selectedMessage?.packets.length]);
 
-    const sidebarRef = useRef<HTMLDivElement>(null);
-    const moreSentinelRef = useRef<HTMLDivElement>(null);
+    const observerRef = useRef<IntersectionObserver | null>(null);
     const [isMoreStuck, setIsMoreStuck] = useState(false);
 
-    useEffect(() => {
-      const sentinel = moreSentinelRef.current;
-      const root = sidebarRef.current;
-      if (!sentinel || !root) return;
+    const moreSentinelRef = useCallback((node: HTMLDivElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+
+      if (!node) return;
+
+      const root = node.closest("#onyx-chat-sidebar");
+      if (!root) return;
 
       const observer = new IntersectionObserver(
         (entries) => setIsMoreStuck(!entries[0]?.isIntersecting),
         { root, threshold: 0 }
       );
-      observer.observe(sentinel);
-      return () => observer.disconnect();
+      observer.observe(node);
+      observerRef.current = observer;
     }, []);
 
     // if these are missing for some reason, then nothing we can do. Just
@@ -191,7 +194,6 @@ const DocumentsSidebar = memo(
 
     return (
       <div
-        ref={sidebarRef}
         id="onyx-chat-sidebar"
         className="bg-background-tint-01 overflow-y-scroll h-full w-full border-l"
       >
@@ -219,7 +221,7 @@ const DocumentsSidebar = memo(
 
           {hasOther && (
             <div>
-              <div ref={moreSentinelRef} className="h-0" />
+              <div ref={moreSentinelRef} className="h-px" />
               <Header
                 isTop={!hasCited || isMoreStuck}
                 onClose={!hasCited || isMoreStuck ? closeSidebar : undefined}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -649,9 +649,9 @@ const AppInputBar = React.memo(
               <Disabled disabled>
                 <Button
                   icon={SvgMicrophone}
-                  aria-label="Set up voice"
+                  aria-label="Configure Voice Mode"
                   prominence="tertiary"
-                  tooltip="Voice not configured. Set up in admin settings."
+                  tooltip="Configure Voice Mode in Admin Settings."
                 />
               </Disabled>
             ))}

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -143,7 +143,7 @@ const LLMStepInner = ({
                   rightIcon={SvgExternalLink}
                   href="/admin/configuration/llm"
                 >
-                  View in Admin Panel
+                  View in Admin Settings
                 </Button>
               </Disabled>
             }

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -134,7 +134,7 @@ const collections = (
               sidebarItem(ADMIN_PATHS.WEB_SEARCH),
               sidebarItem(ADMIN_PATHS.IMAGE_GENERATION),
               {
-                name: "Voice",
+                name: "Voice Mode",
                 icon: SvgAudio,
                 link: "/admin/configuration/voice",
               },

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -613,7 +613,7 @@ const MemoizedAppSidebarInner = memo(
               icon={SvgSettings}
               folded={folded}
             >
-              {isAdmin ? "Admin Panel" : "Curator Panel"}
+              {isAdmin ? "Admin Settings" : "Curator Panel"}
             </SidebarTab>
           )}
           <UserAvatarPopover


### PR DESCRIPTION
## Description
Issues Addressed:
- Fix onboarding blinking the modal to ask for the user’s name before showing the normal “Let’s go” message
- Document sidebar had an extra close button on the More section
- Removed the extra Search icon in document sidebar
- No longer allowing info hovers on document cards in the sidebar
- Standardize naming of “Admin Settings” and “Admin Panel” going to Settings everywhere
- Standardizing Voice to Voice Mode to be more consistent with established marketing (e.g. ChatGPT’s voice mode)

## How Has This Been Tested?
Ran things locally only


https://github.com/user-attachments/assets/dbe32797-f780-44e6-93bb-401c3f7a743f



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished onboarding and the document sidebar, and standardized labels to “Admin Settings” and “Voice Mode” across the app. Fixes onboarding flicker and corrects sidebar headers, icons, and hovers for a smoother UX.

- **Bug Fixes**
  - Gated onboarding until loading completes to prevent the name modal flashing before “Let’s go”.
  - Document sidebar: removed the always-visible close button in “More”, hid the extra search icon, and disabled info hovers on document cards.
  - Sticky header behavior while scrolling: show the search icon and close button only when that section header is at the top, including “More” and “User Files”.

- **Refactors**
  - Standardized copy: “Admin Panel” → “Admin Settings” and “Voice” → “Voice Mode” across pages, sidebars, onboarding, tooltips/ARIA, and comments.

<sup>Written for commit 34356a58532d3b032eca17a5a9746d4dc1b791cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



