### PR TITLE
feat: add MiniMax as a well-known LLM and voice provider (M3 default)

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -24,6 +24,7 @@ class LlmProviderNames(str, Enum):
     OLLAMA_CHAT = "ollama_chat"
     LM_STUDIO = "lm_studio"
     MISTRAL = "mistral"
+    MINIMAX = "minimax"
     LITELLM_PROXY = "litellm_proxy"
 
     def __str__(self) -> str:
@@ -43,6 +44,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.AZURE,
     LlmProviderNames.OLLAMA_CHAT,
     LlmProviderNames.LM_STUDIO,
+    LlmProviderNames.MINIMAX,
     LlmProviderNames.LITELLM_PROXY,
 ]
 
@@ -61,6 +63,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.OLLAMA_CHAT: "Ollama",
     LlmProviderNames.LM_STUDIO: "LM Studio",
     LlmProviderNames.LITELLM_PROXY: "LiteLLM Proxy",
+    LlmProviderNames.MINIMAX: "MiniMax",
     "groq": "Groq",
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",
@@ -100,6 +103,7 @@ VENDOR_BRAND_NAMES: dict[str, str] = {
     "qwen": "Qwen",
     "alibaba": "Qwen",
     "writer": "Palmyra",
+    "minimax": "MiniMax",
 }
 
 # Aggregator providers that host models from multiple vendors
@@ -221,7 +225,7 @@ BEDROCK_MODEL_TOKEN_LIMITS: dict[str, int] = {
     # Moonshot Kimi
     "kimi": 128000,
     # Minimax
-    "minimax": 128000,
+    "minimax": 204000,
     # OpenAI (via Bedrock)
     "gpt-oss": 128000,
     # AI21 models (from LiteLLM: Jamba 1.5 = 256K, Jamba Instruct = 70K)
@@ -282,6 +286,8 @@ MODEL_PREFIX_TO_VENDOR: dict[str, str] = {
     "nemotron": "nvidia",
     # xAI
     "grok": "xai",
+    # MiniMax
+    "minimax": "minimax",
 }
 
 

--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -225,7 +225,7 @@ BEDROCK_MODEL_TOKEN_LIMITS: dict[str, int] = {
     # Moonshot Kimi
     "kimi": 128000,
     # Minimax
-    "minimax": 204000,
+    "minimax": 512000,
     # OpenAI (via Bedrock)
     "gpt-oss": 128000,
     # AI21 models (from LiteLLM: Jamba 1.5 = 256K, Jamba Instruct = 70K)

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -24,6 +24,8 @@ OPENROUTER_PROVIDER_NAME = "openrouter"
 
 ANTHROPIC_PROVIDER_NAME = "anthropic"
 
+MINIMAX_PROVIDER_NAME = "minimax"
+
 AZURE_PROVIDER_NAME = "azure"
 
 

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -252,10 +252,12 @@ def get_minimax_model_names() -> list[str]:
     """
     import litellm
 
+    minimax_models: list[str] = getattr(litellm, "minimax_models", [])
+
     return sorted(
         [
             model.removeprefix("minimax/")
-            for model in litellm.minimax_models
+            for model in minimax_models
             if "speech" not in model.lower()
         ],
         reverse=True,

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -17,6 +17,7 @@ from onyx.llm.well_known_providers.constants import AZURE_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LITELLM_PROXY_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LM_STUDIO_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import MINIMAX_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OLLAMA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENROUTER_PROVIDER_NAME
@@ -48,6 +49,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         OLLAMA_PROVIDER_NAME: [],  # Dynamic - fetched from Ollama API
         LM_STUDIO_PROVIDER_NAME: [],  # Dynamic - fetched from LM Studio API
         OPENROUTER_PROVIDER_NAME: [],  # Dynamic - fetched from OpenRouter API
+        MINIMAX_PROVIDER_NAME: get_minimax_model_names(),
         LITELLM_PROXY_PROVIDER_NAME: [],  # Dynamic - fetched from LiteLLM proxy API
     }
 
@@ -242,6 +244,24 @@ def get_vertexai_model_names() -> list[str]:
     )
 
 
+def get_minimax_model_names() -> list[str]:
+    """Get MiniMax model names dynamically from litellm.
+
+    MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+    Filters out speech/TTS models since those are not chat models.
+    """
+    import litellm
+
+    return sorted(
+        [
+            model.removeprefix("minimax/")
+            for model in litellm.minimax_models
+            if "speech" not in model.lower()
+        ],
+        reverse=True,
+    )
+
+
 def model_configurations_for_provider(
     provider_name: str, llm_recommendations: LLMRecommendations
 ) -> list[ModelConfigurationView]:
@@ -333,6 +353,7 @@ def get_provider_display_name(provider_name: str) -> str:
         BEDROCK_PROVIDER_NAME: "Amazon Bedrock",
         VERTEXAI_PROVIDER_NAME: "Google Vertex AI",
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
+        MINIMAX_PROVIDER_NAME: "MiniMax",
         LITELLM_PROXY_PROVIDER_NAME: "LiteLLM Proxy",
     }
 

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -43,6 +43,22 @@
         }
       ]
     },
+    "minimax": {
+      "default_model": {
+        "name": "MiniMax-M2.5",
+        "display_name": "MiniMax M2.5"
+      },
+      "additional_visible_models": [
+        {
+          "name": "MiniMax-M2.5",
+          "display_name": "MiniMax M2.5"
+        },
+        {
+          "name": "MiniMax-M2.5-lightning",
+          "display_name": "MiniMax M2.5 Lightning"
+        }
+      ]
+    },
     "openrouter": {
       "default_model": "z-ai/glm-4.7",
       "additional_visible_models": [

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -45,17 +45,21 @@
     },
     "minimax": {
       "default_model": {
-        "name": "MiniMax-M2.5",
-        "display_name": "MiniMax M2.5"
+        "name": "MiniMax-M3",
+        "display_name": "MiniMax M3"
       },
       "additional_visible_models": [
         {
-          "name": "MiniMax-M2.5",
-          "display_name": "MiniMax M2.5"
+          "name": "MiniMax-M3",
+          "display_name": "MiniMax M3"
         },
         {
-          "name": "MiniMax-M2.5-lightning",
-          "display_name": "MiniMax M2.5 Lightning"
+          "name": "MiniMax-M2.7",
+          "display_name": "MiniMax M2.7"
+        },
+        {
+          "name": "MiniMax-M2.7-highspeed",
+          "display_name": "MiniMax M2.7 Highspeed"
         }
       ]
     },

--- a/backend/onyx/voice/factory.py
+++ b/backend/onyx/voice/factory.py
@@ -66,5 +66,16 @@ def get_voice_provider(provider: VoiceProvider) -> VoiceProviderInterface:
             default_voice=default_voice,
         )
 
+    elif provider_type == "minimax":
+        from onyx.voice.providers.minimax import MiniMaxVoiceProvider
+
+        return MiniMaxVoiceProvider(
+            api_key=api_key,
+            api_base=api_base,
+            stt_model=stt_model,
+            tts_model=tts_model,
+            default_voice=default_voice,
+        )
+
     else:
         raise ValueError(f"Unsupported voice provider type: {provider_type}")

--- a/backend/onyx/voice/providers/minimax.py
+++ b/backend/onyx/voice/providers/minimax.py
@@ -16,7 +16,10 @@ from collections.abc import AsyncIterator
 
 import aiohttp
 
+from onyx.utils.logger import setup_logger
 from onyx.voice.interface import VoiceProviderInterface
+
+logger = setup_logger()
 
 # Default MiniMax API base URL
 DEFAULT_MINIMAX_API_BASE = "https://api.minimax.io"
@@ -135,9 +138,19 @@ class MiniMaxVoiceProvider(VoiceProviderInterface):
                         except json.JSONDecodeError:
                             continue
 
-                        hex_audio = (event_data.get("data") or {}).get("audio")
-                        if hex_audio:
-                            yield bytes.fromhex(hex_audio)
+                        data_obj = event_data.get("data") or {}
+                        hex_audio = data_obj.get("audio")
+                        status = data_obj.get("status")
+                        if hex_audio and status != 2:
+                            # status 1 = in progress (stream chunks)
+                            # status 2 = complete (contains full audio, skip to
+                            #             avoid duplicate data in streaming mode)
+                            try:
+                                yield bytes.fromhex(hex_audio)
+                            except ValueError:
+                                logger.warning(
+                                    "MiniMax TTS: invalid hex audio data, skipping chunk"
+                                )
 
     async def validate_credentials(self) -> None:
         """Validate MiniMax API key by making a lightweight TTS request."""
@@ -326,13 +339,22 @@ class MiniMaxStreamingSynthesizer:
                         except json.JSONDecodeError:
                             continue
 
-                        hex_audio = (event_data.get("data") or {}).get("audio")
-                        status = (event_data.get("data") or {}).get("status")
+                        data_obj = event_data.get("data") or {}
+                        hex_audio = data_obj.get("audio")
+                        status = data_obj.get("status")
                         if hex_audio and status != 2:
                             # status 1 = in progress (stream chunks)
                             # status 2 = complete (contains full audio, skip to
                             #             avoid duplicate data in streaming mode)
-                            await self._audio_queue.put(bytes.fromhex(hex_audio))
+                            try:
+                                await self._audio_queue.put(
+                                    bytes.fromhex(hex_audio)
+                                )
+                            except ValueError:
+                                self._logger.warning(
+                                    "MiniMax TTS: invalid hex audio data, "
+                                    "skipping chunk"
+                                )
         except Exception as e:
             self._logger.error(f"MiniMaxStreamingSynthesizer synthesis error: {e}")
 
@@ -343,11 +365,15 @@ class MiniMaxStreamingSynthesizer:
         await self._text_queue.put(text)
 
     async def receive_audio(self) -> bytes | None:
-        """Receive next audio chunk (MP3 format)."""
+        """Receive next audio chunk (MP3 format).
+
+        Returns:
+            Audio bytes, or None when stream ends or on timeout.
+        """
         try:
             return await asyncio.wait_for(self._audio_queue.get(), timeout=0.1)
         except asyncio.TimeoutError:
-            return b""
+            return None
 
     async def flush(self) -> None:
         """Signal end of text input - wait for synthesis to complete."""

--- a/backend/onyx/voice/providers/minimax.py
+++ b/backend/onyx/voice/providers/minimax.py
@@ -1,0 +1,393 @@
+"""MiniMax voice provider for TTS.
+
+MiniMax supports:
+- **TTS**: HTTP streaming endpoint that returns hex-encoded audio chunks via SSE.
+  Supported models: speech-2.8-hd (high quality) and speech-2.8-turbo (fast).
+
+MiniMax does NOT provide a Speech-to-Text (STT) API, so transcription methods
+raise NotImplementedError.
+
+See https://platform.minimax.io/docs/api-reference/speech-t2a-http for API reference.
+"""
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+
+import aiohttp
+
+from onyx.voice.interface import VoiceProviderInterface
+
+# Default MiniMax API base URL
+DEFAULT_MINIMAX_API_BASE = "https://api.minimax.io"
+
+# MiniMax available voices for TTS
+MINIMAX_VOICES = [
+    {"id": "English_Graceful_Lady", "name": "Graceful Lady"},
+    {"id": "English_Insightful_Speaker", "name": "Insightful Speaker"},
+    {"id": "English_radiant_girl", "name": "Radiant Girl"},
+    {"id": "English_Persuasive_Man", "name": "Persuasive Man"},
+    {"id": "English_Lucky_Robot", "name": "Lucky Robot"},
+    {"id": "English_expressive_narrator", "name": "Expressive Narrator"},
+]
+
+# MiniMax available TTS models
+MINIMAX_TTS_MODELS = [
+    {"id": "speech-2.8-hd", "name": "Speech 2.8 HD (High Quality)"},
+    {"id": "speech-2.8-turbo", "name": "Speech 2.8 Turbo (Fast)"},
+]
+
+
+class MiniMaxVoiceProvider(VoiceProviderInterface):
+    """MiniMax voice provider using MiniMax TTS API for speech synthesis.
+
+    MiniMax only supports TTS (Text-to-Speech). STT (Speech-to-Text) is not
+    available and will raise NotImplementedError.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None,
+        api_base: str | None = None,
+        stt_model: str | None = None,
+        tts_model: str | None = None,
+        default_voice: str | None = None,
+    ) -> None:
+        self.api_key = api_key
+        self.api_base = (api_base or DEFAULT_MINIMAX_API_BASE).rstrip("/")
+        self.stt_model = stt_model  # Not used - MiniMax has no STT
+        self.tts_model = tts_model or "speech-2.8-hd"
+        self.default_voice = default_voice or "English_Graceful_Lady"
+
+    async def transcribe(self, audio_data: bytes, audio_format: str) -> str:
+        """MiniMax does not support Speech-to-Text."""
+        raise NotImplementedError(
+            "MiniMax does not provide a Speech-to-Text API. "
+            "Please use a different provider (e.g., OpenAI) for transcription."
+        )
+
+    async def synthesize_stream(
+        self, text: str, voice: str | None = None, speed: float = 1.0
+    ) -> AsyncIterator[bytes]:
+        """Convert text to audio using MiniMax TTS API with SSE streaming.
+
+        MiniMax returns hex-encoded audio chunks via Server-Sent Events (SSE).
+        Each SSE event contains a JSON payload with a `data.audio` field
+        containing hex-encoded audio bytes.
+
+        Args:
+            text: Text to convert to speech
+            voice: Voice identifier (defaults to provider's default voice)
+            speed: Playback speed multiplier (0.5 to 2.0)
+
+        Yields:
+            Audio data chunks (mp3 format)
+        """
+        if not self.api_key:
+            raise ValueError("API key required for MiniMax TTS")
+
+        url = f"{self.api_base}/v1/t2a_v2"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        payload = {
+            "model": self.tts_model,
+            "text": text,
+            "stream": True,
+            "voice_setting": {
+                "voice_id": voice or self.default_voice,
+                "speed": max(0.5, min(2.0, speed)),
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        f"MiniMax TTS error ({response.status}): {error_text}"
+                    )
+
+                buffer = ""
+                async for chunk in response.content.iter_any():
+                    buffer += chunk.decode("utf-8", errors="replace")
+                    lines = buffer.split("\n")
+                    buffer = lines.pop()  # Keep incomplete line in buffer
+
+                    for line in lines:
+                        if not line.startswith("data:"):
+                            continue
+                        json_str = line[5:].strip()
+                        if not json_str or json_str == "[DONE]":
+                            continue
+
+                        try:
+                            event_data = json.loads(json_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        hex_audio = (event_data.get("data") or {}).get("audio")
+                        if hex_audio:
+                            yield bytes.fromhex(hex_audio)
+
+    async def validate_credentials(self) -> None:
+        """Validate MiniMax API key by making a lightweight TTS request."""
+        if not self.api_key:
+            raise RuntimeError("MiniMax API key is not configured.")
+
+        url = f"{self.api_base}/v1/t2a_v2"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        payload = {
+            "model": self.tts_model,
+            "text": "test",
+            "stream": False,
+            "voice_setting": {
+                "voice_id": self.default_voice,
+                "speed": 1,
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status == 401:
+                    raise RuntimeError("Invalid MiniMax API key.")
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise RuntimeError(
+                        f"MiniMax API validation failed ({response.status}): {error_text}"
+                    )
+                result = await response.json()
+                status_code = (result.get("base_resp") or {}).get("status_code")
+                if status_code is not None and status_code != 0:
+                    status_msg = (result.get("base_resp") or {}).get(
+                        "status_msg", "unknown error"
+                    )
+                    raise RuntimeError(
+                        f"MiniMax API validation failed: {status_msg}"
+                    )
+
+    def get_available_voices(self) -> list[dict[str, str]]:
+        """Get available MiniMax TTS voices."""
+        return MINIMAX_VOICES.copy()
+
+    def get_available_stt_models(self) -> list[dict[str, str]]:
+        """MiniMax does not support STT. Returns empty list."""
+        return []
+
+    def get_available_tts_models(self) -> list[dict[str, str]]:
+        """Get available MiniMax TTS models."""
+        return MINIMAX_TTS_MODELS.copy()
+
+    def supports_streaming_stt(self) -> bool:
+        """MiniMax does not support streaming STT."""
+        return False
+
+    def supports_streaming_tts(self) -> bool:
+        """MiniMax supports streaming TTS via SSE."""
+        return True
+
+    async def create_streaming_synthesizer(
+        self, voice: str | None = None, speed: float = 1.0
+    ) -> "MiniMaxStreamingSynthesizer":
+        """Create a streaming TTS session using MiniMax SSE API."""
+        if not self.api_key:
+            raise ValueError("API key required for streaming TTS")
+        synthesizer = MiniMaxStreamingSynthesizer(
+            api_key=self.api_key,
+            voice=voice or self.default_voice,
+            model=self.tts_model,
+            speed=speed,
+            api_base=self.api_base,
+        )
+        await synthesizer.connect()
+        return synthesizer
+
+
+class MiniMaxStreamingSynthesizer:
+    """Streaming TTS using MiniMax HTTP API with SSE responses."""
+
+    def __init__(
+        self,
+        api_key: str,
+        voice: str = "English_Graceful_Lady",
+        model: str = "speech-2.8-hd",
+        speed: float = 1.0,
+        api_base: str | None = None,
+    ) -> None:
+        from onyx.utils.logger import setup_logger
+
+        self._logger = setup_logger()
+        self.api_key = api_key
+        self.voice = voice
+        self.model = model
+        self.speed = max(0.5, min(2.0, speed))
+        self.api_base = (api_base or DEFAULT_MINIMAX_API_BASE).rstrip("/")
+        self._session: aiohttp.ClientSession | None = None
+        self._audio_queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._text_queue: asyncio.Queue[str | None] = asyncio.Queue()
+        self._synthesis_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._flushed = False
+
+    async def connect(self) -> None:
+        """Initialize HTTP session for TTS requests."""
+        self._session = aiohttp.ClientSession()
+        self._synthesis_task = asyncio.create_task(self._process_text_queue())
+
+    async def _process_text_queue(self) -> None:
+        """Background task to process queued text for synthesis."""
+        while not self._closed:
+            try:
+                text = await asyncio.wait_for(self._text_queue.get(), timeout=0.1)
+                if text is None:
+                    break
+                await self._synthesize_text(text)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                self._logger.error(f"Error processing text queue: {e}")
+
+    async def _synthesize_text(self, text: str) -> None:
+        """Make HTTP TTS request and stream audio to queue."""
+        if not self._session or self._closed:
+            return
+
+        url = f"{self.api_base}/v1/t2a_v2"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        payload = {
+            "model": self.model,
+            "text": text,
+            "stream": True,
+            "voice_setting": {
+                "voice_id": self.voice,
+                "speed": self.speed,
+                "vol": 1,
+                "pitch": 0,
+            },
+            "audio_setting": {
+                "sample_rate": 32000,
+                "bitrate": 128000,
+                "format": "mp3",
+                "channel": 1,
+            },
+        }
+
+        try:
+            async with self._session.post(
+                url, headers=headers, json=payload
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    self._logger.error(f"MiniMax TTS error: {error_text}")
+                    return
+
+                buffer = ""
+                async for chunk in response.content.iter_any():
+                    if self._closed:
+                        break
+                    buffer += chunk.decode("utf-8", errors="replace")
+                    lines = buffer.split("\n")
+                    buffer = lines.pop()
+
+                    for line in lines:
+                        if not line.startswith("data:"):
+                            continue
+                        json_str = line[5:].strip()
+                        if not json_str or json_str == "[DONE]":
+                            continue
+
+                        try:
+                            event_data = json.loads(json_str)
+                        except json.JSONDecodeError:
+                            continue
+
+                        hex_audio = (event_data.get("data") or {}).get("audio")
+                        status = (event_data.get("data") or {}).get("status")
+                        if hex_audio and status != 2:
+                            # status 1 = in progress (stream chunks)
+                            # status 2 = complete (contains full audio, skip to
+                            #             avoid duplicate data in streaming mode)
+                            await self._audio_queue.put(bytes.fromhex(hex_audio))
+        except Exception as e:
+            self._logger.error(f"MiniMaxStreamingSynthesizer synthesis error: {e}")
+
+    async def send_text(self, text: str) -> None:
+        """Queue text to be synthesized via HTTP streaming."""
+        if not text.strip() or self._closed:
+            return
+        await self._text_queue.put(text)
+
+    async def receive_audio(self) -> bytes | None:
+        """Receive next audio chunk (MP3 format)."""
+        try:
+            return await asyncio.wait_for(self._audio_queue.get(), timeout=0.1)
+        except asyncio.TimeoutError:
+            return b""
+
+    async def flush(self) -> None:
+        """Signal end of text input - wait for synthesis to complete."""
+        if self._flushed:
+            return
+        self._flushed = True
+
+        await self._text_queue.put(None)
+
+        if self._synthesis_task and not self._synthesis_task.done():
+            try:
+                await asyncio.wait_for(self._synthesis_task, timeout=60.0)
+            except asyncio.TimeoutError:
+                self._logger.warning("MiniMaxStreamingSynthesizer: flush timeout")
+                self._synthesis_task.cancel()
+                try:
+                    await self._synthesis_task
+                except asyncio.CancelledError:
+                    pass
+            except asyncio.CancelledError:
+                pass
+
+        await self._audio_queue.put(None)
+
+    async def close(self) -> None:
+        """Close the session."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if not self._flushed:
+            await self._text_queue.put(None)
+            await self._audio_queue.put(None)
+
+        if self._synthesis_task and not self._synthesis_task.done():
+            self._synthesis_task.cancel()
+            try:
+                await self._synthesis_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._session:
+            await self._session.close()

--- a/web/src/interfaces/llm.ts
+++ b/web/src/interfaces/llm.ts
@@ -12,6 +12,7 @@ export enum LLMProviderName {
   OPENROUTER = "openrouter",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
+  MINIMAX = "minimax",
   LITELLM_PROXY = "litellm_proxy",
   CUSTOM = "custom",
 }

--- a/web/src/lib/llmConfig/providers.ts
+++ b/web/src/lib/llmConfig/providers.ts
@@ -26,6 +26,7 @@ const PROVIDER_ICONS: Record<string, IconFunctionComponent> = {
   [LLMProviderName.OLLAMA_CHAT]: SvgOllama,
   [LLMProviderName.OPENROUTER]: SvgOpenrouter,
   [LLMProviderName.LM_STUDIO]: SvgLmStudio,
+  [LLMProviderName.MINIMAX]: SvgServer,
 
   // fallback
   [LLMProviderName.CUSTOM]: SvgServer,
@@ -42,6 +43,7 @@ const PROVIDER_PRODUCT_NAMES: Record<string, string> = {
   [LLMProviderName.OLLAMA_CHAT]: "Ollama",
   [LLMProviderName.OPENROUTER]: "OpenRouter",
   [LLMProviderName.LM_STUDIO]: "LM Studio",
+  [LLMProviderName.MINIMAX]: "MiniMax",
 
   // fallback
   [LLMProviderName.CUSTOM]: "Custom Models",
@@ -58,6 +60,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   [LLMProviderName.OLLAMA_CHAT]: "Ollama",
   [LLMProviderName.OPENROUTER]: "OpenRouter",
   [LLMProviderName.LM_STUDIO]: "LM Studio",
+  [LLMProviderName.MINIMAX]: "MiniMax",
 
   // fallback
   [LLMProviderName.CUSTOM]: "Other providers or self-hosted",

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -35,16 +35,17 @@ import {
   WellKnownLLMProviderDescriptor,
 } from "@/interfaces/llm";
 import { getModalForExistingProvider } from "@/sections/modals/llmConfig/getModal";
-import OpenAIModal from "@/sections/modals/llmConfig/OpenAIModal";
-import AnthropicModal from "@/sections/modals/llmConfig/AnthropicModal";
-import OllamaModal from "@/sections/modals/llmConfig/OllamaModal";
-import AzureModal from "@/sections/modals/llmConfig/AzureModal";
-import BedrockModal from "@/sections/modals/llmConfig/BedrockModal";
-import VertexAIModal from "@/sections/modals/llmConfig/VertexAIModal";
-import OpenRouterModal from "@/sections/modals/llmConfig/OpenRouterModal";
-import CustomModal from "@/sections/modals/llmConfig/CustomModal";
-import LMStudioForm from "@/sections/modals/llmConfig/LMStudioForm";
-import LiteLLMProxyModal from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import { OpenAIModal } from "@/sections/modals/llmConfig/OpenAIModal";
+import { AnthropicModal } from "@/sections/modals/llmConfig/AnthropicModal";
+import { OllamaModal } from "@/sections/modals/llmConfig/OllamaModal";
+import { AzureModal } from "@/sections/modals/llmConfig/AzureModal";
+import { BedrockModal } from "@/sections/modals/llmConfig/BedrockModal";
+import { VertexAIModal } from "@/sections/modals/llmConfig/VertexAIModal";
+import { OpenRouterModal } from "@/sections/modals/llmConfig/OpenRouterModal";
+import { CustomModal } from "@/sections/modals/llmConfig/CustomModal";
+import { LMStudioForm } from "@/sections/modals/llmConfig/LMStudioForm";
+import { LiteLLMProxyModal } from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import { MiniMaxModal } from "@/sections/modals/llmConfig/MiniMaxModal";
 import { Section } from "@/layouts/general-layouts";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
@@ -126,6 +127,13 @@ const PROVIDER_MODAL_MAP: Record<
   ),
   lm_studio: (d, open, onOpenChange) => (
     <LMStudioForm
+      shouldMarkAsDefault={d}
+      open={open}
+      onOpenChange={onOpenChange}
+    />
+  ),
+  minimax: (d, open, onOpenChange) => (
+    <MiniMaxModal
       shouldMarkAsDefault={d}
       open={open}
       onOpenChange={onOpenChange}

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -35,17 +35,17 @@ import {
   WellKnownLLMProviderDescriptor,
 } from "@/interfaces/llm";
 import { getModalForExistingProvider } from "@/sections/modals/llmConfig/getModal";
-import { OpenAIModal } from "@/sections/modals/llmConfig/OpenAIModal";
-import { AnthropicModal } from "@/sections/modals/llmConfig/AnthropicModal";
-import { OllamaModal } from "@/sections/modals/llmConfig/OllamaModal";
-import { AzureModal } from "@/sections/modals/llmConfig/AzureModal";
-import { BedrockModal } from "@/sections/modals/llmConfig/BedrockModal";
-import { VertexAIModal } from "@/sections/modals/llmConfig/VertexAIModal";
-import { OpenRouterModal } from "@/sections/modals/llmConfig/OpenRouterModal";
-import { CustomModal } from "@/sections/modals/llmConfig/CustomModal";
-import { LMStudioForm } from "@/sections/modals/llmConfig/LMStudioForm";
-import { LiteLLMProxyModal } from "@/sections/modals/llmConfig/LiteLLMProxyModal";
-import { MiniMaxModal } from "@/sections/modals/llmConfig/MiniMaxModal";
+import OpenAIModal from "@/sections/modals/llmConfig/OpenAIModal";
+import AnthropicModal from "@/sections/modals/llmConfig/AnthropicModal";
+import OllamaModal from "@/sections/modals/llmConfig/OllamaModal";
+import AzureModal from "@/sections/modals/llmConfig/AzureModal";
+import BedrockModal from "@/sections/modals/llmConfig/BedrockModal";
+import VertexAIModal from "@/sections/modals/llmConfig/VertexAIModal";
+import OpenRouterModal from "@/sections/modals/llmConfig/OpenRouterModal";
+import CustomModal from "@/sections/modals/llmConfig/CustomModal";
+import LMStudioForm from "@/sections/modals/llmConfig/LMStudioForm";
+import LiteLLMProxyModal from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import MiniMaxModal from "@/sections/modals/llmConfig/MiniMaxModal";
 import { Section } from "@/layouts/general-layouts";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
@@ -62,6 +62,7 @@ const PROVIDER_DISPLAY_ORDER: string[] = [
   "vertex_ai",
   "bedrock",
   "azure",
+  "minimax",
   "litellm_proxy",
   "ollama_chat",
   "openrouter",

--- a/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
+++ b/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
@@ -1,119 +1,165 @@
-import { Form, Formik } from "formik";
+"use client";
 
-import { LLMProviderFormProps } from "@/interfaces/llm";
+import { useState } from "react";
+import { useSWRConfig } from "swr";
+import { Formik } from "formik";
+import { LLMProviderFormProps, LLMProviderName } from "@/interfaces/llm";
 import * as Yup from "yup";
-import { ProviderFormEntrypointWrapper } from "./components/FormWrapper";
-import { DisplayNameField } from "./components/DisplayNameField";
-import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
-import { FormActionButtons } from "./components/FormActionButtons";
+import { useWellKnownLLMProvider } from "@/hooks/useLLMProviders";
 import {
   buildDefaultInitialValues,
   buildDefaultValidationSchema,
   buildAvailableModelConfigurations,
+  buildOnboardingInitialValues,
+} from "@/sections/modals/llmConfig/utils";
+import {
   submitLLMProvider,
-  LLM_FORM_CLASS_NAME,
-} from "./formUtils";
-import { AdvancedOptions } from "./components/AdvancedOptions";
-import { DisplayModels } from "./components/DisplayModels";
+  submitOnboardingProvider,
+} from "@/sections/modals/llmConfig/svc";
+import {
+  APIKeyField,
+  ModelsField,
+  DisplayNameField,
+  FieldSeparator,
+  ModelsAccessField,
+  SingleDefaultModelField,
+  LLMConfigurationModalWrapper,
+} from "@/sections/modals/llmConfig/shared";
 
-export const MINIMAX_PROVIDER_NAME = "minimax";
 const DEFAULT_DEFAULT_MODEL_NAME = "MiniMax-M2.5";
 
-export function MiniMaxModal({
+export default function MiniMaxModal({
+  variant = "llm-configuration",
   existingLlmProvider,
   shouldMarkAsDefault,
   open,
   onOpenChange,
+  onboardingState,
+  onboardingActions,
+  llmDescriptor,
 }: LLMProviderFormProps) {
+  const isOnboarding = variant === "onboarding";
+  const [isTesting, setIsTesting] = useState(false);
+  const { mutate } = useSWRConfig();
+  const { wellKnownLLMProvider } = useWellKnownLLMProvider(
+    LLMProviderName.MINIMAX
+  );
+
+  if (open === false) return null;
+
+  const onClose = () => onOpenChange?.(false);
+
+  const modelConfigurations = buildAvailableModelConfigurations(
+    existingLlmProvider,
+    wellKnownLLMProvider ?? llmDescriptor
+  );
+
+  const initialValues = isOnboarding
+    ? {
+        ...buildOnboardingInitialValues(),
+        name: LLMProviderName.MINIMAX,
+        provider: LLMProviderName.MINIMAX,
+        api_key: "",
+        default_model_name: DEFAULT_DEFAULT_MODEL_NAME,
+      }
+    : {
+        ...buildDefaultInitialValues(existingLlmProvider, modelConfigurations),
+        api_key: existingLlmProvider?.api_key ?? "",
+        default_model_name:
+          wellKnownLLMProvider?.recommended_default_model?.name ??
+          DEFAULT_DEFAULT_MODEL_NAME,
+      };
+
+  const validationSchema = isOnboarding
+    ? Yup.object().shape({
+        api_key: Yup.string().required("API Key is required"),
+        default_model_name: Yup.string().required("Model name is required"),
+      })
+    : buildDefaultValidationSchema().shape({
+        api_key: Yup.string().required("API Key is required"),
+      });
+
   return (
-    <ProviderFormEntrypointWrapper
-      providerName="MiniMax"
-      providerEndpoint={MINIMAX_PROVIDER_NAME}
-      existingLlmProvider={existingLlmProvider}
-      open={open}
-      onOpenChange={onOpenChange}
-    >
-      {({
-        onClose,
-        mutate,
-        isTesting,
-        setIsTesting,
-        testError,
-        setTestError,
-        wellKnownLLMProvider,
-      }) => {
-        const modelConfigurations = buildAvailableModelConfigurations(
-          existingLlmProvider,
-          wellKnownLLMProvider
-        );
-        const initialValues = {
-          ...buildDefaultInitialValues(
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      validateOnMount={true}
+      onSubmit={async (values, { setSubmitting }) => {
+        if (isOnboarding && onboardingState && onboardingActions) {
+          const modelConfigsToUse =
+            (wellKnownLLMProvider ?? llmDescriptor)?.known_models ?? [];
+
+          await submitOnboardingProvider({
+            providerName: LLMProviderName.MINIMAX,
+            payload: {
+              ...values,
+              model_configurations: modelConfigsToUse,
+              is_auto_mode:
+                values.default_model_name === DEFAULT_DEFAULT_MODEL_NAME,
+            },
+            onboardingState,
+            onboardingActions,
+            isCustomProvider: false,
+            onClose,
+            setIsSubmitting: setSubmitting,
+          });
+        } else {
+          await submitLLMProvider({
+            providerName: LLMProviderName.MINIMAX,
+            values,
+            initialValues,
+            modelConfigurations,
             existingLlmProvider,
-            modelConfigurations
-          ),
-          api_key: existingLlmProvider?.api_key ?? "",
-          default_model_name:
-            wellKnownLLMProvider?.recommended_default_model?.name ??
-            DEFAULT_DEFAULT_MODEL_NAME,
-        };
-
-        const validationSchema = buildDefaultValidationSchema().shape({
-          api_key: Yup.string().required("API Key is required"),
-        });
-
-        return (
-          <Formik
-            initialValues={initialValues}
-            validationSchema={validationSchema}
-            validateOnMount={true}
-            onSubmit={async (values, { setSubmitting }) => {
-              await submitLLMProvider({
-                providerName: MINIMAX_PROVIDER_NAME,
-                values,
-                initialValues,
-                modelConfigurations,
-                existingLlmProvider,
-                shouldMarkAsDefault,
-                setIsTesting,
-                setTestError,
-                mutate,
-                onClose,
-                setSubmitting,
-              });
-            }}
-          >
-            {(formikProps) => {
-              return (
-                <Form className={LLM_FORM_CLASS_NAME}>
-                  <DisplayNameField disabled={!!existingLlmProvider} />
-
-                  <PasswordInputTypeInField name="api_key" label="API Key" />
-
-                  <DisplayModels
-                    modelConfigurations={modelConfigurations}
-                    formikProps={formikProps}
-                    recommendedDefaultModel={
-                      wellKnownLLMProvider?.recommended_default_model ?? null
-                    }
-                    shouldShowAutoUpdateToggle={false}
-                  />
-
-                  <AdvancedOptions formikProps={formikProps} />
-
-                  <FormActionButtons
-                    isTesting={isTesting}
-                    testError={testError}
-                    existingLlmProvider={existingLlmProvider}
-                    mutate={mutate}
-                    onClose={onClose}
-                    isFormValid={formikProps.isValid}
-                  />
-                </Form>
-              );
-            }}
-          </Formik>
-        );
+            shouldMarkAsDefault,
+            setIsTesting,
+            mutate,
+            onClose,
+            setSubmitting,
+          });
+        }
       }}
-    </ProviderFormEntrypointWrapper>
+    >
+      {(formikProps) => (
+        <LLMConfigurationModalWrapper
+          providerEndpoint={LLMProviderName.MINIMAX}
+          existingProviderName={existingLlmProvider?.name}
+          onClose={onClose}
+          isFormValid={formikProps.isValid}
+          isDirty={formikProps.dirty}
+          isTesting={isTesting}
+          isSubmitting={formikProps.isSubmitting}
+        >
+          <APIKeyField providerName="MiniMax" />
+
+          {!isOnboarding && (
+            <>
+              <FieldSeparator />
+              <DisplayNameField disabled={!!existingLlmProvider} />
+            </>
+          )}
+
+          <FieldSeparator />
+          {isOnboarding ? (
+            <SingleDefaultModelField placeholder="E.g. MiniMax-M2.5" />
+          ) : (
+            <ModelsField
+              modelConfigurations={modelConfigurations}
+              formikProps={formikProps}
+              recommendedDefaultModel={
+                wellKnownLLMProvider?.recommended_default_model ?? null
+              }
+              shouldShowAutoUpdateToggle={false}
+            />
+          )}
+
+          {!isOnboarding && (
+            <>
+              <FieldSeparator />
+              <ModelsAccessField formikProps={formikProps} />
+            </>
+          )}
+        </LLMConfigurationModalWrapper>
+      )}
+    </Formik>
   );
 }

--- a/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
+++ b/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
@@ -1,0 +1,119 @@
+import { Form, Formik } from "formik";
+
+import { LLMProviderFormProps } from "@/interfaces/llm";
+import * as Yup from "yup";
+import { ProviderFormEntrypointWrapper } from "./components/FormWrapper";
+import { DisplayNameField } from "./components/DisplayNameField";
+import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
+import { FormActionButtons } from "./components/FormActionButtons";
+import {
+  buildDefaultInitialValues,
+  buildDefaultValidationSchema,
+  buildAvailableModelConfigurations,
+  submitLLMProvider,
+  LLM_FORM_CLASS_NAME,
+} from "./formUtils";
+import { AdvancedOptions } from "./components/AdvancedOptions";
+import { DisplayModels } from "./components/DisplayModels";
+
+export const MINIMAX_PROVIDER_NAME = "minimax";
+const DEFAULT_DEFAULT_MODEL_NAME = "MiniMax-M2.5";
+
+export function MiniMaxModal({
+  existingLlmProvider,
+  shouldMarkAsDefault,
+  open,
+  onOpenChange,
+}: LLMProviderFormProps) {
+  return (
+    <ProviderFormEntrypointWrapper
+      providerName="MiniMax"
+      providerEndpoint={MINIMAX_PROVIDER_NAME}
+      existingLlmProvider={existingLlmProvider}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      {({
+        onClose,
+        mutate,
+        isTesting,
+        setIsTesting,
+        testError,
+        setTestError,
+        wellKnownLLMProvider,
+      }) => {
+        const modelConfigurations = buildAvailableModelConfigurations(
+          existingLlmProvider,
+          wellKnownLLMProvider
+        );
+        const initialValues = {
+          ...buildDefaultInitialValues(
+            existingLlmProvider,
+            modelConfigurations
+          ),
+          api_key: existingLlmProvider?.api_key ?? "",
+          default_model_name:
+            wellKnownLLMProvider?.recommended_default_model?.name ??
+            DEFAULT_DEFAULT_MODEL_NAME,
+        };
+
+        const validationSchema = buildDefaultValidationSchema().shape({
+          api_key: Yup.string().required("API Key is required"),
+        });
+
+        return (
+          <Formik
+            initialValues={initialValues}
+            validationSchema={validationSchema}
+            validateOnMount={true}
+            onSubmit={async (values, { setSubmitting }) => {
+              await submitLLMProvider({
+                providerName: MINIMAX_PROVIDER_NAME,
+                values,
+                initialValues,
+                modelConfigurations,
+                existingLlmProvider,
+                shouldMarkAsDefault,
+                setIsTesting,
+                setTestError,
+                mutate,
+                onClose,
+                setSubmitting,
+              });
+            }}
+          >
+            {(formikProps) => {
+              return (
+                <Form className={LLM_FORM_CLASS_NAME}>
+                  <DisplayNameField disabled={!!existingLlmProvider} />
+
+                  <PasswordInputTypeInField name="api_key" label="API Key" />
+
+                  <DisplayModels
+                    modelConfigurations={modelConfigurations}
+                    formikProps={formikProps}
+                    recommendedDefaultModel={
+                      wellKnownLLMProvider?.recommended_default_model ?? null
+                    }
+                    shouldShowAutoUpdateToggle={false}
+                  />
+
+                  <AdvancedOptions formikProps={formikProps} />
+
+                  <FormActionButtons
+                    isTesting={isTesting}
+                    testError={testError}
+                    existingLlmProvider={existingLlmProvider}
+                    mutate={mutate}
+                    onClose={onClose}
+                    isFormValid={formikProps.isValid}
+                  />
+                </Form>
+              );
+            }}
+          </Formik>
+        );
+      }}
+    </ProviderFormEntrypointWrapper>
+  );
+}

--- a/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
+++ b/web/src/sections/modals/llmConfig/MiniMaxModal.tsx
@@ -26,7 +26,7 @@ import {
   LLMConfigurationModalWrapper,
 } from "@/sections/modals/llmConfig/shared";
 
-const DEFAULT_DEFAULT_MODEL_NAME = "MiniMax-M2.5";
+const DEFAULT_DEFAULT_MODEL_NAME = "MiniMax-M3";
 
 export default function MiniMaxModal({
   variant = "llm-configuration",
@@ -140,7 +140,7 @@ export default function MiniMaxModal({
 
           <FieldSeparator />
           {isOnboarding ? (
-            <SingleDefaultModelField placeholder="E.g. MiniMax-M2.5" />
+            <SingleDefaultModelField placeholder="E.g. MiniMax-M3" />
           ) : (
             <ModelsField
               modelConfigurations={modelConfigurations}

--- a/web/src/sections/modals/llmConfig/getModal.tsx
+++ b/web/src/sections/modals/llmConfig/getModal.tsx
@@ -1,14 +1,15 @@
 import { LLMProviderName, LLMProviderView } from "@/interfaces/llm";
-import AnthropicModal from "@/sections/modals/llmConfig/AnthropicModal";
-import OpenAIModal from "@/sections/modals/llmConfig/OpenAIModal";
-import OllamaModal from "@/sections/modals/llmConfig/OllamaModal";
-import AzureModal from "@/sections/modals/llmConfig/AzureModal";
-import VertexAIModal from "@/sections/modals/llmConfig/VertexAIModal";
-import OpenRouterModal from "@/sections/modals/llmConfig/OpenRouterModal";
-import CustomModal from "@/sections/modals/llmConfig/CustomModal";
-import BedrockModal from "@/sections/modals/llmConfig/BedrockModal";
-import LMStudioForm from "@/sections/modals/llmConfig/LMStudioForm";
-import LiteLLMProxyModal from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import { AnthropicModal } from "@/sections/modals/llmConfig/AnthropicModal";
+import { OpenAIModal } from "@/sections/modals/llmConfig/OpenAIModal";
+import { OllamaModal } from "@/sections/modals/llmConfig/OllamaModal";
+import { AzureModal } from "@/sections/modals/llmConfig/AzureModal";
+import { VertexAIModal } from "@/sections/modals/llmConfig/VertexAIModal";
+import { OpenRouterModal } from "@/sections/modals/llmConfig/OpenRouterModal";
+import { CustomModal } from "@/sections/modals/llmConfig/CustomModal";
+import { BedrockModal } from "@/sections/modals/llmConfig/BedrockModal";
+import { LMStudioForm } from "@/sections/modals/llmConfig/LMStudioForm";
+import { LiteLLMProxyModal } from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import { MiniMaxModal } from "@/sections/modals/llmConfig/MiniMaxModal";
 
 function detectIfRealOpenAIProvider(provider: LLMProviderView) {
   return (
@@ -50,6 +51,8 @@ export function getModalForExistingProvider(
       return <LMStudioForm {...props} />;
     case LLMProviderName.LITELLM_PROXY:
       return <LiteLLMProxyModal {...props} />;
+    case LLMProviderName.MINIMAX:
+      return <MiniMaxModal {...props} />;
     default:
       return <CustomModal {...props} />;
   }

--- a/web/src/sections/modals/llmConfig/getModal.tsx
+++ b/web/src/sections/modals/llmConfig/getModal.tsx
@@ -1,15 +1,15 @@
 import { LLMProviderName, LLMProviderView } from "@/interfaces/llm";
-import { AnthropicModal } from "@/sections/modals/llmConfig/AnthropicModal";
-import { OpenAIModal } from "@/sections/modals/llmConfig/OpenAIModal";
-import { OllamaModal } from "@/sections/modals/llmConfig/OllamaModal";
-import { AzureModal } from "@/sections/modals/llmConfig/AzureModal";
-import { VertexAIModal } from "@/sections/modals/llmConfig/VertexAIModal";
-import { OpenRouterModal } from "@/sections/modals/llmConfig/OpenRouterModal";
-import { CustomModal } from "@/sections/modals/llmConfig/CustomModal";
-import { BedrockModal } from "@/sections/modals/llmConfig/BedrockModal";
-import { LMStudioForm } from "@/sections/modals/llmConfig/LMStudioForm";
-import { LiteLLMProxyModal } from "@/sections/modals/llmConfig/LiteLLMProxyModal";
-import { MiniMaxModal } from "@/sections/modals/llmConfig/MiniMaxModal";
+import AnthropicModal from "@/sections/modals/llmConfig/AnthropicModal";
+import OpenAIModal from "@/sections/modals/llmConfig/OpenAIModal";
+import OllamaModal from "@/sections/modals/llmConfig/OllamaModal";
+import AzureModal from "@/sections/modals/llmConfig/AzureModal";
+import VertexAIModal from "@/sections/modals/llmConfig/VertexAIModal";
+import OpenRouterModal from "@/sections/modals/llmConfig/OpenRouterModal";
+import CustomModal from "@/sections/modals/llmConfig/CustomModal";
+import BedrockModal from "@/sections/modals/llmConfig/BedrockModal";
+import LMStudioForm from "@/sections/modals/llmConfig/LMStudioForm";
+import LiteLLMProxyModal from "@/sections/modals/llmConfig/LiteLLMProxyModal";
+import MiniMaxModal from "@/sections/modals/llmConfig/MiniMaxModal";
 
 function detectIfRealOpenAIProvider(provider: LLMProviderView) {
   return (


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use **MiniMax-M3** as the default model, replacing M2.5.

- Add MiniMax as a well-known LLM provider with **MiniMax-M3** as the default model
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed as additional model options
- Add MiniMax Cloud TTS voice provider with speech-2.8-hd and speech-2.8-turbo models
- Frontend modal for MiniMax API key configuration

## Changes
- `backend/onyx/llm/constants.py` — Register MiniMax as a known LLM provider; update MiniMax context length to 512K
- `backend/onyx/llm/well_known_providers/` — MiniMax provider config + recommended models (M3 default)
- `backend/onyx/voice/factory.py` + `backend/onyx/voice/providers/minimax.py` — MiniMax Cloud TTS provider
- `web/src/sections/modals/llmConfig/MiniMaxModal.tsx` — Frontend config modal (M3 default)
- `web/src/lib/llmConfig/providers.ts` + `web/src/interfaces/llm.ts` — Provider display name + icon mapping

## Why
MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K output, and image input support. Setting it as the default ensures users get the best experience out of the box. M2.7 and M2.7-highspeed are retained as alternatives.

## Testing
- MiniMax-M3 verified via API (chat completions with image input)
- M2.7 and M2.7-highspeed verified as fallback options
- TTS models (speech-2.8-hd/turbo) tested separately