### PR TITLE
chore: [Running GitHub actions for #9224]

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -530,6 +530,11 @@ class LitellmLLM(LLM):
                 ):
                     messages = _strip_tool_content_from_messages(messages)
 
+                # Only pass tool_choice when tools are present — some providers (e.g. Fireworks)
+                # reject requests where tool_choice is explicitly null.
+                if tools and tool_choice is not None:
+                    optional_kwargs["tool_choice"] = tool_choice
+
                 response = litellm.completion(
                     mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
                     model=model,
@@ -538,7 +543,6 @@ class LitellmLLM(LLM):
                     custom_llm_provider=self._custom_llm_provider or None,
                     messages=messages,
                     tools=tools,
-                    tool_choice=tool_choice,
                     stream=stream,
                     temperature=temperature,
                     timeout=timeout_override or self._timeout,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1460,4 +1460,3 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         assert (
             "tool_choice" not in kwargs
         ), "tool_choice must not be sent to providers when no tools are provided"
-               

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -256,7 +256,6 @@ def test_multiple_tool_calls(default_multi_llm: LitellmLLM) -> None:
                 {"role": "user", "content": "What's the weather and time in New York?"}
             ],
             tools=tools,
-            tool_choice=None,
             stream=True,
             temperature=0.0,  # Default value from GEN_AI_TEMPERATURE
             timeout=30,
@@ -412,7 +411,6 @@ def test_multiple_tool_calls_streaming(default_multi_llm: LitellmLLM) -> None:
                 {"role": "user", "content": "What's the weather and time in New York?"}
             ],
             tools=tools,
-            tool_choice=None,
             stream=True,
             temperature=0.0,  # Default value from GEN_AI_TEMPERATURE
             timeout=30,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1431,25 +1431,28 @@ def test_strip_tool_content_merges_consecutive_tool_results() -> None:
 
 def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> None:
     """Regression test for providers (e.g. Fireworks) that reject tool_choice=null.
-    When no tools are provided, tool_choice must not be forwarded to
-    litellm.completion() at all — not even as None."""
-    messages = [UserMessage(message="Hello!")]
 
-    with patch("litellm.completion") as mock_completion:
-        mock_completion.return_value = litellm.ModelResponse(
+    When no tools are provided, tool_choice must not be forwarded to
+    litellm.completion() at all — not even as None.
+    """
+    messages: LanguageModelInput = [UserMessage(content="Hello!")]
+
+    mock_stream_chunks = [
+        litellm.ModelResponse(
             id="chatcmpl-123",
             choices=[
                 litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hello!"),
                     finish_reason="stop",
                     index=0,
-                    message=litellm.Message(role="assistant", content="Hello!"),
                 )
             ],
             model="gpt-3.5-turbo",
-            usage=litellm.Usage(
-                prompt_tokens=10, completion_tokens=5, total_tokens=15
-            ),
-        )
+        ),
+    ]
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_stream_chunks
 
         default_multi_llm.invoke(messages, tools=None)
 
@@ -1457,4 +1460,3 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         assert "tool_choice" not in kwargs, (
             "tool_choice must not be sent to providers when no tools are provided"
         )
-        

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1460,4 +1460,4 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         assert (
             "tool_choice" not in kwargs
         ), "tool_choice must not be sent to providers when no tools are provided"
-       
+               

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1427,3 +1427,34 @@ def test_strip_tool_content_merges_consecutive_tool_results() -> None:
     assert "sunny 72F" in merged
     assert "tc_2" in merged
     assert "headline news" in merged
+
+
+def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> None:
+    """Regression test for providers (e.g. Fireworks) that reject tool_choice=null.
+    When no tools are provided, tool_choice must not be forwarded to
+    litellm.completion() at all — not even as None."""
+    messages = [UserMessage(message="Hello!")]
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=litellm.Message(role="assistant", content="Hello!"),
+                )
+            ],
+            model="gpt-3.5-turbo",
+            usage=litellm.Usage(
+                prompt_tokens=10, completion_tokens=5, total_tokens=15
+            ),
+        )
+
+        default_multi_llm.invoke(messages, tools=None)
+
+        _, kwargs = mock_completion.call_args
+        assert "tool_choice" not in kwargs, (
+            "tool_choice must not be sent to providers when no tools are provided"
+        )
+        

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1457,6 +1457,7 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         default_multi_llm.invoke(messages, tools=None)
 
         _, kwargs = mock_completion.call_args
-        assert "tool_choice" not in kwargs, (
-            "tool_choice must not be sent to providers when no tools are provided"
-        )
+        assert (
+            "tool_choice" not in kwargs
+        ), "tool_choice must not be sent to providers when no tools are provided"
+       


### PR DESCRIPTION
This PR runs GitHub Actions CI for #9224.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent providers from rejecting requests by omitting `tool_choice` when no `tools` are provided in `litellm.completion`. Adds a regression test and updates mocks to match the new behavior.

- **Bug Fixes**
  - Only pass `tool_choice` when `tools` exist; otherwise do not include the field.
  - Updated unit tests and added a regression test to ensure `tool_choice` is never sent without `tools` (e.g., Fireworks compatibility).

<sup>Written for commit 25a082a36e2f4366dd2af31f2c72f40c830cccae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

