### PR TITLE
[BOUNTY #2281] Jira Service Management Connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -200,6 +200,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,11 @@
+"""Jira Service Management connector for Onyx.
+
+Indexes service desk tickets, customer requests, comments, and attachment
+metadata from Jira Service Management (Cloud or Server/Data Center).
+"""
+
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+
+__all__ = ["JiraServiceManagementConnector"]

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,439 @@
+"""Jira Service Management Connector.
+
+Connects to Jira Service Management (JSM) to index service desk tickets,
+customer requests, comments, and attachment metadata.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from typing_extensions import override
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.exceptions import ConnectorMissingCredentialError
+from onyx.connectors.interfaces import CheckpointedConnector
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.jira_service_management.models import (
+    JSMAttachment,
+    JSMComment,
+    JSMCustomer,
+    JSMTicket,
+    JSMServiceDesk,
+)
+from onyx.connectors.jira_service_management.utils import (
+    JSMAPIError,
+    JSMAuthError,
+    JSMPaginatedClient,
+    JSM_DEFAULT_PAGE_SIZE,
+)
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    """Parse an ISO datetime string from Jira API."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_customer(raw: dict[str, Any] | None) -> JSMCustomer | None:
+    """Parse customer/requester info from raw Jira API data."""
+    if not raw:
+        return None
+    return JSMCustomer(
+        account_id=raw.get("accountId"),
+        name=raw.get("name"),
+        email=raw.get("emailAddress"),
+        display_name=raw.get("displayName"),
+        active=raw.get("active", True),
+    )
+
+
+def _parse_comment(raw: dict[str, Any]) -> JSMComment:
+    """Parse a comment from raw Jira API data."""
+    body = raw.get("body", "")
+    # Handle Atlassian Document Format
+    if isinstance(body, dict):
+        body = _extract_text_from_adf(body)
+
+    author = raw.get("author", {})
+    return JSMComment(
+        id=str(raw.get("id", "")),
+        author_name=author.get("displayName"),
+        author_email=author.get("emailAddress"),
+        body=body,
+        created=_parse_datetime(raw.get("created")),
+        updated=_parse_datetime(raw.get("updated")),
+        is_public=raw.get("visibility", {}).get("type", "role") != "role",
+    )
+
+
+def _parse_attachment(raw: dict[str, Any]) -> JSMAttachment:
+    """Parse attachment metadata from raw Jira API data."""
+    author = raw.get("author", {})
+    return JSMAttachment(
+        id=str(raw.get("id", "")),
+        filename=raw.get("filename", ""),
+        size=raw.get("size", 0),
+        content_type=raw.get("mimeType"),
+        author=author.get("displayName"),
+        created=_parse_datetime(raw.get("created")),
+    )
+
+
+def _extract_text_from_adf(adf: dict[str, Any] | None) -> str:
+    """Extract plain text from Atlassian Document Format."""
+    texts: list[str] = []
+    if adf is None or "content" not in adf:
+        return ""
+    for block in adf["content"]:
+        if "content" in block:
+            for item in block["content"]:
+                if item.get("type") == "text":
+                    texts.append(item.get("text", ""))
+    return " ".join(texts)
+
+
+def _raw_to_ticket(raw: dict[str, Any]) -> JSMTicket:
+    """Convert raw Jira issue JSON to JSMTicket model."""
+    fields = raw.get("fields", {})
+    status = fields.get("status", {})
+    priority = fields.get("priority")
+    resolution = fields.get("resolution")
+    issuetype = fields.get("issuetype", {})
+
+    description = fields.get("description", "")
+    if isinstance(description, dict):
+        description = _extract_text_from_adf(description)
+
+    # Extract request type info if available (JSM-specific)
+    request_type_fields = fields.get("requesttype", {})
+    request_type_id = None
+    request_type_name = None
+    if request_type_fields:
+        request_type_id = request_type_fields.get("requestTypeId") or str(
+            request_type_fields.get("id", "")
+        )
+        request_type_name = request_type_fields.get("name")
+
+    return JSMTicket(
+        id=str(raw.get("id", "")),
+        key=raw.get("key", ""),
+        summary=fields.get("summary", ""),
+        description=description,
+        status=status.get("name") if status else None,
+        status_category=status.get("statusCategory", {}).get("name") if status else None,
+        priority=priority.get("name") if priority else None,
+        resolution=resolution.get("name") if resolution else None,
+        issue_type=issuetype.get("name") if issuetype else None,
+        created=_parse_datetime(fields.get("created")),
+        updated=_parse_datetime(fields.get("updated")),
+        resolved=_parse_datetime(fields.get("resolutiondate")),
+        due_date=_parse_datetime(fields.get("duedate")),
+        request_type_id=request_type_id,
+        request_type_name=request_type_name,
+        reporter=_parse_customer(fields.get("reporter")),
+        assignee_name=(
+            fields.get("assignee", {}).get("displayName")
+            if fields.get("assignee")
+            else None
+        ),
+        assignee_email=(
+            fields.get("assignee", {}).get("emailAddress")
+            if fields.get("assignee")
+            else None
+        ),
+        labels=fields.get("labels", []),
+        components=[c.get("name", "") for c in (fields.get("components") or [])],
+        raw=raw,
+    )
+
+
+def _ticket_to_document(
+    jira_base_url: str,
+    ticket: JSMTicket,
+) -> Document | None:
+    """Convert a JSMTicket to an Onyx Document."""
+    if not ticket.summary and not ticket.description:
+        return None
+
+    # Build text content from description + comments + attachments
+    content_parts: list[str] = []
+
+    if ticket.description:
+        content_parts.append(ticket.description)
+
+    if ticket.comments:
+        for comment in ticket.comments:
+            if comment.body:
+                visibility = "Public" if comment.is_public else "Internal"
+                content_parts.append(
+                    f"[{visibility} Comment by {comment.author_name or 'Unknown'}]: "
+                    f"{comment.body}"
+                )
+
+    if ticket.attachments:
+        attachment_info = ", ".join(
+            f"{a.filename} ({a.content_type or 'unknown type'}, {a.size} bytes)"
+            for a in ticket.attachments
+        )
+        content_parts.append(f"Attachments: {attachment_info}")
+
+    ticket_content = "\n\n".join(content_parts)
+
+    page_url = f"{jira_base_url}/browse/{ticket.key}"
+
+    # Build metadata
+    metadata: dict[str, str | list[str]] = {
+        "key": ticket.key,
+    }
+    if ticket.status:
+        metadata["status"] = ticket.status
+    if ticket.priority:
+        metadata["priority"] = ticket.priority
+    if ticket.issue_type:
+        metadata["issuetype"] = ticket.issue_type
+    if ticket.resolution:
+        metadata["resolution"] = ticket.resolution
+    if ticket.labels:
+        metadata["labels"] = ticket.labels
+    if ticket.components:
+        metadata["components"] = ticket.components
+    if ticket.request_type_name:
+        metadata["request_type"] = ticket.request_type_name
+    if ticket.reporter:
+        metadata["reporter"] = ticket.reporter.display_name or ticket.reporter.name or ""
+        if ticket.reporter.email:
+            metadata["reporter_email"] = ticket.reporter.email
+    if ticket.assignee_name:
+        metadata["assignee"] = ticket.assignee_name
+        if ticket.assignee_email:
+            metadata["assignee_email"] = ticket.assignee_email
+
+    # Determine primary owners
+    primary_owners: list[str] = []
+    if ticket.assignee_name:
+        from onyx.connectors.models import BasicExpertInfo
+
+        primary_owners.append(
+            BasicExpertInfo(
+                display_name=ticket.assignee_name,
+                email=ticket.assignee_email,
+            ).get_semantic_name()
+        )
+    elif ticket.reporter:
+        from onyx.connectors.models import BasicExpertInfo
+
+        reporter_name = ticket.reporter.display_name or ticket.reporter.name
+        if reporter_name:
+            primary_owners.append(
+                BasicExpertInfo(
+                    display_name=reporter_name,
+                    email=ticket.reporter.email,
+                ).get_semantic_name()
+            )
+
+    # Parse updated time for doc_updated_at
+    doc_updated_at = None
+    if ticket.updated:
+        doc_updated_at = ticket.updated
+
+    semantic_identifier = f"{ticket.key}: {ticket.summary}" if ticket.summary else ticket.key
+    title = f"{ticket.key} {ticket.summary}" if ticket.summary else ticket.key
+
+    return Document(
+        id=page_url,
+        sections=[TextSection(link=page_url, text=ticket_content)],
+        source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+        semantic_identifier=semantic_identifier,
+        title=title,
+        doc_updated_at=doc_updated_at,
+        primary_owners=primary_owners or None,
+        metadata=metadata,
+    )
+
+
+class JSMConnectorCheckpoint(ConnectorCheckpoint):
+    """Checkpoint for JSM connector incremental sync."""
+
+    offset: int = 0
+
+
+class JiraServiceManagementConnector(
+    CheckpointedConnector[JSMConnectorCheckpoint],
+):
+    """Connector for Jira Service Management (JSM).
+
+    Indexes service desk tickets (customer requests) including comments
+    and attachment metadata. Supports incremental sync via updated timestamp.
+    """
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str | None = None,
+        service_desk_id: str | None = None,
+        comment_email_blacklist: list[str] | None = None,
+        page_size: int = JSM_DEFAULT_PAGE_SIZE,
+    ) -> None:
+        self.jira_base_url = jira_base_url.rstrip("/")
+        self.project_key = project_key
+        self.service_desk_id = service_desk_id
+        self._comment_email_blacklist = set(comment_email_blacklist or [])
+        self.page_size = min(page_size, 100)
+        self._client: JSMPaginatedClient | None = None
+
+    @property
+    def client(self) -> JSMPaginatedClient:
+        if self._client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+        return self._client
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._client = JSMPaginatedClient(
+            jira_base_url=self.jira_base_url,
+            email=credentials.get("jira_user_email"),
+            api_token=credentials.get("jira_api_token"),
+            personal_token=credentials.get("jira_personal_token"),
+        )
+        return None
+
+    def _build_jql(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> str:
+        """Build JQL query for ticket retrieval with time-based filtering."""
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        start_str = start_dt.strftime("%Y-%m-%d %H:%M")
+        end_str = end_dt.strftime("%Y-%m-%d %H:%M")
+
+        time_clause = f"updated >= '{start_str}' AND updated <= '{end_str}'"
+
+        clauses: list[str] = [time_clause]
+
+        if self.project_key:
+            clauses.insert(0, f'project = "{self.project_key}"')
+
+        return " AND ".join(clauses)
+
+    def _enrich_ticket(self, ticket: JSMTicket) -> JSMTicket:
+        """Fetch comments and attachments for a ticket."""
+        try:
+            raw_comments = self.client.get_ticket_comments(ticket.key)
+            ticket.comments = [
+                c
+                for c in (_parse_comment(rc) for rc in raw_comments)
+                if c.author_email not in self._comment_email_blacklist
+            ]
+        except JSMAPIError as e:
+            logger.warning(f"Failed to fetch comments for {ticket.key}: {e}")
+
+        try:
+            raw_attachments = self.client.get_ticket_attachments(ticket.key)
+            ticket.attachments = [_parse_attachment(ra) for ra in raw_attachments]
+        except JSMAPIError as e:
+            logger.warning(f"Failed to fetch attachments for {ticket.key}: {e}")
+
+        return ticket
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JSMConnectorCheckpoint,
+    ) -> CheckpointOutput[JSMConnectorCheckpoint]:
+        jql = self._build_jql(start, end)
+
+        try:
+            raw_issues = self.client.search_tickets(
+                jql=jql,
+                fields="*all",
+                page_size=self.page_size,
+            )
+        except (JSMAuthError, JSMAPIError) as e:
+            raise ConnectorMissingCredentialError(
+                f"Failed to fetch JSM tickets: {e}"
+            ) from e
+
+        current_offset = checkpoint.offset
+        new_checkpoint = JSMConnectorCheckpoint(offset=current_offset)
+
+        for i, raw_issue in enumerate(raw_issues):
+            if i < current_offset:
+                continue
+
+            try:
+                ticket = _raw_to_ticket(raw_issue)
+                ticket = self._enrich_ticket(ticket)
+
+                document = _ticket_to_document(self.jira_base_url, ticket)
+                if document is not None:
+                    yield document
+            except Exception as e:
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=raw_issue.get("key", "unknown"),
+                        document_link=f"{self.jira_base_url}/browse/{raw_issue.get('key', '')}",
+                    ),
+                    failure_message=f"Failed to process JSM ticket: {e}",
+                    exception=e,
+                )
+
+            new_checkpoint.offset = i + 1
+
+        new_checkpoint.has_more = False
+        return new_checkpoint
+
+    def validate_connector_settings(self) -> None:
+        if self._client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        try:
+            if self.service_desk_id:
+                self.client.get_service_desk_info(self.service_desk_id)
+            elif self.project_key:
+                # Verify project access by doing a simple search
+                self.client.search_tickets(
+                    jql=f'project = "{self.project_key}"',
+                    page_size=1,
+                )
+            else:
+                # Verify general access
+                self.client.get_service_desks()
+        except JSMAuthError as e:
+            from onyx.connectors.exceptions import CredentialExpiredError
+
+            raise CredentialExpiredError(
+                f"JSM credentials are expired or invalid: {e}"
+            ) from e
+        except JSMAPIError as e:
+            from onyx.connectors.exceptions import InsufficientPermissionsError
+
+            raise InsufficientPermissionsError(
+                f"Insufficient permissions for JSM: {e}"
+            ) from e
+
+    @override
+    def validate_checkpoint_json(self, checkpoint_json: str) -> JSMConnectorCheckpoint:
+        return JSMConnectorCheckpoint.model_validate_json(checkpoint_json)
+
+    @override
+    def build_dummy_checkpoint(self) -> JSMConnectorCheckpoint:
+        return JSMConnectorCheckpoint(has_more=True)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -13,7 +13,6 @@ from typing import Any
 from typing_extensions import override
 
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.exceptions import ConnectorMissingCredentialError
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CheckpointOutput
@@ -23,7 +22,6 @@ from onyx.connectors.jira_service_management.models import (
     JSMComment,
     JSMCustomer,
     JSMTicket,
-    JSMServiceDesk,
 )
 from onyx.connectors.jira_service_management.utils import (
     JSMAPIError,
@@ -31,6 +29,7 @@ from onyx.connectors.jira_service_management.utils import (
     JSMPaginatedClient,
     JSM_DEFAULT_PAGE_SIZE,
 )
+from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.models import ConnectorCheckpoint
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
@@ -79,7 +78,7 @@ def _parse_comment(raw: dict[str, Any]) -> JSMComment:
         body=body,
         created=_parse_datetime(raw.get("created")),
         updated=_parse_datetime(raw.get("updated")),
-        is_public=raw.get("visibility", {}).get("type", "role") != "role",
+        is_public=(raw.get("visibility") is None or raw.get("visibility", {}).get("type") != "role"),
     )
 
 
@@ -228,7 +227,6 @@ def _ticket_to_document(
     # Determine primary owners
     primary_owners: list[str] = []
     if ticket.assignee_name:
-        from onyx.connectors.models import BasicExpertInfo
 
         primary_owners.append(
             BasicExpertInfo(
@@ -236,7 +234,6 @@ def _ticket_to_document(
                 email=ticket.assignee_email,
             ).get_semantic_name()
         )
-    elif ticket.reporter:
         from onyx.connectors.models import BasicExpertInfo
 
         reporter_name = ticket.reporter.display_name or ticket.reporter.name
@@ -331,6 +328,9 @@ class JiraServiceManagementConnector(
         if self.project_key:
             clauses.insert(0, f'project = "{self.project_key}"')
 
+        if self.service_desk_id:
+            clauses.insert(0, f'"Service Desk" = "{self.service_desk_id}"')
+
         return " AND ".join(clauses)
 
     def _enrich_ticket(self, ticket: JSMTicket) -> JSMTicket:
@@ -360,43 +360,49 @@ class JiraServiceManagementConnector(
         checkpoint: JSMConnectorCheckpoint,
     ) -> CheckpointOutput[JSMConnectorCheckpoint]:
         jql = self._build_jql(start, end)
-
-        try:
-            raw_issues = self.client.search_tickets(
-                jql=jql,
-                fields="*all",
-                page_size=self.page_size,
-            )
-        except (JSMAuthError, JSMAPIError) as e:
-            raise ConnectorMissingCredentialError(
-                f"Failed to fetch JSM tickets: {e}"
-            ) from e
-
         current_offset = checkpoint.offset
         new_checkpoint = JSMConnectorCheckpoint(offset=current_offset)
 
-        for i, raw_issue in enumerate(raw_issues):
-            if i < current_offset:
-                continue
-
+        while True:
             try:
-                ticket = _raw_to_ticket(raw_issue)
-                ticket = self._enrich_ticket(ticket)
-
-                document = _ticket_to_document(self.jira_base_url, ticket)
-                if document is not None:
-                    yield document
-            except Exception as e:
-                yield ConnectorFailure(
-                    failed_document=DocumentFailure(
-                        document_id=raw_issue.get("key", "unknown"),
-                        document_link=f"{self.jira_base_url}/browse/{raw_issue.get('key', '')}",
-                    ),
-                    failure_message=f"Failed to process JSM ticket: {e}",
-                    exception=e,
+                raw_issues, has_more = self.client.search_tickets_paged(
+                    jql=jql,
+                    fields="*all",
+                    page_size=self.page_size,
+                    start_at=current_offset,
                 )
+            except (JSMAuthError, JSMAPIError) as e:
+                raise ConnectorMissingCredentialError(
+                    f"Failed to fetch JSM tickets: {e}"
+                ) from e
 
-            new_checkpoint.offset = i + 1
+            if not raw_issues:
+                break
+
+            for i, raw_issue in enumerate(raw_issues):
+                try:
+                    ticket = _raw_to_ticket(raw_issue)
+                    ticket = self._enrich_ticket(ticket)
+
+                    document = _ticket_to_document(self.jira_base_url, ticket)
+                    if document is not None:
+                        yield document
+                except Exception as e:
+                    yield ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=raw_issue.get("key", "unknown"),
+                            document_link=f"{self.jira_base_url}/browse/{raw_issue.get('key', '')}",
+                        ),
+                        failure_message=f"Failed to process JSM ticket: {e}",
+                        exception=e,
+                    )
+
+                new_checkpoint.offset = current_offset + i + 1
+
+            current_offset = new_checkpoint.offset
+
+            if not has_more:
+                break
 
         new_checkpoint.has_more = False
         return new_checkpoint

--- a/backend/onyx/connectors/jira_service_management/models.py
+++ b/backend/onyx/connectors/jira_service_management/models.py
@@ -1,0 +1,81 @@
+"""Pydantic models for Jira Service Management connector."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class JSMCustomer(BaseModel):
+    """Represents a JSM customer (requester)."""
+
+    account_id: str | None = None
+    name: str | None = None
+    email: str | None = None
+    display_name: str | None = None
+    active: bool = True
+
+
+class JSMComment(BaseModel):
+    """Represents a comment on a JSM ticket."""
+
+    id: str
+    author_name: str | None = None
+    author_email: str | None = None
+    body: str = ""
+    created: datetime | None = None
+    updated: datetime | None = None
+    is_public: bool = True
+
+
+class JSMServiceDesk(BaseModel):
+    """Represents a Jira Service Management service desk."""
+
+    id: str
+    name: str
+    project_key: str
+    project_name: str | None = None
+    description: str | None = None
+
+
+class JSMAttachment(BaseModel):
+    """Metadata for a JSM ticket attachment."""
+
+    id: str
+    filename: str
+    size: int = 0
+    content_type: str | None = None
+    author: str | None = None
+    created: datetime | None = None
+    download_url: str | None = None
+
+
+class JSMTicket(BaseModel):
+    """Represents a Jira Service Management ticket / customer request."""
+
+    id: str
+    key: str
+    summary: str = ""
+    description: str = ""
+    status: str | None = None
+    status_category: str | None = None
+    priority: str | None = None
+    resolution: str | None = None
+    issue_type: str | None = None
+    created: datetime | None = None
+    updated: datetime | None = None
+    resolved: datetime | None = None
+    due_date: datetime | None = None
+    service_desk_id: str | None = None
+    request_type_id: str | None = None
+    request_type_name: str | None = None
+    reporter: JSMCustomer | None = None
+    assignee_name: str | None = None
+    assignee_email: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    components: list[str] = Field(default_factory=list)
+    comments: list[JSMComment] = Field(default_factory=list)
+    attachments: list[JSMAttachment] = Field(default_factory=list)
+    raw: dict[str, Any] = Field(default_factory=dict)

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -6,7 +6,6 @@ import time
 from typing import Any
 
 import httpx
-from typing_extensions import override
 
 from onyx.utils.logger import setup_logger
 
@@ -203,6 +202,9 @@ class JSMPaginatedClient:
                 data = response.json()
                 all_items.extend(data.get("values", []))
 
+                if not data.get("values"):
+                    break
+
                 next_page = data.get("_links", {}).get("next")
                 if not next_page:
                     break
@@ -222,6 +224,8 @@ class JSMPaginatedClient:
                 response = request_fn("GET", path, params=params)
                 data = response.json()
                 issues = data.get("issues", data.get("values", []))
+                if not issues:
+                    break
                 all_items.extend(issues)
 
                 total = data.get("total", 0)
@@ -265,6 +269,8 @@ class JSMPaginatedClient:
             response = self._request_with_retry("GET", "/search", params=params)
             data = response.json()
             issues = data.get("issues", [])
+            if not issues:
+                break
             all_issues.extend(issues)
 
             total = data.get("total", 0)
@@ -273,6 +279,29 @@ class JSMPaginatedClient:
             start_at += len(issues)
 
         return all_issues
+
+    def search_tickets_paged(
+        self,
+        jql: str,
+        fields: str | None = None,
+        page_size: int = JSM_DEFAULT_PAGE_SIZE,
+        start_at: int = 0,
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Search JSM tickets with pagination. Returns (issues, has_more)."""
+        params: dict[str, Any] = {
+            "jql": jql,
+            "maxResults": min(page_size, JSM_MAX_PAGE_SIZE),
+            "startAt": start_at,
+        }
+        if fields:
+            params["fields"] = fields
+
+        response = self._request_with_retry("GET", "/search", params=params)
+        data = response.json()
+        issues = data.get("issues", [])
+        total = data.get("total", 0)
+        has_more = (start_at + len(issues)) < total
+        return issues, has_more
 
     def get_ticket_comments(self, issue_key: str) -> list[dict[str, Any]]:
         """Get comments for a specific ticket."""

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,285 @@
+"""Utility functions for Jira Service Management connector."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+from typing_extensions import override
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Jira API constraints
+JSM_MAX_PAGE_SIZE = 100
+JSM_DEFAULT_PAGE_SIZE = 50
+JSM_RATE_LIMIT_RETRY_ATTEMPTS = 3
+JSM_RATE_LIMIT_INITIAL_BACKOFF = 1.0  # seconds
+
+
+class JSMRateLimitError(Exception):
+    """Raised when Jira API rate limit is hit."""
+
+
+class JSMAuthError(Exception):
+    """Raised when Jira API authentication fails."""
+
+
+class JSMAPIError(Exception):
+    """General Jira API error."""
+
+
+class JSMPaginatedClient:
+    """Wrapper around httpx for paginated Jira Service Management API calls."""
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        email: str | None = None,
+        api_token: str | None = None,
+        personal_token: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.jira_base_url = jira_base_url.rstrip("/")
+        self.timeout = timeout
+
+        if email and api_token:
+            # Basic Auth (Cloud or Server with username/password)
+            self.auth = (email, api_token)
+            self.headers: dict[str, str] = {}
+        elif personal_token:
+            # Personal Access Token / Bearer Auth (Server/Data Center)
+            self.auth = None
+            self.headers = {"Authorization": f"Bearer {personal_token}"}
+        else:
+            raise JSMAuthError(
+                "Either (email + api_token) or personal_token must be provided."
+            )
+
+        self._client = httpx.Client(
+            base_url=self.jira_base_url,
+            auth=self.auth,
+            headers=self.headers,
+            timeout=httpx.Timeout(timeout),
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> JSMPaginatedClient:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Make an HTTP request with rate-limit retry logic."""
+        url = f"{self.jira_base_url}/rest/api/2{path}"
+        backoff = JSM_RATE_LIMIT_INITIAL_BACKOFF
+
+        for attempt in range(JSM_RATE_LIMIT_RETRY_ATTEMPTS):
+            response = self._client.request(
+                method=method,
+                url=url,
+                params=params,
+                json=json_data,
+            )
+
+            if response.status_code == 429:
+                retry_after = float(response.headers.get("Retry-After", backoff))
+                logger.warning(
+                    f"JSM API rate limit hit. Retrying in {retry_after}s "
+                    f"(attempt {attempt + 1}/{JSM_RATE_LIMIT_RETRY_ATTEMPTS})."
+                )
+                time.sleep(retry_after)
+                backoff *= 2
+                continue
+
+            if response.status_code == 401:
+                raise JSMAuthError("Authentication failed (HTTP 401). Check credentials.")
+
+            if response.status_code == 403:
+                raise JSMAPIError(
+                    f"Insufficient permissions (HTTP 403). Path: {path}"
+                )
+
+            if response.status_code >= 400:
+                raise JSMAPIError(
+                    f"JSM API error: HTTP {response.status_code} - "
+                    f"{response.text[:500]} for path {path}"
+                )
+
+            return response
+
+        raise JSMRateLimitError(
+            f"JSM API rate limit exceeded after {JSM_RATE_LIMIT_RETRY_ATTEMPTS} attempts."
+        )
+
+    def _service_desk_request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        json_data: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Make a request to the Jira Service Management REST API (under /rest/servicedeskapi/)."""
+        url = f"{self.jira_base_url}/rest/servicedeskapi{path}"
+        backoff = JSM_RATE_LIMIT_INITIAL_BACKOFF
+
+        for attempt in range(JSM_RATE_LIMIT_RETRY_ATTEMPTS):
+            response = self._client.request(
+                method=method,
+                url=url,
+                params=params,
+                json=json_data,
+            )
+
+            if response.status_code == 429:
+                retry_after = float(response.headers.get("Retry-After", backoff))
+                logger.warning(
+                    f"JSM Service Desk API rate limit hit. Retrying in {retry_after}s "
+                    f"(attempt {attempt + 1}/{JSM_RATE_LIMIT_RETRY_ATTEMPTS})."
+                )
+                time.sleep(retry_after)
+                backoff *= 2
+                continue
+
+            if response.status_code == 401:
+                raise JSMAuthError("Authentication failed (HTTP 401). Check credentials.")
+
+            if response.status_code == 403:
+                raise JSMAPIError(
+                    f"Insufficient permissions for Service Desk API (HTTP 403). Path: {path}"
+                )
+
+            if response.status_code >= 400:
+                raise JSMAPIError(
+                    f"JSM Service Desk API error: HTTP {response.status_code} - "
+                    f"{response.text[:500]} for path {path}"
+                )
+
+            return response
+
+        raise JSMRateLimitError(
+            f"JSM Service Desk API rate limit exceeded after {JSM_RATE_LIMIT_RETRY_ATTEMPTS} attempts."
+        )
+
+    def paginated_get(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        page_size: int = JSM_DEFAULT_PAGE_SIZE,
+        use_servicedesk_api: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Fetch all pages of a paginated GET endpoint.
+
+        Supports both Jira REST API (/rest/api/2/) and
+        Service Desk REST API (/rest/servicedeskapi/) pagination.
+
+        Jira REST API pagination uses `startAt` and `maxResults`.
+        Service Desk API pagination uses `start` and `limit` with
+        `_links.next` for cursor-based pagination.
+        """
+        if params is None:
+            params = {}
+
+        request_fn = self._service_desk_request if use_servicedesk_api else self._request_with_retry
+
+        if use_servicedesk_api:
+            # Service Desk API uses cursor-based pagination
+            params["limit"] = min(page_size, JSM_MAX_PAGE_SIZE)
+            all_items: list[dict[str, Any]] = []
+
+            while True:
+                response = request_fn("GET", path, params=params)
+                data = response.json()
+                all_items.extend(data.get("values", []))
+
+                next_page = data.get("_links", {}).get("next")
+                if not next_page:
+                    break
+
+                # Reset params for next page (URL is fully qualified in _links.next)
+                params = {}
+
+            return all_items
+        else:
+            # Standard Jira REST API pagination
+            start_at = 0
+            all_items = []
+            params["maxResults"] = min(page_size, JSM_MAX_PAGE_SIZE)
+
+            while True:
+                params["startAt"] = start_at
+                response = request_fn("GET", path, params=params)
+                data = response.json()
+                issues = data.get("issues", data.get("values", []))
+                all_items.extend(issues)
+
+                total = data.get("total", 0)
+                if start_at + len(issues) >= total:
+                    break
+                start_at += len(issues)
+
+            return all_items
+
+    def get_service_desks(self) -> list[dict[str, Any]]:
+        """Get all accessible service desks."""
+        return self.paginated_get(
+            "/servicedesk",
+            use_servicedesk_api=True,
+        )
+
+    def get_service_desk_info(self, service_desk_id: str) -> dict[str, Any]:
+        """Get info about a specific service desk."""
+        response = self._service_desk_request("GET", f"/servicedesk/{service_desk_id}")
+        return response.json()
+
+    def search_tickets(
+        self,
+        jql: str,
+        fields: str | None = None,
+        page_size: int = JSM_DEFAULT_PAGE_SIZE,
+    ) -> list[dict[str, Any]]:
+        """Search JSM tickets using JQL via the standard Jira REST API."""
+        params: dict[str, Any] = {
+            "jql": jql,
+            "maxResults": min(page_size, JSM_MAX_PAGE_SIZE),
+        }
+        if fields:
+            params["fields"] = fields
+
+        start_at = 0
+        all_issues: list[dict[str, Any]] = []
+
+        while True:
+            params["startAt"] = start_at
+            response = self._request_with_retry("GET", "/search", params=params)
+            data = response.json()
+            issues = data.get("issues", [])
+            all_issues.extend(issues)
+
+            total = data.get("total", 0)
+            if start_at + len(issues) >= total:
+                break
+            start_at += len(issues)
+
+        return all_issues
+
+    def get_ticket_comments(self, issue_key: str) -> list[dict[str, Any]]:
+        """Get comments for a specific ticket."""
+        return self.paginated_get(f"/issue/{issue_key}/comment")
+
+    def get_ticket_attachments(self, issue_key: str) -> list[dict[str, Any]]:
+        """Get attachment metadata for a specific ticket."""
+        response = self._request_with_retry("GET", f"/issue/{issue_key}")
+        fields = response.json().get("fields", {})
+        return fields.get("attachment", [])


### PR DESCRIPTION
Closes #2281

## Changes

- `JiraServiceManagementConnector` with checkpoint-based incremental sync
- `JSMPaginatedClient` with rate limit handling
- Support for Cloud and self-hosted Jira Service Management
- Ticket, comment, and attachment metadata enrichment
- Added to DocumentSource enum

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Service Management connector to index service desk tickets with comment and attachment metadata. Implements incremental sync, optional project/service desk scoping, and supports Cloud and self‑hosted JSM to satisfy Linear #2281.

- **New Features**
  - Checkpoint-based incremental sync using updated timestamps and JQL windows.
  - Rate‑limit aware paginated client for Jira REST and Service Desk APIs.
  - Added `JIRA_SERVICE_MANAGEMENT` to the document source enum.

- **Bug Fixes**
  - Fixed Service Desk pagination loop and pagination now respects checkpoint offsets.
  - Corrected comment visibility (no visibility = public) and JQL includes `service_desk_id`.

<sup>Written for commit 8aac4ed31dae5a4f15b765e22d94c8dd456f2809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

