### PR TITLE
feat: add POSTGRES_SSLMODE env var for SSL connections

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -371,6 +371,10 @@ POSTGRES_USE_NULL_POOL = os.environ.get("POSTGRES_USE_NULL_POOL", "").lower() ==
 # defaults to False
 POSTGRES_POOL_PRE_PING = os.environ.get("POSTGRES_POOL_PRE_PING", "").lower() == "true"
 
+# SSL mode for PostgreSQL connections (e.g. "disable", "require", "verify-full")
+# asyncpg uses "ssl" param, psycopg2 uses "sslmode" param
+POSTGRES_SSLMODE = os.environ.get("POSTGRES_SSLMODE", None)
+
 # recycle timeout in seconds
 POSTGRES_POOL_RECYCLE_DEFAULT = 60 * 20  # 20 minutes
 try:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -373,7 +373,16 @@ POSTGRES_POOL_PRE_PING = os.environ.get("POSTGRES_POOL_PRE_PING", "").lower() ==
 
 # SSL mode for PostgreSQL connections (e.g. "disable", "require", "verify-full")
 # asyncpg uses "ssl" param, psycopg2 uses "sslmode" param
-POSTGRES_SSLMODE = os.environ.get("POSTGRES_SSLMODE", None)
+POSTGRES_SSLMODE: str | None = os.environ.get("POSTGRES_SSLMODE", None)
+
+_VALID_SSLMODES = frozenset(
+    {"disable", "allow", "prefer", "require", "verify-ca", "verify-full"}
+)
+if POSTGRES_SSLMODE and POSTGRES_SSLMODE not in _VALID_SSLMODES:
+    raise ValueError(
+        f"Invalid POSTGRES_SSLMODE={POSTGRES_SSLMODE!r}. "
+        f"Must be one of: {sorted(_VALID_SSLMODES)}"
+    )
 
 # recycle timeout in seconds
 POSTGRES_POOL_RECYCLE_DEFAULT = 60 * 20  # 20 minutes

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -21,6 +21,7 @@ from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
+from onyx.configs.app_configs import POSTGRES_SSLMODE
 from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
@@ -72,6 +73,12 @@ def build_connection_string(
         base_conn_str = f"postgresql+{db_api}://{user}@{host}:{port}/{db}"
     else:
         base_conn_str = f"postgresql+{db_api}://{user}:{password}@{host}:{port}/{db}"
+
+    if POSTGRES_SSLMODE:
+        if db_api == ASYNC_DB_API:
+            base_conn_str += f"?ssl={POSTGRES_SSLMODE}"
+        else:
+            base_conn_str += f"?sslmode={POSTGRES_SSLMODE}"
 
     # For asyncpg, do not include application_name in the connection string
     if app_name and db_api != "asyncpg":

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -21,9 +21,9 @@ from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
-from onyx.configs.app_configs import POSTGRES_SSLMODE
 from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
 from onyx.configs.app_configs import POSTGRES_PORT
+from onyx.configs.app_configs import POSTGRES_SSLMODE
 from onyx.configs.app_configs import POSTGRES_USE_NULL_POOL
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.constants import POSTGRES_UNKNOWN_APP_NAME


### PR DESCRIPTION
## Summary
- Add `POSTGRES_SSLMODE` environment variable to configure PostgreSQL SSL mode (e.g. `disable`, `require`, `verify-full`)
- Handles driver difference: asyncpg uses `ssl` query parameter, psycopg2 uses `sslmode`
- Enables secure database connections for cloud-managed PostgreSQL instances that require TLS

Closes #2659

## Test plan
- [ ] Set `POSTGRES_SSLMODE=disable` and verify DB connection works normally
- [ ] Set `POSTGRES_SSLMODE=require` with an SSL-enabled PostgreSQL instance and verify connection
- [ ] Verify no regression when `POSTGRES_SSLMODE` is unset (default behavior)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POSTGRES_SSLMODE` to control PostgreSQL SSL mode across drivers, enabling TLS connections for managed Postgres without code changes. Validates values at startup and maps to `ssl` for `asyncpg` and `sslmode` for `psycopg2`; unset keeps current behavior.

- **Migration**
  - Set `POSTGRES_SSLMODE` to one of: `disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`.
  - Leave unset to keep existing behavior.

<sup>Written for commit ab5356b76dba2bce1cd8f31d8fc61045a74006bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

