### PR TITLE
fix(image): Resize images by dimension before sending to vision API

### DIFF
--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -5,6 +5,7 @@ from PIL import Image
 
 from onyx.configs.app_configs import IMAGE_SUMMARIZATION_SYSTEM_PROMPT
 from onyx.configs.app_configs import IMAGE_SUMMARIZATION_USER_PROMPT
+from onyx.configs.llm_configs import get_image_analysis_max_size_mb
 from onyx.llm.interfaces import LLM
 from onyx.llm.models import ChatCompletionMessage
 from onyx.llm.models import ContentPart
@@ -28,8 +29,10 @@ class UnsupportedImageFormatError(ValueError):
 
 def prepare_image_bytes(image_data: bytes) -> str:
     """Prepare image bytes for summarization.
-    Resizes image if it's larger than 20MB. Encodes image as a base64 string."""
-    image_data = _resize_image_if_needed(image_data)
+    Downsizes large-dimension images for vision API efficiency and enforces the
+    workspace-configurable file-size limit.  Encodes the result as a base64 data URL."""
+    max_size_mb = get_image_analysis_max_size_mb()
+    image_data = _resize_image_if_needed(image_data, max_size_mb=max_size_mb)
 
     # encode image (base64)
     encoded_image = _encode_image_for_llm_prompt(image_data)
@@ -153,20 +156,53 @@ def _encode_image_for_llm_prompt(image_data: bytes) -> str:
     return f"data:{mime_type};base64,{base64_encoded_data}"
 
 
-def _resize_image_if_needed(image_data: bytes, max_size_mb: int = 20) -> bytes:
-    """Resize image if it's larger than the specified max size in MB."""
+_MAX_DIMENSION_PX = 2048
+"""Cap the longest side of any image sent to the vision API.
+
+Full-page PDF renders are commonly ~1700×2400 px — well under typical
+file-size limits but expensive in vision-API tokens.  Capping at 2048 px
+keeps quality high while significantly reducing token cost and latency.
+"""
+
+
+def _resize_image_if_needed(
+    image_data: bytes,
+    max_size_mb: int = 20,
+    max_dimension_px: int = _MAX_DIMENSION_PX,
+) -> bytes:
+    """Resize an image when it exceeds either a dimension or file-size limit.
+
+    The dimension check runs first so that a large-pixel image is down-scaled
+    even when its file size is within limits (common for lossless PNGs from
+    PDF renders).  The file-size check is a safety net for already-compressed
+    images that are still very large.
+    """
     max_size_bytes = max_size_mb * 1024 * 1024
+    needs_resize = False
 
-    if len(image_data) > max_size_bytes:
-        with Image.open(BytesIO(image_data)) as img:
-            # Reduce dimensions for better size reduction
-            img.thumbnail((1024, 1024), Image.Resampling.LANCZOS)
-            output = BytesIO()
+    with Image.open(BytesIO(image_data)) as img:
+        width, height = img.size
 
-            # Save with lower quality for compression
-            img.save(output, format="JPEG", quality=85)
-            resized_data = output.getvalue()
+        if width > max_dimension_px or height > max_dimension_px:
+            needs_resize = True
+        elif len(image_data) > max_size_bytes:
+            needs_resize = True
 
-            return resized_data
+        if not needs_resize:
+            return image_data
 
-    return image_data
+        original_size = (width, height)
+        img.thumbnail((max_dimension_px, max_dimension_px), Image.Resampling.LANCZOS)
+        output = BytesIO()
+        img.save(output, format="JPEG", quality=85)
+        resized_data = output.getvalue()
+
+        logger.info(
+            "Resized image from %s (%d bytes) to %s (%d bytes)",
+            original_size,
+            len(image_data),
+            img.size,
+            len(resized_data),
+        )
+
+        return resized_data

--- a/backend/tests/unit/onyx/file_processing/test_image_resize.py
+++ b/backend/tests/unit/onyx/file_processing/test_image_resize.py
@@ -1,0 +1,88 @@
+"""Tests for image resizing logic in image_summarization.py."""
+
+import io
+from unittest.mock import patch
+
+from PIL import Image
+
+from onyx.file_processing.image_summarization import _MAX_DIMENSION_PX
+from onyx.file_processing.image_summarization import _resize_image_if_needed
+from onyx.file_processing.image_summarization import prepare_image_bytes
+
+
+def _make_png(width: int, height: int) -> bytes:
+    """Create a minimal in-memory PNG of the given dimensions."""
+    img = Image.new("RGB", (width, height), color="red")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# -- _resize_image_if_needed ---------------------------------------------------
+
+
+def test_small_image_unchanged() -> None:
+    """An image within both dimension and file-size limits is returned as-is."""
+    data = _make_png(800, 600)
+    result = _resize_image_if_needed(data)
+    assert result is data  # identity check — no copy
+
+
+def test_oversized_dimensions_resized() -> None:
+    """An image exceeding the max dimension is shrunk even if file size is small."""
+    data = _make_png(3000, 2000)
+    result = _resize_image_if_needed(data)
+
+    with Image.open(io.BytesIO(result)) as img:
+        assert max(img.size) <= _MAX_DIMENSION_PX
+
+
+def test_oversized_file_size_resized() -> None:
+    """An image within dimension limits but over file-size limit is resized."""
+    # Create a small-dimension image, then pretend it's huge via a tiny max_size_mb
+    data = _make_png(800, 600)
+    result = _resize_image_if_needed(data, max_size_mb=0)
+
+    # Should have been re-encoded (different bytes)
+    assert result != data
+
+
+def test_custom_max_dimension() -> None:
+    """The max_dimension_px parameter is respected."""
+    data = _make_png(1200, 900)
+    result = _resize_image_if_needed(data, max_dimension_px=1000)
+
+    with Image.open(io.BytesIO(result)) as img:
+        assert max(img.size) <= 1000
+
+
+def test_aspect_ratio_preserved() -> None:
+    """Resizing preserves the original aspect ratio."""
+    data = _make_png(4000, 2000)  # 2:1
+    result = _resize_image_if_needed(data, max_dimension_px=2048)
+
+    with Image.open(io.BytesIO(result)) as img:
+        w, h = img.size
+        assert w == 2048
+        # Allow ±1 px rounding
+        assert abs(h - 1024) <= 1
+
+
+# -- prepare_image_bytes -------------------------------------------------------
+
+
+@patch("onyx.file_processing.image_summarization.get_image_analysis_max_size_mb")
+def test_prepare_image_bytes_uses_workspace_setting(mock_get_max: object) -> None:
+    """prepare_image_bytes wires the workspace max-size setting through."""
+    from unittest.mock import MagicMock
+
+    mock_get_max = MagicMock(return_value=5)  # type: ignore[assignment]
+    with patch(
+        "onyx.file_processing.image_summarization.get_image_analysis_max_size_mb",
+        mock_get_max,
+    ):
+        data = _make_png(800, 600)
+        result = prepare_image_bytes(data)
+
+    mock_get_max.assert_called_once()
+    assert result.startswith("data:image/")


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Large-dimension images (e.g. full-page PDF renders at ~1700×2400 px) were sent to the vision API at full resolution even when under the file-size limit, wasting tokens and adding latency. Now _resize_image_if_needed caps the longest side at 2048 px regardless of file size. The file-size threshold also uses the workspace-configurable setting from get_image_analysis_max_size_mb() instead of a hardcoded 20 MB.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Adding tests specifically for this case

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downsize large-dimension images before sending to the vision API to cut token usage and latency. Also use the workspace max image size setting instead of a hardcoded limit.

- **New Features**
  - Cap the longest side at 2048 px (aspect ratio preserved); resize also triggers if file size exceeds the workspace limit.
  - Apply the workspace-configurable max size from llm configs instead of a 20 MB default.
  - Re-encode resized images as JPEG (quality 85) and log before/after sizes; added unit tests for dimension cap, file-size path, aspect ratio, and config wiring.

<sup>Written for commit 848a353a399ffb7de168d5eda3de6cce199cb608. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

