### PR TITLE
feat - Initial Phorge/Phabricator connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -197,6 +197,7 @@ class DocumentSource(str, Enum):
     INGESTION_API = "ingestion_api"
     SLACK = "slack"
     WEB = "web"
+    PHABRICATOR = "phabricator"
     GOOGLE_DRIVE = "google_drive"
     GMAIL = "gmail"
     REQUESTTRACKER = "requesttracker"

--- a/backend/onyx/connectors/phabricator/connector.py
+++ b/backend/onyx/connectors/phabricator/connector.py
@@ -1,23 +1,19 @@
 from __future__ import annotations
 
 import datetime
-import itertools
-import tempfile
-import requests
 from urllib.parse import urlparse
 from collections.abc import Generator
-from collections.abc import Iterator
+#from collections.abc import Iterator
 from typing import Any
-from typing import cast
+#from typing import cast
 from typing import ClassVar
 
-from onyx.configs.app_configs import INDEX_BATCH_SIZE
+#from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
-from onyx.connectors.mediawiki.family import family_class_dispatch
 from onyx.connectors.models import Document
 #from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
@@ -80,20 +76,20 @@ class PhabricatorConnector(LoadConnector, PollConnector):
         self.doc_base = urlparse(api_base)._replace(path="/w/").geturl()
         self.maniphest_base = urlparse(api_base)._replace(path="/").geturl()
 
-    def load_credentials(self, creds: dict[str, str]) -> None:
-        self.api_token = creds.get('phab_api_token', '')
+    def load_credentials(self, credentials: dict[str, str]) -> None:
+        self.api_token = credentials.get('phab_api_token', '')
 
-    def _get_docs(self, start = None, end = None) -> Generator[list[Document], None, None]:
+    def _get_docs(self, start : SecondsSinceUnixEpoch | None = None, end : SecondsSinceUnixEpoch | None = None) -> Generator[list[Document], None, None]:
         """
         Fetches documents from the Phabricator Phriction wiki.
         
         Yields:
             Document objects containing the title, path, PHID, and content.
         """
-        docs = get_phriction_docs(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end)
+        docs = get_phriction_docs(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end, logger=logger)
         for doc in docs:
             yield [_ph_to_doc(doc, self.doc_base)]
-        tickets = get_maniphest_tickets(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end)
+        tickets = get_maniphest_tickets(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end, logger=logger)
         for ticket in tickets:
             yield [_maniphest_to_doc(ticket, self.maniphest_base)]
 
@@ -106,7 +102,6 @@ class PhabricatorConnector(LoadConnector, PollConnector):
     def poll_source(self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch) -> GenerateDocumentsOutput:
         '''
         Polls for new documents
-        TODO
         '''
 
         return self._get_docs(start, end)

--- a/backend/onyx/connectors/phabricator/connector.py
+++ b/backend/onyx/connectors/phabricator/connector.py
@@ -3,23 +3,19 @@ from __future__ import annotations
 import datetime
 from urllib.parse import urlparse
 from collections.abc import Generator
-#from collections.abc import Iterator
 from typing import Any
-#from typing import cast
 from typing import ClassVar
 
-#from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import Document
-#from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
 
-from onyx.connectors.phabricator.phapi import get_phriction_docs, get_maniphest_tickets
+from onyx.connectors.phabricator.phapi import get_phriction_docs, get_maniphest_tickets, UserPhidCache
 
 logger = setup_logger()
 
@@ -47,8 +43,14 @@ def _ph_to_doc(doc: dict[str, Any], doc_base : str) -> Document:
 
 def _maniphest_to_doc(doc: dict[str, Any], maniphest_base: str) -> Document:
     '''
-
-
+    Parses out the specific information from a Maniphest ticket into the format needed for embedding.
+    
+    Args:
+        doc: Dict with the information from Maniphest.
+        doc_base: URL base to use to generate a link
+    
+    Returns:
+        A Document object with title, path, PHID, and content.
     '''
 
     return Document(
@@ -72,6 +74,8 @@ class PhabricatorConnector(LoadConnector, PollConnector):
     source: DocumentSource = DocumentSource.PHABRICATOR
 
     def __init__(self, api_base: str) -> None:
+        self.api_token = ''
+        self.user_phid_cache = UserPhidCache()
         self.api_base = api_base
         self.doc_base = urlparse(api_base)._replace(path="/w/").geturl()
         self.maniphest_base = urlparse(api_base)._replace(path="/").geturl()
@@ -89,7 +93,7 @@ class PhabricatorConnector(LoadConnector, PollConnector):
         docs = get_phriction_docs(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end, logger=logger)
         for doc in docs:
             yield [_ph_to_doc(doc, self.doc_base)]
-        tickets = get_maniphest_tickets(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end, logger=logger)
+        tickets = get_maniphest_tickets(limit = -1, api_base=self.api_base, api_token=self.api_token, user_phid_cache=self.user_phid_cache, start=start, end=end, logger=logger)
         for ticket in tickets:
             yield [_maniphest_to_doc(ticket, self.maniphest_base)]
 
@@ -103,6 +107,5 @@ class PhabricatorConnector(LoadConnector, PollConnector):
         '''
         Polls for new documents
         '''
-
         return self._get_docs(start, end)
     

--- a/backend/onyx/connectors/phabricator/connector.py
+++ b/backend/onyx/connectors/phabricator/connector.py
@@ -80,8 +80,9 @@ class PhabricatorConnector(LoadConnector, PollConnector):
         self.doc_base = urlparse(api_base)._replace(path="/w/").geturl()
         self.maniphest_base = urlparse(api_base)._replace(path="/").geturl()
 
-    def load_credentials(self, credentials: dict[str, str]) -> None:
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self.api_token = credentials.get('phab_api_token', '')
+        return None
 
     def _get_docs(self, start : SecondsSinceUnixEpoch | None = None, end : SecondsSinceUnixEpoch | None = None) -> Generator[list[Document], None, None]:
         """

--- a/backend/onyx/connectors/phabricator/connector.py
+++ b/backend/onyx/connectors/phabricator/connector.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import datetime
+import itertools
+import tempfile
+import requests
+from urllib.parse import urlparse
+from collections.abc import Generator
+from collections.abc import Iterator
+from typing import Any
+from typing import cast
+from typing import ClassVar
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.mediawiki.family import family_class_dispatch
+from onyx.connectors.models import Document
+#from onyx.connectors.models import ImageSection
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+from onyx.connectors.phabricator.phapi import get_phriction_docs, get_maniphest_tickets
+
+logger = setup_logger()
+
+def _ph_to_doc(doc: dict[str, Any], doc_base : str) -> Document:
+    """
+    Parses out the specific information from a Phab doc into the format needed for embedding.
+    
+    Args:
+        doc: Dict with the information from Phriction.
+        doc_base: URL base to use to generate a link
+    
+    Returns:
+        A Document object with title, path, PHID, and content.
+    """
+    return Document(
+        title=doc['title'],
+        semantic_identifier=doc['title'],
+        path=doc['path'],
+        doc_updated_at=datetime.datetime.fromtimestamp(doc['date_modified'], tz=datetime.timezone.utc),
+        id=doc['PHID'],
+        sections=[TextSection(text=doc['content'], link=doc_base + doc['path'])],
+        metadata={},
+        source=DocumentSource.PHABRICATOR,
+    )
+
+def _maniphest_to_doc(doc: dict[str, Any], maniphest_base: str) -> Document:
+    '''
+
+
+    '''
+
+    return Document(
+        title=doc['title'],
+        semantic_identifier=f"{doc['tid']} - {doc['title']}",
+        path=doc['tid'],
+        doc_updated_at=datetime.datetime.fromtimestamp(doc['date_modified'], tz=datetime.timezone.utc),
+        id=doc['PHID'],
+        sections=[TextSection(text=doc['description'], link=maniphest_base + doc['tid'])],
+        metadata={},
+        source=DocumentSource.PHABRICATOR
+    )
+
+class PhabricatorConnector(LoadConnector, PollConnector):
+    """
+    Connector for Phabricator, a suite of open-source tools for software development.
+    This connector supports loading documents from Phabricator's Phriction wiki.
+    """
+
+    family: ClassVar[str] = 'phabricator'
+    source: DocumentSource = DocumentSource.PHABRICATOR
+
+    def __init__(self, api_base: str) -> None:
+        self.api_base = api_base
+        self.doc_base = urlparse(api_base)._replace(path="/w/").geturl()
+        self.maniphest_base = urlparse(api_base)._replace(path="/").geturl()
+
+    def load_credentials(self, creds: dict[str, str]) -> None:
+        self.api_token = creds.get('phab_api_token', '')
+
+    def _get_docs(self, start = None, end = None) -> Generator[list[Document], None, None]:
+        """
+        Fetches documents from the Phabricator Phriction wiki.
+        
+        Yields:
+            Document objects containing the title, path, PHID, and content.
+        """
+        docs = get_phriction_docs(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end)
+        for doc in docs:
+            yield [_ph_to_doc(doc, self.doc_base)]
+        tickets = get_maniphest_tickets(limit = -1, api_base=self.api_base, api_token=self.api_token, start=start, end=end)
+        for ticket in tickets:
+            yield [_maniphest_to_doc(ticket, self.maniphest_base)]
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        """
+        Generates documents from the Phabricator Phriction wiki.
+        """
+        return self._get_docs()
+
+    def poll_source(self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch) -> GenerateDocumentsOutput:
+        '''
+        Polls for new documents
+        TODO
+        '''
+
+        return self._get_docs(start, end)
+    

--- a/backend/onyx/connectors/phabricator/connector.py
+++ b/backend/onyx/connectors/phabricator/connector.py
@@ -36,7 +36,7 @@ def _ph_to_doc(doc: dict[str, Any], doc_base : str) -> Document:
         path=doc['path'],
         doc_updated_at=datetime.datetime.fromtimestamp(doc['date_modified'], tz=datetime.timezone.utc),
         id=doc['PHID'],
-        sections=[TextSection(text=doc['content'], link=doc_base + doc['path'])],
+        sections=[TextSection(text=doc['content'], link=doc_base + doc['path'].lstrip('/'))],
         metadata={},
         source=DocumentSource.PHABRICATOR,
     )

--- a/backend/onyx/connectors/phabricator/phapi.py
+++ b/backend/onyx/connectors/phabricator/phapi.py
@@ -5,17 +5,29 @@
 import requests
 import math
 
-user_phid_cache : dict[str, str] = {}
+class UserPhidCache:
+    def __init__(self) -> None:
+        self.cache = {}
 
-def get_user_by_phid(phid : str | None, api_base : str, api_token : str, logger = None) -> str | None:
+    def found(self, phid : str) -> bool:
+        return phid in self.cache.keys()
+
+    def lookup(self, phid : str) -> str | None:
+        if phid in self.cache.keys():
+            return self.cache[phid]
+        return None
+
+    def add(self, phid : str, username : str) -> None:
+        self.cache[phid] = username
+
+def get_user_by_phid(phid : str | None, api_base : str, api_token : str, user_phid_cache : UserPhidCache, logger = None) -> str | None:
     '''
     Returns username based on the passed PHID, or None if it's not found
     '''
-    global user_phid_cache
     if phid is None:
         return None
-    if phid in user_phid_cache.keys():
-        return user_phid_cache[phid]
+    if user_phid_cache.found(phid):
+        return user_phid_cache.lookup(phid)
     q = {
         'api.token': api_token,
         'constraints[phids][]': phid,
@@ -33,10 +45,10 @@ def get_user_by_phid(phid : str | None, api_base : str, api_token : str, logger 
         return None
     username = rjson['result']['data'][0].get('fields', {}).get('username')
     if not username is None:
-        user_phid_cache[phid] = username
+        user_phid_cache.add(phid, username)
     return username
 
-def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = None, logger = None) -> list[dict[str, str]]:
+def get_maniphest_tickets(limit : int, api_base, api_token, user_phid_cache : UserPhidCache, start = None, end = None, logger = None) -> list[dict[str, str]]:
     '''
     Returns a list of the tickets as a dict with the following keys:
     - title: Ticket title
@@ -59,8 +71,8 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
             'PHID': ph_res['phid'],
             'description': ph_res['fields']['description']['raw'],
             'status': ph_res['fields']['status']['value'],
-            'owner': get_user_by_phid(ph_res['fields']['ownerPHID'], api_base, api_token, logger=logger),
-            'author': get_user_by_phid(ph_res['fields']['authorPHID'], api_base, api_token, logger=logger),
+            'owner': get_user_by_phid(ph_res['fields']['ownerPHID'], api_base, api_token, user_phid_cache, logger=logger),
+            'author': get_user_by_phid(ph_res['fields']['authorPHID'], api_base, api_token, user_phid_cache, logger=logger),
             'priority': ph_res['fields']['priority']['name'],
             'date_modified': ph_res['fields']['dateModified']
         }
@@ -78,7 +90,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
             if logger is None:
                 print(f'ERROR: {res.text}')
             else:
-                logger.error(print(f'maniphest.search error: {res.text}'))
+                logger.error(f'maniphest.search error: {res.text}')
             return []
         try:
             num_tts = res.json()['result']['data'][0]['id']
@@ -97,7 +109,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'maniphest.search error: {res.text}'))
+                        logger.error(f'maniphest.search error: {res.text}')
                     return []
                 rjson = res.json()
                 if rjson is None:
@@ -113,7 +125,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'maniphest.search error: {res.text}'))
+                        logger.error(f'maniphest.search error: {res.text}')
                     return []
                 rjson = res.json()
                 if not rjson is None:
@@ -127,7 +139,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'maniphest.search error: {res.text}'))
+                        logger.error(f'maniphest.search error: {res.text}')
                     return []
                 rjson = res.json()
                 if rjson is None:
@@ -143,7 +155,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
             if logger is None:
                 print(f'ERROR: {res.text}')
             else:
-                logger.error(print(f'maniphest.search error: {res.text}'))
+                logger.error(f'maniphest.search error: {res.text}')
             return []
         rjson = res.json()
         if rjson is None:
@@ -176,7 +188,7 @@ def get_phriction_doc_by_phid(phid : str, api_base : str, api_token : str, logge
         if logger is None:
             print(f'ERROR: {res.text}')
         else:
-            logger.error(print(f'phriction.content.search error: {res.text}'))
+            logger.error(f'phriction.content.search error: {res.text}')
         return None
     return res.json()
 
@@ -220,7 +232,7 @@ def get_phriction_docs(limit : int, api_base : str, api_token : str, start = Non
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'phriction.content.search error: {res.text}'))
+                        logger.error(f'phriction.content.search error: {res.text}')
                     return []
                 rjson = res.json()
                 phab_data += rjson['result']['data']
@@ -234,7 +246,7 @@ def get_phriction_docs(limit : int, api_base : str, api_token : str, start = Non
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'phriction.content.search error: {res.text}'))
+                        logger.error(f'phriction.content.search error: {res.text}')
                     return []
                 rjson = res.json()
                 phab_data += rjson['result']['data']
@@ -246,7 +258,7 @@ def get_phriction_docs(limit : int, api_base : str, api_token : str, start = Non
                     if logger is None:
                         print(f'ERROR: {res.text}')
                     else:
-                        logger.error(print(f'phriction.content.search error: {res.text}'))
+                        logger.error(f'phriction.content.search error: {res.text}')
                     return []
                 rjson = res.json()
                 phab_data += rjson['result']['data']
@@ -260,7 +272,7 @@ def get_phriction_docs(limit : int, api_base : str, api_token : str, start = Non
             if logger is None:
                 print(f'ERROR: {res.text}')
             else:
-                logger.error(print(f'phriction.content.search error: {res.text}'))
+                logger.error(f'phriction.content.search error: {res.text}')
             return []
         phab_data = res.json()['result']['data']
 

--- a/backend/onyx/connectors/phabricator/phapi.py
+++ b/backend/onyx/connectors/phabricator/phapi.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env -S uv run --script
+
+# Phabricator API wrapper
+# (C) 2025 Thinkst Applied Research, PTY
+# Author: jacob@thinkst.com
+
+import requests, math
+
+def get_user_by_phid(phid : str | None, api_base, api_token) -> str | None:
+    '''
+    Returns username based on the passed PHID, or None if it's not found
+    '''
+    if phid is None:
+        return None
+    q = {
+        'api.token': api_token,
+        'constraints[phids][]': phid, # This is hideous
+        'limit': 1
+    }
+    res = requests.get(api_base + 'user.search', data=q)
+    if res.status_code != 200:
+        print(f'Error: {res.text}')
+        return None
+    rjson = res.json()
+    if len(rjson['result']['data']) == 0:
+        return None
+    return rjson['result']['data'][0]['fields']['username']
+
+def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = None) -> list[dict[str, str]]:
+    '''
+    Returns a list of the tickets as a dict with the following keys:
+    - title: Ticket title
+    - PHID: Document PHID
+    - owner: Username of the ticket owner/assignee
+    - author: Username of the ticket author
+    - status: Ticket status
+    - tid: Ticket ID (e.g. T123)
+    - description: Ticket description
+    - priority: Ticket priority
+    - date_modified: When the ticket was last edited
+    '''
+    def _mp_to_ticket(ph_res : dict[str, str | int]) -> dict[str, str | int]:
+        '''
+        Parses out the specific information from a Phab doc into the format needed for parsing
+        '''
+        return {
+            'title': ph_res['fields']['name'],
+            'tid': 'T' + str(ph_res['id']),
+            'PHID': ph_res['phid'],
+            'description': ph_res['fields']['description']['raw'],
+            'status': ph_res['fields']['status']['value'],
+            'owner': get_user_by_phid(ph_res['fields']['ownerPHID'], api_base, api_token),
+            'author': get_user_by_phid(ph_res['fields']['authorPHID'], api_base, api_token),
+            'priority': ph_res['fields']['priority']['name'],
+            'date_modified': ph_res['fields']['dateModified']
+        }
+
+    tickets = []
+    phab_data = []
+    q : dict[str, str | int] = {
+        'api.token': api_token,
+        'order': 'newest',
+    }
+    if limit == -1 or limit > 100:
+        q['limit'] = 1
+        res = requests.get(api_base + 'maniphest.search', data=q)
+        if res.status_code != 200:
+            print(f'ERROR: {res.text}')
+            return []
+        num_tts = res.json()['result']['data'][0]['id']
+        print(f'Highest TT# {num_tts}')
+        q['limit'] = 100
+        if limit != -1:
+            limit = min(num_tts, limit)
+            num_calls = math.ceil(limit / 100) # The Phab API only allows 100 at most
+            rem = limit % 100
+            for _ in range(num_calls - 1):
+                res = requests.get(api_base + 'maniphest.search', data=q)
+                if res.status_code != 200:
+                    print(f'ERROR: {res.text}')
+                    return []
+                rjson = res.json()
+                if rjson is None:
+                    continue
+                phab_data += rjson.get('result', {}).get('data', [])
+                if rjson['result']['cursor']['after'] is None:
+                    break
+                q['after'] = rjson['result']['cursor']['after']
+            q['limit'] = rem
+            res = requests.get(api_base + 'maniphest.search', data=q)
+            if res.status_code != 200:
+                print(f'ERROR: {res.text}')
+                return []
+            rjson = res.json()
+            if not rjson is None:
+                phab_data += rjson.get('result', {}).get('data', [])
+        else: # Get all the docs
+            limit = num_tts
+            while True:
+                q['limit'] = 100
+                res = requests.get(api_base + 'maniphest.search', data=q)
+                if res.status_code != 200:
+                    print(f'ERROR: {res.text}')
+                    return []
+                rjson = res.json()
+                if rjson is None:
+                    continue
+                phab_data += rjson['result']['data']
+                if rjson['result']['cursor']['after'] is None:
+                    break
+                q['after'] = rjson['result']['cursor']['after']
+    else:
+        q['limit'] = limit
+        res = requests.get(api_base + 'maniphest.search', data=q)
+        if res.status_code != 200:
+            print(f'ERROR: {res.text}')
+            return []
+        rjson = res.json()
+        if rjson is None:
+            return []
+        phab_data = rjson['result']['data']
+
+    for t in phab_data:
+        if start is not None and t['fields']['dateModified'] < start:
+            continue
+        if end is not None and t['fields']['dateModified'] > end:
+            continue
+        ticket = _mp_to_ticket(t)
+        if len([e for e in tickets if ticket['tid'] == e['tid']]) == 0: # Since every version is treated as a different document/object
+            tickets.append(ticket)
+
+    return tickets        
+
+def get_phriction_doc_by_phid(phid : str, api_base, api_token) -> dict | None:
+    '''
+    Returns a Phriction document based on the passed ID, or None if it's not found
+    '''
+    q = {
+        'api.token': api_token,
+        'constraints[documentPHIDs][]': phid, # This is hideous
+        'attachments[content]': True, # So is this
+        'limit': 1
+    }
+    res = requests.get(api_base + 'phriction.content.search', data=q)
+    if res.status_code != 200:
+        print(f'Error: {res.text}')
+        return None
+    return res.json()
+
+def get_phriction_docs(limit, api_base, api_token, start = None, end = None) -> list[dict[str, str]]:
+    '''
+    Returns a list of the Phriction documents as a dict with the following keys:
+    - title: Document title
+    - PHID: Document PHID
+    - Path: Document path
+    - Content: Raw MD content
+    '''
+    def _ph_to_doc(ph_res : dict) -> dict[str, str | int]:
+        '''
+        Parses out the specific information from a Phab doc into the format needed for parsing
+        '''
+        return {
+            'title': ph_res['attachments']['content']['title'],
+            'path': ph_res['attachments']['content']['path'],
+            'date_modified': ph_res['fields']['dateModified'],
+            'PHID': ph_res['fields']['documentPHID'],
+            'content': ph_res['attachments']['content']['content']['raw']
+        }
+
+    docs = []
+    phab_data = []
+    q = {
+        'api.token': api_token,
+        'order': 'newest',
+        'attachments[content]': True
+    }
+    if limit == -1 or limit > 100:
+        if limit != -1:
+            num_calls = math.ceil(limit / 100) # The Phab API only allows 100 at most
+            rem = limit % 100
+            for _ in range(num_calls - 1):
+                res = requests.get(api_base + 'phriction.content.search', data=q)
+                if res.status_code != 200:
+                    print(f'ERROR: {res.text}')
+                    return []
+                rjson = res.json()
+                phab_data += rjson['result']['data']
+                if rjson['result']['cursor']['after'] is None:
+                    break
+                q['after'] = rjson['result']['cursor']['after']
+            q['limit'] = rem
+            res = requests.get(api_base + 'phriction.content.search', data=q)
+            if res.status_code != 200:
+                print(f'ERROR: {res.text}')
+                return []
+            rjson = res.json()
+            phab_data += rjson['result']['data']
+        else: # Get all the docs
+            while True:
+                q['limit'] = 100
+                res = requests.get(api_base + 'phriction.content.search', data=q)
+                if res.status_code != 200:
+                    print(f'ERROR: {res.text}')
+                    return []
+                rjson = res.json()
+                phab_data += rjson['result']['data']
+                if rjson['result']['cursor']['after'] is None:
+                    break
+                q['after'] = rjson['result']['cursor']['after']
+    else:
+        q['limit'] = limit
+        res = requests.get(api_base + 'phriction.content.search', data=q)
+        if res.status_code != 200:
+            print(f'ERROR: {res.text}')
+            return []
+        phab_data = res.json()['result']['data']
+
+    for d in phab_data:
+        if start is not None and d['fields']['dateModified'] < start:
+            continue
+        if end is not None and d['fields']['dateModified'] > end:
+            continue
+        doc = _ph_to_doc(d)
+        if len([e for e in docs if doc['PHID'] == e['PHID']]) == 0: # Since every version is treated as a different document/object
+            docs.append(doc)
+
+    return docs        
+

--- a/backend/onyx/connectors/phabricator/phapi.py
+++ b/backend/onyx/connectors/phabricator/phapi.py
@@ -7,7 +7,7 @@ import math
 
 class UserPhidCache:
     def __init__(self) -> None:
-        self.cache = {}
+        self.cache : dict[str, str] = {}
 
     def found(self, phid : str) -> bool:
         return phid in self.cache.keys()
@@ -41,7 +41,7 @@ def get_user_by_phid(phid : str | None, api_base : str, api_token : str, user_ph
             logger.error(f'Error performing user.search: {res.text}')
         return None
     rjson = res.json()
-    if len(rjson['result']['data']) == 0:
+    if len(rjson.get('result', {}).get('data', [])) == 0:
         return None
     username = rjson['result']['data'][0].get('fields', {}).get('username')
     if not username is None:

--- a/backend/onyx/connectors/phabricator/phapi.py
+++ b/backend/onyx/connectors/phabricator/phapi.py
@@ -1,32 +1,42 @@
-#!/usr/bin/env -S uv run --script
-
 # Phabricator API wrapper
-# (C) 2025 Thinkst Applied Research, PTY
+# (C) 2026 Thinkst Applied Research, PTY
 # Author: jacob@thinkst.com
 
-import requests, math
+import requests
+import math
 
-def get_user_by_phid(phid : str | None, api_base, api_token) -> str | None:
+user_phid_cache : dict[str, str] = {}
+
+def get_user_by_phid(phid : str | None, api_base : str, api_token : str, logger = None) -> str | None:
     '''
     Returns username based on the passed PHID, or None if it's not found
     '''
+    global user_phid_cache
     if phid is None:
         return None
+    if phid in user_phid_cache.keys():
+        return user_phid_cache[phid]
     q = {
         'api.token': api_token,
-        'constraints[phids][]': phid, # This is hideous
+        'constraints[phids][]': phid,
         'limit': 1
     }
-    res = requests.get(api_base + 'user.search', data=q)
+    res = requests.post(api_base + 'user.search', data=q, timeout=30)
     if res.status_code != 200:
-        print(f'Error: {res.text}')
+        if logger is None:
+            print(f'Error: {res.text}')
+        else:
+            logger.error(f'Error performing user.search: {res.text}')
         return None
     rjson = res.json()
     if len(rjson['result']['data']) == 0:
         return None
-    return rjson['result']['data'][0]['fields']['username']
+    username = rjson['result']['data'][0].get('fields', {}).get('username')
+    if not username is None:
+        user_phid_cache[phid] = username
+    return username
 
-def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = None) -> list[dict[str, str]]:
+def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = None, logger = None) -> list[dict[str, str]]:
     '''
     Returns a list of the tickets as a dict with the following keys:
     - title: Ticket title
@@ -39,18 +49,18 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
     - priority: Ticket priority
     - date_modified: When the ticket was last edited
     '''
-    def _mp_to_ticket(ph_res : dict[str, str | int]) -> dict[str, str | int]:
+    def _mp_to_ticket(ph_res : dict[str, str | int | dict]) -> dict[str, str | int | None]:
         '''
         Parses out the specific information from a Phab doc into the format needed for parsing
         '''
         return {
-            'title': ph_res['fields']['name'],
+            'title': ph_res.get('fields', {})['name'],
             'tid': 'T' + str(ph_res['id']),
             'PHID': ph_res['phid'],
             'description': ph_res['fields']['description']['raw'],
             'status': ph_res['fields']['status']['value'],
-            'owner': get_user_by_phid(ph_res['fields']['ownerPHID'], api_base, api_token),
-            'author': get_user_by_phid(ph_res['fields']['authorPHID'], api_base, api_token),
+            'owner': get_user_by_phid(ph_res['fields']['ownerPHID'], api_base, api_token, logger=logger),
+            'author': get_user_by_phid(ph_res['fields']['authorPHID'], api_base, api_token, logger=logger),
             'priority': ph_res['fields']['priority']['name'],
             'date_modified': ph_res['fields']['dateModified']
         }
@@ -63,21 +73,31 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
     }
     if limit == -1 or limit > 100:
         q['limit'] = 1
-        res = requests.get(api_base + 'maniphest.search', data=q)
+        res = requests.post(api_base + 'maniphest.search', data=q, timeout=30)
         if res.status_code != 200:
-            print(f'ERROR: {res.text}')
+            if logger is None:
+                print(f'ERROR: {res.text}')
+            else:
+                logger.error(print(f'maniphest.search error: {res.text}'))
             return []
-        num_tts = res.json()['result']['data'][0]['id']
-        print(f'Highest TT# {num_tts}')
+        try:
+            num_tts = res.json()['result']['data'][0]['id']
+        except IndexError:
+            num_tts = 0
         q['limit'] = 100
         if limit != -1:
             limit = min(num_tts, limit)
             num_calls = math.ceil(limit / 100) # The Phab API only allows 100 at most
             rem = limit % 100
+            if rem == 0:
+                num_calls += 1
             for _ in range(num_calls - 1):
-                res = requests.get(api_base + 'maniphest.search', data=q)
+                res = requests.post(api_base + 'maniphest.search', data=q, timeout=30)
                 if res.status_code != 200:
-                    print(f'ERROR: {res.text}')
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'maniphest.search error: {res.text}'))
                     return []
                 rjson = res.json()
                 if rjson is None:
@@ -87,20 +107,27 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
                     break
                 q['after'] = rjson['result']['cursor']['after']
             q['limit'] = rem
-            res = requests.get(api_base + 'maniphest.search', data=q)
-            if res.status_code != 200:
-                print(f'ERROR: {res.text}')
-                return []
-            rjson = res.json()
-            if not rjson is None:
-                phab_data += rjson.get('result', {}).get('data', [])
+            if rem != 0:
+                res = requests.post(api_base + 'maniphest.search', data=q, timeout=30)
+                if res.status_code != 200:
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'maniphest.search error: {res.text}'))
+                    return []
+                rjson = res.json()
+                if not rjson is None:
+                    phab_data += rjson.get('result', {}).get('data', [])
         else: # Get all the docs
             limit = num_tts
             while True:
                 q['limit'] = 100
-                res = requests.get(api_base + 'maniphest.search', data=q)
+                res = requests.post(api_base + 'maniphest.search', data=q, timeout=30)
                 if res.status_code != 200:
-                    print(f'ERROR: {res.text}')
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'maniphest.search error: {res.text}'))
                     return []
                 rjson = res.json()
                 if rjson is None:
@@ -111,9 +138,12 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
                 q['after'] = rjson['result']['cursor']['after']
     else:
         q['limit'] = limit
-        res = requests.get(api_base + 'maniphest.search', data=q)
+        res = requests.post(api_base + 'maniphest.search', data=q, timeout=30)
         if res.status_code != 200:
-            print(f'ERROR: {res.text}')
+            if logger is None:
+                print(f'ERROR: {res.text}')
+            else:
+                logger.error(print(f'maniphest.search error: {res.text}'))
             return []
         rjson = res.json()
         if rjson is None:
@@ -131,7 +161,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, start = None, end = 
 
     return tickets        
 
-def get_phriction_doc_by_phid(phid : str, api_base, api_token) -> dict | None:
+def get_phriction_doc_by_phid(phid : str, api_base : str, api_token : str, logger = None) -> dict | None:
     '''
     Returns a Phriction document based on the passed ID, or None if it's not found
     '''
@@ -141,13 +171,16 @@ def get_phriction_doc_by_phid(phid : str, api_base, api_token) -> dict | None:
         'attachments[content]': True, # So is this
         'limit': 1
     }
-    res = requests.get(api_base + 'phriction.content.search', data=q)
+    res = requests.post(api_base + 'phriction.content.search', data=q, timeout=30)
     if res.status_code != 200:
-        print(f'Error: {res.text}')
+        if logger is None:
+            print(f'ERROR: {res.text}')
+        else:
+            logger.error(print(f'phriction.content.search error: {res.text}'))
         return None
     return res.json()
 
-def get_phriction_docs(limit, api_base, api_token, start = None, end = None) -> list[dict[str, str]]:
+def get_phriction_docs(limit : int, api_base : str, api_token : str, start = None, end = None, logger = None) -> list[dict[str, str]]:
     '''
     Returns a list of the Phriction documents as a dict with the following keys:
     - title: Document title
@@ -175,13 +208,19 @@ def get_phriction_docs(limit, api_base, api_token, start = None, end = None) -> 
         'attachments[content]': True
     }
     if limit == -1 or limit > 100:
+        q['limit'] = 100
         if limit != -1:
             num_calls = math.ceil(limit / 100) # The Phab API only allows 100 at most
             rem = limit % 100
+            if rem == 0:
+                num_calls += 1
             for _ in range(num_calls - 1):
-                res = requests.get(api_base + 'phriction.content.search', data=q)
+                res = requests.post(api_base + 'phriction.content.search', data=q, timeout=30)
                 if res.status_code != 200:
-                    print(f'ERROR: {res.text}')
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'phriction.content.search error: {res.text}'))
                     return []
                 rjson = res.json()
                 phab_data += rjson['result']['data']
@@ -189,18 +228,25 @@ def get_phriction_docs(limit, api_base, api_token, start = None, end = None) -> 
                     break
                 q['after'] = rjson['result']['cursor']['after']
             q['limit'] = rem
-            res = requests.get(api_base + 'phriction.content.search', data=q)
-            if res.status_code != 200:
-                print(f'ERROR: {res.text}')
-                return []
-            rjson = res.json()
-            phab_data += rjson['result']['data']
+            if rem != 0:
+                res = requests.post(api_base + 'phriction.content.search', data=q, timeout=30)
+                if res.status_code != 200:
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'phriction.content.search error: {res.text}'))
+                    return []
+                rjson = res.json()
+                phab_data += rjson['result']['data']
         else: # Get all the docs
             while True:
                 q['limit'] = 100
-                res = requests.get(api_base + 'phriction.content.search', data=q)
+                res = requests.post(api_base + 'phriction.content.search', data=q, timeout=30)
                 if res.status_code != 200:
-                    print(f'ERROR: {res.text}')
+                    if logger is None:
+                        print(f'ERROR: {res.text}')
+                    else:
+                        logger.error(print(f'phriction.content.search error: {res.text}'))
                     return []
                 rjson = res.json()
                 phab_data += rjson['result']['data']
@@ -209,9 +255,12 @@ def get_phriction_docs(limit, api_base, api_token, start = None, end = None) -> 
                 q['after'] = rjson['result']['cursor']['after']
     else:
         q['limit'] = limit
-        res = requests.get(api_base + 'phriction.content.search', data=q)
+        res = requests.post(api_base + 'phriction.content.search', data=q, timeout=30)
         if res.status_code != 200:
-            print(f'ERROR: {res.text}')
+            if logger is None:
+                print(f'ERROR: {res.text}')
+            else:
+                logger.error(print(f'phriction.content.search error: {res.text}'))
             return []
         phab_data = res.json()['result']['data']
 

--- a/backend/onyx/connectors/phabricator/phapi.py
+++ b/backend/onyx/connectors/phabricator/phapi.py
@@ -115,7 +115,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, user_phid_cache : Us
                 if rjson is None:
                     continue
                 phab_data += rjson.get('result', {}).get('data', [])
-                if rjson['result']['cursor']['after'] is None:
+                if rjson.get('result', {}).get('cursor', {}).get('after') is None:
                     break
                 q['after'] = rjson['result']['cursor']['after']
             q['limit'] = rem
@@ -144,8 +144,8 @@ def get_maniphest_tickets(limit : int, api_base, api_token, user_phid_cache : Us
                 rjson = res.json()
                 if rjson is None:
                     continue
-                phab_data += rjson['result']['data']
-                if rjson['result']['cursor']['after'] is None:
+                phab_data += rjson.get('result', {}).get('data', [])
+                if rjson.get('result', {}).get('cursor', {}).get('after') is None:
                     break
                 q['after'] = rjson['result']['cursor']['after']
     else:
@@ -160,7 +160,7 @@ def get_maniphest_tickets(limit : int, api_base, api_token, user_phid_cache : Us
         rjson = res.json()
         if rjson is None:
             return []
-        phab_data = rjson['result']['data']
+        phab_data = rjson.get('result', {}).get('data', [])
 
     for t in phab_data:
         if start is not None and t['fields']['dateModified'] < start:

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -208,6 +208,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.bitbucket.connector",
         class_name="BitbucketConnector",
     ),
+    DocumentSource.PHABRICATOR: ConnectorMapping(
+        module_path="onyx.connectors.phabricator.connector",
+        class_name="PhabricatorConnector",
+    ),
     DocumentSource.TESTRAIL: ConnectorMapping(
         module_path="onyx.connectors.testrail.connector",
         class_name="TestRailConnector",

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -936,6 +936,20 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  phabricator: {
+    description: "Configure Phabricator connector",
+    values: [
+      {
+        type: "text",
+        query: "Enter the base URL:",
+        label: "Base URL",
+        name: "api_base",
+        optional: false,
+        description: `Specify the base URL for your Phorge/Phab install. This will look something like: https://phabricator.company.com/api/`,
+      },
+    ],
+    advanced_values: [],
+  },
   drupal_wiki: {
     description: "Configure Drupal Wiki connector",
     values: [

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -57,6 +57,10 @@ export interface GitlabCredentialJson {
   gitlab_access_token: string;
 }
 
+export interface PhabricatorCredentialJson {
+  phab_api_token: string;
+}
+
 export interface BitbucketCredentialJson {
   bitbucket_email: string;
   bitbucket_api_token: string;
@@ -292,6 +296,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
     bitbucket_api_token: "",
   } as BitbucketCredentialJson,
   slack: { slack_bot_token: "" } as SlackCredentialJson,
+  phabricator: { phab_api_token: "" } as PhabricatorCredentialJson,
   bookstack: {
     bookstack_base_url: "",
     bookstack_api_token_id: "",
@@ -532,6 +537,9 @@ export const credentialDisplayNames: Record<string, string> = {
 
   // Slab
   slab_bot_token: "Slab Bot Token",
+
+  // Phabricator
+  phab_api_token: "Phabricator API Token",
 
   // Coda
   coda_bearer_token: "Coda Bearer Token",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -115,6 +115,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Wiki,
     docs: "https://docs.onyx.app/connectors/coda",
   },
+  phabricator: {
+    icon: SvgFileText,
+    displayName: "Phabricator/Phorge",
+    category: SourceCategory.Wiki,
+    docs: "https://docs.onyx.app/connectors/phabricator",
+  },
   notion: {
     icon: NotionIcon,
     displayName: "Notion",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -535,6 +535,7 @@ export enum ValidSources {
   Imap = "imap",
   Bitbucket = "bitbucket",
   TestRail = "testrail",
+  Phabricator = "phabricator",
 
   // Craft-specific sources
   CraftFile = "craft_file",


### PR DESCRIPTION
## Description

This is a new connector for https://www.phorge.it/, formerly Phabricator.

It will allow for the ingestion of both maniphest tickets and phriction wiki documents.

## How Has This Been Tested?

This has been running internally for ~6mo without issue to pull our internal knowledge. That said, we're leaving it running on Onyx v1.0 so there may be some gaps in this PR that need to be ironed out. I will leave this as a draft until I am able to get it tested on a fresh/clean HEAD build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Phorge/Phabricator connector that ingests Phriction pages and Maniphest tickets with full load and poll support. Includes backend, API client, and setup UI; improves link generation and response parsing for reliability.

- **New Features**
  - Backend `PhabricatorConnector` for Phriction docs and Maniphest tickets; builds correct links using `/w/` (wiki) and `/` (tickets) without double slashes.
  - New `DocumentSource.PHABRICATOR`, registry mapping, `ValidSources.Phabricator`, and setup form for Base URL plus source metadata (icon and docs link).
  - API wrapper for `user.search`, `phriction.content.search`, and `maniphest.search` with an instance-level user PHID cache and safer `get()` usage to handle missing fields.

- **Migration**
  - Add credentials: set `phab_api_token`.
  - Create the source with the Base URL (e.g., https://phabricator.company.com/api/) and start a sync.

<sup>Written for commit fd33e911335799f7e696f5095f4217733f92ca71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

