### PR TITLE
feat: add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -208,6 +208,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -669,6 +670,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "outline data",
     DocumentSource.CONFLUENCE: "confluence data (pages, spaces, etc.)",
     DocumentSource.JIRA: "jira data (issues, tickets, projects, etc.)",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "jira service management data (service requests, tickets, queues, etc.)",
     DocumentSource.SLAB: "slab data",
     DocumentSource.PRODUCTBOARD: "productboard data (boards, etc.)",
     DocumentSource.FILE: "files",

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -59,6 +59,10 @@ _DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 _DATE_FORMAT_ALT = "%Y-%m-%dT%H:%M:%S%z"
 
 
+class JsmConnectorCheckpoint(ConnectorCheckpoint):
+    offset: int = 0
+
+
 def _parse_jsm_date(date_str: str | None) -> datetime | None:
     if not date_str:
         return None
@@ -81,7 +85,7 @@ def _build_jql(project_key: str, start_dt: datetime | None, end_dt: datetime | N
 
 
 class JiraServiceManagementConnector(
-    CheckpointedConnectorWithPermSync[ConnectorCheckpoint],
+    CheckpointedConnectorWithPermSync[JsmConnectorCheckpoint],
     SlimConnectorWithPermSync,
 ):
     """Connector that indexes tickets from a Jira Service Management project.
@@ -120,16 +124,31 @@ class JiraServiceManagementConnector(
         self._jira_client = None
         self._jsm_session = None
         self._sla_field_ids: dict[str, str] = {}
-        self._credentials: dict[str, Any] = {}
         self._project_permissions_cache: dict[str, Any] = {}
 
     @override
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
-        self._credentials = credentials
         self._jira_client = build_jira_client(credentials, self.jira_base_url)
         self._jsm_session = build_jsm_session(credentials, self.jira_base_url)
         self._sla_field_ids = discover_sla_field_ids(self._jsm_session, self.jira_base_url)
         return None
+
+    @override
+    def build_dummy_checkpoint(self) -> JsmConnectorCheckpoint:
+        return JsmConnectorCheckpoint(has_more=True)
+
+    @override
+    def validate_checkpoint_json(self, checkpoint_json: str) -> JsmConnectorCheckpoint:
+        return JsmConnectorCheckpoint.model_validate_json(checkpoint_json)
+
+    @override
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JsmConnectorCheckpoint,
+    ) -> CheckpointOutput[JsmConnectorCheckpoint]:
+        return self.load_from_checkpoint_with_perm_sync(start, end, checkpoint)
 
     def _get_project_permissions(
         self, project_key: str, add_prefix: bool = False
@@ -301,13 +320,15 @@ class JiraServiceManagementConnector(
         self,
         start: SecondsSinceUnixEpoch,
         end: SecondsSinceUnixEpoch,
-        checkpoint: ConnectorCheckpoint,
-    ) -> CheckpointOutput[ConnectorCheckpoint]:
+        checkpoint: JsmConnectorCheckpoint,
+    ) -> CheckpointOutput[JsmConnectorCheckpoint]:
         start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
         end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
 
+        current_offset = checkpoint.offset
         batch: list[Document | ConnectorFailure] = []
-        for issue in self._fetch_issues(start_dt, end_dt):
+
+        for issue in self._fetch_issues(start_dt, end_dt, start_at=current_offset):
             doc = self._process_issue(issue)
             if doc is not None:
                 doc.external_access = self._get_project_permissions(
@@ -325,15 +346,13 @@ class JiraServiceManagementConnector(
                         failure_message=f"Failed to process issue {issue.key}",
                     )
                 )
+            current_offset += 1
 
             if len(batch) >= self.batch_size:
-                yield batch, ConnectorCheckpoint(has_more=True)
+                yield batch, JsmConnectorCheckpoint(has_more=True, offset=current_offset)
                 batch = []
 
-        if batch:
-            yield batch, ConnectorCheckpoint(has_more=False)
-        else:
-            yield [], ConnectorCheckpoint(has_more=False)
+        yield batch, JsmConnectorCheckpoint(has_more=False, offset=current_offset)
 
     # -------------------------------------------------------------------------
     # SlimConnectorWithPermSync

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -144,12 +144,12 @@ class JiraServiceManagementConnector(
     def validate_checkpoint_json(self, checkpoint_json: str) -> JsmConnectorCheckpoint:
         return JsmConnectorCheckpoint.model_validate_json(checkpoint_json)
 
-    @override
-    def load_from_checkpoint(
+    def _iter_checkpoint(
         self,
         start: SecondsSinceUnixEpoch,
         end: SecondsSinceUnixEpoch,
         checkpoint: JsmConnectorCheckpoint,
+        with_perm_sync: bool,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
         start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
         end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
@@ -160,6 +160,10 @@ class JiraServiceManagementConnector(
         for issue in self._fetch_issues(start_dt, end_dt, start_at=current_offset):
             doc = self._process_issue(issue)
             if doc is not None:
+                if with_perm_sync:
+                    doc.external_access = self._get_project_permissions(
+                        self.jira_project, add_prefix=True
+                    )
                 batch.append(doc)
             else:
                 issue_url = build_jira_url(self.jira_base_url, issue.key)
@@ -179,6 +183,15 @@ class JiraServiceManagementConnector(
                 batch = []
 
         yield batch, JsmConnectorCheckpoint(has_more=False, offset=current_offset)
+
+    @override
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JsmConnectorCheckpoint,
+    ) -> CheckpointOutput[JsmConnectorCheckpoint]:
+        return self._iter_checkpoint(start, end, checkpoint, with_perm_sync=False)
 
     def _get_project_permissions(
         self, project_key: str, add_prefix: bool = False
@@ -352,37 +365,7 @@ class JiraServiceManagementConnector(
         end: SecondsSinceUnixEpoch,
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
-        start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
-        end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
-
-        current_offset = checkpoint.offset
-        batch: list[Document | ConnectorFailure] = []
-
-        for issue in self._fetch_issues(start_dt, end_dt, start_at=current_offset):
-            doc = self._process_issue(issue)
-            if doc is not None:
-                doc.external_access = self._get_project_permissions(
-                    self.jira_project, add_prefix=True
-                )
-                batch.append(doc)
-            else:
-                issue_url = build_jira_url(self.jira_base_url, issue.key)
-                batch.append(
-                    ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=issue_url,
-                            document_link=issue_url,
-                        ),
-                        failure_message=f"Failed to process issue {issue.key}",
-                    )
-                )
-            current_offset += 1
-
-            if len(batch) >= self.batch_size:
-                yield batch, JsmConnectorCheckpoint(has_more=True, offset=current_offset)
-                batch = []
-
-        yield batch, JsmConnectorCheckpoint(has_more=False, offset=current_offset)
+        return self._iter_checkpoint(start, end, checkpoint, with_perm_sync=True)
 
     # -------------------------------------------------------------------------
     # SlimConnectorWithPermSync

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -29,13 +29,16 @@ from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.jira.access import get_project_permissions
 from onyx.connectors.jira.utils import best_effort_basic_expert_info
 from onyx.connectors.jira.utils import best_effort_get_field_from_issue
 from onyx.connectors.jira.utils import build_jira_client
 from onyx.connectors.jira.utils import build_jira_url
+from onyx.connectors.jira.utils import extract_jira_project
 from onyx.connectors.jira.utils import extract_text_from_adf
 from onyx.connectors.jira.utils import get_comment_strs
 from onyx.connectors.jira_service_management.utils import build_jsm_session
+from onyx.connectors.jira_service_management.utils import discover_sla_field_ids
 from onyx.connectors.jira_service_management.utils import extract_jsm_metadata
 from onyx.connectors.jira_service_management.utils import get_service_desks
 from onyx.connectors.models import ConnectorCheckpoint
@@ -70,13 +73,10 @@ def _build_jql(project_key: str, start_dt: datetime | None, end_dt: datetime | N
     """Build a JQL query scoped to a single JSM project with optional time bounds."""
     parts = [f'project = "{project_key}"']
     if start_dt:
-        ts = start_dt.strftime("%Y-%m-%d %H:%M")
-        parts.append(f'updated >= "{ts}"')
+        parts.append(f'updated >= "{start_dt.strftime("%Y-%m-%d %H:%M")}"')
     if end_dt:
-        ts = end_dt.strftime("%Y-%m-%d %H:%M")
-        parts.append(f'updated <= "{ts}"')
-    parts.append("ORDER BY updated ASC")
-    return " AND ".join(parts[:-1]) + " ORDER BY updated ASC" if len(parts) > 1 else parts[0] + " ORDER BY updated ASC"
+        parts.append(f'updated <= "{end_dt.strftime("%Y-%m-%d %H:%M")}"')
+    return " AND ".join(parts) + " ORDER BY updated ASC"
 
 
 class JiraServiceManagementConnector(
@@ -101,6 +101,15 @@ class JiraServiceManagementConnector(
         comment_email_blacklist: list[str] | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:
+        # If jira_project looks like a full URL, extract base URL and project key from it
+        if "projects" in jira_project:
+            try:
+                extracted_base, extracted_key = extract_jira_project(jira_project)
+                jira_base_url = extracted_base
+                jira_project = extracted_key
+            except ValueError:
+                pass  # fall through to treat it as a plain project key
+
         self.jira_base_url = jira_base_url.rstrip("/")
         self.jira_project = jira_project.strip().upper()
         self.comment_email_blacklist: tuple[str, ...] = tuple(
@@ -109,14 +118,29 @@ class JiraServiceManagementConnector(
         self.batch_size = batch_size
         self._jira_client = None
         self._jsm_session = None
+        self._sla_field_ids: dict[str, str] = {}
         self._credentials: dict[str, Any] = {}
+        self._project_permissions_cache: dict[str, Any] = {}
 
     @override
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._credentials = credentials
         self._jira_client = build_jira_client(credentials, self.jira_base_url)
-        _, self._jsm_session, _ = build_jsm_session(credentials, self.jira_base_url)
+        self._jsm_session = build_jsm_session(credentials, self.jira_base_url)
+        self._sla_field_ids = discover_sla_field_ids(self._jsm_session, self.jira_base_url)
         return None
+
+    def _get_project_permissions(
+        self, project_key: str, add_prefix: bool = False
+    ) -> Any:
+        cache_key = f"{project_key}:{'prefixed' if add_prefix else 'unprefixed'}"
+        if cache_key not in self._project_permissions_cache:
+            self._project_permissions_cache[cache_key] = get_project_permissions(
+                jira_client=self._jira_client,
+                jira_project=project_key,
+                add_prefix=add_prefix,
+            )
+        return self._project_permissions_cache[cache_key]
 
     @override
     def validate_connector_settings(self) -> None:
@@ -202,7 +226,7 @@ class JiraServiceManagementConnector(
                 metadata["updated"] = updated
 
             # JSM-specific fields
-            jsm_meta = extract_jsm_metadata(issue)
+            jsm_meta = extract_jsm_metadata(issue, self._sla_field_ids)
             metadata.update(jsm_meta)
 
             updated_at = _parse_jsm_date(
@@ -212,7 +236,7 @@ class JiraServiceManagementConnector(
             title_field = best_effort_get_field_from_issue(issue, "summary") or issue.key
 
             return Document(
-                id=f"jsm:{issue.key}",
+                id=page_url,
                 sections=[TextSection(link=page_url, text=ticket_content)],
                 source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
                 semantic_identifier=f"[{issue.key}] {title_field}",
@@ -283,13 +307,17 @@ class JiraServiceManagementConnector(
         for issue in self._fetch_issues(start_dt, end_dt):
             doc = self._process_issue(issue)
             if doc is not None:
+                doc.external_access = self._get_project_permissions(
+                    self.jira_project, add_prefix=True
+                )
                 batch.append(doc)
             else:
+                issue_url = build_jira_url(self.jira_base_url, issue.key)
                 batch.append(
                     ConnectorFailure(
                         failed_document=DocumentFailure(
-                            document_id=f"jsm:{issue.key}",
-                            document_link=build_jira_url(self.jira_base_url, issue.key),
+                            document_id=issue_url,
+                            document_link=issue_url,
                         ),
                         failure_message=f"Failed to process issue {issue.key}",
                     )
@@ -320,7 +348,15 @@ class JiraServiceManagementConnector(
 
         batch: list[SlimDocument] = []
         for issue in self._fetch_issues(start_dt, end_dt):
-            batch.append(SlimDocument(id=f"jsm:{issue.key}"))
+            doc_id = build_jira_url(self.jira_base_url, issue.key)
+            batch.append(
+                SlimDocument(
+                    id=doc_id,
+                    external_access=self._get_project_permissions(
+                        self.jira_project, add_prefix=False
+                    ),
+                )
+            )
             if callback:
                 callback.should_continue()
             if len(batch) >= self.batch_size:

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -39,7 +39,7 @@ from onyx.connectors.jira.utils import extract_jira_project
 from onyx.connectors.jira.utils import extract_text_from_adf
 from onyx.connectors.jira.utils import get_comment_strs
 from onyx.connectors.jira_service_management.utils import build_jsm_session
-from onyx.connectors.jira_service_management.utils import discover_sla_field_ids
+from onyx.connectors.jira_service_management.utils import discover_jsm_custom_field_ids
 from onyx.connectors.jira_service_management.utils import extract_jsm_metadata
 from onyx.connectors.jira_service_management.utils import get_service_desks
 from onyx.connectors.models import ConnectorCheckpoint
@@ -123,14 +123,15 @@ class JiraServiceManagementConnector(
         self.batch_size = batch_size
         self._jira_client = None
         self._jsm_session = None
-        self._sla_field_ids: dict[str, str] = {}
+        self._custom_field_ids: dict[str, str] = {}
         self._project_permissions_cache: dict[str, Any] = {}
 
     @override
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._jira_client = build_jira_client(credentials, self.jira_base_url)
         self._jsm_session = build_jsm_session(credentials, self.jira_base_url)
-        self._sla_field_ids = discover_sla_field_ids(self._jsm_session, self.jira_base_url)
+        self._custom_field_ids = discover_jsm_custom_field_ids(self._jsm_session, self.jira_base_url)
+        self._project_permissions_cache = {}
         return None
 
     @override
@@ -248,7 +249,7 @@ class JiraServiceManagementConnector(
                 metadata["updated"] = updated
 
             # JSM-specific fields
-            jsm_meta = extract_jsm_metadata(issue, self._sla_field_ids)
+            jsm_meta = extract_jsm_metadata(issue, self._custom_field_ids)
             metadata.update(jsm_meta)
 
             updated_at = _parse_jsm_date(

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,341 @@
+"""Connector for Jira Service Management (JSM).
+
+Indexes all tickets (requests) from a specified JSM project using the
+Jira REST API and JSM Service Desk API.
+
+Authentication is identical to the existing Jira connector:
+- Cloud: email + API token
+- Server/Data Center: personal access token
+
+The connector accepts either:
+- A JSM project URL  (e.g. https://example.atlassian.net/jira/servicedesk/projects/IT)
+- A plain Jira base URL + project key via the jira_project field
+"""
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from jira.exceptions import JIRAError
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.jira.utils import best_effort_basic_expert_info
+from onyx.connectors.jira.utils import best_effort_get_field_from_issue
+from onyx.connectors.jira.utils import build_jira_client
+from onyx.connectors.jira.utils import build_jira_url
+from onyx.connectors.jira.utils import extract_text_from_adf
+from onyx.connectors.jira.utils import get_comment_strs
+from onyx.connectors.jira_service_management.utils import build_jsm_session
+from onyx.connectors.jira_service_management.utils import extract_jsm_metadata
+from onyx.connectors.jira_service_management.utils import get_service_desks
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import SlimDocument
+from onyx.connectors.models import TextSection
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_JSM_PAGE_SIZE = 50
+_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
+_DATE_FORMAT_ALT = "%Y-%m-%dT%H:%M:%S%z"
+
+
+def _parse_jsm_date(date_str: str | None) -> datetime | None:
+    if not date_str:
+        return None
+    for fmt in (_DATE_FORMAT, _DATE_FORMAT_ALT):
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _build_jql(project_key: str, start_dt: datetime | None, end_dt: datetime | None) -> str:
+    """Build a JQL query scoped to a single JSM project with optional time bounds."""
+    parts = [f'project = "{project_key}"']
+    if start_dt:
+        ts = start_dt.strftime("%Y-%m-%d %H:%M")
+        parts.append(f'updated >= "{ts}"')
+    if end_dt:
+        ts = end_dt.strftime("%Y-%m-%d %H:%M")
+        parts.append(f'updated <= "{ts}"')
+    parts.append("ORDER BY updated ASC")
+    return " AND ".join(parts[:-1]) + " ORDER BY updated ASC" if len(parts) > 1 else parts[0] + " ORDER BY updated ASC"
+
+
+class JiraServiceManagementConnector(
+    CheckpointedConnectorWithPermSync[ConnectorCheckpoint],
+    SlimConnectorWithPermSync,
+):
+    """Connector that indexes tickets from a Jira Service Management project.
+
+    Credentials expected:
+        jira_api_token  — API token (required)
+        jira_user_email — user email for cloud instances (omit for server/DC)
+
+    Connector-level configuration:
+        jira_base_url   — base URL, e.g. https://example.atlassian.net
+        jira_project    — JSM project key, e.g. IT or SD
+    """
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        jira_project: str,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.jira_base_url = jira_base_url.rstrip("/")
+        self.jira_project = jira_project.strip().upper()
+        self.comment_email_blacklist: tuple[str, ...] = tuple(
+            comment_email_blacklist or []
+        )
+        self.batch_size = batch_size
+        self._jira_client = None
+        self._jsm_session = None
+        self._credentials: dict[str, Any] = {}
+
+    @override
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._credentials = credentials
+        self._jira_client = build_jira_client(credentials, self.jira_base_url)
+        _, self._jsm_session, _ = build_jsm_session(credentials, self.jira_base_url)
+        return None
+
+    @override
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        jql = f'project = "{self.jira_project}" ORDER BY updated ASC'
+        try:
+            results = self._jira_client.search_issues(
+                jql_str=jql, startAt=0, maxResults=1
+            )
+            _ = len(results)  # force evaluation
+        except JIRAError as e:
+            status = getattr(e, "status_code", None)
+            if status == 400:
+                raise ConnectorValidationError(
+                    f"Project '{self.jira_project}' not found or invalid. "
+                    f"Ensure the project key is correct. Error: {e.text}"
+                )
+            elif status == 401:
+                raise CredentialExpiredError(
+                    "JSM credentials are expired or invalid (HTTP 401)."
+                )
+            elif status == 403:
+                raise InsufficientPermissionsError(
+                    f"Insufficient permissions to access project '{self.jira_project}'."
+                )
+            raise
+
+    def _process_issue(self, issue: Any) -> Document | None:
+        """Convert a Jira issue object into an Onyx Document."""
+        try:
+            if isinstance(issue.fields.description, str):
+                description = issue.fields.description or ""
+            else:
+                description = extract_text_from_adf(
+                    issue.raw["fields"].get("description")
+                )
+
+            comments = get_comment_strs(
+                issue=issue,
+                comment_email_blacklist=self.comment_email_blacklist,
+            )
+            ticket_content = description
+            if comments:
+                ticket_content += "\n" + "\n".join(
+                    f"Comment: {c}" for c in comments if c
+                )
+
+            page_url = build_jira_url(self.jira_base_url, issue.key)
+
+            metadata: dict[str, str | list[str]] = {}
+            people = set()
+
+            reporter = best_effort_get_field_from_issue(issue, "reporter")
+            if reporter and (info := best_effort_basic_expert_info(reporter)):
+                people.add(info)
+                metadata["reporter"] = info.get_semantic_name()
+                if email := info.get_email():
+                    metadata["reporter_email"] = email
+
+            assignee = best_effort_get_field_from_issue(issue, "assignee")
+            if assignee and (info := best_effort_basic_expert_info(assignee)):
+                people.add(info)
+                metadata["assignee"] = info.get_semantic_name()
+                if email := info.get_email():
+                    metadata["assignee_email"] = email
+
+            metadata["key"] = issue.key
+            metadata["project"] = self.jira_project
+
+            if priority := best_effort_get_field_from_issue(issue, "priority"):
+                metadata["priority"] = priority.name
+            if status := best_effort_get_field_from_issue(issue, "status"):
+                metadata["status"] = status.name
+            if issuetype := best_effort_get_field_from_issue(issue, "issuetype"):
+                metadata["issuetype"] = issuetype.name
+            if labels := best_effort_get_field_from_issue(issue, "labels"):
+                metadata["labels"] = labels
+            if created := best_effort_get_field_from_issue(issue, "created"):
+                metadata["created"] = created
+            if updated := best_effort_get_field_from_issue(issue, "updated"):
+                metadata["updated"] = updated
+
+            # JSM-specific fields
+            jsm_meta = extract_jsm_metadata(issue)
+            metadata.update(jsm_meta)
+
+            updated_at = _parse_jsm_date(
+                best_effort_get_field_from_issue(issue, "updated")
+            )
+
+            title_field = best_effort_get_field_from_issue(issue, "summary") or issue.key
+
+            return Document(
+                id=f"jsm:{issue.key}",
+                sections=[TextSection(link=page_url, text=ticket_content)],
+                source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+                semantic_identifier=f"[{issue.key}] {title_field}",
+                doc_updated_at=updated_at,
+                primary_owners=list(people) if people else None,
+                metadata=metadata,
+            )
+        except Exception as e:
+            logger.error(f"Failed to process JSM issue {issue.key}: {e}")
+            return None
+
+    def _fetch_issues(
+        self,
+        start_dt: datetime | None,
+        end_dt: datetime | None,
+        start_at: int = 0,
+    ):
+        """Yield issues from the JSM project using JQL pagination."""
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+
+        jql = _build_jql(self.jira_project, start_dt, end_dt)
+        while True:
+            try:
+                issues = self._jira_client.search_issues(
+                    jql_str=jql,
+                    startAt=start_at,
+                    maxResults=_JSM_PAGE_SIZE,
+                )
+            except JIRAError as e:
+                status = getattr(e, "status_code", None)
+                if status == 400:
+                    raise ConnectorValidationError(
+                        f"Invalid JQL or project not found: {jql}. Error: {getattr(e, 'text', str(e))}"
+                    )
+                elif status == 401:
+                    raise CredentialExpiredError("JSM credentials expired (HTTP 401).")
+                elif status == 403:
+                    raise InsufficientPermissionsError(
+                        f"Insufficient permissions for project '{self.jira_project}'."
+                    )
+                raise
+
+            if not issues:
+                break
+
+            yield from issues
+
+            if len(issues) < _JSM_PAGE_SIZE:
+                break
+            start_at += _JSM_PAGE_SIZE
+
+    # -------------------------------------------------------------------------
+    # CheckpointedConnectorWithPermSync
+    # -------------------------------------------------------------------------
+
+    @override
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: ConnectorCheckpoint,
+    ) -> CheckpointOutput[ConnectorCheckpoint]:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
+
+        batch: list[Document | ConnectorFailure] = []
+        for issue in self._fetch_issues(start_dt, end_dt):
+            doc = self._process_issue(issue)
+            if doc is not None:
+                batch.append(doc)
+            else:
+                batch.append(
+                    ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=f"jsm:{issue.key}",
+                            document_link=build_jira_url(self.jira_base_url, issue.key),
+                        ),
+                        failure_message=f"Failed to process issue {issue.key}",
+                    )
+                )
+
+            if len(batch) >= self.batch_size:
+                yield batch, ConnectorCheckpoint(has_more=True)
+                batch = []
+
+        if batch:
+            yield batch, ConnectorCheckpoint(has_more=False)
+        else:
+            yield [], ConnectorCheckpoint(has_more=False)
+
+    # -------------------------------------------------------------------------
+    # SlimConnectorWithPermSync
+    # -------------------------------------------------------------------------
+
+    @override
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
+
+        batch: list[SlimDocument] = []
+        for issue in self._fetch_issues(start_dt, end_dt):
+            batch.append(SlimDocument(id=f"jsm:{issue.key}"))
+            if callback:
+                callback.should_continue()
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+
+        if batch:
+            yield batch
+
+    # -------------------------------------------------------------------------
+    # Convenience: list all accessible service desks (used by UI validation)
+    # -------------------------------------------------------------------------
+
+    def list_service_desks(self) -> list[dict[str, Any]]:
+        """Return all service desks the authenticated user can access."""
+        if self._jsm_session is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+        return get_service_desks(self._jsm_session, self.jira_base_url)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -12,6 +12,7 @@ The connector accepts either:
 - A plain Jira base URL + project key via the jira_project field
 """
 
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -133,6 +134,8 @@ class JiraServiceManagementConnector(
     def _get_project_permissions(
         self, project_key: str, add_prefix: bool = False
     ) -> Any:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
         cache_key = f"{project_key}:{'prefixed' if add_prefix else 'unprefixed'}"
         if cache_key not in self._project_permissions_cache:
             self._project_permissions_cache[cache_key] = get_project_permissions(
@@ -244,7 +247,7 @@ class JiraServiceManagementConnector(
                 primary_owners=list(people) if people else None,
                 metadata=metadata,
             )
-        except Exception as e:
+        except (AttributeError, KeyError, TypeError) as e:
             logger.error(f"Failed to process JSM issue {issue.key}: {e}")
             return None
 
@@ -253,7 +256,7 @@ class JiraServiceManagementConnector(
         start_dt: datetime | None,
         end_dt: datetime | None,
         start_at: int = 0,
-    ):
+    ) -> Generator[Any, None, None]:
         """Yield issues from the JSM project using JQL pagination."""
         if self._jira_client is None:
             raise ConnectorMissingCredentialError("Jira Service Management")

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import requests
+from jira import JIRA
 from jira.exceptions import JIRAError
 from typing_extensions import override
 
@@ -121,15 +123,15 @@ class JiraServiceManagementConnector(
             comment_email_blacklist or []
         )
         self.batch_size = batch_size
-        self._jira_client = None
-        self._jsm_session = None
+        self._jira_client: JIRA | None = None
+        self._jsm_session: requests.Session | None = None
         self._custom_field_ids: dict[str, str] = {}
         self._project_permissions_cache: dict[str, Any] = {}
 
     @override
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         self._jira_client = build_jira_client(credentials, self.jira_base_url)
-        self._jsm_session = build_jsm_session(credentials, self.jira_base_url)
+        self._jsm_session = build_jsm_session(credentials)
         self._custom_field_ids = discover_jsm_custom_field_ids(self._jsm_session, self.jira_base_url)
         self._project_permissions_cache = {}
         return None
@@ -381,7 +383,9 @@ class JiraServiceManagementConnector(
                 )
             )
             if callback:
-                callback.should_continue()
+                if callback.should_stop():
+                    return
+                callback.progress("retrieve_all_slim_docs_perm_sync", 1)
             if len(batch) >= self.batch_size:
                 yield batch
                 batch = []

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -151,7 +151,34 @@ class JiraServiceManagementConnector(
         end: SecondsSinceUnixEpoch,
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
-        return self.load_from_checkpoint_with_perm_sync(start, end, checkpoint)
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc) if start else None
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc) if end else None
+
+        current_offset = checkpoint.offset
+        batch: list[Document | ConnectorFailure] = []
+
+        for issue in self._fetch_issues(start_dt, end_dt, start_at=current_offset):
+            doc = self._process_issue(issue)
+            if doc is not None:
+                batch.append(doc)
+            else:
+                issue_url = build_jira_url(self.jira_base_url, issue.key)
+                batch.append(
+                    ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=issue_url,
+                            document_link=issue_url,
+                        ),
+                        failure_message=f"Failed to process issue {issue.key}",
+                    )
+                )
+            current_offset += 1
+
+            if len(batch) >= self.batch_size:
+                yield batch, JsmConnectorCheckpoint(has_more=True, offset=current_offset)
+                batch = []
+
+        yield batch, JsmConnectorCheckpoint(has_more=False, offset=current_offset)
 
     def _get_project_permissions(
         self, project_key: str, add_prefix: bool = False

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,139 @@
+"""Utility functions for the Jira Service Management connector."""
+
+from typing import Any
+
+import requests
+from jira import JIRA
+from requests.auth import HTTPBasicAuth
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+JSM_API_PATH = "rest/servicedeskapi"
+
+
+def build_jsm_session(credentials: dict[str, Any], jira_base: str) -> tuple[JIRA, requests.Session, dict[str, Any]]:
+    """Build a JIRA client and a requests session configured for JSM API calls.
+
+    Returns:
+        Tuple of (jira_client, requests_session, auth_headers)
+    """
+    api_token = credentials["jira_api_token"]
+    session = requests.Session()
+    is_cloud = "jira_user_email" in credentials
+
+    if is_cloud:
+        email = credentials["jira_user_email"]
+        jira_client = JIRA(
+            basic_auth=(email, api_token),
+            server=jira_base,
+            options={"rest_api_version": "3"},
+        )
+        session.auth = HTTPBasicAuth(email, api_token)
+    else:
+        jira_client = JIRA(
+            token_auth=api_token,
+            server=jira_base,
+            options={"rest_api_version": "2"},
+        )
+        session.headers.update({"Authorization": f"Bearer {api_token}"})
+
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-ExperimentalApi": "opt-in",  # Required for some JSM endpoints
+        }
+    )
+    return jira_client, session, {}
+
+
+def get_service_desks(
+    session: requests.Session, jira_base: str
+) -> list[dict[str, Any]]:
+    """Retrieve all service desks accessible to the authenticated user."""
+    url = f"{jira_base.rstrip('/')}/{JSM_API_PATH}/servicedesk"
+    service_desks: list[dict[str, Any]] = []
+    start = 0
+    limit = 50
+
+    while True:
+        resp = session.get(url, params={"start": start, "limit": limit})
+        resp.raise_for_status()
+        data = resp.json()
+        values = data.get("values", [])
+        service_desks.extend(values)
+        if data.get("isLastPage", True):
+            break
+        start += limit
+
+    return service_desks
+
+
+def get_jsm_project_key(session: requests.Session, jira_base: str, service_desk_id: str) -> str | None:
+    """Get the Jira project key for a given service desk ID."""
+    url = f"{jira_base.rstrip('/')}/{JSM_API_PATH}/servicedesk/{service_desk_id}"
+    try:
+        resp = session.get(url)
+        resp.raise_for_status()
+        return resp.json().get("projectKey")
+    except Exception as e:
+        logger.warning(f"Failed to get project key for service desk {service_desk_id}: {e}")
+        return None
+
+
+def extract_jsm_metadata(issue: Any) -> dict[str, str | list[str]]:
+    """Extract JSM-specific metadata from a Jira issue."""
+    metadata: dict[str, str | list[str]] = {}
+
+    try:
+        fields = issue.raw.get("fields", {})
+
+        # Request type (JSM-specific)
+        request_type = fields.get("issuetype", {})
+        if isinstance(request_type, dict):
+            metadata["request_type"] = request_type.get("name", "")
+
+        # SLA fields — stored under customfield keys; try common ones
+        for field_key, label in [
+            ("customfield_10020", "sla_time_to_first_response"),
+            ("customfield_10030", "sla_time_to_resolution"),
+        ]:
+            sla_field = fields.get(field_key)
+            if sla_field and isinstance(sla_field, dict):
+                completed = sla_field.get("completedCycles", [])
+                ongoing = sla_field.get("ongoingCycle", {})
+                if completed:
+                    last = completed[-1]
+                    metadata[label] = (
+                        "breached" if last.get("breached") else "met"
+                    )
+                elif ongoing:
+                    metadata[label] = (
+                        "breached" if ongoing.get("breached") else "ongoing"
+                    )
+
+        # Customer request type
+        customer_request = fields.get("customfield_10010")
+        if customer_request and isinstance(customer_request, dict):
+            rt = customer_request.get("requestType", {})
+            if isinstance(rt, dict):
+                metadata["customer_request_type"] = rt.get("name", "")
+
+        # Priority
+        priority = fields.get("priority", {})
+        if isinstance(priority, dict) and priority.get("name"):
+            metadata["priority"] = priority["name"]
+
+        # Status category
+        status = fields.get("status", {})
+        if isinstance(status, dict):
+            status_category = status.get("statusCategory", {})
+            if isinstance(status_category, dict):
+                metadata["status_category"] = status_category.get("name", "")
+
+    except Exception as e:
+        logger.warning(f"Error extracting JSM metadata: {e}")
+
+    return metadata

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -32,7 +32,7 @@ def build_jsm_session(credentials: dict[str, Any], jira_base: str) -> requests.S
         raise ConnectorMissingCredentialError("jira_api_token is required")
 
     session = requests.Session()
-    is_cloud = "jira_user_email" in credentials
+    is_cloud = bool(credentials.get("jira_user_email"))
 
     if is_cloud:
         email = credentials["jira_user_email"]
@@ -72,7 +72,7 @@ def get_service_desks(
     return service_desks
 
 
-def discover_sla_field_ids(
+def discover_jsm_custom_field_ids(
     session: requests.Session, jira_base: str
 ) -> dict[str, str]:
     """Discover JSM custom field IDs dynamically via the Jira fields API.
@@ -115,27 +115,22 @@ def discover_sla_field_ids(
 
 def extract_jsm_metadata(
     issue: Any,
-    sla_field_ids: dict[str, str],
+    custom_field_ids: dict[str, str],
 ) -> dict[str, str | list[str]]:
     """Extract JSM-specific metadata from a Jira issue.
 
     Args:
         issue: A jira.resources.Issue object.
-        sla_field_ids: Mapping of label → customfield_* key, as returned
-                       by discover_sla_field_ids().
+        custom_field_ids: Mapping of label → customfield_* key, as returned
+                          by discover_jsm_custom_field_ids().
     """
     metadata: dict[str, str | list[str]] = {}
 
     try:
         fields = issue.raw.get("fields", {})
 
-        # Request type (JSM-specific issue type)
-        request_type = fields.get("issuetype", {})
-        if isinstance(request_type, dict) and request_type.get("name"):
-            metadata["request_type"] = request_type["name"]
-
-        # SLA fields — discovered dynamically to avoid hardcoded IDs
-        for label, field_key in sla_field_ids.items():
+        # JSM custom fields — discovered dynamically to avoid hardcoded IDs
+        for label, field_key in custom_field_ids.items():
             field_value = fields.get(field_key)
             if not field_value or not isinstance(field_value, dict):
                 continue

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -60,7 +60,7 @@ def get_service_desks(
     limit = 50
 
     while True:
-        resp = session.get(url, params={"start": start, "limit": limit})
+        resp = session.get(url, params={"start": start, "limit": limit}, timeout=30)
         resp.raise_for_status()
         data = resp.json()
         values = data.get("values", [])
@@ -159,7 +159,7 @@ def extract_jsm_metadata(
             if isinstance(status_category, dict) and status_category.get("name"):
                 metadata["status_category"] = status_category["name"]
 
-    except Exception as e:
+    except (AttributeError, KeyError, TypeError) as e:
         logger.warning(f"Error extracting JSM metadata: {e}")
 
     return metadata

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -11,10 +11,12 @@ logger = setup_logger()
 
 JSM_API_PATH = "rest/servicedeskapi"
 
-# Known name patterns for JSM SLA fields (case-insensitive substring match)
-_SLA_FIELD_PATTERNS = {
+# Known name patterns for JSM custom fields (case-insensitive substring match).
+# Field IDs are assigned per-instance so we discover them dynamically.
+_CUSTOM_FIELD_PATTERNS = {
     "sla_time_to_first_response": ["time to first response"],
     "sla_time_to_resolution": ["time to resolution", "time to resolve"],
+    "customer_request_type": ["customer request type", "portal request type"],
 }
 
 
@@ -73,11 +75,11 @@ def get_service_desks(
 def discover_sla_field_ids(
     session: requests.Session, jira_base: str
 ) -> dict[str, str]:
-    """Discover JSM SLA custom field IDs dynamically via the Jira fields API.
+    """Discover JSM custom field IDs dynamically via the Jira fields API.
 
-    SLA custom field IDs (e.g. customfield_10020) are assigned per-instance
+    Custom field IDs (e.g. customfield_10020) are assigned per-instance
     during project setup and are NOT universal. This function queries
-    GET /rest/api/2/field and matches against known SLA field name patterns.
+    GET /rest/api/2/field and matches against known field name patterns.
 
     Returns a dict mapping our label keys to their customfield_* keys.
     e.g. {"sla_time_to_first_response": "customfield_10020", ...}
@@ -88,7 +90,7 @@ def discover_sla_field_ids(
         resp.raise_for_status()
         fields = resp.json()
     except Exception as e:
-        logger.warning(f"Could not discover JSM SLA field IDs: {e}")
+        logger.warning(f"Could not discover JSM custom field IDs: {e}")
         return {}
 
     result: dict[str, str] = {}
@@ -97,16 +99,16 @@ def discover_sla_field_ids(
         field_name = (field.get("name") or "").lower()
         if not field_id.startswith("customfield_"):
             continue
-        for label, patterns in _SLA_FIELD_PATTERNS.items():
+        for label, patterns in _CUSTOM_FIELD_PATTERNS.items():
             if label not in result and any(p in field_name for p in patterns):
                 result[label] = field_id
 
     if result:
-        logger.debug(f"Discovered SLA field IDs: {result}")
+        logger.debug(f"Discovered JSM custom field IDs: {result}")
     else:
         logger.warning(
-            "No SLA custom fields found via Jira fields API. "
-            "SLA metadata will not be extracted."
+            "No JSM custom fields found via Jira fields API. "
+            "SLA and customer request type metadata will not be extracted."
         )
     return result
 
@@ -134,27 +136,21 @@ def extract_jsm_metadata(
 
         # SLA fields — discovered dynamically to avoid hardcoded IDs
         for label, field_key in sla_field_ids.items():
-            sla_field = fields.get(field_key)
-            if not sla_field or not isinstance(sla_field, dict):
+            field_value = fields.get(field_key)
+            if not field_value or not isinstance(field_value, dict):
                 continue
-            completed = sla_field.get("completedCycles", [])
-            ongoing = sla_field.get("ongoingCycle", {})
-            if completed:
-                metadata[label] = "breached" if completed[-1].get("breached") else "met"
-            elif ongoing:
-                metadata[label] = "breached" if ongoing.get("breached") else "ongoing"
 
-        # Customer request type (portal-facing label)
-        customer_request = fields.get("customfield_10010")
-        if customer_request and isinstance(customer_request, dict):
-            rt = customer_request.get("requestType", {})
-            if isinstance(rt, dict) and rt.get("name"):
-                metadata["customer_request_type"] = rt["name"]
-
-        # Priority
-        priority = fields.get("priority", {})
-        if isinstance(priority, dict) and priority.get("name"):
-            metadata["priority"] = priority["name"]
+            if label == "customer_request_type":
+                rt = field_value.get("requestType", {})
+                if isinstance(rt, dict) and rt.get("name"):
+                    metadata["customer_request_type"] = rt["name"]
+            else:
+                completed = field_value.get("completedCycles", [])
+                ongoing = field_value.get("ongoingCycle", {})
+                if completed:
+                    metadata[label] = "breached" if completed[-1].get("breached") else "met"
+                elif ongoing:
+                    metadata[label] = "breached" if ongoing.get("breached") else "ongoing"
 
         # Status category
         status = fields.get("status", {})

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -89,7 +89,7 @@ def discover_jsm_custom_field_ids(
         resp = session.get(url, timeout=10)
         resp.raise_for_status()
         fields = resp.json()
-    except Exception as e:
+    except (requests.exceptions.RequestException, ValueError) as e:
         logger.warning(f"Could not discover JSM custom field IDs: {e}")
         return {}
 

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,52 +1,51 @@
 """Utility functions for the Jira Service Management connector."""
 
+import requests
+from requests.auth import HTTPBasicAuth
 from typing import Any
 
-import requests
-from jira import JIRA
-from requests.auth import HTTPBasicAuth
-
+from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 JSM_API_PATH = "rest/servicedeskapi"
 
+# Known name patterns for JSM SLA fields (case-insensitive substring match)
+_SLA_FIELD_PATTERNS = {
+    "sla_time_to_first_response": ["time to first response"],
+    "sla_time_to_resolution": ["time to resolution", "time to resolve"],
+}
 
-def build_jsm_session(credentials: dict[str, Any], jira_base: str) -> tuple[JIRA, requests.Session, dict[str, Any]]:
-    """Build a JIRA client and a requests session configured for JSM API calls.
 
-    Returns:
-        Tuple of (jira_client, requests_session, auth_headers)
+def build_jsm_session(credentials: dict[str, Any], jira_base: str) -> requests.Session:
+    """Build a requests.Session configured for JSM API calls.
+
+    Authentication mirrors the existing Jira connector:
+    - Cloud: email + API token (Basic auth)
+    - Server/Data Center: personal access token (Bearer)
     """
-    api_token = credentials["jira_api_token"]
+    api_token: str = credentials.get("jira_api_token", "")
+    if not api_token:
+        raise ConnectorMissingCredentialError("jira_api_token is required")
+
     session = requests.Session()
     is_cloud = "jira_user_email" in credentials
 
     if is_cloud:
         email = credentials["jira_user_email"]
-        jira_client = JIRA(
-            basic_auth=(email, api_token),
-            server=jira_base,
-            options={"rest_api_version": "3"},
-        )
         session.auth = HTTPBasicAuth(email, api_token)
     else:
-        jira_client = JIRA(
-            token_auth=api_token,
-            server=jira_base,
-            options={"rest_api_version": "2"},
-        )
         session.headers.update({"Authorization": f"Bearer {api_token}"})
 
     session.headers.update(
         {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "X-ExperimentalApi": "opt-in",  # Required for some JSM endpoints
+            "X-ExperimentalApi": "opt-in",
         }
     )
-    return jira_client, session, {}
+    return session
 
 
 def get_service_desks(
@@ -71,55 +70,86 @@ def get_service_desks(
     return service_desks
 
 
-def get_jsm_project_key(session: requests.Session, jira_base: str, service_desk_id: str) -> str | None:
-    """Get the Jira project key for a given service desk ID."""
-    url = f"{jira_base.rstrip('/')}/{JSM_API_PATH}/servicedesk/{service_desk_id}"
+def discover_sla_field_ids(
+    session: requests.Session, jira_base: str
+) -> dict[str, str]:
+    """Discover JSM SLA custom field IDs dynamically via the Jira fields API.
+
+    SLA custom field IDs (e.g. customfield_10020) are assigned per-instance
+    during project setup and are NOT universal. This function queries
+    GET /rest/api/2/field and matches against known SLA field name patterns.
+
+    Returns a dict mapping our label keys to their customfield_* keys.
+    e.g. {"sla_time_to_first_response": "customfield_10020", ...}
+    """
+    url = f"{jira_base.rstrip('/')}/rest/api/2/field"
     try:
-        resp = session.get(url)
+        resp = session.get(url, timeout=10)
         resp.raise_for_status()
-        return resp.json().get("projectKey")
+        fields = resp.json()
     except Exception as e:
-        logger.warning(f"Failed to get project key for service desk {service_desk_id}: {e}")
-        return None
+        logger.warning(f"Could not discover JSM SLA field IDs: {e}")
+        return {}
+
+    result: dict[str, str] = {}
+    for field in fields:
+        field_id = field.get("id", "")
+        field_name = (field.get("name") or "").lower()
+        if not field_id.startswith("customfield_"):
+            continue
+        for label, patterns in _SLA_FIELD_PATTERNS.items():
+            if label not in result and any(p in field_name for p in patterns):
+                result[label] = field_id
+
+    if result:
+        logger.debug(f"Discovered SLA field IDs: {result}")
+    else:
+        logger.warning(
+            "No SLA custom fields found via Jira fields API. "
+            "SLA metadata will not be extracted."
+        )
+    return result
 
 
-def extract_jsm_metadata(issue: Any) -> dict[str, str | list[str]]:
-    """Extract JSM-specific metadata from a Jira issue."""
+def extract_jsm_metadata(
+    issue: Any,
+    sla_field_ids: dict[str, str],
+) -> dict[str, str | list[str]]:
+    """Extract JSM-specific metadata from a Jira issue.
+
+    Args:
+        issue: A jira.resources.Issue object.
+        sla_field_ids: Mapping of label → customfield_* key, as returned
+                       by discover_sla_field_ids().
+    """
     metadata: dict[str, str | list[str]] = {}
 
     try:
         fields = issue.raw.get("fields", {})
 
-        # Request type (JSM-specific)
+        # Request type (JSM-specific issue type)
         request_type = fields.get("issuetype", {})
-        if isinstance(request_type, dict):
-            metadata["request_type"] = request_type.get("name", "")
+        if isinstance(request_type, dict) and request_type.get("name"):
+            metadata["request_type"] = request_type["name"]
 
-        # SLA fields — stored under customfield keys; try common ones
-        for field_key, label in [
-            ("customfield_10020", "sla_time_to_first_response"),
-            ("customfield_10030", "sla_time_to_resolution"),
-        ]:
+        # SLA fields — discovered dynamically to avoid hardcoded IDs
+        for label, field_key in sla_field_ids.items():
             sla_field = fields.get(field_key)
-            if sla_field and isinstance(sla_field, dict):
-                completed = sla_field.get("completedCycles", [])
-                ongoing = sla_field.get("ongoingCycle", {})
-                if completed:
-                    last = completed[-1]
-                    metadata[label] = (
-                        "breached" if last.get("breached") else "met"
-                    )
-                elif ongoing:
-                    metadata[label] = (
-                        "breached" if ongoing.get("breached") else "ongoing"
-                    )
+            if not sla_field or not isinstance(sla_field, dict):
+                continue
+            completed = sla_field.get("completedCycles", [])
+            ongoing = sla_field.get("ongoingCycle", {})
+            if completed:
+                metadata[label] = "breached" if completed[-1].get("breached") else "met"
+            elif ongoing:
+                metadata[label] = "breached" if ongoing.get("breached") else "ongoing"
 
-        # Customer request type
+        # Customer request type (portal-facing label)
         customer_request = fields.get("customfield_10010")
         if customer_request and isinstance(customer_request, dict):
             rt = customer_request.get("requestType", {})
-            if isinstance(rt, dict):
-                metadata["customer_request_type"] = rt.get("name", "")
+            if isinstance(rt, dict) and rt.get("name"):
+                metadata["customer_request_type"] = rt["name"]
 
         # Priority
         priority = fields.get("priority", {})
@@ -130,8 +160,8 @@ def extract_jsm_metadata(issue: Any) -> dict[str, str | list[str]]:
         status = fields.get("status", {})
         if isinstance(status, dict):
             status_category = status.get("statusCategory", {})
-            if isinstance(status_category, dict):
-                metadata["status_category"] = status_category.get("name", "")
+            if isinstance(status_category, dict) and status_category.get("name"):
+                metadata["status_category"] = status_category["name"]
 
     except Exception as e:
         logger.warning(f"Error extracting JSM metadata: {e}")

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -20,7 +20,7 @@ _CUSTOM_FIELD_PATTERNS = {
 }
 
 
-def build_jsm_session(credentials: dict[str, Any], jira_base: str) -> requests.Session:
+def build_jsm_session(credentials: dict[str, Any]) -> requests.Session:
     """Build a requests.Session configured for JSM API calls.
 
     Authentication mirrors the existing Jira connector:

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",


### PR DESCRIPTION
## Summary

Adds a new `JiraServiceManagementConnector` for indexing tickets from Jira Service Management (JSM) projects.

Closes #2281

## What's included

**New files:**
- `backend/onyx/connectors/jira_service_management/connector.py` — main connector class
- `backend/onyx/connectors/jira_service_management/utils.py` — JSM API helpers
- `backend/onyx/connectors/jira_service_management/__init__.py`

**Modified files:**
- `backend/onyx/configs/constants.py` — added `DocumentSource.JIRA_SERVICE_MANAGEMENT`
- `backend/onyx/connectors/registry.py` — registered the new connector

## How it works

- Implements `CheckpointedConnectorWithPermSync` and `SlimConnectorWithPermSync` (same interfaces as the existing Jira connector)
- Uses the `jira` Python library for authentication (cloud: email + API token; server/DC: personal access token)
- Fetches tickets via JQL scoped to the specified project key with time-range filtering for incremental indexing
- Extracts JSM-specific metadata: request type, SLA status (time to first response, time to resolution), customer request type, priority, and status category
- Supports listing accessible service desks via the JSM Service Desk API (`/rest/servicedeskapi/servicedesk`)

## Credentials

Same credential shape as the existing Jira connector:
```
jira_api_token    — required
jira_user_email   — required for cloud, omit for server/DC
```

Connector config:
```
jira_base_url  — e.g. https://example.atlassian.net
jira_project   — JSM project key, e.g. IT
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `JiraServiceManagementConnector` to index Jira Service Management tickets with incremental, permission-aware sync and dynamic SLA/customer request type metadata. Registers the `jira_service_management` source with reliable offset-based checkpointing. Closes #2281.

- New Features
  - New connector implementing `CheckpointedConnectorWithPermSync` and `SlimConnectorWithPermSync`; registers `DocumentSource.JIRA_SERVICE_MANAGEMENT` in the registry.
  - Auth via `jira` (cloud: `jira_user_email` + `jira_api_token`; server/DC: `jira_api_token` PAT).
  - Fetch via JQL scoped to `jira_project` with time-range filtering and pagination; accepts a full JSM project URL or key.
  - Dynamic JSM metadata: SLA status and customer request type, plus priority, status, and status category. Helpers: `build_jsm_session`, `discover_jsm_custom_field_ids`, `extract_jsm_metadata`, `get_service_desks` (`list_service_desks()`).

- Bug Fixes
  - Implemented `JsmConnectorCheckpoint` and required methods; incremental sync now tracks an `offset` and resumes correctly.
  - Set `external_access` via `get_project_permissions()` in both checkpointed and slim paths; guard `_get_project_permissions` when credentials are missing.
  - Use `build_jira_url()` for document IDs/links and extract the project key from a full JSM project URL.
  - Robustness: streamlined `build_jsm_session` (returns only `requests.Session`, removed unused `jira_base`); 30s timeout in `get_service_desks`; narrower exceptions; reset permission cache on re-auth; fixed cloud detection with `bool(credentials.get("jira_user_email"))`; removed duplicate priority/request type metadata; renamed field discovery to `discover_jsm_custom_field_ids`; use `callback.should_stop()` with `progress()` in the slim path; added explicit types for `_jira_client` and `_jsm_session`.

<sup>Written for commit f6525693521ed0fb62e7e6a98bd110714559daaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

