### PR TITLE
feat(ux): all pages handle `404`s

### DIFF
--- a/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use } from "react";
 import { SlackChannelConfigCreationForm } from "@/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { SvgSlack } from "@opal/icons";
@@ -66,30 +66,36 @@ function EditSlackChannelConfigContent({ id }: { id: string }) {
         {isLoading ? (
           <SimpleLoader />
         ) : channelsError || !slackChannelConfigs ? (
-          <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch Slack Channels - ${
-              channelsError?.message ?? "unknown error"
-            }`}
+          <ResourceErrorPage
+            errorType="fetch_error"
+            title="Failed to load Slack channels"
+            description={channelsError?.message}
+            backHref="/admin/bots"
+            backLabel="Back to Slack bots"
           />
         ) : !slackChannelConfig ? (
-          <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Did not find Slack Channel config with ID: ${id}`}
+          <ResourceErrorPage
+            errorType="not_found"
+            title="Channel config not found"
+            description={`Slack channel config with ID ${id} could not be found.`}
+            backHref="/admin/bots"
+            backLabel="Back to Slack bots"
           />
         ) : docSetsError || !documentSets ? (
-          <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch document sets - ${
-              docSetsError?.message ?? "unknown error"
-            }`}
+          <ResourceErrorPage
+            errorType="fetch_error"
+            title="Failed to load document sets"
+            description={docSetsError?.message}
+            backHref="/admin/bots"
+            backLabel="Back to Slack bots"
           />
         ) : agentsError ? (
-          <ErrorCallout
-            errorTitle="Something went wrong :("
-            errorMsg={`Failed to fetch agents - ${
-              agentsError?.message ?? "unknown error"
-            }`}
+          <ResourceErrorPage
+            errorType="fetch_error"
+            title="Failed to load agents"
+            description={agentsError?.message}
+            backHref="/admin/bots"
+            backLabel="Back to Slack bots"
           />
         ) : (
           <SlackChannelConfigCreationForm

--- a/web/src/app/admin/bots/[bot-id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use } from "react";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import SlackChannelConfigsTable from "./SlackChannelConfigsTable";
 import { useSlackBot, useSlackChannelConfigsByBot } from "./hooks";
@@ -31,22 +31,24 @@ function SlackBotEditContent({ botId }: { botId: string }) {
 
   if (slackBotError || !slackBot) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch Slack Bot ${botId}: ${getErrorMsg(
-          slackBotError
-        )}`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load Slack bot"
+        description={getErrorMsg(slackBotError)}
+        backHref="/admin/bots"
+        backLabel="Back to Slack bots"
       />
     );
   }
 
   if (slackChannelConfigsError || !slackChannelConfigs) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch Slack Bot ${botId}: ${getErrorMsg(
-          slackChannelConfigsError
-        )}`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load channel configs"
+        description={getErrorMsg(slackChannelConfigsError)}
+        backHref="/admin/bots"
+        backLabel="Back to Slack bots"
       />
     );
   }

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import BackButton from "@/refresh-components/buttons/BackButton";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import { ThreeDotsLoader } from "@/components/Loading";
 import { SourceIcon } from "@/components/SourceIcon";
 import { CCPairStatus, PermissionSyncStatus } from "@/components/Status";
@@ -344,13 +344,16 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   if (!ccPair || (!hasLoadedOnce && ccPairError)) {
     return (
-      <ErrorCallout
-        errorTitle={`Failed to fetch info on Connector with ID ${ccPairId}`}
-        errorMsg={
+      <ResourceErrorPage
+        errorType="not_found"
+        title="Connector not found"
+        description={
           ccPairError?.info?.detail ||
           ccPairError?.toString() ||
-          "Unknown error"
+          `Connector with ID ${ccPairId} could not be found.`
         }
+        backHref="/admin/indexing/status"
+        backLabel="Back to connectors"
       />
     );
   }

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState, useEffect, useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { ThreeDotsLoader } from "@/components/Loading";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
@@ -72,9 +72,12 @@ function GuildDetailContent({
 
   if (guildError || !guild) {
     return (
-      <ErrorCallout
-        errorTitle="Failed to load server"
-        errorMsg={guildError?.info?.detail || "Server not found"}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load server"
+        description={guildError?.info?.detail || "Server not found"}
+        backHref="/admin/discord-bot"
+        backLabel="Back to Discord servers"
       />
     );
   }
@@ -128,9 +131,14 @@ function GuildDetailContent({
         ) : channelsLoading ? (
           <ThreeDotsLoader />
         ) : channelsError ? (
-          <ErrorCallout
-            errorTitle="Failed to load channels"
-            errorMsg={channelsError?.info?.detail || "Could not load channels"}
+          <ResourceErrorPage
+            errorType="fetch_error"
+            title="Failed to load channels"
+            description={
+              channelsError?.info?.detail || "Could not load channels"
+            }
+            backHref="/admin/discord-bot"
+            backLabel="Back to Discord servers"
           />
         ) : (
           <DiscordChannelsTable

--- a/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
+++ b/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { use } from "react";
 
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import { refreshDocumentSets, useDocumentSets } from "../hooks";
 import { useConnectorStatus, useUserGroups } from "@/lib/hooks";
 import { ThreeDotsLoader } from "@/components/Loading";
@@ -47,18 +47,22 @@ function Main({ documentSetId }: { documentSetId: number }) {
 
   if (documentSetsError || !documentSets) {
     return (
-      <ErrorCallout
-        errorTitle="Failed to fetch document sets"
-        errorMsg={documentSetsError}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load document sets"
+        backHref="/admin/documents/sets"
+        backLabel="Back to document sets"
       />
     );
   }
 
   if (vectorDbEnabled && (ccPairsError || !ccPairs)) {
     return (
-      <ErrorCallout
-        errorTitle="Failed to fetch Connectors"
-        errorMsg={ccPairsError}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load connectors"
+        backHref="/admin/documents/sets"
+        backLabel="Back to document sets"
       />
     );
   }
@@ -68,9 +72,12 @@ function Main({ documentSetId }: { documentSetId: number }) {
   );
   if (!documentSet) {
     return (
-      <ErrorCallout
-        errorTitle="Document set not found"
-        errorMsg={`Document set with id ${documentSetId} not found`}
+      <ResourceErrorPage
+        errorType="not_found"
+        title="Document set not found"
+        description={`Document set with ID ${documentSetId} could not be found.`}
+        backHref="/admin/documents/sets"
+        backLabel="Back to document sets"
       />
     );
   }

--- a/web/src/app/admin/federated/[id]/page.tsx
+++ b/web/src/app/admin/federated/[id]/page.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect } from "react";
 import { notFound } from "next/navigation";
-import { Loader2 } from "lucide-react";
 import { useFederatedConnector } from "./useFederatedConnector";
 import { FederatedConnectorForm } from "@/components/admin/federated/FederatedConnectorForm";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 
 export default function EditFederatedConnectorPage(props: {
   params: Promise<{ id: string }>;
@@ -19,35 +20,17 @@ export default function EditFederatedConnectorPage(props: {
     useFederatedConnector(params?.id ?? "");
 
   if (isLoading) {
-    return (
-      <div className="flex justify-center w-full h-full">
-        <div className="mt-12 w-full max-w-4xl mx-auto">
-          <div className="flex flex-col items-center justify-center py-16">
-            <Loader2 className="h-8 w-8 animate-spin text-blue-500 mb-4" />
-            <div className="text-center">
-              <p className="text-lg font-medium text-gray-700 mb-2">
-                Loading connector configuration...
-              </p>
-              <p className="text-sm text-gray-500">
-                Retrieving connector details and credential schema
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
+    return <SimpleLoader />;
   }
 
   if (error) {
     return (
-      <div className="flex justify-center w-full h-full">
-        <div className="mt-12 w-full max-w-4xl mx-auto">
-          <div className="text-center">
-            <h1 className="text-2xl font-bold text-red-600 mb-4">Error</h1>
-            <p className="text-gray-600">{error}</p>
-          </div>
-        </div>
-      </div>
+      <ResourceErrorPage
+        errorType="fetch_error"
+        description={error}
+        backHref="/admin/federated"
+        backLabel="Back to federated connectors"
+      />
     );
   }
 

--- a/web/src/app/app/agents/edit/[id]/page.tsx
+++ b/web/src/app/app/agents/edit/[id]/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { use, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { use } from "react";
 import { useAgent } from "@/hooks/useAgents";
 import AgentEditorPage from "@/refresh-pages/AgentEditorPage";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import * as AppLayouts from "@/layouts/app-layouts";
 
 export interface PageProps {
@@ -11,7 +12,6 @@ export interface PageProps {
 }
 
 export default function Page(props: PageProps) {
-  const router = useRouter();
   const { id } = use(props.params);
   const agentId = parseInt(id);
 
@@ -20,22 +20,19 @@ export default function Page(props: PageProps) {
     isNaN(agentId) ? null : agentId
   );
 
-  // Handle invalid ID (NaN)
-  useEffect(() => {
-    if (isNaN(agentId)) {
-      router.push("/app");
-    }
-  }, [agentId, router]);
+  if (isLoading) return <SimpleLoader />;
 
-  // Redirect to home if agent not found after loading completes
-  useEffect(() => {
-    if (!isLoading && !agent) {
-      router.push("/app");
-    }
-  }, [isLoading, agent, router]);
-
-  // Show nothing while redirecting or loading
-  if (isLoading || !agent) return null;
+  if (isNaN(agentId) || !agent) {
+    return (
+      <ResourceErrorPage
+        errorType="not_found"
+        title="Agent not found"
+        description="This agent doesn't exist or has been deleted."
+        backHref="/app"
+        backLabel="Start a new chat"
+      />
+    );
+  }
 
   return (
     <AppLayouts.Root>

--- a/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/[id]/page.tsx
@@ -11,7 +11,7 @@ import BackButton from "@/refresh-components/buttons/BackButton";
 import { FeedbackBadge } from "../FeedbackBadge";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useSWR from "swr";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import { ThreeDotsLoader } from "@/components/Loading";
 import CardSection from "@/components/admin/CardSection";
 
@@ -81,9 +81,12 @@ export default function QueryPage(props: { params: Promise<{ id: string }> }) {
 
   if (!chatSessionSnapshot || error) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch chat session - ${error}`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load chat session"
+        description={error ? String(error) : undefined}
+        backHref="/admin/performance/query-history"
+        backLabel="Back to query history"
       />
     );
   }

--- a/web/src/app/ee/admin/standard-answer/[id]/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { StandardAnswerCreationForm } from "@/app/ee/admin/standard-answer/StandardAnswerCreationForm";
 import { fetchSS } from "@/lib/utilsSS";
-import { ErrorCallout } from "@/components/ErrorCallout";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { StandardAnswer, StandardAnswerCategory } from "@/lib/types";
@@ -17,18 +17,23 @@ async function Main({ id }: { id: string }) {
 
   if (standardAnswersResponse === undefined) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch standard answers.`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load standard answers"
+        backHref="/admin/standard-answer"
+        backLabel="Back to standard answers"
       />
     );
   }
 
   if (!standardAnswersResponse.ok) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch standard answers - ${await standardAnswersResponse.text()}`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load standard answers"
+        description={`Server returned an error: ${await standardAnswersResponse.text()}`}
+        backHref="/admin/standard-answer"
+        backLabel="Back to standard answers"
       />
     );
   }
@@ -40,27 +45,35 @@ async function Main({ id }: { id: string }) {
 
   if (!standardAnswer) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Did not find standard answer with ID: ${id}`}
+      <ResourceErrorPage
+        errorType="not_found"
+        title="Standard answer not found"
+        description={`Standard answer with ID ${id} could not be found.`}
+        backHref="/admin/standard-answer"
+        backLabel="Back to standard answers"
       />
     );
   }
 
   if (standardAnswerCategoriesResponse === undefined) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch standard answer categories.`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load standard answer categories"
+        backHref="/admin/standard-answer"
+        backLabel="Back to standard answers"
       />
     );
   }
 
   if (!standardAnswerCategoriesResponse.ok) {
     return (
-      <ErrorCallout
-        errorTitle="Something went wrong :("
-        errorMsg={`Failed to fetch standard answer categories - ${await standardAnswerCategoriesResponse.text()}`}
+      <ResourceErrorPage
+        errorType="fetch_error"
+        title="Failed to load standard answer categories"
+        description={`Server returned an error: ${await standardAnswerCategoriesResponse.text()}`}
+        backHref="/admin/standard-answer"
+        backLabel="Back to standard answers"
       />
     );
   }

--- a/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
+++ b/web/src/app/ee/agents/stats/[id]/AgentStats.tsx
@@ -11,6 +11,7 @@ import { useAgents } from "@/hooks/useAgents";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { AreaChartDisplay } from "@/components/ui/areaChart";
+import ResourceErrorPage from "@/sections/error/ResourceErrorPage";
 
 type AgentDailyUsageEntry = {
   date: string;
@@ -117,9 +118,13 @@ export function AgentStats({ agentId }: { agentId: number }) {
     );
   } else if (error) {
     content = (
-      <div className="h-80 text-red-600 font-bold flex flex-col">
-        <p className="m-auto">{error}</p>
-      </div>
+      <ResourceErrorPage
+        errorType={
+          error.includes("permission") ? "access_denied" : "fetch_error"
+        }
+        description={error}
+        backHref="/app"
+      />
     );
   } else if (!agentStats?.daily_stats?.length) {
     content = (

--- a/web/src/sections/error/ResourceErrorPage.tsx
+++ b/web/src/sections/error/ResourceErrorPage.tsx
@@ -1,0 +1,67 @@
+import { Section } from "@/layouts/general-layouts";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNotFound from "@opal/illustrations/not-found";
+import SvgNoAccess from "@opal/illustrations/no-access";
+import SvgDisconnected from "@opal/illustrations/disconnected";
+import { Button } from "@opal/components";
+import type { IconFunctionComponent } from "@opal/types";
+
+type ErrorType = "not_found" | "access_denied" | "fetch_error";
+
+const errorConfig: Record<
+  ErrorType,
+  {
+    illustration: IconFunctionComponent;
+    title: string;
+    description: string;
+  }
+> = {
+  not_found: {
+    illustration: SvgNotFound,
+    title: "Not found",
+    description: "This resource doesn't exist or has been deleted.",
+  },
+  access_denied: {
+    illustration: SvgNoAccess,
+    title: "Access denied",
+    description: "You don't have permission to view this resource.",
+  },
+  fetch_error: {
+    illustration: SvgDisconnected,
+    title: "Something went wrong",
+    description: "We couldn't load this resource. Please try again later.",
+  },
+};
+
+interface ResourceErrorPageProps {
+  errorType: ErrorType;
+  title?: string;
+  description?: string;
+  backHref: string;
+  backLabel?: string;
+}
+
+function ResourceErrorPage({
+  errorType,
+  title,
+  description,
+  backHref,
+  backLabel = "Go back",
+}: ResourceErrorPageProps) {
+  const config = errorConfig[errorType];
+
+  return (
+    <Section flexDirection="column" alignItems="center" gap={1}>
+      <IllustrationContent
+        illustration={config.illustration}
+        title={title ?? config.title}
+        description={description ?? config.description}
+      />
+      <Button href={backHref} prominence="secondary">
+        {backLabel}
+      </Button>
+    </Section>
+  );
+}
+
+export default ResourceErrorPage;


### PR DESCRIPTION
## Description



## How Has This Been Tested?

TBD

## Additional Options

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified ResourceErrorPage and updates key pages to gracefully handle 404s and fetch errors with clear messages and back links. This improves consistency and prevents dead ends across the app.

- **New Features**
  - Introduced `ResourceErrorPage` with `not_found`, `access_denied`, and `fetch_error` variants plus a back button.
  - Applied to admin Slack bot/channel configs, connectors, Discord servers/channels, document sets, federated connectors, agent editor and stats, query history, and standard answers.
  - Standardized loading states with SimpleLoader in updated routes.

<sup>Written for commit b72bd7de58e54d0f6d5876a85012c6bc2213878a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

