### PR TITLE
refactor: Migrate `refresh-components/Text`

### DIFF
--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -31,6 +31,7 @@ import { Credential } from "@/lib/connectors/credentials";
 import { SettingsContext } from "@/providers/SettingsProvider";
 import SourceTile from "@/components/SourceTile";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 

--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -4,8 +4,7 @@ import { createApiKey, updateApiKey } from "./lib";
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { FormikField } from "@/refresh-components/form/FormikField";
@@ -80,7 +79,7 @@ export default function OnyxApiKeyForm({
           {({ isSubmitting }) => (
             <Form className="w-full overflow-visible">
               <Modal.Body>
-                <Text as="p">
+                <Text as="p" color="text-05">
                   Choose a memorable name for your API key. This is optional and
                   can be added or changed later!
                 </Text>

--- a/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
+++ b/web/src/app/admin/api-key/OnyxApiKeyForm.tsx
@@ -4,6 +4,7 @@ import { createApiKey, updateApiKey } from "./lib";
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputSelect from "@/refresh-components/inputs/InputSelect";

--- a/web/src/app/admin/api-key/page.tsx
+++ b/web/src/app/admin/api-key/page.tsx
@@ -29,6 +29,7 @@ import {
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 import { Button } from "@opal/components";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgEdit, SvgInfo, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -9,6 +9,7 @@ import Card from "@/refresh-components/cards/Card";
 import Button from "@/refresh-components/buttons/Button";
 import { Button as OpalButton } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Message from "@/refresh-components/messages/Message";
 import InfoBlock from "@/refresh-components/messages/InfoBlock";

--- a/web/src/app/admin/billing/CheckoutView.tsx
+++ b/web/src/app/admin/billing/CheckoutView.tsx
@@ -5,6 +5,7 @@ import { Section } from "@/layouts/general-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputFile from "@/refresh-components/inputs/InputFile";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/admin/billing/PlansView.tsx
+++ b/web/src/app/admin/billing/PlansView.tsx
@@ -22,6 +22,7 @@ import type { IconProps } from "@opal/types";
 import Card from "@/refresh-components/cards/Card";
 import Button from "@/refresh-components/buttons/Button";
 import { Button as OpalButton } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams, useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgArrowUpCircle, SvgWallet } from "@opal/icons";
 import type { IconProps } from "@opal/types";

--- a/web/src/app/admin/configuration/document-processing/page.tsx
+++ b/web/src/app/admin/configuration/document-processing/page.tsx
@@ -7,6 +7,7 @@ import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import useSWR from "swr";
 import { ThreeDotsLoader } from "@/components/Loading";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { SvgLock } from "@opal/icons";

--- a/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
+++ b/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useMemo } from "react";
 import useSWR from "swr";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Select } from "@/refresh-components/cards";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import { toast } from "@/hooks/useToast";
@@ -136,10 +135,8 @@ export default function ImageGenerationContent() {
       <div className="flex flex-col gap-6">
         {/* Section Header */}
         <div className="flex flex-col gap-0.5">
-          <Text mainContentEmphasis text05>
-            Image Generation Model
-          </Text>
-          <Text secondaryBody text03>
+          <Text font="main-content-emphasis">Image Generation Model</Text>
+          <Text font="secondary-body" color="text-03">
             Select a model to generate images in chat.
           </Text>
         </div>
@@ -158,7 +155,7 @@ export default function ImageGenerationContent() {
         {/* Provider Groups */}
         {IMAGE_PROVIDER_GROUPS.map((group) => (
           <div key={group.name} className="flex flex-col gap-2">
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               {group.name}
             </Text>
             <div className="flex flex-col gap-2">

--- a/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
+++ b/web/src/app/admin/configuration/image-generation/ImageGenerationContent.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import useSWR from "swr";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Select } from "@/refresh-components/cards";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";

--- a/web/src/app/admin/configuration/llm/ModelConfigurationField.tsx
+++ b/web/src/app/admin/configuration/llm/ModelConfigurationField.tsx
@@ -8,6 +8,7 @@ import CreateButton from "@/refresh-components/buttons/CreateButton";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { SvgX } from "@opal/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 function ModelConfigurationRow({

--- a/web/src/app/admin/configuration/web-search/page.tsx
+++ b/web/src/app/admin/configuration/web-search/page.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useMemo, useState, useReducer } from "react";
 import { InfoIcon } from "@/components/icons/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Content } from "@opal/layouts";

--- a/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ConfigDisplay.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { ValidSources } from "@/lib/types";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -10,6 +10,7 @@ import {
 import { IndexAttemptError } from "./types";
 import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -10,8 +10,7 @@ import {
 import { IndexAttemptError } from "./types";
 import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { PageSelector } from "@/components/PageSelector";
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
@@ -114,11 +113,11 @@ export default function IndexAttemptErrorsModal({
         <Modal.Body height="full">
           {!isResolvingErrors && (
             <div className="flex flex-col gap-2 flex-shrink-0">
-              <Text as="p">
+              <Text as="p" color="text-05">
                 Below are the errors encountered during indexing. Each row
                 represents a failed document or entity.
               </Text>
-              <Text as="p">
+              <Text as="p" color="text-05">
                 Click the button below to kick off a full re-index to try and
                 resolve these errors. This full re-index may take much longer
                 than a normal update.

--- a/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/InlineFileManagement.tsx
@@ -21,6 +21,7 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { ThreeDotsLoader } from "@/components/Loading";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   SvgCheck,

--- a/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ReIndexModal.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { toast } from "@/hooks/useToast";
 import { triggerIndexing } from "@/app/admin/connector/[ccPairId]/lib";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Separator from "@/refresh-components/Separator";
 import { SvgRefreshCw } from "@opal/icons";

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -7,6 +7,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { CCPairStatus, PermissionSyncStatus } from "@/components/Status";
 import { toast } from "@/hooks/useToast";
 import CredentialSection from "@/components/credentials/CredentialSection";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   updateConnectorCredentialPairName,

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -59,6 +59,7 @@ import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { deleteConnector } from "@/lib/connector";
 import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgKey, SvgAlertCircle } from "@opal/icons";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";

--- a/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
+++ b/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
@@ -19,8 +19,6 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { buildSimilarCredentialInfoURL } from "@/app/admin/connector/[ccPairId]/lib";
 import { Credential } from "@/lib/connectors/credentials";
 import { useFederatedConnectors } from "@/lib/hooks";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { useToastFromQuery } from "@/hooks/useToast";
 
 export default function ConnectorWrapper({

--- a/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
+++ b/web/src/app/admin/connectors/[connector]/ConnectorWrapper.tsx
@@ -19,6 +19,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { buildSimilarCredentialInfoURL } from "@/app/admin/connector/[ccPairId]/lib";
 import { Credential } from "@/lib/connectors/credentials";
 import { useFederatedConnectors } from "@/lib/hooks";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useToastFromQuery } from "@/hooks/useToast";
 

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -15,8 +15,7 @@ import * as InputLayouts from "@/layouts/input-layouts";
 import { Content } from "@opal/layouts";
 import CheckboxField from "@/refresh-components/form/LabeledCheckboxField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 // Define a general type for form values
 type FormValues = Record<string, any>;
@@ -58,7 +57,7 @@ const TabsField: FC<TabsFieldProps> = ({
 
       {/* Ensure there's at least one tab before rendering */}
       {tabField.tabs.length === 0 ? (
-        <Text text03 secondaryBody>
+        <Text color="text-03" font="secondary-body">
           No tabs to display.
         </Text>
       ) : (
@@ -254,7 +253,7 @@ export const RenderField: FC<RenderFieldProps> = ({
         )
       ) : field.type === "string_tab" ? (
         <GeneralLayouts.Section>
-          <Text text03 secondaryBody>
+          <Text color="text-03" font="secondary-body">
             {description}
           </Text>
         </GeneralLayouts.Section>

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -15,6 +15,7 @@ import * as InputLayouts from "@/layouts/input-layouts";
 import { Content } from "@opal/layouts";
 import CheckboxField from "@/refresh-components/form/LabeledCheckboxField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 // Define a general type for form values

--- a/web/src/app/admin/discord-bot/BotConfigCard.tsx
+++ b/web/src/app/admin/discord-bot/BotConfigCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";

--- a/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
@@ -11,6 +11,7 @@ import {
 import Switch from "@/refresh-components/inputs/Switch";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import EmptyMessage from "@/refresh-components/EmptyMessage";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import {

--- a/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/DiscordChannelsTable.tsx
@@ -11,8 +11,7 @@ import {
 import Switch from "@/refresh-components/inputs/Switch";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import EmptyMessage from "@/refresh-components/EmptyMessage";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import {
   DiscordChannelConfig,
@@ -96,9 +95,7 @@ export function DiscordChannelsTable({
                   width="fit"
                 >
                   <ChannelIcon width={16} height={16} />
-                  <Text text04 mainUiBody>
-                    {channel.channel_name}
-                  </Text>
+                  <Text>{channel.channel_name}</Text>
                 </Section>
               </TableCell>
               <TableCell>

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
 import { Callout } from "@/components/ui/callout";

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -8,12 +8,10 @@ import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import Card from "@/refresh-components/cards/Card";
 import { Callout } from "@/components/ui/callout";
 import Message from "@/refresh-components/messages/Message";
-import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { SvgServer } from "@opal/icons";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
@@ -122,7 +120,7 @@ function GuildDetailContent({
         />
 
         {!isRegistered ? (
-          <Text text03 secondaryBody>
+          <Text color="text-03" font="secondary-body">
             Channel configuration will be available after the server is
             registered.
           </Text>

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -6,8 +6,7 @@ import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 import Modal from "@/refresh-components/Modal";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
@@ -77,7 +76,7 @@ function DiscordBotContent() {
             description="This key will only be shown once!"
           />
           <Modal.Body>
-            <Text text04 mainUiBody>
+            <Text>
               Copy the command and send it from any text channel in your server!
             </Text>
             <Card variant="secondary">
@@ -86,8 +85,8 @@ function DiscordBotContent() {
                 justifyContent="between"
                 alignItems="center"
               >
-                <Text text03 secondaryMono>
-                  !register {registrationKey}
+                <Text color="text-03" font="secondary-mono">
+                  {`!register ${registrationKey}`}
                 </Text>
                 <CopyIconButton
                   getCopyText={() => `!register ${registrationKey}`}
@@ -104,7 +103,7 @@ function DiscordBotContent() {
           justifyContent="between"
           alignItems="center"
         >
-          <Text mainContentEmphasis text05>
+          <Text font="main-content-emphasis" color="text-05">
             Server Configurations
           </Text>
           <CreateButton

--- a/web/src/app/admin/discord-bot/page.tsx
+++ b/web/src/app/admin/discord-bot/page.tsx
@@ -6,6 +6,7 @@ import { ErrorCallout } from "@/components/ErrorCallout";
 import { toast } from "@/hooks/useToast";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 import Modal from "@/refresh-components/Modal";

--- a/web/src/app/admin/document-index-migration/page.tsx
+++ b/web/src/app/admin/document-index-migration/page.tsx
@@ -9,8 +9,7 @@ const route = ADMIN_ROUTES.INDEX_MIGRATION;
 
 import Card from "@/refresh-components/cards/Card";
 import { Content, ContentAction } from "@opal/layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Button from "@/refresh-components/buttons/Button";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -39,10 +38,10 @@ function MigrationStatusSection() {
   if (isLoading) {
     return (
       <Card>
-        <Text headingH3>Migration Status</Text>
-        <Text mainUiBody text03>
-          Loading...
+        <Text font="heading-h3" color="text-05">
+          Migration Status
         </Text>
+        <Text color="text-03">Loading...</Text>
       </Card>
     );
   }
@@ -50,10 +49,10 @@ function MigrationStatusSection() {
   if (error) {
     return (
       <Card>
-        <Text headingH3>Migration Status</Text>
-        <Text mainUiBody text03>
-          Failed to load migration status.
+        <Text font="heading-h3" color="text-05">
+          Migration Status
         </Text>
+        <Text color="text-03">Failed to load migration status.</Text>
       </Card>
     );
   }
@@ -74,14 +73,16 @@ function MigrationStatusSection() {
 
   return (
     <Card>
-      <Text headingH3>Migration Status</Text>
+      <Text font="heading-h3" color="text-05">
+        Migration Status
+      </Text>
 
       <ContentAction
         title="Started"
         sizePreset="main-ui"
         variant="section"
         rightChildren={
-          <Text mainUiBody>
+          <Text color="text-05">
             {hasStarted ? formatTimestamp(data.created_at!) : "Not started"}
           </Text>
         }
@@ -92,7 +93,7 @@ function MigrationStatusSection() {
         sizePreset="main-ui"
         variant="section"
         rightChildren={
-          <Text mainUiBody>
+          <Text color="text-05">
             {progressPercentage !== null
               ? `${totalChunksMigrated} (approx. progress ${Math.round(
                   progressPercentage
@@ -107,7 +108,7 @@ function MigrationStatusSection() {
         sizePreset="main-ui"
         variant="section"
         rightChildren={
-          <Text mainUiBody>
+          <Text color="text-05">
             {hasCompleted
               ? formatTimestamp(data.migration_completed_at!)
               : hasStarted
@@ -160,10 +161,10 @@ function RetrievalSourceSection() {
   if (isLoading) {
     return (
       <Card>
-        <Text headingH3>Retrieval Source</Text>
-        <Text mainUiBody text03>
-          Loading...
+        <Text font="heading-h3" color="text-05">
+          Retrieval Source
         </Text>
+        <Text color="text-03">Loading...</Text>
       </Card>
     );
   }
@@ -171,10 +172,10 @@ function RetrievalSourceSection() {
   if (error) {
     return (
       <Card>
-        <Text headingH3>Retrieval Source</Text>
-        <Text mainUiBody text03>
-          Failed to load retrieval settings.
+        <Text font="heading-h3" color="text-05">
+          Retrieval Source
         </Text>
+        <Text color="text-03">Failed to load retrieval settings.</Text>
       </Card>
     );
   }

--- a/web/src/app/admin/document-index-migration/page.tsx
+++ b/web/src/app/admin/document-index-migration/page.tsx
@@ -9,6 +9,7 @@ const route = ADMIN_ROUTES.INDEX_MIGRATION;
 
 import Card from "@/refresh-components/cards/Card";
 import { Content, ContentAction } from "@opal/layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import Button from "@/refresh-components/buttons/Button";

--- a/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ChangeCredentialsModal.tsx
@@ -3,6 +3,7 @@
 import React, { useRef, useState } from "react";
 import Modal from "@/refresh-components/Modal";
 import { Callout } from "@/components/ui/callout";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Separator from "@/refresh-components/Separator";
 import Button from "@/refresh-components/buttons/Button";

--- a/web/src/app/admin/embeddings/modals/DeleteCredentialsModal.tsx
+++ b/web/src/app/admin/embeddings/modals/DeleteCredentialsModal.tsx
@@ -1,4 +1,5 @@
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Callout } from "@/components/ui/callout";

--- a/web/src/app/admin/embeddings/modals/InstantSwitchConfirmModal.tsx
+++ b/web/src/app/admin/embeddings/modals/InstantSwitchConfirmModal.tsx
@@ -1,5 +1,6 @@
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgAlertTriangle } from "@opal/icons";
 export interface InstantSwitchConfirmModalProps {

--- a/web/src/app/admin/embeddings/modals/ModelSelectionModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ModelSelectionModal.tsx
@@ -1,4 +1,5 @@
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Callout } from "@/components/ui/callout";
 import { Button } from "@opal/components";

--- a/web/src/app/admin/embeddings/modals/ProviderCreationModal.tsx
+++ b/web/src/app/admin/embeddings/modals/ProviderCreationModal.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Callout } from "@/components/ui/callout";
 import { Button } from "@opal/components";

--- a/web/src/app/admin/embeddings/modals/SelectModelModal.tsx
+++ b/web/src/app/admin/embeddings/modals/SelectModelModal.tsx
@@ -1,5 +1,6 @@
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { CloudEmbeddingModel } from "@/components/embedding/interfaces";
 import { SvgServer } from "@opal/icons";

--- a/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
@@ -4,6 +4,7 @@ import { toast } from "@/hooks/useToast";
 
 import EmbeddingModelSelection from "../EmbeddingModelSelectionForm";
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Button from "@/refresh-components/buttons/Button";
 import { Button as OpalButton } from "@opal/components";

--- a/web/src/app/admin/kg/KGEntityTypes.tsx
+++ b/web/src/app/admin/kg/KGEntityTypes.tsx
@@ -8,6 +8,7 @@ import { ValidSources } from "@/lib/types";
 import { FaCircleQuestion } from "react-icons/fa6";
 import { CheckmarkIcon } from "@/components/icons/icons";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { cn } from "@/lib/utils";

--- a/web/src/app/admin/kg/page.tsx
+++ b/web/src/app/admin/kg/page.tsx
@@ -28,6 +28,7 @@ import Title from "@/components/ui/title";
 import { redirect } from "next/navigation";
 import { useIsKGExposed } from "@/app/admin/kg/utils";
 import KGEntityTypes from "@/app/admin/kg/KGEntityTypes";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { SvgSettings } from "@opal/icons";

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -1,10 +1,8 @@
 import { SvgDownload, SvgKey, SvgRefreshCw } from "@opal/icons";
 import { Interactive } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
@@ -64,7 +62,7 @@ export default function ScimModal({
           }
         >
           <Section alignItems="start" gap={0.5}>
-            <Text as="p" text03>
+            <Text as="p" color="text-03">
               Your current SCIM token will be revoked and a new token will be
               generated. You will need to update the token on your identity
               provider before SCIM provisioning will resume.

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -3,6 +3,7 @@ import { Interactive } from "@opal/core";
 import { Section } from "@/layouts/general-layouts";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";

--- a/web/src/app/admin/scim/ScimSyncCard.tsx
+++ b/web/src/app/admin/scim/ScimSyncCard.tsx
@@ -4,6 +4,7 @@ import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Separator from "@/refresh-components/Separator";
 import { timeAgo } from "@/lib/time";

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "@/hooks/useToast";
 import { useScimToken } from "@/hooks/useScimToken";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { ThreeDotsLoader } from "@/components/Loading";
 

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -7,8 +7,7 @@ import { toast } from "@/hooks/useToast";
 import { useScimToken } from "@/hooks/useScimToken";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { ThreeDotsLoader } from "@/components/Loading";
 
 import type { ScimTokenCreatedResponse, ScimModalView } from "./interfaces";
@@ -44,7 +43,7 @@ function ScimContent() {
 
   if (tokenError && !is404) {
     return (
-      <Text as="p" text03>
+      <Text as="p" color="text-03">
         Failed to load SCIM token status.
       </Text>
     );

--- a/web/src/app/app/components/AgentDescription.tsx
+++ b/web/src/app/app/components/AgentDescription.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 

--- a/web/src/app/app/components/AppPopup.tsx
+++ b/web/src/app/app/components/AppPopup.tsx
@@ -3,6 +3,7 @@
 import Modal from "@/refresh-components/Modal";
 import { SettingsContext } from "@/providers/SettingsProvider";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { FormField } from "@/refresh-components/form/FormField";
 import Checkbox from "@/refresh-components/inputs/Checkbox";

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -6,8 +6,7 @@ import {
   GREETING_MESSAGES,
 } from "@/lib/chat/greetingMessages";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import { useState, useEffect } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
@@ -42,7 +41,7 @@ export default function WelcomeMessage({
     content = (
       <div data-testid="onyx-logo" className="flex flex-row items-center gap-4">
         <Logo folded size={32} />
-        <Text as="p" headingH2>
+        <Text as="p" font="heading-h2" color="text-05">
           {greeting}
         </Text>
       </div>
@@ -55,7 +54,7 @@ export default function WelcomeMessage({
           className="flex flex-row items-center gap-3"
         >
           <AgentAvatar agent={agent} size={36} />
-          <Text as="p" headingH2>
+          <Text as="p" font="heading-h2" color="text-05">
             {agent.name}
           </Text>
         </div>

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -6,6 +6,7 @@ import {
   GREETING_MESSAGES,
 } from "@/lib/chat/greetingMessages";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import { useState, useEffect } from "react";

--- a/web/src/app/app/components/projects/ProjectChatSessionList.tsx
+++ b/web/src/app/app/components/projects/ProjectChatSessionList.tsx
@@ -8,6 +8,7 @@ import { ChatSession } from "@/app/app/interfaces";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import { useAgents } from "@/hooks/useAgents";
 import { formatRelativeTime } from "./project_utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { UNNAMED_CHAT } from "@/lib/constants";

--- a/web/src/app/app/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/app/components/projects/ProjectContextPanel.tsx
@@ -12,6 +12,7 @@ import { Button } from "@opal/components";
 import AddInstructionModal from "@/components/modals/AddInstructionModal";
 import UserFilesModal from "@/components/modals/UserFilesModal";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 import { FileCard, FileCardSkeleton } from "@/sections/cards/FileCard";

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import React, { useState, ReactNode, useCallback, useMemo, memo } from "react";
 import { SvgCheck, SvgCode, SvgCopy } from "@opal/icons";

--- a/web/src/app/app/message/CodeBlock.tsx
+++ b/web/src/app/app/message/CodeBlock.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import React, { useState, ReactNode, useCallback, useMemo, memo } from "react";
 import { SvgCheck, SvgCode, SvgCopy } from "@opal/icons";
 
@@ -49,14 +48,14 @@ export const CodeBlock = memo(function CodeBlock({
       {copied ? (
         <div className="flex items-center space-x-2">
           <SvgCheck height={14} width={14} stroke="currentColor" />
-          <Text as="p" secondaryMono>
+          <Text as="p" font="secondary-mono" color="text-05">
             Copied!
           </Text>
         </div>
       ) : (
         <div className="flex items-center space-x-2">
           <SvgCopy height={14} width={14} stroke="currentColor" />
-          <Text as="p" secondaryMono>
+          <Text as="p" font="secondary-mono" color="text-05">
             Copy
           </Text>
         </div>
@@ -132,7 +131,9 @@ export const CodeBlock = memo(function CodeBlock({
                 stroke="currentColor"
                 className="my-auto"
               />
-              <Text secondaryMono>{language}</Text>
+              <Text font="secondary-mono" color="text-05">
+                {language}
+              </Text>
               {codeText && <CopyButton />}
             </div>
           )}

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { FileDescriptor } from "@/app/app/interfaces";
 import "katex/dist/katex.min.css";
 import MessageSwitcher from "@/app/app/message/MessageSwitcher";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import useScreenSize from "@/hooks/useScreenSize";

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -14,6 +14,7 @@ import { SubQuestionDetail, CitationMap } from "../interfaces";
 import { ValidSources } from "@/lib/types";
 import { ProjectFile } from "../projects/projectsService";
 import { BlinkingBar } from "./BlinkingBar";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SourceTag from "@/refresh-components/buttons/source-tag/SourceTag";
 import {

--- a/web/src/app/app/message/MessageSwitcher.tsx
+++ b/web/src/app/app/message/MessageSwitcher.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgChevronLeft, SvgChevronRight } from "@opal/icons";
 const DISABLED_MESSAGE = "Wait for agent message to complete";

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -20,6 +20,7 @@ import { usePacedTurnGroups } from "@/app/app/message/messageComponents/timeline
 import MessageToolbar from "@/app/app/message/messageComponents/MessageToolbar";
 import { LlmDescriptor, LlmManager } from "@/lib/hooks";
 import { Message } from "@/app/app/interfaces";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { AgentTimeline } from "@/app/app/message/messageComponents/timeline/AgentTimeline";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -20,8 +20,7 @@ import { usePacedTurnGroups } from "@/app/app/message/messageComponents/timeline
 import MessageToolbar from "@/app/app/message/messageComponents/MessageToolbar";
 import { LlmDescriptor, LlmManager } from "@/lib/hooks";
 import { Message } from "@/app/app/interfaces";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { AgentTimeline } from "@/app/app/message/messageComponents/timeline/AgentTimeline";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import { getTextContent } from "@/app/app/services/packetUtils";
@@ -320,7 +319,7 @@ const AgentMessage = React.memo(function AgentMessage({
         {/* Show stopped message when user cancelled and no display content */}
         {pacedDisplayGroups.length === 0 &&
           stopReason === StopReason.USER_CANCELLED && (
-            <Text as="p" secondaryBody text04>
+            <Text as="p" font="secondary-body">
               User has stopped generation
             </Text>
           )}

--- a/web/src/app/app/message/messageComponents/renderers/CustomToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/CustomToolRenderer.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../services/streamingModels";
 import { MessageRenderer, RenderType } from "../interfaces";
 import { buildImgUrl } from "../../../components/files/images/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   SvgActions,

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 import {

--- a/web/src/app/app/message/messageComponents/timeline/AgentTimeline.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/AgentTimeline.tsx
@@ -6,6 +6,7 @@ import { FullChatState, RenderType } from "../interfaces";
 import { TurnGroup } from "./transformers";
 import { cn } from "@/lib/utils";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useTimelineExpansion } from "@/app/app/message/messageComponents/timeline/hooks/useTimelineExpansion";
 import { useTimelineMetrics } from "@/app/app/message/messageComponents/timeline/hooks/useTimelineMetrics";

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -2,10 +2,8 @@
 
 import React from "react";
 import { SvgFold, SvgExpand, SvgAddLines, SvgMaximize2 } from "@opal/icons";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import Tag from "@/refresh-components/buttons/Tag";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
@@ -65,7 +63,7 @@ function MemoryTagWithTooltip({
               height="auto"
             >
               <div className="p-1">
-                <Text as="p" secondaryBody text03>
+                <Text as="p" font="secondary-body" color="text-03">
                   {memoryText}
                 </Text>
               </div>
@@ -175,7 +173,7 @@ export const CompletedHeader = React.memo(function CompletedHeader({
       className="flex items-center justify-between w-full"
     >
       <div className="flex items-center gap-2 px-[var(--timeline-header-text-padding-x)] py-[var(--timeline-header-text-padding-y)]">
-        <Text as="p" mainUiAction text03>
+        <Text as="p" font="main-ui-action" color="text-03">
           {isExpanded ? durationText : imageText ?? durationText}
         </Text>
         {memoryOperation && !isExpanded && (

--- a/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/CompletedHeader.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { SvgFold, SvgExpand, SvgAddLines, SvgMaximize2 } from "@opal/icons";
 import { Button } from "@opal/components";
 import Tag from "@/refresh-components/buttons/Tag";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { SvgFold, SvgExpand } from "@opal/icons";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import { cn, noProp } from "@/lib/utils";
 
 export interface StoppedHeaderProps {
@@ -32,7 +30,7 @@ export const StoppedHeader = React.memo(function StoppedHeader({
       aria-disabled={isInteractive ? undefined : true}
     >
       <div className="px-[var(--timeline-header-text-padding-x)] py-[var(--timeline-header-text-padding-y)]">
-        <Text as="p" mainUiAction text03>
+        <Text as="p" font="main-ui-action" color="text-03">
           Interrupted Thinking
         </Text>
       </div>

--- a/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/StoppedHeader.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SvgFold, SvgExpand } from "@opal/icons";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn, noProp } from "@/lib/utils";
 

--- a/web/src/app/app/message/messageComponents/timeline/headers/StreamingHeader.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/headers/StreamingHeader.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { SvgFold, SvgExpand } from "@opal/icons";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useStreamingDuration } from "../hooks/useStreamingDuration";
 import { formatDurationSeconds } from "@/lib/time";

--- a/web/src/app/app/message/messageComponents/timeline/primitives/TimelineStepContent.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/primitives/TimelineStepContent.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { SvgFold, SvgExpand, SvgXOctagon } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { TimelineSurfaceBackground } from "@/app/app/message/messageComponents/timeline/primitives/TimelineSurface";
 

--- a/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/deepresearch/ResearchAgentRenderer.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/app/app/message/messageComponents/timeline/TimelineRendererComponent";
 import { TimelineStepComposer } from "@/app/app/message/messageComponents/timeline/TimelineStepComposer";
 import ExpandableTextDisplay from "@/refresh-components/texts/ExpandableTextDisplay";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   processContent,

--- a/web/src/app/app/message/messageComponents/timeline/renderers/fetch/FetchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/fetch/FetchToolRenderer.tsx
@@ -13,6 +13,7 @@ import {
   INITIAL_URLS_TO_SHOW,
   URLS_PER_EXPANSION,
 } from "./fetchStateUtils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgCircle } from "@opal/icons";
 

--- a/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/filereader/FileReaderToolRenderer.tsx
@@ -12,6 +12,7 @@ import {
 import { BlinkingBar } from "@/app/app/message/BlinkingBar";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface FileReaderState {

--- a/web/src/app/app/message/messageComponents/timeline/renderers/memory/MemoryToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/memory/MemoryToolRenderer.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/app/app/message/messageComponents/interfaces";
 import { BlinkingBar } from "@/app/app/message/BlinkingBar";
 import { constructCurrentMemoryState } from "./memoryStateUtils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgEditBig, SvgMaximize2 } from "@opal/icons";
 import { cn } from "@/lib/utils";

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/InternalSearchToolRenderer.tsx
@@ -16,6 +16,7 @@ import {
   RESULTS_PER_EXPANSION,
   getMetadataTags,
 } from "./searchStateUtils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const queryToSourceInfo = (query: string, index: number): SourceInfo => ({

--- a/web/src/app/app/message/messageComponents/timeline/renderers/search/WebSearchToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/search/WebSearchToolRenderer.tsx
@@ -13,6 +13,7 @@ import {
   INITIAL_QUERIES_TO_SHOW,
   QUERIES_PER_EXPANSION,
 } from "./searchStateUtils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const queryToSourceInfo = (query: string, index: number): SourceInfo => ({

--- a/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/sharedMarkdownComponents.tsx
@@ -1,4 +1,5 @@
 import type { Components } from "react-markdown";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 // Expanded view: normal spacing between paragraphs/lists

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -16,6 +16,7 @@ import { Persona } from "@/app/admin/agents/interfaces";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { UNNAMED_CHAT } from "@/lib/constants";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import useOnMount from "@/hooks/useOnMount";
 import SharedAppInputBar from "@/sections/input/SharedAppInputBar";

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -12,12 +12,12 @@ import { Section } from "@/layouts/general-layouts";
 import { IllustrationContent } from "@opal/layouts";
 import SvgNotFound from "@opal/illustrations/not-found";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
+import Text from "@/refresh-components/texts/Text";
 import { Persona } from "@/app/admin/agents/interfaces";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { UNNAMED_CHAT } from "@/lib/constants";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import useOnMount from "@/hooks/useOnMount";
 import SharedAppInputBar from "@/sections/input/SharedAppInputBar";
 

--- a/web/src/app/auth/error/AuthErrorContent.tsx
+++ b/web/src/app/auth/error/AuthErrorContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -11,6 +11,7 @@ import { toast } from "@/hooks/useToast";
 import { TextFormField } from "@/components/Field";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const ImpersonateSchema = Yup.object().shape({

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -6,6 +6,7 @@ import SignInButton from "@/app/auth/login/SignInButton";
 import EmailPasswordForm from "./EmailPasswordForm";
 import { AuthType, NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 import { useSendAuthRequiredMessage } from "@/lib/extension/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import Message from "@/refresh-components/messages/Message";

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -6,9 +6,7 @@ import SignInButton from "@/app/auth/login/SignInButton";
 import EmailPasswordForm from "./EmailPasswordForm";
 import { AuthType, NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 import { useSendAuthRequiredMessage } from "@/lib/extension/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import Message from "@/refresh-components/messages/Message";
 
 interface LoginPageProps {
@@ -69,7 +67,7 @@ export default function LoginPage({
               />
               <div className="flex flex-row items-center w-full gap-2">
                 <div className="flex-1 border-t border-text-01" />
-                <Text as="p" text03 mainUiMuted>
+                <Text as="p" color="text-03" font="main-ui-muted">
                   or
                 </Text>
                 <div className="flex-1 border-t border-text-01" />

--- a/web/src/app/auth/login/LoginText.tsx
+++ b/web/src/app/auth/login/LoginText.tsx
@@ -2,6 +2,7 @@
 
 import React, { useContext } from "react";
 import { SettingsContext } from "@/providers/SettingsProvider";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export default function LoginText() {

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -11,6 +11,7 @@ import SignInButton from "@/app/auth/login/SignInButton";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import ReferralSourceSelector from "./ReferralSourceSelector";
 import AuthErrorDisplay from "@/components/auth/AuthErrorDisplay";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { AuthType } from "@/lib/constants";

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -2,6 +2,7 @@
 
 import Switch from "@/refresh-components/inputs/Switch";
 import { useNRFPreferences } from "@/components/context/NRFPreferencesContext";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgX, SvgSettings, SvgSun, SvgMoon, SvgCheck } from "@opal/icons";
 import { Button } from "@opal/components";

--- a/web/src/app/craft/components/BigButton.tsx
+++ b/web/src/app/craft/components/BigButton.tsx
@@ -2,6 +2,7 @@
 
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export interface BigButtonProps

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -7,6 +7,7 @@ import {
   SvgChevronRight,
   SvgPlug,
 } from "@opal/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Popover, { PopoverMenu } from "@/refresh-components/Popover";
 import Switch from "@/refresh-components/inputs/Switch";

--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -2,8 +2,7 @@
 
 import { useRef } from "react";
 import { BuildFile } from "@/app/craft/contexts/UploadFilesContext";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import Logo from "@/refresh-components/Logo";
 import InputBar, { InputBarHandle } from "@/app/craft/components/InputBar";
 import SuggestedPrompts from "@/app/craft/components/SuggestedPrompts";
@@ -44,7 +43,7 @@ export default function BuildWelcome({
     <div className="h-full flex flex-col items-center justify-center px-4">
       <div className="flex flex-col items-center gap-4 mb-6">
         <Logo folded size={48} />
-        <Text headingH2 text05>
+        <Text font="heading-h2" color="text-05">
           What shall we craft today?
         </Text>
       </div>

--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import { BuildFile } from "@/app/craft/contexts/UploadFilesContext";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Logo from "@/refresh-components/Logo";
 import InputBar, { InputBarHandle } from "@/app/craft/components/InputBar";

--- a/web/src/app/craft/components/ConnectDataBanner.tsx
+++ b/web/src/app/craft/components/ConnectDataBanner.tsx
@@ -2,8 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   ConfluenceIcon,
   GoogleDriveIcon,
@@ -91,7 +90,7 @@ export default function ConnectDataBanner({
 
         {/* Center: Text and Arrow */}
         <div className="flex items-center justify-center gap-1">
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             Connect your data
           </Text>
           <SvgChevronRight className="h-4 w-4 text-text-03" />

--- a/web/src/app/craft/components/ConnectDataBanner.tsx
+++ b/web/src/app/craft/components/ConnectDataBanner.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   ConfluenceIcon,

--- a/web/src/app/craft/components/ConnectorBannersRow.tsx
+++ b/web/src/app/craft/components/ConnectorBannersRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   ConfluenceIcon,

--- a/web/src/app/craft/components/ConnectorBannersRow.tsx
+++ b/web/src/app/craft/components/ConnectorBannersRow.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   ConfluenceIcon,
   GoogleDriveIcon,
@@ -109,7 +108,7 @@ export default function ConnectorBannersRow({
 
         {/* Center: Text and Arrow */}
         <div className="flex items-center justify-center gap-1">
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             Connect your data
           </Text>
           <SvgChevronRight className="h-4 w-4 text-text-03" />
@@ -162,7 +161,7 @@ export default function ConnectorBannersRow({
         <SvgCalendar className="h-4 w-4 text-text-03" />
 
         {/* Text */}
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           Get help setting up connectors
         </Text>
 

--- a/web/src/app/craft/components/FileBrowser.tsx
+++ b/web/src/app/craft/components/FileBrowser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import {

--- a/web/src/app/craft/components/FilePreviewModal.tsx
+++ b/web/src/app/craft/components/FilePreviewModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";

--- a/web/src/app/craft/components/IntroContent.tsx
+++ b/web/src/app/craft/components/IntroContent.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { motion } from "motion/react";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { OnyxLogoTypeIcon } from "@/components/icons/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import BigButton from "@/app/craft/components/BigButton";
 

--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -20,6 +20,7 @@ import {
   exportDocx,
 } from "@/app/craft/services/apiServices";
 import { cn, getFileIcon } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   SvgGlobe,

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -9,6 +9,7 @@ import {
   useIsPreProvisioningFailed,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { Card } from "@/components/ui/card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const STATUS_CONFIG = {

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -9,8 +9,7 @@ import {
   useIsPreProvisioningFailed,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { Card } from "@/components/ui/card";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 const STATUS_CONFIG = {
   provisioning: {
@@ -144,7 +143,7 @@ export default function SandboxStatusIndicator(
             exit={{ opacity: 0, y: -5 }}
             transition={{ duration: 0.2 }}
           >
-            <Text text05>{label}</Text>
+            <Text color="text-05">{label}</Text>
           </motion.span>
         </AnimatePresence>
       </Card>

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { SvgLink, SvgCopy, SvgCheck, SvgX } from "@opal/icons";
 import { setSessionSharing } from "@/app/craft/services/apiServices";

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { SvgLink, SvgCopy, SvgCheck, SvgX } from "@opal/icons";

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -12,6 +12,7 @@ import {
 import { useUsageLimits } from "@/app/craft/hooks/useUsageLimits";
 import { CRAFT_SEARCH_PARAM_NAMES } from "@/app/craft/services/searchParams";
 import SidebarTab from "@/refresh-components/buttons/SidebarTab";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
 import SidebarBody from "@/sections/sidebar/SidebarBody";

--- a/web/src/app/craft/components/ToggleWarningModal.tsx
+++ b/web/src/app/craft/components/ToggleWarningModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface ToggleWarningModalProps {

--- a/web/src/app/craft/components/UpgradePlanModal.tsx
+++ b/web/src/app/craft/components/UpgradePlanModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgAlertTriangle } from "@opal/icons";
 import { UsageLimits } from "@/app/craft/types/streamingTypes";

--- a/web/src/app/craft/components/UserMessage.tsx
+++ b/web/src/app/craft/components/UserMessage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface UserMessageProps {

--- a/web/src/app/craft/components/UserMessage.tsx
+++ b/web/src/app/craft/components/UserMessage.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 interface UserMessageProps {
   content: string;
@@ -11,7 +10,7 @@ export default function UserMessage({ content }: UserMessageProps) {
   return (
     <div className="flex justify-end py-4">
       <div className="max-w-[80%] whitespace-break-spaces rounded-t-16 rounded-bl-16 bg-background-tint-02 py-3 px-4">
-        <Text as="p" mainContentBody>
+        <Text as="p" font="main-content-body" color="text-05">
           {content}
         </Text>
       </div>

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import useSWR from "swr";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import {

--- a/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
+++ b/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import useSWR from "swr";
 import { fetchFileContent } from "@/app/craft/services/apiServices";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -10,6 +10,7 @@ import {
 import { fetchDirectoryListing } from "@/app/craft/services/apiServices";
 import { FileSystemEntry } from "@/app/craft/types/streamingTypes";
 import { cn, getFileIcon } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   SvgHardDrive,

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgImage } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgImage } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 
@@ -38,10 +37,10 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
         padding={2}
       >
         <SvgImage size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           Failed to load image
         </Text>
-        <Text secondaryBody text02>
+        <Text font="secondary-body" color="text-02">
           The image could not be displayed
         </Text>
       </Section>
@@ -53,7 +52,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
       <div className="flex-1 flex items-center justify-center p-4">
         {imageLoading && (
           <div className="absolute">
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               Loading image...
             </Text>
           </div>

--- a/web/src/app/craft/components/output-panel/PdfPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PdfPreview.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/craft/components/output-panel/PptxPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PptxPreview.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgChevronLeft, SvgChevronRight, SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/analytics";
 import { SvgArrowRight, SvgArrowLeft, SvgX } from "@opal/icons";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   BuildUserInfo,

--- a/web/src/app/craft/onboarding/components/NoLlmProvidersModal.tsx
+++ b/web/src/app/craft/onboarding/components/NoLlmProvidersModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgLock, SvgArrowRight } from "@opal/icons";
 import { logout } from "@/lib/user";

--- a/web/src/app/craft/onboarding/components/NotAllowedModal.tsx
+++ b/web/src/app/craft/onboarding/components/NotAllowedModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgLock, SvgArrowRight } from "@opal/icons";
 import { logout } from "@/lib/user";

--- a/web/src/app/craft/onboarding/components/OnboardingInfoPages.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingInfoPages.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import {

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -3,6 +3,7 @@
 import { SvgCheckCircle } from "@opal/icons";
 import { cn } from "@/lib/utils";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import { LLMProviderName, LLMProviderDescriptor } from "@/interfaces/llm";

--- a/web/src/app/craft/onboarding/components/OnboardingUserInfo.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingUserInfo.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   WorkArea,

--- a/web/src/app/craft/v1/configure/components/ComingSoonConnectors.tsx
+++ b/web/src/app/craft/v1/configure/components/ComingSoonConnectors.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Card from "@/refresh-components/cards/Card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Content } from "@opal/layouts";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/app/craft/v1/configure/components/CreateCredentialInline.tsx
+++ b/web/src/app/craft/v1/configure/components/CreateCredentialInline.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/app/craft/v1/configure/components/DemoDataConfirmModal.tsx
+++ b/web/src/app/craft/v1/configure/components/DemoDataConfirmModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface DemoDataConfirmModalProps {

--- a/web/src/app/craft/v1/configure/components/RequestConnectorModal.tsx
+++ b/web/src/app/craft/v1/configure/components/RequestConnectorModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -11,6 +11,7 @@ import {
   deleteLibraryFile,
 } from "@/app/craft/services/apiServices";
 import { LibraryEntry } from "@/app/craft/types/user-library";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/app/craft/v1/configure/page.tsx
+++ b/web/src/app/craft/v1/configure/page.tsx
@@ -12,6 +12,7 @@ import SandboxStatusIndicator from "@/app/craft/components/SandboxStatusIndicato
 import { useBuildLlmSelection } from "@/app/craft/hooks/useBuildLlmSelection";
 import { useBuildConnectors } from "@/app/craft/hooks/useBuildConnectors";
 import { BuildLLMPopover } from "@/app/craft/components/BuildLLMPopover";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
 import {

--- a/web/src/app/craft/v1/configure/page.tsx
+++ b/web/src/app/craft/v1/configure/page.tsx
@@ -12,8 +12,6 @@ import SandboxStatusIndicator from "@/app/craft/components/SandboxStatusIndicato
 import { useBuildLlmSelection } from "@/app/craft/hooks/useBuildLlmSelection";
 import { useBuildConnectors } from "@/app/craft/hooks/useBuildConnectors";
 import { BuildLLMPopover } from "@/app/craft/components/BuildLLMPopover";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import Card from "@/refresh-components/cards/Card";
 import {
   SvgPlug,
@@ -36,7 +34,7 @@ import {
 import { ConfirmEntityModal } from "@/components/modals/ConfirmEntityModal";
 import { getSourceMetadata } from "@/lib/sources";
 import { deleteConnector } from "@/app/craft/services/apiServices";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import {
   OAUTH_STATE_KEY,
@@ -397,7 +395,9 @@ export default function BuildConfigPage() {
           {isLoading ? (
             <Card variant="tertiary">
               <Section alignItems="center" gap={0.5} height="fit">
-                <Text mainContentBody>Loading...</Text>
+                <Text font="main-content-body" color="text-05">
+                  Loading...
+                </Text>
               </Section>
             </Card>
           ) : (
@@ -481,7 +481,9 @@ export default function BuildConfigPage() {
                               );
                               return <ProviderIcon className="w-4 h-4" />;
                             })()}
-                          <Text mainUiAction>{pendingLlmDisplayName}</Text>
+                          <Text font="main-ui-action" color="text-05">
+                            {pendingLlmDisplayName}
+                          </Text>
                           <SvgChevronDown className="w-4 h-4 text-text-03" />
                         </button>
                       </BuildLLMPopover>
@@ -491,10 +493,8 @@ export default function BuildConfigPage() {
                 <Separator />
                 <div className="w-full flex items-center justify-between">
                   <div className="flex flex-col gap-0.25">
-                    <Text mainContentEmphasis text04>
-                      Connectors
-                    </Text>
-                    <Text secondaryBody text03>
+                    <Text font="main-content-emphasis">Connectors</Text>
+                    <Text font="secondary-body" color="text-03">
                       Connect your own data sources
                     </Text>
                   </div>
@@ -541,7 +541,9 @@ export default function BuildConfigPage() {
                                 />
                               </span>
                             </SimpleTooltip>
-                            <Text mainUiAction>Use Demo Dataset</Text>
+                            <Text font="main-ui-action" color="text-05">
+                              Use Demo Dataset
+                            </Text>
                           </div>
                           <Switch
                             checked={pendingDemoData ?? demoDataEnabled}

--- a/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
+++ b/web/src/app/ee/admin/performance/query-history/QueryHistoryTable.tsx
@@ -7,6 +7,7 @@ import {
   TableCell,
   TableHeader,
 } from "@/components/ui/table";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { ThreeDotsLoader } from "@/components/Loading";

--- a/web/src/app/ee/admin/theme/Preview.tsx
+++ b/web/src/app/ee/admin/theme/Preview.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { Components } from "react-markdown";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { cn, ensureHrefProtocol } from "@/lib/utils";

--- a/web/src/app/nrf/NRFChrome.tsx
+++ b/web/src/app/nrf/NRFChrome.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { cn, ensureHrefProtocol, noProp } from "@/lib/utils";
 import type { Components } from "react-markdown";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Popover from "@/refresh-components/Popover";
 import { OpenButton } from "@opal/components";

--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -5,6 +5,7 @@ import { ConnectorStatus } from "@/lib/types";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import Label from "@/refresh-components/form/Label";
 import { ErrorMessage } from "formik";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { SvgX } from "@opal/icons";

--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -7,6 +7,7 @@ import {
 import { SourceIcon } from "@/components/SourceIcon";
 import Label from "@/refresh-components/form/Label";
 import { ErrorMessage } from "formik";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { SvgX } from "@opal/icons";

--- a/web/src/components/FederatedConnectorSelector.tsx
+++ b/web/src/components/FederatedConnectorSelector.tsx
@@ -7,11 +7,9 @@ import {
 import { SourceIcon } from "@/components/SourceIcon";
 import Label from "@/refresh-components/form/Label";
 import { ErrorMessage } from "formik";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { SvgX } from "@opal/icons";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 
 interface FederatedConnectorSelectorProps {
   name: string;
@@ -131,11 +129,11 @@ export const FederatedConnectorSelector = ({
     <div className="flex flex-col w-full space-y-2 mb-4">
       {label && (
         <Label>
-          <Text>{label}</Text>
+          <Text color="text-05">{label}</Text>
         </Label>
       )}
 
-      <Text as="p" mainUiMuted text03>
+      <Text as="p" font="main-ui-muted" color="text-03">
         Documents from selected federated connectors will be searched in
         real-time during queries.
       </Text>

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -38,8 +38,7 @@ import {
   getFileTypeDefinitionForField,
   FILE_TYPE_DEFINITIONS,
 } from "@/lib/connectors/fileTypes";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
@@ -141,7 +140,7 @@ export function ExplanationText({
       {text}
     </a>
   ) : (
-    <Text as="p" text03 secondaryBody>
+    <Text as="p" color="text-03" font="secondary-body">
       {text}
     </Text>
   );

--- a/web/src/components/Field.tsx
+++ b/web/src/components/Field.tsx
@@ -38,6 +38,7 @@ import {
   getFileTypeDefinitionForField,
   FILE_TYPE_DEFINITIONS,
 } from "@/lib/connectors/fileTypes";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CreateButton from "@/refresh-components/buttons/CreateButton";
 

--- a/web/src/components/GenericMultiSelect.tsx
+++ b/web/src/components/GenericMultiSelect.tsx
@@ -1,4 +1,5 @@
 import { FormikProps, ErrorMessage } from "formik";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Button from "@/refresh-components/buttons/Button";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboBox";

--- a/web/src/components/NonSelectableConnectors.tsx
+++ b/web/src/components/NonSelectableConnectors.tsx
@@ -1,6 +1,7 @@
 import { ConnectorStatus } from "@/lib/types";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { Content } from "@opal/layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgLock } from "@opal/icons";
 interface NonSelectableConnectorsProps {

--- a/web/src/components/SourceTile.tsx
+++ b/web/src/components/SourceTile.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { Route } from "next";
 import { SourceMetadata } from "@/lib/search/interfaces";
 import React from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface SourceTileProps {

--- a/web/src/components/admin/Title.tsx
+++ b/web/src/components/admin/Title.tsx
@@ -3,6 +3,7 @@
 import { JSX } from "react";
 import Separator from "@/refresh-components/Separator";
 import type { IconProps } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export interface AdminPageTitleProps {

--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -1,9 +1,7 @@
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import React, { useState, useEffect } from "react";
 import { FieldArray, ArrayHelpers, ErrorMessage, useField } from "formik";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import Separator from "@/refresh-components/Separator";
 import { UserGroup, UserRole } from "@/lib/types";
 import { useUserGroups } from "@/lib/hooks";
@@ -111,13 +109,13 @@ export function AccessTypeGroupSelector({
           <>
             <Separator />
             <div className="flex flex-col gap-3 pt-4">
-              <Text as="p" mainUiAction text05>
+              <Text as="p" font="main-ui-action" color="text-05">
                 Assign group access for this Connector
               </Text>
               {userGroupsIsLoading ? (
                 <div className="animate-pulse bg-background-200 h-8 w-32 rounded" />
               ) : (
-                <Text as="p" mainUiMuted text03>
+                <Text as="p" font="main-ui-muted" color="text-03">
                   {isAdmin
                     ? "This Connector will be visible/accessible by the groups selected below"
                     : "Curators must select one or more groups to give access to this Connector"}

--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -1,6 +1,7 @@
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
 import React, { useState, useEffect } from "react";
 import { FieldArray, ArrayHelpers, ErrorMessage, useField } from "formik";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/components/admin/federated/FederatedConnectorForm.tsx
+++ b/web/src/components/admin/federated/FederatedConnectorForm.tsx
@@ -16,6 +16,7 @@ import { SourceIcon } from "@/components/SourceIcon";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useRouter } from "next/navigation";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { AlertTriangle, Check, Loader2, Trash2Icon, Info } from "lucide-react";
 import BackButton from "@/refresh-components/buttons/BackButton";

--- a/web/src/components/admin/users/ResetPasswordModal.tsx
+++ b/web/src/components/admin/users/ResetPasswordModal.tsx
@@ -3,6 +3,7 @@ import Modal from "@/refresh-components/Modal";
 import Button from "@/refresh-components/buttons/Button";
 import { User } from "@/lib/types";
 import { toast } from "@/hooks/useToast";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { LoadingAnimation } from "@/components/Loading";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -5,6 +5,7 @@ import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
 import { Input } from "@/components/ui/input";
 import Label from "@/refresh-components/form/Label";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgAlertCircle, SvgEye, SvgEyeClosed, SvgKey } from "@opal/icons";
 import { Disabled } from "@opal/core";

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -2,11 +2,9 @@
 
 import { useState, useEffect } from "react";
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Input } from "@/components/ui/input";
 import Label from "@/refresh-components/form/Label";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { SvgAlertCircle, SvgEye, SvgEyeClosed, SvgKey } from "@opal/icons";
 import { Disabled } from "@opal/core";
 interface MCPAuthTemplate {
@@ -162,12 +160,12 @@ export default function MCPApiKeyModal({
           onClose={handleClose}
         />
         <Modal.Body>
-          <Text as="p">
+          <Text as="p" color="text-05">
             {isAuthenticated
               ? `Update your ${credsType} for ${serverName}.`
               : `Enter your ${credsType} for ${serverName} to enable authentication.`}
           </Text>
-          <Text as="p" text02>
+          <Text as="p" color="text-02">
             {isAuthenticated
               ? "Changes will be validated against the server before being saved."
               : `Your ${credsType} will be validated against the server and stored securely.`}
@@ -187,7 +185,7 @@ export default function MCPApiKeyModal({
                 {authTemplate!.required_fields.map((field) => (
                   <div key={field} className="space-y-2">
                     <Label name={field}>
-                      <Text>
+                      <Text color="text-05">
                         {field
                           .replace(/_/g, " ")
                           .replace(/\b\w/g, (l) => l.toUpperCase())}
@@ -224,7 +222,7 @@ export default function MCPApiKeyModal({
               // Legacy API key field
               <div className="space-y-2">
                 <Label name="apiKey">
-                  <Text>{credsType}</Text>
+                  <Text color="text-05">{credsType}</Text>
                 </Label>
                 <div className="relative">
                   <Input

--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Badge } from "@/components/ui/badge";
 import { AccessType } from "@/lib/types";

--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -12,6 +12,7 @@ import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { useLicense } from "@/hooks/useLicense";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { ApplicationStatus } from "@/interfaces/settings";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgLock } from "@opal/icons";
 

--- a/web/src/components/errorPages/CloudErrorPage.tsx
+++ b/web/src/components/errorPages/CloudErrorPage.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 

--- a/web/src/components/errorPages/CloudErrorPage.tsx
+++ b/web/src/components/errorPages/CloudErrorPage.tsx
@@ -1,20 +1,19 @@
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 
 export default function CloudError() {
   return (
     <ErrorPageLayout>
-      <Text as="p" headingH2>
+      <Text as="p" font="heading-h2" color="text-05">
         Maintenance in Progress
       </Text>
 
-      <Text as="p" text03>
+      <Text as="p" color="text-03">
         Onyx is currently in a maintenance window. Please check back in a couple
         of minutes.
       </Text>
 
-      <Text as="p" text03>
+      <Text as="p" color="text-03">
         We apologize for any inconvenience this may cause and appreciate your
         patience.
       </Text>

--- a/web/src/components/errorPages/ErrorPage.tsx
+++ b/web/src/components/errorPages/ErrorPage.tsx
@@ -1,4 +1,5 @@
 import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { DOCS_BASE_URL } from "@/lib/constants";
 import { SvgAlertCircle } from "@opal/icons";

--- a/web/src/components/modals/ConfirmEntityModal.tsx
+++ b/web/src/components/modals/ConfirmEntityModal.tsx
@@ -1,5 +1,6 @@
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgAlertCircle } from "@opal/icons";
 import type { IconProps } from "@opal/types";

--- a/web/src/components/modals/GenericConfirmModal.tsx
+++ b/web/src/components/modals/GenericConfirmModal.tsx
@@ -1,5 +1,6 @@
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgCheck } from "@opal/icons";
 export interface GenericConfirmModalProps {

--- a/web/src/components/modals/GenericConfirmModal.tsx
+++ b/web/src/components/modals/GenericConfirmModal.tsx
@@ -1,7 +1,5 @@
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import { SvgCheck } from "@opal/icons";
 export interface GenericConfirmModalProps {
   title: string;
@@ -23,7 +21,9 @@ export default function GenericConfirmModal({
       <Modal.Content width="sm" height="sm">
         <Modal.Header icon={SvgCheck} title={title} onClose={onClose} />
         <Modal.Body>
-          <Text as="p">{message}</Text>
+          <Text as="p" color="text-05">
+            {message}
+          </Text>
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={onConfirm}>{confirmText}</Button>

--- a/web/src/components/modals/MoveCustomAgentChatModal.tsx
+++ b/web/src/components/modals/MoveCustomAgentChatModal.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgAlertCircle } from "@opal/icons";
 interface MoveCustomAgentChatModalProps {

--- a/web/src/components/modals/NoAgentModal.tsx
+++ b/web/src/components/modals/NoAgentModal.tsx
@@ -2,6 +2,7 @@
 
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useUser } from "@/providers/UserProvider";
 import { SvgUser } from "@opal/icons";

--- a/web/src/components/modals/NoAgentModal.tsx
+++ b/web/src/components/modals/NoAgentModal.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import { useUser } from "@/providers/UserProvider";
 import { SvgUser } from "@opal/icons";
 
@@ -15,13 +13,13 @@ export default function NoAgentModal() {
       <Modal.Content width="sm" height="sm">
         <Modal.Header icon={SvgUser} title="No Agent Available" />
         <Modal.Body>
-          <Text as="p">
+          <Text as="p" color="text-05">
             You currently have no agent configured. To use this feature, you
             need to take action.
           </Text>
           {isAdmin ? (
             <>
-              <Text as="p">
+              <Text as="p" color="text-05">
                 As an administrator, you can create a new agent by visiting the
                 admin panel.
               </Text>
@@ -30,7 +28,7 @@ export default function NoAgentModal() {
               </Button>
             </>
           ) : (
-            <Text as="p">
+            <Text as="p" color="text-05">
               Please contact your administrator to configure an agent for you.
             </Text>
           )}

--- a/web/src/components/modals/UserFilesModal.tsx
+++ b/web/src/components/modals/UserFilesModal.tsx
@@ -4,8 +4,7 @@ import React, { useRef, useState, useEffect, useMemo } from "react";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { ProjectFile } from "@/providers/ProjectsContext";
 import { formatRelativeTime } from "@/app/app/components/projects/project_utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import type { IconProps } from "@opal/types";
 import { getFileExtension, isImageExtension } from "@/lib/utils";
 import { UserFileStatus } from "@/app/app/projects/projectsService";
@@ -25,7 +24,6 @@ import {
 } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import useFilter from "@/hooks/useFilter";
-import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
 
@@ -212,7 +210,7 @@ export default function UserFilesModal({
           >
             {/* File display section */}
             {filtered.length === 0 ? (
-              <Text text03>No files found</Text>
+              <Text color="text-03">No files found</Text>
             ) : (
               <ScrollIndicatorDiv className="p-2 gap-2 max-h-[70vh]">
                 {filtered.map((projectFle) => {
@@ -266,9 +264,10 @@ export default function UserFilesModal({
             {/* Left side: file count and controls */}
             {onPickRecent && (
               <Section flexDirection="row" justifyContent="start" gap={0.5}>
-                <Text as="p" text03>
-                  {selectedCount} {selectedCount === 1 ? "file" : "files"}{" "}
-                  selected
+                <Text as="p" color="text-03">
+                  {`${selectedCount} ${
+                    selectedCount === 1 ? "file" : "files"
+                  } selected`}
                 </Text>
                 <Button
                   icon={SvgEye}

--- a/web/src/components/modals/UserFilesModal.tsx
+++ b/web/src/components/modals/UserFilesModal.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState, useEffect, useMemo } from "react";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { ProjectFile } from "@/providers/ProjectsContext";
 import { formatRelativeTime } from "@/app/app/components/projects/project_utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
 import { getFileExtension, isImageExtension } from "@/lib/utils";

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -3,6 +3,7 @@ import React, { JSX } from "react";
 import { MinimalOnyxDocument, OnyxDocument } from "@/lib/search/interfaces";
 import { SourceIcon } from "../SourceIcon";
 import { WebResultIcon } from "../WebResultIcon";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { openDocument } from "@/lib/search/utils";
 import { SubQuestionDetail } from "@/app/app/interfaces";

--- a/web/src/components/search/results/Citation.tsx
+++ b/web/src/components/search/results/Citation.tsx
@@ -15,6 +15,7 @@ import { openDocument } from "@/lib/search/utils";
 import { SubQuestionDetail } from "@/app/app/interfaces";
 import { getSourceDisplayName } from "@/lib/sources";
 import { ValidSources } from "@/lib/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const MAX_CITATION_TEXT_LENGTH = 40;

--- a/web/src/components/tools/CSVContent.tsx
+++ b/web/src/components/tools/CSVContent.tsx
@@ -11,6 +11,7 @@ import {
 import { ContentComponentProps } from "./ExpandableContentWrapper";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { SvgAlertCircle } from "@opal/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 

--- a/web/src/components/tools/ExpandableContentWrapper.tsx
+++ b/web/src/components/tools/ExpandableContentWrapper.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import { SvgDownloadCloud, SvgFold, SvgMaximize2, SvgX } from "@opal/icons";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { FileDescriptor } from "@/app/app/interfaces";
 import { cn } from "@/lib/utils";

--- a/web/src/ee/sections/SearchCard.tsx
+++ b/web/src/ee/sections/SearchCard.tsx
@@ -3,6 +3,7 @@
 import { SearchDocWithContent } from "@/lib/search/interfaces";
 import { SourceIcon } from "@/components/SourceIcon";
 import { WebResultIcon } from "@/components/WebResultIcon";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Chip from "@/refresh-components/Chip";
 import { buildDocumentSummaryDisplay } from "@/components/search/DocumentDisplay";

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -7,7 +7,12 @@ import {
   SourceMetadata,
 } from "@/lib/search/interfaces";
 import SearchCard from "@/ee/sections/SearchCard";
-import { Pagination } from "@opal/components";
+import {
+  FilterButton,
+  LineItemButton,
+  Pagination,
+  Text,
+} from "@opal/components";
 import Separator from "@/refresh-components/Separator";
 import EmptyMessage from "@/refresh-components/EmptyMessage";
 import { IllustrationContent } from "@opal/layouts";
@@ -17,15 +22,11 @@ import { Tag, ValidSources } from "@/lib/types";
 import { getTimeFilterDate, TimeFilter } from "@/lib/time";
 import useTags from "@/hooks/useTags";
 import { SourceIcon } from "@/components/SourceIcon";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import Popover, { PopoverMenu } from "@/refresh-components/Popover";
 import { SvgCheck, SvgClock, SvgTag } from "@opal/icons";
-import { FilterButton } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import useFilter from "@/hooks/useFilter";
-import { LineItemButton } from "@opal/components";
 import { useQueryController } from "@/providers/QueryControllerProvider";
 import { cn } from "@/lib/utils";
 import { toast } from "@/hooks/useToast";
@@ -317,8 +318,8 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
         {!showEmpty && (
           <div className="flex-1 flex flex-col justify-end gap-3">
             <Section alignItems="start">
-              <Text text03 mainUiMuted>
-                {results.length} Results
+              <Text color="text-03" font="main-ui-muted">
+                {`${results.length} Results`}
               </Text>
             </Section>
 
@@ -382,7 +383,7 @@ export default function SearchUI({ onDocumentClick }: SearchResultsProps) {
                   selectVariant="select-heavy"
                   sizePreset="main-ui"
                   variant="section"
-                  rightChildren={<Text text03>{count}</Text>}
+                  rightChildren={<Text color="text-03">{String(count)}</Text>}
                 />
               ))}
             </Section>

--- a/web/src/ee/sections/SearchUI.tsx
+++ b/web/src/ee/sections/SearchUI.tsx
@@ -17,6 +17,7 @@ import { Tag, ValidSources } from "@/lib/types";
 import { getTimeFilterDate, TimeFilter } from "@/lib/time";
 import useTags from "@/hooks/useTags";
 import { SourceIcon } from "@/components/SourceIcon";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import Popover, { PopoverMenu } from "@/refresh-components/Popover";

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -27,6 +27,7 @@ import {
   noProp,
 } from "@/lib/utils";
 import type { Components } from "react-markdown";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useCallback, useMemo, useRef, useState, useEffect } from "react";
 import { useAppBackground } from "@/providers/AppBackgroundProvider";

--- a/web/src/layouts/general-layouts.tsx
+++ b/web/src/layouts/general-layouts.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { WithoutStyles } from "@/types";

--- a/web/src/layouts/input-layouts.tsx
+++ b/web/src/layouts/input-layouts.tsx
@@ -2,6 +2,7 @@
 
 import type { RichStr } from "@opal/types";
 import { resolveStr } from "@opal/components/text/InlineMarkdown";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgXOctagon, SvgAlertCircle } from "@opal/icons";
 import { useField, useFormikContext } from "formik";

--- a/web/src/refresh-components/Attachment.tsx
+++ b/web/src/refresh-components/Attachment.tsx
@@ -1,6 +1,4 @@
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { SvgFileText, SvgMaximize2 } from "@opal/icons";
 export interface AttachmentsProps {
   fileName: string;
@@ -14,10 +12,10 @@ export default function Attachments({ fileName, open }: AttachmentsProps) {
         <SvgFileText className="w-[1.25rem] h-[1.25rem] stroke-text-02" />
       </div>
       <div className="flex flex-col px-2">
-        <Text as="p" secondaryAction>
+        <Text as="p" font="secondary-action" color="text-05">
           {fileName}
         </Text>
-        <Text as="p" secondaryBody text03>
+        <Text as="p" font="secondary-body" color="text-03">
           Document
         </Text>
       </div>

--- a/web/src/refresh-components/Attachment.tsx
+++ b/web/src/refresh-components/Attachment.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { SvgFileText, SvgMaximize2 } from "@opal/icons";

--- a/web/src/refresh-components/CharacterCount.tsx
+++ b/web/src/refresh-components/CharacterCount.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 export interface CharacterCountProps {
   value: string;

--- a/web/src/refresh-components/CharacterCount.tsx
+++ b/web/src/refresh-components/CharacterCount.tsx
@@ -1,5 +1,4 @@
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 export interface CharacterCountProps {
   value: string;
   limit: number;
@@ -7,8 +6,8 @@ export interface CharacterCountProps {
 export default function CharacterCount({ value, limit }: CharacterCountProps) {
   const length = value?.length || 0;
   return (
-    <Text text03 secondaryBody>
-      ({length}/{limit} characters)
+    <Text color="text-03" font="secondary-body">
+      {`(${length}/${limit} characters)`}
     </Text>
   );
 }

--- a/web/src/refresh-components/Chip.tsx
+++ b/web/src/refresh-components/Chip.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgX } from "@opal/icons";
 import { Button } from "@opal/components";

--- a/web/src/refresh-components/Divider.tsx
+++ b/web/src/refresh-components/Divider.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 import { SvgChevronRight, SvgChevronDown, SvgInfoSmall } from "@opal/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
 import Truncated from "./texts/Truncated";

--- a/web/src/refresh-components/EmptyMessage.tsx
+++ b/web/src/refresh-components/EmptyMessage.tsx
@@ -30,8 +30,7 @@
 
 import { SvgEmpty } from "@opal/icons";
 import Card from "@/refresh-components/cards/Card";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Content } from "@opal/layouts";
 import { IconProps } from "@opal/types";
 
@@ -56,7 +55,7 @@ export default function EmptyMessage({
         prominence="muted"
       />
       {description && (
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           {description}
         </Text>
       )}

--- a/web/src/refresh-components/EmptyMessage.tsx
+++ b/web/src/refresh-components/EmptyMessage.tsx
@@ -30,6 +30,7 @@
 
 import { SvgEmpty } from "@opal/icons";
 import Card from "@/refresh-components/cards/Card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Content } from "@opal/layouts";
 import { IconProps } from "@opal/types";

--- a/web/src/refresh-components/EnabledCount.tsx
+++ b/web/src/refresh-components/EnabledCount.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface EnabledCountProps {

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -6,6 +6,7 @@ import {
   NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED,
 } from "@/lib/constants";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { useMemo } from "react";

--- a/web/src/refresh-components/SimplePopover.stories.tsx
+++ b/web/src/refresh-components/SimplePopover.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import SimplePopover from "./SimplePopover";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const meta: Meta<typeof SimplePopover> = {

--- a/web/src/refresh-components/SimpleTooltip.tsx
+++ b/web/src/refresh-components/SimpleTooltip.tsx
@@ -40,8 +40,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 export interface SimpleTooltipProps
   extends React.ComponentPropsWithoutRef<typeof TooltipContent> {
@@ -73,7 +72,7 @@ export default function SimpleTooltip({
   // Check if tooltip is a string to wrap in Text component, otherwise render as-is
   const tooltipContent =
     typeof hoverContent === "string" ? (
-      <Text as="p" textLight05>
+      <Text as="p" color="text-light-05">
         {hoverContent}
       </Text>
     ) : (

--- a/web/src/refresh-components/SimpleTooltip.tsx
+++ b/web/src/refresh-components/SimpleTooltip.tsx
@@ -40,6 +40,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export interface SimpleTooltipProps

--- a/web/src/refresh-components/TextSeparator.tsx
+++ b/web/src/refresh-components/TextSeparator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export interface TextSeparatorProps {

--- a/web/src/refresh-components/TextSeparator.tsx
+++ b/web/src/refresh-components/TextSeparator.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 export interface TextSeparatorProps {
   count?: number;
@@ -21,11 +20,11 @@ export default function TextSeparator({
       <div className="flex-1 h-px bg-border" />
       <div className="flex flex-row items-center gap-1 flex-shrink-0">
         {count !== undefined && (
-          <Text as="p" secondaryBody text03>
-            {count}
+          <Text as="p" font="secondary-body" color="text-03">
+            {String(count)}
           </Text>
         )}
-        <Text as="p" secondaryBody text03>
+        <Text as="p" font="secondary-body" color="text-03">
           {text}
         </Text>
       </div>

--- a/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import type { IconProps } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Image from "next/image";
 import { DEFAULT_AVATAR_SIZE_PX } from "@/lib/constants";

--- a/web/src/refresh-components/avatars/UserAvatar.tsx
+++ b/web/src/refresh-components/avatars/UserAvatar.tsx
@@ -1,6 +1,7 @@
 import { SvgUser } from "@opal/icons";
 import { DEFAULT_AVATAR_SIZE_PX } from "@/lib/constants";
 import { getUserEmail, getUserInitials } from "@/lib/user";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import type { User } from "@/lib/types";
 

--- a/web/src/refresh-components/buttons/AttachmentButton.tsx
+++ b/web/src/refresh-components/buttons/AttachmentButton.tsx
@@ -68,6 +68,7 @@ import { noProp } from "@/lib/utils";
 import Truncated from "@/refresh-components/texts/Truncated";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
 import Checkbox from "@/refresh-components/inputs/Checkbox";

--- a/web/src/refresh-components/buttons/AttachmentButton.tsx
+++ b/web/src/refresh-components/buttons/AttachmentButton.tsx
@@ -67,9 +67,7 @@ import React from "react";
 import { noProp } from "@/lib/utils";
 import Truncated from "@/refresh-components/texts/Truncated";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import type { IconProps } from "@opal/types";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
 import { SvgExternalLink } from "@opal/icons";
@@ -149,7 +147,7 @@ export default function AttachmentButton({
 
       <div className="attachment-button__actions">
         {rightText && (
-          <Text as="p" secondaryBody text03>
+          <Text as="p" font="secondary-body" color="text-03">
             {rightText}
           </Text>
         )}

--- a/web/src/refresh-components/buttons/Button.tsx
+++ b/web/src/refresh-components/buttons/Button.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import Link from "next/link";
 import type { Route } from "next";
 import type { IconProps } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 export interface ButtonProps

--- a/web/src/refresh-components/buttons/LineItem.stories.tsx
+++ b/web/src/refresh-components/buttons/LineItem.stories.tsx
@@ -9,6 +9,7 @@ import {
   SvgSearch,
 } from "@opal/icons";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const meta: Meta<typeof LineItem> = {

--- a/web/src/refresh-components/buttons/SelectButton.tsx
+++ b/web/src/refresh-components/buttons/SelectButton.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { IconProps } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgChevronDownSmall } from "@opal/icons";
 import { useContentSize } from "@/hooks/useContentSize";

--- a/web/src/refresh-components/buttons/Tag.tsx
+++ b/web/src/refresh-components/buttons/Tag.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgX } from "@opal/icons";
 import type { IconProps } from "@opal/types";

--- a/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTag.tsx
@@ -9,6 +9,7 @@ import {
   useLayoutEffect,
 } from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import {

--- a/web/src/refresh-components/buttons/source-tag/SourceTagDetailsCard.tsx
+++ b/web/src/refresh-components/buttons/source-tag/SourceTagDetailsCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { memo } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/refresh-components/cards/Card.stories.tsx
+++ b/web/src/refresh-components/cards/Card.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Card from "./Card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 const meta: Meta<typeof Card> = {

--- a/web/src/refresh-components/cards/Select.tsx
+++ b/web/src/refresh-components/cards/Select.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import type { IconProps } from "@opal/types";
 import { cn, noProp } from "@/lib/utils";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import SelectButton from "@/refresh-components/buttons/SelectButton";

--- a/web/src/refresh-components/cards/Select.tsx
+++ b/web/src/refresh-components/cards/Select.tsx
@@ -4,9 +4,7 @@ import React, { useState } from "react";
 import type { IconProps } from "@opal/types";
 import { cn, noProp } from "@/lib/utils";
 import { Disabled } from "@opal/core";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import SelectButton from "@/refresh-components/buttons/SelectButton";
 import {
   SvgArrowExchange,
@@ -112,10 +110,10 @@ export default function Select({
             />
           </div>
           <div className="flex flex-col gap-0.5">
-            <Text mainUiAction text05>
+            <Text font="main-ui-action" color="text-05">
               {title}
             </Text>
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               {description}
             </Text>
           </div>

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -12,6 +12,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import useContainerCenter from "@/hooks/useContainerCenter";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import LineItem from "@/refresh-components/buttons/LineItem";

--- a/web/src/refresh-components/commandmenu/CommandMenu.tsx
+++ b/web/src/refresh-components/commandmenu/CommandMenu.tsx
@@ -12,12 +12,10 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import useContainerCenter from "@/hooks/useContainerCenter";
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import Tag from "@/refresh-components/buttons/Tag";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
 import Divider from "@/refresh-components/Divider";
 import { Section } from "@/layouts/general-layouts";
@@ -528,7 +526,7 @@ function CommandMenuList({ children, emptyMessage }: CommandMenuListProps) {
         role="status"
         aria-live="polite"
       >
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           {emptyMessage}
         </Text>
       </div>
@@ -718,7 +716,7 @@ function CommandMenuAction({
         icon={icon}
         rightChildren={
           shortcut ? (
-            <Text figureKeystroke text02>
+            <Text font="figure-keystroke" color="text-02">
               {shortcut}
             </Text>
           ) : undefined
@@ -778,9 +776,7 @@ function CommandMenuFooterAction({
         className="w-[0.875rem] h-[0.875rem] stroke-text-02"
         aria-hidden="true"
       />
-      <Text mainUiBody text03>
-        {label}
-      </Text>
+      <Text color="text-03">{label}</Text>
     </div>
   );
 }

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { OptionItem } from "./OptionItem";
 import { ComboBoxOption } from "../types";
 import { cn } from "@/lib/utils";
@@ -121,7 +120,7 @@ export const OptionsList: React.FC<OptionsListProps> = ({
         (matchedOptions.length > 0 ||
           (!hasSearchTerm && unmatchedOptions.length > 0)) && (
           <div className="px-3 py-1">
-            <Text as="p" text03 secondaryBody>
+            <Text as="p" color="text-03" font="secondary-body">
               {separatorLabel}
             </Text>
           </div>

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { OptionItem } from "./OptionItem";
 import { ComboBoxOption } from "../types";

--- a/web/src/refresh-components/inputs/InputImage.tsx
+++ b/web/src/refresh-components/inputs/InputImage.tsx
@@ -5,6 +5,7 @@ import { cn, noProp } from "@/lib/utils";
 import { SvgPlus, SvgX } from "@opal/icons";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { useImageDropzone } from "@/hooks/useImageDropzone";
 

--- a/web/src/refresh-components/inputs/InputKeyValue.tsx
+++ b/web/src/refresh-components/inputs/InputKeyValue.tsx
@@ -81,6 +81,7 @@ import InputTypeIn from "./InputTypeIn";
 import { Button, EmptyMessageCard } from "@opal/components";
 import { Disabled } from "@opal/core";
 import type { WithoutStyles } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { FieldContext } from "../form/FieldContext";
 import { FieldMessage } from "../messages/FieldMessage";

--- a/web/src/refresh-components/inputs/InputKeyValue.tsx
+++ b/web/src/refresh-components/inputs/InputKeyValue.tsx
@@ -78,11 +78,9 @@ import React, {
 } from "react";
 import { cn } from "@/lib/utils";
 import InputTypeIn from "./InputTypeIn";
-import { Button, EmptyMessageCard } from "@opal/components";
+import { Button, EmptyMessageCard, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import type { WithoutStyles } from "@opal/types";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { FieldContext } from "../form/FieldContext";
 import { FieldMessage } from "../messages/FieldMessage";
 import { SvgMinusCircle, SvgPlusCircle } from "@opal/icons";
@@ -455,9 +453,13 @@ export default function KeyValueInput({
             Since we're using a `grid` template, the padding below *one* item in a row applies additional height to *all* items in that row.
           */}
           <div className="pb-1">
-            <Text mainUiAction>{keyTitle}</Text>
+            <Text font="main-ui-action" color="text-05">
+              {keyTitle}
+            </Text>
           </div>
-          <Text mainUiAction>{valueTitle}</Text>
+          <Text font="main-ui-action" color="text-05">
+            {valueTitle}
+          </Text>
           <div aria-hidden />
 
           {items.map((item, index) => (

--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { cn } from "@/lib/utils";
 import LineItem, { LineItemProps } from "@/refresh-components/buttons/LineItem";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import type { IconProps } from "@opal/types";
 import {

--- a/web/src/refresh-components/inputs/InputSelect.tsx
+++ b/web/src/refresh-components/inputs/InputSelect.tsx
@@ -4,8 +4,7 @@ import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { cn } from "@/lib/utils";
 import LineItem, { LineItemProps } from "@/refresh-components/buttons/LineItem";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import type { IconProps } from "@opal/types";
 import {
   iconClasses,
@@ -211,14 +210,14 @@ function InputSelectTrigger({
   if (!selectedItemDisplay) {
     displayContent = placeholder ? (
       typeof placeholder === "string" ? (
-        <Text as="p" text03>
+        <Text as="p" color="text-03">
           {placeholder}
         </Text>
       ) : (
         placeholder
       )
     ) : (
-      <Text as="p" text03>
+      <Text as="p" color="text-03">
         Select an option
       </Text>
     );

--- a/web/src/refresh-components/layouts/ConfirmationModalLayout.tsx
+++ b/web/src/refresh-components/layouts/ConfirmationModalLayout.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import type { IconProps } from "@opal/types";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
 import { useModalClose } from "../contexts/ModalContext";
 
@@ -45,7 +43,7 @@ export default function ConfirmationModalLayout({
         />
         <Modal.Body twoTone={twoTone}>
           {typeof children === "string" ? (
-            <Text as="p" text03>
+            <Text as="p" color="text-03">
               {children}
             </Text>
           ) : (

--- a/web/src/refresh-components/layouts/ConfirmationModalLayout.tsx
+++ b/web/src/refresh-components/layouts/ConfirmationModalLayout.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { IconProps } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import Modal from "@/refresh-components/Modal";

--- a/web/src/refresh-components/messages/Message.tsx
+++ b/web/src/refresh-components/messages/Message.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import {

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -5,9 +5,7 @@ import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import Separator from "@/refresh-components/Separator";
@@ -304,7 +302,7 @@ export default function MemoriesModal({
         <Modal.Body padding={0.5}>
           {filteredMemories.length === 0 ? (
             <Section alignItems="center" padding={2}>
-              <Text secondaryBody text03>
+              <Text font="secondary-body" color="text-03">
                 {searchQuery.trim()
                   ? "No memories match your search."
                   : 'No memories yet. Click "Add Line" to get started.'}

--- a/web/src/refresh-components/modals/MemoriesModal.tsx
+++ b/web/src/refresh-components/modals/MemoriesModal.tsx
@@ -5,6 +5,7 @@ import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/refresh-components/popovers/FilePickerPopover.tsx
+++ b/web/src/refresh-components/popovers/FilePickerPopover.tsx
@@ -13,6 +13,7 @@ import LineItem from "@/refresh-components/buttons/LineItem";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { toast } from "@/hooks/useToast";
 import { useProjectsContext } from "@/providers/ProjectsContext";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { MAX_FILES_TO_SHOW } from "@/lib/constants";
 import { isImageFile } from "@/lib/utils";

--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -13,6 +13,7 @@ import { Slider } from "@/components/ui/slider";
 import { useUser } from "@/providers/UserProvider";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import {

--- a/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
+++ b/web/src/refresh-components/texts/ExpandableTextDisplay.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import Modal from "@/refresh-components/Modal";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgDownload, SvgMaximize2, SvgX } from "@opal/icons";
 import { Button } from "@opal/components";

--- a/web/src/refresh-components/texts/Truncated.tsx
+++ b/web/src/refresh-components/texts/Truncated.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useRef, useCallback, useLayoutEffect } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import { TextProps } from "@/refresh-components/texts/Text";
 import {
   Tooltip,
@@ -8,6 +9,7 @@ import {
   TooltipTrigger,
   TooltipProvider,
 } from "@/components/ui/tooltip";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 

--- a/web/src/refresh-components/tiles/ButtonTile.tsx
+++ b/web/src/refresh-components/tiles/ButtonTile.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from "react";
 
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Disabled, Interactive } from "@opal/core";
 import type { IconProps } from "@opal/types";

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import Button from "@/refresh-components/buttons/Button";
-import { Button as OpalButton } from "@opal/components";
+import { Button as OpalButton, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
 import { buildImgUrl } from "@/app/app/components/files/images/utils";
@@ -34,8 +34,6 @@ import {
   SEARCH_TOOL_ID,
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { Card } from "@/refresh-components/cards";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import SwitchField from "@/refresh-components/form/SwitchField";
@@ -1576,7 +1574,7 @@ export default function AgentEditorPage({
                                   placeholder="Remember, I want you to always format your response as a numbered list."
                                 />
                               </InputLayouts.Vertical>
-                              <Text text03 secondaryBody>
+                              <Text color="text-03" font="secondary-body">
                                 Append a brief reminder to the prompt messages.
                                 Use this to remind the agent if you find that it
                                 tends to forget certain instructions as the chat

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -34,6 +34,7 @@ import {
   SEARCH_TOOL_ID,
   OPEN_URL_TOOL_ID,
 } from "@/app/app/components/tools/constants";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Card } from "@/refresh-components/cards";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";

--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -6,6 +6,7 @@ import { useUser } from "@/providers/UserProvider";
 import { checkUserOwnsAgent as checkUserOwnsAgent } from "@/lib/agents";
 import { useAgents } from "@/hooks/useAgents";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import * as SettingsLayouts from "@/layouts/settings-layouts";

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -41,6 +41,7 @@ import useCCPairs from "@/hooks/useCCPairs";
 import { ValidSources } from "@/lib/types";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
 import Separator from "@/refresh-components/Separator";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import Code from "@/refresh-components/Code";

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -19,6 +19,7 @@ import {
 } from "@opal/icons";
 import Popover, { PopoverMenu } from "@/refresh-components/Popover";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { toast } from "@/hooks/useToast";
 import { useRouter } from "next/navigation";

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Table, createTableColumns } from "@opal/components";
+import { Table, Text, createTableColumns } from "@opal/components";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import type { MinimalUserSnapshot } from "@/lib/types";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
@@ -100,7 +98,7 @@ function buildColumns(onMutate: () => void) {
       header: "Name",
       weight: 25,
       cell: (value) => (
-        <Text as="span" mainUiBody text05>
+        <Text as="span" color="text-05">
           {value}
         </Text>
       ),
@@ -109,7 +107,7 @@ function buildColumns(onMutate: () => void) {
       header: "Description",
       weight: 35,
       cell: (value) => (
-        <Text as="span" mainUiBody text03>
+        <Text as="span" color="text-03">
           {value || "\u2014"}
         </Text>
       ),
@@ -174,7 +172,7 @@ export default function AgentsTable() {
   if (error) {
     console.error("Failed to load agents:", error);
     return (
-      <Text as="p" secondaryBody text03>
+      <Text as="p" font="secondary-body" color="text-03">
         Failed to load agents. Please try refreshing the page.
       </Text>
     );

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -5,6 +5,7 @@ import { Table, createTableColumns } from "@opal/components";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import type { MinimalUserSnapshot } from "@/lib/types";

--- a/web/src/refresh-pages/admin/CodeInterpreterPage.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage.tsx
@@ -15,6 +15,7 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Section } from "@/layouts/general-layouts";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";

--- a/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
@@ -3,15 +3,13 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
-import { Table, Button } from "@opal/components";
+import { Button, Table, Text } from "@opal/components";
 import { IllustrationContent } from "@opal/layouts";
 import { SvgUsers } from "@opal/icons";
 import SvgNoResult from "@opal/illustrations/no-result";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import Separator from "@/refresh-components/Separator";
 import { toast } from "@/hooks/useToast";
@@ -119,9 +117,7 @@ function CreateGroupPage() {
           alignItems="stretch"
           justifyContent="start"
         >
-          <Text mainUiBody text04>
-            Group Name
-          </Text>
+          <Text>Group Name</Text>
           <InputTypeIn
             placeholder="Name your group"
             value={groupName}
@@ -135,7 +131,7 @@ function CreateGroupPage() {
         {isLoading && <SimpleLoader />}
 
         {error && (
-          <Text as="p" secondaryBody text03>
+          <Text as="p" font="secondary-body" color="text-03">
             Failed to load users.
           </Text>
         )}

--- a/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
@@ -10,6 +10,7 @@ import SvgNoResult from "@opal/illustrations/no-result";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -13,6 +13,7 @@ import SvgNoResult from "@opal/illustrations/no-result";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -8,6 +8,7 @@ import { ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   isBuiltInGroup,

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -7,9 +7,7 @@ import { SvgChevronRight, SvgUserManage, SvgUsers } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import {
   isBuiltInGroup,
   buildGroupDescription,
@@ -56,7 +54,7 @@ function GroupCard({ group }: GroupCardProps) {
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
-              <Text mainUiBody text03>
+              <Text color="text-03">
                 {formatMemberCount(
                   group.users.filter((u) => u.is_active).length
                 )}

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/ResourcePopover.tsx
@@ -7,6 +7,7 @@ import { Section } from "@/layouts/general-layouts";
 import Popover from "@/refresh-components/Popover";
 import Separator from "@/refresh-components/Separator";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import type { ResourcePopoverProps } from "@/refresh-pages/admin/GroupsPage/SharedGroupResources/interfaces";

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -6,6 +6,7 @@ import { Content } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import LineItem from "@/refresh-components/buttons/LineItem";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Separator from "@/refresh-components/Separator";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";

--- a/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/SharedGroupResources/index.tsx
@@ -6,8 +6,7 @@ import { Content } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import LineItem from "@/refresh-components/buttons/LineItem";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import Separator from "@/refresh-components/Separator";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
@@ -35,7 +34,7 @@ interface SharedGroupResourcesProps {
 
 function SharedBadge() {
   return (
-    <Text as="span" secondaryBody text03>
+    <Text as="span" font="secondary-body" color="text-03">
       Shared
     </Text>
   );
@@ -289,9 +288,7 @@ function SharedGroupResources({
                 alignItems="stretch"
                 justifyContent="start"
               >
-                <Text mainUiAction text04>
-                  Connectors & Document Sets
-                </Text>
+                <Text font="main-ui-action">Connectors & Document Sets</Text>
                 <ResourcePopover
                   placeholder="Add connectors, document sets"
                   searchValue={connectorSearch}
@@ -356,9 +353,7 @@ function SharedGroupResources({
                 alignItems="stretch"
                 justifyContent="start"
               >
-                <Text mainUiAction text04>
-                  Agents
-                </Text>
+                <Text font="main-ui-action">Agents</Text>
                 <ResourcePopover
                   placeholder="Add agents"
                   searchValue={agentSearch}

--- a/web/src/refresh-pages/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/TokenLimitSection.tsx
@@ -6,6 +6,7 @@ import { Button } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import InputNumber from "@/refresh-components/inputs/InputNumber";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";

--- a/web/src/refresh-pages/admin/GroupsPage/shared.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/shared.tsx
@@ -2,6 +2,7 @@ import { createTableColumns } from "@opal/components";
 import { Content } from "@opal/layouts";
 import { SvgUser, SvgUserManage, SvgGlobe, SvgSlack } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { UserRole, UserStatus, USER_ROLE_LABELS } from "@/lib/types";
 import type { ApiKeyDescriptor, MemberRow } from "./interfaces";

--- a/web/src/refresh-pages/admin/GroupsPage/shared.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/shared.tsx
@@ -1,9 +1,7 @@
-import { createTableColumns } from "@opal/components";
+import { createTableColumns, Text } from "@opal/components";
 import { Content } from "@opal/layouts";
 import { SvgUser, SvgUserManage, SvgGlobe, SvgSlack } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { UserRole, UserStatus, USER_ROLE_LABELS } from "@/lib/types";
 import type { ApiKeyDescriptor, MemberRow } from "./interfaces";
 
@@ -63,7 +61,7 @@ function renderAccountTypeColumn(_value: unknown, row: MemberRow) {
   return (
     <div className="flex flex-row items-center gap-1">
       <Icon className="w-4 h-4 text-text-03" />
-      <Text as="span" mainUiBody text03>
+      <Text as="span" color="text-03">
         {row.role ? USER_ROLE_LABELS[row.role] ?? row.role : "\u2014"}
       </Text>
     </div>
@@ -89,7 +87,7 @@ export const baseColumns = [
     enableSorting: false,
     cell: (value) =>
       value ? (
-        <Text as="span" secondaryBody text03>
+        <Text as="span" font="secondary-body" color="text-03">
           {value}
         </Text>
       ) : null,

--- a/web/src/refresh-pages/admin/HooksPage/HooksContent.tsx
+++ b/web/src/refresh-pages/admin/HooksPage/HooksContent.tsx
@@ -8,6 +8,7 @@ import { ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
 import InputSearch from "@/refresh-components/inputs/InputSearch";
 import Card from "@/refresh-components/cards/Card";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   SvgArrowExchange,

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/llmConfig/providers";
 import { refreshLlmProviderCaches } from "@/lib/llmConfig/cache";
 import { deleteLlmProvider, setDefaultLlmModel } from "@/lib/llmConfig/svc";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Horizontal as HorizontalInput } from "@/layouts/input-layouts";
 import Card from "@/refresh-components/cards/Card";

--- a/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
@@ -10,6 +10,7 @@ import {
 import { Hoverable } from "@opal/core";
 import { SvgEdit } from "@opal/icons";
 import { Button, Tag } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import EditUserModal from "./EditUserModal";

--- a/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
@@ -9,9 +9,7 @@ import {
 } from "react";
 import { Hoverable } from "@opal/core";
 import { SvgEdit } from "@opal/icons";
-import { Button, Tag } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Tag, Text } from "@opal/components";
 import SimpleTooltip from "@/refresh-components/SimpleTooltip";
 import EditUserModal from "./EditUserModal";
 import type { UserRow, UserGroupInfo } from "./interfaces";
@@ -149,7 +147,7 @@ export default function GroupsCell({
               ref={containerRef}
               className="flex items-center gap-1 overflow-hidden flex-nowrap min-w-0 -mr-7"
             >
-              <Text as="span" secondaryBody text03>
+              <Text as="span" font="secondary-body" color="text-03">
                 —
               </Text>
             </div>

--- a/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
@@ -7,6 +7,7 @@ import { Disabled } from "@opal/core";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import InputChipField from "@/refresh-components/inputs/InputChipField";
 import type { ChipItem } from "@/refresh-components/inputs/InputChipField";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { toast } from "@/hooks/useToast";
 import { inviteUsers } from "./svc";

--- a/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { SvgUsers, SvgAlertTriangle } from "@opal/icons";
 import { Disabled } from "@opal/core";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import InputChipField from "@/refresh-components/inputs/InputChipField";
 import type { ChipItem } from "@/refresh-components/inputs/InputChipField";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { toast } from "@/hooks/useToast";
 import { inviteUsers } from "./svc";
 
@@ -156,7 +154,7 @@ export default function InviteUsersModal({
                 size={14}
                 className="text-status-warning-05 shrink-0"
               />
-              <Text secondaryBody text03>
+              <Text font="secondary-body" color="text-03">
                 Some email addresses are invalid and will be skipped.
               </Text>
             </div>

--- a/web/src/refresh-pages/admin/UsersPage/UserActionModals.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserActionModals.tsx
@@ -5,6 +5,7 @@ import { Button } from "@opal/components";
 import { SvgUserPlus, SvgUserX, SvgXCircle, SvgKey } from "@opal/icons";
 import { Disabled } from "@opal/core";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { toast } from "@/hooks/useToast";
 import {

--- a/web/src/refresh-pages/admin/UsersPage/UserFilters.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserFilters.tsx
@@ -13,6 +13,7 @@ import { FilterButton } from "@opal/components";
 import Popover from "@/refresh-components/Popover";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import LineItem from "@/refresh-components/buttons/LineItem";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import ShadowDiv from "@/refresh-components/ShadowDiv";
 import {

--- a/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
@@ -13,6 +13,7 @@ import {
   SvgUserManage,
 } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Popover from "@/refresh-components/Popover";
 import LineItem from "@/refresh-components/buttons/LineItem";

--- a/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRoleCell.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from "react";
 import { UserRole, USER_ROLE_LABELS } from "@/lib/types";
 import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidEnterpriseFeaturesEnabled";
-import { OpenButton } from "@opal/components";
+import { OpenButton, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import {
   SvgCheck,
@@ -13,8 +13,6 @@ import {
   SvgUserManage,
 } from "@opal/icons";
 import type { IconFunctionComponent } from "@opal/types";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import Popover from "@/refresh-components/Popover";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { toast } from "@/hooks/useToast";
@@ -46,7 +44,7 @@ export default function UserRoleCell({ user, onMutate }: UserRoleCellProps) {
 
   if (!user.role) {
     return (
-      <Text as="span" secondaryBody text03>
+      <Text as="span" font="secondary-body" color="text-03">
         —
       </Text>
     );

--- a/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UserRowActions.tsx
@@ -16,6 +16,7 @@ import LineItem from "@/refresh-components/buttons/LineItem";
 import Popover from "@/refresh-components/Popover";
 import Separator from "@/refresh-components/Separator";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { UserStatus } from "@/lib/types";
 import { toast } from "@/hooks/useToast";

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -1,11 +1,9 @@
 import { SvgArrowUpRight, SvgFilterPlus, SvgUserSync } from "@opal/icons";
 import { ContentAction } from "@opal/layouts";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import IconButton from "@/refresh-components/buttons/IconButton";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
@@ -29,10 +27,10 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
       }`}
       onClick={onFilter}
     >
-      <Text as="span" mainUiAction text04>
+      <Text as="span" font="main-ui-action">
         {display}
       </Text>
-      <Text as="span" secondaryBody text03>
+      <Text as="span" font="secondary-body" color="text-03">
         {label}
       </Text>
       {onFilter && (

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -4,6 +4,7 @@ import { Button } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import Card from "@/refresh-components/cards/Card";
 import IconButton from "@/refresh-components/buttons/IconButton";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";

--- a/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Table, createTableColumns } from "@opal/components";
-import { Content } from "@opal/layouts";
-import { Button } from "@opal/components";
+import { Button, Table, Text, createTableColumns } from "@opal/components";
+import { Content, IllustrationContent } from "@opal/layouts";
 import { SvgDownload } from "@opal/icons";
 import SvgNoResult from "@opal/illustrations/no-result";
-import { IllustrationContent } from "@opal/layouts";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { UserRole, UserStatus, USER_STATUS_LABELS } from "@/lib/types";
 import { timeAgo } from "@/lib/time";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { toast } from "@/hooks/useToast";
 import useAdminUsers from "@/hooks/useAdminUsers";
@@ -48,11 +44,11 @@ function renderNameColumn(email: string, row: UserRow) {
 function renderStatusColumn(value: UserStatus, row: UserRow) {
   return (
     <div className="flex flex-col">
-      <Text as="span" mainUiBody text03>
+      <Text as="span" color="text-03">
         {USER_STATUS_LABELS[value] ?? value}
       </Text>
       {row.is_scim_synced && (
-        <Text as="span" secondaryBody text03>
+        <Text as="span" font="secondary-body" color="text-03">
           SCIM synced
         </Text>
       )}
@@ -62,7 +58,7 @@ function renderStatusColumn(value: UserStatus, row: UserRow) {
 
 function renderLastUpdatedColumn(value: string | null) {
   return (
-    <Text as="span" secondaryBody text03>
+    <Text as="span" font="secondary-body" color="text-03">
       {value ? timeAgo(value) ?? "\u2014" : "\u2014"}
     </Text>
   );
@@ -195,7 +191,7 @@ export default function UsersTable({
 
   if (error) {
     return (
-      <Text as="p" secondaryBody text03>
+      <Text as="p" font="secondary-body" color="text-03">
         Failed to load users. Please try refreshing the page.
       </Text>
     );

--- a/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersTable.tsx
@@ -10,6 +10,7 @@ import { IllustrationContent } from "@opal/layouts";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { UserRole, UserStatus, USER_STATUS_LABELS } from "@/lib/types";
 import { timeAgo } from "@/lib/time";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { toast } from "@/hooks/useToast";

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -7,8 +7,7 @@ import {
   IconProps,
   OpenAIIcon,
 } from "@/components/icons/icons";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Select } from "@/refresh-components/cards";
 import Message from "@/refresh-components/messages/Message";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
@@ -312,7 +311,7 @@ export default function VoiceConfigurationPage() {
           <Callout type="danger" title="Failed to load voice settings">
             {message}
             {detail && (
-              <Text as="p" mainContentBody text03>
+              <Text as="p" font="main-content-body" color="text-03">
                 {detail}
               </Text>
             )}
@@ -402,7 +401,7 @@ export default function VoiceConfigurationPage() {
 
           {TTS_PROVIDER_GROUPS.map((group) => (
             <div key={group.providerType} className="flex flex-col gap-2">
-              <Text secondaryBody text03>
+              <Text font="secondary-body" color="text-03">
                 {group.providerLabel}
               </Text>
               <div className="flex flex-col gap-2">

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -7,6 +7,7 @@ import {
   IconProps,
   OpenAIIcon,
 } from "@/components/icons/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Select } from "@/refresh-components/cards";
 import Message from "@/refresh-components/messages/Message";

--- a/web/src/sections/actions/ActionCardHeader.tsx
+++ b/web/src/sections/actions/ActionCardHeader.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { cn } from "@/lib/utils";
 import { ActionStatus } from "@/lib/tools/interfaces";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import ButtonRenaming from "@/refresh-components/buttons/ButtonRenaming";

--- a/web/src/sections/actions/Actionbar.tsx
+++ b/web/src/sections/actions/Actionbar.tsx
@@ -2,10 +2,8 @@
 
 import React from "react";
 import { cn } from "@/lib/utils";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { SvgPlusCircle } from "@opal/icons";
 interface ActionbarProps {
   hasActions: boolean;
@@ -51,7 +49,7 @@ const Actionbar: React.FC<ActionbarProps> = ({
         </div>
       ) : (
         <div className="flex-1">
-          <Text as="p" mainUiMuted text03>
+          <Text as="p" font="main-ui-muted" color="text-03">
             {barText}
           </Text>
         </div>

--- a/web/src/sections/actions/Actionbar.tsx
+++ b/web/src/sections/actions/Actionbar.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgPlusCircle } from "@opal/icons";
 interface ActionbarProps {

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -24,6 +24,7 @@ import type { IconProps } from "@opal/types";
 import { SvgRefreshCw, SvgServer, SvgTrash } from "@opal/icons";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { timeAgo } from "@/lib/time";
 import { cn } from "@/lib/utils";

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -13,6 +13,7 @@ import { updateToolStatus } from "@/lib/tools/mcpService";
 import { SvgServer, SvgTrash } from "@opal/icons";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -6,6 +6,7 @@ import InputKeyValue, {
   KeyValue,
 } from "@/refresh-components/inputs/InputKeyValue";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Separator from "@/refresh-components/Separator";
 import type { MCPAuthFormValues } from "@/sections/actions/modals/MCPAuthenticationModal";

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import Switch from "@/refresh-components/inputs/Switch";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import type { IconProps } from "@opal/types";

--- a/web/src/sections/actions/ToolsList.tsx
+++ b/web/src/sections/actions/ToolsList.tsx
@@ -2,9 +2,7 @@
 
 import React from "react";
 import { cn } from "@/lib/utils";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import FadingEdgeContainer from "@/refresh-components/FadingEdgeContainer";
 import ToolItemSkeleton from "@/sections/actions/skeleton/ToolItemSkeleton";
 import EnabledCount from "@/refresh-components/EnabledCount";
@@ -70,7 +68,7 @@ const ToolsList: React.FC<ToolsListProps> = ({
           ))
         ) : isEmpty ? (
           <div className="flex items-center justify-center w-full py-8">
-            <Text as="p" text03 mainUiBody>
+            <Text as="p" color="text-03">
               {searchQuery ? emptySearchMessage : emptyMessage}
             </Text>
           </div>

--- a/web/src/sections/actions/ToolsList.tsx
+++ b/web/src/sections/actions/ToolsList.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { cn } from "@/lib/utils";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import FadingEdgeContainer from "@/refresh-components/FadingEdgeContainer";

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -21,6 +21,7 @@ import { toast } from "@/hooks/useToast";
 import { ModalCreationInterface } from "@/refresh-components/contexts/ModalContext";
 import { SvgCheckCircle, SvgServer, SvgUnplug } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface AddMCPServerModalProps {

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -15,14 +15,12 @@ import {
 } from "@/lib/tools/interfaces";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import Separator from "@/refresh-components/Separator";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { toast } from "@/hooks/useToast";
 import { ModalCreationInterface } from "@/refresh-components/contexts/ModalContext";
 import { SvgCheckCircle, SvgServer, SvgUnplug } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 
 interface AddMCPServerModalProps {
   skipOverlay?: boolean;
@@ -199,9 +197,11 @@ export default function AddMCPServerModal({
                           width="fit"
                         >
                           <SvgCheckCircle className="w-4 h-4 stroke-status-success-05" />
-                          <Text>Authenticated &amp; Connected</Text>
+                          <Text color="text-05">
+                            Authenticated &amp; Connected
+                          </Text>
                         </Section>
-                        <Text secondaryBody text03>
+                        <Text font="secondary-body" color="text-03">
                           {server.auth_type === "OAUTH"
                             ? `OAuth connected to ${server.owner}`
                             : server.auth_type === "API_TOKEN"

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -3,6 +3,7 @@
 import { markdown } from "@opal/utils";
 import Link from "next/link";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import * as InputLayouts from "@/layouts/input-layouts";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";

--- a/web/src/sections/actions/modals/DisconnectEntityModal.tsx
+++ b/web/src/sections/actions/modals/DisconnectEntityModal.tsx
@@ -2,10 +2,8 @@
 
 import { useRef } from "react";
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { SvgUnplug } from "@opal/icons";
 interface DisconnectEntityModalProps {
@@ -58,11 +56,10 @@ export default function DisconnectEntityModal({
         />
 
         <Modal.Body>
-          <Text as="p" text03 mainUiBody>
-            All tools connected to {name} will stop working. You can reconnect
-            to this server later if needed.
+          <Text as="p" color="text-03">
+            {`All tools connected to ${name} will stop working. You can reconnect to this server later if needed.`}
           </Text>
-          <Text as="p" text03 mainUiBody>
+          <Text as="p" color="text-03">
             Are you sure you want to proceed?
           </Text>
         </Modal.Body>

--- a/web/src/sections/actions/modals/DisconnectEntityModal.tsx
+++ b/web/src/sections/actions/modals/DisconnectEntityModal.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { SvgUnplug } from "@opal/icons";

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -11,6 +11,7 @@ import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -11,6 +11,7 @@ import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
 import { FormField } from "@/refresh-components/form/FormField";
 import Separator from "@/refresh-components/Separator";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import KeyValueInput, {

--- a/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
+++ b/web/src/sections/document-sidebar/ChatDocumentDisplay.tsx
@@ -10,6 +10,7 @@ import { openDocument } from "@/lib/search/utils";
 import { ValidSources } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import Truncated from "@/refresh-components/texts/Truncated";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 
 interface DocumentMetadataBlockProps {

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -9,6 +9,7 @@ import {
   useCurrentMessageTree,
   useSelectedNodeForDocDisplay,
 } from "@/app/app/stores/useChatSessionStore";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { SvgSearchMenu, SvgX } from "@opal/icons";

--- a/web/src/sections/document-sidebar/DocumentsSidebar.tsx
+++ b/web/src/sections/document-sidebar/DocumentsSidebar.tsx
@@ -9,9 +9,7 @@ import {
   useCurrentMessageTree,
   useSelectedNodeForDocDisplay,
 } from "@/app/app/stores/useChatSessionStore";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { SvgSearchMenu, SvgX } from "@opal/icons";
 import Separator from "@/refresh-components/Separator";
 
@@ -50,7 +48,7 @@ function Header({ children, onClose }: HeaderProps) {
       <div className="flex flex-row w-full items-center justify-between gap-2 py-3">
         <div className="flex items-center gap-2 w-full px-3">
           <SvgSearchMenu className="w-[1.3rem] h-[1.3rem] stroke-text-03" />
-          <Text as="p" headingH3 text03>
+          <Text as="p" font="heading-h3" color="text-03">
             {children}
           </Text>
         </div>

--- a/web/src/sections/input/SharedAppInputBar.tsx
+++ b/web/src/sections/input/SharedAppInputBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button, OpenButton, SelectButton } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -14,6 +14,7 @@ import * as TableLayouts from "@/layouts/table-layouts";
 import * as InputLayouts from "@/layouts/input-layouts";
 import { Card } from "@/refresh-components/cards";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -10,6 +10,7 @@ import React, {
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
+++ b/web/src/sections/knowledge/SourceHierarchyBrowser.tsx
@@ -9,9 +9,7 @@ import React, {
 } from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import Truncated from "@/refresh-components/texts/Truncated";
 import Separator from "@/refresh-components/Separator";
 import Checkbox from "@/refresh-components/inputs/Checkbox";
@@ -85,14 +83,14 @@ function HierarchyBreadcrumb({
           {sourceMetadata.displayName}
         </Button>
       ) : (
-        <Text text03>{sourceMetadata.displayName}</Text>
+        <Text color="text-03">{sourceMetadata.displayName}</Text>
       )}
 
       {/* Collapsed indicator */}
       {shouldCollapse && (
         <>
           <SvgChevronRight size={12} className="stroke-text-04" />
-          <Text text03 secondaryBody>
+          <Text font="secondary-body" color="text-03">
             ...
           </Text>
         </>
@@ -109,7 +107,7 @@ function HierarchyBreadcrumb({
           <React.Fragment key={node.id}>
             <SvgChevronRight size={12} className="stroke-text-04" />
             {isLast ? (
-              <Text text03>{node.title}</Text>
+              <Text color="text-03">{node.title}</Text>
             ) : (
               <Button
                 prominence="tertiary"
@@ -655,7 +653,7 @@ export default function SourceHierarchyBrowser({
   if (isLoadingNodes) {
     return (
       <GeneralLayouts.Section height="auto" padding={1}>
-        <Text text03 secondaryBody>
+        <Text font="secondary-body" color="text-03">
           Loading folders...
         </Text>
       </GeneralLayouts.Section>
@@ -666,7 +664,7 @@ export default function SourceHierarchyBrowser({
   if (nodesError) {
     return (
       <GeneralLayouts.Section height="auto" padding={1}>
-        <Text text03 secondaryBody>
+        <Text font="secondary-body" color="text-03">
           {nodesError}
         </Text>
       </GeneralLayouts.Section>
@@ -734,7 +732,7 @@ export default function SourceHierarchyBrowser({
           )}
         </TableLayouts.CheckboxCell>
         <TableLayouts.TableCell flex>
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             Name
           </Text>
         </TableLayouts.TableCell>
@@ -837,7 +835,7 @@ export default function SourceHierarchyBrowser({
       >
         {filteredItems.length === 0 && !isLoadingDocuments ? (
           <GeneralLayouts.Section height="auto" padding={1}>
-            <Text text03 secondaryBody>
+            <Text font="secondary-body" color="text-03">
               {path.length === 0
                 ? "Select a folder to browse documents."
                 : "No items in this folder."}
@@ -887,7 +885,7 @@ export default function SourceHierarchyBrowser({
                     </GeneralLayouts.Section>
                   </TableLayouts.TableCell>
                   <TableLayouts.TableCell width={8}>
-                    <Text text03 secondaryBody>
+                    <Text font="secondary-body" color="text-03">
                       {isFolder
                         ? "—"
                         : timeAgo(
@@ -902,7 +900,7 @@ export default function SourceHierarchyBrowser({
             {/* Loading more indicator */}
             {isLoadingDocuments && documents.length > 0 && (
               <GeneralLayouts.Section height="auto" padding={0.5}>
-                <Text text03 secondaryBody>
+                <Text font="secondary-body" color="text-03">
                   Loading more...
                 </Text>
               </GeneralLayouts.Section>
@@ -922,9 +920,10 @@ export default function SourceHierarchyBrowser({
             gap={0.5}
             height="auto"
           >
-            <Text text03 secondaryBody>
-              {currentSourceSelectedCount}{" "}
-              {currentSourceSelectedCount === 1 ? "item" : "items"} selected
+            <Text font="secondary-body" color="text-03">
+              {`${currentSourceSelectedCount} ${
+                currentSourceSelectedCount === 1 ? "item" : "items"
+              } selected`}
             </Text>
             <Button
               icon={SvgEye}

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -8,8 +8,7 @@ import { useModal } from "@/refresh-components/contexts/ModalContext";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import { Content, ContentAction } from "@opal/layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import Separator from "@/refresh-components/Separator";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
@@ -30,7 +29,6 @@ import { MCPServer, ToolSnapshot } from "@/lib/tools/interfaces";
 import EmptyMessage from "@/refresh-components/EmptyMessage";
 import { Horizontal } from "@/layouts/input-layouts";
 import Switch from "@/refresh-components/inputs/Switch";
-import { Button } from "@opal/components";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import AppInputBar from "@/sections/input/AppInputBar";
 import { useFilters, useLlmManager } from "@/lib/hooks";
@@ -281,7 +279,9 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
           </Section>
 
           {/* Description */}
-          {agent.description && <Text text03>{agent.description}</Text>}
+          {agent.description && (
+            <Text color="text-03">{agent.description}</Text>
+          )}
 
           {/* Knowledge */}
           <Separator noPadding />
@@ -357,7 +357,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                     nonInteractive
                     sizePreset="main-ui"
                   >
-                    <Text>{defaultModel}</Text>
+                    <Text color="text-05">{defaultModel}</Text>
                   </Horizontal>
                 )}
                 {agent.search_start_date && (
@@ -367,7 +367,7 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                     nonInteractive
                     sizePreset="main-ui"
                   >
-                    <Text mainUiMono>
+                    <Text font="main-ui-mono" color="text-05">
                       {formatMmDdYyyy(agent.search_start_date)}
                     </Text>
                   </Horizontal>

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -8,6 +8,7 @@ import { useModal } from "@/refresh-components/contexts/ModalContext";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import { Content, ContentAction } from "@opal/layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/sections/modals/NewTenantModal.tsx
+++ b/web/src/sections/modals/NewTenantModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { toast } from "@/hooks/useToast";
 import { SvgArrowRight, SvgUsers, SvgX } from "@opal/icons";
@@ -10,8 +10,6 @@ import { logout } from "@/lib/user";
 import { useUser } from "@/providers/UserProvider";
 import { NewTenantInfo } from "@/lib/types";
 import { useRouter } from "next/navigation";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import { ErrorTextLayout } from "@/layouts/input-layouts";
 
 // App domain should not be hardcoded
@@ -138,7 +136,7 @@ export default function NewTenantModal({
         <Modal.Header icon={SvgUsers} title={title} onClose={onClose} />
 
         <Modal.Body>
-          <Text>{description}</Text>
+          <Text color="text-05">{description}</Text>
           {error && <ErrorTextLayout>{error}</ErrorTextLayout>}
         </Modal.Body>
 

--- a/web/src/sections/modals/NewTenantModal.tsx
+++ b/web/src/sections/modals/NewTenantModal.tsx
@@ -10,6 +10,7 @@ import { logout } from "@/lib/user";
 import { useUser } from "@/providers/UserProvider";
 import { NewTenantInfo } from "@/lib/types";
 import { useRouter } from "next/navigation";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { ErrorTextLayout } from "@/layouts/input-layouts";
 

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import Modal from "@/refresh-components/Modal";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import FloatingFooter from "@/sections/modals/PreviewModal/FloatingFooter";
@@ -181,9 +180,7 @@ export default function PreviewModal({
             </Section>
           ) : loadError ? (
             <Section padding={1}>
-              <Text text03 mainUiBody>
-                {loadError}
-              </Text>
+              <Text color="text-03">{loadError}</Text>
             </Section>
           ) : (
             variant.renderContent(ctx)

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import Modal from "@/refresh-components/Modal";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import { getCodeLanguage } from "@/lib/languages";

--- a/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/csvVariant.tsx
@@ -6,6 +6,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import { getDataLanguage, getLanguageByMime } from "@/lib/languages";

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { renderAsync } from "docx-preview";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import { PreviewContext } from "@/sections/modals/PreviewModal/interfaces";
@@ -94,9 +93,7 @@ function DocxPreview({ fileUrl, onLoad }: DocxPreviewProps) {
   if (error) {
     return (
       <Section justifyContent="center" alignItems="center" padding={1.5}>
-        <Text text03 mainUiBody>
-          {error}
-        </Text>
+        <Text color="text-03">{error}</Text>
       </Section>
     );
   }
@@ -147,7 +144,7 @@ export const docxVariant: PreviewVariant = {
       lastDocxResult = null;
       return (
         <Section justifyContent="center" alignItems="center" padding={1.5}>
-          <Text text03 mainUiBody>
+          <Text color="text-03">
             Legacy .doc format cannot be previewed. Download the file to view
             it.
           </Text>

--- a/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/docxVariant.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { renderAsync } from "docx-preview";
 import ScrollIndicatorDiv from "@/refresh-components/ScrollIndicatorDiv";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/sections/modals/PreviewModal/variants/shared.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/shared.tsx
@@ -1,7 +1,5 @@
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { SvgDownload, SvgZoomIn, SvgZoomOut } from "@opal/icons";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Section } from "@/layouts/general-layouts";
 
@@ -50,8 +48,8 @@ export function ZoomControls({ zoom, onZoomIn, onZoomOut }: ZoomControlsProps) {
           onClick={onZoomOut}
           tooltip="Zoom Out"
         />
-        <Text mainUiMono text03>
-          {zoom}%
+        <Text font="main-ui-mono" color="text-03">
+          {`${zoom}%`}
         </Text>
         <Button
           prominence="tertiary"

--- a/web/src/sections/modals/PreviewModal/variants/shared.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/shared.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@opal/components";
 import { SvgDownload, SvgZoomIn, SvgZoomOut } from "@opal/icons";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import { Section } from "@/layouts/general-layouts";

--- a/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
@@ -1,3 +1,4 @@
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";

--- a/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@opal/components";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";

--- a/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
@@ -1,6 +1,4 @@
-import { Button } from "@opal/components";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 
@@ -14,7 +12,7 @@ export const unsupportedVariant: PreviewVariant = {
 
   renderContent: (ctx) => (
     <div className="flex flex-col items-center justify-center flex-1 w-full min-h-0 gap-4 p-6">
-      <Text as="p" text03 mainUiBody>
+      <Text as="p" color="text-03">
         This file format is not supported for preview.
       </Text>
       <a href={ctx.fileUrl} download={ctx.fileName}>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -20,15 +20,13 @@ import * as InputLayouts from "@/layouts/input-layouts";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { Section } from "@/layouts/general-layouts";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import useShareableUsers from "@/hooks/useShareableUsers";
 import useShareableGroups from "@/hooks/useShareableGroups";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import { useUser } from "@/providers/UserProvider";
 import { Formik, useFormikContext } from "formik";
 import { useAgent } from "@/hooks/useAgents";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { useLabels } from "@/lib/hooks";
 import { PersonaLabel } from "@/app/admin/agents/interfaces";
@@ -245,7 +243,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                               // Note:
                               // This user, during creation, is assumed to be the "owner".
                               // That is why the `(isCurrentUser && !agent)` condition exists.
-                              <Text secondaryBody text03>
+                              <Text font="secondary-body" color="text-03">
                                 Owner
                               </Text>
                             ) : (
@@ -330,7 +328,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                   placeholder="Add labels..."
                   icon={SvgTag}
                 />
-                <Text secondaryBody text04>
+                <Text font="secondary-body">
                   Add labels and categories to help people better discover this
                   agent.
                 </Text>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -20,6 +20,7 @@ import * as InputLayouts from "@/layouts/input-layouts";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import useShareableUsers from "@/hooks/useShareableUsers";
 import useShareableGroups from "@/hooks/useShareableGroups";

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -12,6 +12,7 @@ import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { SvgLink, SvgShare, SvgUsers } from "@opal/icons";
 import SvgCheck from "@opal/icons/check";

--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -27,6 +27,7 @@ import KeyValueInput, {
 } from "@/refresh-components/inputs/InputKeyValue";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button, Card, EmptyMessageCard } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -27,9 +27,7 @@ import KeyValueInput, {
 } from "@/refresh-components/inputs/InputKeyValue";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button, Card, EmptyMessageCard } from "@opal/components";
+import { Button, Card, EmptyMessageCard, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { SvgMinusCircle, SvgPlusCircle } from "@opal/icons";
 import { toast } from "@/hooks/useToast";
@@ -149,11 +147,19 @@ function ModelConfigurationList({ formikProps }: ModelConfigurationListProps) {
       {models.length > 0 ? (
         <div className={`grid items-center gap-1 ${MODEL_GRID_COLS}`}>
           <div className="pb-1">
-            <Text mainUiAction>Model Name</Text>
+            <Text font="main-ui-action" color="text-05">
+              Model Name
+            </Text>
           </div>
-          <Text mainUiAction>Display Name</Text>
-          <Text mainUiAction>Input Type</Text>
-          <Text mainUiAction>Max Tokens</Text>
+          <Text font="main-ui-action" color="text-05">
+            Display Name
+          </Text>
+          <Text font="main-ui-action" color="text-05">
+            Input Type
+          </Text>
+          <Text font="main-ui-action" color="text-05">
+            Max Tokens
+          </Text>
           <div aria-hidden />
 
           {models.map((model, index) => (

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -13,9 +13,14 @@ import InputComboBox from "@/refresh-components/inputs/InputComboBox";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import Switch from "@/refresh-components/inputs/Switch";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button, LineItemButton, Tag } from "@opal/components";
+import {
+  Button,
+  Card,
+  EmptyMessageCard,
+  LineItemButton,
+  Tag,
+  Text,
+} from "@opal/components";
 import { BaseLLMFormValues } from "@/sections/modals/llmConfig/utils";
 import { WithoutStyles } from "@opal/types";
 import Separator from "@/refresh-components/Separator";
@@ -33,7 +38,6 @@ import {
   SvgX,
 } from "@opal/icons";
 import SvgOnyxLogo from "@opal/icons/onyx-logo";
-import { Card, EmptyMessageCard } from "@opal/components";
 import { ContentAction } from "@opal/layouts";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
@@ -276,7 +280,7 @@ export function ModelsAccessField<T extends BaseLLMFormValues>({
                 sizePreset="main-ui"
                 variant="section"
                 rightChildren={
-                  <Text secondaryBody text03>
+                  <Text font="secondary-body" color="text-03">
                     Always shared
                   </Text>
                 }

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -13,6 +13,7 @@ import InputComboBox from "@/refresh-components/inputs/InputComboBox";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import Switch from "@/refresh-components/inputs/Switch";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button, LineItemButton, Tag } from "@opal/components";
 import { BaseLLMFormValues } from "@/sections/modals/llmConfig/utils";

--- a/web/src/sections/onboarding/components/LLMProviderCard.tsx
+++ b/web/src/sections/onboarding/components/LLMProviderCard.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { memo, useCallback, useState } from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import Truncated from "@/refresh-components/texts/Truncated";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import { cn, noProp } from "@/lib/utils";
@@ -82,7 +81,7 @@ function LLMProviderCardInner({
             )}
           </div>
           <div className="min-w-0 flex flex-col justify-center">
-            <Text as="p" text04 mainUiAction>
+            <Text as="p" font="main-ui-action">
               {title}
             </Text>
             <Truncated text03 secondaryBody>
@@ -109,7 +108,7 @@ function LLMProviderCardInner({
         ) : (
           <div className="flex items-start p-1">
             <div className="flex items-center gap-0.5">
-              <Text as="p" text03 secondaryAction>
+              <Text as="p" font="secondary-action" color="text-03">
                 Connect
               </Text>
               <div className="p-0.5">

--- a/web/src/sections/onboarding/components/LLMProviderCard.tsx
+++ b/web/src/sections/onboarding/components/LLMProviderCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useCallback, useState } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import IconButton from "@/refresh-components/buttons/IconButton";

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { updateUserPersonalization } from "@/lib/userSettings";
 import { useUser } from "@/providers/UserProvider";
 import { toast } from "@/hooks/useToast";
 import IconButton from "@/refresh-components/buttons/IconButton";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import InputAvatar from "@/refresh-components/inputs/InputAvatar";
 import { cn } from "@/lib/utils";
@@ -143,11 +141,11 @@ export default function NonAdminStep() {
                 "w-5 h-5"
               )}
             >
-              <Text as="p" inverted secondaryBody>
+              <Text as="p" font="secondary-body" color="text-inverted-05">
                 {savedName?.[0]?.toUpperCase()}
               </Text>
             </InputAvatar>
-            <Text as="p" text04 mainUiAction>
+            <Text as="p" font="main-ui-action">
               {savedName}
             </Text>
           </div>

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { updateUserPersonalization } from "@/lib/userSettings";

--- a/web/src/sections/onboarding/components/OnboardingHeader.tsx
+++ b/web/src/sections/onboarding/components/OnboardingHeader.tsx
@@ -5,6 +5,7 @@ import {
   OnboardingState,
   OnboardingStep,
 } from "@/interfaces/onboarding";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import { Disabled } from "@opal/core";

--- a/web/src/sections/onboarding/components/OnboardingHeader.tsx
+++ b/web/src/sections/onboarding/components/OnboardingHeader.tsx
@@ -5,9 +5,7 @@ import {
   OnboardingState,
   OnboardingStep,
 } from "@/interfaces/onboarding";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { SvgProgressCircle, SvgX } from "@opal/icons";
 import { Card } from "@/refresh-components/cards";
@@ -55,9 +53,8 @@ const OnboardingHeader = React.memo(
             stepButtonText ? (
               <Section flexDirection="row">
                 {!isWelcomeStep && (
-                  <Text as="p" text03 mainUiBody>
-                    Step {onboardingState.stepIndex} of{" "}
-                    {onboardingState.totalSteps}
+                  <Text as="p" color="text-03">
+                    {`Step ${onboardingState.stepIndex} of ${onboardingState.totalSteps}`}
                   </Text>
                 )}
                 <Disabled disabled={!onboardingState.isButtonActive}>

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useState, useCallback } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { Button } from "@opal/components";
 import Separator from "@/refresh-components/Separator";

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { memo, useState, useCallback } from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import Separator from "@/refresh-components/Separator";
 import LLMProviderCard from "../components/LLMProviderCard";
 import {
@@ -81,8 +79,8 @@ const StackedProviderIcons = ({ providers }: StackedProviderIconsProps) => {
             zIndex: 0,
           }}
         >
-          <Text as="p" text03 secondaryBody>
-            +{providers.length - 3}
+          <Text as="p" font="secondary-body" color="text-03">
+            {`+${providers.length - 3}`}
           </Text>
         </div>
       )}
@@ -232,12 +230,12 @@ const LLMStepInner = ({
           <StackedProviderIcons
             providers={onboardingState.data.llmProviders || []}
           />
-          <Text as="p" text04 mainUiAction>
-            {onboardingState.data.llmProviders?.length || 0}{" "}
-            {(onboardingState.data.llmProviders?.length || 0) === 1
-              ? "model"
-              : "models"}{" "}
-            connected
+          <Text as="p" font="main-ui-action">
+            {`${onboardingState.data.llmProviders?.length || 0} ${
+              (onboardingState.data.llmProviders?.length || 0) === 1
+                ? "model"
+                : "models"
+            } connected`}
           </Text>
         </div>
         <div className="p-1">

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React, { useRef } from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import {
   OnboardingState,
@@ -85,11 +84,11 @@ const NameStep = React.memo(
               "w-5 h-5"
             )}
           >
-            <Text as="p" inverted secondaryBody>
+            <Text as="p" font="secondary-body" color="text-inverted-05">
               {userName?.[0]?.toUpperCase()}
             </Text>
           </InputAvatar>
-          <Text as="p" text04 mainUiAction>
+          <Text as="p" font="main-ui-action">
             {userName}
           </Text>
         </div>

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef } from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import {

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -26,6 +26,7 @@ import { ADMIN_ROUTES, sidebarItem } from "@/lib/admin-routes";
 import useFilter from "@/hooks/useFilter";
 import { IconFunctionComponent } from "@opal/types";
 import { Section } from "@/layouts/general-layouts";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { getUserDisplayName } from "@/lib/user";
 import { APP_SLOGAN } from "@/lib/constants";

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { useRouter } from "next/navigation";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import ChatButton from "@/sections/sidebar/ChatButton";
 import AgentButton from "@/sections/sidebar/AgentButton";

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -15,8 +15,7 @@ import {
 } from "@/sections/sidebar/chatSearchUtils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { useCurrentAgent } from "@/hooks/useAgents";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   useChatSearchOptimistic,
   FilterableChat,
@@ -266,11 +265,11 @@ export default function ChatSearchCommandMenu({
                       icon={SvgBubbleText}
                       rightContent={({ isHighlighted }) =>
                         isHighlighted ? (
-                          <Text figureKeystroke text02>
+                          <Text font="figure-keystroke" color="text-02">
                             ↵
                           </Text>
                         ) : (
-                          <Text secondaryBody text03>
+                          <Text font="secondary-body" color="text-03">
                             {formatDisplayTime(chat.time)}
                           </Text>
                         )
@@ -323,11 +322,11 @@ export default function ChatSearchCommandMenu({
                     icon={SvgFolder}
                     rightContent={({ isHighlighted }) =>
                       isHighlighted ? (
-                        <Text figureKeystroke text02>
+                        <Text font="figure-keystroke" color="text-02">
                           ↵
                         </Text>
                       ) : (
-                        <Text secondaryBody text03>
+                        <Text font="secondary-body" color="text-03">
                           {formatDisplayTime(project.time)}
                         </Text>
                       )

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/sections/sidebar/chatSearchUtils";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { useCurrentAgent } from "@/hooks/useAgents";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import {
   useChatSearchOptimistic,

--- a/web/src/sections/sidebar/CreateConnectorSidebar.tsx
+++ b/web/src/sections/sidebar/CreateConnectorSidebar.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from "@/components/context/FormContext";
 import { credentialTemplates } from "@/lib/connectors/credentials";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import StepSidebar from "@/sections/sidebar/StepSidebarWrapper";
 import { useUser } from "@/providers/UserProvider";

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -6,6 +6,7 @@ import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { Notification, NotificationType } from "@/interfaces/settings";
 import { errorHandlingFetcher } from "@/lib/fetcher";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { SvgSparkle, SvgRefreshCw, SvgX } from "@opal/icons";

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -6,12 +6,10 @@ import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { Notification, NotificationType } from "@/interfaces/settings";
 import { errorHandlingFetcher } from "@/lib/fetcher";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Button, Text } from "@opal/components";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { SvgSparkle, SvgRefreshCw, SvgX } from "@opal/icons";
 import { IconProps } from "@opal/types";
-import { Button } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import Separator from "@/refresh-components/Separator";
@@ -104,7 +102,9 @@ export default function NotificationsPopover({
   return (
     <Section gap={0.5} padding={0.25}>
       <Section flexDirection="row" justifyContent="between" padding={0.5}>
-        <Text headingH3>Notifications</Text>
+        <Text font="heading-h3" color="text-05">
+          Notifications
+        </Text>
         <Button icon={SvgX} prominence="tertiary" size="sm" onClick={onClose} />
       </Section>
 
@@ -120,7 +120,7 @@ export default function NotificationsPopover({
         ) : !notifications || notifications.length === 0 ? (
           <div className="h-48">
             <Section>
-              <Text as="p" text03>
+              <Text as="p" color="text-03">
                 No notifications
               </Text>
             </Section>

--- a/web/src/sections/sidebar/SidebarSection.tsx
+++ b/web/src/sections/sidebar/SidebarSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { cn } from "@/lib/utils";
 
 export interface SidebarSectionProps {
@@ -21,7 +20,7 @@ export default function SidebarSection({
   return (
     <div className={cn("flex flex-col group/SidebarSection", className)}>
       <div className="pl-2 pr-1.5 py-1 sticky top-[0rem] bg-background-tint-02 z-10 flex flex-row items-center justify-between min-h-[2rem]">
-        <Text as="p" secondaryBody text02>
+        <Text as="p" font="secondary-body" color="text-02">
           {title}
         </Text>
         {action && (

--- a/web/src/sections/sidebar/SidebarSection.tsx
+++ b/web/src/sections/sidebar/SidebarSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import { cn } from "@/lib/utils";
 

--- a/web/src/sections/sidebar/UpsertEmbeddingSidebar.tsx
+++ b/web/src/sections/sidebar/UpsertEmbeddingSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEmbeddingFormContext } from "@/components/context/EmbeddingContext";
+// TODO(@raunakab): migrate this `refresh-components/Text` to `@opal/components` Text
 import Text from "@/refresh-components/texts/Text";
 import StepSidebar from "@/sections/sidebar/StepSidebarWrapper";
 import { SvgSettings } from "@opal/icons";


### PR DESCRIPTION
## Description

Migrates `refresh-components/Text` to the new `opal/Text` component. All UI is preserved in this change. No need for screenshots / videos.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continues migrating `@/refresh-components/texts/Text` to `@opal/components` Text. Migrates 57 more files (86 total) and adds TODOs on all remaining imports; no UI changes expected.

- **Migration**
  - Replaced legacy `Text` with `@opal/components` `Text` and converted boolean flags (e.g., `mainContentEmphasis`, `text03`) to `font`/`color` enums.
  - Added a standard TODO above every remaining legacy `Text` import noting API differences (no `className`, markdown by default); left TODOs where JSX children or conditional props need follow-up.

<sup>Written for commit c079cd867a1c006e7a343de588f6ae0356f65a0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

