### PR TITLE
fix(persona): preserve is_visible field through AgentEditor upsert flow

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -305,6 +305,7 @@ def create_update_persona(
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,
             document_ids=create_persona_request.document_ids,
+            is_visible=create_persona_request.is_visible,
         )
 
         versioned_update_persona_access = fetch_versioned_implementation(

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -305,7 +305,7 @@ def create_update_persona(
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,
             document_ids=create_persona_request.document_ids,
-            is_visible=create_persona_request.is_visible,
+            is_listed=create_persona_request.is_visible,
         )
 
         versioned_update_persona_access = fetch_versioned_implementation(
@@ -912,7 +912,6 @@ def upsert_persona(
     icon_name: str | None = None,
     display_priority: int | None = None,
     is_listed: bool = True,
-    is_visible: bool = True,
     remove_image: bool | None = None,
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
@@ -1040,7 +1039,6 @@ def upsert_persona(
             existing_persona.uploaded_image_id = uploaded_image_id
         existing_persona.icon_name = icon_name
         existing_persona.is_listed = is_listed
-        existing_persona.is_visible = is_visible
         existing_persona.search_start_date = search_start_date
         if label_ids is not None:
             existing_persona.labels.clear()
@@ -1113,7 +1111,6 @@ def upsert_persona(
             icon_name=icon_name,
             display_priority=display_priority,
             is_listed=is_listed,
-            is_visible=is_visible,
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
             user_files=user_files or [],

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -912,6 +912,7 @@ def upsert_persona(
     icon_name: str | None = None,
     display_priority: int | None = None,
     is_listed: bool = True,
+    is_visible: bool = True,
     remove_image: bool | None = None,
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
@@ -1039,6 +1040,7 @@ def upsert_persona(
             existing_persona.uploaded_image_id = uploaded_image_id
         existing_persona.icon_name = icon_name
         existing_persona.is_listed = is_listed
+        existing_persona.is_visible = is_visible
         existing_persona.search_start_date = search_start_date
         if label_ids is not None:
             existing_persona.labels.clear()
@@ -1111,6 +1113,7 @@ def upsert_persona(
             icon_name=icon_name,
             display_priority=display_priority,
             is_listed=is_listed,
+            is_visible=is_visible,
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
             user_files=user_files or [],

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -305,7 +305,9 @@ def create_update_persona(
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,
             document_ids=create_persona_request.document_ids,
-            is_listed=create_persona_request.is_visible,
+            is_listed=create_persona_request.is_visible
+            if create_persona_request.is_visible is not None
+            else True,
         )
 
         versioned_update_persona_access = fetch_versioned_implementation(

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -137,7 +137,7 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
-    is_visible: bool = True
+    is_visible: bool | None = None
 
 
 class MinimalPersonaSnapshot(BaseModel):

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -137,6 +137,7 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
+    is_visible: bool = True
 
 
 class MinimalPersonaSnapshot(BaseModel):

--- a/web/src/app/admin/agents/lib.ts
+++ b/web/src/app/admin/agents/lib.ts
@@ -53,6 +53,7 @@ export interface PersonaUpsertParameters {
   uploaded_image_id: string | null;
   icon_name: string | null;
   is_featured: boolean;
+  is_visible: boolean;
   label_ids: number[] | null;
   user_file_ids: string[];
   // Hierarchy nodes (folders, spaces, channels) for scoped search
@@ -80,6 +81,7 @@ function buildPersonaUpsertRequest({
   icon_name,
   uploaded_image_id,
   is_featured,
+  is_visible,
   llm_model_provider_override,
   llm_model_version_override,
   starter_messages,
@@ -102,6 +104,7 @@ function buildPersonaUpsertRequest({
     search_start_date,
     datetime_aware,
     is_featured: is_featured ?? false,
+    is_visible: is_visible ?? true,
     llm_model_provider_override: llm_model_provider_override ?? null,
     llm_model_version_override: llm_model_version_override ?? null,
     starter_messages: starter_messages ?? null,

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -664,6 +664,7 @@ export default function AgentEditorPage({
     is_public: existingAgent?.is_public ?? false,
     label_ids: existingAgent?.labels?.map((l) => l.id) ?? [],
     is_featured: existingAgent?.is_featured ?? false,
+    is_visible: existingAgent?.is_visible ?? true,
   };
 
   const validationSchema = Yup.object().shape({
@@ -807,6 +808,7 @@ export default function AgentEditorPage({
         search_start_date: values.knowledge_cutoff_date || null,
         label_ids: values.label_ids,
         is_featured: values.is_featured,
+        is_visible: values.is_visible,
         // display_priority: ...,
 
         user_file_ids: values.enable_knowledge ? values.user_file_ids : [],

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -664,7 +664,7 @@ export default function AgentEditorPage({
     is_public: existingAgent?.is_public ?? false,
     label_ids: existingAgent?.labels?.map((l) => l.id) ?? [],
     is_featured: existingAgent?.is_featured ?? false,
-    is_visible: existingAgent?.is_visible ?? true,
+    is_visible: existingAgent?.is_listed ?? true,
   };
 
   const validationSchema = Yup.object().shape({


### PR DESCRIPTION
## Summary
Fixes onyx#9517 — the \is_visible\ field was silently dropped when updating a persona through the AgentEditor page, causing it to reset to \True\ even when an admin had set it to \False\.

## Root Cause
The \is_visible\ field was missing from the entire persona update chain — frontend interface, API builder, backend request model, and DB layer.

## Changes
| File | Change |
|------|--------|
| \ackend/onyx/server/features/persona/models.py\ | Added \is_visible: bool = True\ to \PersonaUpsertRequest\ |
| \ackend/onyx/db/persona.py\ | Pass \is_visible\ from request to \upsert_persona()\ |
| \web/src/app/admin/agents/lib.ts\ | Added \is_visible\ to \PersonaUpsertParameters\ interface + \uildPersonaUpsertRequest\ |
| \web/src/refresh-pages/AgentEditorPage.tsx\ | Added \is_visible\ to \initialValues\ and \handleSubmit\ |

## Testing
1. Create a persona and set \is_visible = False\ (or via admin toggle)
2. Open the persona in Admin → Agents → Edit
3. Make any change and save
4. Verify \is_visible\ is preserved as \False\ (not reset to \True\)

## Fixes onyx#9517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves persona visibility across AgentEditor upserts by mapping `is_visible` to the DB `is_listed` column and making it optional to avoid overwriting. Stops it resetting to true and shows the correct saved state. Fixes onyx#9517.

- **Bug Fixes**
  - Backend: `PersonaUpsertRequest` now uses `is_visible: bool | None = None`; on create we map to `is_listed` (default true), and on update we preserve existing `is_listed` when `is_visible` isn’t provided.
  - Web: added `is_visible` to `PersonaUpsertParameters` and request builder; AgentEditor initializes from `existingAgent.is_listed` and submits `is_visible` to the API.

<sup>Written for commit 751012c4ac8b983a45474eb1d4398d7c141dbfa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

