### PR TITLE
fix(llm): preserve custom_config from PUT request when explicitly provided

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -470,7 +470,10 @@ def put_llm_provider(
             else None
         )
     if existing_provider and not llm_provider_upsert_request.custom_config_changed:
-        llm_provider_upsert_request.custom_config = existing_provider.custom_config
+        # Only preserve existing if caller didn't provide custom_config in this request.
+        # If custom_config was explicitly sent (even if same value), use the caller's value.
+        if llm_provider_upsert_request.custom_config is None:
+            llm_provider_upsert_request.custom_config = existing_provider.custom_config
 
     # Check if we're transitioning to Auto mode
     transitioning_to_auto_mode = llm_provider_upsert_request.is_auto_mode and (


### PR DESCRIPTION
## Summary
Fixes onyx#9483 — PUT `/api/admin/llm/provider` silently ignores `custom_config` in the request body, always returning `null`.

## Root Cause
In `server/manage/llm/api.py`, when `custom_config_changed` is `False` (the default), the backend unconditionally overwrites the `custom_config` value in the request with the existing provider's stored value — even when the caller explicitly sent a `custom_config` in the request body.

## Fix
Changed the overwrite logic to only preserve the existing `custom_config` when the caller did **not** provide `custom_config` in the request body (i.e., it is `None`). If `custom_config` is explicitly provided in the request, it is now used.

Before: always overwrote when `custom_config_changed` was `False`
After: only overwrites when `custom_config_changed` is `False` AND `custom_config` is `None` (not provided)

## Testing
1. Send PUT `/api/admin/llm/provider` with `custom_config: {"think": "false"}` in the body
2. Verify the response returns the custom_config (not null)
3. Verify GET `/api/admin/llm/provider` also returns the custom_config

## Fixes onyx#9483


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onyx#9483 by making PUT `/api/admin/llm/provider` respect `custom_config` when provided. We now only fall back to the existing value when the request omits `custom_config`, enabling clients to update and persist it via the API.

<sup>Written for commit 09959b774f2c17f5d489ff19f9a8bf1fb00316c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

