### PR TITLE
fix(lite): add DISABLE_MODEL_SERVER and ENABLE_OPENSEARCH_INDEXING to lite overlay

### DIFF
--- a/deployment/docker_compose/docker-compose.onyx-lite.yml
+++ b/deployment/docker_compose/docker-compose.onyx-lite.yml
@@ -54,6 +54,8 @@ services:
         required: false
     environment:
       - DISABLE_VECTOR_DB=true
+      - DISABLE_MODEL_SERVER=true
+      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false
       - FILE_STORE_BACKEND=postgres
       - CACHE_BACKEND=postgres
       - AUTH_BACKEND=postgres


### PR DESCRIPTION
## Summary
Fixes onyx#9588 — the onyx-lite docker-compose overlay was missing two env vars required to fully disable model serving and OpenSearch indexing in lite mode.

## Root Cause
Users running lite mode still got Redis/Vespa connection errors even with the lite overlay, because:
1. DISABLE_MODEL_SERVER=true was not set (model server still tried to start)
2. ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false was not set (indexing still attempted)

These had to be manually added by users to get lite mode working.

## Fix
Added the two missing env vars to the pi_server environment in docker-compose.onyx-lite.yml:
- DISABLE_MODEL_SERVER=true
- ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false

## Testing
Run with the lite overlay:
\\\ash
docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml up -d
\\\
Verify:
- No Redis connection errors in api_server logs
- No Vespa/OpenSearch connection errors
- Backend starts without requiring --profile redis

## Fixes onyx#9588

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `DISABLE_MODEL_SERVER=true` and `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false` to the `onyx-lite` Docker Compose overlay to fully disable model serving and OpenSearch indexing. Prevents Redis/Vespa/OpenSearch connection errors so the API server starts cleanly in lite mode; fixes onyx#9588.

<sup>Written for commit 5f3a0b58b35871d07d6e92e14a89bdea58d4368a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

