### PR TITLE
feat: add Jira Service Management connector

### DIFF
--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,1 @@
+# Jira Service Management connector package

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,251 @@
+"""
+Jira Service Management (JSM) Connector for Onyx.
+
+Fetches tickets (Service Requests, Incidents, Problems, Changes) from a
+specified JSM project using the Jira REST API v2.
+
+Credentials required:
+  - jira_user_email   : Atlassian account e-mail
+  - jira_api_token    : Atlassian API token  (https://id.atlassian.com/manage/api-tokens)
+  - jira_base_url     : e.g. https://yourcompany.atlassian.net
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Generator
+
+from jira import JIRA, JIRAError
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import (
+    CheckpointConnector,
+    CheckpointOutput,
+    ConnectorCheckpoint,
+    ConnectorFailure,
+    CredentialedConnector,
+    SecondsSinceUnixEpoch,
+)
+from onyx.connectors.models import (
+    BasicExpertInfo,
+    ConnectorMissingCredentialError,
+    Document,
+    Section,
+)
+
+logger = logging.getLogger(__name__)
+
+# JSM issue types we want to index
+JSM_ISSUE_TYPES = ("Service Request", "Incident", "Problem", "Change", "Service Task")
+
+# Jira date format
+JIRA_DATE_FMT = "%Y-%m-%d %H:%M"
+
+
+def _build_jsm_jql(
+    project_key: str,
+    start: SecondsSinceUnixEpoch | None = None,
+    end: SecondsSinceUnixEpoch | None = None,
+) -> str:
+    issue_type_filter = ", ".join(f'"{t}"' for t in JSM_ISSUE_TYPES)
+    jql = f'project = "{project_key}" AND issuetype in ({issue_type_filter})'
+
+    if start is not None:
+        start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(JIRA_DATE_FMT)
+        jql += f' AND updated >= "{start_str}"'
+
+    if end is not None:
+        end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(JIRA_DATE_FMT)
+        jql += f' AND updated <= "{end_str}"'
+
+    jql += " ORDER BY updated ASC"
+    return jql
+
+
+def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
+    """Convert a jira.Issue object into an Onyx Document."""
+    fields = issue.fields
+
+    # ----- text content -----
+    summary = fields.summary or ""
+    description = fields.description or ""
+
+    # Include comments
+    comment_texts: list[str] = []
+    try:
+        for comment in fields.comment.comments:
+            author = getattr(comment.author, "displayName", "Unknown")
+            body = comment.body or ""
+            comment_texts.append(f"[{author}]: {body}")
+    except Exception:
+        pass
+
+    full_text = "\n\n".join(filter(None, [summary, description] + comment_texts))
+
+    # ----- metadata -----
+    issue_url = f"{jira_base_url.rstrip('/')}/browse/{issue.key}"
+    status = getattr(fields.status, "name", "Unknown")
+    priority = getattr(fields.priority, "name", None) if fields.priority else None
+    issue_type = getattr(fields.issuetype, "name", "Unknown")
+
+    assignee_name = (
+        fields.assignee.displayName if fields.assignee else None
+    )
+    reporter_name = (
+        fields.reporter.displayName if fields.reporter else None
+    )
+
+    experts: list[BasicExpertInfo] = []
+    if assignee_name:
+        experts.append(BasicExpertInfo(display_name=assignee_name))
+    if reporter_name and reporter_name != assignee_name:
+        experts.append(BasicExpertInfo(display_name=reporter_name))
+
+    metadata: dict[str, str | list[str]] = {
+        "issue_key": issue.key,
+        "issue_type": issue_type,
+        "status": status,
+    }
+    if priority:
+        metadata["priority"] = priority
+
+    # Parse updated time
+    updated_at: datetime | None = None
+    try:
+        updated_at = datetime.strptime(
+            fields.updated[:19], "%Y-%m-%dT%H:%M:%S"
+        ).replace(tzinfo=timezone.utc)
+    except Exception:
+        pass
+
+    return Document(
+        id=f"jsm:{issue.key}",
+        sections=[Section(link=issue_url, text=full_text)],
+        source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+        semantic_identifier=f"{issue.key}: {summary}",
+        doc_updated_at=updated_at,
+        primary_owners=experts,
+        metadata=metadata,
+        title=f"{issue.key}: {summary}",
+    )
+
+
+class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector):
+    """
+    Connector that indexes JSM tickets from a single Jira Service Management project.
+
+    Config args (set in Admin UI):
+        jira_base_url  : e.g. https://yourcompany.atlassian.net
+        project_key    : JSM project key, e.g. "IT" or "HELPDESK"
+
+    Credentials (stored as connector credential):
+        jira_user_email : your Atlassian email
+        jira_api_token  : Atlassian API token
+    """
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_key: str,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.jira_base_url = jira_base_url.rstrip("/")
+        self.project_key = project_key.strip()
+        self.batch_size = batch_size
+        self._jira_client: JIRA | None = None
+
+    # ------------------------------------------------------------------
+    # CredentialedConnector
+    # ------------------------------------------------------------------
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        email = credentials.get("jira_user_email")
+        token = credentials.get("jira_api_token")
+        if not email or not token:
+            raise ConnectorMissingCredentialError(
+                "jira_user_email and jira_api_token are required."
+            )
+        self._jira_client = JIRA(
+            server=self.jira_base_url,
+            basic_auth=(email, token),
+        )
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _client(self) -> JIRA:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError(
+                "load_credentials() must be called before indexing."
+            )
+        return self._jira_client
+
+    def _fetch_batch(
+        self,
+        jql: str,
+        start_at: int,
+    ) -> tuple[list[Document], bool]:
+        """
+        Fetch one page of issues. Returns (documents, has_more).
+        """
+        try:
+            issues = self._client.search_issues(
+                jql,
+                startAt=start_at,
+                maxResults=self.batch_size,
+                fields="*all",
+            )
+        except JIRAError as e:
+            logger.error(f"JSM connector JQL error: {e.text} | JQL: {jql}")
+            raise
+
+        docs: list[Document] = []
+        for issue in issues:
+            try:
+                docs.append(_issue_to_document(issue, self.jira_base_url))
+            except Exception as exc:
+                logger.warning(f"Failed to process JSM issue {issue.key}: {exc}")
+
+        has_more = (start_at + len(issues)) < issues.total
+        return docs, has_more
+
+    # ------------------------------------------------------------------
+    # CheckpointConnector
+    # ------------------------------------------------------------------
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: ConnectorCheckpoint,
+    ) -> CheckpointOutput:
+        """
+        Incrementally fetch JSM issues updated between *start* and *end*.
+        The checkpoint stores the current pagination offset.
+        """
+        jql = _build_jsm_jql(self.project_key, start=start, end=end)
+        start_at: int = checkpoint.get("start_at", 0) if checkpoint else 0
+
+        while True:
+            docs, has_more = self._fetch_batch(jql, start_at)
+
+            if docs:
+                yield docs
+
+            start_at += len(docs)
+
+            if not has_more:
+                break
+
+            yield ConnectorCheckpoint({"start_at": start_at})
+
+    def build_dummy_checkpoint(self) -> ConnectorCheckpoint:
+        return ConnectorCheckpoint({"start_at": 0})
+
+    def validate_checkpoint_json(self, checkpoint_json: dict[str, Any]) -> ConnectorCheckpoint:
+        return ConnectorCheckpoint(checkpoint_json)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Generator
+from typing import Any
 
 from jira import JIRA, JIRAError
 
@@ -32,15 +32,12 @@ from onyx.connectors.models import (
     BasicExpertInfo,
     ConnectorMissingCredentialError,
     Document,
-    Section,
+    TextSection,
 )
 
 logger = logging.getLogger(__name__)
 
-# JSM issue types we want to index
 JSM_ISSUE_TYPES = ("Service Request", "Incident", "Problem", "Change", "Service Task")
-
-# Jira date format
 JIRA_DATE_FMT = "%Y-%m-%d %H:%M"
 
 
@@ -51,28 +48,21 @@ def _build_jsm_jql(
 ) -> str:
     issue_type_filter = ", ".join(f'"{t}"' for t in JSM_ISSUE_TYPES)
     jql = f'project = "{project_key}" AND issuetype in ({issue_type_filter})'
-
     if start is not None:
         start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(JIRA_DATE_FMT)
         jql += f' AND updated >= "{start_str}"'
-
     if end is not None:
         end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(JIRA_DATE_FMT)
         jql += f' AND updated <= "{end_str}"'
-
     jql += " ORDER BY updated ASC"
     return jql
 
 
 def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
-    """Convert a jira.Issue object into an Onyx Document."""
     fields = issue.fields
-
-    # ----- text content -----
     summary = fields.summary or ""
     description = fields.description or ""
 
-    # Include comments
     comment_texts: list[str] = []
     try:
         for comment in fields.comment.comments:
@@ -83,19 +73,12 @@ def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
         pass
 
     full_text = "\n\n".join(filter(None, [summary, description] + comment_texts))
-
-    # ----- metadata -----
     issue_url = f"{jira_base_url.rstrip('/')}/browse/{issue.key}"
     status = getattr(fields.status, "name", "Unknown")
     priority = getattr(fields.priority, "name", None) if fields.priority else None
     issue_type = getattr(fields.issuetype, "name", "Unknown")
-
-    assignee_name = (
-        fields.assignee.displayName if fields.assignee else None
-    )
-    reporter_name = (
-        fields.reporter.displayName if fields.reporter else None
-    )
+    assignee_name = fields.assignee.displayName if fields.assignee else None
+    reporter_name = fields.reporter.displayName if fields.reporter else None
 
     experts: list[BasicExpertInfo] = []
     if assignee_name:
@@ -111,7 +94,6 @@ def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
     if priority:
         metadata["priority"] = priority
 
-    # Parse updated time
     updated_at: datetime | None = None
     try:
         updated_at = datetime.strptime(
@@ -122,7 +104,7 @@ def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
 
     return Document(
         id=f"jsm:{issue.key}",
-        sections=[Section(link=issue_url, text=full_text)],
+        sections=[TextSection(link=issue_url, text=full_text)],
         source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
         semantic_identifier=f"{issue.key}: {summary}",
         doc_updated_at=updated_at,
@@ -134,14 +116,14 @@ def _issue_to_document(issue: Any, jira_base_url: str) -> Document:
 
 class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector):
     """
-    Connector that indexes JSM tickets from a single Jira Service Management project.
+    Indexes JSM tickets from a single Jira Service Management project.
 
-    Config args (set in Admin UI):
-        jira_base_url  : e.g. https://yourcompany.atlassian.net
-        project_key    : JSM project key, e.g. "IT" or "HELPDESK"
+    Config args:
+        jira_base_url : e.g. https://yourcompany.atlassian.net
+        project_key   : JSM project key, e.g. "IT" or "HELPDESK"
 
-    Credentials (stored as connector credential):
-        jira_user_email : your Atlassian email
+    Credentials:
+        jira_user_email : Atlassian email
         jira_api_token  : Atlassian API token
     """
 
@@ -156,10 +138,6 @@ class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector)
         self.batch_size = batch_size
         self._jira_client: JIRA | None = None
 
-    # ------------------------------------------------------------------
-    # CredentialedConnector
-    # ------------------------------------------------------------------
-
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         email = credentials.get("jira_user_email")
         token = credentials.get("jira_api_token")
@@ -171,24 +149,13 @@ class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector)
         )
         return None
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
     @property
     def _client(self) -> JIRA:
         if self._jira_client is None:
             raise ConnectorMissingCredentialError("JiraServiceManagement")
         return self._jira_client
 
-    def _fetch_batch(
-        self,
-        jql: str,
-        start_at: int,
-    ) -> tuple[list[Document], bool]:
-        """
-        Fetch one page of issues. Returns (documents, has_more).
-        """
+    def _fetch_batch(self, jql: str, start_at: int) -> tuple[list[Document], bool]:
         try:
             issues = self._client.search_issues(
                 jql,
@@ -210,34 +177,22 @@ class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector)
         has_more = (start_at + len(issues)) < issues.total
         return docs, has_more
 
-    # ------------------------------------------------------------------
-    # CheckpointConnector
-    # ------------------------------------------------------------------
-
     def load_from_checkpoint(
         self,
         start: SecondsSinceUnixEpoch,
         end: SecondsSinceUnixEpoch,
         checkpoint: ConnectorCheckpoint,
     ) -> CheckpointOutput:
-        """
-        Incrementally fetch JSM issues updated between *start* and *end*.
-        The checkpoint stores the current pagination offset.
-        """
         jql = _build_jsm_jql(self.project_key, start=start, end=end)
         start_at: int = checkpoint.get("start_at", 0) if checkpoint else 0
 
         while True:
             docs, has_more = self._fetch_batch(jql, start_at)
-
             if docs:
                 yield docs
-
             start_at += len(docs)
-
             if not has_more:
                 break
-
             yield ConnectorCheckpoint({"start_at": start_at})
 
     def build_dummy_checkpoint(self) -> ConnectorCheckpoint:

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -164,9 +164,7 @@ class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector)
         email = credentials.get("jira_user_email")
         token = credentials.get("jira_api_token")
         if not email or not token:
-            raise ConnectorMissingCredentialError(
-                "jira_user_email and jira_api_token are required."
-            )
+            raise ConnectorMissingCredentialError("JiraServiceManagement")
         self._jira_client = JIRA(
             server=self.jira_base_url,
             basic_auth=(email, token),
@@ -180,9 +178,7 @@ class JiraServiceManagementConnector(CheckpointConnector, CredentialedConnector)
     @property
     def _client(self) -> JIRA:
         if self._jira_client is None:
-            raise ConnectorMissingCredentialError(
-                "load_credentials() must be called before indexing."
-            )
+            raise ConnectorMissingCredentialError("JiraServiceManagement")
         return self._jira_client
 
     def _fetch_batch(

--- a/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
+++ b/backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py
@@ -1,0 +1,70 @@
+"""
+Basic integration test for the Jira Service Management connector.
+
+To run locally:
+    export JSM_BASE_URL="https://yourcompany.atlassian.net"
+    export JSM_PROJECT_KEY="IT"
+    export JSM_USER_EMAIL="you@company.com"
+    export JSM_API_TOKEN="your-token"
+
+    pytest backend/tests/daily/connectors/jira_service_management/test_jsm_basic.py -v
+"""
+
+import os
+import pytest
+
+from onyx.connectors.jira_service_management.connector import JiraServiceManagementConnector
+
+
+@pytest.fixture()
+def jsm_connector() -> JiraServiceManagementConnector:
+    base_url = os.environ["JSM_BASE_URL"]
+    project_key = os.environ["JSM_PROJECT_KEY"]
+    email = os.environ["JSM_USER_EMAIL"]
+    api_token = os.environ["JSM_API_TOKEN"]
+
+    connector = JiraServiceManagementConnector(
+        jira_base_url=base_url,
+        project_key=project_key,
+    )
+    connector.load_credentials(
+        {"jira_user_email": email, "jira_api_token": api_token}
+    )
+    return connector
+
+
+def test_jsm_connector_returns_documents(jsm_connector: JiraServiceManagementConnector) -> None:
+    """Smoke test: connector should yield at least one document."""
+    import time
+
+    start = 0.0  # epoch beginning → fetch everything
+    end = float(time.time())
+    checkpoint = jsm_connector.build_dummy_checkpoint()
+
+    docs_found = 0
+    for output in jsm_connector.load_from_checkpoint(start, end, checkpoint):
+        if isinstance(output, list):
+            docs_found += len(output)
+            if docs_found >= 5:
+                break
+
+    assert docs_found > 0, "No documents returned from JSM connector"
+
+
+def test_jsm_document_fields(jsm_connector: JiraServiceManagementConnector) -> None:
+    """Each document should have the required fields populated."""
+    import time
+
+    start = 0.0
+    end = float(time.time())
+    checkpoint = jsm_connector.build_dummy_checkpoint()
+
+    for output in jsm_connector.load_from_checkpoint(start, end, checkpoint):
+        if isinstance(output, list) and output:
+            doc = output[0]
+            assert doc.id.startswith("jsm:")
+            assert doc.title
+            assert doc.sections
+            assert doc.sections[0].link.startswith("http")
+            assert doc.metadata.get("issue_key")
+            break


### PR DESCRIPTION
Closes #2281

## Description
Adds a new Jira Service Management (JSM) connector that indexes tickets (Service Requests, Incidents, Problems, Changes) from a specified JSM project.

## How Has This Been Tested?
Added unit tests under backend/tests/daily/connectors/jira_service_management/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Jira Service Management connector to index tickets from a project with incremental sync (Service Requests, Incidents, Problems, Changes, Service Tasks) and fix credential error handling.

- **New Features**
  - Adds `JiraServiceManagementConnector` querying Jira REST API with JQL filtered by `project_key` and updated time; paginates via checkpoint.
  - Converts issues to `Document` with summary, description, comments, link, status, priority, and owners; source is `JIRA_SERVICE_MANAGEMENT`.
  - Requires `jira_user_email`, `jira_api_token`; config needs `jira_base_url`, `project_key`; honors `INDEX_BATCH_SIZE`. Includes basic daily tests.

- **Bug Fixes**
  - Correctly raises `ConnectorMissingCredentialError` when credentials are missing or the client is not initialized, and uses `TextSection` for document sections.

<sup>Written for commit 221554aaed445a048cd60a60defadedd9906ef98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

