### PR TITLE
fix(mcp): fix per-user OAuth token exchange timing out (closes #9444)

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -167,6 +167,13 @@ class OnyxTokenStorage(TokenStorage):
                 r = get_redis_client()
                 r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
                 r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
+            else:
+                # Per-user OAuth: signal using connection_config_id so the
+                # waiting callback_handler (which uses connection_config_id as
+                # its key) receives the tokens without timing out.
+                r = get_redis_client()
+                r.rpush(key_tokens(str(self.connection_config_id)), tokens.model_dump_json())
+                r.expire(key_tokens(str(self.connection_config_id)), OAUTH_WAIT_SECONDS)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         with get_session_with_current_tenant() as db_session:
@@ -621,12 +628,22 @@ async def process_oauth_callback(
         )
 
     # Run the blocking blpop operation in a thread pool to avoid blocking the event loop
-    # Wait until set_tokens is called
-    admin_config_id = admin_config.id
+    # Wait until set_tokens is called on the correct Redis key
+    if state_data.is_admin:
+        redis_key = key_tokens(str(admin_config.id))
+    else:
+        # Per-user OAuth: look up the user's connection config to get the right Redis key
+        user_connection_config = get_user_connection_config(
+            server_id=mcp_server.id, user_email=user_id, db_session=db_session
+        )
+        if user_connection_config is None:
+            raise HTTPException(status_code=400, detail="User connection config not found")
+        redis_key = key_tokens(str(user_connection_config.id))
+
     loop = asyncio.get_running_loop()
     tokens_raw = await loop.run_in_executor(
         None,
-        lambda: r.blpop([key_tokens(str(admin_config_id))], timeout=OAUTH_WAIT_SECONDS),
+        lambda: r.blpop([redis_key], timeout=OAUTH_WAIT_SECONDS),
     )
     if tokens_raw is None:
         raise HTTPException(status_code=400, detail="No tokens found")


### PR DESCRIPTION
## Summary
Fixes onyx#9444 — MCP per-user OAuth shows connected in admin but runtime tool execution fails with "no credentials found" and oauth_user_token stays empty.

## Root Cause
Two bugs in the per-user MCP OAuth flow where admin_config_id=None:

**Bug 1: OnyxTokenStorage.set_tokens never signaled Redis**
When alt_config_id was None (per-user OAuth), the Redis rpush was skipped entirely. The callback_handler was waiting on blpop but set_tokens never pushed — timeout was guaranteed.

**Bug 2: /oauth/callback waited on wrong Redis key**
The callback route always waited on admin_config.id, but for per-user OAuth set_tokens was pushing to connection_config_id — a completely different Redis key.

## Fix

**1. OnyxTokenStorage.set_tokens**: Added else branch for per-user OAuth — now uses connection_config_id as the Redis key when alt_config_id is None.

**2. /oauth/callback route**: Added is_admin branching — per-user OAuth now calls get_user_connection_config(server_id, user_email) and waits on that key instead of admin_config.id.

Before: per-user OAuth hung indefinitely at token exchange
After: set_tokens and callback_handler use matching Redis keys

## Testing
1. Add MCP server with per-user OAuth (admin OAuth disabled)
2. Go through the OAuth flow as a non-admin user
3. Verify oauth_user_token is populated after the callback completes
4. Verify tool execution succeeds without "no credentials found" error

## Fixes onyx#9444


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user MCP OAuth token exchange timing out by aligning Redis signaling and callback keys for non-admin flows. Tokens now populate correctly and tool execution no longer fails. Fixes onyx#9444.

- **Bug Fixes**
  - On per-user OAuth, `set_tokens` now pushes to Redis using `connection_config_id` (when `alt_config_id` is None) and sets TTL.
  - `/oauth/callback` branches on `is_admin`; for users, it resolves the user connection config and waits on that Redis key instead of `admin_config.id`.

<sup>Written for commit 1026f7dfbfe83a26b46baa94941ac33433cb0196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

