### PR TITLE
feat: add account_type to users and auto-assign default groups on creation

### DIFF
--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -26,7 +26,8 @@ _ANONYMOUS = "ANONYMOUS"
 ANONYMOUS_USER_ID = "00000000-0000-0000-0000-000000000002"
 
 # Email pattern for API key virtual users
-API_KEY_EMAIL_PATTERN = "API_KEY__%@%.onyxapikey.ai"
+
+API_KEY_EMAIL_PATTERN = r"API\_KEY\_\_%"
 
 
 def upgrade() -> None:
@@ -42,7 +43,7 @@ def upgrade() -> None:
     conn.execute(
         sa.text(
             'UPDATE "user" SET account_type = :acct_type '
-            "WHERE email LIKE :pattern AND account_type IS NULL"
+            "WHERE email ILIKE :pattern AND account_type IS NULL"
         ),
         {"acct_type": _SERVICE_ACCOUNT, "pattern": API_KEY_EMAIL_PATTERN},
     )

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -86,12 +86,17 @@ def upgrade() -> None:
     # ------------------------------------------------------------------
     # Step 2: Set account_type to NOT NULL now that every row is filled.
     # ------------------------------------------------------------------
-    op.alter_column("user", "account_type", nullable=False)
+    op.alter_column(
+        "user",
+        "account_type",
+        nullable=False,
+        server_default="STANDARD",
+    )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
 
     # Revert to nullable first, then clear backfilled values
-    op.alter_column("user", "account_type", nullable=True)
+    op.alter_column("user", "account_type", nullable=True, server_default=None)
     conn.execute(sa.text('UPDATE "user" SET account_type = NULL'))

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -1,0 +1,98 @@
+"""backfill_account_type
+
+Revision ID: 03d085c5c38d
+Revises: 977e834c1427
+Create Date: 2026-03-25 16:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "03d085c5c38d"
+down_revision = "977e834c1427"
+branch_labels = None
+depends_on = None
+
+_STANDARD = "standard"
+_BOT = "bot"
+_EXT_PERM_USER = "ext_perm_user"
+_SERVICE_ACCOUNT = "service_account"
+_ANONYMOUS = "anonymous"
+
+# Well-known anonymous user UUID
+ANONYMOUS_USER_ID = "00000000-0000-0000-0000-000000000002"
+
+# Email pattern for API key virtual users
+API_KEY_EMAIL_PATTERN = "API_KEY__%@%.onyxapikey.ai"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # Step 1: Backfill account_type from role.
+    # Order matters — most-specific matches first so the final catch-all
+    # only touches rows that haven't been classified yet.
+    # ------------------------------------------------------------------
+
+    # 1a. API key virtual users (any role) → SERVICE_ACCOUNT
+    conn.execute(
+        sa.text(
+            'UPDATE "user" SET account_type = :acct_type '
+            "WHERE email LIKE :pattern AND account_type IS NULL"
+        ),
+        {"acct_type": _SERVICE_ACCOUNT, "pattern": API_KEY_EMAIL_PATTERN},
+    )
+
+    # 1b. Anonymous user → ANONYMOUS
+    conn.execute(
+        sa.text(
+            'UPDATE "user" SET account_type = :acct_type '
+            "WHERE id = :anon_id AND account_type IS NULL"
+        ),
+        {"acct_type": _ANONYMOUS, "anon_id": ANONYMOUS_USER_ID},
+    )
+
+    # 1c. SLACK_USER → BOT
+    conn.execute(
+        sa.text(
+            'UPDATE "user" SET account_type = :acct_type '
+            "WHERE role = 'slack_user' AND account_type IS NULL"
+        ),
+        {"acct_type": _BOT},
+    )
+
+    # 1d. EXT_PERM_USER → EXT_PERM_USER
+    conn.execute(
+        sa.text(
+            'UPDATE "user" SET account_type = :acct_type '
+            "WHERE role = 'ext_perm_user' AND account_type IS NULL"
+        ),
+        {"acct_type": _EXT_PERM_USER},
+    )
+
+    # 1e. Remaining (ADMIN, BASIC, CURATOR, GLOBAL_CURATOR) → STANDARD
+    conn.execute(
+        sa.text(
+            'UPDATE "user" SET account_type = :acct_type ' "WHERE account_type IS NULL"
+        ),
+        {"acct_type": _STANDARD},
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Set account_type to NOT NULL now that every row is filled.
+    # ------------------------------------------------------------------
+    op.alter_column("user", "account_type", nullable=False)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Clear backfilled values
+    conn.execute(sa.text('UPDATE "user" SET account_type = NULL'))
+
+    # Revert to nullable
+    op.alter_column("user", "account_type", nullable=True)

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -26,61 +26,70 @@ _ANONYMOUS = "ANONYMOUS"
 ANONYMOUS_USER_ID = "00000000-0000-0000-0000-000000000002"
 
 # Email pattern for API key virtual users
-
 API_KEY_EMAIL_PATTERN = r"API\_KEY\_\_%"
+
+# Reflect the table structure for use in DML
+user_table = sa.table(
+    "user",
+    sa.column("id", sa.Uuid),
+    sa.column("email", sa.String),
+    sa.column("role", sa.String),
+    sa.column("account_type", sa.String),
+)
 
 
 def upgrade() -> None:
-    conn = op.get_bind()
-
     # ------------------------------------------------------------------
     # Step 1: Backfill account_type from role.
     # Order matters — most-specific matches first so the final catch-all
     # only touches rows that haven't been classified yet.
     # ------------------------------------------------------------------
 
-    # 1a. API key virtual users (any role) → SERVICE_ACCOUNT
-    conn.execute(
-        sa.text(
-            'UPDATE "user" SET account_type = :acct_type '
-            "WHERE email ILIKE :pattern AND account_type IS NULL"
-        ),
-        {"acct_type": _SERVICE_ACCOUNT, "pattern": API_KEY_EMAIL_PATTERN},
+    # 1a. API key virtual users → SERVICE_ACCOUNT
+    op.execute(
+        sa.update(user_table)
+        .where(
+            user_table.c.email.ilike(API_KEY_EMAIL_PATTERN),
+            user_table.c.account_type.is_(None),
+        )
+        .values(account_type=_SERVICE_ACCOUNT)
     )
 
     # 1b. Anonymous user → ANONYMOUS
-    conn.execute(
-        sa.text(
-            'UPDATE "user" SET account_type = :acct_type '
-            "WHERE id = :anon_id AND account_type IS NULL"
-        ),
-        {"acct_type": _ANONYMOUS, "anon_id": ANONYMOUS_USER_ID},
+    op.execute(
+        sa.update(user_table)
+        .where(
+            user_table.c.id == ANONYMOUS_USER_ID,
+            user_table.c.account_type.is_(None),
+        )
+        .values(account_type=_ANONYMOUS)
     )
 
-    # 1c. SLACK_USER → BOT
-    conn.execute(
-        sa.text(
-            'UPDATE "user" SET account_type = :acct_type '
-            "WHERE role = 'SLACK_USER' AND account_type IS NULL"
-        ),
-        {"acct_type": _BOT},
+    # 1c. SLACK_USER role → BOT
+    op.execute(
+        sa.update(user_table)
+        .where(
+            user_table.c.role == "SLACK_USER",
+            user_table.c.account_type.is_(None),
+        )
+        .values(account_type=_BOT)
     )
 
-    # 1d. EXT_PERM_USER → EXT_PERM_USER
-    conn.execute(
-        sa.text(
-            'UPDATE "user" SET account_type = :acct_type '
-            "WHERE role = 'EXT_PERM_USER' AND account_type IS NULL"
-        ),
-        {"acct_type": _EXT_PERM_USER},
+    # 1d. EXT_PERM_USER role → EXT_PERM_USER
+    op.execute(
+        sa.update(user_table)
+        .where(
+            user_table.c.role == "EXT_PERM_USER",
+            user_table.c.account_type.is_(None),
+        )
+        .values(account_type=_EXT_PERM_USER)
     )
 
-    # 1e. Remaining (ADMIN, BASIC, CURATOR, GLOBAL_CURATOR) → STANDARD
-    conn.execute(
-        sa.text(
-            'UPDATE "user" SET account_type = :acct_type ' "WHERE account_type IS NULL"
-        ),
-        {"acct_type": _STANDARD},
+    # 1e. Everything else → STANDARD
+    op.execute(
+        sa.update(user_table)
+        .where(user_table.c.account_type.is_(None))
+        .values(account_type=_STANDARD)
     )
 
     # ------------------------------------------------------------------
@@ -95,8 +104,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
-    # Revert to nullable first, then clear backfilled values
     op.alter_column("user", "account_type", nullable=True, server_default=None)
-    conn.execute(sa.text('UPDATE "user" SET account_type = NULL'))
+    op.execute(sa.update(user_table).values(account_type=None))

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -60,7 +60,7 @@ def upgrade() -> None:
     conn.execute(
         sa.text(
             'UPDATE "user" SET account_type = :acct_type '
-            "WHERE role = 'slack_user' AND account_type IS NULL"
+            "WHERE role = 'SLACK_USER' AND account_type IS NULL"
         ),
         {"acct_type": _BOT},
     )
@@ -69,7 +69,7 @@ def upgrade() -> None:
     conn.execute(
         sa.text(
             'UPDATE "user" SET account_type = :acct_type '
-            "WHERE role = 'ext_perm_user' AND account_type IS NULL"
+            "WHERE role = 'EXT_PERM_USER' AND account_type IS NULL"
         ),
         {"acct_type": _EXT_PERM_USER},
     )

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -91,8 +91,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     conn = op.get_bind()
 
-    # Clear backfilled values
-    conn.execute(sa.text('UPDATE "user" SET account_type = NULL'))
-
-    # Revert to nullable
+    # Revert to nullable first, then clear backfilled values
     op.alter_column("user", "account_type", nullable=True)
+    conn.execute(sa.text('UPDATE "user" SET account_type = NULL'))

--- a/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
+++ b/backend/alembic/versions/03d085c5c38d_backfill_account_type.py
@@ -16,11 +16,11 @@ down_revision = "977e834c1427"
 branch_labels = None
 depends_on = None
 
-_STANDARD = "standard"
-_BOT = "bot"
-_EXT_PERM_USER = "ext_perm_user"
-_SERVICE_ACCOUNT = "service_account"
-_ANONYMOUS = "anonymous"
+_STANDARD = "STANDARD"
+_BOT = "BOT"
+_EXT_PERM_USER = "EXT_PERM_USER"
+_SERVICE_ACCOUNT = "SERVICE_ACCOUNT"
+_ANONYMOUS = "ANONYMOUS"
 
 # Well-known anonymous user UUID
 ANONYMOUS_USER_ID = "00000000-0000-0000-0000-000000000002"

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -34,9 +34,7 @@ def _find_available_name(conn: sa.engine.Connection, base: str) -> str:
     attempt = 1
     while attempt <= MAX_RENAME_ATTEMPTS:
         exists = conn.execute(
-            sa.text(
-                "SELECT 1 FROM user_group WHERE LOWER(name) = LOWER(:name) LIMIT 1"
-            ),
+            sa.text("SELECT 1 FROM user_group WHERE name = :name LIMIT 1"),
             {"name": candidate},
         ).fetchone()
         if exists is None:
@@ -55,9 +53,7 @@ def upgrade() -> None:
     for group_name, permission_value in DEFAULT_GROUPS:
         # Step 1: Rename ALL existing groups that clash with the canonical name.
         conflicting = conn.execute(
-            sa.text(
-                "SELECT id, name FROM user_group " "WHERE LOWER(name) = LOWER(:name)"
-            ),
+            sa.text("SELECT id, name FROM user_group " "WHERE name = :name"),
             {"name": group_name},
         ).fetchall()
 

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -1,7 +1,7 @@
 """seed_default_groups
 
 Revision ID: 977e834c1427
-Revises: a3f8b2c1d4e5
+Revises: 1d78c0ca7853
 Create Date: 2026-03-25 14:59:41.313091
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "977e834c1427"
-down_revision = "a3f8b2c1d4e5"
+down_revision = "1d78c0ca7853"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -85,7 +85,7 @@ def upgrade() -> None:
         conn.execute(
             sa.text(
                 "INSERT INTO permission_grant (group_id, permission, grant_source) "
-                "VALUES (:group_id, :permission, 'system') "
+                "VALUES (:group_id, :permission, 'SYSTEM') "
                 "ON CONFLICT (group_id, permission) DO NOTHING"
             ),
             {"group_id": group_id, "permission": permission_value},

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -8,6 +8,7 @@ Create Date: 2026-03-25 14:59:41.313091
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
 # revision identifiers, used by Alembic.
@@ -24,8 +25,30 @@ DEFAULT_GROUPS = [
 
 CUSTOM_SUFFIX = "(Custom)"
 
-
 MAX_RENAME_ATTEMPTS = 100
+
+# Reflect table structures for use in DML
+user_group_table = sa.table(
+    "user_group",
+    sa.column("id", sa.Integer),
+    sa.column("name", sa.String),
+    sa.column("is_up_to_date", sa.Boolean),
+    sa.column("is_up_for_deletion", sa.Boolean),
+    sa.column("is_default", sa.Boolean),
+)
+
+permission_grant_table = sa.table(
+    "permission_grant",
+    sa.column("group_id", sa.Integer),
+    sa.column("permission", sa.String),
+    sa.column("grant_source", sa.String),
+)
+
+user__user_group_table = sa.table(
+    "user__user_group",
+    sa.column("user_group_id", sa.Integer),
+    sa.column("user_id", sa.Uuid),
+)
 
 
 def _find_available_name(conn: sa.engine.Connection, base: str) -> str:
@@ -34,8 +57,10 @@ def _find_available_name(conn: sa.engine.Connection, base: str) -> str:
     attempt = 1
     while attempt <= MAX_RENAME_ATTEMPTS:
         exists = conn.execute(
-            sa.text("SELECT 1 FROM user_group WHERE name = :name LIMIT 1"),
-            {"name": candidate},
+            sa.select(sa.literal(1))
+            .select_from(user_group_table)
+            .where(user_group_table.c.name == candidate)
+            .limit(1)
         ).fetchone()
         if exists is None:
             return candidate
@@ -53,56 +78,59 @@ def upgrade() -> None:
     for group_name, permission_value in DEFAULT_GROUPS:
         # Step 1: Rename ALL existing groups that clash with the canonical name.
         conflicting = conn.execute(
-            sa.text("SELECT id, name FROM user_group " "WHERE name = :name"),
-            {"name": group_name},
+            sa.select(user_group_table.c.id, user_group_table.c.name).where(
+                user_group_table.c.name == group_name
+            )
         ).fetchall()
 
         for row_id, row_name in conflicting:
             new_name = _find_available_name(conn, row_name)
-            conn.execute(
-                sa.text(
-                    "UPDATE user_group "
-                    "SET name = :new_name, is_up_to_date = false "
-                    "WHERE id = :id"
-                ),
-                {"new_name": new_name, "id": row_id},
+            op.execute(
+                sa.update(user_group_table)
+                .where(user_group_table.c.id == row_id)
+                .values(name=new_name, is_up_to_date=False)
             )
 
         # Step 2: Create a fresh default group.
         result = conn.execute(
-            sa.text(
-                "INSERT INTO user_group "
-                "(name, is_up_to_date, is_up_for_deletion, is_default) "
-                "VALUES (:name, true, false, true) "
-                "RETURNING id"
-            ),
-            {"name": group_name},
+            user_group_table.insert()
+            .values(
+                name=group_name,
+                is_up_to_date=True,
+                is_up_for_deletion=False,
+                is_default=True,
+            )
+            .returning(user_group_table.c.id)
         ).fetchone()
         assert result is not None
         group_id = result[0]
 
         # Step 3: Upsert permission grant.
-        conn.execute(
-            sa.text(
-                "INSERT INTO permission_grant (group_id, permission, grant_source) "
-                "VALUES (:group_id, :permission, 'SYSTEM') "
-                "ON CONFLICT (group_id, permission) DO NOTHING"
-            ),
-            {"group_id": group_id, "permission": permission_value},
+        op.execute(
+            pg_insert(permission_grant_table)
+            .values(
+                group_id=group_id,
+                permission=permission_value,
+                grant_source="SYSTEM",
+            )
+            .on_conflict_do_nothing(index_elements=["group_id", "permission"])
         )
 
 
 def downgrade() -> None:
-    conn = op.get_bind()
-
     # Remove the default groups created by this migration.
     # First remove user-group memberships that reference default groups
     # to avoid FK violations, then delete the groups themselves.
-    conn.execute(
-        sa.text(
-            "DELETE FROM user__user_group "
-            "WHERE user_group_id IN "
-            "(SELECT id FROM user_group WHERE is_default = true)"
+    default_group_ids = sa.select(user_group_table.c.id).where(
+        user_group_table.c.is_default == True  # noqa: E712
+    )
+    op.execute(
+        sa.delete(user__user_group_table).where(
+            user__user_group_table.c.user_group_id.in_(default_group_ids)
         )
     )
-    conn.execute(sa.text("DELETE FROM user_group WHERE is_default = true"))
+    op.execute(
+        sa.delete(user_group_table).where(
+            user_group_table.c.is_default == True  # noqa: E712
+        )
+    )

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -1,0 +1,104 @@
+"""seed_default_groups
+
+Revision ID: 977e834c1427
+Revises: 25a5501dc766
+Create Date: 2026-03-25 14:59:41.313091
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "977e834c1427"
+down_revision = "25a5501dc766"
+branch_labels = None
+depends_on = None
+
+# (group_name, permission_value)
+DEFAULT_GROUPS = [
+    ("Admin", "admin"),
+    ("Basic", "basic"),
+]
+
+CUSTOM_SUFFIX = "(Custom)"
+
+
+MAX_RENAME_ATTEMPTS = 100
+
+
+def _find_available_name(conn: sa.engine.Connection, base: str) -> str:
+    """Return a name like 'Admin (Custom)' or 'Admin (Custom 2)' that is not taken."""
+    candidate = f"{base} {CUSTOM_SUFFIX}"
+    attempt = 1
+    while attempt <= MAX_RENAME_ATTEMPTS:
+        exists = conn.execute(
+            sa.text(
+                "SELECT 1 FROM user_group WHERE LOWER(name) = LOWER(:name) LIMIT 1"
+            ),
+            {"name": candidate},
+        ).fetchone()
+        if exists is None:
+            return candidate
+        attempt += 1
+        candidate = f"{base} (Custom {attempt})"
+    raise RuntimeError(
+        f"Could not find an available name for group '{base}' "
+        f"after {MAX_RENAME_ATTEMPTS} attempts"
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for group_name, permission_value in DEFAULT_GROUPS:
+        # Step 1: Rename ALL existing groups that clash with the canonical name.
+        conflicting = conn.execute(
+            sa.text(
+                "SELECT id, name FROM user_group " "WHERE LOWER(name) = LOWER(:name)"
+            ),
+            {"name": group_name},
+        ).fetchall()
+
+        for row_id, row_name in conflicting:
+            new_name = _find_available_name(conn, row_name)
+            conn.execute(
+                sa.text(
+                    "UPDATE user_group "
+                    "SET name = :new_name, is_up_to_date = false "
+                    "WHERE id = :id"
+                ),
+                {"new_name": new_name, "id": row_id},
+            )
+
+        # Step 2: Create a fresh default group.
+        result = conn.execute(
+            sa.text(
+                "INSERT INTO user_group "
+                "(name, is_up_to_date, is_up_for_deletion, is_default) "
+                "VALUES (:name, true, false, true) "
+                "RETURNING id"
+            ),
+            {"name": group_name},
+        ).fetchone()
+        assert result is not None
+        group_id = result[0]
+
+        # Step 3: Upsert permission grant.
+        conn.execute(
+            sa.text(
+                "INSERT INTO permission_grant (group_id, permission, grant_source) "
+                "VALUES (:group_id, :permission, 'system') "
+                "ON CONFLICT (group_id, permission) DO NOTHING"
+            ),
+            {"group_id": group_id, "permission": permission_value},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Remove the default groups created by this migration.
+    # Permission grants cascade-delete via FK.
+    conn.execute(sa.text("DELETE FROM user_group WHERE is_default = true"))

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -96,5 +96,13 @@ def downgrade() -> None:
     conn = op.get_bind()
 
     # Remove the default groups created by this migration.
-    # Permission grants cascade-delete via FK.
+    # First remove user-group memberships that reference default groups
+    # to avoid FK violations, then delete the groups themselves.
+    conn.execute(
+        sa.text(
+            "DELETE FROM user__user_group "
+            "WHERE user_group_id IN "
+            "(SELECT id FROM user_group WHERE is_default = true)"
+        )
+    )
     conn.execute(sa.text("DELETE FROM user_group WHERE is_default = true"))

--- a/backend/alembic/versions/977e834c1427_seed_default_groups.py
+++ b/backend/alembic/versions/977e834c1427_seed_default_groups.py
@@ -1,7 +1,7 @@
 """seed_default_groups
 
 Revision ID: 977e834c1427
-Revises: 25a5501dc766
+Revises: a3f8b2c1d4e5
 Create Date: 2026-03-25 14:59:41.313091
 
 """
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "977e834c1427"
-down_revision = "25a5501dc766"
+down_revision = "a3f8b2c1d4e5"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -51,8 +51,8 @@ def upgrade() -> None:
             sa.text(
                 "INSERT INTO user__user_group (user_group_id, user_id) "
                 'SELECT :gid, id FROM "user" '
-                "WHERE (account_type = 'standard' AND role != 'admin') "
-                "OR (account_type = 'service_account' AND role = 'basic') "
+                "WHERE (account_type = 'STANDARD' AND role != 'admin') "
+                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'basic') "
                 "ON CONFLICT (user_group_id, user_id) DO NOTHING"
             ),
             {"gid": basic_row[0]},

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -39,7 +39,7 @@ def upgrade() -> None:
             sa.text(
                 "INSERT INTO user__user_group (user_group_id, user_id) "
                 'SELECT :gid, id FROM "user" '
-                "WHERE role = 'admin' "
+                "WHERE role = 'ADMIN' "
                 "ON CONFLICT (user_group_id, user_id) DO NOTHING"
             ),
             {"gid": admin_row[0]},
@@ -51,8 +51,8 @@ def upgrade() -> None:
             sa.text(
                 "INSERT INTO user__user_group (user_group_id, user_id) "
                 'SELECT :gid, id FROM "user" '
-                "WHERE (account_type = 'STANDARD' AND role != 'admin') "
-                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'basic') "
+                "WHERE (account_type = 'STANDARD' AND role != 'ADMIN') "
+                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC') "
                 "ON CONFLICT (user_group_id, user_id) DO NOTHING"
             ),
             {"gid": basic_row[0]},

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -33,34 +33,44 @@ def upgrade() -> None:
         )
     ).fetchone()
 
+    if admin_row is None:
+        raise RuntimeError(
+            "Default 'Admin' group not found. "
+            "Ensure migration 977e834c1427 (seed_default_groups) ran successfully."
+        )
+
+    if basic_row is None:
+        raise RuntimeError(
+            "Default 'Basic' group not found. "
+            "Ensure migration 977e834c1427 (seed_default_groups) ran successfully."
+        )
+
     # Users with role=admin → Admin group
     # Exclude inactive placeholder/anonymous users that are not real users
-    if admin_row is not None:
-        conn.execute(
-            sa.text(
-                "INSERT INTO user__user_group (user_group_id, user_id) "
-                'SELECT :gid, id FROM "user" '
-                "WHERE role = 'ADMIN' AND is_active = true "
-                "ON CONFLICT (user_group_id, user_id) DO NOTHING"
-            ),
-            {"gid": admin_row[0]},
-        )
+    conn.execute(
+        sa.text(
+            "INSERT INTO user__user_group (user_group_id, user_id) "
+            'SELECT :gid, id FROM "user" '
+            "WHERE role = 'ADMIN' AND is_active = true "
+            "ON CONFLICT (user_group_id, user_id) DO NOTHING"
+        ),
+        {"gid": admin_row[0]},
+    )
 
     # STANDARD users (non-admin) and SERVICE_ACCOUNT users (role=basic) → Basic group
     # Exclude inactive placeholder/anonymous users that are not real users
-    if basic_row is not None:
-        conn.execute(
-            sa.text(
-                "INSERT INTO user__user_group (user_group_id, user_id) "
-                'SELECT :gid, id FROM "user" '
-                "WHERE is_active = true AND ("
-                "(account_type = 'STANDARD' AND role != 'ADMIN') "
-                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC')"
-                ") "
-                "ON CONFLICT (user_group_id, user_id) DO NOTHING"
-            ),
-            {"gid": basic_row[0]},
-        )
+    conn.execute(
+        sa.text(
+            "INSERT INTO user__user_group (user_group_id, user_id) "
+            'SELECT :gid, id FROM "user" '
+            "WHERE is_active = true AND ("
+            "(account_type = 'STANDARD' AND role != 'ADMIN') "
+            "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC')"
+            ") "
+            "ON CONFLICT (user_group_id, user_id) DO NOTHING"
+        ),
+        {"gid": basic_row[0]},
+    )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -34,25 +34,29 @@ def upgrade() -> None:
     ).fetchone()
 
     # Users with role=admin → Admin group
+    # Exclude inactive placeholder/anonymous users that are not real users
     if admin_row is not None:
         conn.execute(
             sa.text(
                 "INSERT INTO user__user_group (user_group_id, user_id) "
                 'SELECT :gid, id FROM "user" '
-                "WHERE role = 'ADMIN' "
+                "WHERE role = 'ADMIN' AND is_active = true "
                 "ON CONFLICT (user_group_id, user_id) DO NOTHING"
             ),
             {"gid": admin_row[0]},
         )
 
     # STANDARD users (non-admin) and SERVICE_ACCOUNT users (role=basic) → Basic group
+    # Exclude inactive placeholder/anonymous users that are not real users
     if basic_row is not None:
         conn.execute(
             sa.text(
                 "INSERT INTO user__user_group (user_group_id, user_id) "
                 'SELECT :gid, id FROM "user" '
-                "WHERE (account_type = 'STANDARD' AND role != 'ADMIN') "
-                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC') "
+                "WHERE is_active = true AND ("
+                "(account_type = 'STANDARD' AND role != 'ADMIN') "
+                "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC')"
+                ") "
                 "ON CONFLICT (user_group_id, user_id) DO NOTHING"
             ),
             {"gid": basic_row[0]},

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -1,0 +1,65 @@
+"""assign_users_to_default_groups
+
+Revision ID: b7bcc991d722
+Revises: 03d085c5c38d
+Create Date: 2026-03-25 16:30:39.529301
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b7bcc991d722"
+down_revision = "03d085c5c38d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Look up default group IDs
+    admin_row = conn.execute(
+        sa.text(
+            "SELECT id FROM user_group " "WHERE name = 'Admin' AND is_default = true"
+        )
+    ).fetchone()
+
+    basic_row = conn.execute(
+        sa.text(
+            "SELECT id FROM user_group " "WHERE name = 'Basic' AND is_default = true"
+        )
+    ).fetchone()
+
+    # Users with role=admin → Admin group
+    if admin_row is not None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO user__user_group (user_group_id, user_id) "
+                'SELECT :gid, id FROM "user" '
+                "WHERE role = 'admin' "
+                "ON CONFLICT (user_group_id, user_id) DO NOTHING"
+            ),
+            {"gid": admin_row[0]},
+        )
+
+    # STANDARD users (non-admin) and SERVICE_ACCOUNT users (role=basic) → Basic group
+    if basic_row is not None:
+        conn.execute(
+            sa.text(
+                "INSERT INTO user__user_group (user_group_id, user_id) "
+                'SELECT :gid, id FROM "user" '
+                "WHERE (account_type = 'standard' AND role != 'admin') "
+                "OR (account_type = 'service_account' AND role = 'basic') "
+                "ON CONFLICT (user_group_id, user_id) DO NOTHING"
+            ),
+            {"gid": basic_row[0]},
+        )
+
+
+def downgrade() -> None:
+    # Group memberships are left in place — removing them risks
+    # deleting memberships that existed before this migration.
+    pass

--- a/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
+++ b/backend/alembic/versions/b7bcc991d722_assign_users_to_default_groups.py
@@ -8,6 +8,7 @@ Create Date: 2026-03-25 16:30:39.529301
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
 # revision identifiers, used by Alembic.
@@ -16,20 +17,44 @@ down_revision = "03d085c5c38d"
 branch_labels = None
 depends_on = None
 
+# Reflect table structures for use in DML
+user_group_table = sa.table(
+    "user_group",
+    sa.column("id", sa.Integer),
+    sa.column("name", sa.String),
+    sa.column("is_default", sa.Boolean),
+)
+
+user_table = sa.table(
+    "user",
+    sa.column("id", sa.Uuid),
+    sa.column("role", sa.String),
+    sa.column("account_type", sa.String),
+    sa.column("is_active", sa.Boolean),
+)
+
+user__user_group_table = sa.table(
+    "user__user_group",
+    sa.column("user_group_id", sa.Integer),
+    sa.column("user_id", sa.Uuid),
+)
+
 
 def upgrade() -> None:
     conn = op.get_bind()
 
     # Look up default group IDs
     admin_row = conn.execute(
-        sa.text(
-            "SELECT id FROM user_group " "WHERE name = 'Admin' AND is_default = true"
+        sa.select(user_group_table.c.id).where(
+            user_group_table.c.name == "Admin",
+            user_group_table.c.is_default == True,  # noqa: E712
         )
     ).fetchone()
 
     basic_row = conn.execute(
-        sa.text(
-            "SELECT id FROM user_group " "WHERE name = 'Basic' AND is_default = true"
+        sa.select(user_group_table.c.id).where(
+            user_group_table.c.name == "Basic",
+            user_group_table.c.is_default == True,  # noqa: E712
         )
     ).fetchone()
 
@@ -47,29 +72,41 @@ def upgrade() -> None:
 
     # Users with role=admin → Admin group
     # Exclude inactive placeholder/anonymous users that are not real users
-    conn.execute(
-        sa.text(
-            "INSERT INTO user__user_group (user_group_id, user_id) "
-            'SELECT :gid, id FROM "user" '
-            "WHERE role = 'ADMIN' AND is_active = true "
-            "ON CONFLICT (user_group_id, user_id) DO NOTHING"
-        ),
-        {"gid": admin_row[0]},
+    admin_users = sa.select(
+        sa.literal(admin_row[0]).label("user_group_id"),
+        user_table.c.id.label("user_id"),
+    ).where(
+        user_table.c.role == "ADMIN",
+        user_table.c.is_active == True,  # noqa: E712
+    )
+    op.execute(
+        pg_insert(user__user_group_table)
+        .from_select(["user_group_id", "user_id"], admin_users)
+        .on_conflict_do_nothing(index_elements=["user_group_id", "user_id"])
     )
 
     # STANDARD users (non-admin) and SERVICE_ACCOUNT users (role=basic) → Basic group
     # Exclude inactive placeholder/anonymous users that are not real users
-    conn.execute(
-        sa.text(
-            "INSERT INTO user__user_group (user_group_id, user_id) "
-            'SELECT :gid, id FROM "user" '
-            "WHERE is_active = true AND ("
-            "(account_type = 'STANDARD' AND role != 'ADMIN') "
-            "OR (account_type = 'SERVICE_ACCOUNT' AND role = 'BASIC')"
-            ") "
-            "ON CONFLICT (user_group_id, user_id) DO NOTHING"
+    basic_users = sa.select(
+        sa.literal(basic_row[0]).label("user_group_id"),
+        user_table.c.id.label("user_id"),
+    ).where(
+        user_table.c.is_active == True,  # noqa: E712
+        sa.or_(
+            sa.and_(
+                user_table.c.account_type == "STANDARD",
+                user_table.c.role != "ADMIN",
+            ),
+            sa.and_(
+                user_table.c.account_type == "SERVICE_ACCOUNT",
+                user_table.c.role == "BASIC",
+            ),
         ),
-        {"gid": basic_row[0]},
+    )
+    op.execute(
+        pg_insert(user__user_group_table)
+        .from_select(["user_group_id", "user_id"], basic_users)
+        .on_conflict_do_nothing(index_elements=["user_group_id", "user_id"])
     )
 
 

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -255,6 +255,7 @@ def fetch_user_groups(
     db_session: Session,
     only_up_to_date: bool = True,
     eager_load_for_snapshot: bool = False,
+    include_default: bool = True,
 ) -> Sequence[UserGroup]:
     """
     Fetches user groups from the database.
@@ -269,6 +270,7 @@ def fetch_user_groups(
             to include only up to date user groups. Defaults to `True`.
         eager_load_for_snapshot: If True, adds eager loading for all relationships
             needed by UserGroup.from_model snapshot creation.
+        include_default: If False, excludes system default groups (is_default=True).
 
     Returns:
         Sequence[UserGroup]: A sequence of `UserGroup` objects matching the query criteria.
@@ -276,6 +278,8 @@ def fetch_user_groups(
     stmt = select(UserGroup)
     if only_up_to_date:
         stmt = stmt.where(UserGroup.is_up_to_date == True)  # noqa: E712
+    if not include_default:
+        stmt = stmt.where(UserGroup.is_default == False)  # noqa: E712
     if eager_load_for_snapshot:
         stmt = _add_user_group_snapshot_eager_loads(stmt)
     return db_session.scalars(stmt).unique().all()
@@ -286,6 +290,7 @@ def fetch_user_groups_for_user(
     user_id: UUID,
     only_curator_groups: bool = False,
     eager_load_for_snapshot: bool = False,
+    include_default: bool = True,
 ) -> Sequence[UserGroup]:
     stmt = (
         select(UserGroup)
@@ -295,6 +300,8 @@ def fetch_user_groups_for_user(
     )
     if only_curator_groups:
         stmt = stmt.where(User__UserGroup.is_curator == True)  # noqa: E712
+    if not include_default:
+        stmt = stmt.where(UserGroup.is_default == False)  # noqa: E712
     if eager_load_for_snapshot:
         stmt = _add_user_group_snapshot_eager_loads(stmt)
     return db_session.scalars(stmt).unique().all()

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -52,11 +52,13 @@ from ee.onyx.server.scim.schema_definitions import SERVICE_PROVIDER_CONFIG
 from ee.onyx.server.scim.schema_definitions import USER_RESOURCE_TYPE
 from ee.onyx.server.scim.schema_definitions import USER_SCHEMA_DEF
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import AccountType
 from onyx.db.models import ScimToken
 from onyx.db.models import ScimUserMapping
 from onyx.db.models import User
 from onyx.db.models import UserGroup
 from onyx.db.models import UserRole
+from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
@@ -486,6 +488,7 @@ def create_user(
         email=email,
         hashed_password=_pw_helper.hash(_pw_helper.generate()),
         role=UserRole.BASIC,
+        account_type=AccountType.STANDARD,
         is_active=user_resource.active,
         is_verified=True,
         personal_name=personal_name,
@@ -506,12 +509,24 @@ def create_user(
             scim_username=scim_username,
             fields=fields,
         )
-        dal.commit()
     except IntegrityError:
         dal.rollback()
         return _scim_error_response(
             409, f"User with email {email} already has a SCIM mapping"
         )
+
+    # Assign user to default group BEFORE commit so everything is atomic.
+    # If this fails, the entire user creation rolls back and IdP can retry.
+    try:
+        assign_user_to_default_groups__no_commit(db_session, user)
+    except Exception:
+        dal.rollback()
+        logger.exception(f"Failed to assign SCIM user {email} to default groups")
+        return _scim_error_response(
+            500, f"Failed to assign user {email} to default group"
+        )
+
+    dal.commit()
 
     return _scim_resource_response(
         provider.build_user_resource(

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -43,12 +43,16 @@ router = APIRouter(prefix="/manage", tags=PUBLIC_API_TAGS)
 
 @router.get("/admin/user-group")
 def list_user_groups(
+    include_default: bool = False,
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> list[UserGroup]:
     if user.role == UserRole.ADMIN:
         user_groups = fetch_user_groups(
-            db_session, only_up_to_date=False, eager_load_for_snapshot=True
+            db_session,
+            only_up_to_date=False,
+            eager_load_for_snapshot=True,
+            include_default=include_default,
         )
     else:
         user_groups = fetch_user_groups_for_user(
@@ -56,21 +60,28 @@ def list_user_groups(
             user_id=user.id,
             only_curator_groups=user.role == UserRole.CURATOR,
             eager_load_for_snapshot=True,
+            include_default=include_default,
         )
     return [UserGroup.from_model(user_group) for user_group in user_groups]
 
 
 @router.get("/user-groups/minimal")
 def list_minimal_user_groups(
+    include_default: bool = False,
     user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> list[MinimalUserGroupSnapshot]:
     if user.role == UserRole.ADMIN:
-        user_groups = fetch_user_groups(db_session, only_up_to_date=False)
+        user_groups = fetch_user_groups(
+            db_session,
+            only_up_to_date=False,
+            include_default=include_default,
+        )
     else:
         user_groups = fetch_user_groups_for_user(
             db_session=db_session,
             user_id=user.id,
+            include_default=include_default,
         )
     return [
         MinimalUserGroupSnapshot.from_model(user_group) for user_group in user_groups
@@ -100,6 +111,9 @@ def rename_user_group_endpoint(
     _: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
+    group = fetch_user_group(db_session, rename_request.id)
+    if group and group.is_default:
+        raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot rename a default system group.")
     try:
         return UserGroup.from_model(
             rename_user_group(
@@ -185,6 +199,9 @@ def delete_user_group(
     _: User = Depends(current_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
+    group = fetch_user_group(db_session, user_group_id)
+    if group and group.is_default:
+        raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot delete a default system group.")
     try:
         prepare_user_group_for_deletion(db_session, user_group_id)
     except ValueError as e:

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -22,6 +22,7 @@ class UserGroup(BaseModel):
     personas: list[PersonaSnapshot]
     is_up_to_date: bool
     is_up_for_deletion: bool
+    is_default: bool
 
     @classmethod
     def from_model(cls, user_group_model: UserGroupModel) -> "UserGroup":
@@ -74,18 +75,21 @@ class UserGroup(BaseModel):
             ],
             is_up_to_date=user_group_model.is_up_to_date,
             is_up_for_deletion=user_group_model.is_up_for_deletion,
+            is_default=user_group_model.is_default,
         )
 
 
 class MinimalUserGroupSnapshot(BaseModel):
     id: int
     name: str
+    is_default: bool
 
     @classmethod
     def from_model(cls, user_group_model: UserGroupModel) -> "MinimalUserGroupSnapshot":
         return cls(
             id=user_group_model.id,
             name=user_group_model.name,
+            is_default=user_group_model.is_default,
         )
 
 

--- a/backend/onyx/auth/schemas.py
+++ b/backend/onyx/auth/schemas.py
@@ -5,6 +5,8 @@ from typing import Any
 from fastapi_users import schemas
 from typing_extensions import override
 
+from onyx.db.enums import AccountType
+
 
 class UserRole(str, Enum):
     """
@@ -41,6 +43,7 @@ class UserRead(schemas.BaseUser[uuid.UUID]):
 
 class UserCreate(schemas.BaseUserCreate):
     role: UserRole = UserRole.BASIC
+    account_type: AccountType = AccountType.STANDARD
     tenant_id: str | None = None
     # Captcha token for cloud signup protection (optional, only used when captcha is enabled)
     # Excluded from create_update_dict so it never reaches the DB layer
@@ -50,12 +53,15 @@ class UserCreate(schemas.BaseUserCreate):
     def create_update_dict(self) -> dict[str, Any]:
         d = super().create_update_dict()
         d.pop("captcha_token", None)
+        # Always include account_type — it's NOT NULL with no DB default
+        d.setdefault("account_type", self.account_type)
         return d
 
     @override
     def create_update_dict_superuser(self) -> dict[str, Any]:
         d = super().create_update_dict_superuser()
         d.pop("captcha_token", None)
+        d.setdefault("account_type", self.account_type)
         return d
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -107,6 +107,7 @@ from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.configs.constants import MilestoneRecordType
+from onyx.configs.constants import NotificationType
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import PASSWORD_SPECIAL_CHARS
 from onyx.configs.constants import UNNAMED_KEY_PLACEHOLDER
@@ -125,6 +126,7 @@ from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import Persona
 from onyx.db.models import User
+from onyx.db.notification import create_notification
 from onyx.db.pat import fetch_user_for_pat
 from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.db.users import get_user_by_email
@@ -757,12 +759,33 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 )
 
                 # Assign upgraded user to the Basic default group.
-                # Let exceptions propagate — user without a group has no permissions.
-                with get_session_with_current_tenant() as sync_db:
-                    sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
-                    if sync_user:
-                        assign_user_to_default_groups__no_commit(sync_db, sync_user)
-                        sync_db.commit()
+                # If this fails, the user update is already committed, so
+                # log the error and notify admins rather than leaving a
+                # silently broken state.
+                try:
+                    with get_session_with_current_tenant() as sync_db:
+                        sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
+                        if sync_user:
+                            assign_user_to_default_groups__no_commit(sync_db, sync_user)
+                            sync_db.commit()
+                except Exception:
+                    logger.exception(
+                        "Failed to assign user %s to default groups after "
+                        "account upgrade",
+                        user.email,
+                    )
+                    with get_session_with_current_tenant() as sync_db:
+                        create_notification(
+                            user_id=None,
+                            notif_type=NotificationType.USER_GROUP_ASSIGNMENT_FAILED,
+                            db_session=sync_db,
+                            title="User group assignment failed",
+                            description=(
+                                f"User {user.email} was upgraded to STANDARD "
+                                f"but could not be assigned to default groups. "
+                                f"Please assign them manually."
+                            ),
+                        )
 
             # this is needed if an organization goes from `TRACK_EXTERNAL_IDP_EXPIRY=true` to `false`
             # otherwise, the oidc expiry will always be old, and the user will never be able to login

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -759,7 +759,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 # Assign upgraded user to the Basic default group.
                 # Let exceptions propagate — user without a group has no permissions.
                 with get_session_with_current_tenant() as sync_db:
-                    sync_user = sync_db.query(User).filter(User.id == user.id).first()
+                    sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
                     if sync_user:
                         assign_user_to_default_groups__no_commit(sync_db, sync_user)
                         sync_db.commit()

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -107,7 +107,6 @@ from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.configs.constants import MilestoneRecordType
-from onyx.configs.constants import NotificationType
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import PASSWORD_SPECIAL_CHARS
 from onyx.configs.constants import UNNAMED_KEY_PLACEHOLDER
@@ -126,7 +125,6 @@ from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import Persona
 from onyx.db.models import User
-from onyx.db.notification import create_notification
 from onyx.db.pat import fetch_user_for_pat
 from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.db.users import get_user_by_email
@@ -748,44 +746,23 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     with get_session_with_current_tenant() as sync_db:
                         enforce_seat_limit(sync_db)
 
-                await self.user_db.update(
-                    user,
-                    {
-                        "is_verified": is_verified_by_default,
-                        "role": UserRole.BASIC,
-                        "account_type": AccountType.STANDARD,
-                        **({"is_active": True} if not user.is_active else {}),
-                    },
-                )
+                # Upgrade the user and assign default groups in a single
+                # transaction so neither change is visible without the other.
+                was_inactive = not user.is_active
+                with get_session_with_current_tenant() as sync_db:
+                    sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
+                    if sync_user:
+                        sync_user.is_verified = is_verified_by_default
+                        sync_user.role = UserRole.BASIC
+                        sync_user.account_type = AccountType.STANDARD
+                        if was_inactive:
+                            sync_user.is_active = True
+                        assign_user_to_default_groups__no_commit(sync_db, sync_user)
+                        sync_db.commit()
 
-                # Assign upgraded user to the Basic default group.
-                # If this fails, the user update is already committed, so
-                # log the error and notify admins rather than leaving a
-                # silently broken state.
-                try:
-                    with get_session_with_current_tenant() as sync_db:
-                        sync_user = sync_db.query(User).filter(User.id == user.id).first()  # type: ignore[arg-type]
-                        if sync_user:
-                            assign_user_to_default_groups__no_commit(sync_db, sync_user)
-                            sync_db.commit()
-                except Exception:
-                    logger.exception(
-                        "Failed to assign user %s to default groups after "
-                        "account upgrade",
-                        user.email,
-                    )
-                    with get_session_with_current_tenant() as sync_db:
-                        create_notification(
-                            user_id=None,
-                            notif_type=NotificationType.USER_GROUP_ASSIGNMENT_FAILED,
-                            db_session=sync_db,
-                            title="User group assignment failed",
-                            description=(
-                                f"User {user.email} was upgraded to STANDARD "
-                                f"but could not be assigned to default groups. "
-                                f"Please assign them manually."
-                            ),
-                        )
+                # Refresh the async user object so downstream code
+                # (e.g. oidc_expiry check) sees the updated fields.
+                user = await self.user_db.get(user.id)  # type: ignore[arg-type]
 
             # this is needed if an organization goes from `TRACK_EXTERNAL_IDP_EXPIRY=true` to `false`
             # otherwise, the oidc expiry will always be old, and the user will never be able to login

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -120,11 +120,13 @@ from onyx.db.engine.async_sql_engine import get_async_session
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import AccountType
 from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.pat import fetch_user_for_pat
+from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.db.users import get_user_by_email
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import log_onyx_error
@@ -694,6 +696,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         "email": account_email,
                         "hashed_password": self.password_helper.hash(password),
                         "is_verified": is_verified_by_default,
+                        "account_type": AccountType.STANDARD,
                     }
 
                     user = await self.user_db.create(user_dict)
@@ -748,9 +751,18 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     {
                         "is_verified": is_verified_by_default,
                         "role": UserRole.BASIC,
+                        "account_type": AccountType.STANDARD,
                         **({"is_active": True} if not user.is_active else {}),
                     },
                 )
+
+                # Assign upgraded user to the Basic default group.
+                # Let exceptions propagate — user without a group has no permissions.
+                with get_session_with_current_tenant() as sync_db:
+                    sync_user = sync_db.query(User).filter(User.id == user.id).first()
+                    if sync_user:
+                        assign_user_to_default_groups__no_commit(sync_db, sync_user)
+                        sync_db.commit()
 
             # this is needed if an organization goes from `TRACK_EXTERNAL_IDP_EXPIRY=true` to `false`
             # otherwise, the oidc expiry will always be old, and the user will never be able to login
@@ -889,6 +901,18 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 event=MilestoneRecordType.USER_SIGNED_UP,
                 properties=properties,
             )
+
+        # Assign user to the appropriate default group (Admin or Basic).
+        # Use the user_count already fetched above to determine admin status
+        # instead of reading user.role — keeps group assignment role-independent.
+        # Let exceptions propagate — a user without a group has no permissions,
+        # so it's better to surface the error than silently create a broken user.
+        is_admin = user_count == 1 or user.email in get_default_admin_user_emails()
+        with get_session_with_current_tenant() as db_session:
+            assign_user_to_default_groups__no_commit(
+                db_session, user, is_admin=is_admin
+            )
+            db_session.commit()
 
         logger.debug(f"User {user.id} has registered.")
         optional_telemetry(
@@ -1554,6 +1578,7 @@ def get_anonymous_user() -> User:
         is_verified=True,
         is_superuser=False,
         role=UserRole.LIMITED,
+        account_type=AccountType.ANONYMOUS,
         use_memories=False,
         enable_memory_tool=False,
     )

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -277,6 +277,7 @@ class NotificationType(str, Enum):
     RELEASE_NOTES = "release_notes"
     ASSISTANT_FILES_READY = "assistant_files_ready"
     FEATURE_ANNOUNCEMENT = "feature_announcement"
+    USER_GROUP_ASSIGNMENT_FAILED = "user_group_assignment_failed"
 
 
 class BlobType(str, Enum):

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -11,13 +11,18 @@ from onyx.auth.api_key import ApiKeyDescriptor
 from onyx.auth.api_key import build_displayable_api_key
 from onyx.auth.api_key import generate_api_key
 from onyx.auth.api_key import hash_api_key
+from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import UNNAMED_KEY_PLACEHOLDER
+from onyx.db.enums import AccountType
 from onyx.db.models import ApiKey
 from onyx.db.models import User
 from onyx.server.api_key.models import APIKeyArgs
+from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
 
 
 def get_api_key_email_pattern() -> str:
@@ -87,6 +92,7 @@ def insert_api_key(
         is_superuser=False,
         is_verified=True,
         role=api_key_args.role,
+        account_type=AccountType.SERVICE_ACCOUNT,
     )
     db_session.add(api_key_user_row)
 
@@ -99,7 +105,19 @@ def insert_api_key(
     )
     db_session.add(api_key_row)
 
+    # Assign the API key virtual user to the appropriate default group
+    # before commit so everything is atomic.
+    # Late import to avoid circular dependency (api_key <- users <- api_key).
+    from onyx.db.users import assign_user_to_default_groups__no_commit
+
+    assign_user_to_default_groups__no_commit(
+        db_session,
+        api_key_user_row,
+        is_admin=(api_key_args.role == UserRole.ADMIN),
+    )
+
     db_session.commit()
+
     return ApiKeyDescriptor(
         api_key_id=api_key_row.id,
         api_key_role=api_key_user_row.role,

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -107,14 +107,16 @@ def insert_api_key(
 
     # Assign the API key virtual user to the appropriate default group
     # before commit so everything is atomic.
+    # LIMITED role service accounts should have no group membership.
     # Late import to avoid circular dependency (api_key <- users <- api_key).
-    from onyx.db.users import assign_user_to_default_groups__no_commit
+    if api_key_args.role != UserRole.LIMITED:
+        from onyx.db.users import assign_user_to_default_groups__no_commit
 
-    assign_user_to_default_groups__no_commit(
-        db_session,
-        api_key_user_row,
-        is_admin=(api_key_args.role == UserRole.ADMIN),
-    )
+        assign_user_to_default_groups__no_commit(
+            db_session,
+            api_key_user_row,
+            is_admin=(api_key_args.role == UserRole.ADMIN),
+        )
 
     db_session.commit()
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -305,8 +305,8 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     role: Mapped[UserRole] = mapped_column(
         Enum(UserRole, native_enum=False, default=UserRole.BASIC)
     )
-    account_type: Mapped[AccountType | None] = mapped_column(
-        Enum(AccountType, native_enum=False), nullable=True
+    account_type: Mapped[AccountType] = mapped_column(
+        Enum(AccountType, native_enum=False), nullable=False
     )
 
     """

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -306,7 +306,10 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         Enum(UserRole, native_enum=False, default=UserRole.BASIC)
     )
     account_type: Mapped[AccountType] = mapped_column(
-        Enum(AccountType, native_enum=False), nullable=False
+        Enum(AccountType, native_enum=False),
+        nullable=False,
+        default=AccountType.STANDARD,
+        server_default="STANDARD",
     )
 
     """

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4016,7 +4016,12 @@ class PermissionGrant(Base):
         ForeignKey("user_group.id", ondelete="CASCADE"), nullable=False
     )
     permission: Mapped[Permission] = mapped_column(
-        Enum(Permission, native_enum=False), nullable=False
+        Enum(
+            Permission,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=False,
     )
     grant_source: Mapped[GrantSource] = mapped_column(
         Enum(GrantSource, native_enum=False), nullable=False

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -3,6 +3,7 @@ from datetime import timezone
 from uuid import UUID
 
 from sqlalchemy import cast
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
@@ -90,9 +91,18 @@ def get_notifications(
     notif_type: NotificationType | None = None,
     include_dismissed: bool = True,
 ) -> list[Notification]:
-    query = select(Notification).where(
-        Notification.user_id == user.id if user else Notification.user_id.is_(None)
-    )
+    if user is None:
+        user_filter = Notification.user_id.is_(None)
+    elif user.role == UserRole.ADMIN:
+        # Admins see their own notifications AND admin-targeted ones (user_id IS NULL)
+        user_filter = or_(
+            Notification.user_id == user.id,
+            Notification.user_id.is_(None),
+        )
+    else:
+        user_filter = Notification.user_id == user.id
+
+    query = select(Notification).where(user_filter)
     if not include_dismissed:
         query = query.where(Notification.dismissed.is_(False))
     if notif_type:

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -3,7 +3,6 @@ from datetime import timezone
 from uuid import UUID
 
 from sqlalchemy import cast
-from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
@@ -91,18 +90,9 @@ def get_notifications(
     notif_type: NotificationType | None = None,
     include_dismissed: bool = True,
 ) -> list[Notification]:
-    if user is None:
-        user_filter = Notification.user_id.is_(None)
-    elif user.role == UserRole.ADMIN:
-        # Admins see their own notifications AND admin-targeted ones (user_id IS NULL)
-        user_filter = or_(
-            Notification.user_id == user.id,
-            Notification.user_id.is_(None),
-        )
-    else:
-        user_filter = Notification.user_id == user.id
-
-    query = select(Notification).where(user_filter)
+    query = select(Notification).where(
+        Notification.user_id == user.id if user else Notification.user_id.is_(None)
+    )
     if not include_dismissed:
         query = query.where(Notification.dismissed.is_(False))
     if notif_type:

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -313,6 +313,7 @@ def add_slack_user_if_not_exists(db_session: Session, email: str) -> User:
         # If the user is an external permissioned user, we update it to a slack user
         if user.role == UserRole.EXT_PERM_USER:
             user.role = UserRole.SLACK_USER
+            user.account_type = AccountType.BOT
             db_session.commit()
         return user
 
@@ -415,11 +416,11 @@ def assign_user_to_default_groups__no_commit(
     )
 
     if default_group is None:
-        logger.warning(
-            f"No default group found with name='{target_group_name}' "
-            f"for user {user.email}"
+        raise RuntimeError(
+            f"Default group '{target_group_name}' not found. "
+            f"Cannot assign user {user.email} to a group. "
+            f"Ensure the seed_default_groups migration has run."
         )
-        return
 
     # Check if the user is already in the group
     existing = (

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -19,15 +19,21 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
 from onyx.configs.constants import NO_AUTH_PLACEHOLDER_USER_EMAIL
 from onyx.db.api_key import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+from onyx.db.enums import AccountType
+from onyx.db.enums import Permission
 from onyx.db.models import DocumentSet
 from onyx.db.models import DocumentSet__User
+from onyx.db.models import PermissionGrant
 from onyx.db.models import Persona
 from onyx.db.models import Persona__User
 from onyx.db.models import SamlAccount
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
+from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+
+logger = setup_logger()
 
 
 def validate_user_role_update(
@@ -298,6 +304,7 @@ def _generate_slack_user(email: str) -> User:
         email=email,
         hashed_password=hashed_pass,
         role=UserRole.SLACK_USER,
+        account_type=AccountType.BOT,
     )
 
 
@@ -344,6 +351,7 @@ def _generate_ext_permissioned_user(email: str) -> User:
         email=email,
         hashed_password=hashed_pass,
         role=UserRole.EXT_PERM_USER,
+        account_type=AccountType.EXT_PERM_USER,
     )
 
 
@@ -373,6 +381,82 @@ def batch_add_ext_perm_user_if_not_exists(
     # Fetch all users again to ensure we have the most up-to-date list
     all_users, _ = _get_users_by_emails(db_session, lower_emails)
     return all_users
+
+
+def assign_user_to_default_groups__no_commit(
+    db_session: Session,
+    user: User,
+    is_admin: bool = False,
+) -> None:
+    """Assign a newly created user to the appropriate default group.
+
+    Does NOT commit — callers must commit the session themselves so that
+    group assignment can be part of the same transaction as user creation.
+
+    Args:
+        is_admin: If True, assign to Admin default group; otherwise Basic.
+            Callers determine this from their own context (e.g. user_count,
+            admin email list, explicit choice). Defaults to False (Basic).
+    """
+    if user.account_type in (
+        AccountType.BOT,
+        AccountType.EXT_PERM_USER,
+        AccountType.ANONYMOUS,
+    ):
+        return
+
+    target_permission = (
+        Permission.FULL_ADMIN_PANEL_ACCESS if is_admin else Permission.BASIC_ACCESS
+    )
+
+    # Find the default group with the matching permission
+    default_group = (
+        db_session.query(UserGroup)
+        .join(PermissionGrant, PermissionGrant.group_id == UserGroup.id)
+        .filter(
+            UserGroup.is_default.is_(True),
+            PermissionGrant.permission == target_permission,
+            PermissionGrant.is_deleted.is_(False),
+        )
+        .first()
+    )
+
+    if default_group is None:
+        logger.warning(
+            f"No default group found with permission={target_permission.value} "
+            f"for user {user.email}"
+        )
+        return
+
+    # Check if the user is already in the group
+    existing = (
+        db_session.query(User__UserGroup)
+        .filter(
+            User__UserGroup.user_id == user.id,
+            User__UserGroup.user_group_id == default_group.id,
+        )
+        .first()
+    )
+    if existing is not None:
+        return
+
+    savepoint = db_session.begin_nested()
+    try:
+        db_session.add(
+            User__UserGroup(
+                user_id=user.id,
+                user_group_id=default_group.id,
+            )
+        )
+        db_session.flush()
+    except IntegrityError:
+        # Race condition: another transaction inserted this membership
+        # between our SELECT and INSERT. The savepoint isolates the failure
+        # so the outer transaction (user creation) stays intact.
+        savepoint.rollback()
+        return
+
+    logger.info(f"Assigned user {user.email} to default group '{default_group.name}'")
 
 
 def delete_user_from_db(

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -20,10 +20,8 @@ from onyx.configs.constants import ANONYMOUS_USER_EMAIL
 from onyx.configs.constants import NO_AUTH_PLACEHOLDER_USER_EMAIL
 from onyx.db.api_key import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.db.enums import AccountType
-from onyx.db.enums import Permission
 from onyx.db.models import DocumentSet
 from onyx.db.models import DocumentSet__User
-from onyx.db.models import PermissionGrant
 from onyx.db.models import Persona
 from onyx.db.models import Persona__User
 from onyx.db.models import SamlAccount
@@ -405,25 +403,20 @@ def assign_user_to_default_groups__no_commit(
     ):
         return
 
-    target_permission = (
-        Permission.FULL_ADMIN_PANEL_ACCESS if is_admin else Permission.BASIC_ACCESS
-    )
+    target_group_name = "Admin" if is_admin else "Basic"
 
-    # Find the default group with the matching permission
     default_group = (
         db_session.query(UserGroup)
-        .join(PermissionGrant, PermissionGrant.group_id == UserGroup.id)
         .filter(
+            UserGroup.name == target_group_name,
             UserGroup.is_default.is_(True),
-            PermissionGrant.permission == target_permission,
-            PermissionGrant.is_deleted.is_(False),
         )
         .first()
     )
 
     if default_group is None:
         logger.warning(
-            f"No default group found with permission={target_permission.value} "
+            f"No default group found with name='{target_group_name}' "
             f"for user {user.email}"
         )
         return

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -498,13 +498,14 @@ def delete_user_from_db(
 def batch_get_user_groups(
     db_session: Session,
     user_ids: list[UUID],
+    include_default: bool = False,
 ) -> dict[UUID, list[tuple[int, str]]]:
     """Fetch group memberships for a batch of users in a single query.
     Returns a mapping of user_id -> list of (group_id, group_name) tuples."""
     if not user_ids:
         return {}
 
-    rows = db_session.execute(
+    stmt = (
         select(
             User__UserGroup.user_id,
             UserGroup.id,
@@ -512,7 +513,11 @@ def batch_get_user_groups(
         )
         .join(UserGroup, UserGroup.id == User__UserGroup.user_group_id)
         .where(User__UserGroup.user_id.in_(user_ids))
-    ).all()
+    )
+    if not include_default:
+        stmt = stmt.where(UserGroup.is_default == False)  # noqa: E712
+
+    rows = db_session.execute(stmt).all()
 
     result: dict[UUID, list[tuple[int, str]]] = {uid: [] for uid in user_ids}
     for user_id, group_id, group_name in rows:

--- a/backend/onyx/server/models.py
+++ b/backend/onyx/server/models.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
 from onyx.db.models import User
 
 
@@ -41,6 +42,7 @@ class FullUserSnapshot(BaseModel):
     id: UUID
     email: str
     role: UserRole
+    account_type: AccountType
     is_active: bool
     password_configured: bool
     personal_name: str | None
@@ -60,6 +62,7 @@ class FullUserSnapshot(BaseModel):
             id=user.id,
             email=user.email,
             role=user.role,
+            account_type=user.account_type,
             is_active=user.is_active,
             password_configured=user.password_configured,
             personal_name=user.personal_name,

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccountType
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.file_store.file_store import get_default_file_store
@@ -52,7 +53,12 @@ def tenant_context() -> Generator[None, None, None]:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
-def create_test_user(db_session: Session, email_prefix: str) -> User:
+def create_test_user(
+    db_session: Session,
+    email_prefix: str,
+    role: UserRole = UserRole.BASIC,
+    account_type: AccountType = AccountType.STANDARD,
+) -> User:
     """Helper to create a test user with a unique email"""
     # Use UUID to ensure unique email addresses
     unique_email = f"{email_prefix}_{uuid4().hex[:8]}@example.com"
@@ -68,7 +74,8 @@ def create_test_user(db_session: Session, email_prefix: str) -> User:
         is_active=True,
         is_superuser=False,
         is_verified=True,
-        role=UserRole.EXT_PERM_USER,
+        role=role,
+        account_type=account_type,
     )
     db_session.add(user)
     db_session.commit()

--- a/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
+++ b/backend/tests/external_dependency_unit/connectors/google_drive/test_google_drive_group_sync.py
@@ -13,14 +13,27 @@ from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
+from onyx.db.enums import AccountType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import PublicExternalUserGroup
+from onyx.db.models import User
 from onyx.db.models import User__ExternalUserGroupId
+from onyx.db.models import UserRole
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+def _create_ext_perm_user(db_session: Session, name: str) -> User:
+    """Create an external-permission user for group sync tests."""
+    return create_test_user(
+        db_session,
+        name,
+        role=UserRole.EXT_PERM_USER,
+        account_type=AccountType.EXT_PERM_USER,
+    )
 
 
 def _create_test_connector_credential_pair(
@@ -100,9 +113,9 @@ class TestPerformExternalGroupSync:
     def test_initial_group_sync(self, db_session: Session) -> None:
         """Test syncing external groups for the first time (initial sync)"""
         # Create test data
-        user1 = create_test_user(db_session, "user1")
-        user2 = create_test_user(db_session, "user2")
-        user3 = create_test_user(db_session, "user3")
+        user1 = _create_ext_perm_user(db_session, "user1")
+        user2 = _create_ext_perm_user(db_session, "user2")
+        user3 = _create_ext_perm_user(db_session, "user3")
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         # Mock external groups data as a generator that yields the expected groups
@@ -175,9 +188,9 @@ class TestPerformExternalGroupSync:
     def test_update_existing_groups(self, db_session: Session) -> None:
         """Test updating existing groups (adding/removing users)"""
         # Create test data
-        user1 = create_test_user(db_session, "user1")
-        user2 = create_test_user(db_session, "user2")
-        user3 = create_test_user(db_session, "user3")
+        user1 = _create_ext_perm_user(db_session, "user1")
+        user2 = _create_ext_perm_user(db_session, "user2")
+        user3 = _create_ext_perm_user(db_session, "user3")
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         # Initial sync with original groups
@@ -272,8 +285,8 @@ class TestPerformExternalGroupSync:
     def test_remove_groups(self, db_session: Session) -> None:
         """Test removing groups (groups that no longer exist in external system)"""
         # Create test data
-        user1 = create_test_user(db_session, "user1")
-        user2 = create_test_user(db_session, "user2")
+        user1 = _create_ext_perm_user(db_session, "user1")
+        user2 = _create_ext_perm_user(db_session, "user2")
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         # Initial sync with multiple groups
@@ -357,7 +370,7 @@ class TestPerformExternalGroupSync:
     def test_empty_group_sync(self, db_session: Session) -> None:
         """Test syncing when no groups are returned (all groups removed)"""
         # Create test data
-        user1 = create_test_user(db_session, "user1")
+        user1 = _create_ext_perm_user(db_session, "user1")
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         # Initial sync with groups
@@ -413,7 +426,7 @@ class TestPerformExternalGroupSync:
         # Create many test users
         users = []
         for i in range(150):  # More than the batch size of 100
-            users.append(create_test_user(db_session, f"user{i}"))
+            users.append(_create_ext_perm_user(db_session, f"user{i}"))
 
         cc_pair = _create_test_connector_credential_pair(db_session)
 
@@ -452,8 +465,8 @@ class TestPerformExternalGroupSync:
     def test_mixed_regular_and_public_groups(self, db_session: Session) -> None:
         """Test syncing a mix of regular and public groups"""
         # Create test data
-        user1 = create_test_user(db_session, "user1")
-        user2 = create_test_user(db_session, "user2")
+        user1 = _create_ext_perm_user(db_session, "user1")
+        user2 = _create_ext_perm_user(db_session, "user2")
         cc_pair = _create_test_connector_credential_pair(db_session)
 
         def mixed_group_sync_func(

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.enums import AccountType
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import BuildSession
 from onyx.db.models import User
@@ -52,6 +53,7 @@ def test_user(db_session: Session, tenant_context: None) -> User:  # noqa: ARG00
         is_superuser=False,
         is_verified=True,
         role=UserRole.EXT_PERM_USER,
+        account_type=AccountType.EXT_PERM_USER,
     )
     db_session.add(user)
     db_session.commit()

--- a/backend/tests/external_dependency_unit/db/test_user_account_type.py
+++ b/backend/tests/external_dependency_unit/db/test_user_account_type.py
@@ -1,0 +1,54 @@
+"""
+Tests that account_type is correctly set when creating users through
+the internal DB functions: add_slack_user_if_not_exists and
+batch_add_ext_perm_user_if_not_exists.
+
+These functions are called by background workers (Slack bot, permission sync)
+and are not exposed via API endpoints, so they must be tested directly.
+"""
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import AccountType
+from onyx.db.models import UserRole
+from onyx.db.users import add_slack_user_if_not_exists
+from onyx.db.users import batch_add_ext_perm_user_if_not_exists
+
+
+def test_slack_user_creation_sets_account_type_bot(db_session: Session) -> None:
+    """add_slack_user_if_not_exists sets account_type=BOT and role=SLACK_USER."""
+    user = add_slack_user_if_not_exists(db_session, "slack_acct_type@test.com")
+
+    assert user.role == UserRole.SLACK_USER
+    assert user.account_type == AccountType.BOT
+
+
+def test_ext_perm_user_creation_sets_account_type(db_session: Session) -> None:
+    """batch_add_ext_perm_user_if_not_exists sets account_type=EXT_PERM_USER."""
+    users = batch_add_ext_perm_user_if_not_exists(
+        db_session, ["extperm_acct_type@test.com"]
+    )
+
+    assert len(users) == 1
+    user = users[0]
+    assert user.role == UserRole.EXT_PERM_USER
+    assert user.account_type == AccountType.EXT_PERM_USER
+
+
+def test_ext_perm_to_slack_upgrade_updates_role(db_session: Session) -> None:
+    """When an EXT_PERM_USER is upgraded to slack, role becomes SLACK_USER.
+
+    Note: currently account_type is NOT updated during this upgrade path —
+    it remains EXT_PERM_USER. This test documents the current behaviour.
+    """
+    email = "ext_to_slack_acct_type@test.com"
+
+    # Create as ext_perm user first
+    batch_add_ext_perm_user_if_not_exists(db_session, [email])
+
+    # Now "upgrade" via slack path
+    user = add_slack_user_if_not_exists(db_session, email)
+
+    assert user.role == UserRole.SLACK_USER
+    # Documents current gap: account_type stays EXT_PERM_USER after upgrade
+    assert user.account_type == AccountType.EXT_PERM_USER

--- a/backend/tests/external_dependency_unit/db/test_user_account_type.py
+++ b/backend/tests/external_dependency_unit/db/test_user_account_type.py
@@ -35,12 +35,10 @@ def test_ext_perm_user_creation_sets_account_type(db_session: Session) -> None:
     assert user.account_type == AccountType.EXT_PERM_USER
 
 
-def test_ext_perm_to_slack_upgrade_updates_role(db_session: Session) -> None:
-    """When an EXT_PERM_USER is upgraded to slack, role becomes SLACK_USER.
-
-    Note: currently account_type is NOT updated during this upgrade path —
-    it remains EXT_PERM_USER. This test documents the current behaviour.
-    """
+def test_ext_perm_to_slack_upgrade_updates_role_and_account_type(
+    db_session: Session,
+) -> None:
+    """When an EXT_PERM_USER is upgraded to slack, both role and account_type update."""
     email = "ext_to_slack_acct_type@test.com"
 
     # Create as ext_perm user first
@@ -50,5 +48,4 @@ def test_ext_perm_to_slack_upgrade_updates_role(db_session: Session) -> None:
     user = add_slack_user_if_not_exists(db_session, email)
 
     assert user.role == UserRole.SLACK_USER
-    # Documents current gap: account_type stays EXT_PERM_USER after upgrade
-    assert user.account_type == AccountType.EXT_PERM_USER
+    assert user.account_type == AccountType.BOT

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_called.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_called.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi_users.password import PasswordHelper
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import AccountType
 from onyx.db.llm import fetch_existing_llm_provider
 from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import update_default_provider
@@ -46,6 +47,7 @@ def _create_admin(db_session: Session) -> User:
         is_superuser=True,
         is_verified=True,
         role=UserRole.ADMIN,
+        account_type=AccountType.STANDARD,
     )
     db_session.add(user)
     db_session.commit()

--- a/backend/tests/integration/common_utils/managers/user_group.py
+++ b/backend/tests/integration/common_utils/managers/user_group.py
@@ -107,10 +107,15 @@ class UserGroupManager:
     @staticmethod
     def get_all(
         user_performing_action: DATestUser,
+        include_default: bool = False,
     ) -> list[UserGroup]:
+        params: dict[str, str] = {}
+        if include_default:
+            params["include_default"] = "true"
         response = requests.get(
             f"{API_SERVER_URL}/manage/admin/user-group",
             headers=user_performing_action.headers,
+            params=params,
         )
         response.raise_for_status()
         return [UserGroup(**ug) for ug in response.json()]

--- a/backend/tests/integration/tests/api_key/test_api_key.py
+++ b/backend/tests/integration/tests/api_key/test_api_key.py
@@ -1,9 +1,13 @@
+from uuid import UUID
+
 import requests
 
 from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -33,3 +37,120 @@ def test_limited(reset: None) -> None:  # noqa: ARG001
         headers=api_key.headers,
     )
     assert response.status_code == 403
+
+
+def _get_service_account_account_type(
+    admin_user: DATestUser,
+    api_key_user_id: UUID,
+) -> AccountType:
+    """Fetch the account_type of a service account user via the user listing API."""
+    response = requests.get(
+        f"{API_SERVER_URL}/manage/users",
+        headers=admin_user.headers,
+        params={"include_api_keys": "true"},
+    )
+    response.raise_for_status()
+    data = response.json()
+    user_id_str = str(api_key_user_id)
+    for user in data["accepted"]:
+        if user["id"] == user_id_str:
+            return AccountType(user["account_type"])
+    raise AssertionError(
+        f"Service account user {user_id_str} not found in user listing"
+    )
+
+
+def _get_default_group_user_ids(
+    admin_user: DATestUser,
+) -> tuple[set[str], set[str]]:
+    """Return (admin_group_user_ids, basic_group_user_ids) from default groups."""
+    all_groups = UserGroupManager.get_all(
+        user_performing_action=admin_user,
+        include_default=True,
+    )
+    admin_group = next(
+        (g for g in all_groups if g.name == "Admin" and g.is_default), None
+    )
+    basic_group = next(
+        (g for g in all_groups if g.name == "Basic" and g.is_default), None
+    )
+    assert admin_group is not None, "Admin default group not found"
+    assert basic_group is not None, "Basic default group not found"
+
+    admin_ids = {str(u.id) for u in admin_group.users}
+    basic_ids = {str(u.id) for u in basic_group.users}
+    return admin_ids, basic_ids
+
+
+def test_api_key_limited_service_account(reset: None) -> None:  # noqa: ARG001
+    """LIMITED role API key: account_type is SERVICE_ACCOUNT, no group membership."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    api_key: DATestAPIKey = APIKeyManager.create(
+        api_key_role=UserRole.LIMITED,
+        user_performing_action=admin_user,
+    )
+
+    # Verify account_type
+    account_type = _get_service_account_account_type(admin_user, api_key.user_id)
+    assert (
+        account_type == AccountType.SERVICE_ACCOUNT
+    ), f"Expected account_type={AccountType.SERVICE_ACCOUNT}, got {account_type}"
+
+    # Verify no group membership
+    admin_ids, basic_ids = _get_default_group_user_ids(admin_user)
+    user_id_str = str(api_key.user_id)
+    assert (
+        user_id_str not in admin_ids
+    ), "LIMITED API key should NOT be in Admin default group"
+    assert (
+        user_id_str not in basic_ids
+    ), "LIMITED API key should NOT be in Basic default group"
+
+
+def test_api_key_basic_service_account(reset: None) -> None:  # noqa: ARG001
+    """BASIC role API key: account_type is SERVICE_ACCOUNT, in Basic group only."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    api_key: DATestAPIKey = APIKeyManager.create(
+        api_key_role=UserRole.BASIC,
+        user_performing_action=admin_user,
+    )
+
+    # Verify account_type
+    account_type = _get_service_account_account_type(admin_user, api_key.user_id)
+    assert (
+        account_type == AccountType.SERVICE_ACCOUNT
+    ), f"Expected account_type={AccountType.SERVICE_ACCOUNT}, got {account_type}"
+
+    # Verify Basic group membership
+    admin_ids, basic_ids = _get_default_group_user_ids(admin_user)
+    user_id_str = str(api_key.user_id)
+    assert user_id_str in basic_ids, "BASIC API key should be in Basic default group"
+    assert (
+        user_id_str not in admin_ids
+    ), "BASIC API key should NOT be in Admin default group"
+
+
+def test_api_key_admin_service_account(reset: None) -> None:  # noqa: ARG001
+    """ADMIN role API key: account_type is SERVICE_ACCOUNT, in Admin group only."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    api_key: DATestAPIKey = APIKeyManager.create(
+        api_key_role=UserRole.ADMIN,
+        user_performing_action=admin_user,
+    )
+
+    # Verify account_type
+    account_type = _get_service_account_account_type(admin_user, api_key.user_id)
+    assert (
+        account_type == AccountType.SERVICE_ACCOUNT
+    ), f"Expected account_type={AccountType.SERVICE_ACCOUNT}, got {account_type}"
+
+    # Verify Admin group membership
+    admin_ids, basic_ids = _get_default_group_user_ids(admin_user)
+    user_id_str = str(api_key.user_id)
+    assert user_id_str in admin_ids, "ADMIN API key should be in Admin default group"
+    assert (
+        user_id_str not in basic_ids
+    ), "ADMIN API key should NOT be in Basic default group"

--- a/backend/tests/integration/tests/auth/test_saml_user_conversion.py
+++ b/backend/tests/integration/tests/auth/test_saml_user_conversion.py
@@ -6,6 +6,7 @@ import requests
 from onyx.auth.schemas import UserRole
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -95,3 +96,63 @@ def test_saml_user_conversion(reset: None) -> None:  # noqa: ARG001
 
     # Verify the user's role was changed in the database
     assert UserManager.is_role(slack_user, UserRole.BASIC)
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="SAML tests are enterprise only",
+)
+def test_saml_user_conversion_sets_account_type_and_group(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """
+    Test that SAML login sets account_type to STANDARD when converting a
+    non-web user (EXT_PERM_USER) and that the user receives the correct role
+    (BASIC) after conversion.
+
+    This validates the permissions-migration-phase2 changes which ensure that:
+    1. account_type is updated to 'standard' on SAML conversion
+    2. The converted user is assigned to the Basic default group
+    """
+    # Create an admin user (first user is automatically admin)
+    admin_user: DATestUser = UserManager.create(email="admin@example.com")
+
+    # Create a user and set them as EXT_PERM_USER
+    test_email = "ext_convert@example.com"
+    test_user = UserManager.create(email=test_email)
+    UserManager.set_role(
+        user_to_set=test_user,
+        target_role=UserRole.EXT_PERM_USER,
+        user_performing_action=admin_user,
+        explicit_override=True,
+    )
+    assert UserManager.is_role(test_user, UserRole.EXT_PERM_USER)
+
+    # Simulate SAML login
+    response = requests.post(
+        f"{API_SERVER_URL}/manage/users/test-upsert-user",
+        json={"email": test_email},
+        headers=admin_user.headers,
+    )
+    response.raise_for_status()
+    user_data = response.json()
+
+    # Verify account_type is set to standard after conversion
+    assert (
+        user_data["account_type"] == "standard"
+    ), f"Expected account_type='standard', got '{user_data['account_type']}'"
+
+    # Verify role is BASIC after conversion
+    assert user_data["role"] == UserRole.BASIC.value
+
+    # Verify the user was assigned to the Basic default group
+    all_groups = UserGroupManager.get_all(admin_user, include_default=True)
+    basic_default = [g for g in all_groups if g.is_default and g.name == "Basic"]
+    assert basic_default, "Basic default group not found"
+
+    basic_group = basic_default[0]
+    member_emails = {u.email for u in basic_group.users}
+    assert test_email in member_emails, (
+        f"Converted user '{test_email}' not found in Basic default group members: "
+        f"{member_emails}"
+    )

--- a/backend/tests/integration/tests/scim/test_scim_users.py
+++ b/backend/tests/integration/tests/scim/test_scim_users.py
@@ -35,9 +35,16 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.app_configs import REDIS_DB_NUMBER
 from onyx.configs.app_configs import REDIS_HOST
 from onyx.configs.app_configs import REDIS_PORT
+from onyx.db.enums import AccountType
 from onyx.server.settings.models import ApplicationStatus
+from tests.integration.common_utils.constants import ADMIN_USER_NAME
+from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.scim_client import ScimClient
 from tests.integration.common_utils.managers.scim_token import ScimTokenManager
+from tests.integration.common_utils.managers.user import build_email
+from tests.integration.common_utils.managers.user import DEFAULT_PASSWORD
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
 
 
 SCIM_USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
@@ -209,6 +216,49 @@ def test_create_user(scim_token: str, idp_style: str) -> None:
     if idp_style == "entra":
         _assert_entra_extension(body)
         _assert_entra_emails(body, email)
+
+
+def test_create_user_default_group_and_account_type(
+    scim_token: str, idp_style: str
+) -> None:
+    """SCIM-provisioned users get Basic default group and STANDARD account_type."""
+    email = f"scim_defaults_{idp_style}@example.com"
+    ext_id = f"ext-defaults-{idp_style}"
+    resp = _create_scim_user(scim_token, email, ext_id, idp_style)
+    assert resp.status_code == 201
+    user_id = resp.json()["id"]
+
+    # --- Verify group assignment via SCIM GET ---
+    get_resp = ScimClient.get(f"/Users/{user_id}", scim_token)
+    assert get_resp.status_code == 200
+    groups = get_resp.json().get("groups", [])
+    group_names = {g["display"] for g in groups}
+    assert "Basic" in group_names, f"Expected 'Basic' in groups, got {group_names}"
+    assert "Admin" not in group_names, "SCIM user should not be in Admin group"
+
+    # --- Verify account_type via admin API ---
+    admin = UserManager.login_as_user(
+        DATestUser(
+            id="",
+            email=build_email(ADMIN_USER_NAME),
+            password=DEFAULT_PASSWORD,
+            headers=GENERAL_HEADERS,
+            role=UserRole.ADMIN,
+            is_active=True,
+        )
+    )
+    page = UserManager.get_user_page(
+        user_performing_action=admin,
+        search_query=email,
+    )
+    assert page.total_items >= 1
+    scim_user_snapshot = next((u for u in page.items if u.email == email), None)
+    assert (
+        scim_user_snapshot is not None
+    ), f"SCIM user {email} not found in user listing"
+    assert (
+        scim_user_snapshot.account_type == AccountType.STANDARD
+    ), f"Expected STANDARD, got {scim_user_snapshot.account_type}"
 
 
 def test_get_user(scim_token: str, idp_style: str) -> None:

--- a/backend/tests/integration/tests/users/test_default_group_assignment.py
+++ b/backend/tests/integration/tests/users/test_default_group_assignment.py
@@ -1,0 +1,78 @@
+"""Integration tests for default group assignment on user registration.
+
+Verifies that:
+- The first registered user is assigned to the Admin default group
+- Subsequent registered users are assigned to the Basic default group
+- account_type is set to STANDARD for email/password registrations
+"""
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_default_group_assignment_on_registration(reset: None) -> None:  # noqa: ARG001
+    # Register first user — should become admin
+    admin_user: DATestUser = UserManager.create(name="first_user")
+    assert admin_user.role == UserRole.ADMIN
+
+    # Register second user — should become basic
+    basic_user: DATestUser = UserManager.create(name="second_user")
+    assert basic_user.role == UserRole.BASIC
+
+    # Fetch all groups including default ones
+    all_groups = UserGroupManager.get_all(
+        user_performing_action=admin_user,
+        include_default=True,
+    )
+
+    # Find the default Admin and Basic groups
+    admin_group = next(
+        (g for g in all_groups if g.name == "Admin" and g.is_default), None
+    )
+    basic_group = next(
+        (g for g in all_groups if g.name == "Basic" and g.is_default), None
+    )
+    assert admin_group is not None, "Admin default group not found"
+    assert basic_group is not None, "Basic default group not found"
+
+    # Verify admin user is in Admin group and NOT in Basic group
+    admin_group_user_ids = {str(u.id) for u in admin_group.users}
+    basic_group_user_ids = {str(u.id) for u in basic_group.users}
+
+    assert (
+        admin_user.id in admin_group_user_ids
+    ), "First user should be in Admin default group"
+    assert (
+        admin_user.id not in basic_group_user_ids
+    ), "First user should NOT be in Basic default group"
+
+    # Verify basic user is in Basic group and NOT in Admin group
+    assert (
+        basic_user.id in basic_group_user_ids
+    ), "Second user should be in Basic default group"
+    assert (
+        basic_user.id not in admin_group_user_ids
+    ), "Second user should NOT be in Admin default group"
+
+    # Verify account_type is STANDARD for both users via user listing API
+    paginated_result = UserManager.get_user_page(
+        user_performing_action=admin_user,
+        page_num=0,
+        page_size=10,
+    )
+    users_by_id = {str(u.id): u for u in paginated_result.items}
+
+    admin_snapshot = users_by_id.get(admin_user.id)
+    basic_snapshot = users_by_id.get(basic_user.id)
+    assert admin_snapshot is not None, "Admin user not found in user listing"
+    assert basic_snapshot is not None, "Basic user not found in user listing"
+
+    assert (
+        admin_snapshot.account_type == AccountType.STANDARD
+    ), f"Admin user account_type should be STANDARD, got {admin_snapshot.account_type}"
+    assert (
+        basic_snapshot.account_type == AccountType.STANDARD
+    ), f"Basic user account_type should be STANDARD, got {basic_snapshot.account_type}"

--- a/backend/tests/unit/onyx/auth/test_user_create_schema.py
+++ b/backend/tests/unit/onyx/auth/test_user_create_schema.py
@@ -2,7 +2,7 @@
 Unit tests for UserCreate schema dict methods.
 
 Verifies that account_type is always included in create_update_dict
-and create_update_dict_superuser, and that captcha_token is excluded.
+and create_update_dict_superuser.
 """
 
 from onyx.auth.schemas import UserCreate

--- a/backend/tests/unit/onyx/auth/test_user_create_schema.py
+++ b/backend/tests/unit/onyx/auth/test_user_create_schema.py
@@ -1,0 +1,29 @@
+"""
+Unit tests for UserCreate schema dict methods.
+
+Verifies that account_type is always included in create_update_dict
+and create_update_dict_superuser, and that captcha_token is excluded.
+"""
+
+from onyx.auth.schemas import UserCreate
+from onyx.db.enums import AccountType
+
+
+def test_create_update_dict_includes_default_account_type() -> None:
+    uc = UserCreate(email="a@b.com", password="secret123")
+    d = uc.create_update_dict()
+    assert d["account_type"] == AccountType.STANDARD
+
+
+def test_create_update_dict_includes_explicit_account_type() -> None:
+    uc = UserCreate(
+        email="a@b.com", password="secret123", account_type=AccountType.SERVICE_ACCOUNT
+    )
+    d = uc.create_update_dict()
+    assert d["account_type"] == AccountType.SERVICE_ACCOUNT
+
+
+def test_create_update_dict_superuser_includes_account_type() -> None:
+    uc = UserCreate(email="a@b.com", password="secret123")
+    d = uc.create_update_dict_superuser()
+    assert d["account_type"] == AccountType.STANDARD

--- a/backend/tests/unit/onyx/db/test_assign_default_groups.py
+++ b/backend/tests/unit/onyx/db/test_assign_default_groups.py
@@ -4,14 +4,13 @@ Unit tests for assign_user_to_default_groups__no_commit in onyx.db.users.
 Covers:
 1. Standard/service-account users get assigned to the correct default group
 2. BOT, EXT_PERM_USER, ANONYMOUS account types are skipped
-3. Missing default group logs a warning and returns
+3. Missing default group raises RuntimeError
 4. Already-in-group is a no-op
 5. IntegrityError race condition is handled gracefully
 6. The function never commits the session
 """
 
 from unittest.mock import MagicMock
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -129,17 +128,12 @@ def test_service_account_not_skipped() -> None:
     db_session.add.assert_called_once()
 
 
-@patch("onyx.db.users.logger")
-def test_missing_default_group_logs_warning(mock_logger: MagicMock) -> None:
+def test_missing_default_group_raises_error() -> None:
     db_session = _setup_db_session(group_result=None)
     user = _mock_user()
 
-    assign_user_to_default_groups__no_commit(db_session, user)
-
-    mock_logger.warning.assert_called_once()
-    warning_msg = mock_logger.warning.call_args[0][0]
-    assert "No default group found" in warning_msg
-    db_session.add.assert_not_called()
+    with pytest.raises(RuntimeError, match="Default group .* not found"):
+        assign_user_to_default_groups__no_commit(db_session, user)
 
 
 def test_already_in_group_is_noop() -> None:

--- a/backend/tests/unit/onyx/db/test_assign_default_groups.py
+++ b/backend/tests/unit/onyx/db/test_assign_default_groups.py
@@ -161,7 +161,7 @@ def test_integrity_error_race_condition_handled() -> None:
     db_session = _setup_db_session(group_result=group, membership_result=None)
     savepoint = MagicMock()
     db_session.begin_nested.return_value = savepoint
-    db_session.flush.side_effect = IntegrityError(None, None, None)
+    db_session.flush.side_effect = IntegrityError(None, None, Exception("duplicate"))
     user = _mock_user()
 
     # Should not raise

--- a/backend/tests/unit/onyx/db/test_assign_default_groups.py
+++ b/backend/tests/unit/onyx/db/test_assign_default_groups.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for assign_user_to_default_groups__no_commit in onyx.db.users.
+
+Covers:
+1. Standard/service-account users get assigned to the correct default group
+2. BOT, EXT_PERM_USER, ANONYMOUS account types are skipped
+3. Missing default group logs a warning and returns
+4. Already-in-group is a no-op
+5. IntegrityError race condition is handled gracefully
+6. The function never commits the session
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from onyx.db.enums import AccountType
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
+from onyx.db.users import assign_user_to_default_groups__no_commit
+
+
+def _mock_user(
+    account_type: AccountType = AccountType.STANDARD,
+    email: str = "test@example.com",
+) -> MagicMock:
+    user = MagicMock()
+    user.id = uuid4()
+    user.email = email
+    user.account_type = account_type
+    return user
+
+
+def _mock_group(name: str = "Basic", group_id: int = 1) -> MagicMock:
+    group = MagicMock()
+    group.id = group_id
+    group.name = name
+    group.is_default = True
+    return group
+
+
+def _make_query_chain(first_return: object = None) -> MagicMock:
+    """Returns a mock that supports .filter(...).filter(...).first() chaining."""
+    chain = MagicMock()
+    chain.filter.return_value = chain
+    chain.first.return_value = first_return
+    return chain
+
+
+def _setup_db_session(
+    group_result: object = None,
+    membership_result: object = None,
+) -> MagicMock:
+    """Create a db_session mock that routes query(UserGroup) and query(User__UserGroup)."""
+    db_session = MagicMock()
+
+    group_chain = _make_query_chain(group_result)
+    membership_chain = _make_query_chain(membership_result)
+
+    def query_side_effect(model: type) -> MagicMock:
+        if model is UserGroup:
+            return group_chain
+        if model is User__UserGroup:
+            return membership_chain
+        return MagicMock()
+
+    db_session.query.side_effect = query_side_effect
+    return db_session
+
+
+def test_standard_user_assigned_to_basic_group() -> None:
+    group = _mock_group("Basic")
+    db_session = _setup_db_session(group_result=group, membership_result=None)
+    savepoint = MagicMock()
+    db_session.begin_nested.return_value = savepoint
+    user = _mock_user(AccountType.STANDARD)
+
+    assign_user_to_default_groups__no_commit(db_session, user, is_admin=False)
+
+    db_session.add.assert_called_once()
+    added = db_session.add.call_args[0][0]
+    assert isinstance(added, User__UserGroup)
+    assert added.user_id == user.id
+    assert added.user_group_id == group.id
+    db_session.flush.assert_called_once()
+
+
+def test_admin_user_assigned_to_admin_group() -> None:
+    group = _mock_group("Admin", group_id=2)
+    db_session = _setup_db_session(group_result=group, membership_result=None)
+    savepoint = MagicMock()
+    db_session.begin_nested.return_value = savepoint
+    user = _mock_user(AccountType.STANDARD)
+
+    assign_user_to_default_groups__no_commit(db_session, user, is_admin=True)
+
+    db_session.add.assert_called_once()
+    added = db_session.add.call_args[0][0]
+    assert isinstance(added, User__UserGroup)
+    assert added.user_group_id == group.id
+
+
+@pytest.mark.parametrize(
+    "account_type",
+    [AccountType.BOT, AccountType.EXT_PERM_USER, AccountType.ANONYMOUS],
+)
+def test_excluded_account_types_skipped(account_type: AccountType) -> None:
+    db_session = MagicMock()
+    user = _mock_user(account_type)
+
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+    db_session.query.assert_not_called()
+    db_session.add.assert_not_called()
+
+
+def test_service_account_not_skipped() -> None:
+    group = _mock_group("Basic")
+    db_session = _setup_db_session(group_result=group, membership_result=None)
+    savepoint = MagicMock()
+    db_session.begin_nested.return_value = savepoint
+    user = _mock_user(AccountType.SERVICE_ACCOUNT)
+
+    assign_user_to_default_groups__no_commit(db_session, user, is_admin=False)
+
+    db_session.add.assert_called_once()
+
+
+@patch("onyx.db.users.logger")
+def test_missing_default_group_logs_warning(mock_logger: MagicMock) -> None:
+    db_session = _setup_db_session(group_result=None)
+    user = _mock_user()
+
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+    mock_logger.warning.assert_called_once()
+    warning_msg = mock_logger.warning.call_args[0][0]
+    assert "No default group found" in warning_msg
+    db_session.add.assert_not_called()
+
+
+def test_already_in_group_is_noop() -> None:
+    group = _mock_group("Basic")
+    existing_membership = MagicMock()
+    db_session = _setup_db_session(
+        group_result=group, membership_result=existing_membership
+    )
+    user = _mock_user()
+
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+    db_session.add.assert_not_called()
+    db_session.begin_nested.assert_not_called()
+
+
+def test_integrity_error_race_condition_handled() -> None:
+    group = _mock_group("Basic")
+    db_session = _setup_db_session(group_result=group, membership_result=None)
+    savepoint = MagicMock()
+    db_session.begin_nested.return_value = savepoint
+    db_session.flush.side_effect = IntegrityError(None, None, None)
+    user = _mock_user()
+
+    # Should not raise
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+    savepoint.rollback.assert_called_once()
+
+
+def test_no_commit_called_on_successful_assignment() -> None:
+    group = _mock_group("Basic")
+    db_session = _setup_db_session(group_result=group, membership_result=None)
+    savepoint = MagicMock()
+    db_session.begin_nested.return_value = savepoint
+    user = _mock_user()
+
+    assign_user_to_default_groups__no_commit(db_session, user)
+
+    db_session.commit.assert_not_called()

--- a/backend/tests/unit/onyx/server/test_full_user_snapshot.py
+++ b/backend/tests/unit/onyx/server/test_full_user_snapshot.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
 from onyx.server.models import FullUserSnapshot
 from onyx.server.models import UserGroupInfo
 
@@ -25,6 +26,7 @@ def _mock_user(
     user.updated_at = updated_at or datetime.datetime(
         2025, 6, 15, tzinfo=datetime.timezone.utc
     )
+    user.account_type = AccountType.STANDARD
     return user
 
 

--- a/web/src/hooks/useAdminUsers.ts
+++ b/web/src/hooks/useAdminUsers.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
-import { UserStatus } from "@/lib/types";
+import { AccountType, UserStatus } from "@/lib/types";
 import type { UserRole, InvitedUserSnapshot } from "@/lib/types";
 import type {
   UserRow,
@@ -19,12 +19,7 @@ interface FullUserSnapshot {
   id: string;
   email: string;
   role: UserRole;
-  account_type:
-    | "standard"
-    | "bot"
-    | "ext_perm_user"
-    | "service_account"
-    | "anonymous";
+  account_type: AccountType;
   is_active: boolean;
   password_configured: boolean;
   personal_name: string | null;

--- a/web/src/hooks/useAdminUsers.ts
+++ b/web/src/hooks/useAdminUsers.ts
@@ -19,6 +19,12 @@ interface FullUserSnapshot {
   id: string;
   email: string;
   role: UserRole;
+  account_type:
+    | "standard"
+    | "bot"
+    | "ext_perm_user"
+    | "service_account"
+    | "anonymous";
   is_active: boolean;
   password_configured: boolean;
   personal_name: string | null;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -479,6 +479,7 @@ export interface UserGroup {
   personas: Persona[];
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
+  is_default: boolean;
 }
 
 export enum ValidSources {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,6 +52,14 @@ export interface UserPersonalization {
   user_preferences: string;
 }
 
+export enum AccountType {
+  STANDARD = "standard",
+  BOT = "bot",
+  EXT_PERM_USER = "ext_perm_user",
+  SERVICE_ACCOUNT = "service_account",
+  ANONYMOUS = "anonymous",
+}
+
 export enum UserRole {
   LIMITED = "limited",
   BASIC = "basic",

--- a/web/src/refresh-pages/admin/GroupsPage/utils.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/utils.ts
@@ -1,10 +1,8 @@
 import type { UserGroup } from "@/lib/types";
 
-/** Groups that are created by the system and cannot be deleted. */
-export const BUILT_IN_GROUP_NAMES = ["Basic", "Admin"] as const;
-
+/** Whether this group is a system default group (Admin, Basic). */
 export function isBuiltInGroup(group: UserGroup): boolean {
-  return (BUILT_IN_GROUP_NAMES as readonly string[]).includes(group.name);
+  return group.is_default;
 }
 
 /** Human-readable description for built-in groups. */

--- a/web/tests/e2e/admin/groups/groups.spec.ts
+++ b/web/tests/e2e/admin/groups/groups.spec.ts
@@ -79,8 +79,9 @@ test.describe("Groups page — layout", () => {
   test("shows built-in groups (Admin, Basic)", async ({ groupsPage }) => {
     await groupsPage.goto();
 
-    await groupsPage.expectGroupVisible("Admin");
-    await groupsPage.expectGroupVisible("Basic");
+    //will be uncommented once the group permissions are implemented.
+    // await groupsPage.expectGroupVisible("Admin");
+    // await groupsPage.expectGroupVisible("Basic");
   });
 
   test("search filters groups by name", async ({ groupsPage, api }) => {

--- a/web/tests/e2e/admin/groups/groups.spec.ts
+++ b/web/tests/e2e/admin/groups/groups.spec.ts
@@ -53,19 +53,18 @@ test.describe("Groups page — layout", () => {
 
   test.beforeAll(async ({ browser }) => {
     await withApiContext(browser, async (api) => {
-      adminGroupId = await api.createUserGroup("Admin");
-      basicGroupId = await api.createUserGroup("Basic");
-      await api.waitForGroupSync(adminGroupId);
-      await api.waitForGroupSync(basicGroupId);
+      const groups = await api.getUserGroups();
+      const adminGroup = groups.find((g) => g.name === "Admin" && g.is_default);
+      const basicGroup = groups.find((g) => g.name === "Basic" && g.is_default);
+      if (!adminGroup || !basicGroup) {
+        throw new Error("Default Admin/Basic groups not found");
+      }
+      adminGroupId = adminGroup.id;
+      basicGroupId = basicGroup.id;
     });
   });
 
-  test.afterAll(async ({ browser }) => {
-    await withApiContext(browser, async (api) => {
-      await softCleanup(() => api.deleteUserGroup(adminGroupId));
-      await softCleanup(() => api.deleteUserGroup(basicGroupId));
-    });
-  });
+  // No afterAll — these are built-in default groups and must not be deleted
 
   test("renders page title, search, and new group button", async ({
     groupsPage,

--- a/web/tests/e2e/admin/groups/groups.spec.ts
+++ b/web/tests/e2e/admin/groups/groups.spec.ts
@@ -76,12 +76,12 @@ test.describe("Groups page — layout", () => {
     await expect(groupsPage.newGroupButton).toBeVisible();
   });
 
-  test("shows built-in groups (Admin, Basic)", async ({ groupsPage }) => {
+  test.skip("shows built-in groups (Admin, Basic)", async ({ groupsPage }) => {
+    // TODO: Enable once default groups are shown via include_default=true
     await groupsPage.goto();
 
-    //will be uncommented once the group permissions are implemented.
-    // await groupsPage.expectGroupVisible("Admin");
-    // await groupsPage.expectGroupVisible("Basic");
+    await groupsPage.expectGroupVisible("Admin");
+    await groupsPage.expectGroupVisible("Basic");
   });
 
   test("search filters groups by name", async ({ groupsPage, api }) => {

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -638,7 +638,9 @@ export class OnyxApiClient {
   async getUserGroups(): Promise<
     Array<{ id: number; name: string; is_default: boolean }>
   > {
-    const response = await this.get("/manage/admin/user-group");
+    const response = await this.get(
+      "/manage/admin/user-group?include_default=true"
+    );
     return response.json();
   }
 

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -632,6 +632,16 @@ export class OnyxApiClient {
     this.log(`Deleted user group: ${groupId}`);
   }
 
+  /**
+   * Lists all user groups.
+   */
+  async getUserGroups(): Promise<
+    Array<{ id: number; name: string; is_default: boolean }>
+  > {
+    const response = await this.get("/manage/admin/user-group");
+    return response.json();
+  }
+
   async setUserRole(
     email: string,
     role: "admin" | "curator" | "global_curator" | "basic",


### PR DESCRIPTION
## Description
  - Makes account_type a required (NOT NULL) column on the User model, with values derived from user role/context
  (STANDARD, BOT, EXT_PERM_USER, SERVICE_ACCOUNT, ANONYMOUS)
  - Seeds system default groups ("Admin" and "Basic") with corresponding permission grants, safely renaming any
  pre-existing groups with conflicting names
  - Backfills account_type for all existing users and assigns them to the appropriate default group via migrations
  - Auto-assigns new users to the correct default group at creation time across all entry points: regular signup, SAML
  conversion, SCIM provisioning, and API key creation
  - Exposes account_type and is_default in API responses and frontend types; prevents renaming or deleting default
  groups
## How Has This Been Tested?
Basic, OAuth, and SAML were tested via email. The others were tested through integration tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make account_type required (default STANDARD) and seed non-deletable “Admin” and “Basic” groups. New users and service accounts are auto-assigned to default groups during creation across signup, OAuth, SAML/SCIM, and API keys, with transactional safety.

- **New Features**
  - Enforces non-null account_type on users (standard, bot, ext_perm_user, service_account, anonymous); backfills and sets model/server default to STANDARD.
  - Seeds default “Admin” and “Basic” groups with SYSTEM grants; safely renames conflicts; blocks renaming/deleting defaults.
  - Assigns default groups in the same transaction across signup, OAuth upgrades, SAML/SCIM provisioning, and API key creation; service_account joins Admin/Basic by role, limited joins none; IdP flows set STANDARD; failures roll back.
  - API/UI: group list endpoints accept include_default; user/group snapshots and admin user list include account_type/is_default; batch group fetch can exclude defaults; built-in checks use is_default; web adds AccountType enum.

- **Migration**
  - Order: seed default groups → backfill account_type and enforce NOT NULL/default → assign active users to default groups (admins→Admin; standard non-admin and service_account with BASIC role→Basic); skip inactive/anonymous.
  - Validates defaults exist and uses SQLAlchemy-based DML for safety; downgrade makes account_type nullable and clears it, then deletes default groups and memberships.

<sup>Written for commit b9be304ede51dd73ac76875a1332ee34b4003c45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

