### PR TITLE
fix(model-server): add semaphore to limit concurrent embedding on CPU

### DIFF
--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -181,7 +181,7 @@ async def embed_text(
         # Run CPU-bound embedding in a thread pool, with concurrency limiting
         # to prevent thread contention on CPU (see issue #8396)
         loop = asyncio.get_event_loop()
-        semaphore = _get_embed_semaphore(gpu_type)
+        semaphore = _get_embed_semaphore()
         async with semaphore:
             embeddings_vectors = await loop.run_in_executor(
                 None,

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -30,26 +30,41 @@ _GLOBAL_MODELS_DICT: dict[str, "SentenceTransformer"] = {}
 # (e.g., 7 requests × 6 torch threads = 42 threads fighting over 6 cores),
 # degrading performance by ~30-200x.
 _EMBED_SEMAPHORE: asyncio.Semaphore | None = None
+_EMBED_SEMAPHORE_GPU_TYPE: str | None = None
 
 
-def _get_embed_semaphore(gpu_type: str) -> asyncio.Semaphore:
-    """Get or create the embedding concurrency semaphore.
+def init_embed_semaphore(gpu_type: str) -> None:
+    """Initialize the embedding semaphore eagerly at app startup.
 
-    On CPU (gpu_type == "none"), serialize requests (max_concurrent=1) to
-    avoid thread contention — this is actually *faster* than concurrent
-    execution on CPU due to reduced context switching overhead.
-
-    On GPU, allow moderate concurrency (max_concurrent=4) since GPU
-    operations are less affected by CPU thread contention.
+    Must be called once during FastAPI lifespan when gpu_type is known,
+    before any embedding requests arrive. This avoids the risk of the
+    semaphore being lazily initialized with a wrong gpu_type (e.g.
+    the default "UNKNOWN" from a warm-up probe or unit test).
     """
+    global _EMBED_SEMAPHORE, _EMBED_SEMAPHORE_GPU_TYPE
+    if _EMBED_SEMAPHORE is not None:
+        logger.warning(
+            f"Embed semaphore already initialized with gpu_type="
+            f"{_EMBED_SEMAPHORE_GPU_TYPE}, ignoring re-init with {gpu_type}"
+        )
+        return
+    max_concurrent: int = 1 if gpu_type.lower() == "none" else 4
+    logger.info(
+        f"Initializing embedding semaphore with max_concurrent={max_concurrent} "
+        f"(gpu_type={gpu_type})"
+    )
+    _EMBED_SEMAPHORE = asyncio.Semaphore(max_concurrent)
+    _EMBED_SEMAPHORE_GPU_TYPE = gpu_type
+
+
+def _get_embed_semaphore() -> asyncio.Semaphore:
+    """Get the embedding semaphore. Must be initialized via init_embed_semaphore()."""
     global _EMBED_SEMAPHORE
     if _EMBED_SEMAPHORE is None:
-        max_concurrent = 1 if gpu_type.lower() == "none" else 4
-        logger.info(
-            f"Initializing embedding semaphore with max_concurrent={max_concurrent} "
-            f"(gpu_type={gpu_type})"
+        raise RuntimeError(
+            "Embed semaphore not initialized. Call init_embed_semaphore() "
+            "at app startup before making embedding requests."
         )
-        _EMBED_SEMAPHORE = asyncio.Semaphore(max_concurrent)
     return _EMBED_SEMAPHORE
 
 

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -24,6 +24,34 @@ router = APIRouter(prefix="/encoder")
 
 _GLOBAL_MODELS_DICT: dict[str, "SentenceTransformer"] = {}
 
+# Semaphore to limit concurrent embedding calls and prevent thread contention.
+# On CPU, PyTorch spawns multiple internal threads per model.encode() call.
+# Without a limit, unbounded concurrent requests cause massive thread contention
+# (e.g., 7 requests × 6 torch threads = 42 threads fighting over 6 cores),
+# degrading performance by ~30-200x.
+_EMBED_SEMAPHORE: asyncio.Semaphore | None = None
+
+
+def _get_embed_semaphore(gpu_type: str) -> asyncio.Semaphore:
+    """Get or create the embedding concurrency semaphore.
+
+    On CPU (gpu_type == "none"), serialize requests (max_concurrent=1) to
+    avoid thread contention — this is actually *faster* than concurrent
+    execution on CPU due to reduced context switching overhead.
+
+    On GPU, allow moderate concurrency (max_concurrent=4) since GPU
+    operations are less affected by CPU thread contention.
+    """
+    global _EMBED_SEMAPHORE
+    if _EMBED_SEMAPHORE is None:
+        max_concurrent = 1 if gpu_type.lower() == "none" else 4
+        logger.info(
+            f"Initializing embedding semaphore with max_concurrent={max_concurrent} "
+            f"(gpu_type={gpu_type})"
+        )
+        _EMBED_SEMAPHORE = asyncio.Semaphore(max_concurrent)
+    return _EMBED_SEMAPHORE
+
 
 def get_embedding_model(
     model_name: str,
@@ -135,13 +163,17 @@ async def embed_text(
         local_model = get_embedding_model(
             model_name=model_name, max_context_length=max_context_length
         )
-        # Run CPU-bound embedding in a thread pool
-        embeddings_vectors = await asyncio.get_event_loop().run_in_executor(
-            None,
-            lambda: _concurrent_embedding(
-                prefixed_texts, local_model, normalize_embeddings
-            ),
-        )
+        # Run CPU-bound embedding in a thread pool, with concurrency limiting
+        # to prevent thread contention on CPU (see issue #8396)
+        loop = asyncio.get_event_loop()
+        semaphore = _get_embed_semaphore(gpu_type)
+        async with semaphore:
+            embeddings_vectors = await loop.run_in_executor(
+                None,
+                lambda: _concurrent_embedding(
+                    prefixed_texts, local_model, normalize_embeddings
+                ),
+            )
         embeddings = [
             embedding if isinstance(embedding, list) else embedding.tolist()
             for embedding in embeddings_vectors

--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -14,6 +14,7 @@ from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from transformers import logging as transformer_logging
 
+from model_server.encoders import init_embed_semaphore
 from model_server.encoders import router as encoders_router
 from model_server.management_endpoints import router as management_router
 from model_server.utils import get_gpu_type
@@ -72,6 +73,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     logger.notice(f"Torch GPU Detection: gpu_type={gpu_type}")
 
     app.state.gpu_type = gpu_type
+
+    # Initialize the embedding concurrency semaphore based on GPU type.
+    # On CPU, this serializes embedding calls to avoid thread contention (#8396).
+    init_embed_semaphore(gpu_type)
 
     try:
         if TEMP_HF_CACHE_PATH.is_dir():


### PR DESCRIPTION
## Summary

Fixes #8396

## Problem

CPU embedding performance degrades catastrophically due to unbounded concurrent requests. Each batch of 8 texts takes **~110 seconds** instead of the expected **~2-5 seconds** — a ~30-200x slowdown caused by thread contention.

**Root cause:**
- `asyncio.run_in_executor(None, ...)` uses the default ThreadPoolExecutor with **no concurrency limit**
- Background worker (concurrency=20) sends multiple embedding requests in parallel
- PyTorch spawns 6 internal threads per `model.encode()` call
- 7 concurrent requests = 42 threads fighting over 6 CPU cores = massive contention

## Solution

Add an `asyncio.Semaphore` to limit concurrent embedding calls:

- **CPU** (`gpu_type == "none"`): `semaphore=1` — serialize to avoid thread contention. Counter-intuitively, this is **faster** because it eliminates context switching overhead
- **GPU**: `semaphore=4` — moderate concurrency, GPU handles parallelism natively

The semaphore is lazily initialized on first call based on `gpu_type`, so no config changes needed.

## Expected Improvement

| Metric | Before | After |
|--------|--------|-------|
| CPU batch time | ~110s | ~2-5s |
| CPU throughput | ~0.07 texts/s | ~2-4 texts/s |
| GPU performance | Normal | No regression |

## Files Changed

- `backend/model_server/encoders.py` — Added `_EMBED_SEMAPHORE` with lazy initialization based on GPU type

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8396 by limiting concurrent embedding calls with an `asyncio.Semaphore`, initialized at app startup based on GPU type to prevent CPU thread contention. Restores CPU performance (~110s → ~2–5s per 8-text batch) with no GPU regression.

- **Bug Fixes**
  - Serialize CPU embedding when `gpu_type == "none"` (semaphore=1); allow moderate GPU concurrency (4).
  - Eagerly initialize the semaphore in the FastAPI lifespan via `init_embed_semaphore(gpu_type)` to ensure correct setup (raises if missing).

<sup>Written for commit d6b2fa1a33715b0646585df777b65f4cf361ee7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

