### PR TITLE
fix: add peft dependency for jina-embeddings-v5-text-nano (fixes #9354)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ ee = [
 model_server = [
     "accelerate==1.6.0",
     "einops==0.8.1",
+    "peft>=0.13.0",
     "numpy==2.4.1",
     "safetensors==0.5.3",
     "sentence-transformers==4.0.2",


### PR DESCRIPTION
## Summary

Fixes issue #9354 - jinaai/jina-embeddings-v5-text-nano fails to load due to missing peft package.

## Root Cause

The peft (Parameter-Efficient Fine-Tuning) package is required for models that use LoRA adapters and custom architectures like EuroBERT. Without it, the model fails with:

ImportError: This modeling file requires the following packages that were not found in your environment: peft

TypeError: EuroBertModel.__init__() got an unexpected keyword argument dtype

## Fix

Added peft>=0.13.0 to the model_server dependency group in pyproject.toml.

## Testing

This fix ensures the peft package is available in the Onyx model server Docker image when deploying with jinaai/jina-embeddings-v5-text-nano.

Fixes #9354

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `peft>=0.13.0` to the `model_server` dependencies so `jinaai/jina-embeddings-v5-text-nano` loads correctly with LoRA adapters and EuroBERT. Fixes the missing `peft` ImportError and the EuroBertModel dtype init error.

<sup>Written for commit 4620c002ac178f681ba2ecfc20cc8f86439beb92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

