### PR TITLE
fix: prevent install.sh from silently exiting on non-default input

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -202,14 +202,14 @@ prompt_or_default() {
     local prompt_text="$1"
     local default_value="$2"
     read_prompt_line "$prompt_text"
-    [[ -z "$REPLY" ]] && REPLY="$default_value"
+    if [[ -z "$REPLY" ]]; then REPLY="$default_value"; fi
 }
 
 prompt_yn_or_default() {
     local prompt_text="$1"
     local default_value="$2"
     read_prompt_char "$prompt_text"
-    [[ -z "$REPLY" ]] && REPLY="$default_value"
+    if [[ -z "$REPLY" ]]; then REPLY="$default_value"; fi
 }
 
 confirm_action() {


### PR DESCRIPTION
## Summary

Fixes #9622

The `install.sh` script silently exits whenever a user provides any non-default input to interactive prompts (e.g., selecting Standard mode, typing a version tag, answering "n" to a Y/n prompt).

## Root Cause

The script uses `set -euo pipefail` (line 3) combined with the pattern:

```bash
[[ -z "$REPLY" ]] && REPLY="$default_value"
```

When the user provides non-empty input, `[[ -z "$REPLY" ]]` evaluates to false (exit code 1), the `&&` short-circuits, and the entire line returns exit code 1. Under `set -e`, this immediately terminates the script with no error message.

## Fix

Replace the `&&` short-circuit pattern with explicit `if` statements in both `prompt_or_default()` and `prompt_yn_or_default()`:

```bash
if [[ -z "$REPLY" ]]; then REPLY="$default_value"; fi
```

This ensures the line always returns exit code 0 regardless of whether `$REPLY` is empty or not, making it safe under `set -e`.

## Test plan

- [ ] Run `install.sh` and select option 2 (Standard mode) -- script should continue
- [ ] Run `install.sh` and press Enter at prompts (accept defaults) -- script should continue as before
- [ ] Run `install.sh` and answer `n` to Y/n prompts -- script should continue and skip the feature

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented `install.sh` from exiting silently when users choose non-default answers in interactive prompts. Uses safe input handling under `set -euo pipefail`. Fixes #9622.

- **Bug Fixes**
  - Replaced `[[ -z "$REPLY" ]] && REPLY="$default_value"` with `if [[ -z "$REPLY" ]]; then REPLY="$default_value"; fi` in `prompt_or_default` and `prompt_yn_or_default` to avoid non-zero exits.

<sup>Written for commit 6e4d65ce419e922d02233e2e4bc695dbbfd2f466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

