### PR TITLE
feat(gitlab): add Include Code Files checkbox to connector UI

### DIFF
--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -320,6 +320,15 @@ export const connectorConfigs: Record<
         description: "Index issues from repositories",
         default: true,
       },
+      {
+        type: "checkbox",
+        query: "Include code files?",
+        label: "Include Code Files",
+        name: "include_code_files",
+        description:
+          "Index code files, documentation, and other repository files",
+        default: false,
+      },
     ],
   },
   bitbucket: {
@@ -1930,6 +1939,7 @@ export interface GitlabConfig {
   project_name: string;
   include_mrs: boolean;
   include_issues: boolean;
+  include_code_files: boolean;
 }
 
 export interface BitbucketConfig {


### PR DESCRIPTION
## Summary

Closes #9305

- Added "Include Code Files" checkbox to the GitLab connector's Advanced Options section (default: `false`, matching the backend default)
- Updated `GitlabConfig` TypeScript interface with `include_code_files: boolean`

The GitLab backend connector already supports the `include_code_files` parameter ([connector.py#L138](https://github.com/onyx-dot-app/onyx/blob/main/backend/onyx/connectors/gitlab/connector.py#L138)), which enables indexing of repository files (code, documentation, configs) via tree traversal. However, the frontend UI had no corresponding checkbox, so users could only enable this feature through the API.

## Test plan

- [ ] Create a new GitLab connector in Admin UI — verify "Include Code Files" checkbox appears under Advanced Options
- [ ] Checkbox defaults to unchecked (off)
- [ ] Create connector with checkbox enabled — verify `include_code_files: true` is sent in the API payload
- [ ] Verify existing connectors without the field continue to work (backend defaults to `false`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Include Code Files" checkbox to the GitLab connector’s Advanced Options so users can opt in to indexing repository files. Updates the `GitlabConfig` interface with `include_code_files: boolean` (default false), exposing an existing backend option and addressing #9305.

<sup>Written for commit 844bcc26b485bdc9ec5dfa479072bea63d6ec004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

