### PR TITLE
Fix PUT /api/admin/llm/provider silently ignoring custom_config

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -302,7 +302,8 @@ def test_llm_configuration(
                 else None
             )
         if existing_provider and not test_llm_request.custom_config_changed:
-            test_custom_config = existing_provider.custom_config
+            if test_custom_config is None:
+                test_custom_config = existing_provider.custom_config
 
     # For this "testing" workflow, we do *not* need the actual `max_input_tokens`.
     # Therefore, instead of performing additional, more complex logic, we just use a dummy value

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -471,8 +471,14 @@ def put_llm_provider(
             if existing_provider.api_key
             else None
         )
+    # When custom_config_changed is False and the request body includes a non-None
+    # custom_config, we still honour the value the caller sent (after masked-value
+    # restoration that already happened above).  We only fall back to the stored
+    # config when the request omitted / nulled custom_config, so that existing
+    # credentials are not accidentally wiped out.
     if existing_provider and not llm_provider_upsert_request.custom_config_changed:
-        llm_provider_upsert_request.custom_config = existing_provider.custom_config
+        if llm_provider_upsert_request.custom_config is None:
+            llm_provider_upsert_request.custom_config = existing_provider.custom_config
 
     # Check if we're transitioning to Auto mode
     transitioning_to_auto_mode = llm_provider_upsert_request.is_auto_mode and (


### PR DESCRIPTION
## Summary
- Fixes #9483: The PUT `/api/admin/llm/provider` endpoint silently discarded the `custom_config` field when `custom_config_changed` was not explicitly set to `true` (its default is `false`).
- The root cause was an unconditional overwrite of `custom_config` with the stored DB value whenever `custom_config_changed` was `False`, even when the caller provided a new non-null value.
- Now, the stored config is only used as a fallback when the request omits `custom_config` (sends `null`). When a non-null value is provided, it passes through after the existing masked-value restoration logic, so both sensitive and non-sensitive keys are handled correctly.

## Test plan
- [ ] Send PUT `/api/admin/llm/provider` with `"custom_config": {"think": "false"}` (without `custom_config_changed: true`) and verify the response returns the value
- [ ] Send GET `/api/admin/llm/provider` and verify `custom_config` is persisted
- [ ] Send PUT without `custom_config` field (or with `null`) and verify existing config is preserved
- [ ] Send PUT with `custom_config_changed: true` and verify it still works as before
- [ ] Verify sensitive config keys (e.g. AWS credentials) are still correctly restored from masked values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #9483: The PUT `/api/admin/llm/provider` now keeps a provided `custom_config` even when `custom_config_changed` is false, falling back to the stored value only when the field is omitted or null. The `test_llm_configuration` endpoint now follows the same fallback logic; masked-value restoration for sensitive keys is unchanged.

<sup>Written for commit 3d46db0fc0b063f38e756d8bf62c20441722aeb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

