### PR TITLE
Fix duplicate MCP tool names causing Anthropic 400 error

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -72,7 +72,7 @@ class MCPTool(Tool[None]):
         # "Tool names must be unique" errors when multiple MCP servers expose
         # tools with the same name.  The numeric server ID guarantees
         # uniqueness; the original _name is kept for MCP protocol calls.
-        safe_tool_name = re.sub(r"[^a-zA-Z0-9_]", "_", tool_name)
+        safe_tool_name: str = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name)
         self._llm_name = f"mcp_{mcp_server.id}_{safe_tool_name}"
 
     @property

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 
 from mcp.client.auth import OAuthClientProvider
@@ -71,7 +72,7 @@ class MCPTool(Tool[None]):
         # "Tool names must be unique" errors when multiple MCP servers expose
         # tools with the same name.  The numeric server ID guarantees
         # uniqueness; the original _name is kept for MCP protocol calls.
-        safe_tool_name = tool_name.replace("-", "_")
+        safe_tool_name = re.sub(r"[^a-zA-Z0-9_]", "_", tool_name)
         self._llm_name = f"mcp_{mcp_server.id}_{safe_tool_name}"
 
     @property

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -67,7 +67,12 @@ class MCPTool(Tool[None]):
         self._tool_definition = tool_definition
         self._description = tool_description
         self._display_name = tool_definition.get("displayName", tool_name)
-        self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
+        # Use a unique, LLM-safe name (must match [a-zA-Z0-9_-]+) to avoid
+        # "Tool names must be unique" errors when multiple MCP servers expose
+        # tools with the same name.  The numeric server ID guarantees
+        # uniqueness; the original _name is kept for MCP protocol calls.
+        safe_tool_name = tool_name.replace("-", "_")
+        self._llm_name = f"mcp_{mcp_server.id}_{safe_tool_name}"
 
     @property
     def id(self) -> int:
@@ -75,7 +80,7 @@ class MCPTool(Tool[None]):
 
     @property
     def name(self) -> str:
-        return self._name
+        return self._llm_name
 
     @property
     def description(self) -> str:
@@ -95,7 +100,7 @@ class MCPTool(Tool[None]):
         return {
             "type": "function",
             "function": {
-                "name": self._name,
+                "name": self._llm_name,
                 "description": self._description,
                 "parameters": self._tool_definition,
             },


### PR DESCRIPTION
## Summary
- Namespaces MCP tool names using `mcp_{server_id}_{tool_name}` format so each tool gets a unique, LLM-safe identifier
- Fixes the Anthropic 400 "Tool names must be unique" error when multiple MCP servers expose tools with the same name (e.g., both Intercom and Jira exposing `search`)
- The original tool name (`_name`) is preserved for actual MCP protocol calls in `run()`; only the name sent to the LLM and used for tool routing is namespaced

## Details
When two MCP servers both expose a tool called `search`, the current code sends duplicate `"name": "search"` entries to the LLM, triggering Anthropic's validation error. The existing `_llm_name` field used colons (`mcp:server:tool`) which is also invalid for Anthropic (tool names must match `[a-zA-Z0-9_-]+`).

This PR:
1. Changes `_llm_name` to use `mcp_{server.id}_{safe_tool_name}` (underscores, numeric server ID)
2. Updates the `name` property to return `_llm_name` (used by `tools_by_name` dict in `tool_runner.py` and `llm_loop.py`)
3. Updates `tool_definition()` to use `_llm_name` as the function name sent to the LLM

Fixes #9229

## Test plan
- [ ] Configure an agent with two MCP servers that expose tools with the same name (e.g., both have `search`)
- [ ] Verify the agent no longer returns a 400 error from Anthropic
- [ ] Verify tool calls are correctly routed to the right MCP server instance
- [ ] Verify single MCP server setups continue to work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces MCP tool names to unique, LLM-safe identifiers and sanitizes invalid characters to prevent Anthropic 400 "Tool names must be unique" errors when different MCP servers share a tool name. Original tool names are still used for MCP protocol calls; hyphens are preserved.

- **Bug Fixes**
  - Use `mcp_{server_id}_{safe_tool_name}` for the LLM-exposed name; `safe_tool_name` preserves hyphens and replaces other invalid chars with `_` to meet `[a-zA-Z0-9_-]+`.
  - Return the namespaced value from `name` and use it in `tool_definition()`.
  - Fixes #9229.

<sup>Written for commit 2a21771239b3214e73c43394f9baadb01348f517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

