### PR TITLE
Fix persona is_visible field reset on update

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -311,6 +311,7 @@ def create_update_persona(
             search_start_date=create_persona_request.search_start_date,
             label_ids=create_persona_request.label_ids,
             is_featured=create_persona_request.is_featured,
+            is_listed=create_persona_request.is_visible,
             user_file_ids=converted_user_file_ids,
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -921,7 +921,7 @@ def upsert_persona(
     uploaded_image_id: str | None = None,
     icon_name: str | None = None,
     display_priority: int | None = None,
-    is_listed: bool = True,
+    is_listed: bool | None = None,
     remove_image: bool | None = None,
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
@@ -1048,7 +1048,9 @@ def upsert_persona(
         if remove_image or uploaded_image_id:
             existing_persona.uploaded_image_id = uploaded_image_id
         existing_persona.icon_name = icon_name
-        existing_persona.is_listed = is_listed
+        existing_persona.is_listed = (
+            is_listed if is_listed is not None else existing_persona.is_listed
+        )
         existing_persona.search_start_date = search_start_date
         if label_ids is not None:
             existing_persona.labels.clear()
@@ -1120,7 +1122,7 @@ def upsert_persona(
             uploaded_image_id=uploaded_image_id,
             icon_name=icon_name,
             display_priority=display_priority,
-            is_listed=is_listed,
+            is_listed=is_listed if is_listed is not None else True,
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
             user_files=user_files or [],

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -123,6 +123,7 @@ class PersonaUpsertRequest(BaseModel):
     )
     search_start_date: datetime | None = None
     label_ids: list[int] | None = None
+    is_visible: bool = True
     is_featured: bool = False
     display_priority: int | None = None
     # Accept string UUIDs from frontend

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -123,7 +123,7 @@ class PersonaUpsertRequest(BaseModel):
     )
     search_start_date: datetime | None = None
     label_ids: list[int] | None = None
-    is_visible: bool = True
+    is_visible: bool | None = None
     is_featured: bool = False
     display_priority: int | None = None
     # Accept string UUIDs from frontend

--- a/web/src/app/admin/agents/lib.ts
+++ b/web/src/app/admin/agents/lib.ts
@@ -12,6 +12,7 @@ interface PersonaUpsertRequest {
   datetime_aware: boolean;
   document_set_ids: number[];
   is_public: boolean;
+  is_visible: boolean;
   llm_model_provider_override: string | null;
   llm_model_version_override: string | null;
   starter_messages: StarterMessage[] | null;
@@ -42,6 +43,7 @@ export interface PersonaUpsertParameters {
   datetime_aware: boolean;
   document_set_ids: number[];
   is_public: boolean;
+  is_visible: boolean;
   llm_model_provider_override: string | null;
   llm_model_version_override: string | null;
   starter_messages: StarterMessage[] | null;
@@ -68,6 +70,7 @@ function buildPersonaUpsertRequest({
   task_prompt,
   document_set_ids,
   is_public,
+  is_visible,
   groups,
   datetime_aware,
   users,
@@ -93,6 +96,7 @@ function buildPersonaUpsertRequest({
     task_prompt,
     document_set_ids,
     is_public,
+    is_visible,
     uploaded_image_id,
     icon_name,
     groups,

--- a/web/src/app/admin/agents/lib.ts
+++ b/web/src/app/admin/agents/lib.ts
@@ -12,7 +12,7 @@ interface PersonaUpsertRequest {
   datetime_aware: boolean;
   document_set_ids: number[];
   is_public: boolean;
-  is_visible: boolean;
+  is_visible?: boolean;
   llm_model_provider_override: string | null;
   llm_model_version_override: string | null;
   starter_messages: StarterMessage[] | null;
@@ -43,7 +43,7 @@ export interface PersonaUpsertParameters {
   datetime_aware: boolean;
   document_set_ids: number[];
   is_public: boolean;
-  is_visible: boolean;
+  is_visible?: boolean;
   llm_model_provider_override: string | null;
   llm_model_version_override: string | null;
   starter_messages: StarterMessage[] | null;

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -663,6 +663,7 @@ export default function AgentEditorPage({
     shared_user_ids: existingAgent?.users?.map((user) => user.id) ?? [],
     shared_group_ids: existingAgent?.groups ?? [],
     is_public: existingAgent?.is_public ?? false,
+    is_visible: existingAgent?.is_listed ?? true,
     label_ids: existingAgent?.labels?.map((l) => l.id) ?? [],
     is_featured: existingAgent?.is_featured ?? false,
   };
@@ -802,6 +803,7 @@ export default function AgentEditorPage({
           ? values.document_set_ids
           : [],
         is_public: values.is_public,
+        is_visible: values.is_visible,
         llm_model_provider_override: values.llm_model_provider_override || null,
         llm_model_version_override: values.llm_model_version_override || null,
         starter_messages: finalStarterMessages,


### PR DESCRIPTION
## Summary

- Fixes #9517: The `is_visible` (`is_listed`) field was being reset to `True` whenever a persona was updated through the AgentEditor page, because the field was never passed through the update chain.
- Added `is_visible` to the frontend form state (`AgentEditorPage.tsx`), the frontend API interfaces and request builder (`lib.ts`), the backend Pydantic model (`PersonaUpsertRequest`), and the `create_update_persona` DB function call to `upsert_persona`.
- On edit, the form now initializes `is_visible` from the existing persona's `is_listed` value and passes it through to the backend, preserving the admin's hidden/visible setting.

## Test plan

- [ ] Create a persona and set it to hidden via `PATCH /api/admin/persona/{id}/visible` with `{"is_visible": false}`
- [ ] Edit that persona through the AgentEditor (e.g., change description) and save
- [ ] Verify that `is_listed` remains `false` in the database after the edit
- [ ] Create a new persona through the editor and verify it defaults to `is_listed=true`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes persona visibility resetting on edit and when the field is omitted. `is_visible` now flows end-to-end and preserves existing `is_listed` on update; new personas still default to visible. Fixes #9517.

- **Bug Fixes**
  - Added `is_visible` to AgentEditor form state and request builder.
  - Made backend `PersonaUpsertRequest.is_visible` optional; omitting it keeps the current value.
  - Passed `is_visible` to DB upsert as `is_listed`; on update uses existing when `None`, on create defaults to `True`.

<sup>Written for commit 31b0462b5987f5c4912579beb0ad8e0e2f38524b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

