### PR TITLE
fix: restore api_base and api_key fields in Custom LLM modal

### DIFF
--- a/web/src/sections/modals/llmConfig/CustomModal.test.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.test.tsx
@@ -477,6 +477,105 @@ describe("Custom LLM Provider Configuration Workflow", () => {
     });
   });
 
+  test("includes api_base in the request when provided", async () => {
+    const user = setupUser();
+
+    // Mock POST /api/admin/llm/test
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    // Mock PUT /api/admin/llm/provider?is_creation=true
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 1, name: "vLLM Provider", provider: "openai" }),
+    } as Response);
+
+    render(<CustomModal open={true} onOpenChange={() => {}} />);
+
+    await fillBasicFields(user, {
+      name: "vLLM Provider",
+      provider: "openai",
+      modelName: "my-model",
+    });
+
+    // Fill in the API Base URL
+    const apiBaseInput = screen.getByPlaceholderText(
+      "https://your-api-endpoint.example.com/v1"
+    );
+    await user.type(apiBaseInput, "https://my-vllm-server:8000/v1");
+
+    // Submit
+    const submitButton = screen.getByRole("button", { name: /connect/i });
+    await user.click(submitButton);
+
+    // Verify the api_base was included in the test request
+    await waitFor(() => {
+      const testCall = fetchSpy.mock.calls.find(
+        ([url]) => url === "/api/admin/llm/test"
+      );
+      expect(testCall).toBeDefined();
+
+      const body = JSON.parse(testCall![1].body);
+      expect(body.api_base).toBe("https://my-vllm-server:8000/v1");
+    });
+
+    // Verify the api_base was included in the create request
+    await waitFor(() => {
+      const createCall = fetchSpy.mock.calls.find((call) =>
+        call[0].includes("/api/admin/llm/provider")
+      );
+      expect(createCall).toBeDefined();
+
+      const body = JSON.parse(createCall![1].body);
+      expect(body.api_base).toBe("https://my-vllm-server:8000/v1");
+    });
+  });
+
+  test("preserves api_base when editing an existing provider", async () => {
+    const user = setupUser();
+
+    const existingProvider = {
+      id: 3,
+      name: "My vLLM",
+      provider: "openai",
+      api_key: "sk-test",
+      api_base: "https://my-vllm-server:8000/v1",
+      api_version: "",
+      model_configurations: [
+        {
+          name: "my-model",
+          display_name: "",
+          is_visible: true,
+          max_input_tokens: null,
+          supports_image_input: false,
+          supports_reasoning: false,
+        },
+      ],
+      custom_config: {},
+      is_public: true,
+      is_auto_mode: false,
+      groups: [],
+      personas: [],
+      deployment_name: null,
+    };
+
+    render(
+      <CustomModal
+        existingLlmProvider={existingProvider}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    );
+
+    // Verify the api_base field is pre-populated
+    const apiBaseInput = screen.getByPlaceholderText(
+      "https://your-api-endpoint.example.com/v1"
+    );
+    expect(apiBaseInput).toHaveValue("https://my-vllm-server:8000/v1");
+  });
+
   test("adds custom configuration key-value pairs", async () => {
     const user = setupUser();
 

--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -14,6 +14,7 @@ import {
   submitOnboardingProvider,
 } from "@/sections/modals/llmConfig/svc";
 import {
+  APIKeyField,
   DisplayNameField,
   FieldSeparator,
   ModelsAccessField,
@@ -209,14 +210,19 @@ export default function CustomModal({
 
   const onClose = () => onOpenChange?.(false);
 
+  const existingModelConfigurations =
+    existingLlmProvider?.model_configurations ?? [];
+
   const initialValues = {
     ...buildDefaultInitialValues(
       existingLlmProvider,
-      undefined,
+      existingModelConfigurations,
       defaultModelName
     ),
     ...(isOnboarding ? buildOnboardingInitialValues() : {}),
     provider: existingLlmProvider?.provider ?? "",
+    api_key: existingLlmProvider?.api_key ?? "",
+    api_base: existingLlmProvider?.api_base ?? "",
     model_configurations: existingLlmProvider?.model_configurations.map(
       (mc) => ({
         name: mc.name,
@@ -304,10 +310,15 @@ export default function CustomModal({
             (config) => config.name
           );
 
+          // Ensure default_model_name is set to the first model if not already
+          const defaultModelName =
+            values.default_model_name || selectedModelNames[0] || "";
+
           await submitLLMProvider({
             providerName: values.provider,
             values: {
               ...values,
+              default_model_name: defaultModelName,
               selected_model_names: selectedModelNames,
               custom_config: customConfigProcessing(values.custom_config_list),
             },
@@ -357,6 +368,26 @@ export default function CustomModal({
               </FieldWrapper>
             </Section>
           )}
+
+          <FieldSeparator />
+
+          <Section gap={0}>
+            <APIKeyField />
+
+            <FieldWrapper>
+              <InputLayouts.Vertical
+                name="api_base"
+                title="API Base URL"
+                subDescription="Custom API endpoint URL for OpenAI-compatible providers (e.g. LiteLLM, vLLM, Ollama)."
+                suffix="optional"
+              >
+                <InputTypeInField
+                  name="api_base"
+                  placeholder="https://your-api-endpoint.example.com/v1"
+                />
+              </InputLayouts.Vertical>
+            </FieldWrapper>
+          </Section>
 
           <FieldSeparator />
 


### PR DESCRIPTION
## Summary
- Restores the `api_base` input field that was dropped during the #9270 refactor of the LLM config modals
- Adds the `APIKeyField` shared component to the Custom modal (was also missing)
- Fixes `default_model_name` not being set for Custom providers by passing `existingModelConfigurations` to `buildDefaultInitialValues()` and falling back to the first model name on submit

## Problem
After PR #9270 replaced inline form fields with shared components, the Custom Models modal (`CustomModal.tsx`) lost its `api_base` field. This made it impossible to configure OpenAI-compatible providers that use custom endpoints (LiteLLM proxy, vLLM, Ollama remote, etc.) through the UI.

Additionally, `buildDefaultInitialValues()` was called without `modelConfigurations`, so `default_model_name` was always empty, causing test requests to fail with "Not found" from LiteLLM.

## Changes
- **`CustomModal.tsx`**: Added `APIKeyField` and `api_base` input field to the form UI; added `api_key` and `api_base` to `initialValues`; passed `existingModelConfigurations` to `buildDefaultInitialValues()`; ensured `default_model_name` falls back to first model name on submit
- **`CustomModal.test.tsx`**: Added tests verifying `api_base` is included in API requests and pre-populated when editing existing providers

## Test plan
- [ ] Open Admin > Language Models > Add Provider > Custom
- [ ] Verify API Key and API Base URL fields are present
- [ ] Configure a custom OpenAI-compatible provider with a custom `api_base`
- [ ] Verify the test request succeeds with the custom endpoint
- [ ] Edit an existing custom provider and verify `api_base` is pre-populated
- [ ] Run `CustomModal.test.tsx` unit tests

Fixes #9592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores API Base URL and API Key fields in the Custom LLM provider modal and fixes default model selection so OpenAI-compatible providers with custom endpoints can be configured and tested. Fixes #9592.

- **Bug Fixes**
  - Added API Key and `api_base` inputs; included `api_key` and `api_base` in initial values and request payloads.
  - Passed `model_configurations` to `buildDefaultInitialValues()` and set `default_model_name` with a fallback to the first model on submit.
  - Added tests to ensure `api_base` is sent in test/create requests and is pre-populated when editing.

<sup>Written for commit 54dbbc1b5761a2a01c76ca81769784e4ee52bb85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

