### PR TITLE
Add S3-compatible endpoint support for BlobStorageConnector

### DIFF
--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -8,6 +8,8 @@ from numbers import Integral
 from typing import Any
 from typing import Optional
 from urllib.parse import quote
+from urllib.parse import urlparse
+from urllib.parse import urlunparse
 
 import boto3
 from botocore.client import Config
@@ -50,6 +52,17 @@ logger = setup_logger()
 
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 SIZE_THRESHOLD_BUFFER = 64
+
+
+def _sanitize_url(url: str) -> str:
+    """Strip embedded credentials from a URL before logging."""
+    parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        sanitized = parsed._replace(
+            netloc="***@" + parsed.hostname + (f":{parsed.port}" if parsed.port else "")
+        )
+        return urlunparse(sanitized)
+    return url
 
 
 class BlobStorageConnector(LoadConnector, PollConnector):
@@ -152,19 +165,19 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             extra_client_kwargs: dict[str, Any] = {}
             if self.endpoint_url:
                 logger.info(
-                    f"Using custom S3 endpoint: {self.endpoint_url}"
+                    f"Using custom S3 endpoint: {_sanitize_url(self.endpoint_url)}"
                 )
                 extra_client_kwargs["endpoint_url"] = self.endpoint_url
                 extra_client_kwargs["config"] = Config(
                     signature_version="s3v4",
                     s3={"addressing_style": "path"},
                 )
-            if self.s3_skip_ssl_verification:
+            if self.endpoint_url and self.s3_skip_ssl_verification:
                 extra_client_kwargs["verify"] = False
                 logger.warning(
                     "SSL verification is disabled for S3 endpoint '%s'. "
                     "This is not recommended for production use.",
-                    self.endpoint_url,
+                    _sanitize_url(self.endpoint_url),
                 )
 
             # For S3, we can use either access keys or IAM roles.
@@ -337,7 +350,10 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
         elif self.bucket_type == BlobType.S3:
             if self.endpoint_url:
-                # For custom S3-compatible endpoints, use path-style URL
+                # For custom S3-compatible endpoints (MinIO, Ceph, etc.) we
+                # intentionally return a direct object URL rather than a
+                # dashboard URL because these services do not have a
+                # standardised web console path.
                 base = self.endpoint_url.rstrip("/")
                 return f"{base}/{self.bucket_name}/{encoded_key}"
             region = self.bucket_region or self.s3_client.meta.region_name

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -60,6 +60,8 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         prefix: str = "",
         batch_size: int = INDEX_BATCH_SIZE,
         european_residency: bool = False,
+        endpoint_url: str = "",
+        s3_skip_ssl_verification: bool = False,
     ) -> None:
         self.bucket_type: BlobType = BlobType(bucket_type)
         self.bucket_name = bucket_name.strip()
@@ -70,6 +72,8 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.size_threshold: int | None = BLOB_STORAGE_SIZE_THRESHOLD
         self.bucket_region: Optional[str] = None
         self.european_residency: bool = european_residency
+        self.endpoint_url: str = endpoint_url.strip() if endpoint_url else ""
+        self.s3_skip_ssl_verification: bool = s3_skip_ssl_verification
 
     def set_allow_images(self, allow_images: bool) -> None:
         """Set whether to process images in this connector."""
@@ -140,6 +144,20 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             )
 
         elif self.bucket_type == BlobType.S3:
+            # Build extra kwargs for custom S3-compatible endpoints (MinIO, Ceph, etc.)
+            extra_client_kwargs: dict[str, Any] = {}
+            if self.endpoint_url:
+                logger.info(
+                    f"Using custom S3 endpoint: {self.endpoint_url}"
+                )
+                extra_client_kwargs["endpoint_url"] = self.endpoint_url
+                extra_client_kwargs["config"] = Config(
+                    signature_version="s3v4",
+                    s3={"addressing_style": "path"},
+                )
+            if self.s3_skip_ssl_verification:
+                extra_client_kwargs["verify"] = False
+
             # For S3, we can use either access keys or IAM roles.
             authentication_method = credentials.get(
                 "authentication_method", "access_key"
@@ -159,7 +177,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                     aws_access_key_id=credentials["aws_access_key_id"],
                     aws_secret_access_key=credentials["aws_secret_access_key"],
                 )
-                self.s3_client = session.client("s3")
+                self.s3_client = session.client("s3", **extra_client_kwargs)
             elif authentication_method == "iam_role":
                 # If using IAM roles, we assume the role and let boto3 handle the credentials.
                 role_arn = credentials.get("aws_role_arn")
@@ -192,17 +210,19 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                 botocore_session = get_session()
                 botocore_session._credentials = refreshable  # type: ignore[attr-defined]
                 session = boto3.Session(botocore_session=botocore_session)
-                self.s3_client = session.client("s3")
+                self.s3_client = session.client("s3", **extra_client_kwargs)
             elif authentication_method == "assume_role":
                 # We will assume the instance role to access S3.
                 logger.debug("Using instance role authentication for S3 bucket.")
-                self.s3_client = boto3.client("s3")
+                self.s3_client = boto3.client("s3", **extra_client_kwargs)
             else:
                 raise ConnectorValidationError("Invalid authentication method for S3. ")
 
             # This is important for correct citation links
             # NOTE: the client region actually doesn't matter for accessing the bucket
-            self._detect_bucket_region()
+            # Skip region detection for custom endpoints (not applicable for MinIO, Ceph, etc.)
+            if not self.endpoint_url:
+                self._detect_bucket_region()
 
         elif self.bucket_type == BlobType.GOOGLE_CLOUD_STORAGE:
             if not all(
@@ -307,6 +327,10 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             return f"https://dash.cloudflare.com/{account_id}/r2/{subdomain}buckets/{self.bucket_name}/objects/{encoded_key}/details"
 
         elif self.bucket_type == BlobType.S3:
+            if self.endpoint_url:
+                # For custom S3-compatible endpoints, use path-style URL
+                base = self.endpoint_url.rstrip("/")
+                return f"{base}/{self.bucket_name}/{encoded_key}"
             region = self.bucket_region or self.s3_client.meta.region_name
             return f"https://s3.console.aws.amazon.com/s3/object/{self.bucket_name}?region={region}&prefix={encoded_key}"
 

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -73,6 +73,10 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.bucket_region: Optional[str] = None
         self.european_residency: bool = european_residency
         self.endpoint_url: str = endpoint_url.strip() if endpoint_url else ""
+        if self.endpoint_url and not self.endpoint_url.startswith(("http://", "https://")):
+            raise ValueError(
+                f"Invalid S3 endpoint URL: must start with http:// or https://"
+            )
         self.s3_skip_ssl_verification: bool = s3_skip_ssl_verification
 
     def set_allow_images(self, allow_images: bool) -> None:
@@ -157,6 +161,11 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                 )
             if self.s3_skip_ssl_verification:
                 extra_client_kwargs["verify"] = False
+                logger.warning(
+                    "SSL verification is disabled for S3 endpoint '%s'. "
+                    "This is not recommended for production use.",
+                    self.endpoint_url,
+                )
 
             # For S3, we can use either access keys or IAM roles.
             authentication_method = credentials.get(

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -1366,7 +1366,26 @@ For example, specifying .*-support.* as a "channel" will cause the connector to 
         hidden: true,
       },
     ],
-    advanced_values: [],
+    advanced_values: [
+      {
+        type: "text",
+        query: "Enter a custom S3-compatible endpoint URL (e.g. https://minio.example.com:9000):",
+        label: "Endpoint URL",
+        name: "endpoint_url",
+        optional: true,
+        description:
+          "For S3-compatible storage services such as MinIO or Ceph. Leave empty for AWS S3.",
+      },
+      {
+        type: "checkbox",
+        label: "Skip SSL Verification",
+        name: "s3_skip_ssl_verification",
+        description:
+          "Disable SSL certificate verification when connecting to the custom endpoint. Not recommended for production use.",
+        optional: true,
+        default: false,
+      },
+    ],
     overrideDefaultFreq: 60 * 60 * 24,
   },
   r2: {
@@ -2081,6 +2100,8 @@ export interface S3Config {
   bucket_type: "s3";
   bucket_name: string;
   prefix: string;
+  endpoint_url?: string;
+  s3_skip_ssl_verification?: boolean;
 }
 
 export interface R2Config {


### PR DESCRIPTION
## Summary

- Add `endpoint_url` (optional string) and `s3_skip_ssl_verification` (optional bool, default false) parameters to `BlobStorageConnector` for S3-compatible storage services (MinIO, Ceph, etc.)
- When a custom endpoint is configured: use path-style addressing with s3v4 signatures, skip AWS region auto-detection, and generate path-style object links instead of AWS Console links
- Add "Advanced Options" section to the S3 connector frontend configuration with an Endpoint URL text input and Skip SSL Verification checkbox

## Test plan

- [ ] Verify existing AWS S3 connector behavior is unchanged (no endpoint_url set)
- [ ] Test with MinIO instance using a custom endpoint URL
- [ ] Test with `s3_skip_ssl_verification` enabled against a self-signed cert endpoint
- [ ] Verify generated object links use path-style URLs when custom endpoint is set
- [ ] Confirm frontend form shows advanced options and submits correctly

Fixes #9171

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds S3-compatible endpoint support to `BlobStorageConnector`, enabling MinIO/Ceph via a custom endpoint and optional SSL verification skip (only when a custom endpoint is set). Validates endpoint URLs, sanitizes logged endpoints, warns on disabled SSL verification, and keeps AWS S3 behavior unchanged. Fixes #9171.

- **New Features**
  - Backend: add `endpoint_url` and `s3_skip_ssl_verification` to `BlobStorageConnector`.
  - Validate `endpoint_url` must start with http:// or https://; sanitize endpoint in logs and warn when SSL verification is skipped.
  - When `endpoint_url` is set: use `s3v4`, path-style addressing, gate `verify=False` only with custom endpoints, skip region detection, and generate path-style object links.
  - Frontend: add S3 “Advanced Options” (Endpoint URL, Skip SSL Verification) and extend `S3Config` with optional fields.

- **Migration**
  - No changes needed for existing AWS S3 connectors.
  - For MinIO/Ceph: set the Endpoint URL; optionally enable Skip SSL Verification for self-signed certs (only applies with a custom endpoint).

<sup>Written for commit 7ef9665f3959f0f59338a9a5f203626a6ab65dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

