### PR TITLE
Fix Max Input Tokens not editable for Ollama providers

### DIFF
--- a/web/src/sections/modals/llmConfig/OllamaModal.tsx
+++ b/web/src/sections/modals/llmConfig/OllamaModal.tsx
@@ -58,6 +58,8 @@ interface OllamaModalInternalsProps {
   isTesting: boolean;
   onClose: () => void;
   isOnboarding: boolean;
+  maxTokenOverrides: Record<string, number | null>;
+  onMaxInputTokensChange: (modelName: string, value: number | null) => void;
 }
 
 function OllamaModalInternals({
@@ -68,6 +70,8 @@ function OllamaModalInternals({
   isTesting,
   onClose,
   isOnboarding,
+  maxTokenOverrides,
+  onMaxInputTokensChange,
 }: OllamaModalInternalsProps) {
   const isInitialMount = useRef(true);
 
@@ -121,10 +125,16 @@ function OllamaModalInternals({
     existingLlmProvider,
   ]);
 
-  const currentModels =
+  const baseModels =
     fetchedModels.length > 0
       ? fetchedModels
       : existingLlmProvider?.model_configurations || [];
+
+  const currentModels = baseModels.map((m) =>
+    m.name in maxTokenOverrides
+      ? { ...m, max_input_tokens: maxTokenOverrides[m.name] }
+      : m
+  );
 
   const hasApiKey = !!formikProps.values.custom_config?.OLLAMA_API_KEY;
   const defaultTab =
@@ -136,7 +146,7 @@ function OllamaModalInternals({
       existingProviderName={existingLlmProvider?.name}
       onClose={onClose}
       isFormValid={formikProps.isValid}
-      isDirty={formikProps.dirty}
+      isDirty={formikProps.dirty || Object.keys(maxTokenOverrides).length > 0}
       isTesting={isTesting}
       isSubmitting={formikProps.isSubmitting}
     >
@@ -193,6 +203,8 @@ function OllamaModalInternals({
           formikProps={formikProps}
           recommendedDefaultModel={null}
           shouldShowAutoUpdateToggle={false}
+          showMaxInputTokens
+          onMaxInputTokensChange={onMaxInputTokensChange}
         />
       )}
 
@@ -218,11 +230,31 @@ export default function OllamaModal({
   llmDescriptor,
 }: LLMProviderFormProps) {
   const [fetchedModels, setFetchedModels] = useState<ModelConfiguration[]>([]);
+  const [maxTokenOverrides, setMaxTokenOverrides] = useState<
+    Record<string, number | null>
+  >({});
   const [isTesting, setIsTesting] = useState(false);
   const isOnboarding = variant === "onboarding";
   const { mutate } = useSWRConfig();
   const { wellKnownLLMProvider } =
     useWellKnownLLMProvider(OLLAMA_PROVIDER_NAME);
+
+  const handleMaxInputTokensChange = useCallback(
+    (modelName: string, value: number | null) => {
+      setMaxTokenOverrides((prev) => ({ ...prev, [modelName]: value }));
+    },
+    []
+  );
+
+  const applyMaxTokenOverrides = useCallback(
+    (configs: ModelConfiguration[]): ModelConfiguration[] =>
+      configs.map((m) =>
+        m.name in maxTokenOverrides
+          ? { ...m, max_input_tokens: maxTokenOverrides[m.name] }
+          : m
+      ),
+    [maxTokenOverrides]
+  );
 
   if (open === false) return null;
 
@@ -286,8 +318,9 @@ export default function OllamaModal({
         };
 
         if (isOnboarding && onboardingState && onboardingActions) {
-          const modelConfigsToUse =
-            fetchedModels.length > 0 ? fetchedModels : [];
+          const modelConfigsToUse = applyMaxTokenOverrides(
+            fetchedModels.length > 0 ? fetchedModels : []
+          );
 
           await submitOnboardingProvider({
             providerName: OLLAMA_PROVIDER_NAME,
@@ -302,12 +335,15 @@ export default function OllamaModal({
             setIsSubmitting: setSubmitting,
           });
         } else {
+          const configsToSubmit = applyMaxTokenOverrides(
+            fetchedModels.length > 0 ? fetchedModels : modelConfigurations
+          );
+
           await submitLLMProvider({
             providerName: OLLAMA_PROVIDER_NAME,
             values: submitValues,
             initialValues,
-            modelConfigurations:
-              fetchedModels.length > 0 ? fetchedModels : modelConfigurations,
+            modelConfigurations: configsToSubmit,
             existingLlmProvider,
             shouldMarkAsDefault,
             setIsTesting,
@@ -327,6 +363,8 @@ export default function OllamaModal({
           isTesting={isTesting}
           onClose={onClose}
           isOnboarding={isOnboarding}
+          maxTokenOverrides={maxTokenOverrides}
+          onMaxInputTokensChange={handleMaxInputTokensChange}
         />
       )}
     </Formik>

--- a/web/src/sections/modals/llmConfig/OllamaModal.tsx
+++ b/web/src/sections/modals/llmConfig/OllamaModal.tsx
@@ -60,6 +60,7 @@ interface OllamaModalInternalsProps {
   isOnboarding: boolean;
   maxTokenOverrides: Record<string, number | null>;
   onMaxInputTokensChange: (modelName: string, value: number | null) => void;
+  onClearOverrides: () => void;
 }
 
 function OllamaModalInternals({
@@ -72,6 +73,7 @@ function OllamaModalInternals({
   isOnboarding,
   maxTokenOverrides,
   onMaxInputTokensChange,
+  onClearOverrides,
 }: OllamaModalInternalsProps) {
   const isInitialMount = useRef(true);
 
@@ -109,6 +111,7 @@ function OllamaModalInternals({
     }
 
     if (formikProps.values.api_base) {
+      onClearOverrides();
       const controller = new AbortController();
       debouncedFetchModels(formikProps.values.api_base, controller.signal);
       return () => {
@@ -116,6 +119,7 @@ function OllamaModalInternals({
         controller.abort();
       };
     } else {
+      onClearOverrides();
       setFetchedModels([]);
     }
   }, [
@@ -123,6 +127,7 @@ function OllamaModalInternals({
     debouncedFetchModels,
     setFetchedModels,
     existingLlmProvider,
+    onClearOverrides,
   ]);
 
   const baseModels =
@@ -146,7 +151,7 @@ function OllamaModalInternals({
       existingProviderName={existingLlmProvider?.name}
       onClose={onClose}
       isFormValid={formikProps.isValid}
-      isDirty={formikProps.dirty || Object.keys(maxTokenOverrides).length > 0}
+      isDirty={formikProps.dirty || Object.values(maxTokenOverrides).some(v => v !== null && v !== undefined)}
       isTesting={isTesting}
       isSubmitting={formikProps.isSubmitting}
     >
@@ -245,6 +250,10 @@ export default function OllamaModal({
     },
     []
   );
+
+  const handleClearOverrides = useCallback(() => {
+    setMaxTokenOverrides({});
+  }, []);
 
   const applyMaxTokenOverrides = useCallback(
     (configs: ModelConfiguration[]): ModelConfiguration[] =>
@@ -365,6 +374,7 @@ export default function OllamaModal({
           isOnboarding={isOnboarding}
           maxTokenOverrides={maxTokenOverrides}
           onMaxInputTokensChange={handleMaxInputTokensChange}
+          onClearOverrides={handleClearOverrides}
         />
       )}
     </Formik>

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -596,16 +596,26 @@ export function ModelsField<T extends BaseLLMFormValues>({
                                 modelConfiguration.max_input_tokens?.toString() ??
                                 ""
                               }
-                              onChange={(e) =>
-                                onMaxInputTokensChange?.(
-                                  modelConfiguration.name,
-                                  e.target.value === ""
-                                    ? null
-                                    : Number(e.target.value)
-                                )
-                              }
+                              onChange={(e) => {
+                                const val = e.target.value;
+                                if (val === "") {
+                                  onMaxInputTokensChange?.(
+                                    modelConfiguration.name,
+                                    null
+                                  );
+                                } else {
+                                  const num = Number(val);
+                                  if (!isNaN(num) && num > 0) {
+                                    onMaxInputTokensChange?.(
+                                      modelConfiguration.name,
+                                      num
+                                    );
+                                  }
+                                }
+                              }}
                               showClearButton={false}
                               type="number"
+                              min={1}
                             />
                           </div>
                         </div>

--- a/web/src/sections/modals/llmConfig/shared.tsx
+++ b/web/src/sections/modals/llmConfig/shared.tsx
@@ -11,6 +11,7 @@ import Checkbox from "@/refresh-components/inputs/Checkbox";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import Switch from "@/refresh-components/inputs/Switch";
 import Text from "@/refresh-components/texts/Text";
@@ -378,6 +379,10 @@ export interface ModelsFieldProps<T> {
   shouldShowAutoUpdateToggle: boolean;
   /** Called when the user clicks the refresh button to re-fetch models. */
   onRefetch?: () => Promise<void> | void;
+  /** When true, show an editable Max Input Tokens field for each model. */
+  showMaxInputTokens?: boolean;
+  /** Callback invoked when a model's max_input_tokens value is changed. */
+  onMaxInputTokensChange?: (modelName: string, value: number | null) => void;
 }
 
 export function ModelsField<T extends BaseLLMFormValues>({
@@ -386,6 +391,8 @@ export function ModelsField<T extends BaseLLMFormValues>({
   recommendedDefaultModel,
   shouldShowAutoUpdateToggle,
   onRefetch,
+  showMaxInputTokens = false,
+  onMaxInputTokensChange,
 }: ModelsFieldProps<T>) {
   const isAutoMode = formikProps.values.is_auto_mode;
   const selectedModels = formikProps.values.selected_model_names ?? [];
@@ -526,52 +533,84 @@ export function ModelsField<T extends BaseLLMFormValues>({
                   const isDefault = defaultModel === modelConfiguration.name;
 
                   return (
-                    <Hoverable.Root
+                    <div
                       key={modelConfiguration.name}
-                      group="LLMConfigurationButton"
-                      widthVariant="full"
+                      className="flex flex-col w-full"
                     >
-                      <LineItemButton
-                        variant="section"
-                        sizePreset="main-ui"
-                        selectVariant="select-heavy"
-                        state={isSelected ? "selected" : "empty"}
-                        icon={() => <Checkbox checked={isSelected} />}
-                        title={modelConfiguration.name}
-                        onClick={() =>
-                          handleCheckboxChange(
-                            modelConfiguration.name,
-                            !isSelected
-                          )
-                        }
-                        rightChildren={
-                          isSelected ? (
-                            isDefault ? (
-                              <Section>
-                                <Tag color="blue" title="Default Model" />
-                              </Section>
-                            ) : (
-                              <Hoverable.Item
-                                group="LLMConfigurationButton"
-                                variant="opacity-on-hover"
-                              >
-                                <Button
-                                  size="sm"
-                                  prominence="internal"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleSetDefault(modelConfiguration.name);
-                                  }}
-                                  type="button"
-                                >
-                                  Set as default
-                                </Button>
-                              </Hoverable.Item>
+                      <Hoverable.Root
+                        group="LLMConfigurationButton"
+                        widthVariant="full"
+                      >
+                        <LineItemButton
+                          variant="section"
+                          sizePreset="main-ui"
+                          selectVariant="select-heavy"
+                          state={isSelected ? "selected" : "empty"}
+                          icon={() => <Checkbox checked={isSelected} />}
+                          title={modelConfiguration.name}
+                          onClick={() =>
+                            handleCheckboxChange(
+                              modelConfiguration.name,
+                              !isSelected
                             )
-                          ) : undefined
-                        }
-                      />
-                    </Hoverable.Root>
+                          }
+                          rightChildren={
+                            isSelected ? (
+                              isDefault ? (
+                                <Section>
+                                  <Tag color="blue" title="Default Model" />
+                                </Section>
+                              ) : (
+                                <Hoverable.Item
+                                  group="LLMConfigurationButton"
+                                  variant="opacity-on-hover"
+                                >
+                                  <Button
+                                    size="sm"
+                                    prominence="internal"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleSetDefault(
+                                        modelConfiguration.name
+                                      );
+                                    }}
+                                    type="button"
+                                  >
+                                    Set as default
+                                  </Button>
+                                </Hoverable.Item>
+                              )
+                            ) : undefined
+                          }
+                        />
+                      </Hoverable.Root>
+                      {showMaxInputTokens && isSelected && (
+                        <div className="flex items-center gap-2 pl-10 pr-2 pb-2">
+                          <Text secondaryBody text03>
+                            Max Input Tokens
+                          </Text>
+                          <div className="w-36">
+                            <InputTypeIn
+                              placeholder="Default"
+                              value={
+                                modelConfiguration.max_input_tokens?.toString() ??
+                                ""
+                              }
+                              onChange={(e) =>
+                                onMaxInputTokensChange?.(
+                                  modelConfiguration.name,
+                                  e.target.value === ""
+                                    ? null
+                                    : Number(e.target.value)
+                                )
+                              }
+                              showClearButton={false}
+                              type="number"
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
           </Section>


### PR DESCRIPTION
## Summary
- Adds an inline **Max Input Tokens** editor to the Ollama provider configuration modal, so token limits can be viewed and updated after initial provider setup
- Extends the shared `ModelsField` component with optional `showMaxInputTokens` / `onMaxInputTokensChange` props, keeping the change backward-compatible with all other provider modals
- Tracks token overrides outside Formik state and merges them into model configurations on submit; the wrapper's `isDirty` flag accounts for pending overrides so the Update button enables correctly

## Context
When a user creates an Ollama provider (either via the native Ollama dialog or the Custom Models dialog), the provider is saved with `provider: "ollama_chat"`. On subsequent edits the app opens the Ollama-specific modal, which previously had no UI for Max Input Tokens — making the value impossible to change without deleting and recreating the provider.

Fixes #9363

## Test plan
- [ ] Create a new Ollama provider via the Ollama dialog, select models, set Max Input Tokens values, and save — verify the values persist
- [ ] Re-open the provider settings and confirm Max Input Tokens fields are pre-populated with saved values
- [ ] Change a Max Input Tokens value and verify the Update button becomes enabled
- [ ] Submit the update and re-open to confirm the new value was saved
- [ ] Create an Ollama provider via the Custom Models dialog with explicit Max Input Tokens — verify editing through the Ollama modal afterwards works correctly
- [ ] Verify other provider modals (OpenAI, Anthropic, etc.) are unaffected (no Max Input Tokens field shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Max Input Tokens editable for Ollama provider models in the configuration modal so users can update limits after setup. This fixes #9363.

- **Bug Fixes**
  - Added inline Max Input Tokens editor in the Ollama modal (per selected model).
  - Extended shared `ModelsField` with `showMaxInputTokens` and `onMaxInputTokensChange` (backward-compatible).
  - Tracked overrides outside Formik and merged on submit; Update button enables only when actual values change.
  - Applied overrides in both onboarding and regular submit flows; cleared overrides when the API base URL changes.
  - Improved input UX/validation: numeric only, min=1, prevents NaN.
  - Other provider modals unchanged.

<sup>Written for commit 2819a9eea104c99a521f984407201e543929c812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

