### PR TITLE
Add Granola connector for meeting notes (#9681)

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -245,6 +245,8 @@ class DocumentSource(str, Enum):
     HIGHSPOT = "highspot"
     DRUPAL_WIKI = "drupal_wiki"
 
+    GRANOLA = "granola"
+
     IMAP = "imap"
     BITBUCKET = "bitbucket"
     TESTRAIL = "testrail"
@@ -705,6 +707,7 @@ project management, and collaboration tools into a single, customizable platform
     DocumentSource.AIRTABLE: "airtable - database",
     DocumentSource.HIGHSPOT: "highspot - CRM data",
     DocumentSource.DRUPAL_WIKI: "drupal wiki - knowledge base content (pages, spaces, attachments)",
+    DocumentSource.GRANOLA: "granola - meeting notes and transcripts",
     DocumentSource.IMAP: "imap - email data",
     DocumentSource.TESTRAIL: "testrail - test case management tool for QA processes",
 }

--- a/backend/onyx/connectors/granola/connector.py
+++ b/backend/onyx/connectors/granola/connector.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import Any, List, cast
+from typing import Any, cast
 import time
 
 import requests
@@ -128,7 +128,7 @@ class GranolaConnector(PollConnector, LoadConnector):
             resp = self._request("GET", "/notes", params=params)
             data = resp.json()
 
-            notes = cast(List[dict[str, Any]], data.get("notes", []))
+            notes = cast(list[dict[str, Any]], data.get("notes", []))
             if not notes:
                 break
 
@@ -272,7 +272,7 @@ class GranolaConnector(PollConnector, LoadConnector):
 
         return Document(
             id=doc_id,
-            sections=cast(List[TextSection | ImageSection], sections),
+            sections=cast(list[TextSection | ImageSection], sections),
             source=DocumentSource.GRANOLA,
             semantic_identifier=title,
             doc_metadata={"hierarchy": hierarchy},
@@ -295,7 +295,7 @@ class GranolaConnector(PollConnector, LoadConnector):
         created_before: str | None = None,
         updated_after: str | None = None,
     ) -> GenerateDocumentsOutput:
-        doc_batch: List[Document | HierarchyNode] = []
+        doc_batch: list[Document | HierarchyNode] = []
 
         for notes_page in self._iter_notes(
             created_after=created_after,
@@ -336,8 +336,13 @@ class GranolaConnector(PollConnector, LoadConnector):
     ) -> GenerateDocumentsOutput:
         """Incremental sync based on creation and update time.
 
-        We bound the window using created_after/created_before and also include
-        notes whose updated_at falls within the same window via updated_after.
+        We fetch the union of:
+          - notes created in the window [start, end]
+          - notes updated after ``start`` (regardless of creation time)
+
+        This avoids relying on the Granola API treating created/updated
+        filters with OR semantics and ensures we don't miss notes created
+        before the window but updated within it.
         """
 
         start_iso = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
@@ -347,8 +352,34 @@ class GranolaConnector(PollConnector, LoadConnector):
             "%Y-%m-%dT%H:%M:%SZ"
         )
 
-        return self._generate_documents(
-            created_after=start_iso,
-            created_before=end_iso,
-            updated_after=start_iso,
-        )
+        def _iterator() -> GenerateDocumentsOutput:
+            seen_ids: set[str] = set()
+
+            def _stream(gen: GenerateDocumentsOutput) -> GenerateDocumentsOutput:
+                for batch in gen:
+                    new_batch: list[Document | HierarchyNode] = []
+                    for item in batch:
+                        if isinstance(item, Document):
+                            if item.id in seen_ids:
+                                continue
+                            seen_ids.add(item.id)
+                        new_batch.append(item)
+                    if new_batch:
+                        yield new_batch
+
+            # First: notes created in the window
+            yield from _stream(
+                self._generate_documents(
+                    created_after=start_iso,
+                    created_before=end_iso,
+                )
+            )
+
+            # Second: notes updated after the window start
+            yield from _stream(
+                self._generate_documents(
+                    updated_after=start_iso,
+                )
+            )
+
+        return _iterator()

--- a/backend/onyx/connectors/granola/connector.py
+++ b/backend/onyx/connectors/granola/connector.py
@@ -106,6 +106,7 @@ class GranolaConnector(PollConnector, LoadConnector):
         created_after: str | None = None,
         created_before: str | None = None,
         updated_after: str | None = None,
+        updated_before: str | None = None,
     ) -> Iterator[list[dict[str, Any]]]:
         """Yield pages of notes from Granola.
 
@@ -119,6 +120,8 @@ class GranolaConnector(PollConnector, LoadConnector):
             params["created_before"] = created_before
         if updated_after:
             params["updated_after"] = updated_after
+        if updated_before:
+            params["updated_before"] = updated_before
 
         cursor: str | None = None
         while True:
@@ -294,6 +297,7 @@ class GranolaConnector(PollConnector, LoadConnector):
         created_after: str | None = None,
         created_before: str | None = None,
         updated_after: str | None = None,
+        updated_before: str | None = None,
     ) -> GenerateDocumentsOutput:
         doc_batch: list[Document | HierarchyNode] = []
 
@@ -301,17 +305,21 @@ class GranolaConnector(PollConnector, LoadConnector):
             created_after=created_after,
             created_before=created_before,
             updated_after=updated_after,
+            updated_before=updated_before,
         ):
             for note_summary in notes_page:
                 note_id = note_summary.get("id")
                 if not isinstance(note_id, str):
                     continue
 
+                # Surface per-note fetch failures rather than silently dropping
+                # notes, so upstream callers can decide how to handle errors
+                # and avoid advancing checkpoints while data is missing.
                 try:
                     note = self._get_note_details(note_id)
                 except Exception as e:  # pragma: no cover - defensive logging
                     logger.error("Failed to fetch Granola note %s: %s", note_id, e)
-                    continue
+                    raise
 
                 doc = self._create_document_from_note(note_summary, note)
                 if not doc:
@@ -338,7 +346,7 @@ class GranolaConnector(PollConnector, LoadConnector):
 
         We fetch the union of:
           - notes created in the window [start, end]
-          - notes updated after ``start`` (regardless of creation time)
+                    - notes updated in the window [start, end]
 
         This avoids relying on the Granola API treating created/updated
         filters with OR semantics and ensures we don't miss notes created
@@ -375,10 +383,11 @@ class GranolaConnector(PollConnector, LoadConnector):
                 )
             )
 
-            # Second: notes updated after the window start
+            # Second: notes updated within the window
             yield from _stream(
                 self._generate_documents(
                     updated_after=start_iso,
+                    updated_before=end_iso,
                 )
             )
 

--- a/backend/onyx/connectors/granola/connector.py
+++ b/backend/onyx/connectors/granola/connector.py
@@ -25,6 +25,7 @@ _GRANOLA_BASE_URL = "https://public-api.granola.ai/v1"
 _GRANOLA_ID_PREFIX = "GRANOLA_"
 _GRANOLA_PAGE_SIZE = 30  # Max page size per Granola docs
 _MIN_REQUEST_INTERVAL = 0.25  # seconds; stay under 5 req/sec sustained
+_REQUEST_TIMEOUT_SECONDS = 30  # prevent workers from hanging on stalled upstream
 
 
 def _parse_iso_datetime(dt_str: str | None) -> datetime | None:
@@ -57,7 +58,7 @@ class GranolaConnector(PollConnector, LoadConnector):
     # ---------------------------------------------------------------------
     # Credentials
     # ---------------------------------------------------------------------
-    def load_credentials(self, credentials: dict[str, str]) -> None:
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         api_key = credentials.get("granola_api_key")
 
         if not isinstance(api_key, str):
@@ -66,6 +67,8 @@ class GranolaConnector(PollConnector, LoadConnector):
             )
 
         self.api_key = api_key
+
+        return None
 
     # ---------------------------------------------------------------------
     # HTTP helpers
@@ -86,7 +89,13 @@ class GranolaConnector(PollConnector, LoadConnector):
             time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
 
         url = f"{_GRANOLA_BASE_URL}{path}"
-        response = self._session.request(method, url, headers=headers, **kwargs)
+        response = self._session.request(
+            method,
+            url,
+            headers=headers,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+            **kwargs,
+        )
         self._last_request_time = time.monotonic()
 
         response.raise_for_status()
@@ -155,6 +164,8 @@ class GranolaConnector(PollConnector, LoadConnector):
 
         created_at_str = cast(str | None, note.get("created_at"))
         created_at = _parse_iso_datetime(created_at_str) or datetime.now(timezone.utc)
+        updated_at_str = cast(str | None, note.get("updated_at"))
+        updated_at = _parse_iso_datetime(updated_at_str) or created_at
 
         year_month = created_at.strftime("%Y-%m")
 
@@ -250,10 +261,14 @@ class GranolaConnector(PollConnector, LoadConnector):
 
         metadata: dict[str, Any] = {
             "created_at": created_at_str,
-            "updated_at": note.get("updated_at"),
+            "updated_at": updated_at_str,
             "scheduled_start_time": calendar_event.get("scheduled_start_time"),
             "scheduled_end_time": calendar_event.get("scheduled_end_time"),
         }
+
+        if not sections:
+            # Skip documents with no indexable content (no summary or transcript)
+            return None
 
         return Document(
             id=doc_id,
@@ -266,7 +281,7 @@ class GranolaConnector(PollConnector, LoadConnector):
                 for k, v in metadata.items()
                 if v is not None
             },
-            doc_updated_at=created_at,
+            doc_updated_at=updated_at,
             primary_owners=primary_owners,
             secondary_owners=attendees_infos,
         )
@@ -278,12 +293,14 @@ class GranolaConnector(PollConnector, LoadConnector):
         self,
         created_after: str | None = None,
         created_before: str | None = None,
+        updated_after: str | None = None,
     ) -> GenerateDocumentsOutput:
         doc_batch: List[Document | HierarchyNode] = []
 
         for notes_page in self._iter_notes(
             created_after=created_after,
             created_before=created_before,
+            updated_after=updated_after,
         ):
             for note_summary in notes_page:
                 note_id = note_summary.get("id")
@@ -317,9 +334,10 @@ class GranolaConnector(PollConnector, LoadConnector):
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> GenerateDocumentsOutput:
-        """Incremental sync based on note creation time.
+        """Incremental sync based on creation and update time.
 
-        We bound the window using created_after/created_before filters.
+        We bound the window using created_after/created_before and also include
+        notes whose updated_at falls within the same window via updated_after.
         """
 
         start_iso = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
@@ -332,4 +350,5 @@ class GranolaConnector(PollConnector, LoadConnector):
         return self._generate_documents(
             created_after=start_iso,
             created_before=end_iso,
+            updated_after=start_iso,
         )

--- a/backend/onyx/connectors/granola/connector.py
+++ b/backend/onyx/connectors/granola/connector.py
@@ -15,7 +15,6 @@ from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
-from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
 
@@ -200,7 +199,7 @@ class GranolaConnector(PollConnector, LoadConnector):
                 )
             )
 
-        sections: list[TextSection | ImageSection] = []
+        sections: list[TextSection] = []
 
         # First section: AI-generated summary
         summary_markdown = note.get("summary_markdown")
@@ -275,7 +274,7 @@ class GranolaConnector(PollConnector, LoadConnector):
 
         return Document(
             id=doc_id,
-            sections=cast(list[TextSection | ImageSection], sections),
+            sections=cast(list[TextSection], sections),
             source=DocumentSource.GRANOLA,
             semantic_identifier=title,
             doc_metadata={"hierarchy": hierarchy},

--- a/backend/onyx/connectors/granola/connector.py
+++ b/backend/onyx/connectors/granola/connector.py
@@ -1,0 +1,335 @@
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from typing import Any, List, cast
+import time
+
+import requests
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import BasicExpertInfo
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import ImageSection
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_GRANOLA_BASE_URL = "https://public-api.granola.ai/v1"
+_GRANOLA_ID_PREFIX = "GRANOLA_"
+_GRANOLA_PAGE_SIZE = 30  # Max page size per Granola docs
+_MIN_REQUEST_INTERVAL = 0.25  # seconds; stay under 5 req/sec sustained
+
+
+def _parse_iso_datetime(dt_str: str | None) -> datetime | None:
+    if not dt_str:
+        return None
+    # Granola returns RFC 3339 with Z suffix, e.g. 2026-01-27T15:30:00Z
+    try:
+        if dt_str.endswith("Z"):
+            dt_str = dt_str.replace("Z", "+00:00")
+        return datetime.fromisoformat(dt_str).astimezone(timezone.utc)
+    except Exception:
+        logger.warning(f"Failed to parse Granola datetime: {dt_str}")
+        return None
+
+
+class GranolaConnector(PollConnector, LoadConnector):
+    """Connector for Granola (AI meeting notes).
+
+    Uses the public Granola REST API:
+      - GET /notes to list notes with cursor-based pagination
+      - GET /notes/{id}?include=transcript for full details and transcript
+    """
+
+    def __init__(self, batch_size: int = INDEX_BATCH_SIZE) -> None:
+        self.batch_size = batch_size
+        self.api_key: str | None = None
+        self._session = requests.Session()
+        self._last_request_time: float = 0.0
+
+    # ---------------------------------------------------------------------
+    # Credentials
+    # ---------------------------------------------------------------------
+    def load_credentials(self, credentials: dict[str, str]) -> None:
+        api_key = credentials.get("granola_api_key")
+
+        if not isinstance(api_key, str):
+            raise ConnectorMissingCredentialError(
+                "The Granola API key must be a string"
+            )
+
+        self.api_key = api_key
+
+    # ---------------------------------------------------------------------
+    # HTTP helpers
+    # ---------------------------------------------------------------------
+    def _request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        if self.api_key is None:
+            raise ConnectorMissingCredentialError("Granola")
+
+        headers = kwargs.pop("headers", {})
+        headers.setdefault("Authorization", f"Bearer {self.api_key}")
+        headers.setdefault("Accept", "application/json")
+
+        # Simple client-side rate limiting to stay within Granola's
+        # documented 5 req/sec sustained, 25 burst.
+        now = time.monotonic()
+        elapsed = now - self._last_request_time
+        if elapsed < _MIN_REQUEST_INTERVAL:
+            time.sleep(_MIN_REQUEST_INTERVAL - elapsed)
+
+        url = f"{_GRANOLA_BASE_URL}{path}"
+        response = self._session.request(method, url, headers=headers, **kwargs)
+        self._last_request_time = time.monotonic()
+
+        response.raise_for_status()
+        return response
+
+    def _iter_notes(
+        self,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        updated_after: str | None = None,
+    ) -> Iterator[list[dict[str, Any]]]:
+        """Yield pages of notes from Granola.
+
+        Uses cursor-based pagination with page_size capped at 30.
+        """
+
+        params: dict[str, Any] = {"page_size": _GRANOLA_PAGE_SIZE}
+        if created_after:
+            params["created_after"] = created_after
+        if created_before:
+            params["created_before"] = created_before
+        if updated_after:
+            params["updated_after"] = updated_after
+
+        cursor: str | None = None
+        while True:
+            if cursor:
+                params["cursor"] = cursor
+
+            resp = self._request("GET", "/notes", params=params)
+            data = resp.json()
+
+            notes = cast(List[dict[str, Any]], data.get("notes", []))
+            if not notes:
+                break
+
+            yield notes
+
+            has_more = data.get("hasMore")
+            cursor = data.get("cursor")
+            if not has_more or not cursor:
+                break
+
+    def _get_note_details(self, note_id: str) -> dict[str, Any]:
+        resp = self._request(
+            "GET",
+            f"/notes/{note_id}",
+            params={"include": "transcript"},
+        )
+        return resp.json()
+
+    # ---------------------------------------------------------------------
+    # Document construction
+    # ---------------------------------------------------------------------
+    def _create_document_from_note(
+        self, note_summary: dict[str, Any], note: dict[str, Any]
+    ) -> Document | None:
+        note_id = note.get("id") or note_summary.get("id")
+        if not isinstance(note_id, str):
+            logger.warning("Skipping Granola note with missing id: %s", note_id)
+            return None
+
+        doc_id = f"{_GRANOLA_ID_PREFIX}{note_id}"
+
+        title = note.get("title") or note_summary.get("title") or "Untitled meeting"
+
+        created_at_str = cast(str | None, note.get("created_at"))
+        created_at = _parse_iso_datetime(created_at_str) or datetime.now(timezone.utc)
+
+        year_month = created_at.strftime("%Y-%m")
+
+        owner = cast(dict[str, Any] | None, note.get("owner")) or {}
+        owner_email = owner.get("email")
+        owner_name = owner.get("name")
+
+        primary_owners: list[BasicExpertInfo] = []
+        if owner_email or owner_name:
+            primary_owners.append(
+                BasicExpertInfo(
+                    display_name=owner_name,
+                    email=owner_email,
+                )
+            )
+
+        attendees_infos: list[BasicExpertInfo] = []
+        for attendee in cast(list[dict[str, Any]] | None, note.get("attendees")) or []:
+            email = attendee.get("email")
+            name = attendee.get("name")
+            if not email and not name:
+                continue
+            if email and email == owner_email:
+                continue
+            attendees_infos.append(
+                BasicExpertInfo(
+                    display_name=name,
+                    email=email,
+                )
+            )
+
+        sections: list[TextSection | ImageSection] = []
+
+        # First section: AI-generated summary
+        summary_markdown = note.get("summary_markdown")
+        summary_text = note.get("summary_text")
+        if summary_markdown or summary_text:
+            summary = cast(str, summary_markdown or summary_text)
+            sections.append(
+                TextSection(
+                    link=None,
+                    text=summary,
+                )
+            )
+
+        # Transcript segments with (best-effort) speaker labels
+        transcript = cast(list[dict[str, Any]] | None, note.get("transcript")) or []
+        for segment in transcript:
+            speaker = cast(dict[str, Any] | None, segment.get("speaker")) or {}
+            speaker_name = speaker.get("name")
+            speaker_email = speaker.get("email")
+            speaker_source = speaker.get("source")
+
+            if speaker_name and speaker_email:
+                speaker_label = f"{speaker_name} ({speaker_email})"
+            elif speaker_name:
+                speaker_label = speaker_name
+            elif speaker_email:
+                speaker_label = speaker_email
+            elif speaker_source:
+                speaker_label = speaker_source
+            else:
+                speaker_label = "Unknown speaker"
+
+            text = segment.get("text")
+            if not text:
+                continue
+
+            sections.append(
+                TextSection(
+                    link=None,
+                    text=f"{speaker_label}: {text}",
+                )
+            )
+
+        folder_membership = cast(
+            list[dict[str, Any]] | None, note.get("folder_membership")
+        ) or []
+        folder_names = [
+            folder.get("name")
+            for folder in folder_membership
+            if isinstance(folder.get("name"), str)
+        ]
+
+        hierarchy = {
+            "source_path": [year_month] + folder_names if folder_names else [year_month],
+            "year_month": year_month,
+            "meeting_title": title,
+            "owner_email": owner_email,
+        }
+
+        calendar_event = cast(dict[str, Any] | None, note.get("calendar_event")) or {}
+
+        metadata: dict[str, Any] = {
+            "created_at": created_at_str,
+            "updated_at": note.get("updated_at"),
+            "scheduled_start_time": calendar_event.get("scheduled_start_time"),
+            "scheduled_end_time": calendar_event.get("scheduled_end_time"),
+        }
+
+        return Document(
+            id=doc_id,
+            sections=cast(List[TextSection | ImageSection], sections),
+            source=DocumentSource.GRANOLA,
+            semantic_identifier=title,
+            doc_metadata={"hierarchy": hierarchy},
+            metadata={
+                k: str(v)
+                for k, v in metadata.items()
+                if v is not None
+            },
+            doc_updated_at=created_at,
+            primary_owners=primary_owners,
+            secondary_owners=attendees_infos,
+        )
+
+    # ---------------------------------------------------------------------
+    # Streaming interface required by connector runner
+    # ---------------------------------------------------------------------
+    def _generate_documents(
+        self,
+        created_after: str | None = None,
+        created_before: str | None = None,
+    ) -> GenerateDocumentsOutput:
+        doc_batch: List[Document | HierarchyNode] = []
+
+        for notes_page in self._iter_notes(
+            created_after=created_after,
+            created_before=created_before,
+        ):
+            for note_summary in notes_page:
+                note_id = note_summary.get("id")
+                if not isinstance(note_id, str):
+                    continue
+
+                try:
+                    note = self._get_note_details(note_id)
+                except Exception as e:  # pragma: no cover - defensive logging
+                    logger.error("Failed to fetch Granola note %s: %s", note_id, e)
+                    continue
+
+                doc = self._create_document_from_note(note_summary, note)
+                if not doc:
+                    continue
+
+                doc_batch.append(doc)
+
+                if len(doc_batch) >= self.batch_size:
+                    yield doc_batch
+                    doc_batch = []
+
+        if doc_batch:
+            yield doc_batch
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        """Full sync: fetch all accessible notes."""
+
+        return self._generate_documents()
+
+    def poll_source(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> GenerateDocumentsOutput:
+        """Incremental sync based on note creation time.
+
+        We bound the window using created_after/created_before filters.
+        """
+
+        start_iso = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        end_iso = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+
+        return self._generate_documents(
+            created_after=start_iso,
+            created_before=end_iso,
+        )

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -212,6 +212,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.testrail.connector",
         class_name="TestRailConnector",
     ),
+    DocumentSource.GRANOLA: ConnectorMapping(
+        module_path="onyx.connectors.granola.connector",
+        class_name="GranolaConnector",
+    ),
     # just for integration tests
     DocumentSource.MOCK_CONNECTOR: ConnectorMapping(
         module_path="onyx.connectors.mock_connector.connector",

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -96,7 +96,6 @@ import loopioIcon from "@public/Loopio.png";
 import notionIcon from "@public/Notion.png";
 import productboardIcon from "@public/Productboard.png";
 import slabLogoIcon from "@public/SlabLogo.png";
-import granolaIcon from "@public/Granola.png";
 
 export interface IconProps {
   size?: number;
@@ -845,7 +844,6 @@ export const DiscourseIcon = createLogoIcon(discourseIcon);
 export const Document360Icon = createLogoIcon(document360Icon);
 export const DropboxIcon = createLogoIcon(dropboxIcon);
 export const DrupalWikiIcon = createLogoIcon(drupalwikiIcon);
-export const GranolaIcon = createLogoIcon(granolaIcon);
 export const EgnyteIcon = createLogoIcon(egnyteIcon);
 export const ElevenLabsIcon = createLogoIcon(elevenLabsSVG, {
   darkSrc: elevenLabsDarkSVG,

--- a/web/src/components/icons/icons.tsx
+++ b/web/src/components/icons/icons.tsx
@@ -96,6 +96,7 @@ import loopioIcon from "@public/Loopio.png";
 import notionIcon from "@public/Notion.png";
 import productboardIcon from "@public/Productboard.png";
 import slabLogoIcon from "@public/SlabLogo.png";
+import granolaIcon from "@public/Granola.png";
 
 export interface IconProps {
   size?: number;
@@ -844,6 +845,7 @@ export const DiscourseIcon = createLogoIcon(discourseIcon);
 export const Document360Icon = createLogoIcon(document360Icon);
 export const DropboxIcon = createLogoIcon(dropboxIcon);
 export const DrupalWikiIcon = createLogoIcon(drupalwikiIcon);
+export const GranolaIcon = createLogoIcon(granolaIcon);
 export const EgnyteIcon = createLogoIcon(egnyteIcon);
 export const ElevenLabsIcon = createLogoIcon(elevenLabsSVG, {
   darkSrc: elevenLabsDarkSVG,

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -1641,6 +1641,11 @@ For example, specifying .*-support.* as a "channel" will cause the connector to 
     values: [],
     advanced_values: [],
   },
+  granola: {
+    description: "Configure Granola connector",
+    values: [],
+    advanced_values: [],
+  },
   egnyte: {
     description: "Configure Egnyte connector",
     values: [

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -248,6 +248,10 @@ export interface FirefliesCredentialJson {
   fireflies_api_key: string;
 }
 
+export interface GranolaCredentialJson {
+  granola_api_key: string;
+}
+
 export interface MediaWikiCredentialJson {}
 export interface WikipediaCredentialJson extends MediaWikiCredentialJson {}
 
@@ -445,6 +449,9 @@ export const credentialTemplates: Record<ValidSources, any> = {
   fireflies: {
     fireflies_api_key: "",
   } as FirefliesCredentialJson,
+  granola: {
+    granola_api_key: "",
+  } as GranolaCredentialJson,
   egnyte: {
     domain: "",
     access_token: "",
@@ -639,6 +646,9 @@ export const credentialDisplayNames: Record<string, string> = {
 
   // Fireflies
   fireflies_api_key: "Fireflies API Key",
+
+  // Granola
+  granola_api_key: "Granola API Key",
 
   // GitBook
   gitbook_space_id: "GitBook Space ID",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -364,7 +364,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/fireflies`,
   },
   granola: {
-    icon: FirefliesIcon,
+    icon: SvgGlobe,
     displayName: "Granola",
     category: SourceCategory.Sales,
     // Placeholder docs path; can be updated when official docs exist

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -47,7 +47,6 @@ import {
   DrupalWikiIcon,
   EmailIcon,
   TestRailIcon,
-  GranolaIcon,
 } from "@/components/icons/icons";
 import { ValidSources } from "./types";
 import { SourceCategory, SourceMetadata } from "./search/interfaces";
@@ -365,7 +364,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/fireflies`,
   },
   granola: {
-    icon: GranolaIcon,
+    icon: FirefliesIcon,
     displayName: "Granola",
     category: SourceCategory.Sales,
     // Placeholder docs path; can be updated when official docs exist

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -47,6 +47,7 @@ import {
   DrupalWikiIcon,
   EmailIcon,
   TestRailIcon,
+  GranolaIcon,
 } from "@/components/icons/icons";
 import { ValidSources } from "./types";
 import { SourceCategory, SourceMetadata } from "./search/interfaces";
@@ -364,7 +365,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/fireflies`,
   },
   granola: {
-    icon: FirefliesIcon,
+    icon: GranolaIcon,
     displayName: "Granola",
     category: SourceCategory.Sales,
     // Placeholder docs path; can be updated when official docs exist

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -363,6 +363,13 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     category: SourceCategory.Sales,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/fireflies`,
   },
+  granola: {
+    icon: FirefliesIcon,
+    displayName: "Granola",
+    category: SourceCategory.Sales,
+    // Placeholder docs path; can be updated when official docs exist
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/granola`,
+  },
   highspot: {
     icon: HighspotIcon,
     displayName: "Highspot",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -536,6 +536,8 @@ export enum ValidSources {
   Bitbucket = "bitbucket",
   TestRail = "testrail",
 
+  Granola = "granola",
+
   // Craft-specific sources
   CraftFile = "craft_file",
 


### PR DESCRIPTION
Summary
Adds a new Granola connector to index AI meeting notes (summaries and transcripts) from Granola’s public REST API and exposes it in the Onyx admin UI.

Resolves #9681.

Motivation
Granola is a popular AI meeting notes app; its notes and transcripts contain high-signal knowledge that teams frequently search across. Onyx already supports similar tools like Fireflies and Gong. This connector lets customers index Granola notes alongside their other sales / meeting data.

Implementation details

Backend

Introduced DocumentSource.GRANOLA and a description entry in DocumentSourceDescription.
Implemented GranolaConnector in backend/onyx/connectors/granola/connector.py:
Uses granola_api_key (Bearer grn_*) for authentication.
Lists notes via GET /v1/notes using page_size, created_after, created_before, and cursor-based pagination.
Fetches full note details and transcript via GET /v1/notes/{id}?include=transcript.
Builds Document objects that include:
AI-generated summaries (summary_markdown or summary_text) as the first text section.
Full transcript as additional text sections with best-effort speaker labels (name/email/source).
Metadata: created_at, updated_at, and calendar event scheduled_start_time / scheduled_end_time.
Hierarchy based on year-month and Granola folder membership (for example: ["2026-01", "Top secret recipes"]).
Primary owner from the note owner; secondary owners from attendees.
Registered the connector under DocumentSource.GRANOLA in backend/onyx/connectors/registry.py.
Frontend

Added ValidSources.Granola = "granola" in web/src/lib/types.ts.
Defined credentials in web/src/lib/connectors/credentials.ts:
GranolaCredentialJson { granola_api_key: string }.
credentialTemplates.granola with granola_api_key.
Display name: granola_api_key → “Granola API Key”.
Added a basic connector config in web/src/lib/connectors/connectors.tsx (no extra options beyond the API key).
Exposed Granola as a source in web/src/lib/sources.ts under the Sales category with a docs path pointing to connectors/official/granola (placeholder until docs exist).
Testing

Manual: verified types and wiring compile locally (no new issues beyond existing ones).
Automated: connector tests did not run locally because pytest is not installed in the current environment; relying on CI to run the connector test suite.
Notes / follow-ups

The docs URL for Granola currently points to a placeholder; once official docs exist, that page should be created or the path updated.
A small connector unit test that mocks the Granola API (for example, around GranolaConnector document shaping) can be added in a follow-up if desired.