### PR TITLE
fix custom llm default model submission

### DIFF
--- a/web/src/sections/modals/llmConfig/CustomModal.tsx
+++ b/web/src/sections/modals/llmConfig/CustomModal.tsx
@@ -19,6 +19,7 @@ import {
   ModelsAccessField,
   LLMConfigurationModalWrapper,
   FieldWrapper,
+  SingleDefaultModelField,
 } from "@/sections/modals/llmConfig/shared";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import * as InputLayouts from "@/layouts/input-layouts";
@@ -191,6 +192,12 @@ function customConfigProcessing(items: KeyValue[]) {
   return customConfig;
 }
 
+function getFirstConfiguredModelName(
+  models: CustomModelConfiguration[] | undefined
+): string {
+  return models?.find((model) => model.name.trim() !== "")?.name ?? "";
+}
+
 export default function CustomModal({
   variant = "llm-configuration",
   existingLlmProvider,
@@ -232,6 +239,16 @@ export default function CustomModal({
         supports_image_input: false,
       },
     ],
+    default_model_name:
+      existingLlmProvider?.model_configurations?.[0]?.name ??
+      getFirstConfiguredModelName(
+        existingLlmProvider?.model_configurations.map((mc) => ({
+          name: mc.name,
+          display_name: mc.display_name ?? "",
+          max_input_tokens: mc.max_input_tokens ?? null,
+          supports_image_input: mc.supports_image_input,
+        }))
+      ),
     custom_config_list: existingLlmProvider?.custom_config
       ? Object.entries(existingLlmProvider.custom_config).map(
           ([key, value]) => ({ key, value: String(value) })
@@ -252,11 +269,13 @@ export default function CustomModal({
   const validationSchema = isOnboarding
     ? Yup.object().shape({
         provider: Yup.string().required("Provider Name is required"),
+        default_model_name: Yup.string().required("Default model is required"),
         model_configurations: Yup.array(modelConfigurationSchema),
       })
     : Yup.object().shape({
         name: Yup.string().required("Display Name is required"),
         provider: Yup.string().required("Provider Name is required"),
+        default_model_name: Yup.string().required("Default model is required"),
         model_configurations: Yup.array(modelConfigurationSchema),
       });
 
@@ -285,11 +304,21 @@ export default function CustomModal({
           return;
         }
 
+        const resolvedDefaultModelName =
+          values.default_model_name || modelConfigurations[0]?.name || "";
+
+        if (!resolvedDefaultModelName) {
+          toast.error("A default model is required");
+          setSubmitting(false);
+          return;
+        }
+
         if (isOnboarding && onboardingState && onboardingActions) {
           await submitOnboardingProvider({
             providerName: values.provider,
             payload: {
               ...values,
+              default_model_name: resolvedDefaultModelName,
               model_configurations: modelConfigurations,
               custom_config: customConfigProcessing(values.custom_config_list),
             },
@@ -308,6 +337,7 @@ export default function CustomModal({
             providerName: values.provider,
             values: {
               ...values,
+              default_model_name: resolvedDefaultModelName,
               selected_model_names: selectedModelNames,
               custom_config: customConfigProcessing(values.custom_config_list),
             },
@@ -397,6 +427,12 @@ export default function CustomModal({
               <ModelConfigurationList formikProps={formikProps as any} />
             </Card>
           </Section>
+
+          <FieldSeparator />
+
+          <FieldWrapper>
+            <SingleDefaultModelField placeholder="E.g. gemini-3-flash" />
+          </FieldWrapper>
 
           {!isOnboarding && (
             <>


### PR DESCRIPTION
Previously, the Set up Custom Models modal let users define model configurations, but it did not expose or reliably populate the top-level default_model_name field required by the backend test/save flow. As a result, /api/admin/llm/test could be sent with an empty model, causing valid OpenAI-compatible providers to fail setup.

This change:
- adds a visible Default Model field to the Custom LLM modal
- requires default_model_name during validation
- falls back to the first configured model during submit if no default was explicitly selected
- ensures the resolved default model is sent in the provider test/save payload

How Has This Been Tested?

- Rebuilt and redeployed the patched web_server
- Verified the updated frontend is serving successfully
- Confirmed the target OpenAI-compatible endpoint responds from inside onyx-api_server for:
- GET /v1/models
- POST /v1/chat/completions
- Reproduced the original issue by inspecting the failing payload where model was empty
- Verified the UI fix now provides a path for sending a non-empty default model value

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Custom LLM setup so a valid default model is always captured and sent when testing or saving. This prevents empty model submissions that caused OpenAI-compatible providers to fail.

- **Bug Fixes**
  - Added a visible Default Model field in the Custom LLM modal.
  - Required `default_model_name` in validation (onboarding and edit).
  - Fallback to the first configured model if no default is selected.
  - Send the resolved `default_model_name` in provider test/save payloads.

<sup>Written for commit fe756af0992869fe9eb97e347a7aa5f69c386c56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

