### PR TITLE
fix(web): guard LLMSelector against undefined llmProviders

### DIFF
--- a/web/src/components/llm/LLMSelector.tsx
+++ b/web/src/components/llm/LLMSelector.tsx
@@ -22,7 +22,7 @@ interface LLMOption {
 export interface LLMSelectorProps {
   name?: string;
   userSettings?: boolean;
-  llmProviders: LLMProviderDescriptor[];
+  llmProviders: LLMProviderDescriptor[] | undefined;
   defaultText?: DefaultModel | null;
   currentLlm: string | null;
   onSelect: (value: string | null) => void;
@@ -46,6 +46,8 @@ export default function LLMSelector({
   );
 
   const llmOptions = useMemo(() => {
+    if (!llmProviders) return [];
+
     const seenKeys = new Set<string>();
     const options: LLMOption[] = [];
 
@@ -142,7 +144,7 @@ export default function LLMSelector({
   }, [llmOptions]);
 
   const defaultProvider = defaultText
-    ? llmProviders.find((p) => p.id === defaultText.provider_id)
+    ? llmProviders?.find((p) => p.id === defaultText.provider_id)
     : undefined;
 
   const defaultModelName = defaultText?.model_name;


### PR DESCRIPTION
## Summary
Fixes #9365

- Added `undefined` guard in `LLMSelector` to prevent `TypeError: eu.forEach is not a function` crash on startup when no LLM provider is configured
- Updated `llmProviders` prop type from `LLMProviderDescriptor[]` to `LLMProviderDescriptor[] | undefined` to match the actual data flow from `useLLMProviders()`
- Added optional chaining on `.find()` call for the same reason

## Root Cause
`useLLMProviders()` returns `undefined` while loading or on error (`data?.providers`). Other LLM components (`LLMPopover`, `BuildLLMPopover`) already guard against this, but `LLMSelector` did not — it called `.forEach()` and `.find()` directly on the prop, crashing when providers hadn't loaded yet.

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [ ] Manual: log in with no LLM provider configured — page should render without crash
- [ ] Manual: chat page with providers configured — LLM selector works as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded the web LLM selector against undefined providers to prevent a startup crash. It now waits for provider data and works as before once loaded.

- **Bug Fixes**
  - Return empty options when `llmProviders` is undefined and use optional chaining in `.find()`.
  - Update `LLMSelectorProps.llmProviders` type to `LLMProviderDescriptor[] | undefined` to match `useLLMProviders()`.

<sup>Written for commit 7c38fe22d1cfaf69baf9d2257e1b9399dde6d4b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

