### PR TITLE
fix(lite): lazy RedisPool init and add missing lite env vars

### DIFF
--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -142,27 +142,33 @@ class TenantRedis(redis.Redis):
 class RedisPool:
     _instance: Optional["RedisPool"] = None
     _lock: threading.Lock = threading.Lock()
-    _pool: redis.BlockingConnectionPool
-    _replica_pool: redis.BlockingConnectionPool
+    _pool: redis.BlockingConnectionPool | None
+    _replica_pool: redis.BlockingConnectionPool | None
 
     def __new__(cls) -> "RedisPool":
         if not cls._instance:
             with cls._lock:
                 if not cls._instance:
                     cls._instance = super(RedisPool, cls).__new__(cls)
-                    cls._instance._init_pools()
+                    cls._instance._pool = None
+                    cls._instance._replica_pool = None
         return cls._instance
 
-    def _init_pools(self) -> None:
-        self._pool = RedisPool.create_pool(ssl=REDIS_SSL)
-        self._replica_pool = RedisPool.create_pool(
-            host=REDIS_REPLICA_HOST, ssl=REDIS_SSL
-        )
+    def _ensure_pools(self) -> None:
+        if self._pool is None:
+            with self._lock:
+                if self._pool is None:
+                    self._pool = RedisPool.create_pool(ssl=REDIS_SSL)
+                    self._replica_pool = RedisPool.create_pool(
+                        host=REDIS_REPLICA_HOST, ssl=REDIS_SSL
+                    )
 
     def get_client(self, tenant_id: str) -> Redis:
+        self._ensure_pools()
         return TenantRedis(tenant_id, connection_pool=self._pool)
 
     def get_replica_client(self, tenant_id: str) -> Redis:
+        self._ensure_pools()
         return TenantRedis(tenant_id, connection_pool=self._replica_pool)
 
     def get_raw_client(self) -> Redis:
@@ -170,6 +176,7 @@ class RedisPool:
         Returns a Redis client with direct access to the primary connection pool,
         without tenant prefixing.
         """
+        self._ensure_pools()
         return redis.Redis(connection_pool=self._pool)
 
     def get_raw_replica_client(self) -> Redis:
@@ -177,6 +184,7 @@ class RedisPool:
         Returns a Redis client with direct access to the replica connection pool,
         without tenant prefixing.
         """
+        self._ensure_pools()
         return redis.Redis(connection_pool=self._replica_pool)
 
     @staticmethod

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -158,10 +158,12 @@ class RedisPool:
         if self._pool is None:
             with self._lock:
                 if self._pool is None:
-                    self._pool = RedisPool.create_pool(ssl=REDIS_SSL)
-                    self._replica_pool = RedisPool.create_pool(
+                    pool = RedisPool.create_pool(ssl=REDIS_SSL)
+                    replica_pool = RedisPool.create_pool(
                         host=REDIS_REPLICA_HOST, ssl=REDIS_SSL
                     )
+                    self._replica_pool = replica_pool
+                    self._pool = pool
 
     def get_client(self, tenant_id: str) -> Redis:
         self._ensure_pools()

--- a/deployment/docker_compose/docker-compose.onyx-lite.yml
+++ b/deployment/docker_compose/docker-compose.onyx-lite.yml
@@ -57,6 +57,8 @@ services:
       - FILE_STORE_BACKEND=postgres
       - CACHE_BACKEND=postgres
       - AUTH_BACKEND=postgres
+      - DISABLE_MODEL_SERVER=true
+      - ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false
 
   # Move the background worker to a profile so it does not start by default.
   # The API server handles all background work in lite mode.


### PR DESCRIPTION
## Summary
Fixes #9588

- Made `RedisPool` initialization lazy — connection pools are now created on first use (`_ensure_pools()`) instead of eagerly at module import time. In lite mode (`CACHE_BACKEND=postgres`), Redis pools are never created since no code path touches them.
- Added `DISABLE_MODEL_SERVER=true` and `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false` to `docker-compose.onyx-lite.yml` — these were missing and had to be manually discovered as workarounds (per issue commenter).

## Test plan
- [x] `pytest backend/tests/unit/onyx/utils/test_gpu_utils.py` — 9/9 pass
- [x] Smoke test confirms `redis_pool._pool` is `None` after import (lazy)
- [ ] Manual: `docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml up -d` starts without Redis/Vespa/model server errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `RedisPool` initialization lazy and harden it against partial init, and add missing lite env flags to avoid Redis and model server errors in Onyx Lite.

- **Bug Fixes**
  - Lazy init via `_ensure_pools()` with staged locals before assignment to prevent partial initialization; in lite (`CACHE_BACKEND=postgres`), pools are never created.
  - Added `DISABLE_MODEL_SERVER=true` and `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false` to `docker-compose.onyx-lite.yml`.

<sup>Written for commit 5d0c8131b768061a0fc8366ae4274aa2238c8945. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

