### PR TITLE
fix(install): protect is_interactive() from set -e with || true

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -174,7 +174,7 @@ ensure_file() {
 
 # --- Interactive prompt helpers ---
 is_interactive() {
-    [[ "$NO_PROMPT" = false ]] && [[ -r /dev/tty ]] && [[ -w /dev/tty ]]
+    [[ "$NO_PROMPT" = false ]] && [[ -r /dev/tty ]] && [[ -w /dev/tty ]] || true
 }
 
 read_prompt_line() {


### PR DESCRIPTION
## Summary

Fixes #9746. The `is_interactive()` function in `install.sh` causes script exit when `set -e` is enabled and the condition evaluates to false.

## Fix

Add `|| true` to the is_interactive() return statement.

Closes #9746

---
*Replacement PR for #9742 (divergent branch conflicts).*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `install.sh` from exiting when `set -e` is enabled and `is_interactive()` evaluates to false. Appends `|| true` so non-interactive runs skip prompts without aborting.

<sup>Written for commit 3cae39905a6c038bea2ebdd85075b607fbcd1ff7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

