### PR TITLE
refactor: db sessions in tasks

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -470,6 +470,7 @@ def connector_permission_sync_generator_task(
         return None
 
     try:
+        # --- Phase 1: Read cc_pair config + validate (short-lived session) ---
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair_from_id(
                 db_session=db_session,
@@ -498,7 +499,6 @@ def connector_permission_sync_generator_task(
                 task_logger.exception(
                     f"validate_ccpair_permissions_sync exceptioned: cc_pair={cc_pair_id}"
                 )
-                # TODO: add some notification to the admins here
                 raise
 
             source_type = cc_pair.connector.source
@@ -523,94 +523,100 @@ def connector_permission_sync_generator_task(
 
             mark_doc_permission_sync_attempt_in_progress(attempt_id, db_session)
 
-            payload = redis_connector.permissions.payload
-            if not payload:
-                raise ValueError(f"No fence payload found: cc_pair={cc_pair_id}")
+            # Extract identifiers for closures below (survive session close)
+            _connector_id = cc_pair.connector.id
+            _credential_id = cc_pair.credential.id
 
-            new_payload = RedisConnectorPermissionSyncPayload(
-                id=payload.id,
-                submitted=payload.submitted,
-                started=datetime.now(timezone.utc),
-                celery_task_id=payload.celery_task_id,
-            )
-            redis_connector.permissions.set_fence(new_payload)
+        # --- Phase 2: External work (no session held) ---
+        payload = redis_connector.permissions.payload
+        if not payload:
+            raise ValueError(f"No fence payload found: cc_pair={cc_pair_id}")
 
-            callback = PermissionSyncCallback(
-                redis_connector, lock, r, timeout_seconds=JOB_TIMEOUT
-            )
+        new_payload = RedisConnectorPermissionSyncPayload(
+            id=payload.id,
+            submitted=payload.submitted,
+            started=datetime.now(timezone.utc),
+            celery_task_id=payload.celery_task_id,
+        )
+        redis_connector.permissions.set_fence(new_payload)
 
-            # pass in the capability to fetch all existing docs for the cc_pair
-            # this is can be used to determine documents that are "missing" and thus
-            # should no longer be accessible. The decision as to whether we should find
-            # every document during the doc sync process is connector-specific.
-            def fetch_all_existing_docs_fn(
-                sort_order: SortOrder | None = None,
-            ) -> list[DocumentRow]:
+        callback = PermissionSyncCallback(
+            redis_connector, lock, r, timeout_seconds=JOB_TIMEOUT
+        )
+
+        # These closures open their own sessions so the caller doesn't need
+        # to hold a long-lived session during the external doc_sync_func call.
+        def fetch_all_existing_docs_fn(
+            sort_order: SortOrder | None = None,
+        ) -> list[DocumentRow]:
+            with get_session_with_current_tenant() as inner_db:
                 result = get_documents_for_connector_credential_pair_limited_columns(
-                    db_session=db_session,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
+                    db_session=inner_db,
+                    connector_id=_connector_id,
+                    credential_id=_credential_id,
                     sort_order=sort_order,
                 )
                 return list(result)
 
-            def fetch_all_existing_docs_ids_fn() -> list[str]:
-                result = get_document_ids_for_connector_credential_pair(
-                    db_session=db_session,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
+        def fetch_all_existing_docs_ids_fn() -> list[str]:
+            with get_session_with_current_tenant() as inner_db:
+                return get_document_ids_for_connector_credential_pair(
+                    db_session=inner_db,
+                    connector_id=_connector_id,
+                    credential_id=_credential_id,
                 )
-                return result
 
-            doc_sync_func = sync_config.doc_sync_config.doc_sync_func
-            document_external_accesses = doc_sync_func(
-                cc_pair,
-                fetch_all_existing_docs_fn,
-                fetch_all_existing_docs_ids_fn,
-                callback,
-            )
+        doc_sync_func = sync_config.doc_sync_config.doc_sync_func
+        document_external_accesses = doc_sync_func(
+            cc_pair,
+            fetch_all_existing_docs_fn,
+            fetch_all_existing_docs_ids_fn,
+            callback,
+        )
 
-            task_logger.info(
-                f"RedisConnector.permissions.generate_tasks starting. cc_pair={cc_pair_id}"
-            )
+        task_logger.info(
+            f"RedisConnector.permissions.generate_tasks starting. cc_pair={cc_pair_id}"
+        )
 
-            tasks_generated = 0
-            docs_with_errors = 0
-            for doc_external_access in document_external_accesses:
-                if callback.should_stop():
-                    raise RuntimeError(
-                        f"Permission sync task timed out or stop signal detected: "
-                        f"cc_pair={cc_pair_id} "
-                        f"tasks_generated={tasks_generated}"
-                    )
-
-                result = redis_connector.permissions.update_db(
-                    lock=lock,
-                    new_permissions=[doc_external_access],
-                    source_string=source_type,
-                    connector_id=cc_pair.connector.id,
-                    credential_id=cc_pair.credential.id,
-                    task_logger=task_logger,
+        tasks_generated = 0
+        docs_with_errors = 0
+        for doc_external_access in document_external_accesses:
+            if callback.should_stop():
+                raise RuntimeError(
+                    f"Permission sync task timed out or stop signal detected: "
+                    f"cc_pair={cc_pair_id} "
+                    f"tasks_generated={tasks_generated}"
                 )
-                tasks_generated += result.num_updated
-                docs_with_errors += result.num_errors
 
-            task_logger.info(
-                f"RedisConnector.permissions.generate_tasks finished. "
-                f"cc_pair={cc_pair_id} tasks_generated={tasks_generated} docs_with_errors={docs_with_errors}"
+            result = redis_connector.permissions.update_db(
+                lock=lock,
+                new_permissions=[doc_external_access],
+                source_string=source_type,
+                connector_id=_connector_id,
+                credential_id=_credential_id,
+                task_logger=task_logger,
             )
+            tasks_generated += result.num_updated
+            docs_with_errors += result.num_errors
 
+        task_logger.info(
+            f"RedisConnector.permissions.generate_tasks finished. "
+            f"cc_pair={cc_pair_id} tasks_generated={tasks_generated} docs_with_errors={docs_with_errors}"
+        )
+
+        # --- Phase 3: Write completion (short-lived session) ---
+        with get_session_with_current_tenant() as db_session:
             complete_doc_permission_sync_attempt(
                 db_session=db_session,
                 attempt_id=attempt_id,
                 total_docs_synced=tasks_generated,
                 docs_with_permission_errors=docs_with_errors,
             )
-            task_logger.info(
-                f"Completed doc permission sync attempt {attempt_id}: {tasks_generated} docs, {docs_with_errors} errors"
-            )
+        task_logger.info(
+            f"Completed doc permission sync attempt {attempt_id}: {tasks_generated} docs, {docs_with_errors} errors"
+        )
 
-            redis_connector.permissions.generator_complete = tasks_generated
+        redis_connector.permissions.generator_complete = tasks_generated
 
     except Exception as e:
         error_msg = format_error_for_logging(e)

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -37,6 +37,7 @@ from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import CELERY_EXTERNAL_GROUP_SYNC_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_TASK_WAIT_FOR_FENCE_TIMEOUT
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -460,6 +461,21 @@ def connector_external_group_sync_generator_task(
     )
 
 
+def _upsert_group_batch(
+    cc_pair_id: int,
+    source: DocumentSource,
+    batch: list[ExternalUserGroup],
+) -> None:
+    """Write a batch of external groups in a short-lived session."""
+    with get_session_with_current_tenant() as db_session:
+        upsert_external_groups(
+            db_session=db_session,
+            cc_pair_id=cc_pair_id,
+            external_groups=batch,
+            source=source,
+        )
+
+
 def _perform_external_group_sync(
     cc_pair_id: int,
     tenant_id: str,
@@ -475,6 +491,7 @@ def _perform_external_group_sync(
             f"Created external group sync attempt: {attempt_id} for cc_pair={cc_pair_id}"
         )
 
+    # --- Phase 1: Read cc_pair config + mark stale (short-lived session) ---
     with get_session_with_current_tenant() as db_session:
         cc_pair = get_connector_credential_pair_from_id(
             db_session=db_session,
@@ -505,84 +522,66 @@ def _perform_external_group_sync(
         )
         mark_old_external_groups_as_stale(db_session, cc_pair_id)
 
-        # Mark attempt as in progress
         mark_external_group_sync_attempt_in_progress(attempt_id, db_session)
         logger.info(f"Marked external group sync attempt {attempt_id} as in progress")
 
-        logger.info(
-            f"Syncing external groups for {source_type} for cc_pair: {cc_pair_id}"
-        )
-        external_user_group_batch: list[ExternalUserGroup] = []
-        seen_users: set[str] = set()  # Track unique users across all groups
-        total_groups_processed = 0
-        total_group_memberships_synced = 0
-        start_time = time.monotonic()
-        try:
-            external_user_group_generator = ext_group_sync_func(tenant_id, cc_pair)
-            for external_user_group in external_user_group_generator:
-                # Check if the task has exceeded its timeout
-                # NOTE: Celery's soft_time_limit does not work with thread pools,
-                # so we must enforce timeouts internally.
-                elapsed = time.monotonic() - start_time
-                if elapsed > timeout_seconds:
-                    raise RuntimeError(
-                        f"External group sync task timed out: "
-                        f"cc_pair={cc_pair_id} "
-                        f"elapsed={elapsed:.0f}s "
-                        f"timeout={timeout_seconds}s "
-                        f"groups_processed={total_groups_processed}"
-                    )
-
-                external_user_group_batch.append(external_user_group)
-
-                # Track progress
-                total_groups_processed += 1
-                total_group_memberships_synced += len(external_user_group.user_emails)
-                seen_users = seen_users.union(external_user_group.user_emails)
-
-                if len(external_user_group_batch) >= _EXTERNAL_GROUP_BATCH_SIZE:
-                    logger.debug(
-                        f"New external user groups: {external_user_group_batch}"
-                    )
-                    upsert_external_groups(
-                        db_session=db_session,
-                        cc_pair_id=cc_pair_id,
-                        external_groups=external_user_group_batch,
-                        source=cc_pair.connector.source,
-                    )
-                    external_user_group_batch = []
-
-            if external_user_group_batch:
-                logger.debug(f"New external user groups: {external_user_group_batch}")
-                upsert_external_groups(
-                    db_session=db_session,
-                    cc_pair_id=cc_pair_id,
-                    external_groups=external_user_group_batch,
-                    source=cc_pair.connector.source,
+    # --- Phase 2: External work (no session held) ---
+    # cc_pair survives session close because sessions use expire_on_commit=False
+    logger.info(f"Syncing external groups for {source_type} for cc_pair: {cc_pair_id}")
+    external_user_group_batch: list[ExternalUserGroup] = []
+    seen_users: set[str] = set()
+    total_groups_processed = 0
+    total_group_memberships_synced = 0
+    start_time = time.monotonic()
+    try:
+        external_user_group_generator = ext_group_sync_func(tenant_id, cc_pair)
+        for external_user_group in external_user_group_generator:
+            elapsed = time.monotonic() - start_time
+            if elapsed > timeout_seconds:
+                raise RuntimeError(
+                    f"External group sync task timed out: "
+                    f"cc_pair={cc_pair_id} "
+                    f"elapsed={elapsed:.0f}s "
+                    f"timeout={timeout_seconds}s "
+                    f"groups_processed={total_groups_processed}"
                 )
-        except Exception as e:
-            format_error_for_logging(e)
 
-            # Mark as failed (this also updates progress to show partial progress)
+            external_user_group_batch.append(external_user_group)
+
+            total_groups_processed += 1
+            total_group_memberships_synced += len(external_user_group.user_emails)
+            seen_users = seen_users.union(external_user_group.user_emails)
+
+            if len(external_user_group_batch) >= _EXTERNAL_GROUP_BATCH_SIZE:
+                logger.debug(f"New external user groups: {external_user_group_batch}")
+                _upsert_group_batch(cc_pair_id, source_type, external_user_group_batch)
+                external_user_group_batch = []
+
+        if external_user_group_batch:
+            logger.debug(f"New external user groups: {external_user_group_batch}")
+            _upsert_group_batch(cc_pair_id, source_type, external_user_group_batch)
+    except Exception as e:
+        format_error_for_logging(e)
+
+        with get_session_with_current_tenant() as db_session:
             mark_external_group_sync_attempt_failed(
                 attempt_id, db_session, error_message=str(e)
             )
 
-            # TODO: add some notification to the admins here
-            logger.exception(
-                f"Error syncing external groups for {source_type} for cc_pair: {cc_pair_id} {e}"
-            )
-            raise e
+        logger.exception(
+            f"Error syncing external groups for {source_type} for cc_pair: {cc_pair_id} {e}"
+        )
+        raise e
 
+    # --- Phase 3: Write completion (short-lived session) ---
+    with get_session_with_current_tenant() as db_session:
         logger.info(
             f"Removing stale external groups for {source_type} for cc_pair: {cc_pair_id}"
         )
         remove_stale_external_groups(db_session, cc_pair_id)
 
-        # Calculate total unique users processed
         total_users_processed = len(seen_users)
 
-        # Complete the sync attempt with final progress
         complete_external_group_sync_attempt(
             db_session=db_session,
             attempt_id=attempt_id,

--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -30,6 +30,7 @@ from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.connectors.factory import ConnectorMissingException
+from onyx.connectors.factory import extract_credential_json
 from onyx.connectors.factory import identify_connector_class
 from onyx.connectors.factory import instantiate_connector
 from onyx.connectors.interfaces import HierarchyConnector
@@ -247,63 +248,19 @@ def check_for_hierarchy_fetching(self: Task, *, tenant_id: str) -> int | None:
 HIERARCHY_NODE_BATCH_SIZE = 100
 
 
-def _run_hierarchy_extraction(
-    db_session: Session,
-    cc_pair: ConnectorCredentialPair,
+def _process_hierarchy_batch(
+    node_batch: list[PydanticHierarchyNode],
     source: DocumentSource,
-    tenant_id: str,
+    connector_id: int,
+    credential_id: int,
+    is_connector_public: bool,
+    redis_client: Redis,
 ) -> int:
-    """
-    Run the hierarchy extraction for a connector.
-
-    Instantiates the connector and calls load_hierarchy() if the connector
-    implements HierarchyConnector.
-
-    Returns the total number of hierarchy nodes extracted.
-    """
-    connector = cc_pair.connector
-    credential = cc_pair.credential
-
-    # Instantiate the connector using its configured input type
-    runnable_connector = instantiate_connector(
-        db_session=db_session,
-        source=source,
-        input_type=connector.input_type,
-        connector_specific_config=connector.connector_specific_config,
-        credential=credential,
-    )
-
-    # Check if the connector supports hierarchy fetching
-    if not isinstance(runnable_connector, HierarchyConnector):
-        task_logger.debug(
-            f"Connector {source} does not implement HierarchyConnector, skipping"
-        )
+    """Write a batch of hierarchy nodes to DB and Redis cache in a short-lived session."""
+    if not node_batch:
         return 0
 
-    redis_client = get_redis_client(tenant_id=tenant_id)
-
-    # Ensure the SOURCE-type root node exists before processing hierarchy nodes.
-    # This is the root of the hierarchy tree - all other nodes for this source
-    # should ultimately have this as an ancestor.
-    ensure_source_node_exists(redis_client, db_session, source)
-
-    # Determine time range: start from last hierarchy fetch, end at now
-    last_fetch = cc_pair.last_time_hierarchy_fetch
-    start_time = last_fetch.timestamp() if last_fetch else 0
-    end_time = datetime.now(timezone.utc).timestamp()
-
-    # Check if connector is public - all hierarchy nodes from public connectors
-    # should be accessible to all users
-    is_connector_public = cc_pair.access_type == AccessType.PUBLIC
-
-    total_nodes = 0
-    node_batch: list[PydanticHierarchyNode] = []
-
-    def _process_batch() -> int:
-        """Process accumulated hierarchy nodes batch."""
-        if not node_batch:
-            return 0
-
+    with get_session_with_current_tenant() as db_session:
         upserted_nodes = upsert_hierarchy_nodes_batch(
             db_session=db_session,
             nodes=node_batch,
@@ -315,35 +272,21 @@ def _run_hierarchy_extraction(
         upsert_hierarchy_node_cc_pair_entries(
             db_session=db_session,
             hierarchy_node_ids=[n.id for n in upserted_nodes],
-            connector_id=cc_pair.connector_id,
-            credential_id=cc_pair.credential_id,
+            connector_id=connector_id,
+            credential_id=credential_id,
             commit=True,
         )
 
-        # Cache in Redis for fast ancestor resolution
-        cache_entries = [
-            HierarchyNodeCacheEntry.from_db_model(node) for node in upserted_nodes
-        ]
-        cache_hierarchy_nodes_batch(
-            redis_client=redis_client,
-            source=source,
-            entries=cache_entries,
-        )
+    cache_entries = [
+        HierarchyNodeCacheEntry.from_db_model(node) for node in upserted_nodes
+    ]
+    cache_hierarchy_nodes_batch(
+        redis_client=redis_client,
+        source=source,
+        entries=cache_entries,
+    )
 
-        count = len(node_batch)
-        node_batch.clear()
-        return count
-
-    # Fetch hierarchy nodes from the connector
-    for node in runnable_connector.load_hierarchy(start=start_time, end=end_time):
-        node_batch.append(node)
-        if len(node_batch) >= HIERARCHY_NODE_BATCH_SIZE:
-            total_nodes += _process_batch()
-
-    # Process any remaining nodes
-    total_nodes += _process_batch()
-
-    return total_nodes
+    return len(node_batch)
 
 
 @shared_task(
@@ -368,6 +311,7 @@ def connector_hierarchy_fetching_task(
     )
 
     try:
+        # --- Phase 1: Read cc_pair config (short-lived session) ---
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair_from_id(
                 db_session=db_session,
@@ -387,18 +331,72 @@ def connector_hierarchy_fetching_task(
                 return
 
             source = cc_pair.connector.source
-            total_nodes = _run_hierarchy_extraction(
-                db_session=db_session,
-                cc_pair=cc_pair,
-                source=source,
-                tenant_id=tenant_id,
+            input_type = cc_pair.connector.input_type
+            connector_specific_config = cc_pair.connector.connector_specific_config
+            credential_json = extract_credential_json(cc_pair.credential)
+            cred_id = cc_pair.credential.id
+            connector_id = cc_pair.connector_id
+            credential_id = cc_pair.credential_id
+            last_fetch = cc_pair.last_time_hierarchy_fetch
+            is_connector_public = cc_pair.access_type == AccessType.PUBLIC
+
+        # --- Phase 2: External work (no session held) ---
+        runnable_connector = instantiate_connector(
+            source=source,
+            input_type=input_type,
+            connector_specific_config=connector_specific_config,
+            credential_json=credential_json,
+            credential_id=cred_id,
+        )
+
+        if not isinstance(runnable_connector, HierarchyConnector):
+            task_logger.debug(
+                f"Connector {source} does not implement HierarchyConnector, skipping"
+            )
+            with get_session_with_current_tenant() as db_session:
+                mark_cc_pair_as_hierarchy_fetched(db_session, cc_pair_id)
+            return
+
+        redis_client = get_redis_client(tenant_id=tenant_id)
+
+        with get_session_with_current_tenant() as db_session:
+            ensure_source_node_exists(redis_client, db_session, source)
+
+        start_time = last_fetch.timestamp() if last_fetch else 0
+        end_time = datetime.now(timezone.utc).timestamp()
+
+        total_nodes = 0
+        node_batch: list[PydanticHierarchyNode] = []
+
+        for node in runnable_connector.load_hierarchy(start=start_time, end=end_time):
+            node_batch.append(node)
+            if len(node_batch) >= HIERARCHY_NODE_BATCH_SIZE:
+                total_nodes += _process_hierarchy_batch(
+                    node_batch,
+                    source,
+                    connector_id,
+                    credential_id,
+                    is_connector_public,
+                    redis_client,
+                )
+                node_batch = []
+
+        if node_batch:
+            total_nodes += _process_hierarchy_batch(
+                node_batch,
+                source,
+                connector_id,
+                credential_id,
+                is_connector_public,
+                redis_client,
             )
 
-            task_logger.info(
-                f"connector_hierarchy_fetching_task: Extracted {total_nodes} hierarchy nodes for cc_pair={cc_pair_id}"
-            )
+        task_logger.info(
+            f"connector_hierarchy_fetching_task: Extracted {total_nodes} hierarchy nodes for cc_pair={cc_pair_id}"
+        )
 
-            # Update the last fetch time to prevent re-running until next interval
+        # --- Phase 3: Final write ---
+        with get_session_with_current_tenant() as db_session:
             mark_cc_pair_as_hierarchy_fetched(db_session, cc_pair_id)
 
     except Exception:

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -37,6 +37,7 @@ from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisConstants
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.configs.constants import OnyxRedisSignals
+from onyx.connectors.factory import extract_credential_json
 from onyx.connectors.factory import instantiate_connector
 from onyx.connectors.models import InputType
 from onyx.db.connector import mark_ccpair_as_pruned
@@ -524,6 +525,7 @@ def connector_pruning_generator_task(
         return None
 
     try:
+        # --- Phase 1: Read cc_pair config (short-lived session) ---
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair(
                 db_session=db_session,
@@ -537,55 +539,58 @@ def connector_pruning_generator_task(
                 )
                 return
 
-            payload = redis_connector.prune.payload
-            if not payload:
-                raise ValueError(f"No fence payload found: cc_pair={cc_pair_id}")
-
-            new_payload = RedisConnectorPrunePayload(
-                id=payload.id,
-                submitted=payload.submitted,
-                started=datetime.now(timezone.utc),
-                celery_task_id=payload.celery_task_id,
-            )
-            redis_connector.prune.set_fence(new_payload)
-
-            task_logger.info(
-                f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={cc_pair.connector.source}"
-            )
-
-            runnable_connector = instantiate_connector(
-                db_session,
-                cc_pair.connector.source,
-                InputType.SLIM_RETRIEVAL,
-                cc_pair.connector.connector_specific_config,
-                cc_pair.credential,
-            )
-
-            callback = PruneCallback(
-                0,
-                redis_connector,
-                lock,
-                r,
-                timeout_seconds=JOB_TIMEOUT,
-            )
-
-            # Extract docs and hierarchy nodes from the source
-            extraction_result = extract_ids_from_runnable_connector(
-                runnable_connector, callback
-            )
-            all_connector_doc_ids = extraction_result.raw_id_to_parent
-
-            # Process hierarchy nodes (same as docfetching):
-            # upsert to Postgres and cache in Redis
             source = cc_pair.connector.source
+            connector_specific_config = cc_pair.connector.connector_specific_config
+            credential_json = extract_credential_json(cc_pair.credential)
+            cred_id = cc_pair.credential.id
+            is_connector_public = cc_pair.access_type == AccessType.PUBLIC
+
+        payload = redis_connector.prune.payload
+        if not payload:
+            raise ValueError(f"No fence payload found: cc_pair={cc_pair_id}")
+
+        new_payload = RedisConnectorPrunePayload(
+            id=payload.id,
+            submitted=payload.submitted,
+            started=datetime.now(timezone.utc),
+            celery_task_id=payload.celery_task_id,
+        )
+        redis_connector.prune.set_fence(new_payload)
+
+        task_logger.info(
+            f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={source}"
+        )
+
+        # --- Phase 2: External work (no session held) ---
+        runnable_connector = instantiate_connector(
+            source=source,
+            input_type=InputType.SLIM_RETRIEVAL,
+            connector_specific_config=connector_specific_config,
+            credential_json=credential_json,
+            credential_id=cred_id,
+        )
+
+        callback = PruneCallback(
+            0,
+            redis_connector,
+            lock,
+            r,
+            timeout_seconds=JOB_TIMEOUT,
+        )
+
+        extraction_result = extract_ids_from_runnable_connector(
+            runnable_connector, callback
+        )
+        all_connector_doc_ids = extraction_result.raw_id_to_parent
+
+        # --- Phase 3: Write results (new session) ---
+        with get_session_with_current_tenant() as db_session:
             redis_client = get_redis_client(tenant_id=tenant_id)
 
             ensure_source_node_exists(redis_client, db_session, source)
 
             upserted_nodes: list[DBHierarchyNode] = []
             if extraction_result.hierarchy_nodes:
-                is_connector_public = cc_pair.access_type == AccessType.PUBLIC
-
                 upserted_nodes = upsert_hierarchy_nodes_batch(
                     db_session=db_session,
                     nodes=extraction_result.hierarchy_nodes,
@@ -617,8 +622,6 @@ def connector_pruning_generator_task(
                     f"hierarchy nodes for cc_pair={cc_pair_id}"
                 )
 
-            # Resolve parent_hierarchy_raw_node_id → parent_hierarchy_node_id
-            # and bulk-update documents, mirroring the docfetching resolution
             _resolve_and_update_document_parents(
                 db_session=db_session,
                 redis_client=redis_client,
@@ -626,8 +629,6 @@ def connector_pruning_generator_task(
                 raw_id_to_parent=all_connector_doc_ids,
             )
 
-            # Link hierarchy nodes to documents for sources where pages can be
-            # both hierarchy nodes AND documents (e.g. Notion, Confluence)
             all_doc_id_list = list(all_connector_doc_ids.keys())
             link_hierarchy_nodes_to_documents(
                 db_session=db_session,
@@ -636,7 +637,6 @@ def connector_pruning_generator_task(
                 commit=True,
             )
 
-            # a list of docs in our local index
             all_indexed_document_ids = {
                 doc.id
                 for doc in get_documents_for_connector_credential_pair(
@@ -646,16 +646,12 @@ def connector_pruning_generator_task(
                 )
             }
 
-            # generate list of docs to remove (no longer in the source)
             doc_ids_to_remove = list(
                 all_indexed_document_ids - all_connector_doc_ids.keys()
             )
 
             task_logger.info(
-                "Pruning set collected: "
-                f"cc_pair={cc_pair_id} "
-                f"connector_source={cc_pair.connector.source} "
-                f"docs_to_remove={len(doc_ids_to_remove)}"
+                f"Pruning set collected: cc_pair={cc_pair_id} connector_source={source} docs_to_remove={len(doc_ids_to_remove)}"
             )
 
             task_logger.info(

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -26,6 +26,7 @@ from onyx.configs.constants import OnyxCeleryTask
 from onyx.connectors.connector_runner import ConnectorRunner
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import UnexpectedValidationError
+from onyx.connectors.factory import extract_credential_json
 from onyx.connectors.factory import instantiate_connector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.models import ConnectorFailure
@@ -100,13 +101,15 @@ def _get_connector_runner(
 
     task = attempt.connector_credential_pair.connector.input_type
 
+    credential = attempt.connector_credential_pair.credential
+
     try:
         runnable_connector = instantiate_connector(
-            db_session=db_session,
             source=attempt.connector_credential_pair.connector.source,
             input_type=task,
             connector_specific_config=attempt.connector_credential_pair.connector.connector_specific_config,
-            credential=attempt.connector_credential_pair.credential,
+            credential_json=extract_credential_json(credential),
+            credential_id=credential.id,
         )
 
         # validate the connector settings

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -18,7 +18,6 @@ from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.models import InputType
 from onyx.connectors.registry import CONNECTOR_CLASS_MAP
 from onyx.db.connector import fetch_connector_by_id
-from onyx.db.credentials import backend_update_credential_json
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.enums import AccessType
 from onyx.db.models import Credential
@@ -101,12 +100,36 @@ def identify_connector_class(
     return connector
 
 
+def extract_credential_json(credential: Credential) -> dict[str, Any]:
+    """Extract the plain credential dict from a Credential ORM object.
+    Safe to call while the session is still open; the returned dict
+    is independent of the ORM and can be used after session close."""
+    if credential.credential_json is None:
+        return {}
+    return credential.credential_json.get_value(apply_mask=False)
+
+
+def _refresh_credential_json(
+    credential_id: int, new_credential_json: dict[str, Any]
+) -> None:
+    """Write back refreshed OAuth tokens in a short-lived session.
+    Called only when a connector's load_credentials returns new data."""
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
+
+    with get_session_with_current_tenant() as db_session:
+        credential = db_session.get(Credential, credential_id)
+        if credential is None:
+            return
+        credential.credential_json = new_credential_json  # type: ignore[assignment]
+        db_session.commit()
+
+
 def instantiate_connector(
-    db_session: Session,
     source: DocumentSource,
     input_type: InputType,
     connector_specific_config: dict[str, Any],
-    credential: Credential,
+    credential_json: dict[str, Any],
+    credential_id: int,
 ) -> BaseConnector:
     connector_class = identify_connector_class(source, input_type)
 
@@ -114,19 +137,14 @@ def instantiate_connector(
 
     if isinstance(connector, CredentialsConnector):
         provider = OnyxDBCredentialsProvider(
-            get_current_tenant_id(), str(source), credential.id
+            get_current_tenant_id(), str(source), credential_id
         )
         connector.set_credentials_provider(provider)
     else:
-        credential_json = (
-            credential.credential_json.get_value(apply_mask=False)
-            if credential.credential_json
-            else {}
-        )
         new_credentials = connector.load_credentials(credential_json)
 
         if new_credentials is not None:
-            backend_update_credential_json(credential, new_credentials, db_session)
+            _refresh_credential_json(credential_id, new_credentials)
 
     connector.set_allow_images(get_image_extraction_and_analysis_enabled())
 
@@ -164,11 +182,11 @@ def validate_ccpair_for_user(
 
     try:
         runnable_connector = instantiate_connector(
-            db_session=db_session,
             source=connector.source,
             input_type=connector.input_type,
             connector_specific_config=connector.connector_specific_config,
-            credential=credential,
+            credential_json=extract_credential_json(credential),
+            credential_id=credential.id,
         )
     except ConnectorValidationError as e:
         raise e

--- a/backend/tests/unit/onyx/connectors/test_connector_factory.py
+++ b/backend/tests/unit/onyx/connectors/test_connector_factory.py
@@ -247,23 +247,15 @@ class TestInstantiateConnectorIntegration:
 
     def test_instantiate_connector_loads_class_lazily(self) -> None:
         """Test that instantiate_connector triggers lazy loading."""
-        from onyx.utils.sensitive import make_mock_sensitive_value
-
-        # Mock the database session and credential
-        mock_session = MagicMock()
-        mock_credential = MagicMock()
-        mock_credential.id = 123
-        mock_credential.credential_json = make_mock_sensitive_value({"test": "data"})
-
         # This should trigger lazy loading but will fail on actual instantiation
         # due to missing real configuration - that's expected
         with pytest.raises(Exception):  # We expect some kind of error due to mock data
             instantiate_connector(
-                mock_session,
                 DocumentSource.WEB,  # Simple connector
                 InputType.SLIM_RETRIEVAL,
                 {},  # Empty config
-                mock_credential,
+                {"test": "data"},
+                123,
             )
 
         # But the class should have been loaded into cache


### PR DESCRIPTION
## Description

reducing the number of db sessions we hold for a long time in tasks.

## How Has This Been Tested?

CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor background tasks to avoid long-held DB sessions by splitting work into short read/write phases and running external I/O without an open session. Update connector instantiation to use plain `credential_json` + `credential_id`, reducing lock time and improving reliability.

- **Refactors**
  - Split permission sync, external group sync, hierarchy fetching, and pruning into: short-lived config read → external work → short-lived completion writes.
  - Change `instantiate_connector` (remove `db_session`; add `credential_json` and `credential_id`); add `extract_credential_json`; refresh tokens via `_refresh_credential_json` with a short-lived session.
  - External group syncing: batch DB writes via `_upsert_group_batch`; keep timeout check; mark/remove stale groups and failures with short-lived sessions.
  - Hierarchy/pruning: perform connector work without a session; `_process_hierarchy_batch` writes nodes and caches; ensure source node and mark fetched/pruned with short-lived sessions; update indexing runner and tests.

<sup>Written for commit 2e9c3c1891670fc0003a4d4b343cd7e8b0b28b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

