### PR TITLE
Fix PUT /api/admin/llm/provider silently ignoring custom_config

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -476,7 +476,7 @@ def put_llm_provider(
     # custom_config_changed=False; only use stored config as a fallback when
     # custom_config is omitted/null.
     if existing_provider and not llm_provider_upsert_request.custom_config_changed:
-        if llm_provider_upsert_request.custom_config is None:
+        if not llm_provider_upsert_request.custom_config:
             llm_provider_upsert_request.custom_config = existing_provider.custom_config
 
     # Check if we're transitioning to Auto mode

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -302,7 +302,8 @@ def test_llm_configuration(
                 else None
             )
         if existing_provider and not test_llm_request.custom_config_changed:
-            test_custom_config = existing_provider.custom_config
+            if test_custom_config is None:
+                test_custom_config = existing_provider.custom_config
 
     # For this "testing" workflow, we do *not* need the actual `max_input_tokens`.
     # Therefore, instead of performing additional, more complex logic, we just use a dummy value
@@ -471,8 +472,12 @@ def put_llm_provider(
             if existing_provider.api_key
             else None
         )
+    # Keep caller-supplied custom_config when present even if
+    # custom_config_changed=False; only use stored config as a fallback when
+    # custom_config is omitted/null.
     if existing_provider and not llm_provider_upsert_request.custom_config_changed:
-        llm_provider_upsert_request.custom_config = existing_provider.custom_config
+        if llm_provider_upsert_request.custom_config is None:
+            llm_provider_upsert_request.custom_config = existing_provider.custom_config
 
     # Check if we're transitioning to Auto mode
     transitioning_to_auto_mode = llm_provider_upsert_request.is_auto_mode and (

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -332,6 +332,90 @@ def test_update_model_configurations(
     )
 
 
+def test_update_provider_custom_config_respects_non_null_without_change_flag(
+    reset: None,  # noqa: ARG001
+) -> None:
+    admin_user = UserManager.create(name="admin_user")
+
+    create_response = requests.put(
+        f"{API_SERVER_URL}/admin/llm/provider?is_creation=true",
+        headers=admin_user.headers,
+        json={
+            "name": f"custom-config-provider-{uuid.uuid4()}",
+            "provider": LlmProviderNames.OPENAI,
+            "api_key": "sk-000000000000000000000000000000000000000000000000",
+            "model_configurations": [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True
+                ).model_dump()
+            ],
+            "custom_config": {"think": "true"},
+            "custom_config_changed": True,
+            "is_public": True,
+            "groups": [],
+            "personas": [],
+        },
+    )
+    assert create_response.status_code == 200
+    created_provider = create_response.json()
+
+    # Do not set custom_config_changed=True; the server should still honor
+    # a non-null custom_config value instead of overwriting it with stored config.
+    update_response = requests.put(
+        f"{API_SERVER_URL}/admin/llm/provider",
+        headers=admin_user.headers,
+        json={
+            "id": created_provider["id"],
+            "name": created_provider["name"],
+            "provider": created_provider["provider"],
+            "api_key": created_provider["api_key"],
+            "model_configurations": [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True
+                ).model_dump()
+            ],
+            "custom_config": {"think": "false"},
+            "is_public": True,
+            "groups": [],
+            "personas": [],
+        },
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["custom_config"] == {"think": "false"}
+
+    persisted_provider = _get_provider_by_id(admin_user, created_provider["id"])
+    assert persisted_provider is not None
+    assert persisted_provider["custom_config"] == {"think": "false"}
+
+    # Null custom_config should keep the stored config when
+    # custom_config_changed remains false.
+    null_update_response = requests.put(
+        f"{API_SERVER_URL}/admin/llm/provider",
+        headers=admin_user.headers,
+        json={
+            "id": created_provider["id"],
+            "name": created_provider["name"],
+            "provider": created_provider["provider"],
+            "api_key": created_provider["api_key"],
+            "model_configurations": [
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o-mini", is_visible=True
+                ).model_dump()
+            ],
+            "custom_config": None,
+            "is_public": True,
+            "groups": [],
+            "personas": [],
+        },
+    )
+    assert null_update_response.status_code == 200
+    assert null_update_response.json()["custom_config"] == {"think": "false"}
+
+    persisted_provider = _get_provider_by_id(admin_user, created_provider["id"])
+    assert persisted_provider is not None
+    assert persisted_provider["custom_config"] == {"think": "false"}
+
+
 @pytest.mark.parametrize(
     "model_configurations",
     [

--- a/backend/tests/unit/onyx/server/manage/llm/test_custom_config_fallback.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_custom_config_fallback.py
@@ -1,0 +1,151 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from onyx.server.manage.llm.models import TestLLMRequest as LLMTestRequest
+
+
+def _existing_provider(custom_config: dict[str, str] | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=123,
+        name="provider-name",
+        provider="openai",
+        api_base=None,
+        custom_config=custom_config,
+        api_key=SimpleNamespace(get_value=lambda apply_mask=False: "sk-existing"),
+        is_auto_mode=False,
+        model_configurations=[],
+    )
+
+
+def test_put_llm_provider_keeps_non_null_custom_config_when_change_flag_false() -> None:
+    from onyx.server.manage.llm.api import put_llm_provider
+
+    existing = _existing_provider({"think": "true"})
+    request = LLMProviderUpsertRequest(
+        id=existing.id,
+        name=existing.name,
+        provider=existing.provider,
+        api_key="sk-existing",
+        custom_config={"think": "false"},
+        custom_config_changed=False,
+        api_key_changed=False,
+        model_configurations=[],
+        groups=[],
+        personas=[],
+        is_public=True,
+    )
+
+    with (
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
+            return_value=existing,
+        ),
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+            return_value=existing,
+        ),
+        patch("onyx.server.manage.llm.api._validate_llm_provider_change"),
+        patch("onyx.server.manage.llm.api._mask_provider_credentials"),
+        patch("onyx.server.manage.llm.api.upsert_llm_provider") as mock_upsert,
+    ):
+        mock_upsert.side_effect = (
+            lambda llm_provider_upsert_request, db_session: llm_provider_upsert_request
+        )
+        updated = put_llm_provider(request, is_creation=False, _=MagicMock(), db_session=MagicMock())
+
+        assert updated.custom_config == {"think": "false"}
+
+
+def test_put_llm_provider_falls_back_to_existing_custom_config_when_null() -> None:
+    from onyx.server.manage.llm.api import put_llm_provider
+
+    existing = _existing_provider({"think": "true"})
+    request = LLMProviderUpsertRequest(
+        id=existing.id,
+        name=existing.name,
+        provider=existing.provider,
+        api_key="sk-existing",
+        custom_config=None,
+        custom_config_changed=False,
+        api_key_changed=False,
+        model_configurations=[],
+        groups=[],
+        personas=[],
+        is_public=True,
+    )
+
+    with (
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
+            return_value=existing,
+        ),
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider",
+            return_value=existing,
+        ),
+        patch("onyx.server.manage.llm.api._validate_llm_provider_change"),
+        patch("onyx.server.manage.llm.api._mask_provider_credentials"),
+        patch("onyx.server.manage.llm.api.upsert_llm_provider") as mock_upsert,
+    ):
+        mock_upsert.side_effect = (
+            lambda llm_provider_upsert_request, db_session: llm_provider_upsert_request
+        )
+        updated = put_llm_provider(request, is_creation=False, _=MagicMock(), db_session=MagicMock())
+
+        assert updated.custom_config == {"think": "true"}
+
+
+def test_test_llm_configuration_keeps_non_null_custom_config_when_change_flag_false() -> None:
+    from onyx.server.manage.llm.api import test_llm_configuration
+
+    existing = _existing_provider({"think": "true"})
+    request = LLMTestRequest(
+        id=existing.id,
+        provider=existing.provider,
+        model="gpt-4o-mini",
+        api_key="sk-existing",
+        custom_config={"think": "false"},
+        api_key_changed=False,
+        custom_config_changed=False,
+    )
+
+    with (
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
+            return_value=existing,
+        ),
+        patch("onyx.server.manage.llm.api._validate_llm_provider_change"),
+        patch("onyx.server.manage.llm.api.get_llm") as mock_get_llm,
+        patch("onyx.server.manage.llm.api.test_llm", return_value=None),
+    ):
+        test_llm_configuration(request, _=MagicMock(), db_session=MagicMock())
+        assert mock_get_llm.call_args.kwargs["custom_config"] == {"think": "false"}
+
+
+def test_test_llm_configuration_falls_back_to_existing_custom_config_when_null() -> None:
+    from onyx.server.manage.llm.api import test_llm_configuration
+
+    existing = _existing_provider({"think": "true"})
+    request = LLMTestRequest(
+        id=existing.id,
+        provider=existing.provider,
+        model="gpt-4o-mini",
+        api_key="sk-existing",
+        custom_config=None,
+        api_key_changed=False,
+        custom_config_changed=False,
+    )
+
+    with (
+        patch(
+            "onyx.server.manage.llm.api.fetch_existing_llm_provider_by_id",
+            return_value=existing,
+        ),
+        patch("onyx.server.manage.llm.api._validate_llm_provider_change"),
+        patch("onyx.server.manage.llm.api.get_llm") as mock_get_llm,
+        patch("onyx.server.manage.llm.api.test_llm", return_value=None),
+    ):
+        test_llm_configuration(request, _=MagicMock(), db_session=MagicMock())
+        assert mock_get_llm.call_args.kwargs["custom_config"] == {"think": "true"}


### PR DESCRIPTION
## Summary
- Fixes #9732 (root issue #9483): `PUT /api/admin/llm/provider` no longer discards a provided non-null `custom_config` when `custom_config_changed` is `false`.
- Preserves existing behavior for omitted/null `custom_config`: when `custom_config_changed` is `false` and `custom_config` is null, fallback uses stored DB config.
- Applies matching fallback behavior in `POST /api/admin/llm/test` (`test_llm_configuration`) so test flow is consistent.

## Changes
- Updated fallback logic in `backend/onyx/server/manage/llm/api.py`:
  - `put_llm_provider`: fallback to existing custom config only when request `custom_config` is null.
  - `test_llm_configuration`: same null-only fallback logic.
- Added integration regression coverage in `backend/tests/integration/tests/llm_provider/test_llm_provider.py`.
- Added focused unit coverage in `backend/tests/unit/onyx/server/manage/llm/test_custom_config_fallback.py`.

## Test Plan
- [x] `cd /workspaces/onyx/backend && uv run pytest -xv tests/unit/onyx/server/manage/llm/test_custom_config_fallback.py`
- [ ] Integration test execution in this codespace is blocked by generated OpenAPI client dependency in current local test infra.
