### PR TITLE
Fix LM Studio supports_reasoning validation for v0.4.6+

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1321,7 +1321,7 @@ def get_lm_studio_available_models(
                 display_name=display_name,
                 max_input_tokens=max_context_length,
                 supports_image_input=capabilities.get("vision", False),
-                supports_reasoning=bool(capabilities.get("reasoning", False))
+                supports_reasoning=capabilities.get("reasoning", False)
                 or is_reasoning_model(model_key, display_name),
             )
         )

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1321,7 +1321,7 @@ def get_lm_studio_available_models(
                 display_name=display_name,
                 max_input_tokens=max_context_length,
                 supports_image_input=capabilities.get("vision", False),
-                supports_reasoning=capabilities.get("reasoning", False)
+                supports_reasoning=bool(capabilities.get("reasoning", False))
                 or is_reasoning_model(model_key, display_name),
             )
         )

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1315,13 +1315,25 @@ def get_lm_studio_available_models(
         max_context_length = item.get("max_context_length")
         capabilities = item.get("capabilities") or {}
 
+        # LM Studio 0.4.8+ changed some capability fields from booleans
+        # to dicts (e.g. {"allowed_options": ["off", "on"], "default": "on"}).
+        # Coerce to bool: a dict with non-empty allowed_options is truthy.
+        def _capability_as_bool(val: object) -> bool:
+            if isinstance(val, dict):
+                return bool(val.get("allowed_options"))
+            return bool(val)
+
         results.append(
             LMStudioFinalModelResponse(
                 name=model_key,
                 display_name=display_name,
                 max_input_tokens=max_context_length,
-                supports_image_input=capabilities.get("vision", False),
-                supports_reasoning=capabilities.get("reasoning", False)
+                supports_image_input=_capability_as_bool(
+                    capabilities.get("vision", False)
+                ),
+                supports_reasoning=_capability_as_bool(
+                    capabilities.get("reasoning", False)
+                )
                 or is_reasoning_model(model_key, display_name),
             )
         )

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1301,6 +1301,14 @@ def get_lm_studio_available_models(
             "No models found from your LM Studio server.",
         )
 
+    # LM Studio 0.4.8+ changed some capability fields from booleans
+    # to dicts (e.g. {"allowed_options": ["off", "on"], "default": "on"}).
+    # Coerce to bool: a dict with non-empty allowed_options is truthy.
+    def _capability_as_bool(val: object) -> bool:
+        if isinstance(val, dict):
+            return bool(val.get("allowed_options"))
+        return bool(val)
+
     results: list[LMStudioFinalModelResponse] = []
     for item in models:
         # Filter to LLM-type models only (skip embeddings, etc.)
@@ -1314,14 +1322,6 @@ def get_lm_studio_available_models(
         display_name = item.get("display_name") or model_key
         max_context_length = item.get("max_context_length")
         capabilities = item.get("capabilities") or {}
-
-        # LM Studio 0.4.8+ changed some capability fields from booleans
-        # to dicts (e.g. {"allowed_options": ["off", "on"], "default": "on"}).
-        # Coerce to bool: a dict with non-empty allowed_options is truthy.
-        def _capability_as_bool(val: object) -> bool:
-            if isinstance(val, dict):
-                return bool(val.get("allowed_options"))
-            return bool(val)
 
         results.append(
             LMStudioFinalModelResponse(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -386,6 +386,13 @@ class LMStudioFinalModelResponse(BaseModel):
     supports_image_input: bool
     supports_reasoning: bool
 
+    @field_validator("supports_reasoning", mode="before")
+    @classmethod
+    def coerce_reasoning(cls, v: Any) -> bool:
+        if isinstance(v, dict):
+            return bool(v.get("allowed_options"))
+        return bool(v)
+
 
 class DefaultModel(BaseModel):
     provider_id: int
@@ -464,3 +471,10 @@ class BifrostFinalModelResponse(BaseModel):
     max_input_tokens: int | None
     supports_image_input: bool
     supports_reasoning: bool
+
+    @field_validator("supports_reasoning", mode="before")
+    @classmethod
+    def coerce_reasoning(cls, v: Any) -> bool:
+        if isinstance(v, dict):
+            return bool(v.get("allowed_options"))
+        return bool(v)

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -386,9 +386,11 @@ class LMStudioFinalModelResponse(BaseModel):
     supports_image_input: bool
     supports_reasoning: bool
 
-    @field_validator("supports_reasoning", mode="before")
+    @field_validator("supports_image_input", "supports_reasoning", mode="before")
     @classmethod
-    def coerce_reasoning(cls, v: Any) -> bool:
+    def coerce_capability(cls, v: Any) -> bool:
+        """LM Studio 0.4.8+ may return capabilities as dicts
+        (e.g. {"allowed_options": ["off", "on"]}) instead of booleans."""
         if isinstance(v, dict):
             return bool(v.get("allowed_options"))
         return bool(v)
@@ -472,9 +474,10 @@ class BifrostFinalModelResponse(BaseModel):
     supports_image_input: bool
     supports_reasoning: bool
 
-    @field_validator("supports_reasoning", mode="before")
+    @field_validator("supports_image_input", "supports_reasoning", mode="before")
     @classmethod
-    def coerce_reasoning(cls, v: Any) -> bool:
+    def coerce_capability(cls, v: Any) -> bool:
+        """Capability fields may arrive as dicts with allowed_options."""
         if isinstance(v, dict):
             return bool(v.get("allowed_options"))
         return bool(v)

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -389,7 +389,7 @@ class LMStudioFinalModelResponse(BaseModel):
     @field_validator("supports_image_input", "supports_reasoning", mode="before")
     @classmethod
     def coerce_capability(cls, v: Any) -> bool:
-        """LM Studio 0.4.8+ may return capabilities as dicts
+        """LM Studio 0.4.8+ changed some capability fields from booleans to dicts
         (e.g. {"allowed_options": ["off", "on"]}) instead of booleans."""
         if isinstance(v, dict):
             return bool(v.get("allowed_options"))

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -621,6 +621,157 @@ class TestGetLMStudioAvailableModels:
             with pytest.raises(OnyxError):
                 get_lm_studio_available_models(request, MagicMock(), mock_session)
 
+    def test_handles_new_dict_capabilities_format(self) -> None:
+        """Test that LM Studio 0.4.8+ dict-style capabilities are parsed correctly."""
+        from onyx.server.manage.llm.api import get_lm_studio_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "models": [
+                {
+                    "key": "reasoning-model",
+                    "type": "llm",
+                    "display_name": "Reasoning Model",
+                    "max_context_length": 32768,
+                    "capabilities": {
+                        "vision": False,
+                        "reasoning": {
+                            "allowed_options": ["off", "on", "low", "medium", "high"],
+                            "default": "on",
+                        },
+                    },
+                },
+                {
+                    "key": "vision-reasoning-model",
+                    "type": "llm",
+                    "display_name": "Vision Reasoning Model",
+                    "max_context_length": 65536,
+                    "capabilities": {
+                        "vision": True,
+                        "reasoning": {
+                            "allowed_options": ["off", "on"],
+                            "default": "on",
+                        },
+                    },
+                },
+                {
+                    "key": "basic-model",
+                    "type": "llm",
+                    "display_name": "Basic Model",
+                    "max_context_length": 4096,
+                    "capabilities": {
+                        "vision": False,
+                        "reasoning": False,
+                    },
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_response
+
+            request = LMStudioModelsRequest(api_base="http://localhost:1234")
+            results = get_lm_studio_available_models(
+                request, MagicMock(), mock_session
+            )
+
+            reasoning = next(r for r in results if r.name == "reasoning-model")
+            assert reasoning.supports_reasoning is True
+            assert reasoning.supports_image_input is False
+
+            vision_reasoning = next(
+                r for r in results if r.name == "vision-reasoning-model"
+            )
+            assert vision_reasoning.supports_reasoning is True
+            assert vision_reasoning.supports_image_input is True
+
+            basic = next(r for r in results if r.name == "basic-model")
+            assert basic.supports_reasoning is False
+            assert basic.supports_image_input is False
+
+    def test_handles_empty_allowed_options(self) -> None:
+        """Test that an empty allowed_options list is treated as False."""
+        from onyx.server.manage.llm.api import get_lm_studio_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "models": [
+                {
+                    "key": "model-empty-options",
+                    "type": "llm",
+                    "display_name": "Empty Options Model",
+                    "max_context_length": 4096,
+                    "capabilities": {
+                        "reasoning": {"allowed_options": []},
+                    },
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_response
+
+            request = LMStudioModelsRequest(api_base="http://localhost:1234")
+            results = get_lm_studio_available_models(
+                request, MagicMock(), mock_session
+            )
+
+            assert results[0].supports_reasoning is False
+
+    def test_backwards_compatible_with_bool_capabilities(self) -> None:
+        """Test that old-style boolean capabilities still work (pre-0.4.8)."""
+        from onyx.server.manage.llm.api import get_lm_studio_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "models": [
+                {
+                    "key": "old-format-model",
+                    "type": "llm",
+                    "display_name": "Old Format Model",
+                    "max_context_length": 4096,
+                    "capabilities": {
+                        "vision": True,
+                        "reasoning": True,
+                    },
+                },
+                {
+                    "key": "old-format-basic",
+                    "type": "llm",
+                    "display_name": "Old Format Basic",
+                    "max_context_length": 4096,
+                    "capabilities": {
+                        "vision": False,
+                    },
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_response
+
+            request = LMStudioModelsRequest(api_base="http://localhost:1234")
+            results = get_lm_studio_available_models(
+                request, MagicMock(), mock_session
+            )
+
+            old = next(r for r in results if r.name == "old-format-model")
+            assert old.supports_image_input is True
+            assert old.supports_reasoning is True
+
+            basic = next(r for r in results if r.name == "old-format-basic")
+            assert basic.supports_image_input is False
+            assert basic.supports_reasoning is False
+
 
 class TestGetLitellmAvailableModels:
     """Tests for the Litellm proxy model fetch endpoint."""

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -626,12 +626,14 @@ class TestGetLMStudioAvailableModels:
         from onyx.server.manage.llm.api import get_lm_studio_available_models
 
         mock_session = MagicMock()
+        # Use generic model names that won't trigger is_reasoning_model()
+        # heuristics, so the test validates dict parsing specifically.
         response = {
             "models": [
                 {
-                    "key": "reasoning-model",
+                    "key": "publisher/generic-chat-7b",
                     "type": "llm",
-                    "display_name": "Reasoning Model",
+                    "display_name": "Generic Chat 7B",
                     "max_context_length": 32768,
                     "capabilities": {
                         "vision": False,
@@ -642,9 +644,9 @@ class TestGetLMStudioAvailableModels:
                     },
                 },
                 {
-                    "key": "vision-reasoning-model",
+                    "key": "publisher/generic-multimodal-13b",
                     "type": "llm",
-                    "display_name": "Vision Reasoning Model",
+                    "display_name": "Generic Multimodal 13B",
                     "max_context_length": 65536,
                     "capabilities": {
                         "vision": True,
@@ -655,9 +657,9 @@ class TestGetLMStudioAvailableModels:
                     },
                 },
                 {
-                    "key": "basic-model",
+                    "key": "publisher/generic-base-3b",
                     "type": "llm",
-                    "display_name": "Basic Model",
+                    "display_name": "Generic Base 3B",
                     "max_context_length": 4096,
                     "capabilities": {
                         "vision": False,
@@ -678,19 +680,17 @@ class TestGetLMStudioAvailableModels:
                 request, MagicMock(), mock_session
             )
 
-            reasoning = next(r for r in results if r.name == "reasoning-model")
-            assert reasoning.supports_reasoning is True
-            assert reasoning.supports_image_input is False
+            chat = next(r for r in results if "generic-chat" in r.name)
+            assert chat.supports_reasoning is True
+            assert chat.supports_image_input is False
 
-            vision_reasoning = next(
-                r for r in results if r.name == "vision-reasoning-model"
-            )
-            assert vision_reasoning.supports_reasoning is True
-            assert vision_reasoning.supports_image_input is True
+            multimodal = next(r for r in results if "generic-multimodal" in r.name)
+            assert multimodal.supports_reasoning is True
+            assert multimodal.supports_image_input is True
 
-            basic = next(r for r in results if r.name == "basic-model")
-            assert basic.supports_reasoning is False
-            assert basic.supports_image_input is False
+            base = next(r for r in results if "generic-base" in r.name)
+            assert base.supports_reasoning is False
+            assert base.supports_image_input is False
 
     def test_handles_empty_allowed_options(self) -> None:
         """Test that an empty allowed_options list is treated as False."""


### PR DESCRIPTION
## Summary
- LM Studio 0.4.6+ changed their `/api/v1/models` API response — the `supports_reasoning` capability is now a dict (e.g. `{"allowed_options": ["off", "on", "low", "medium", "high"]}`) instead of a boolean
- This caused a Pydantic validation error (`Input should be a valid boolean`) when adding LM Studio as a provider in Onyx, breaking auto-discovery
- Wraps `capabilities.get("reasoning", False)` with `bool()` at the call site in `api.py` and adds a defensive `field_validator` on `LMStudioFinalModelResponse` and `BifrostFinalModelResponse` to coerce dicts to bools before validation

## Test plan
- [ ] Add LM Studio 0.4.6+ as a provider in Onyx admin panel — models should auto-discover without validation errors
- [ ] Verify older LM Studio versions (that return plain booleans) still work
- [ ] Verify the validator handles edge cases: empty dict → `False`, non-empty `allowed_options` → `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LM Studio provider auto-discovery by handling dict-style capability fields (`vision`, `reasoning`) introduced in v0.4.8+, preventing Pydantic boolean validation errors. Coerces `allowed_options` to a bool and stays compatible with older boolean responses.

- **Bug Fixes**
  - Coerce capability values at the call site via `_capability_as_bool()` (hoisted outside the loop) for `vision` and `reasoning` before building responses.
  - Add `field_validator` for `supports_image_input` and `supports_reasoning` on `LMStudioFinalModelResponse` and `BifrostFinalModelResponse` to handle dicts as a safety net.
  - Add tests for the new dict format, empty `allowed_options` → False, and old boolean format; use generic model names to avoid reasoning-name heuristics.

<sup>Written for commit 06db1c049aa3433a7abbcf1374dd8b567d1bab0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

