### PR TITLE
fix(mt): Revamp Preprovision

### DIFF
--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -16,6 +16,7 @@ from ee.onyx.server.tenants.models import TenantCreationPayload
 from ee.onyx.server.tenants.models import TenantDeletionPayload
 from ee.onyx.server.tenants.schema_management import create_schema_if_not_exists
 from ee.onyx.server.tenants.schema_management import drop_schema
+from ee.onyx.server.tenants.schema_management import fast_provision_tenant_schema
 from ee.onyx.server.tenants.schema_management import run_alembic_migrations
 from ee.onyx.server.tenants.user_mapping import add_users_to_tenant
 from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
@@ -668,11 +669,12 @@ async def setup_tenant(tenant_id: str) -> None:
     try:
         token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-        # Run Alembic migrations in a way that isolates it from the current event loop
-        # Create a new event loop for this synchronous operation
+        # Fast path: create tables directly from model definitions + seed data
+        # instead of running hundreds of sequential Alembic migrations (~80s → ~2s)
         loop = asyncio.get_event_loop()
-        # Use run_in_executor which properly isolates the thread execution
-        await loop.run_in_executor(None, lambda: run_alembic_migrations(tenant_id))
+        await loop.run_in_executor(
+            None, lambda: fast_provision_tenant_schema(tenant_id)
+        )
 
         # Configure the tenant with default settings
         with get_session_with_tenant(tenant_id=tenant_id) as db_session:

--- a/backend/ee/onyx/server/tenants/schema_management.py
+++ b/backend/ee/onyx/server/tenants/schema_management.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import re
@@ -6,6 +7,8 @@ from types import SimpleNamespace
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 from sqlalchemy.schema import CreateSchema
+from sqlalchemy.schema import MetaData
+from sqlalchemy.sql.elements import quoted_name
 
 from alembic import command
 from alembic.config import Config
@@ -14,6 +17,22 @@ from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from shared_configs.configs import TENANT_ID_PREFIX
 
 logger = logging.getLogger(__name__)
+
+
+def _get_current_alembic_head() -> str:
+    """Return the head revision from the alembic migration scripts."""
+    from alembic.script import ScriptDirectory
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.abspath(os.path.join(current_dir, "..", "..", "..", ".."))
+    alembic_cfg = Config(os.path.join(root_dir, "alembic.ini"))
+    alembic_cfg.set_main_option("script_location", os.path.join(root_dir, "alembic"))
+    script = ScriptDirectory.from_config(alembic_cfg)
+    head = script.get_current_head()
+    if head is None:
+        raise RuntimeError("Could not determine alembic head revision")
+    return head
+
 
 # Regex pattern for valid tenant IDs:
 # - UUID format: tenant_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -101,6 +120,132 @@ def drop_schema(tenant_id: str) -> None:
         with connection.begin():
             # Use string formatting with validated tenant_id (safe after validation)
             connection.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
+
+
+def _deduplicate_ddl_names(
+    metadata: MetaData,
+) -> dict[str, str]:
+    """Temporarily rename duplicate index/constraint names across tables.
+
+    Some KG models share index and constraint names (a pre-existing model
+    bug that works with Alembic because they're created in separate
+    migrations). Returns a mapping of {new_name: original_name} for
+    restoration.
+    """
+    seen: set[str] = set()
+    renames: dict[str, str] = {}
+
+    def _make_unique(original: str, table_name: str) -> str:
+        # Use a short hash suffix to stay under PostgreSQL's 63-char limit
+        suffix = hashlib.sha256(table_name.encode()).hexdigest()[:6]
+        # Truncate the original name if needed to leave room for suffix
+        max_base = 63 - 1 - len(suffix)  # 1 for underscore
+        return f"{original[:max_base]}_{suffix}"
+
+    for table in metadata.sorted_tables:
+        # Deduplicate indexes
+        for idx in list(table.indexes):
+            if idx.name and idx.name in seen:
+                original_name = idx.name
+                new_name = _make_unique(original_name, table.name)
+                idx.name = quoted_name(new_name, quote=False)
+                renames[new_name] = original_name
+            elif idx.name:
+                seen.add(idx.name)
+
+        # Deduplicate named constraints (UniqueConstraint, etc.)
+        for constraint in list(table.constraints):
+            name = getattr(constraint, "name", None)
+            if name and name in seen:
+                original_name = name
+                new_name = _make_unique(original_name, table.name)
+                constraint.name = new_name
+                renames[new_name] = original_name
+            elif name:
+                seen.add(name)
+
+    return renames
+
+
+def _restore_ddl_names(metadata: MetaData, renames: dict[str, str]) -> None:
+    """Restore original index/constraint names after create_all."""
+    if not renames:
+        return
+    for table in metadata.sorted_tables:
+        for idx in table.indexes:
+            if idx.name in renames:
+                idx.name = quoted_name(renames[idx.name], quote=False)
+        for constraint in table.constraints:
+            name = getattr(constraint, "name", None)
+            if name and name in renames:
+                constraint.name = renames[name]
+
+
+def fast_provision_tenant_schema(tenant_id: str) -> None:
+    """Create all tables via metadata.create_all() and seed default data.
+
+    This is dramatically faster than running hundreds of sequential Alembic
+    migrations (~80s → ~2s) and produces an identical schema since the
+    models are the single source of truth for both paths.
+    """
+    from ee.onyx.server.tenants.seed_tenant_data import seed_tenant_defaults
+    from onyx.db.models import Base
+
+    engine = get_sqlalchemy_engine()
+    head_rev = _get_current_alembic_head()
+
+    logger.info(f"Fast-provisioning schema for tenant: {tenant_id}")
+
+    # Temporarily deduplicate index names to avoid collisions during create_all
+    renames = _deduplicate_ddl_names(Base.metadata)
+
+    try:
+        with engine.connect() as conn:
+            # Create schema (already exists from create_schema_if_not_exists,
+            # but be safe)
+            conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
+            conn.execute(text(f'SET search_path TO "{tenant_id}"'))
+
+            # Create tenant-specific tables only.
+            # Exclude: tables with explicit schema (e.g. public),
+            # public-only tables without schema annotation, and tables
+            # defined in models but never created by migrations.
+            _PUBLIC_ONLY_TABLES = {
+                "available_tenant",
+                "tenant_anonymous_user_path",
+                "milestone",
+            }
+            tenant_tables = [
+                t
+                for t in Base.metadata.sorted_tables
+                if t.schema is None and t.name not in _PUBLIC_ONLY_TABLES
+            ]
+            Base.metadata.create_all(bind=conn, checkfirst=True, tables=tenant_tables)
+            # Note: ResultModelBase (Celery) tables are NOT created per-tenant;
+            # they only exist in the public/default schema.
+
+            # Stamp the alembic_version table so future migrations work
+            conn.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS alembic_version "
+                    "(version_num VARCHAR(32) NOT NULL)"
+                )
+            )
+            conn.execute(
+                text("INSERT INTO alembic_version (version_num) VALUES (:rev)"),
+                {"rev": head_rev},
+            )
+
+            # Insert seed/default data
+            seed_tenant_defaults(conn)
+
+            conn.commit()
+    finally:
+        _restore_ddl_names(Base.metadata, renames)
+
+    logger.info(
+        f"Fast-provisioning complete for tenant {tenant_id} " f"(stamped at {head_rev})"
+    )
 
 
 def get_current_alembic_version(tenant_id: str) -> str:

--- a/backend/ee/onyx/server/tenants/schema_management.py
+++ b/backend/ee/onyx/server/tenants/schema_management.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import re
+import threading
 from types import SimpleNamespace
 
 from sqlalchemy import text
@@ -17,6 +18,19 @@ from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from shared_configs.configs import TENANT_ID_PREFIX
 
 logger = logging.getLogger(__name__)
+
+# Lock to protect Base.metadata mutations during fast provisioning.
+# _deduplicate_ddl_names / _restore_ddl_names mutate the global metadata
+# singleton, so concurrent calls must be serialized.
+_METADATA_LOCK = threading.Lock()
+
+# Tables that exist in Base.metadata but should only be created in the
+# public schema, not in per-tenant schemas.
+_PUBLIC_ONLY_TABLES: set[str] = {
+    "available_tenant",
+    "tenant_anonymous_user_path",
+    "milestone",
+}
 
 
 def _get_current_alembic_head() -> str:
@@ -191,57 +205,61 @@ def fast_provision_tenant_schema(tenant_id: str) -> None:
     from ee.onyx.server.tenants.seed_tenant_data import seed_tenant_defaults
     from onyx.db.models import Base
 
+    if not validate_tenant_id(tenant_id):
+        raise ValueError(f"Invalid tenant_id format: {tenant_id}")
+
     engine = get_sqlalchemy_engine()
     head_rev = _get_current_alembic_head()
 
     logger.info(f"Fast-provisioning schema for tenant: {tenant_id}")
 
-    # Temporarily deduplicate index names to avoid collisions during create_all
-    renames = _deduplicate_ddl_names(Base.metadata)
+    # Hold the lock for the entire metadata mutation + create_all + restore
+    # sequence to prevent concurrent threads from corrupting each other's
+    # index/constraint renames on the shared Base.metadata singleton.
+    with _METADATA_LOCK:
+        renames = _deduplicate_ddl_names(Base.metadata)
+        try:
+            with engine.connect() as conn:
+                # Create schema (already exists from create_schema_if_not_exists,
+                # but be safe)
+                conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
+                conn.execute(text(f'SET search_path TO "{tenant_id}"'))
 
-    try:
-        with engine.connect() as conn:
-            # Create schema (already exists from create_schema_if_not_exists,
-            # but be safe)
-            conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{tenant_id}"'))
-            conn.execute(text(f'SET search_path TO "{tenant_id}"'))
-
-            # Create tenant-specific tables only.
-            # Exclude: tables with explicit schema (e.g. public),
-            # public-only tables without schema annotation, and tables
-            # defined in models but never created by migrations.
-            _PUBLIC_ONLY_TABLES = {
-                "available_tenant",
-                "tenant_anonymous_user_path",
-                "milestone",
-            }
-            tenant_tables = [
-                t
-                for t in Base.metadata.sorted_tables
-                if t.schema is None and t.name not in _PUBLIC_ONLY_TABLES
-            ]
-            Base.metadata.create_all(bind=conn, checkfirst=True, tables=tenant_tables)
-            # Note: ResultModelBase (Celery) tables are NOT created per-tenant;
-            # they only exist in the public/default schema.
-
-            # Stamp the alembic_version table so future migrations work
-            conn.execute(
-                text(
-                    "CREATE TABLE IF NOT EXISTS alembic_version "
-                    "(version_num VARCHAR(32) NOT NULL)"
+                # Create tenant-specific tables only.
+                # Exclude: tables with explicit schema (e.g. public),
+                # public-only tables without schema annotation, and tables
+                # defined in models but never created by migrations.
+                tenant_tables = [
+                    t
+                    for t in Base.metadata.sorted_tables
+                    if t.schema is None and t.name not in _PUBLIC_ONLY_TABLES
+                ]
+                Base.metadata.create_all(
+                    bind=conn, checkfirst=True, tables=tenant_tables
                 )
-            )
-            conn.execute(
-                text("INSERT INTO alembic_version (version_num) VALUES (:rev)"),
-                {"rev": head_rev},
-            )
+                # Note: ResultModelBase (Celery) tables are NOT created
+                # per-tenant; they only exist in the public/default schema.
 
-            # Insert seed/default data
-            seed_tenant_defaults(conn)
+                # Stamp the alembic_version table so future migrations work.
+                # Match Alembic's own DDL including the primary key constraint.
+                conn.execute(
+                    text(
+                        "CREATE TABLE IF NOT EXISTS alembic_version "
+                        "(version_num VARCHAR(32) NOT NULL, "
+                        "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+                    )
+                )
+                conn.execute(
+                    text("INSERT INTO alembic_version (version_num) VALUES (:rev)"),
+                    {"rev": head_rev},
+                )
 
-            conn.commit()
-    finally:
-        _restore_ddl_names(Base.metadata, renames)
+                # Insert seed/default data
+                seed_tenant_defaults(conn)
+
+                conn.commit()
+        finally:
+            _restore_ddl_names(Base.metadata, renames)
 
     logger.info(
         f"Fast-provisioning complete for tenant {tenant_id} " f"(stamped at {head_rev})"

--- a/backend/ee/onyx/server/tenants/seed_tenant_data.py
+++ b/backend/ee/onyx/server/tenants/seed_tenant_data.py
@@ -1,0 +1,532 @@
+"""
+Seed data for fast tenant provisioning.
+
+When using metadata.create_all() instead of running Alembic migrations,
+the database tables are created but empty. This module inserts the default
+seed data that various migrations would have inserted.
+
+IMPORTANT: If you add an Alembic migration that INSERTs default/seed data
+into tables, you MUST also update seed_tenant_defaults() here. The parity
+test in test_fast_provision_parity.py will catch drift.
+"""
+
+import json
+import logging
+from datetime import datetime
+from datetime import timedelta
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.configs.model_configs import DOC_EMBEDDING_DIM
+from onyx.configs.model_configs import DOCUMENT_ENCODER_MODEL
+from onyx.configs.model_configs import NORMALIZE_EMBEDDINGS
+from onyx.configs.model_configs import OLD_DEFAULT_DOCUMENT_ENCODER_MODEL
+from onyx.configs.model_configs import OLD_DEFAULT_MODEL_DOC_EMBEDDING_DIM
+from onyx.configs.model_configs import OLD_DEFAULT_MODEL_NORMALIZE_EMBEDDINGS
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import IndexModelStatus
+from onyx.db.search_settings import user_has_overridden_embedding_model
+from onyx.natural_language_processing.search_nlp_models import clean_model_name
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tool definitions ────────────────────────────────────────────────────────
+# Mirrors the final state after all tool-seeding migrations have run.
+BUILT_IN_TOOLS: list[dict[str, object]] = [
+    {
+        "name": "internal_search",
+        "display_name": "Internal Search",
+        "description": (
+            "The Search Action allows the agent to search through "
+            "connected knowledge to help build an answer."
+        ),
+        "in_code_tool_id": "SearchTool",
+        "enabled": True,
+    },
+    {
+        "name": "generate_image",
+        "display_name": "Image Generation",
+        "description": (
+            "The Image Generation Action allows the agent to use "
+            "DALL-E 3 or GPT-IMAGE-1 to generate images. The action will "
+            "be used when the user asks the agent to generate an image."
+        ),
+        "in_code_tool_id": "ImageGenerationTool",
+        "enabled": True,
+    },
+    {
+        "name": "web_search",
+        "display_name": "Web Search",
+        "description": (
+            "The Web Search Action allows the agent to perform "
+            "internet searches for up-to-date information."
+        ),
+        "in_code_tool_id": "WebSearchTool",
+        "enabled": True,
+    },
+    {
+        "name": "run_kg_search",
+        "display_name": "Knowledge Graph Search",
+        "description": (
+            "The Knowledge Graph Search Action allows the agent to "
+            "search the Knowledge Graph for information. This tool can "
+            "(for now) only be active in the KG Beta Agent, and it "
+            "requires the Knowledge Graph to be enabled."
+        ),
+        "in_code_tool_id": "KnowledgeGraphTool",
+        "enabled": True,
+    },
+    {
+        "name": "OktaProfileTool",
+        "display_name": "Okta Profile",
+        "description": (
+            "The Okta Profile Action allows the agent to fetch the "
+            "current user's information from Okta. This may include the "
+            "user's name, email, phone number, address, and other details "
+            "such as their manager and direct reports."
+        ),
+        "in_code_tool_id": "OktaProfileTool",
+        "enabled": True,
+    },
+    {
+        "name": "read_file",
+        "display_name": "File Reader",
+        "description": (
+            "Read sections of user-uploaded files by character offset. "
+            "Useful for inspecting large files that cannot fit entirely "
+            "in context."
+        ),
+        "in_code_tool_id": "FileReaderTool",
+        "enabled": True,
+    },
+    {
+        "name": "MemoryTool",
+        "display_name": "Add Memory",
+        "description": "Save memories about the user for future conversations.",
+        "in_code_tool_id": "MemoryTool",
+        "enabled": True,
+    },
+    {
+        "name": "python",
+        "display_name": "Code Interpreter",
+        "description": (
+            "The Code Interpreter Action allows the assistant to execute "
+            "Python code in a secure, isolated environment for data "
+            "analysis, computation, visualization, and file processing."
+        ),
+        "in_code_tool_id": "PythonTool",
+        "enabled": True,
+    },
+    {
+        "name": "open_url",
+        "display_name": "Open URL",
+        "description": (
+            "The Open URL Action allows the agent to fetch and read "
+            "contents of web pages."
+        ),
+        "in_code_tool_id": "OpenURLTool",
+        "enabled": True,
+    },
+    {
+        "name": "research_agent",
+        "display_name": "Research Agent",
+        "description": (
+            "The Research Agent is a sub-agent that conducts research "
+            "on a specific topic."
+        ),
+        "in_code_tool_id": "ResearchAgent",
+        "enabled": False,
+    },
+]
+
+# Tools to attach to the default persona (id=0)
+_DEFAULT_PERSONA_TOOL_IDS = {
+    "SearchTool",
+    "ImageGenerationTool",
+    "WebSearchTool",
+    "FileReaderTool",
+    "PythonTool",
+    "OpenURLTool",
+}
+
+# ── Default persona (Assistant) ────────────────────────────────────────────
+
+DEFAULT_SYSTEM_PROMPT = """You are a highly capable, thoughtful, and precise assistant. Your goal is to deeply understand the \
+user's intent, ask clarifying questions when needed, think step-by-step through complex problems, \
+provide clear and accurate answers, and proactively anticipate helpful follow-up information. Always \
+prioritize being truthful, nuanced, insightful, and efficient.
+The current date is [[CURRENT_DATETIME]]
+
+You use different text styles, bolding, emojis (sparingly), block quotes, and other formatting to make \
+your responses more readable and engaging.
+You use proper Markdown and LaTeX to format your responses for math, scientific, and chemical formulas, \
+symbols, etc.: '$$\\n[expression]\\n$$' for standalone cases and '\\( [expression] \\)' when inline.
+For code you prefer to use Markdown and specify the language.
+You can use Markdown horizontal rules (---) to separate sections of your responses.
+You can use Markdown tables to format your responses for data, lists, and other structured information."""
+
+# ── Hierarchy node display names ───────────────────────────────────────────
+
+SOURCE_DISPLAY_NAMES: dict[str, str] = {
+    "ingestion_api": "Ingestion API",
+    "slack": "Slack",
+    "web": "Web",
+    "google_drive": "Google Drive",
+    "gmail": "Gmail",
+    "requesttracker": "Request Tracker",
+    "github": "GitHub",
+    "gitbook": "GitBook",
+    "gitlab": "GitLab",
+    "guru": "Guru",
+    "bookstack": "BookStack",
+    "outline": "Outline",
+    "confluence": "Confluence",
+    "jira": "Jira",
+    "slab": "Slab",
+    "productboard": "Productboard",
+    "file": "File",
+    "coda": "Coda",
+    "notion": "Notion",
+    "zulip": "Zulip",
+    "linear": "Linear",
+    "hubspot": "HubSpot",
+    "document360": "Document360",
+    "gong": "Gong",
+    "google_sites": "Google Sites",
+    "zendesk": "Zendesk",
+    "loopio": "Loopio",
+    "dropbox": "Dropbox",
+    "sharepoint": "SharePoint",
+    "teams": "Teams",
+    "salesforce": "Salesforce",
+    "discourse": "Discourse",
+    "axero": "Axero",
+    "clickup": "ClickUp",
+    "mediawiki": "MediaWiki",
+    "wikipedia": "Wikipedia",
+    "asana": "Asana",
+    "s3": "S3",
+    "r2": "R2",
+    "google_cloud_storage": "Google Cloud Storage",
+    "oci_storage": "OCI Storage",
+    "xenforo": "XenForo",
+    "not_applicable": "Not Applicable",
+    "discord": "Discord",
+    "freshdesk": "Freshdesk",
+    "fireflies": "Fireflies",
+    "egnyte": "Egnyte",
+    "airtable": "Airtable",
+    "highspot": "Highspot",
+    "drupal_wiki": "Drupal Wiki",
+    "imap": "IMAP",
+    "bitbucket": "Bitbucket",
+    "testrail": "TestRail",
+    "mock_connector": "Mock Connector",
+    "user_file": "User File",
+}
+
+
+def seed_tenant_defaults(conn: Connection) -> None:
+    """Insert all default/seed data that migrations normally provide.
+
+    Must be called AFTER create_all() has created all tables in the
+    tenant's schema and the search_path has been set appropriately.
+    """
+    _add_extra_columns(conn)
+    _seed_search_settings(conn)
+    _seed_tools(conn)
+    _seed_default_persona(conn)
+    _seed_persona_tool_associations(conn)
+    _seed_code_interpreter_server(conn)
+    _seed_hierarchy_nodes(conn)
+    _seed_anonymous_user(conn)
+    _seed_kg_config(conn)
+    logger.info("Seed data inserted successfully")
+
+
+def _add_extra_columns(conn: Connection) -> None:
+    """Add columns that migrations create via raw SQL (not in models.py).
+
+    These are generated/derived columns that SQLAlchemy models can't
+    represent but which the application relies on.
+    """
+    # tsvector columns for full-text search (from migration 3bd4c84fe72f)
+    conn.execute(
+        text(
+            """
+            ALTER TABLE chat_message
+            ADD COLUMN IF NOT EXISTS message_tsv tsvector
+            GENERATED ALWAYS AS (to_tsvector('english', message)) STORED
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_chat_message_tsv
+            ON chat_message USING GIN (message_tsv)
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            ALTER TABLE chat_session
+            ADD COLUMN IF NOT EXISTS description_tsv tsvector
+            GENERATED ALWAYS AS (
+                to_tsvector('english', coalesce(description, ''))
+            ) STORED
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_chat_session_desc_tsv
+            ON chat_session USING GIN (description_tsv)
+            """
+        )
+    )
+
+
+def _seed_search_settings(conn: Connection) -> None:
+    """Seed the initial PRESENT and FUTURE search_settings rows.
+
+    Mirrors the logic from migration dbaa756c2ccf_embedding_models.py:
+    - PRESENT row uses the old/current embedding model
+    - FUTURE row uses the new default model (if not overridden)
+    """
+    is_overridden = user_has_overridden_embedding_model()
+
+    _SEARCH_SETTINGS_SQL = text(
+        """
+        INSERT INTO search_settings (
+            model_name, model_dim, normalize, query_prefix,
+            passage_prefix, status, index_name, embedding_precision,
+            switchover_type, multipass_indexing, enable_contextual_rag,
+            multilingual_expansion
+        ) VALUES (
+            :model_name, :model_dim, :normalize, :query_prefix,
+            :passage_prefix, :status, :index_name, :embedding_precision,
+            :switchover_type, :multipass_indexing, :enable_contextual_rag,
+            CAST(:multilingual_expansion AS VARCHAR[])
+        )
+        """
+    )
+
+    # PRESENT row: old/current embedding model
+    present_model = (
+        DOCUMENT_ENCODER_MODEL if is_overridden else OLD_DEFAULT_DOCUMENT_ENCODER_MODEL
+    )
+    present_dim = (
+        DOC_EMBEDDING_DIM if is_overridden else OLD_DEFAULT_MODEL_DOC_EMBEDDING_DIM
+    )
+    present_normalize = (
+        NORMALIZE_EMBEDDINGS
+        if is_overridden
+        else OLD_DEFAULT_MODEL_NORMALIZE_EMBEDDINGS
+    )
+    present_query_prefix = ASYM_QUERY_PREFIX if is_overridden else ""
+    present_passage_prefix = ASYM_PASSAGE_PREFIX if is_overridden else ""
+
+    conn.execute(
+        _SEARCH_SETTINGS_SQL,
+        {
+            "model_name": present_model,
+            "model_dim": present_dim,
+            "normalize": present_normalize,
+            "query_prefix": present_query_prefix,
+            "passage_prefix": present_passage_prefix,
+            "status": IndexModelStatus.PRESENT.name,
+            "index_name": "danswer_chunk",
+            "embedding_precision": EmbeddingPrecision.FLOAT.name,
+            "switchover_type": SwitchoverType.REINDEX.name,
+            "multipass_indexing": False,
+            "enable_contextual_rag": False,
+            "multilingual_expansion": "{}",
+        },
+    )
+
+    # FUTURE row: new default model (only if user hasn't overridden)
+    if not is_overridden:
+        future_index = f"danswer_chunk_{clean_model_name(DOCUMENT_ENCODER_MODEL)}"
+        conn.execute(
+            _SEARCH_SETTINGS_SQL,
+            {
+                "model_name": DOCUMENT_ENCODER_MODEL,
+                "model_dim": DOC_EMBEDDING_DIM,
+                "normalize": NORMALIZE_EMBEDDINGS,
+                "query_prefix": ASYM_QUERY_PREFIX,
+                "passage_prefix": ASYM_PASSAGE_PREFIX,
+                "status": IndexModelStatus.FUTURE.name,
+                "index_name": future_index,
+                "embedding_precision": EmbeddingPrecision.FLOAT.name,
+                "switchover_type": SwitchoverType.REINDEX.name,
+                "multipass_indexing": False,
+                "enable_contextual_rag": False,
+                "multilingual_expansion": "{}",
+            },
+        )
+
+
+def _seed_tools(conn: Connection) -> None:
+    """Insert all built-in tools."""
+    for tool in BUILT_IN_TOOLS:
+        conn.execute(
+            text(
+                """
+                INSERT INTO tool (
+                    name, display_name, description, in_code_tool_id,
+                    enabled, passthrough_auth
+                )
+                VALUES (
+                    :name, :display_name, :description, :in_code_tool_id,
+                    :enabled, false
+                )
+                """
+            ),
+            tool,
+        )
+
+
+def _seed_default_persona(conn: Connection) -> None:
+    """Insert the default Assistant persona (id=0)."""
+    # Matches migration 505c488f6662: system_prompt is NULL by default,
+    # is_featured is True for the default assistant.
+    conn.execute(
+        text(
+            """
+            INSERT INTO persona (
+                id, name, description,
+                builtin_persona, is_public, is_listed, is_featured,
+                display_priority, deleted, datetime_aware,
+                replace_base_system_prompt
+            ) VALUES (
+                0, :name, :description,
+                true, true, true, true,
+                0, false, true,
+                false
+            )
+            """
+        ),
+        {
+            "name": "Assistant",
+            "description": (
+                "Your AI assistant with search, web browsing, "
+                "and image generation capabilities."
+            ),
+        },
+    )
+
+
+def _seed_persona_tool_associations(conn: Connection) -> None:
+    """Link the default persona to its tools."""
+    for tool_id in _DEFAULT_PERSONA_TOOL_IDS:
+        conn.execute(
+            text(
+                """
+                INSERT INTO persona__tool (persona_id, tool_id)
+                SELECT 0, id FROM tool WHERE in_code_tool_id = :in_code_tool_id
+                ON CONFLICT DO NOTHING
+                """
+            ),
+            {"in_code_tool_id": tool_id},
+        )
+
+
+def _seed_code_interpreter_server(conn: Connection) -> None:
+    """Insert the single code_interpreter_server row."""
+    conn.execute(
+        text("INSERT INTO code_interpreter_server (server_enabled) VALUES (true)")
+    )
+
+
+def _seed_hierarchy_nodes(conn: Connection) -> None:
+    """Insert SOURCE-type hierarchy nodes for every DocumentSource."""
+    for source in DocumentSource:
+        source_name = source.name  # e.g. 'GOOGLE_DRIVE' (enum storage)
+        source_value = source.value  # e.g. 'google_drive' (raw_node_id)
+        display_name = SOURCE_DISPLAY_NAMES.get(
+            source_value, source_value.replace("_", " ").title()
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO hierarchy_node (
+                    raw_node_id, display_name, source, node_type, parent_id, is_public
+                ) VALUES (
+                    :raw_node_id, :display_name, :source, 'SOURCE', NULL, true
+                )
+                ON CONFLICT (raw_node_id, source) DO NOTHING
+                """
+            ),
+            {
+                "raw_node_id": source_value,
+                "display_name": display_name,
+                "source": source_name,
+            },
+        )
+
+
+def _seed_anonymous_user(conn: Connection) -> None:
+    """Insert the anonymous user placeholder."""
+    conn.execute(
+        text(
+            """
+            INSERT INTO "user" (
+                id, email, hashed_password,
+                is_active, is_superuser, is_verified, role,
+                shortcut_enabled, temperature_override_enabled,
+                default_app_mode, use_memories,
+                enable_memory_tool, visible_assistants, hidden_assistants,
+                voice_auto_send, voice_auto_playback, voice_playback_speed,
+                account_type, effective_permissions
+            ) VALUES (
+                :id, :email, :hashed_password,
+                :is_active, :is_superuser, :is_verified, :role,
+                false, false,
+                'CHAT', true,
+                true, '[]'::jsonb, '[]'::jsonb,
+                false, false, 1.0,
+                'ANONYMOUS', '[]'::jsonb
+            )
+            ON CONFLICT (id) DO NOTHING
+            """
+        ),
+        {
+            "id": "00000000-0000-0000-0000-000000000002",
+            "email": "anonymous@onyx.app",
+            "hashed_password": "",
+            "is_active": True,
+            "is_superuser": False,
+            "is_verified": True,
+            "role": "LIMITED",
+        },
+    )
+
+
+def _seed_kg_config(conn: Connection) -> None:
+    """Insert default KG config into key_value_store."""
+    # Values match migration 03bf8be6b53a which stores booleans and
+    # integers as strings (from the original kg_config table format)
+    kg_defaults: dict[str, str | list[str] | None] = {
+        "KG_EXPOSED": "false",
+        "KG_ENABLED": "false",
+        "KG_VENDOR": None,
+        "KG_VENDOR_DOMAINS": [],
+        "KG_IGNORE_EMAIL_DOMAINS": [],
+        "KG_COVERAGE_START": (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d"),
+        "KG_MAX_COVERAGE_DAYS": "90",
+        "KG_MAX_PARENT_RECURSION_DEPTH": "2",
+        "KG_BETA_PERSONA_ID": None,
+    }
+    conn.execute(
+        text("INSERT INTO key_value_store (key, value) VALUES (:key, :value)"),
+        {"key": "kg_config", "value": json.dumps(kg_defaults)},
+    )

--- a/backend/tests/external_dependency_unit/test_fast_provision_parity.py
+++ b/backend/tests/external_dependency_unit/test_fast_provision_parity.py
@@ -1,0 +1,304 @@
+"""
+Drift-detection test: verifies that fast tenant provisioning
+(metadata.create_all + seed data) produces the same result as
+running full Alembic migrations.
+
+If this test fails, it means a migration was added that either:
+  1. Creates/alters a table not reflected in models.py (schema drift)
+  2. Inserts seed data not replicated in seed_tenant_data.py (data drift)
+
+Fix by updating the relevant source of truth.
+"""
+
+import uuid
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from ee.onyx.server.tenants.schema_management import fast_provision_tenant_schema
+from ee.onyx.server.tenants.schema_management import run_alembic_migrations
+from onyx.db.engine.sql_engine import SqlEngine
+
+
+# Tables whose seed data we compare between the two provisioning paths.
+# These are the tables that migrations insert default/seed rows into.
+SEED_TABLES = [
+    "tool",
+    "persona",
+    "persona__tool",
+    "code_interpreter_server",
+    "hierarchy_node",
+    '"user"',  # quoted because user is a reserved word
+    "key_value_store",
+    "search_settings",
+]
+
+# Columns to EXCLUDE from seed-data comparison because they contain
+# non-deterministic values (timestamps, auto-increment IDs, etc.)
+NONDETERMINISTIC_COLUMNS = {
+    "id",
+    "date_created",
+    "time_created",
+    "time_updated",
+    "created_at",
+    "updated_at",
+    "oidc_expiry",
+    # tool_id in persona__tool differs because auto-increment IDs
+    # depend on insertion order
+    "tool_id",
+}
+
+
+def _get_engine() -> Engine:
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+    return SqlEngine.get_engine()
+
+
+def _create_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+        conn.commit()
+
+
+def _drop_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        # Terminate any lingering connections
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_stat_activity "
+                "WHERE datname = current_database() "
+                "AND pid != pg_backend_pid() "
+                f"AND query LIKE '%{schema}%'"
+            )
+        )
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+def _get_table_columns(engine: Engine, schema: str, table_name: str) -> list[str]:
+    """Get ordered column names for a table, excluding non-deterministic ones."""
+    clean_table = table_name.strip('"')
+    with engine.connect() as conn:
+        result = conn.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = :schema AND table_name = :table "
+                "ORDER BY ordinal_position"
+            ),
+            {"schema": schema, "table": clean_table},
+        )
+        return [row[0] for row in result if row[0] not in NONDETERMINISTIC_COLUMNS]
+
+
+def _get_table_data(
+    engine: Engine, schema: str, table_name: str, columns: list[str]
+) -> list[tuple[object, ...]]:
+    """Fetch all rows from a table, selecting only the given columns."""
+    if not columns:
+        return []
+    cols_sql = ", ".join(f'"{c}"' for c in columns)
+    # Order by all columns for deterministic comparison
+    with engine.connect() as conn:
+        conn.execute(text(f'SET search_path TO "{schema}"'))
+        result = conn.execute(
+            text(f"SELECT {cols_sql} FROM {table_name} ORDER BY {cols_sql}")
+        )
+        return [tuple(row) for row in result]
+
+
+def _get_all_tables(engine: Engine, schema: str) -> set[str]:
+    """Get all table names in a schema."""
+    with engine.connect() as conn:
+        result = conn.execute(
+            text(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = :schema AND table_type = 'BASE TABLE' "
+                "ORDER BY table_name"
+            ),
+            {"schema": schema},
+        )
+        return {row[0] for row in result}
+
+
+def _get_column_info(
+    engine: Engine, schema: str
+) -> dict[str, list[tuple[str, str, str]]]:
+    """Get column definitions for all tables: {table: [(name, type, nullable)]}."""
+    with engine.connect() as conn:
+        result = conn.execute(
+            text(
+                "SELECT table_name, column_name, data_type, is_nullable "
+                "FROM information_schema.columns "
+                "WHERE table_schema = :schema "
+                "ORDER BY table_name, ordinal_position"
+            ),
+            {"schema": schema},
+        )
+        columns: dict[str, list[tuple[str, str, str]]] = {}
+        for row in result:
+            columns.setdefault(row[0], []).append((row[1], row[2], row[3]))
+        return columns
+
+
+@pytest.fixture
+def migration_schema() -> Generator[str, None, None]:
+    """Create a tenant schema via full Alembic migrations."""
+    engine = _get_engine()
+    schema = f"tenant_test_migration_{uuid.uuid4().hex[:8]}"
+    _create_schema(engine, schema)
+    try:
+        run_alembic_migrations(schema)
+        yield schema
+    finally:
+        _drop_schema(engine, schema)
+
+
+@pytest.fixture
+def fast_schema() -> Generator[str, None, None]:
+    """Create a tenant schema via fast provisioning."""
+    engine = _get_engine()
+    schema = f"tenant_test_fast_{uuid.uuid4().hex[:8]}"
+    _create_schema(engine, schema)
+    try:
+        fast_provision_tenant_schema(schema)
+        yield schema
+    finally:
+        _drop_schema(engine, schema)
+
+
+class TestFastProvisionParity:
+    """Ensure fast provisioning matches full migration output."""
+
+    def test_same_tables_exist(self, migration_schema: str, fast_schema: str) -> None:
+        """Both paths should create the same set of tables."""
+        engine = _get_engine()
+        migration_tables = _get_all_tables(engine, migration_schema)
+        fast_tables = _get_all_tables(engine, fast_schema)
+
+        missing = migration_tables - fast_tables
+        extra = fast_tables - migration_tables
+
+        assert (
+            not missing
+        ), f"Tables in migration schema but missing from fast schema: {missing}"
+        assert not extra, f"Tables in fast schema but not in migration schema: {extra}"
+
+    def test_same_columns(self, migration_schema: str, fast_schema: str) -> None:
+        """Both paths should produce tables with the same columns.
+
+        Columns present in fast schema but missing from migration schema
+        indicate missing Alembic migrations (model has columns not yet
+        migrated). These are logged as warnings since create_all()
+        correctly reflects the model.
+
+        Columns present in migration schema but missing from fast schema
+        would indicate a models.py bug and are treated as failures.
+        """
+        engine = _get_engine()
+        migration_cols = _get_column_info(engine, migration_schema)
+        fast_cols = _get_column_info(engine, fast_schema)
+
+        # Columns in migration schema that were removed from models.py
+        # but never dropped. These are harmless orphans.
+        _KNOWN_ORPHANED_COLUMNS: dict[str, set[str]] = {
+            "persona_label": {"description"},
+            "user_project": {"display_priority"},
+        }
+
+        errors: list[str] = []
+        warnings: list[str] = []
+        all_tables = set(migration_cols.keys()) | set(fast_cols.keys())
+
+        for table in sorted(all_tables):
+            m_cols = migration_cols.get(table, [])
+            f_cols = fast_cols.get(table, [])
+            if m_cols != f_cols:
+                m_names = {c[0] for c in m_cols}
+                f_names = {c[0] for c in f_cols}
+                orphans = _KNOWN_ORPHANED_COLUMNS.get(table, set())
+                # Columns in migration but not fast (excluding known orphans)
+                missing_from_fast = m_names - f_names - orphans
+                # Columns in fast but not migration = missing migration
+                extra_in_fast = f_names - m_names
+                if missing_from_fast:
+                    errors.append(
+                        f"Table '{table}': columns in migration but "
+                        f"missing from models.py: {missing_from_fast}"
+                    )
+                if extra_in_fast:
+                    warnings.append(
+                        f"Table '{table}': columns in models.py but "
+                        f"missing migration: {extra_in_fast}"
+                    )
+
+        if warnings:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Columns in models.py without migrations (fast schema "
+                "is ahead of migration schema):\n" + "\n".join(warnings)
+            )
+
+        assert not errors, (
+            "Column differences — models.py is MISSING columns that "
+            "migrations create:\n" + "\n".join(errors)
+        )
+
+    def test_same_seed_data(self, migration_schema: str, fast_schema: str) -> None:
+        """Seed tables should contain the same data in both schemas."""
+        engine = _get_engine()
+        differences: list[str] = []
+
+        for table in SEED_TABLES:
+            # Use columns from migration schema as reference
+            columns = _get_table_columns(engine, migration_schema, table)
+            if not columns:
+                continue
+
+            migration_data = _get_table_data(engine, migration_schema, table, columns)
+            fast_data = _get_table_data(engine, fast_schema, table, columns)
+
+            if migration_data != fast_data:
+                # Convert to strings for hashable comparison
+                m_strs = {str(r) for r in migration_data}
+                f_strs = {str(r) for r in fast_data}
+                only_migration = m_strs - f_strs
+                only_fast = f_strs - m_strs
+                differences.append(
+                    f"Table '{table}' (cols: {columns}):\n"
+                    f"  Only in migration ({len(only_migration)} rows): "
+                    f"{list(only_migration)[:3]}\n"
+                    f"  Only in fast ({len(only_fast)} rows): "
+                    f"{list(only_fast)[:3]}"
+                )
+
+        assert (
+            not differences
+        ), "Seed data differences between migration and fast schema:\n" + "\n".join(
+            differences
+        )
+
+    def test_alembic_version_matches(
+        self, migration_schema: str, fast_schema: str
+    ) -> None:
+        """Both should be stamped at the same alembic head revision."""
+        engine = _get_engine()
+        with engine.connect() as conn:
+            conn.execute(text(f'SET search_path TO "{migration_schema}"'))
+            m_rev = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
+
+        with engine.connect() as conn:
+            conn.execute(text(f'SET search_path TO "{fast_schema}"'))
+            f_rev = conn.execute(
+                text("SELECT version_num FROM alembic_version")
+            ).scalar()
+
+        assert (
+            m_rev == f_rev
+        ), f"Alembic version mismatch: migration={m_rev}, fast={f_rev}"

--- a/backend/tests/external_dependency_unit/test_fast_provision_parity.py
+++ b/backend/tests/external_dependency_unit/test_fast_provision_parity.py
@@ -147,7 +147,7 @@ def _get_column_info(
 def migration_schema() -> Generator[str, None, None]:
     """Create a tenant schema via full Alembic migrations."""
     engine = _get_engine()
-    schema = f"tenant_test_migration_{uuid.uuid4().hex[:8]}"
+    schema = f"tenant_{uuid.uuid4()}"
     _create_schema(engine, schema)
     try:
         run_alembic_migrations(schema)
@@ -160,7 +160,7 @@ def migration_schema() -> Generator[str, None, None]:
 def fast_schema() -> Generator[str, None, None]:
     """Create a tenant schema via fast provisioning."""
     engine = _get_engine()
-    schema = f"tenant_test_fast_{uuid.uuid4().hex[:8]}"
+    schema = f"tenant_{uuid.uuid4()}"
     _create_schema(engine, schema)
     try:
         fast_provision_tenant_schema(schema)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
We are currently hitting some bottlenecks with the pre-provisioning workflow. We are trying to pre-provision the tenants but due to the large influx of new users, the DB operations cannot keep up. This is partially due to the fact that the amount of time to spawn a new tenant is quite high due to the amount of schema migrations that is being run.

This change introduces a `create_all` workflow that will create the current table state. The problem with this is that we are disregarding all of the insertions that are happening with the schema migrations so this also adds a seeding operation that pre-seeds all of the default values that have been added historically.

This should hopefully help us see a 40~80x speed up in the cloud for pre-provisioning new blank tenants.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
This has been tested by utilizing the old provisioning workflow where we are running an entire schema migration and then comparing the final DB state to ensure there is parity. 

This also ensures that if others add insertions that they are caught prior to the schema migration PR's get in.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace slow Alembic-based tenant pre-provisioning with a fast create_all + seed workflow to cut setup time from ~80s to ~2s and reduce DB load.

- **New Features**
  - Added `fast_provision_tenant_schema` to create tables from models, deduplicate conflicting index/constraint names, serialize metadata changes with a lock, exclude public-only tables, stamp `alembic_version`, and seed defaults.
  - Introduced `seed_tenant_defaults` to insert default tools, Assistant persona + tool links, code interpreter server, hierarchy nodes for all `DocumentSource`, anonymous user, KG config, search settings, and add FTS tsvector columns + GIN indexes via SQL.
  - Switched `setup_tenant` to the fast path instead of running full Alembic migrations.
  - Added a parity test that compares tables/columns, seed data, and Alembic head between the fast path and full migrations (ignores nondeterministic fields and known orphaned columns).

- **Migration**
  - No deploy action required; future Alembic migrations will continue from the stamped head.
  - When adding migrations that insert default data, also update `seed_tenant_data.py` (the parity test will catch any drift).

<sup>Written for commit 83cc13d32a114a6a1dce4595eaf710035a4fb93b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

