### PR TITLE
fix(mcp): preserve tool results across conversation turns

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -527,10 +527,10 @@ def _build_tool_call_response_history_message(
     generated_images: list[dict] | None,
     tool_call_response: str | None,
 ) -> str:
-    if tool_name != IMAGE_GENERATION_TOOL_NAME:
-        return TOOL_CALL_RESPONSE_CROSS_MESSAGE
-
-    if generated_images:
+    # If we have a stored tool response, use it — this preserves MCP and
+    # custom tool results across conversation turns instead of replacing
+    # them with an opaque "no longer accessible" placeholder.
+    if tool_name == IMAGE_GENERATION_TOOL_NAME and generated_images:
         llm_image_context: list[dict[str, str]] = []
         for image in generated_images:
             file_id = image.get("file_id")

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -5,6 +5,7 @@ This module provides a proper MCP client that follows the JSON-RPC 2.0 specifica
 and handles connection initialization, session management, and protocol communication.
 """
 
+import json
 from collections.abc import Awaitable
 from collections.abc import Callable
 from enum import Enum
@@ -214,10 +215,19 @@ async def _call_mcp_client_function_async(
     return await run_client_function()
 
 
-def process_mcp_result(call_tool_result: CallToolResult) -> str:
-    """Flatten MCP CallToolResult->text (prefers text content blocks)."""
-    # TODO: use structured_content if available
-    parts = []
+def process_mcp_result(call_tool_result: CallToolResult) -> dict | list | str:
+    """Extract a clean, LLM-readable result from an MCP CallToolResult.
+
+    Prefers structuredContent (MCP spec 2025-03-26+) over raw content
+    text blocks. Returns a parsed object when possible so callers can
+    serialize once at the boundary, avoiding double-serialization.
+    """
+    # Prefer structuredContent — it's already a parsed object
+    if call_tool_result.structuredContent is not None:
+        return call_tool_result.structuredContent
+
+    # Fall back to content blocks
+    parts: list[str] = []
     for content_block in call_tool_result.content:
         if content_block.type == ContentBlockTypes.TEXT.value:
             parts.append(content_block.text or "")
@@ -231,11 +241,23 @@ def process_mcp_result(call_tool_result: CallToolResult) -> str:
             )
         # TODO: handle other content block types
 
-    return "\n\n".join(p for p in parts if p) or str(call_tool_result.structuredContent)
+    joined = "\n\n".join(p for p in parts if p)
+
+    # If the result is a single JSON text block, parse it so callers
+    # can serialize cleanly (avoids JSON-string-inside-JSON-string)
+    if joined:
+        try:
+            return json.loads(joined)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    return joined
 
 
-def _call_mcp_tool(tool_name: str, arguments: dict[str, Any]) -> MCPClientFunction[str]:
-    async def call_tool(session: ClientSession) -> str:
+def _call_mcp_tool(
+    tool_name: str, arguments: dict[str, Any]
+) -> MCPClientFunction[dict | list | str]:
+    async def call_tool(session: ClientSession) -> dict | list | str:
         await session.initialize()
         result = await session.call_tool(tool_name, arguments)
         return process_mcp_result(result)
@@ -250,7 +272,7 @@ def call_mcp_tool(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
-) -> str:
+) -> dict | list | str:
     """Call a specific tool on the MCP server"""
     return _call_mcp_client_function_sync(
         _call_mcp_tool(tool_name, arguments),

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -242,9 +242,17 @@ class MCPTool(Tool[None]):
 
             logger.info(f"MCP tool '{self._name}' executed successfully")
 
-            # Format the tool result for response
-            tool_result_dict = {"tool_result": tool_result}
-            llm_facing_response = json.dumps(tool_result_dict)
+            # Normalize result to a serializable object.
+            # process_mcp_result returns dict|list|str — if it's already
+            # structured, use it directly (matches custom_tool.py pattern).
+            # If it's a plain string, wrap it so json.dumps produces valid JSON.
+            if isinstance(tool_result, (dict, list)):
+                tool_result_obj = tool_result
+            else:
+                tool_result_obj = {"tool_result": tool_result}
+
+            response_type = "json" if isinstance(tool_result_obj, (dict, list)) else "text"
+            llm_facing_response = json.dumps(tool_result_obj)
 
             # Emit CustomToolDelta packet
             self.emitter.emit(
@@ -252,8 +260,8 @@ class MCPTool(Tool[None]):
                     placement=placement,
                     obj=CustomToolDelta(
                         tool_name=self._name,
-                        response_type="json",
-                        data=tool_result_dict,
+                        response_type=response_type,
+                        data=tool_result_obj,
                     ),
                 )
             )
@@ -261,8 +269,8 @@ class MCPTool(Tool[None]):
             return ToolResponse(
                 rich_response=CustomToolCallSummary(
                     tool_name=self._name,
-                    response_type="json",
-                    tool_result=tool_result_dict,
+                    response_type=response_type,
+                    tool_result=tool_result_obj,
                 ),
                 llm_facing_response=llm_facing_response,
             )


### PR DESCRIPTION
## Problem

MCP tool results are lost after the turn they execute in. On every subsequent conversation turn, the model receives `"This tool call completed but the results are no longer accessible"` instead of the actual tool output. This causes the model to hallucinate, re-execute tools, or report context loss.

## Root Cause

Three issues in the MCP tool result pipeline, all required to fully resolve the symptom:

### 1. History replay discards all non-image tool results

**`backend/onyx/chat/chat_utils.py:530`**

`_build_tool_call_response_history_message()` early-returns `TOOL_CALL_RESPONSE_CROSS_MESSAGE` for every tool that is not `IMAGE_GENERATION_TOOL_NAME`. The stored `tool_call_response` is saved to the DB correctly (`llm_loop.py:1051-1053`) but never read back — the early return at line 530 prevents execution from reaching line 553 where `tool_call_response` would have been used.

```python
# Before — blanket early return kills all non-image tool results
if tool_name != IMAGE_GENERATION_TOOL_NAME:
    return TOOL_CALL_RESPONSE_CROSS_MESSAGE

# After — only special-case image generation with generated images
if tool_name == IMAGE_GENERATION_TOOL_NAME and generated_images:
```

### 2. Double serialization of structured results

**`backend/onyx/tools/tool_implementations/mcp/mcp_tool.py:246`**

`process_mcp_result()` returns a string. `MCPTool.run()` wraps it in `{"tool_result": str}` then calls `json.dumps()`. If the MCP tool returns JSON, the LLM receives `{"tool_result": "{\"key\": \"value\"}"}` — escaped JSON inside a JSON envelope.

Fix: `process_mcp_result()` now returns `dict | list | str`. If the result is already structured, `MCPTool.run()` uses it directly with one `json.dumps()` at the boundary — matching the existing `custom_tool.py` pattern.

### 3. `structuredContent` field unused

**`backend/onyx/tools/tool_implementations/mcp/mcp_client.py:219`**

`CallToolResult.structuredContent` ([MCP spec 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26)) was acknowledged with a TODO comment but only used as a `str()` fallback when all content blocks were empty.

Fix: `structuredContent` is now preferred when present. Text content blocks containing valid JSON are parsed into objects to avoid downstream double-serialization.

## Testing

Tested against a self-hosted Onyx deployment with multiple MCP servers (knowledge graph, search, messaging). Before the fix, tool results vanished on the second turn. After the fix, results persist across the full conversation.

## Related

This is a known failure pattern across MCP client implementations:
- n8n-io/n8n#26963
- langchain-ai/langchain#34669

---

*Bug investigation and fix developed with assistance from [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Anthropic).*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves MCP tool results across conversation turns and sends clean, single-serialized outputs to the model. This prevents context loss, re-execution, and hallucinations.

- **Bug Fixes**
  - History replay now uses stored tool responses for all tools; non-image results are no longer replaced with a placeholder.
  - Eliminated double serialization: `process_mcp_result()` returns `dict | list | str`, and `MCPTool.run()` serializes once and sets `response_type` to `json` or `text`.
  - `structuredContent` is now preferred when present; JSON text blocks are parsed to objects to avoid escaped JSON in JSON.

<sup>Written for commit c6410070a3328c13b6413d20a2e6eccd48d0f2b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

