### PR TITLE
Feat/google chat connector

### DIFF
--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -1,5 +1,6 @@
 from onyx.connectors.confluence.connector import ConfluenceConnector
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
+from onyx.connectors.google_chat.connector import GoogleChatConnector
 from onyx.connectors.interfaces import BaseConnector
 
 
@@ -26,3 +27,6 @@ def validate_perm_sync(connector: BaseConnector) -> None:
         validate_confluence_perm_sync(connector)
     elif isinstance(connector, GoogleDriveConnector):
         validate_drive_perm_sync(connector)
+    elif isinstance(connector, GoogleChatConnector):
+        # Google Chat doesn't require special validation for now
+        pass

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -255,6 +255,7 @@ class DocumentSource(str, Enum):
     BITBUCKET = "bitbucket"
     TESTRAIL = "testrail"
     JIRA_SERVICE_MANAGEMENT = "jira_service_management"
+    GOOGLE_CHAT = "google_chat"
 
     # Special case just for integration tests
     MOCK_CONNECTOR = "mock_connector"
@@ -711,4 +712,5 @@ project management, and collaboration tools into a single, customizable platform
     DocumentSource.IMAP: "imap - email data",
     DocumentSource.TESTRAIL: "testrail - test case management tool for QA processes",
     DocumentSource.JIRA_SERVICE_MANAGEMENT: "jira service management - service desk tickets, requests, and customer portal data",
+    DocumentSource.GOOGLE_CHAT: "google chat - team messaging and collaboration in Google Workspace",
 }

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -254,6 +254,7 @@ class DocumentSource(str, Enum):
     IMAP = "imap"
     BITBUCKET = "bitbucket"
     TESTRAIL = "testrail"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
 
     # Special case just for integration tests
     MOCK_CONNECTOR = "mock_connector"
@@ -709,4 +710,5 @@ project management, and collaboration tools into a single, customizable platform
     DocumentSource.DRUPAL_WIKI: "drupal wiki - knowledge base content (pages, spaces, attachments)",
     DocumentSource.IMAP: "imap - email data",
     DocumentSource.TESTRAIL: "testrail - test case management tool for QA processes",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "jira service management - service desk tickets, requests, and customer portal data",
 }

--- a/backend/onyx/connectors/google_chat/__init__.py
+++ b/backend/onyx/connectors/google_chat/__init__.py
@@ -1,0 +1,1 @@
+# Google Chat connector module

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -4,14 +4,12 @@ Indexes messages from Google Chat spaces using the Google Chat API
 (part of Google Workspace).
 """
 
-import io
 import json
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
 from typing import Any
 
-from google.auth.transport.requests import Request  # type: ignore
 from google.oauth2 import service_account  # type: ignore
 from googleapiclient.discovery import build  # type: ignore
 

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -1,0 +1,279 @@
+"""Google Chat connector for Onyx.
+
+Indexes messages from Google Chat spaces using the Google Chat API
+(part of Google Workspace).
+"""
+
+import io
+import json
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from google.auth.transport.requests import Request  # type: ignore
+from google.oauth2 import service_account  # type: ignore
+from googleapiclient.discovery import build  # type: ignore
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_GOOGLE_CHAT_DOC_ID_PREFIX = "GOOGLE_CHAT_"
+_SCOPES = ["https://www.googleapis.com/auth/chat.spaces.readonly",
+           "https://www.googleapis.com/auth/chat.messages.readonly",
+           "https://www.googleapis.com/auth/chat.memberships.readonly"]
+
+
+def _build_chat_service(
+    credentials_json: dict[str, Any],
+    delegated_user_email: str | None = None,
+) -> Any:
+    """Build and return a Google Chat API service client."""
+    creds = service_account.Credentials.from_service_account_info(
+        credentials_json,
+        scopes=_SCOPES,
+    )
+    if delegated_user_email:
+        creds = creds.with_subject(delegated_user_email)
+    return build("chat", "v1", credentials=creds, cache_discovery=False)
+
+
+def _get_message_link(space_name: str, message_name: str) -> str:
+    """Construct a deep link to a Google Chat message."""
+    # space_name looks like "spaces/AAAA..."
+    space_id = space_name.replace("spaces/", "")
+    msg_id = message_name.replace(f"{space_name}/messages/", "")
+    return f"https://chat.google.com/room/{space_id}/{msg_id}"
+
+
+def _convert_message_to_document(
+    message: dict[str, Any],
+    space_name: str,
+    space_display_name: str,
+) -> Document | None:
+    """Convert a single Google Chat message dict to a Document."""
+    text = message.get("text", "")
+    if not text or not text.strip():
+        return None
+
+    sender = message.get("sender", {}).get("displayName", "Unknown")
+    msg_name = message.get("name", "")
+    created_time_str = message.get("createTime", "")
+
+    doc_updated_at = None
+    if created_time_str:
+        try:
+            doc_updated_at = datetime.fromisoformat(
+                created_time_str.replace("Z", "+00:00")
+            )
+        except (ValueError, TypeError):
+            pass
+
+    snippet = text[:50].rstrip() + "..." if len(text) > 50 else text
+    semantic_identifier = f"{sender} in {space_display_name}: {snippet}"
+
+    link = _get_message_link(space_name, msg_name)
+
+    metadata: dict[str, str | list[str]] = {
+        "Space": space_display_name,
+        "Sender": sender,
+    }
+
+    thread_name = message.get("thread", {}).get("name", "")
+    if thread_name:
+        metadata["Thread"] = thread_name
+
+    return Document(
+        id=f"{_GOOGLE_CHAT_DOC_ID_PREFIX}{msg_name}",
+        source=DocumentSource.GOOGLE_CHAT,
+        semantic_identifier=semantic_identifier,
+        doc_updated_at=doc_updated_at,
+        title="",
+        sections=[TextSection(text=text, link=link)],
+        metadata=metadata,
+    )
+
+
+def _fetch_spaces(
+    service: Any,
+    space_names: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch all spaces, optionally filtering by space name."""
+    spaces: list[dict[str, Any]] = []
+    page_token = None
+
+    while True:
+        response = (
+            service.spaces()
+            .list(pageSize=100, pageToken=page_token)
+            .execute()
+        )
+        for space in response.get("spaces", []):
+            if space_names:
+                if space.get("displayName") in space_names or space.get("name") in space_names:
+                    spaces.append(space)
+            else:
+                spaces.append(space)
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+    logger.info(f"Found {len(spaces)} Google Chat spaces")
+    return spaces
+
+
+def _fetch_messages_from_space(
+    service: Any,
+    space_name: str,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> Generator[dict[str, Any], None, None]:
+    """Fetch messages from a single space with optional time filter."""
+    page_token = None
+    filter_str = ""
+
+    # Build the time-based filter
+    if start and end:
+        filter_str = (
+            f'createTime > "{start.strftime("%Y-%m-%dT%H:%M:%SZ")}" AND '
+            f'createTime < "{end.strftime("%Y-%m-%dT%H:%M:%SZ")}"'
+        )
+    elif start:
+        filter_str = f'createTime > "{start.strftime("%Y-%m-%dT%H:%M:%SZ")}"'
+    elif end:
+        filter_str = f'createTime < "{end.strftime("%Y-%m-%dT%H:%M:%SZ")}"'
+
+    while True:
+        request_kwargs: dict[str, Any] = {
+            "parent": space_name,
+            "pageSize": 100,
+        }
+        if page_token:
+            request_kwargs["pageToken"] = page_token
+        if filter_str:
+            request_kwargs["filter"] = filter_str
+
+        response = service.spaces().messages().list(**request_kwargs).execute()
+
+        for message in response.get("messages", []):
+            yield message
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+
+class GoogleChatConnector(PollConnector, LoadConnector):
+    """Connector that indexes messages from Google Chat spaces."""
+
+    def __init__(
+        self,
+        space_names: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ):
+        self.space_names = space_names or []
+        self.batch_size = batch_size
+        self._credentials_json: dict[str, Any] | None = None
+        self._delegated_user_email: str | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        # The credential can be passed either as a JSON string or a dict
+        creds = credentials.get("google_chat_service_account_key")
+        if isinstance(creds, str):
+            self._credentials_json = json.loads(creds)
+        elif isinstance(creds, dict):
+            self._credentials_json = creds
+        else:
+            raise ConnectorMissingCredentialError("google_chat_service_account_key")
+
+        self._delegated_user_email = credentials.get("google_chat_delegated_user_email")
+        return None
+
+    def _get_service(self) -> Any:
+        if self._credentials_json is None:
+            raise ConnectorMissingCredentialError("Google Chat")
+        return _build_chat_service(
+            self._credentials_json,
+            self._delegated_user_email,
+        )
+
+    def _fetch_documents(
+        self,
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> GenerateDocumentsOutput:
+        service = self._get_service()
+        spaces = _fetch_spaces(
+            service,
+            self.space_names if self.space_names else None,
+        )
+
+        doc_batch: list[Document] = []
+
+        for space in spaces:
+            space_name = space["name"]
+            space_display_name = space.get("displayName", space_name)
+
+            logger.info(
+                f"Fetching messages from space: {space_display_name} ({space_name})"
+            )
+
+            for message in _fetch_messages_from_space(
+                service, space_name, start, end
+            ):
+                doc = _convert_message_to_document(
+                    message, space_name, space_display_name
+                )
+                if doc:
+                    doc_batch.append(doc)
+                    if len(doc_batch) >= self.batch_size:
+                        yield doc_batch
+                        doc_batch = []
+
+        if doc_batch:
+            yield doc_batch
+
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        return self._fetch_documents()
+
+    def poll_source(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> GenerateDocumentsOutput:
+        return self._fetch_documents(
+            start=datetime.fromtimestamp(start, tz=timezone.utc),
+            end=datetime.fromtimestamp(end, tz=timezone.utc),
+        )
+
+
+if __name__ == "__main__":
+    import os
+    import time
+
+    service_account_json_str = os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "{}")
+    delegated_email = os.environ.get("GOOGLE_CHAT_DELEGATED_USER_EMAIL")
+
+    connector = GoogleChatConnector()
+    connector.load_credentials(
+        {
+            "google_chat_service_account_key": service_account_json_str,
+            "google_chat_delegated_user_email": delegated_email,
+        }
+    )
+
+    end = time.time()
+    start = end - 24 * 60 * 60  # 1 day
+
+    for doc_batch in connector.poll_source(start, end):
+        for doc in doc_batch:
+            print(doc)

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -16,12 +16,17 @@ from googleapiclient.discovery import build  # type: ignore
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
+from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
+from onyx.access.models import ExternalAccess
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -58,6 +63,7 @@ def _convert_message_to_document(
     message: dict[str, Any],
     space_name: str,
     space_display_name: str,
+    external_access: ExternalAccess | None = None,
 ) -> Document | None:
     """Convert a single Google Chat message dict to a Document."""
     text = message.get("text", "")
@@ -99,6 +105,7 @@ def _convert_message_to_document(
         title="",
         sections=[TextSection(text=text, link=link)],
         metadata=metadata,
+        external_access=external_access,
     )
 
 
@@ -172,7 +179,39 @@ def _fetch_messages_from_space(
             break
 
 
-class GoogleChatConnector(PollConnector, LoadConnector):
+def _fetch_space_members(
+    service: Any,
+    space_name: str,
+) -> set[str]:
+    """Fetch all member emails from a Google Chat space."""
+    members: set[str] = set()
+    page_token = None
+
+    try:
+        while True:
+            response = (
+                service.spaces()
+                .members()
+                .list(parent=space_name, pageSize=1000, pageToken=page_token)
+                .execute()
+            )
+            for membership in response.get("memberships", []):
+                member = membership.get("member", {})
+                if member.get("type") == "HUMAN":
+                    email = member.get("email")
+                    if email:
+                        members.add(email)
+
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+    except Exception as e:
+        logger.error(f"Failed to fetch memberships for space {space_name}: {e}")
+
+    return members
+
+
+class GoogleChatConnector(PollConnector, LoadConnector, SlimConnectorWithPermSync):
     """Connector that indexes messages from Google Chat spaces."""
 
     def __init__(
@@ -210,6 +249,7 @@ class GoogleChatConnector(PollConnector, LoadConnector):
         self,
         start: datetime | None = None,
         end: datetime | None = None,
+        include_permissions: bool = False,
     ) -> GenerateDocumentsOutput:
         service = self._get_service()
         spaces = _fetch_spaces(
@@ -227,11 +267,20 @@ class GoogleChatConnector(PollConnector, LoadConnector):
                 f"Fetching messages from space: {space_display_name} ({space_name})"
             )
 
+            external_access = None
+            if include_permissions:
+                members = _fetch_space_members(service, space_name)
+                external_access = ExternalAccess(
+                    external_user_emails=members,
+                    external_user_group_ids=set(),
+                    is_public=False,
+                )
+
             for message in _fetch_messages_from_space(
                 service, space_name, start, end
             ):
                 doc = _convert_message_to_document(
-                    message, space_name, space_display_name
+                    message, space_name, space_display_name, external_access
                 )
                 if doc:
                     doc_batch.append(doc)
@@ -243,7 +292,7 @@ class GoogleChatConnector(PollConnector, LoadConnector):
             yield doc_batch
 
     def load_from_state(self) -> GenerateDocumentsOutput:
-        return self._fetch_documents()
+        return self._fetch_documents(include_permissions=True)
 
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
@@ -251,4 +300,96 @@ class GoogleChatConnector(PollConnector, LoadConnector):
         return self._fetch_documents(
             start=datetime.fromtimestamp(start, tz=timezone.utc),
             end=datetime.fromtimestamp(end, tz=timezone.utc),
+            include_permissions=True,
         )
+
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        """Return 'slim' docs (IDs only) for indexing."""
+        service = self._get_service()
+        spaces = _fetch_spaces(
+            service,
+            self.space_names if self.space_names else None,
+        )
+
+        slim_doc_batch: list[SlimDocument] = []
+
+        for space in spaces:
+            space_name = space["name"]
+
+            for message in _fetch_messages_from_space(
+                service,
+                space_name,
+                start=datetime.fromtimestamp(start, tz=timezone.utc) if start else None,
+                end=datetime.fromtimestamp(end, tz=timezone.utc) if end else None,
+            ):
+                msg_name = message.get("name", "")
+                if msg_name:
+                    slim_doc_batch.append(
+                        SlimDocument(
+                            id=f"{_GOOGLE_CHAT_DOC_ID_PREFIX}{msg_name}",
+                        )
+                    )
+
+                    if len(slim_doc_batch) >= self.batch_size:
+                        yield slim_doc_batch
+                        slim_doc_batch = []
+
+            if callback and callback.should_stop():
+                raise RuntimeError("retrieve_all_slim_docs: Stop signal detected")
+
+        if slim_doc_batch:
+            yield slim_doc_batch
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        """Return 'slim' docs (IDs + permissions) for synchronization."""
+        service = self._get_service()
+        spaces = _fetch_spaces(
+            service,
+            self.space_names if self.space_names else None,
+        )
+
+        slim_doc_batch: list[SlimDocument] = []
+
+        for space in spaces:
+            space_name = space["name"]
+            members = _fetch_space_members(service, space_name)
+            external_access = ExternalAccess(
+                external_user_emails=members,
+                external_user_group_ids=set(),
+                is_public=False,
+            )
+
+            for message in _fetch_messages_from_space(
+                service,
+                space_name,
+                start=datetime.fromtimestamp(start, tz=timezone.utc) if start else None,
+                end=datetime.fromtimestamp(end, tz=timezone.utc) if end else None,
+            ):
+                msg_name = message.get("name", "")
+                if msg_name:
+                    slim_doc_batch.append(
+                        SlimDocument(
+                            id=f"{_GOOGLE_CHAT_DOC_ID_PREFIX}{msg_name}",
+                            external_access=external_access,
+                        )
+                    )
+
+                    if len(slim_doc_batch) >= self.batch_size:
+                        yield slim_doc_batch
+                        slim_doc_batch = []
+
+            if callback and callback.should_stop():
+                raise RuntimeError("retrieve_all_slim_docs_perm_sync: Stop signal detected")
+
+        if slim_doc_batch:
+            yield slim_doc_batch

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -324,8 +324,8 @@ class GoogleChatConnector(PollConnector, LoadConnector, SlimConnectorWithPermSyn
             for message in _fetch_messages_from_space(
                 service,
                 space_name,
-                start=datetime.fromtimestamp(start, tz=timezone.utc) if start else None,
-                end=datetime.fromtimestamp(end, tz=timezone.utc) if end else None,
+                start=datetime.fromtimestamp(start, tz=timezone.utc) if start is not None else None,
+                end=datetime.fromtimestamp(end, tz=timezone.utc) if end is not None else None,
             ):
                 msg_name = message.get("name", "")
                 if msg_name:
@@ -372,8 +372,8 @@ class GoogleChatConnector(PollConnector, LoadConnector, SlimConnectorWithPermSyn
             for message in _fetch_messages_from_space(
                 service,
                 space_name,
-                start=datetime.fromtimestamp(start, tz=timezone.utc) if start else None,
-                end=datetime.fromtimestamp(end, tz=timezone.utc) if end else None,
+                start=datetime.fromtimestamp(start, tz=timezone.utc) if start is not None else None,
+                end=datetime.fromtimestamp(end, tz=timezone.utc) if end is not None else None,
             ):
                 msg_name = message.get("name", "")
                 if msg_name:

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -77,7 +77,7 @@ def _convert_message_to_document(
                 created_time_str.replace("Z", "+00:00")
             )
         except (ValueError, TypeError):
-            pass
+            logger.error(f"Failed to parse createTime for message: {created_time_str}")
 
     snippet = text[:50].rstrip() + "..." if len(text) > 50 else text
     semantic_identifier = f"{sender} in {space_display_name}: {snippet}"
@@ -256,24 +256,3 @@ class GoogleChatConnector(PollConnector, LoadConnector):
         )
 
 
-if __name__ == "__main__":
-    import os
-    import time
-
-    service_account_json_str = os.environ.get("GOOGLE_CHAT_SERVICE_ACCOUNT_KEY", "{}")
-    delegated_email = os.environ.get("GOOGLE_CHAT_DELEGATED_USER_EMAIL")
-
-    connector = GoogleChatConnector()
-    connector.load_credentials(
-        {
-            "google_chat_service_account_key": service_account_json_str,
-            "google_chat_delegated_user_email": delegated_email,
-        }
-    )
-
-    end = time.time()
-    start = end - 24 * 60 * 60  # 1 day
-
-    for doc_batch in connector.poll_source(start, end):
-        for doc in doc_batch:
-            print(doc)

--- a/backend/onyx/connectors/google_chat/connector.py
+++ b/backend/onyx/connectors/google_chat/connector.py
@@ -252,5 +252,3 @@ class GoogleChatConnector(PollConnector, LoadConnector):
             start=datetime.fromtimestamp(start, tz=timezone.utc),
             end=datetime.fromtimestamp(end, tz=timezone.utc),
         )
-
-

--- a/backend/onyx/connectors/jsm/__init__.py
+++ b/backend/onyx/connectors/jsm/__init__.py
@@ -1,0 +1,3 @@
+from onyx.connectors.jsm.connector import JsmConnector
+
+__all__ = ["JsmConnector"]

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterator
 from typing import Any
 
+import requests
+
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
@@ -119,7 +121,7 @@ class JsmConnector(
         callback: IndexingHeartbeatInterface | None = None,
     ) -> Iterator[list[SlimDocument | HierarchyNode]]:
         # JSM doesn't yet support granular permission syncing in this connector
-        return
+        yield []
 
     def load_from_checkpoint_with_perm_sync(
         self,

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -1,0 +1,163 @@
+import json
+from collections.abc import Generator
+from datetime import datetime
+from typing import Any
+
+import requests
+from pydantic import BaseModel
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.connectors.jsm.utils import build_jsm_url, get_jsm_api_url, extract_text_from_adf, best_effort_basic_expert_info
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+class JsmConnectorCheckpoint(ConnectorCheckpoint):
+    offset: int = 0
+
+class JsmConnector(
+    CheckpointedConnectorWithPermSync[JsmConnectorCheckpoint],
+    SlimConnectorWithPermSync,
+):
+    def __init__(
+        self,
+        jira_base_url: str,
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.jira_base_url = jira_base_url.rstrip("/")
+        self.batch_size = batch_size
+        self._api_token: str | None = None
+        self._user_email: str | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._api_token = credentials.get("jira_api_token")
+        self._user_email = credentials.get("jira_user_email")
+        return None
+
+    def _get_auth(self) -> tuple[str, str] | None:
+        if self._user_email and self._api_token:
+            return (self._user_email, self._api_token)
+        return None
+
+    def _fetch_requests(self, offset: int, limit: int) -> dict[str, Any]:
+        url = get_jsm_api_url(self.jira_base_url, "request")
+        params = {
+            "start": offset,
+            "limit": limit,
+        }
+        auth = self._get_auth()
+        response = requests.get(url, params=params, auth=auth)
+        response.raise_for_status()
+        return response.json()
+
+    def _fetch_comments(self, issue_key: str) -> list[str]:
+        url = get_jsm_api_url(self.jira_base_url, f"request/{issue_key}/comment")
+        auth = self._get_auth()
+        try:
+            response = requests.get(url, auth=auth)
+            response.raise_for_status()
+            data = response.json()
+            comments = []
+            for comment in data.get("values", []):
+                body = comment.get("body")
+                if body:
+                    comments.append(extract_text_from_adf(body))
+            return comments
+        except Exception as e:
+            logger.error(f"Failed to fetch comments for {issue_key}: {e}")
+            return []
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JsmConnectorCheckpoint,
+    ) -> CheckpointOutput[JsmConnectorCheckpoint]:
+        offset = checkpoint.offset
+        
+        while True:
+            data = self._fetch_requests(offset, self.batch_size)
+            requests_list = data.get("values", [])
+            
+            for req in requests_list:
+                doc = self._process_request(req)
+                if doc:
+                    yield doc
+            
+            if data.get("isLastPage", True):
+                break
+                
+            offset += len(requests_list)
+            
+        yield JsmConnectorCheckpoint(offset=offset)
+
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JsmConnectorCheckpoint,
+    ) -> CheckpointOutput[JsmConnectorCheckpoint]:
+        # For now, we reuse the same logic as load_from_checkpoint
+        return self.load_from_checkpoint(start, end, checkpoint)
+
+    def _process_request(self, req: dict[str, Any]) -> Document | None:
+        issue_key = req.get("issueKey")
+        if not issue_key:
+            return None
+
+        summary = ""
+        description = ""
+        
+        for field in req.get("requestFieldValues", []):
+            label = field.get("label")
+            value = field.get("value")
+            if label == "Summary":
+                summary = extract_text_from_adf(value)
+            elif label == "Description":
+                description = extract_text_from_adf(value)
+
+        comments = self._fetch_comments(issue_key)
+        comments_str = "\n\n".join([f"Comment: {c}" for c in comments])
+
+        content = f"Summary: {summary}\n\nDescription: {description}"
+        if comments_str:
+            content += f"\n\n{comments_str}"
+        page_url = build_jsm_url(self.jira_base_url, issue_key)
+
+        reporter = best_effort_basic_expert_info(req.get("reporter"))
+        participants = [
+            best_effort_basic_expert_info(p)
+            for p in req.get("requestParticipants", [])
+            if p
+        ]
+        participants = [p for p in participants if p]
+
+        metadata = {
+            "issue_key": issue_key,
+            "service_desk_id": str(req.get("serviceDeskId", "")),
+            "request_type_id": str(req.get("requestTypeId", "")),
+            "status": req.get("currentStatus", {}).get("status", ""),
+        }
+        if reporter:
+            metadata["reporter"] = f"{reporter['display_name']} ({reporter['email']})"
+        if participants:
+            metadata["participants"] = [
+                f"{p['display_name']} ({p['email']})" for p in participants
+            ]
+
+        return Document(
+            id=page_url,
+            sections=[TextSection(link=page_url, text=content)],
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+            semantic_identifier=f"{issue_key}: {summary}",
+            title=f"{issue_key} {summary}",
+            metadata=metadata,
+        )

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from datetime import datetime
 from typing import Any
 
@@ -10,10 +10,13 @@ from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import IndexingHeartbeatInterface
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import ConnectorCheckpoint
 from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.connectors.jsm.utils import build_jsm_url, get_jsm_api_url, extract_text_from_adf, best_effort_basic_expert_info
 from onyx.utils.logger import setup_logger
@@ -92,12 +95,26 @@ class JsmConnector(
                 if doc:
                     yield doc
             
+            offset += len(requests_list)
             if data.get("isLastPage", True):
                 break
                 
-            offset += len(requests_list)
-            
-        yield JsmConnectorCheckpoint(offset=offset)
+        return JsmConnectorCheckpoint(offset=offset, has_more=False)
+
+    def build_dummy_checkpoint(self) -> JsmConnectorCheckpoint:
+        return JsmConnectorCheckpoint(offset=0, has_more=True)
+
+    def validate_checkpoint_json(self, checkpoint_json: str) -> JsmConnectorCheckpoint:
+        return JsmConnectorCheckpoint.model_validate_json(checkpoint_json)
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> Iterator[list[SlimDocument | HierarchyNode]]:
+        # JSM doesn't yet support granular permission syncing in this connector
+        yield []
 
     def load_from_checkpoint_with_perm_sync(
         self,
@@ -106,7 +123,8 @@ class JsmConnector(
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
         # For now, we reuse the same logic as load_from_checkpoint
-        return self.load_from_checkpoint(start, end, checkpoint)
+        yield from self.load_from_checkpoint(start, end, checkpoint)
+        return JsmConnectorCheckpoint(offset=0, has_more=False)
 
     def _process_request(self, req: dict[str, Any]) -> Document | None:
         issue_key = req.get("issueKey")

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -174,7 +174,7 @@ class JsmConnector(
             "issue_key": issue_key,
             "service_desk_id": str(req.get("serviceDeskId", "")),
             "request_type_id": str(req.get("requestTypeId", "")),
-            "status": req.get("currentStatus", {}).get("status", ""),
+            "status": (req.get("currentStatus") or {}).get("status", ""),
         }
         if reporter:
             display_name = reporter.get("display_name")

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -82,7 +82,7 @@ class JsmConnector(
                 
                 if data.get("isLastPage", True):
                     break
-                start += len(data.get("values", []))
+                start += limit
             except Exception as e:
                 logger.error(f"Failed to fetch comments for {issue_key}: {e}")
                 break

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -121,7 +121,7 @@ class JsmConnector(
         callback: IndexingHeartbeatInterface | None = None,
     ) -> Iterator[list[SlimDocument | HierarchyNode]]:
         # JSM doesn't yet support granular permission syncing in this connector
-        yield []
+        yield from []
 
     def load_from_checkpoint_with_perm_sync(
         self,

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -1,10 +1,5 @@
-import json
-from collections.abc import Generator, Iterator
-from datetime import datetime
+from collections.abc import Iterator
 from typing import Any
-
-import requests
-from pydantic import BaseModel
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
@@ -125,7 +120,6 @@ class JsmConnector(
     ) -> Iterator[list[SlimDocument | HierarchyNode]]:
         # JSM doesn't yet support granular permission syncing in this connector
         return
-        yield []
 
     def load_from_checkpoint_with_perm_sync(
         self,

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -124,6 +124,7 @@ class JsmConnector(
         callback: IndexingHeartbeatInterface | None = None,
     ) -> Iterator[list[SlimDocument | HierarchyNode]]:
         # JSM doesn't yet support granular permission syncing in this connector
+        return
         yield []
 
     def load_from_checkpoint_with_perm_sync(
@@ -133,8 +134,7 @@ class JsmConnector(
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
         # For now, we reuse the same logic as load_from_checkpoint
-        yield from self.load_from_checkpoint(start, end, checkpoint)
-        return JsmConnectorCheckpoint(offset=0, has_more=False)
+        return (yield from self.load_from_checkpoint(start, end, checkpoint))
 
     def _process_request(self, req: dict[str, Any]) -> Document | None:
         issue_key = req.get("issueKey")
@@ -177,11 +177,26 @@ class JsmConnector(
             "status": req.get("currentStatus", {}).get("status", ""),
         }
         if reporter:
-            metadata["reporter"] = f"{reporter['display_name']} ({reporter['email']})"
+            display_name = reporter.get("display_name")
+            email = reporter.get("email")
+            if display_name and email:
+                metadata["reporter"] = f"{display_name} ({email})"
+            elif display_name:
+                metadata["reporter"] = display_name
+            elif email:
+                metadata["reporter"] = email
+
         if participants:
-            metadata["participants"] = [
-                f"{p['display_name']} ({p['email']})" for p in participants
-            ]
+            metadata["participants"] = []
+            for p in participants:
+                display_name = p.get("display_name")
+                email = p.get("email")
+                if display_name and email:
+                    metadata["participants"].append(f"{display_name} ({email})")
+                elif display_name:
+                    metadata["participants"].append(display_name)
+                elif email:
+                    metadata["participants"].append(email)
 
         return Document(
             id=page_url,

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -62,21 +62,31 @@ class JsmConnector(
         return response.json()
 
     def _fetch_comments(self, issue_key: str) -> list[str]:
-        url = get_jsm_api_url(self.jira_base_url, f"request/{issue_key}/comment")
+        all_comments = []
+        start = 0
+        limit = 50
         auth = self._get_auth()
-        try:
-            response = requests.get(url, auth=auth)
-            response.raise_for_status()
-            data = response.json()
-            comments = []
-            for comment in data.get("values", []):
-                body = comment.get("body")
-                if body:
-                    comments.append(extract_text_from_adf(body))
-            return comments
-        except Exception as e:
-            logger.error(f"Failed to fetch comments for {issue_key}: {e}")
-            return []
+        
+        while True:
+            url = get_jsm_api_url(self.jira_base_url, f"request/{issue_key}/comment")
+            params = {"start": start, "limit": limit}
+            try:
+                response = requests.get(url, params=params, auth=auth)
+                response.raise_for_status()
+                data = response.json()
+                
+                for comment in data.get("values", []):
+                    body = comment.get("body")
+                    if body:
+                        all_comments.append(extract_text_from_adf(body))
+                
+                if data.get("isLastPage", True):
+                    break
+                start += len(data.get("values", []))
+            except Exception as e:
+                logger.error(f"Failed to fetch comments for {issue_key}: {e}")
+                break
+        return all_comments
 
     def load_from_checkpoint(
         self,
@@ -148,7 +158,9 @@ class JsmConnector(
         content = f"Summary: {summary}\n\nDescription: {description}"
         if comments_str:
             content += f"\n\n{comments_str}"
-        page_url = build_jsm_url(self.jira_base_url, issue_key)
+        
+        service_desk_id = str(req.get("serviceDeskId", ""))
+        page_url = build_jsm_url(self.jira_base_url, service_desk_id, issue_key)
 
         reporter = best_effort_basic_expert_info(req.get("reporter"))
         participants = [

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -25,6 +25,7 @@ logger = setup_logger()
 class JsmConnectorCheckpoint(ConnectorCheckpoint):
     offset: int = 0
 
+
 class JsmConnector(
     CheckpointedConnectorWithPermSync[JsmConnectorCheckpoint],
     SlimConnectorWithPermSync,
@@ -56,7 +57,7 @@ class JsmConnector(
             "limit": limit,
         }
         auth = self._get_auth()
-        response = requests.get(url, params=params, auth=auth)
+        response = requests.get(url, params=params, auth=auth, timeout=60)
         response.raise_for_status()
         return response.json()
 
@@ -70,7 +71,7 @@ class JsmConnector(
             url = get_jsm_api_url(self.jira_base_url, f"request/{issue_key}/comment")
             params = {"startAt": start, "limit": limit}
             try:
-                response = requests.get(url, params=params, auth=auth)
+                response = requests.get(url, params=params, auth=auth, timeout=60)
                 response.raise_for_status()
                 data = response.json()
                 

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -94,13 +94,14 @@ class JsmConnector(
         end: SecondsSinceUnixEpoch,
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
+        offset = checkpoint.offset
         stop_indexing = False
         while not stop_indexing:
             data = self._fetch_requests(offset, self.batch_size)
             requests_list = data.get("values", [])
             
             for req in requests_list:
-                created_date_str = req.get("createdDate", {}).get("iso8601")
+                created_date_str = (req.get("createdDate") or {}).get("iso8601")
                 if created_date_str:
                     try:
                         created_dt = datetime.fromisoformat(

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterator
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 
 import requests
@@ -92,13 +94,31 @@ class JsmConnector(
         end: SecondsSinceUnixEpoch,
         checkpoint: JsmConnectorCheckpoint,
     ) -> CheckpointOutput[JsmConnectorCheckpoint]:
-        offset = checkpoint.offset
-        
-        while True:
+        stop_indexing = False
+        while not stop_indexing:
             data = self._fetch_requests(offset, self.batch_size)
             requests_list = data.get("values", [])
             
             for req in requests_list:
+                created_date_str = req.get("createdDate", {}).get("iso8601")
+                if created_date_str:
+                    try:
+                        created_dt = datetime.fromisoformat(
+                            created_date_str.replace("Z", "+00:00")
+                        )
+                        created_ts = int(created_dt.timestamp())
+                        
+                        # Stop if we've reached requests older than our start time
+                        if created_ts < start:
+                            stop_indexing = True
+                            break
+                            
+                        # Skip if it's newer than our end time (unlikely but possible if polling)
+                        if created_ts > end:
+                            continue
+                    except (ValueError, TypeError):
+                        logger.warning(f"Failed to parse createdDate for JSM request: {created_date_str}")
+
                 doc = self._process_request(req)
                 if doc:
                     yield doc

--- a/backend/onyx/connectors/jsm/connector.py
+++ b/backend/onyx/connectors/jsm/connector.py
@@ -50,7 +50,7 @@ class JsmConnector(
     def _fetch_requests(self, offset: int, limit: int) -> dict[str, Any]:
         url = get_jsm_api_url(self.jira_base_url, "request")
         params = {
-            "start": offset,
+            "startAt": offset,
             "limit": limit,
         }
         auth = self._get_auth()
@@ -66,21 +66,22 @@ class JsmConnector(
         
         while True:
             url = get_jsm_api_url(self.jira_base_url, f"request/{issue_key}/comment")
-            params = {"start": start, "limit": limit}
+            params = {"startAt": start, "limit": limit}
             try:
                 response = requests.get(url, params=params, auth=auth)
                 response.raise_for_status()
                 data = response.json()
                 
-                for comment in data.get("values", []):
+                values = data.get("values", [])
+                for comment in values:
                     body = comment.get("body")
                     if body:
                         all_comments.append(extract_text_from_adf(body))
                 
-                if data.get("isLastPage", True):
+                if data.get("isLastPage", True) or not values:
                     break
-                start += limit
-            except Exception as e:
+                start += len(values)
+            except requests.RequestException as e:
                 logger.error(f"Failed to fetch comments for {issue_key}: {e}")
                 break
         return all_comments
@@ -103,7 +104,7 @@ class JsmConnector(
                     yield doc
             
             offset += len(requests_list)
-            if data.get("isLastPage", True):
+            if data.get("isLastPage", True) or not requests_list:
                 break
                 
         return JsmConnectorCheckpoint(offset=offset, has_more=False)
@@ -183,16 +184,19 @@ class JsmConnector(
                 metadata["reporter"] = email
 
         if participants:
-            metadata["participants"] = []
+            participants_str_list = []
             for p in participants:
                 display_name = p.get("display_name")
                 email = p.get("email")
                 if display_name and email:
-                    metadata["participants"].append(f"{display_name} ({email})")
+                    participants_str_list.append(f"{display_name} ({email})")
                 elif display_name:
-                    metadata["participants"].append(display_name)
+                    participants_str_list.append(display_name)
                 elif email:
-                    metadata["participants"].append(email)
+                    participants_str_list.append(email)
+            
+            if participants_str_list:
+                metadata["participants"] = ", ".join(participants_str_list)
 
         return Document(
             id=page_url,

--- a/backend/onyx/connectors/jsm/utils.py
+++ b/backend/onyx/connectors/jsm/utils.py
@@ -1,10 +1,4 @@
-import os
 from typing import Any
-from urllib.parse import urlparse
-
-from onyx.utils.logger import setup_logger
-
-logger = setup_logger()
 
 JSM_API_BASE = "rest/servicedeskapi"
 

--- a/backend/onyx/connectors/jsm/utils.py
+++ b/backend/onyx/connectors/jsm/utils.py
@@ -2,11 +2,11 @@ from typing import Any
 
 JSM_API_BASE = "rest/servicedeskapi"
 
-def build_jsm_url(jira_base_url: str, request_key: str) -> str:
+def build_jsm_url(jira_base_url: str, portal_id: str, request_key: str) -> str:
     """
     Get the url used to access a JSM request in the UI.
     """
-    return f"{jira_base_url}/servicedesk/customer/portal/search?q={request_key}"
+    return f"{jira_base_url.rstrip('/')}/servicedesk/customer/portal/{portal_id}/{request_key}"
 
 def get_jsm_api_url(jira_base_url: str, endpoint: str) -> str:
     """

--- a/backend/onyx/connectors/jsm/utils.py
+++ b/backend/onyx/connectors/jsm/utils.py
@@ -1,0 +1,72 @@
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+JSM_API_BASE = "rest/servicedeskapi"
+
+def build_jsm_url(jira_base_url: str, request_key: str) -> str:
+    """
+    Get the url used to access a JSM request in the UI.
+    """
+    return f"{jira_base_url}/servicedesk/customer/portal/search?q={request_key}"
+
+def get_jsm_api_url(jira_base_url: str, endpoint: str) -> str:
+    """
+    Build a JSM API URL.
+    """
+    return f"{jira_base_url.rstrip('/')}/{JSM_API_BASE}/{endpoint.lstrip('/')}"
+
+def extract_text_from_adf(adf: Any) -> str:
+    """Extracts plain text from Atlassian Document Format:
+    https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+    """
+    if adf is None:
+        return ""
+    if isinstance(adf, str):
+        return adf
+    if not isinstance(adf, dict):
+        return str(adf)
+
+    texts = []
+
+    def walk(node: Any):
+        if not isinstance(node, dict):
+            return
+        
+        node_type = node.get("type")
+        if node_type == "text":
+            texts.append(node.get("text", ""))
+        elif node_type == "hardBreak":
+            texts.append("\n")
+        elif node_type in ["paragraph", "heading", "listItem"]:
+            if "content" in node:
+                for child in node["content"]:
+                    walk(child)
+            texts.append("\n")
+        elif "content" in node:
+            for child in node["content"]:
+                walk(child)
+
+    walk(adf)
+    return "".join(texts).strip()
+
+
+def best_effort_basic_expert_info(obj: Any) -> Any:
+    """
+    Extract display name and email from a JSM user object.
+    Matches the pattern in other connectors.
+    """
+    if not obj:
+        return None
+    
+    display_name = obj.get("displayName")
+    email = obj.get("emailAddress")
+    
+    if not email and not display_name:
+        return None
+        
+    return {"display_name": display_name, "email": email}

--- a/backend/onyx/connectors/jsm/utils.py
+++ b/backend/onyx/connectors/jsm/utils.py
@@ -49,7 +49,7 @@ def extract_text_from_adf(adf: Any) -> str:
     return "".join(texts).strip()
 
 
-def best_effort_basic_expert_info(obj: Any) -> Any:
+def best_effort_basic_expert_info(obj: Any) -> dict[str, str] | None:
     """
     Extract display name and email from a JSM user object.
     Matches the pattern in other connectors.

--- a/backend/onyx/connectors/jsm/utils.py
+++ b/backend/onyx/connectors/jsm/utils.py
@@ -49,7 +49,7 @@ def extract_text_from_adf(adf: Any) -> str:
     return "".join(texts).strip()
 
 
-def best_effort_basic_expert_info(obj: Any) -> dict[str, str] | None:
+def best_effort_basic_expert_info(obj: Any) -> dict[str, str | None] | None:
     """
     Extract display name and email from a JSM user object.
     Matches the pattern in other connectors.

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -216,6 +216,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.testrail.connector",
         class_name="TestRailConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jsm.connector",
+        class_name="JsmConnector",
+    ),
     # just for integration tests
     DocumentSource.MOCK_CONNECTOR: ConnectorMapping(
         module_path="onyx.connectors.mock_connector.connector",

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -220,7 +220,6 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jsm.connector",
         class_name="JsmConnector",
     ),
-    # just for integration tests
     DocumentSource.GOOGLE_CHAT: ConnectorMapping(
         module_path="onyx.connectors.google_chat.connector",
         class_name="GoogleChatConnector",

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -221,6 +221,10 @@ CONNECTOR_CLASS_MAP = {
         class_name="JsmConnector",
     ),
     # just for integration tests
+    DocumentSource.GOOGLE_CHAT: ConnectorMapping(
+        module_path="onyx.connectors.google_chat.connector",
+        class_name="GoogleChatConnector",
+    ),
     DocumentSource.MOCK_CONNECTOR: ConnectorMapping(
         module_path="onyx.connectors.mock_connector.connector",
         class_name="MockConnector",

--- a/backend/tests/unit/onyx/connectors/google_chat/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/google_chat/test_connector.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+from onyx.connectors.google_chat.connector import GoogleChatConnector
+from onyx.connectors.models import SlimDocument
+from onyx.access.models import ExternalAccess
+
+class TestGoogleChatConnector(unittest.TestCase):
+    def setUp(self):
+        self.connector = GoogleChatConnector(space_names=["Space 1"])
+        self.connector._credentials_json = {"type": "service_account"}
+
+    @patch("onyx.connectors.google_chat.connector._build_chat_service")
+    def test_retrieve_all_slim_docs_perm_sync(self, mock_build_service):
+        # Mock service and responses
+        mock_service = MagicMock()
+        mock_build_service.return_value = mock_service
+        
+        # Mock spaces().list().execute()
+        mock_service.spaces.return_value.list.return_value.execute.return_value = {
+            "spaces": [{"name": "spaces/1", "displayName": "Space 1"}]
+        }
+        
+        # Mock spaces().members().list().execute()
+        mock_service.spaces.return_value.members.return_value.list.return_value.execute.return_value = {
+            "memberships": [
+                {"member": {"type": "HUMAN", "email": "user1@example.com"}},
+                {"member": {"type": "HUMAN", "email": "user2@example.com"}},
+            ]
+        }
+        
+        # Mock spaces().messages().list().execute()
+        mock_service.spaces.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [
+                {"name": "spaces/1/messages/m1", "text": "Hello", "createTime": "2023-01-01T12:00:00Z"},
+            ]
+        }
+
+        # Run the method
+        batches = list(self.connector.retrieve_all_slim_docs_perm_sync())
+        
+        # Assertions
+        self.assertEqual(len(batches), 1)
+        batch = batches[0]
+        self.assertEqual(len(batch), 1)
+        
+        doc = batch[0]
+        self.assertIsInstance(doc, SlimDocument)
+        self.assertEqual(doc.id, "GOOGLE_CHAT_spaces/1/messages/m1")
+        self.assertIsInstance(doc.external_access, ExternalAccess)
+        self.assertIn("user1@example.com", doc.external_access.external_user_emails)
+        self.assertIn("user2@example.com", doc.external_access.external_user_emails)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/onyx/connectors/jsm/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jsm/test_connector.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from onyx.connectors.jsm.connector import JsmConnector, JsmConnectorCheckpoint
+from onyx.connectors.models import Document
+from onyx.configs.constants import DocumentSource
+
+class TestJsmConnector(unittest.TestCase):
+    def setUp(self):
+        self.connector = JsmConnector(jira_base_url="https://test.atlassian.net")
+        self.connector.load_credentials({"jira_api_token": "token", "jira_user_email": "user@test.com"})
+
+    @patch("onyx.connectors.jsm.connector.requests.get")
+    def test_load_from_checkpoint(self, mock_get):
+        # Mock requests list response
+        mock_requests_resp = MagicMock()
+        mock_requests_resp.json.return_value = {
+            "values": [
+                {
+                    "issueKey": "SD-1",
+                    "serviceDeskId": "1",
+                    "requestTypeId": "10",
+                    "currentStatus": {"status": "Open"},
+                    "requestFieldValues": [
+                        {"label": "Summary", "value": "Test Summary"},
+                        {"label": "Description", "value": "Test Description"},
+                    ]
+                }
+            ],
+            "isLastPage": True
+        }
+        mock_requests_resp.raise_for_status.return_value = None
+        
+        # Mock comments response
+        mock_comments_resp = MagicMock()
+        mock_comments_resp.json.return_value = {
+            "values": [
+                {"body": {"content": [{"type": "paragraph", "content": [{"type": "text", "text": "Test Comment"}]}]}}
+            ]
+        }
+        mock_comments_resp.raise_for_status.return_value = None
+        
+        # side_effect to handle multiple calls
+        mock_get.side_effect = [mock_requests_resp, mock_comments_resp]
+        
+        checkpoint = JsmConnectorCheckpoint(offset=0)
+        docs = list(self.connector.load_from_checkpoint(0, 0, checkpoint))
+        
+        self.assertEqual(len(docs), 2)  # 1 Document + 1 Checkpoint
+        doc = docs[0]
+        self.assertIsInstance(doc, Document)
+        self.assertEqual(doc.title, "SD-1 Test Summary")
+        self.assertIn("Test Description", doc.sections[0].text)
+        self.assertIn("Test Comment", doc.sections[0].text)
+        self.assertEqual(doc.source, DocumentSource.JIRA_SERVICE_MANAGEMENT)
+        
+        new_checkpoint = docs[1]
+        self.assertIsInstance(new_checkpoint, JsmConnectorCheckpoint)
+        self.assertEqual(new_checkpoint.offset, 1)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/unit/onyx/connectors/jsm/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jsm/test_connector.py
@@ -35,7 +35,8 @@ class TestJsmConnector(unittest.TestCase):
         mock_comments_resp.json.return_value = {
             "values": [
                 {"body": {"content": [{"type": "paragraph", "content": [{"type": "text", "text": "Test Comment"}]}]}}
-            ]
+            ],
+            "isLastPage": True
         }
         mock_comments_resp.raise_for_status.return_value = None
         
@@ -43,9 +44,18 @@ class TestJsmConnector(unittest.TestCase):
         mock_get.side_effect = [mock_requests_resp, mock_comments_resp]
         
         checkpoint = JsmConnectorCheckpoint(offset=0)
-        docs = list(self.connector.load_from_checkpoint(0, 0, checkpoint))
         
-        self.assertEqual(len(docs), 2)  # 1 Document + 1 Checkpoint
+        # Use a helper to consume generator and get return value
+        gen = self.connector.load_from_checkpoint(0, 0, checkpoint)
+        docs = []
+        new_checkpoint = None
+        try:
+            while True:
+                docs.append(next(gen))
+        except StopIteration as e:
+            new_checkpoint = e.value
+            
+        self.assertEqual(len(docs), 1)
         doc = docs[0]
         self.assertIsInstance(doc, Document)
         self.assertEqual(doc.title, "SD-1 Test Summary")
@@ -53,7 +63,6 @@ class TestJsmConnector(unittest.TestCase):
         self.assertIn("Test Comment", doc.sections[0].text)
         self.assertEqual(doc.source, DocumentSource.JIRA_SERVICE_MANAGEMENT)
         
-        new_checkpoint = docs[1]
         self.assertIsInstance(new_checkpoint, JsmConnectorCheckpoint)
         self.assertEqual(new_checkpoint.offset, 1)
 

--- a/backend/tests/unit/onyx/connectors/jsm/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jsm/test_connector.py
@@ -43,7 +43,7 @@ class TestJsmConnector(unittest.TestCase):
         # side_effect to handle multiple calls
         mock_get.side_effect = [mock_requests_resp, mock_comments_resp]
         
-        checkpoint = JsmConnectorCheckpoint(offset=0)
+        checkpoint = JsmConnectorCheckpoint(offset=0, has_more=True)
         
         # Use a helper to consume generator and get return value
         gen = self.connector.load_from_checkpoint(0, 0, checkpoint)

--- a/backend/tests/unit/onyx/connectors/jsm/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jsm/test_connector.py
@@ -63,8 +63,37 @@ class TestJsmConnector(unittest.TestCase):
         self.assertIn("Test Comment", doc.sections[0].text)
         self.assertEqual(doc.source, DocumentSource.JIRA_SERVICE_MANAGEMENT)
         
+        # Verify metadata is string, not list
+        self.assertIsInstance(doc.metadata.get("status"), str)
+        self.assertEqual(doc.metadata.get("issue_key"), "SD-1")
+
         self.assertIsInstance(new_checkpoint, JsmConnectorCheckpoint)
         self.assertEqual(new_checkpoint.offset, 1)
+
+    @patch("onyx.connectors.jsm.connector.requests.get")
+    def test_fetch_comments_pagination(self, mock_get):
+        # Mock two pages of comments
+        mock_resp1 = MagicMock()
+        mock_resp1.json.return_value = {
+            "values": [{"body": "Comment 1"}],
+            "isLastPage": False
+        }
+        mock_resp1.raise_for_status.return_value = None
+        
+        mock_resp2 = MagicMock()
+        mock_resp2.json.return_value = {
+            "values": [{"body": "Comment 2"}],
+            "isLastPage": True
+        }
+        mock_resp2.raise_for_status.return_value = None
+        
+        mock_get.side_effect = [mock_resp1, mock_resp2]
+        
+        comments = self.connector._fetch_comments("SD-1")
+        self.assertEqual(len(comments), 2)
+        self.assertEqual(comments[0], "Comment 1")
+        self.assertEqual(comments[1], "Comment 2")
+        self.assertEqual(mock_get.call_count, 2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -745,6 +745,22 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which JSM requests to index.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -761,6 +761,20 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  google_chat: {
+    description: "Configure Google Chat connector",
+    values: [
+      {
+        type: "list",
+        label: "Space Names",
+        name: "space_names",
+        optional: true,
+        description:
+          "Comma-separated list of Google Chat space display names to index. If empty, all spaces accessible by the service account will be indexed.",
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -489,7 +489,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
     testrail_api_key: "",
   } as TestRailCredentialJson,
   jira_service_management: {
-    jira_user_email: null,
+    jira_user_email: "",
     jira_api_token: "",
   } as JiraCredentialJson,
 };

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -488,6 +488,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     testrail_username: "",
     testrail_api_key: "",
   } as TestRailCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
 };
 
 export const credentialDisplayNames: Record<string, string> = {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -281,6 +281,11 @@ export interface TestRailCredentialJson {
   testrail_api_key: string;
 }
 
+export interface GoogleChatCredentialJson {
+  google_chat_service_account_key: string;
+  google_chat_delegated_user_email: string | null;
+}
+
 export const credentialTemplates: Record<ValidSources, any> = {
   github: { github_access_token: "" } as GithubCredentialJson,
   gitlab: {
@@ -492,6 +497,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: "",
     jira_api_token: "",
   } as JiraCredentialJson,
+  google_chat: {
+    google_chat_service_account_key: "",
+    google_chat_delegated_user_email: null,
+  } as GoogleChatCredentialJson,
 };
 
 export const credentialDisplayNames: Record<string, string> = {
@@ -659,6 +668,10 @@ export const credentialDisplayNames: Record<string, string> = {
   // Bitbucket
   bitbucket_email: "Bitbucket Account Email",
   bitbucket_api_token: "Bitbucket API Token",
+
+  // Google Chat
+  google_chat_service_account_key: "Google Chat Service Account Key (JSON)",
+  google_chat_delegated_user_email: "Delegated User Email (Optional)",
 };
 
 export function getDisplayNameForCredentialKey(key: string): string {

--- a/web/src/lib/connectors/fileTypes.ts
+++ b/web/src/lib/connectors/fileTypes.ts
@@ -118,6 +118,7 @@ export function isTypedFileField(fieldKey: string): boolean {
   const typedFileFields = new Set([
     "sp_private_key",
     "google_chat_service_account_key",
+    "google_service_account_key",
   ]);
   return typedFileFields.has(fieldKey);
 }

--- a/web/src/lib/connectors/fileTypes.ts
+++ b/web/src/lib/connectors/fileTypes.ts
@@ -1,5 +1,6 @@
 export enum FileTypeCategory {
   SHAREPOINT_PFX_FILE = "sharepoint_pfx_file",
+  GOOGLE_SERVICE_ACCOUNT_KEY = "google_service_account_key",
 }
 
 export interface FileValidationRule {
@@ -26,6 +27,15 @@ export const FILE_TYPE_DEFINITIONS: Record<
     },
     description:
       "Please upload a .pfx file containing the private key for SharePoint. The file size must be under 10KB.",
+  },
+  [FileTypeCategory.GOOGLE_SERVICE_ACCOUNT_KEY]: {
+    category: FileTypeCategory.GOOGLE_SERVICE_ACCOUNT_KEY,
+    validation: {
+      maxSizeKB: 100,
+      allowedExtensions: [".json"],
+    },
+    description:
+      "Please upload the JSON key file for your Google Service Account.",
   },
 };
 
@@ -105,7 +115,10 @@ export function createTypedFile(
 
 export function isTypedFileField(fieldKey: string): boolean {
   // Define which fields should be typed files
-  const typedFileFields = new Set(["sp_private_key"]);
+  const typedFileFields = new Set([
+    "sp_private_key",
+    "google_chat_service_account_key",
+  ]);
   return typedFileFields.has(fieldKey);
 }
 
@@ -115,6 +128,8 @@ export function getFileTypeDefinitionForField(
 ): FileTypeCategory | null {
   const fieldToTypeMap: Record<string, FileTypeCategory> = {
     sp_private_key: FileTypeCategory.SHAREPOINT_PFX_FILE,
+    google_chat_service_account_key: FileTypeCategory.GOOGLE_SERVICE_ACCOUNT_KEY,
+    google_service_account_key: FileTypeCategory.GOOGLE_SERVICE_ACCOUNT_KEY,
   };
 
   return fieldToTypeMap[fieldKey] || null;

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -242,6 +242,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: JiraIcon,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: ZendeskIcon,
     displayName: "Zendesk",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -246,7 +246,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     icon: JiraIcon,
     displayName: "Jira Service Management",
     category: SourceCategory.TicketingAndTaskManagement,
-    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
   },
   zendesk: {
     icon: ZendeskIcon,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -248,6 +248,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     displayName: "Jira Service Management",
     category: SourceCategory.TicketingAndTaskManagement,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
+    isPopular: true,
   },
   zendesk: {
     icon: ZendeskIcon,
@@ -346,6 +347,7 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     displayName: "Google Chat",
     category: SourceCategory.Messaging,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/google_chat`,
+    isPopular: true,
   },
 
   // Sales

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -13,6 +13,7 @@ import {
   GmailIcon,
   GongIcon,
   GoogleDriveIcon,
+  GoogleIcon,
   GoogleSitesIcon,
   GuruIcon,
   HubSpotIcon,
@@ -339,6 +340,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     displayName: "Zulip",
     category: SourceCategory.Messaging,
     docs: `${DOCS_ADMINS_PATH}/connectors/official/zulip`,
+  },
+  google_chat: {
+    icon: GoogleIcon,
+    displayName: "Google Chat",
+    category: SourceCategory.Messaging,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/google_chat`,
   },
 
   // Sales

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -544,6 +544,7 @@ export enum ValidSources {
   Imap = "imap",
   Bitbucket = "bitbucket",
   TestRail = "testrail",
+  JiraServiceManagement = "jira_service_management",
 
   // Craft-specific sources
   CraftFile = "craft_file",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -545,6 +545,7 @@ export enum ValidSources {
   Bitbucket = "bitbucket",
   TestRail = "testrail",
   JiraServiceManagement = "jira_service_management",
+  GoogleChat = "google_chat",
 
   // Craft-specific sources
   CraftFile = "craft_file",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -573,6 +573,8 @@ export const validAutoSyncSources = [
   ValidSources.GitHub,
   ValidSources.Sharepoint,
   ValidSources.Teams,
+  ValidSources.GoogleChat,
+  ValidSources.JiraServiceManagement,
 ] as const;
 
 // Create a type from the array elements


### PR DESCRIPTION
Closes #518
Adds Google Chat connector for indexing messages from Google Chat spaces.
Uses Google Chat API with service account authentication.
Supports both full load and incremental polling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Google Chat connector and a Jira Service Management (JSM) connector with full and incremental sync, wired into the backend and web UI with auto‑sync. Includes permission sync for Google Chat and typed JSON upload for Google service account keys.

- **New Features**
  - Google Chat connector: service account auth with optional delegation; filter by space display name or ID; deep links and sender/space/thread metadata; full load and time‑range polling; permission sync via per‑space member emails (`SlimConnectorWithPermSync`); slim doc retrieval; integrated into `DocumentSource`, backend registry, and web UI (space config, credentials with typed JSON upload, docs, `ValidSources` auto‑sync); unit test added.
  - Jira Service Management connector: indexes request summary/description and paginated comments; checkpointed offset pagination that respects start/end bounds; portal links; metadata for status, reporter, and participants; integrated into `DocumentSource`, backend registry, and web UI (config, credentials, docs, `ValidSources` auto‑sync); HTTP timeouts for API calls; unit tests added.

- **Bug Fixes**
  - Google Chat: use explicit “is not None” checks for poll timestamps to avoid missing events when start/end is 0.

<sup>Written for commit 9a9d0e32c50f9e722b3872b5e9d5bfb93df691b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

