### PR TITLE
feat: multi-rds for cloud

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -2,11 +2,11 @@ from typing import Any
 from onyx.db.engine.iam_auth import get_iam_auth_token
 from onyx.configs.app_configs import USE_IAM_AUTH
 from onyx.configs.app_configs import POSTGRES_HOST
+from onyx.configs.app_configs import POSTGRES_HOSTS
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from sqlalchemy import event
 from sqlalchemy import pool
 from sqlalchemy import text
@@ -241,6 +241,61 @@ def provide_iam_token_for_alembic(
         cparams["ssl"] = ssl_context
 
 
+def _create_async_engine_for_host(host: str) -> Any:
+    """Create a NullPool async engine targeting a specific Postgres host."""
+    conn_str = build_connection_string(host=host)
+    eng = create_async_engine(conn_str, poolclass=pool.NullPool)
+    if USE_IAM_AUTH:
+
+        @event.listens_for(eng.sync_engine, "do_connect")
+        def _iam(dialect: Any, conn_rec: Any, cargs: Any, cparams: Any) -> None:
+            provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
+
+    return eng
+
+
+def _discover_tenant_schemas_sync(engine: Any) -> list[str]:
+    """Query information_schema.schemata on the given engine (sync)."""
+    with engine.sync_engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                f"""
+                SELECT schema_name
+                FROM information_schema.schemata
+                WHERE schema_name NOT IN (
+                    'pg_catalog', 'information_schema', '{POSTGRES_DEFAULT_SCHEMA}'
+                )"""
+            )
+        )
+        return [r[0] for r in rows if r[0].startswith(TENANT_ID_PREFIX)]
+
+
+async def _migrate_schemas(
+    engine: Any,
+    schemas: list[str],
+    create_schema: bool,
+    continue_on_error: bool,
+    label: str = "",
+) -> None:
+    num = len(schemas)
+    for i, schema in enumerate(schemas, 1):
+        logger.info(f"Migrating schema: index={i} total={num} schema={schema} {label}")
+        try:
+            async with engine.connect() as connection:
+                await connection.run_sync(
+                    do_run_migrations,
+                    schema_name=schema,
+                    create_schema=create_schema,
+                )
+                await connection.commit()
+        except Exception as e:
+            logger.error(f"Error migrating schema {schema}: {e}")
+            if not continue_on_error:
+                logger.error("--continue=true is not set, raising exception!")
+                raise
+            logger.warning("--continue=true is set, continuing to next schema.")
+
+
 async def run_async_migrations() -> None:
     (
         create_schema,
@@ -254,96 +309,50 @@ async def run_async_migrations() -> None:
     if not schemas and not MULTI_TENANT:
         schemas = [POSTGRES_DEFAULT_SCHEMA]
 
-    # without init_engine, subsequent engine calls fail hard intentionally
-    SqlEngine.init_engine(pool_size=20, max_overflow=5)
-
-    engine = create_async_engine(
-        build_connection_string(),
-        poolclass=pool.NullPool,
-    )
-
-    if USE_IAM_AUTH:
-
-        @event.listens_for(engine.sync_engine, "do_connect")
-        def event_provide_iam_token_for_alembic(
-            dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
-        ) -> None:
-            provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
+    SqlEngine.init_all_engines(pool_size=20, max_overflow=5)
 
     if schemas:
-        # Use specific schema names directly without fetching all tenants
-        logger.info(f"Migrating specific schema names: {schemas}")
-
-        i_schema = 0
-        num_schemas = len(schemas)
-        for schema in schemas:
-            i_schema += 1
-            logger.info(
-                f"Migrating schema: index={i_schema} num_schemas={num_schemas} schema={schema}"
+        # Specific schemas: migrate on every host (the schema only physically
+        # exists on one of them, but CREATE SCHEMA IF NOT EXISTS is harmless).
+        for host_idx, host in enumerate(POSTGRES_HOSTS):
+            engine = _create_async_engine_for_host(host)
+            await _migrate_schemas(
+                engine,
+                schemas,
+                create_schema,
+                continue_on_error,
+                label=f"host={host_idx}",
             )
-            try:
-                async with engine.connect() as connection:
-                    await connection.run_sync(
-                        do_run_migrations,
-                        schema_name=schema,
-                        create_schema=create_schema,
-                    )
-                    await connection.commit()
-            except Exception as e:
-                logger.error(f"Error migrating schema {schema}: {e}")
-                if not continue_on_error:
-                    logger.error("--continue=true is not set, raising exception!")
-                    raise
-
-                logger.warning("--continue=true is set, continuing to next schema.")
+            await engine.dispose()
 
     elif upgrade_all_tenants:
-        tenant_schemas = get_all_tenant_ids()
-
-        filtered_tenant_schemas = filter_tenants_by_range(
-            tenant_schemas, tenant_range_start, tenant_range_end
-        )
-
-        if tenant_range_start is not None or tenant_range_end is not None:
-            logger.info(
-                f"Filtering tenants by range: start={tenant_range_start}, end={tenant_range_end}"
+        for host_idx, host in enumerate(POSTGRES_HOSTS):
+            engine = _create_async_engine_for_host(host)
+            tenant_schemas = _discover_tenant_schemas_sync(engine)
+            filtered = filter_tenants_by_range(
+                tenant_schemas, tenant_range_start, tenant_range_end
             )
+            if tenant_range_start is not None or tenant_range_end is not None:
+                logger.info(
+                    f"Host {host_idx}: total={len(tenant_schemas)}, "
+                    f"filtered={len(filtered)}"
+                )
             logger.info(
-                f"Total tenants: {len(tenant_schemas)}, Filtered tenants: {len(filtered_tenant_schemas)}"
+                f"Migrating {len(filtered)} schemas on host {host_idx} ({host})"
             )
-
-        i_tenant = 0
-        num_tenants = len(filtered_tenant_schemas)
-        for schema in filtered_tenant_schemas:
-            i_tenant += 1
-            logger.info(
-                f"Migrating schema: index={i_tenant} num_tenants={num_tenants} schema={schema}"
+            await _migrate_schemas(
+                engine,
+                filtered,
+                create_schema,
+                continue_on_error,
+                label=f"host={host_idx}",
             )
-            try:
-                async with engine.connect() as connection:
-                    await connection.run_sync(
-                        do_run_migrations,
-                        schema_name=schema,
-                        create_schema=create_schema,
-                    )
-                    await connection.commit()
-            except Exception as e:
-                logger.error(f"Error migrating schema {schema}: {e}")
-                if not continue_on_error:
-                    logger.error("--continue=true is not set, raising exception!")
-                    raise
-
-                logger.warning("--continue=true is set, continuing to next schema.")
-
+            await engine.dispose()
     else:
-        # This should not happen in the new design since we require either
-        # upgrade_all_tenants=true or schemas in multi-tenant mode
-        # and for non-multi-tenant mode, we should use schemas with the default schema
         raise ValueError(
-            "No migration target specified. Use either upgrade_all_tenants=true for all tenants or schemas for specific schemas."
+            "No migration target specified. Use either upgrade_all_tenants=true "
+            "for all tenants or schemas for specific schemas."
         )
-
-    await engine.dispose()
 
 
 def run_migrations_offline() -> None:
@@ -359,8 +368,7 @@ def run_migrations_offline() -> None:
 
     logger.info("run_migrations_offline starting.")
 
-    # without init_engine, subsequent engine calls fail hard intentionally
-    SqlEngine.init_engine(pool_size=20, max_overflow=5)
+    SqlEngine.init_all_engines(pool_size=20, max_overflow=5)
 
     (
         create_schema,
@@ -370,71 +378,61 @@ def run_migrations_offline() -> None:
         tenant_range_end,
         schemas,
     ) = get_schema_options()
-    url = build_connection_string()
 
     if schemas:
-        # Use specific schema names directly without fetching all tenants
-        logger.info(f"Migrating specific schema names: {schemas}")
-
-        for schema in schemas:
-            logger.info(f"Migrating schema: {schema}")
-            context.configure(
-                url=url,
-                target_metadata=target_metadata,  # type: ignore
-                literal_binds=True,
-                version_table_schema=schema,
-                include_schemas=True,
-                script_location=config.get_main_option("script_location"),
-                dialect_opts={"paramstyle": "named"},
-            )
-
-            with context.begin_transaction():
-                context.run_migrations()
+        for host in POSTGRES_HOSTS:
+            url = build_connection_string(host=host)
+            for schema in schemas:
+                logger.info(f"Migrating schema: {schema}")
+                context.configure(
+                    url=url,
+                    target_metadata=target_metadata,  # type: ignore
+                    literal_binds=True,
+                    version_table_schema=schema,
+                    include_schemas=True,
+                    script_location=config.get_main_option("script_location"),
+                    dialect_opts={"paramstyle": "named"},
+                )
+                with context.begin_transaction():
+                    context.run_migrations()
 
     elif upgrade_all_tenants:
-        engine = create_async_engine(url)
+        for host in POSTGRES_HOSTS:
+            url = build_connection_string(host=host)
+            engine = create_async_engine(url)
 
-        if USE_IAM_AUTH:
+            if USE_IAM_AUTH:
 
-            @event.listens_for(engine.sync_engine, "do_connect")
-            def event_provide_iam_token_for_alembic_offline(
-                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
-            ) -> None:
-                provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
+                @event.listens_for(engine.sync_engine, "do_connect")
+                def event_provide_iam_token_for_alembic_offline(
+                    dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
+                ) -> None:
+                    provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
 
-        tenant_schemas = get_all_tenant_ids()
-        engine.sync_engine.dispose()
+            tenant_schemas = _discover_tenant_schemas_sync(engine)
+            engine.sync_engine.dispose()
 
-        filtered_tenant_schemas = filter_tenants_by_range(
-            tenant_schemas, tenant_range_start, tenant_range_end
-        )
-
-        if tenant_range_start is not None or tenant_range_end is not None:
-            logger.info(
-                f"Filtering tenants by range: start={tenant_range_start}, end={tenant_range_end}"
-            )
-            logger.info(
-                f"Total tenants: {len(tenant_schemas)}, Filtered tenants: {len(filtered_tenant_schemas)}"
+            filtered = filter_tenants_by_range(
+                tenant_schemas, tenant_range_start, tenant_range_end
             )
 
-        for schema in filtered_tenant_schemas:
-            logger.info(f"Migrating schema: {schema}")
-            context.configure(
-                url=url,
-                target_metadata=target_metadata,  # type: ignore
-                literal_binds=True,
-                version_table_schema=schema,
-                include_schemas=True,
-                script_location=config.get_main_option("script_location"),
-                dialect_opts={"paramstyle": "named"},
-            )
-
-            with context.begin_transaction():
-                context.run_migrations()
+            for schema in filtered:
+                logger.info(f"Migrating schema: {schema}")
+                context.configure(
+                    url=url,
+                    target_metadata=target_metadata,  # type: ignore
+                    literal_binds=True,
+                    version_table_schema=schema,
+                    include_schemas=True,
+                    script_location=config.get_main_option("script_location"),
+                    dialect_opts={"paramstyle": "named"},
+                )
+                with context.begin_transaction():
+                    context.run_migrations()
     else:
-        # This should not happen in the new design
         raise ValueError(
-            "No migration target specified. Use either upgrade_all_tenants=true for all tenants or schemas for specific schemas."
+            "No migration target specified. Use either upgrade_all_tenants=true "
+            "for all tenants or schemas for specific schemas."
         )
 
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -227,16 +227,13 @@ def provide_iam_token_for_alembic(
     cparams: Any,
 ) -> None:
     if USE_IAM_AUTH:
-        # Database connection settings
         region = AWS_REGION_NAME
-        host = POSTGRES_HOST
-        port = POSTGRES_PORT
-        user = POSTGRES_USER
+        host = cparams.get("host") or POSTGRES_HOST
+        port = str(cparams.get("port", POSTGRES_PORT))
+        user = cparams.get("user") or POSTGRES_USER
 
-        # Get IAM authentication token
         token = get_iam_auth_token(host, port, user, region)
 
-        # For Alembic / SQLAlchemy in this context, set SSL and password
         cparams["password"] = token
         cparams["ssl"] = ssl_context
 
@@ -312,18 +309,32 @@ async def run_async_migrations() -> None:
     SqlEngine.init_all_engines(pool_size=20, max_overflow=5)
 
     if schemas:
-        # Specific schemas: migrate on every host (the schema only physically
-        # exists on one of them, but CREATE SCHEMA IF NOT EXISTS is harmless).
-        for host_idx, host in enumerate(POSTGRES_HOSTS):
-            engine = _create_async_engine_for_host(host)
-            await _migrate_schemas(
-                engine,
-                schemas,
-                create_schema,
-                continue_on_error,
-                label=f"host={host_idx}",
-            )
-            await engine.dispose()
+        # Specific schemas target a single host.  When called programmatically
+        # (e.g. schema_management.run_alembic_migrations) the sqlalchemy.url
+        # in the Alembic config already points at the correct host.  When
+        # called from the CLI, default to host 0.  We must NOT iterate every
+        # host — that would duplicate the schema across RDS instances.
+        url_override = config.get_main_option("sqlalchemy.url")
+        if url_override:
+            engine = create_async_engine(url_override, poolclass=pool.NullPool)
+            if USE_IAM_AUTH:
+
+                @event.listens_for(engine.sync_engine, "do_connect")
+                def _iam_specific(
+                    dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
+                ) -> None:
+                    provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
+
+        else:
+            engine = _create_async_engine_for_host(POSTGRES_HOSTS[0])
+
+        await _migrate_schemas(
+            engine,
+            schemas,
+            create_schema,
+            continue_on_error,
+        )
+        await engine.dispose()
 
     elif upgrade_all_tenants:
         for host_idx, host in enumerate(POSTGRES_HOSTS):
@@ -380,21 +391,21 @@ def run_migrations_offline() -> None:
     ) = get_schema_options()
 
     if schemas:
-        for host in POSTGRES_HOSTS:
-            url = build_connection_string(host=host)
-            for schema in schemas:
-                logger.info(f"Migrating schema: {schema}")
-                context.configure(
-                    url=url,
-                    target_metadata=target_metadata,  # type: ignore
-                    literal_binds=True,
-                    version_table_schema=schema,
-                    include_schemas=True,
-                    script_location=config.get_main_option("script_location"),
-                    dialect_opts={"paramstyle": "named"},
-                )
-                with context.begin_transaction():
-                    context.run_migrations()
+        url_override = config.get_main_option("sqlalchemy.url")
+        url = url_override or build_connection_string(host=POSTGRES_HOSTS[0])
+        for schema in schemas:
+            logger.info(f"Migrating schema: {schema}")
+            context.configure(
+                url=url,
+                target_metadata=target_metadata,  # type: ignore
+                literal_binds=True,
+                version_table_schema=schema,
+                include_schemas=True,
+                script_location=config.get_main_option("script_location"),
+                dialect_opts={"paramstyle": "named"},
+            )
+            with context.begin_transaction():
+                context.run_migrations()
 
     elif upgrade_all_tenants:
         for host in POSTGRES_HOSTS:

--- a/backend/alembic_tenants/env.py
+++ b/backend/alembic_tenants/env.py
@@ -72,10 +72,12 @@ async def run_async_migrations() -> None:
     """In this scenario we need to create an Engine
     and associate a connection with the context.
 
+    Always targets host 0 — the catalog host where public-schema tables live.
     """
+    from onyx.configs.app_configs import POSTGRES_HOSTS
 
     connectable = create_async_engine(
-        build_connection_string(),
+        build_connection_string(host=POSTGRES_HOSTS[0]),
         poolclass=pool.NullPool,
     )
 

--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -194,20 +194,31 @@ def pre_provision_tenant() -> bool:
         tenant_id = TENANT_ID_PREFIX + str(uuid.uuid4())
         task_logger.info(f"Pre-provisioning tenant: {tenant_id}")
 
-        # Create the schema for the new tenant
-        schema_created = create_schema_if_not_exists(tenant_id)
+        # Determine target host via cutoff-based routing
+        from datetime import timezone as _tz
+
+        from onyx.db.engine.tenant_host_mapping import compute_host_index
+        from onyx.db.engine.tenant_host_mapping import set_tenant_host_in_redis
+
+        host_index = compute_host_index(datetime.datetime.now(_tz.utc))
+
+        # Create the schema on the correct host
+        schema_created = create_schema_if_not_exists(tenant_id, host_index=host_index)
         if schema_created:
             task_logger.debug(f"Created schema for tenant: {tenant_id}")
         else:
             task_logger.debug(f"Schema already exists for tenant: {tenant_id}")
 
+        # Seed Redis so the pool-claim path can read the mapping
+        set_tenant_host_in_redis(tenant_id, host_index)
+
         # Set up the tenant with all necessary configurations
         task_logger.debug(f"Setting up tenant configuration: {tenant_id}")
-        asyncio.run(setup_tenant(tenant_id))
+        asyncio.run(setup_tenant(tenant_id, host_index=host_index))
         task_logger.debug(f"Tenant configuration completed: {tenant_id}")
 
-        # Get the current Alembic version
-        alembic_version = get_current_alembic_version(tenant_id)
+        # Get the current Alembic version from the correct host
+        alembic_version = get_current_alembic_version(tenant_id, host_index=host_index)
         task_logger.debug(
             f"Tenant {tenant_id} using Alembic version: {alembic_version}"
         )

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -101,10 +101,17 @@ async def get_or_provision_tenant(
         tenant_id = await get_available_tenant()
 
         if tenant_id:
-            from onyx.db.engine.tenant_host_mapping import get_host_index_for_tenant
+            from onyx.db.engine.tenant_host_mapping import compute_host_index
+            from onyx.db.engine.tenant_host_mapping import get_host_index_from_redis
+            from onyx.db.engine.tenant_host_mapping import set_tenant_host_in_redis
 
             _tenant_id: str = tenant_id
-            _host_index = get_host_index_for_tenant(_tenant_id)
+            # Pool creator seeds Redis at creation time.  Don't fall through
+            # to the CP — it doesn't know about this tenant yet.
+            _host_index = get_host_index_from_redis(_tenant_id)
+            if _host_index is None:
+                _host_index = compute_host_index(datetime.now(timezone.utc))
+                set_tenant_host_in_redis(_tenant_id, _host_index)
             loop = asyncio.get_running_loop()
             try:
                 await loop.run_in_executor(
@@ -250,12 +257,16 @@ async def rollback_tenant_provisioning(tenant_id: str) -> None:
     """
     logger.info(f"Rolling back tenant provisioning for tenant_id: {tenant_id}")
 
+    from onyx.db.engine.tenant_host_mapping import get_host_index_from_redis
+
+    host_index = get_host_index_from_redis(tenant_id) or 0
+
     # Track if any part of the rollback fails
     rollback_errors = []
 
-    # 1. Try to drop the tenant's schema
+    # 1. Try to drop the tenant's schema on the correct host
     try:
-        drop_schema(tenant_id)
+        drop_schema(tenant_id, host_index=host_index)
         logger.info(f"Successfully dropped schema for tenant {tenant_id}")
     except Exception as e:
         error_msg = f"Failed to drop schema for tenant {tenant_id}: {str(e)}"

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -1,5 +1,7 @@
 import asyncio
 import uuid
+from datetime import datetime
+from datetime import timezone
 
 import aiohttp  # Async HTTP client
 import httpx
@@ -99,14 +101,15 @@ async def get_or_provision_tenant(
         tenant_id = await get_available_tenant()
 
         if tenant_id:
-            # Run migrations to ensure the pre-provisioned tenant schema is current.
-            # Pool tenants may have been created before a new migration was deployed.
-            # Capture as a non-optional local so mypy can type the lambda correctly.
+            from onyx.db.engine.tenant_host_mapping import get_host_index_for_tenant
+
             _tenant_id: str = tenant_id
+            _host_index = get_host_index_for_tenant(_tenant_id)
             loop = asyncio.get_running_loop()
             try:
                 await loop.run_in_executor(
-                    None, lambda: run_alembic_migrations(_tenant_id)
+                    None,
+                    lambda: run_alembic_migrations(_tenant_id, host_index=_host_index),
                 )
             except Exception:
                 # The tenant was already dequeued from the pool — roll it back so
@@ -170,6 +173,13 @@ async def create_tenant(
     return tenant_id
 
 
+def _compute_host_index_for_new_tenant() -> int:
+    """Determine which Postgres host a brand-new tenant should live on."""
+    from onyx.db.engine.tenant_host_mapping import compute_host_index
+
+    return compute_host_index(datetime.now(timezone.utc))
+
+
 async def provision_tenant(tenant_id: str, email: str) -> None:
     if not MULTI_TENANT:
         raise HTTPException(status_code=403, detail="Multi-tenancy is not enabled")
@@ -179,19 +189,24 @@ async def provision_tenant(tenant_id: str, email: str) -> None:
             status_code=409, detail="User already belongs to an organization"
         )
 
-    logger.debug(f"Provisioning tenant {tenant_id} for user {email}")
+    host_index = _compute_host_index_for_new_tenant()
+    logger.info(
+        f"Provisioning tenant {tenant_id} for user {email} on host_index={host_index}"
+    )
 
     try:
-        # Create the schema for the tenant
-        if not create_schema_if_not_exists(tenant_id):
+        if not create_schema_if_not_exists(tenant_id, host_index=host_index):
             logger.debug(f"Created schema for tenant {tenant_id}")
         else:
             logger.debug(f"Schema already exists for tenant {tenant_id}")
 
-        # Set up the tenant with all necessary configurations
-        await setup_tenant(tenant_id)
+        # Pre-populate the Redis cache so the host mapping is warm from the start
+        from onyx.db.engine.tenant_host_mapping import set_tenant_host_in_redis
 
-        # Assign the tenant to the user
+        set_tenant_host_in_redis(tenant_id, host_index)
+
+        await setup_tenant(tenant_id, host_index=host_index)
+
         await assign_tenant_to_user(tenant_id, email)
 
     except Exception as e:
@@ -659,7 +674,7 @@ async def get_available_tenant() -> str | None:
             return None
 
 
-async def setup_tenant(tenant_id: str) -> None:
+async def setup_tenant(tenant_id: str, host_index: int = 0) -> None:
     """
     Set up a tenant with all necessary configurations.
     This is a centralized function that handles all tenant setup logic.
@@ -668,11 +683,10 @@ async def setup_tenant(tenant_id: str) -> None:
     try:
         token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-        # Run Alembic migrations in a way that isolates it from the current event loop
-        # Create a new event loop for this synchronous operation
         loop = asyncio.get_event_loop()
-        # Use run_in_executor which properly isolates the thread execution
-        await loop.run_in_executor(None, lambda: run_alembic_migrations(tenant_id))
+        await loop.run_in_executor(
+            None, lambda: run_alembic_migrations(tenant_id, host_index=host_index)
+        )
 
         # Configure the tenant with default settings
         with get_session_with_tenant(tenant_id=tenant_id) as db_session:

--- a/backend/ee/onyx/server/tenants/schema_management.py
+++ b/backend/ee/onyx/server/tenants/schema_management.py
@@ -9,20 +9,17 @@ from sqlalchemy.schema import CreateSchema
 
 from alembic import command
 from alembic.config import Config
+from onyx.configs.app_configs import POSTGRES_HOSTS
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.engine.sql_engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import SqlEngine
 from shared_configs.configs import TENANT_ID_PREFIX
 
 logger = logging.getLogger(__name__)
 
-# Regex pattern for valid tenant IDs:
-# - UUID format: tenant_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-# - AWS instance ID format: tenant_i-xxxxxxxxxxxxxxxxx
-# Also useful for not accidentally dropping `public` schema
 TENANT_ID_PATTERN = re.compile(
     rf"^{re.escape(TENANT_ID_PREFIX)}("
-    r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"  # UUID
-    r"|i-[a-f0-9]+"  # AWS instance ID
+    r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+    r"|i-[a-f0-9]+"
     r")$"
 )
 
@@ -36,32 +33,37 @@ def validate_tenant_id(tenant_id: str) -> bool:
     return bool(TENANT_ID_PATTERN.match(tenant_id))
 
 
-def run_alembic_migrations(schema_name: str) -> None:
-    logger.info(f"Starting Alembic migrations for schema: {schema_name}")
+def run_alembic_migrations(schema_name: str, host_index: int = 0) -> None:
+    logger.info(
+        f"Starting Alembic migrations for schema: {schema_name} "
+        f"on host_index={host_index}"
+    )
 
     try:
         current_dir = os.path.dirname(os.path.abspath(__file__))
         root_dir = os.path.abspath(os.path.join(current_dir, "..", "..", "..", ".."))
         alembic_ini_path = os.path.join(root_dir, "alembic.ini")
 
-        # Configure Alembic
+        host = (
+            POSTGRES_HOSTS[host_index]
+            if host_index < len(POSTGRES_HOSTS)
+            else POSTGRES_HOSTS[0]
+        )
         alembic_cfg = Config(alembic_ini_path)
-        alembic_cfg.set_main_option("sqlalchemy.url", build_connection_string())
+        alembic_cfg.set_main_option(
+            "sqlalchemy.url", build_connection_string(host=host)
+        )
         alembic_cfg.set_main_option(
             "script_location", os.path.join(root_dir, "alembic")
         )
 
-        # Ensure that logging isn't broken
         alembic_cfg.attributes["configure_logger"] = False
 
-        # Mimic command-line options by adding 'cmd_opts' to the config
         alembic_cfg.cmd_opts = SimpleNamespace()  # type: ignore
         alembic_cfg.cmd_opts.x = [f"schemas={schema_name}"]  # type: ignore
 
-        # Run migrations programmatically
         command.upgrade(alembic_cfg, "head")
 
-        # Run migrations programmatically
         logger.info(
             f"Alembic migrations completed successfully for schema: {schema_name}"
         )
@@ -71,8 +73,9 @@ def run_alembic_migrations(schema_name: str) -> None:
         raise
 
 
-def create_schema_if_not_exists(tenant_id: str) -> bool:
-    with Session(get_sqlalchemy_engine()) as db_session:
+def create_schema_if_not_exists(tenant_id: str, host_index: int = 0) -> bool:
+    engine = SqlEngine.get_engine(host_index)
+    with Session(engine) as db_session:
         with db_session.begin():
             result = db_session.execute(
                 text(
@@ -88,7 +91,7 @@ def create_schema_if_not_exists(tenant_id: str) -> bool:
             return False
 
 
-def drop_schema(tenant_id: str) -> None:
+def drop_schema(tenant_id: str, host_index: int = 0) -> None:
     """Drop a tenant's schema.
 
     Uses strict regex validation to reject unexpected formats early,
@@ -97,24 +100,22 @@ def drop_schema(tenant_id: str) -> None:
     if not validate_tenant_id(tenant_id):
         raise ValueError(f"Invalid tenant_id format: {tenant_id}")
 
-    with get_sqlalchemy_engine().connect() as connection:
+    engine = SqlEngine.get_engine(host_index)
+    with engine.connect() as connection:
         with connection.begin():
-            # Use string formatting with validated tenant_id (safe after validation)
             connection.execute(text(f'DROP SCHEMA IF EXISTS "{tenant_id}" CASCADE'))
 
 
-def get_current_alembic_version(tenant_id: str) -> str:
+def get_current_alembic_version(tenant_id: str, host_index: int = 0) -> str:
     """Get the current Alembic version for a tenant."""
     from alembic.runtime.migration import MigrationContext
     from sqlalchemy import text
 
-    engine = get_sqlalchemy_engine()
+    engine = SqlEngine.get_engine(host_index)
 
-    # Set the search path to the tenant's schema
     with engine.connect() as connection:
         connection.execute(text(f'SET search_path TO "{tenant_id}"'))
 
-        # Get the current version from the alembic_version table
         context = MigrationContext.configure(connection)
         current_rev = context.get_current_revision()
 

--- a/backend/onyx/background/celery/apps/beat.py
+++ b/backend/onyx/background/celery/apps/beat.py
@@ -238,7 +238,7 @@ def on_beat_init(sender: Any, **kwargs: Any) -> None:
 
     # Celery beat shouldn't touch the db at all. But just setting a low minimum here.
     SqlEngine.set_app_name(POSTGRES_CELERY_BEAT_APP_NAME)
-    SqlEngine.init_engine(pool_size=2, max_overflow=0)
+    SqlEngine.init_all_engines(pool_size=2, max_overflow=0)
 
     app_base.wait_for_redis(sender, **kwargs)
     path = make_probe_path("readiness", "beat@hostname")

--- a/backend/onyx/background/celery/apps/docfetching.py
+++ b/backend/onyx/background/celery/apps/docfetching.py
@@ -101,7 +101,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_DOCFETCHING_APP_NAME)
     pool_size = cast(int, sender.concurrency)  # type: ignore
-    SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
+    SqlEngine.init_all_engines(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -107,7 +107,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     # actually setting the spawn method in the cloud fixes 95% of these.
     # setting pre ping might help even more, but not worrying about that yet
     pool_size = cast(int, sender.concurrency)  # type: ignore
-    SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
+    SqlEngine.init_all_engines(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/heavy.py
+++ b/backend/onyx/background/celery/apps/heavy.py
@@ -61,7 +61,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_HEAVY_APP_NAME)
     pool_size = cast(int, sender.concurrency)  # type: ignore
-    SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
+    SqlEngine.init_all_engines(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -66,7 +66,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     logger.info(f"Concurrency: {sender.concurrency}")  # type: ignore
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_LIGHT_APP_NAME)
-    SqlEngine.init_engine(pool_size=sender.concurrency, max_overflow=EXTRA_CONCURRENCY)  # type: ignore
+    SqlEngine.init_all_engines(pool_size=sender.concurrency, max_overflow=EXTRA_CONCURRENCY)  # type: ignore
 
     if MANAGED_VESPA:
         httpx_init_vespa_pool(

--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -66,7 +66,7 @@ def on_worker_init(sender: Any, **kwargs: Any) -> None:
     logger.info(f"Multiprocessing start method: {multiprocessing.get_start_method()}")
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_MONITORING_APP_NAME)
-    SqlEngine.init_engine(pool_size=sender.concurrency, max_overflow=3)
+    SqlEngine.init_all_engines(pool_size=sender.concurrency, max_overflow=3)
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -86,7 +86,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_PRIMARY_APP_NAME)
     pool_size = cast(int, sender.concurrency)  # type: ignore
-    SqlEngine.init_engine(
+    SqlEngine.init_all_engines(
         pool_size=pool_size, max_overflow=CELERY_WORKER_PRIMARY_POOL_OVERFLOW
     )
 

--- a/backend/onyx/background/celery/apps/user_file_processing.py
+++ b/backend/onyx/background/celery/apps/user_file_processing.py
@@ -67,7 +67,7 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
     # actually setting the spawn method in the cloud fixes 95% of these.
     # setting pre ping might help even more, but not worrying about that yet
     pool_size = cast(int, sender.concurrency)  # type: ignore
-    SqlEngine.init_engine(pool_size=pool_size, max_overflow=8)
+    SqlEngine.init_all_engines(pool_size=pool_size, max_overflow=8)
 
     app_base.wait_for_redis(sender, **kwargs)
     app_base.wait_for_db(sender, **kwargs)

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -75,7 +75,7 @@ def _initializer(
     SqlEngine.set_app_name(POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME)
 
     # Initialize a new engine with desired parameters
-    SqlEngine.init_engine(
+    SqlEngine.init_all_engines(
         pool_size=4, max_overflow=12, pool_recycle=60, pool_pre_ping=True
     )
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -388,6 +388,16 @@ POSTGRES_HOSTS: list[str] = (
     else [POSTGRES_HOST]
 )
 
+# ISO-8601 cutoff timestamps that partition tenants across POSTGRES_HOSTS by creation
+# date.  Length must be len(POSTGRES_HOSTS) - 1.  Tenants created before the first
+# cutoff route to host 0, between cutoff 0 and 1 to host 1, etc.
+_POSTGRES_HOST_CUTOFFS_STR = os.environ.get("POSTGRES_HOST_CUTOFFS", "").strip()
+POSTGRES_HOST_CUTOFFS: list[str] = (
+    [c.strip() for c in _POSTGRES_HOST_CUTOFFS_STR.split(",") if c.strip()]
+    if _POSTGRES_HOST_CUTOFFS_STR
+    else []
+)
+
 POSTGRES_API_SERVER_POOL_SIZE = int(
     os.environ.get("POSTGRES_API_SERVER_POOL_SIZE") or 40
 )

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -1,3 +1,4 @@
+import threading
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -16,6 +17,7 @@ from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
 from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
+from onyx.configs.app_configs import POSTGRES_HOSTS
 from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
 from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
 from onyx.configs.app_configs import POSTGRES_PORT
@@ -33,76 +35,101 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import get_current_tenant_id
 
 
-# Global so we don't create more than one engine per process
-_ASYNC_ENGINE: AsyncEngine | None = None
+_ASYNC_ENGINES: dict[int, AsyncEngine] = {}
+_ASYNC_ENGINE_LOCK = threading.Lock()
 
 
 async def get_async_connection() -> Any:
-    """
-    Custom connection function for async engine when using IAM auth.
-    """
+    """Custom connection function for async engine when using IAM auth."""
     host = POSTGRES_HOST
     port = POSTGRES_PORT
     user = POSTGRES_USER
     db = POSTGRES_DB
     token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
 
-    # asyncpg requires 'ssl="require"' if SSL needed
     return await asyncpg.connect(
         user=user, password=token, host=host, port=int(port), database=db, ssl="require"
     )
 
 
-def get_sqlalchemy_async_engine() -> AsyncEngine:
-    global _ASYNC_ENGINE
-    if _ASYNC_ENGINE is None:
-        app_name = SqlEngine.get_app_name() + "_async"
-        connection_string = build_connection_string(
-            db_api=ASYNC_DB_API,
-            use_iam_auth=USE_IAM_AUTH,
+def _create_async_engine_for_host(
+    host: str,
+    pool_size: int = POSTGRES_API_SERVER_POOL_SIZE,
+    max_overflow: int = POSTGRES_API_SERVER_POOL_OVERFLOW,
+) -> AsyncEngine:
+    app_name = SqlEngine.get_app_name() + "_async"
+    connection_string = build_connection_string(
+        db_api=ASYNC_DB_API,
+        host=host,
+        use_iam_auth=USE_IAM_AUTH,
+    )
+
+    connect_args: dict[str, Any] = {}
+    if app_name:
+        connect_args["server_settings"] = {"application_name": app_name}
+    connect_args["ssl"] = create_ssl_context_if_iam()
+
+    engine_kwargs: dict[str, Any] = {
+        "connect_args": connect_args,
+        "pool_pre_ping": POSTGRES_POOL_PRE_PING,
+        "pool_recycle": POSTGRES_POOL_RECYCLE,
+    }
+
+    if POSTGRES_USE_NULL_POOL:
+        engine_kwargs["poolclass"] = pool.NullPool
+    else:
+        engine_kwargs["pool_size"] = pool_size
+        engine_kwargs["max_overflow"] = max_overflow
+
+    engine = create_async_engine(connection_string, **engine_kwargs)
+
+    if USE_IAM_AUTH:
+
+        @event.listens_for(engine.sync_engine, "do_connect")
+        def provide_iam_token_async(
+            dialect: Any,  # noqa: ARG001
+            conn_rec: Any,  # noqa: ARG001
+            cargs: Any,  # noqa: ARG001
+            cparams: Any,
+        ) -> None:
+            h = host
+            token = get_iam_auth_token(h, POSTGRES_PORT, POSTGRES_USER, AWS_REGION_NAME)
+            cparams["password"] = token
+            cparams["ssl"] = create_ssl_context_if_iam()
+
+    return engine
+
+
+def get_sqlalchemy_async_engine(host_index: int = 0) -> AsyncEngine:
+    engine = _ASYNC_ENGINES.get(host_index)
+    if engine is not None:
+        return engine
+
+    with _ASYNC_ENGINE_LOCK:
+        engine = _ASYNC_ENGINES.get(host_index)
+        if engine is not None:
+            return engine
+
+        host = (
+            POSTGRES_HOSTS[host_index]
+            if host_index < len(POSTGRES_HOSTS)
+            else POSTGRES_HOST
         )
+        num_hosts = max(1, len(POSTGRES_HOSTS))
+        per_host_pool = max(1, POSTGRES_API_SERVER_POOL_SIZE // num_hosts)
+        per_host_overflow = max(0, POSTGRES_API_SERVER_POOL_OVERFLOW // num_hosts)
 
-        connect_args: dict[str, Any] = {}
-        if app_name:
-            connect_args["server_settings"] = {"application_name": app_name}
-
-        connect_args["ssl"] = create_ssl_context_if_iam()
-
-        engine_kwargs = {
-            "connect_args": connect_args,
-            "pool_pre_ping": POSTGRES_POOL_PRE_PING,
-            "pool_recycle": POSTGRES_POOL_RECYCLE,
-        }
-
-        if POSTGRES_USE_NULL_POOL:
-            engine_kwargs["poolclass"] = pool.NullPool
-        else:
-            engine_kwargs["pool_size"] = POSTGRES_API_SERVER_POOL_SIZE
-            engine_kwargs["max_overflow"] = POSTGRES_API_SERVER_POOL_OVERFLOW
-
-        _ASYNC_ENGINE = create_async_engine(
-            connection_string,
-            **engine_kwargs,
+        engine = _create_async_engine_for_host(
+            host, pool_size=per_host_pool, max_overflow=per_host_overflow
         )
+        _ASYNC_ENGINES[host_index] = engine
+        return engine
 
-        if USE_IAM_AUTH:
 
-            @event.listens_for(_ASYNC_ENGINE.sync_engine, "do_connect")
-            def provide_iam_token_async(
-                dialect: Any,  # noqa: ARG001
-                conn_rec: Any,  # noqa: ARG001
-                cargs: Any,  # noqa: ARG001
-                cparams: Any,
-            ) -> None:
-                # For async engine using asyncpg, we still need to set the IAM token here.
-                host = POSTGRES_HOST
-                port = POSTGRES_PORT
-                user = POSTGRES_USER
-                token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
-                cparams["password"] = token
-                cparams["ssl"] = create_ssl_context_if_iam()
+def _get_host_index_for_tenant(tenant_id: str) -> int:
+    from onyx.db.engine.tenant_host_mapping import get_host_index_for_tenant
 
-    return _ASYNC_ENGINE
+    return get_host_index_for_tenant(tenant_id)
 
 
 async def get_async_session(
@@ -112,22 +139,20 @@ async def get_async_session(
 
     For standard `async with ... as ...` use, use get_async_session_context_manager.
     """
-
     if tenant_id is None:
         tenant_id = get_current_tenant_id()
 
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")
 
-    engine = get_sqlalchemy_async_engine()
+    host_index = _get_host_index_for_tenant(tenant_id)
+    engine = get_sqlalchemy_async_engine(host_index)
 
-    # no need to use the schema translation map for self-hosted + default schema
     if not MULTI_TENANT and tenant_id == POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE:
         async with AsyncSession(bind=engine, expire_on_commit=False) as session:
             yield session
         return
 
-    # Create connection with schema translation to handle querying the right schema
     schema_translate_map = {None: tenant_id}
     async with engine.connect() as connection:
         connection = await connection.execution_options(

--- a/backend/onyx/db/engine/connection_warmup.py
+++ b/backend/onyx/db/engine/connection_warmup.py
@@ -1,27 +1,28 @@
 from sqlalchemy import text
 
 from onyx.db.engine.async_sql_engine import get_sqlalchemy_async_engine
-from onyx.db.engine.sql_engine import get_sqlalchemy_engine
+from onyx.db.engine.sql_engine import SqlEngine
 
 
 async def warm_up_connections(
     sync_connections_to_warm_up: int = 20, async_connections_to_warm_up: int = 20
 ) -> None:
-    sync_postgres_engine = get_sqlalchemy_engine()
-    connections = [
-        sync_postgres_engine.connect() for _ in range(sync_connections_to_warm_up)
-    ]
-    for conn in connections:
-        conn.execute(text("SELECT 1"))
-    for conn in connections:
-        conn.close()
+    for host_index, engine in SqlEngine.get_all_engines().items():
+        count = max(
+            1, sync_connections_to_warm_up // max(1, len(SqlEngine.get_all_engines()))
+        )
+        connections = [engine.connect() for _ in range(count)]
+        for conn in connections:
+            conn.execute(text("SELECT 1"))
+        for conn in connections:
+            conn.close()
 
-    async_postgres_engine = get_sqlalchemy_async_engine()
-    async_connections = [
-        await async_postgres_engine.connect()
-        for _ in range(async_connections_to_warm_up)
-    ]
-    for async_conn in async_connections:
-        await async_conn.execute(text("SELECT 1"))
-    for async_conn in async_connections:
-        await async_conn.close()
+        async_engine = get_sqlalchemy_async_engine(host_index)
+        a_count = max(
+            1, async_connections_to_warm_up // max(1, len(SqlEngine.get_all_engines()))
+        )
+        async_connections_list = [await async_engine.connect() for _ in range(a_count)]
+        for async_conn in async_connections_list:
+            await async_conn.execute(text("SELECT 1"))
+        for async_conn in async_connections_list:
+            await async_conn.close()

--- a/backend/onyx/db/engine/iam_auth.py
+++ b/backend/onyx/db/engine/iam_auth.py
@@ -44,11 +44,10 @@ def provide_iam_token(
     cparams: Any,
 ) -> None:
     if USE_IAM_AUTH:
-        host = POSTGRES_HOST
-        port = POSTGRES_PORT
-        user = POSTGRES_USER
+        host = cparams.get("host") or POSTGRES_HOST
+        port = str(cparams.get("port", POSTGRES_PORT))
+        user = cparams.get("user") or POSTGRES_USER
         region = os.getenv("AWS_REGION_NAME", "us-east-2")
-        # Configure for psycopg2 with IAM token
         configure_psycopg2_iam_auth(cparams, host, port, user, region)
 
 

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -19,6 +19,7 @@ from onyx.configs.app_configs import LOG_POSTGRES_CONN_COUNTS
 from onyx.configs.app_configs import LOG_POSTGRES_LATENCY
 from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
+from onyx.configs.app_configs import POSTGRES_HOSTS
 from onyx.configs.app_configs import POSTGRES_PASSWORD
 from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
 from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
@@ -35,13 +36,10 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import get_current_tenant_id
 
-# Moved is_valid_schema_name here to avoid circular import
-
 
 logger = setup_logger()
 
 
-# Schema name validation (moved here to avoid circular import)
 SCHEMA_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
@@ -52,7 +50,6 @@ def is_valid_schema_name(name: str) -> bool:
 SYNC_DB_API = "psycopg2"
 ASYNC_DB_API = "asyncpg"
 
-# why isn't this in configs?
 USE_IAM_AUTH = os.getenv("USE_IAM_AUTH", "False").lower() == "true"
 
 
@@ -73,7 +70,6 @@ def build_connection_string(
     else:
         base_conn_str = f"postgresql+{db_api}://{user}:{password}@{host}:{port}/{db}"
 
-    # For asyncpg, do not include application_name in the connection string
     if app_name and db_api != "asyncpg":
         if "?" in base_conn_str:
             return f"{base_conn_str}&application_name={app_name}"
@@ -139,87 +135,107 @@ if LOG_POSTGRES_CONN_COUNTS:
 
 
 class SqlEngine:
-    _engine: Engine | None = None
-    _readonly_engine: Engine | None = None
+    """Registry of SQLAlchemy engines keyed by Postgres host index.
+
+    Host index 0 is always the "catalog" host (where the public schema
+    lives).  Additional hosts can be registered for tenant routing.
+    """
+
+    _engines: dict[int, Engine] = {}
+    _readonly_engines: dict[int, Engine] = {}
     _lock: threading.Lock = threading.Lock()
     _readonly_lock: threading.Lock = threading.Lock()
     _app_name: str = POSTGRES_UNKNOWN_APP_NAME
+
+    # ── write engines ──────────────────────────────────────────────
 
     @classmethod
     def init_engine(
         cls,
         pool_size: int,
-        # is really `pool_max_overflow`, but calling it `max_overflow` to stay consistent with SQLAlchemy
         max_overflow: int,
+        host_index: int = 0,
+        host: str | None = None,
         app_name: str | None = None,  # noqa: ARG003
         db_api: str = SYNC_DB_API,
         use_iam: bool = USE_IAM_AUTH,
         connection_string: str | None = None,
         **extra_engine_kwargs: Any,
     ) -> None:
-        """NOTE: enforce that pool_size and pool_max_overflow are passed in. These are
-        important args, and if incorrectly specified, we have run into hitting the pool
-        limit / using too many connections and overwhelming the database.
-
-        Specifying connection_string directly will cause some of the other parameters
-        to be ignored.
-        """
         with cls._lock:
-            if cls._engine:
+            if host_index in cls._engines:
                 return
 
             if not connection_string:
                 connection_string = build_connection_string(
                     db_api=db_api,
+                    host=host or POSTGRES_HOST,
                     app_name=cls._app_name + "_sync",
                     use_iam_auth=use_iam,
                 )
 
-            # Start with base kwargs that are valid for all pool types
             final_engine_kwargs: dict[str, Any] = {}
 
             if POSTGRES_USE_NULL_POOL:
-                # if null pool is specified, then we need to make sure that
-                # we remove any passed in kwargs related to pool size that would
-                # cause the initialization to fail
                 final_engine_kwargs.update(extra_engine_kwargs)
-
                 final_engine_kwargs["poolclass"] = pool.NullPool
-                if "pool_size" in final_engine_kwargs:
-                    del final_engine_kwargs["pool_size"]
-                if "max_overflow" in final_engine_kwargs:
-                    del final_engine_kwargs["max_overflow"]
+                final_engine_kwargs.pop("pool_size", None)
+                final_engine_kwargs.pop("max_overflow", None)
             else:
                 final_engine_kwargs["pool_size"] = pool_size
                 final_engine_kwargs["max_overflow"] = max_overflow
                 final_engine_kwargs["pool_pre_ping"] = POSTGRES_POOL_PRE_PING
                 final_engine_kwargs["pool_recycle"] = POSTGRES_POOL_RECYCLE
-
-                # any passed in kwargs override the defaults
                 final_engine_kwargs.update(extra_engine_kwargs)
 
-            logger.info(f"Creating engine with kwargs: {final_engine_kwargs}")
-            # echo=True here for inspecting all emitted db queries
+            logger.info(
+                f"Creating engine for host_index={host_index} "
+                f"with kwargs: {final_engine_kwargs}"
+            )
             engine = create_engine(connection_string, **final_engine_kwargs)
 
             if use_iam:
                 event.listen(engine, "do_connect", provide_iam_token)
 
-            cls._engine = engine
+            cls._engines[host_index] = engine
+
+    @classmethod
+    def init_all_engines(
+        cls,
+        pool_size: int,
+        max_overflow: int,
+        **extra_engine_kwargs: Any,
+    ) -> None:
+        """Initialize one engine per configured Postgres host.
+
+        Pool sizes are divided evenly across hosts so total connection
+        consumption stays roughly the same.
+        """
+        num_hosts = len(POSTGRES_HOSTS)
+        per_host_pool = max(1, pool_size // num_hosts)
+        per_host_overflow = max(0, max_overflow // num_hosts)
+        for idx, host in enumerate(POSTGRES_HOSTS):
+            cls.init_engine(
+                pool_size=per_host_pool,
+                max_overflow=per_host_overflow,
+                host_index=idx,
+                host=host,
+                **extra_engine_kwargs,
+            )
+
+    # ── readonly engines ───────────────────────────────────────────
 
     @classmethod
     def init_readonly_engine(
         cls,
         pool_size: int,
-        # is really `pool_max_overflow`, but calling it `max_overflow` to stay consistent with SQLAlchemy
         max_overflow: int,
+        host_index: int = 0,
+        host: str | None = None,
         **extra_engine_kwargs: Any,
     ) -> None:
-        """NOTE: enforce that pool_size and pool_max_overflow are passed in. These are
-        important args, and if incorrectly specified, we have run into hitting the pool
-        limit / using too many connections and overwhelming the database."""
         with cls._readonly_lock:
-            if cls._readonly_engine:
+            if host_index in cls._readonly_engines:
                 return
 
             if not DB_READONLY_USER or not DB_READONLY_PASSWORD:
@@ -227,59 +243,85 @@ class SqlEngine:
                     "Custom database user credentials not configured in environment variables"
                 )
 
-            # Build connection string with custom user
             connection_string = build_connection_string(
                 user=DB_READONLY_USER,
                 password=DB_READONLY_PASSWORD,
-                use_iam_auth=False,  # Custom users typically don't use IAM auth
-                db_api=SYNC_DB_API,  # Explicitly use sync DB API
+                host=host or POSTGRES_HOST,
+                use_iam_auth=False,
+                db_api=SYNC_DB_API,
             )
 
-            # Start with base kwargs that are valid for all pool types
             final_engine_kwargs: dict[str, Any] = {}
 
             if POSTGRES_USE_NULL_POOL:
-                # if null pool is specified, then we need to make sure that
-                # we remove any passed in kwargs related to pool size that would
-                # cause the initialization to fail
                 final_engine_kwargs.update(extra_engine_kwargs)
-
                 final_engine_kwargs["poolclass"] = pool.NullPool
-                if "pool_size" in final_engine_kwargs:
-                    del final_engine_kwargs["pool_size"]
-                if "max_overflow" in final_engine_kwargs:
-                    del final_engine_kwargs["max_overflow"]
+                final_engine_kwargs.pop("pool_size", None)
+                final_engine_kwargs.pop("max_overflow", None)
             else:
                 final_engine_kwargs["pool_size"] = pool_size
                 final_engine_kwargs["max_overflow"] = max_overflow
                 final_engine_kwargs["pool_pre_ping"] = POSTGRES_POOL_PRE_PING
                 final_engine_kwargs["pool_recycle"] = POSTGRES_POOL_RECYCLE
-
-                # any passed in kwargs override the defaults
                 final_engine_kwargs.update(extra_engine_kwargs)
 
-            logger.info(f"Creating engine with kwargs: {final_engine_kwargs}")
-            # echo=True here for inspecting all emitted db queries
+            logger.info(
+                f"Creating readonly engine for host_index={host_index} "
+                f"with kwargs: {final_engine_kwargs}"
+            )
             engine = create_engine(connection_string, **final_engine_kwargs)
 
             if USE_IAM_AUTH:
                 event.listen(engine, "do_connect", provide_iam_token)
 
-            cls._readonly_engine = engine
+            cls._readonly_engines[host_index] = engine
 
     @classmethod
-    def get_engine(cls) -> Engine:
-        if not cls._engine:
-            raise RuntimeError("Engine not initialized. Must call init_engine first.")
-        return cls._engine
-
-    @classmethod
-    def get_readonly_engine(cls) -> Engine:
-        if not cls._readonly_engine:
-            raise RuntimeError(
-                "Readonly engine not initialized. Must call init_readonly_engine first."
+    def init_all_readonly_engines(
+        cls,
+        pool_size: int,
+        max_overflow: int,
+        **extra_engine_kwargs: Any,
+    ) -> None:
+        num_hosts = len(POSTGRES_HOSTS)
+        per_host_pool = max(1, pool_size // num_hosts)
+        per_host_overflow = max(0, max_overflow // num_hosts)
+        for idx, host in enumerate(POSTGRES_HOSTS):
+            cls.init_readonly_engine(
+                pool_size=per_host_pool,
+                max_overflow=per_host_overflow,
+                host_index=idx,
+                host=host,
+                **extra_engine_kwargs,
             )
-        return cls._readonly_engine
+
+    # ── getters ────────────────────────────────────────────────────
+
+    @classmethod
+    def get_engine(cls, host_index: int = 0) -> Engine:
+        engine = cls._engines.get(host_index)
+        if engine is None:
+            raise RuntimeError(
+                f"Engine for host_index={host_index} not initialized. "
+                "Must call init_engine / init_all_engines first."
+            )
+        return engine
+
+    @classmethod
+    def get_readonly_engine(cls, host_index: int = 0) -> Engine:
+        engine = cls._readonly_engines.get(host_index)
+        if engine is None:
+            raise RuntimeError(
+                f"Readonly engine for host_index={host_index} not initialized. "
+                "Must call init_readonly_engine / init_all_readonly_engines first."
+            )
+        return engine
+
+    @classmethod
+    def get_all_engines(cls) -> dict[int, Engine]:
+        return dict(cls._engines)
+
+    # ── metadata ───────────────────────────────────────────────────
 
     @classmethod
     def set_app_name(cls, app_name: str) -> None:
@@ -291,12 +333,14 @@ class SqlEngine:
             return ""
         return cls._app_name
 
+    # ── lifecycle ──────────────────────────────────────────────────
+
     @classmethod
     def reset_engine(cls) -> None:
         with cls._lock:
-            if cls._engine:
-                cls._engine.dispose()
-                cls._engine = None
+            for engine in cls._engines.values():
+                engine.dispose()
+            cls._engines.clear()
 
     @classmethod
     @contextmanager
@@ -309,12 +353,25 @@ class SqlEngine:
             cls.reset_engine()
 
 
-def get_sqlalchemy_engine() -> Engine:
-    return SqlEngine.get_engine()
+# ── convenience accessors ──────────────────────────────────────────
 
 
-def get_readonly_sqlalchemy_engine() -> Engine:
-    return SqlEngine.get_readonly_engine()
+def get_sqlalchemy_engine(host_index: int = 0) -> Engine:
+    return SqlEngine.get_engine(host_index)
+
+
+def get_readonly_sqlalchemy_engine(host_index: int = 0) -> Engine:
+    return SqlEngine.get_readonly_engine(host_index)
+
+
+# ── session factories ──────────────────────────────────────────────
+
+
+def _get_host_index_for_tenant(tenant_id: str) -> int:
+    """Thin wrapper to keep the import lazy and avoid circular deps."""
+    from onyx.db.engine.tenant_host_mapping import get_host_index_for_tenant
+
+    return get_host_index_for_tenant(tenant_id)
 
 
 @contextmanager
@@ -337,32 +394,30 @@ def get_session_with_current_tenant_if_none(
         yield session
 
 
-# Used in multi tenant mode when need to refer to the shared `public` schema
 @contextmanager
 def get_session_with_shared_schema() -> Generator[Session, None, None]:
+    """Always targets host 0 — the catalog host where public-schema tables live."""
     token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA)
-    with get_session_with_tenant(tenant_id=POSTGRES_DEFAULT_SCHEMA) as session:
+    engine = SqlEngine.get_engine(host_index=0)
+    with Session(bind=engine, expire_on_commit=False) as session:
         yield session
     CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 @contextmanager
 def get_session_with_tenant(*, tenant_id: str) -> Generator[Session, None, None]:
-    """
-    Generate a database session for a specific tenant.
-    """
-    engine = get_sqlalchemy_engine()
-
+    """Generate a database session for a specific tenant."""
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")
 
-    # no need to use the schema translation map for self-hosted + default schema
+    host_index = _get_host_index_for_tenant(tenant_id)
+    engine = SqlEngine.get_engine(host_index)
+
     if not MULTI_TENANT and tenant_id == POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE:
         with Session(bind=engine, expire_on_commit=False) as session:
             yield session
         return
 
-    # Create connection with schema translation to handle querying the right schema
     schema_translate_map = {None: tenant_id}
     with engine.connect().execution_options(
         schema_translate_map=schema_translate_map
@@ -391,18 +446,15 @@ def get_session() -> Generator[Session, None, None]:
 def get_db_readonly_user_session_with_current_tenant() -> (
     Generator[Session, None, None]
 ):
-    """
-    Generate a database session using a custom database user for the current tenant.
-    The custom user credentials are obtained from environment variables.
-    """
+    """Generate a database session using a readonly database user for the current tenant."""
     tenant_id = get_current_tenant_id()
 
-    readonly_engine = get_readonly_sqlalchemy_engine()
+    host_index = _get_host_index_for_tenant(tenant_id)
+    readonly_engine = get_readonly_sqlalchemy_engine(host_index)
 
     if not is_valid_schema_name(tenant_id):
         raise HTTPException(status_code=400, detail="Invalid tenant ID")
 
-    # no need to use the schema translation map for self-hosted + default schema
     if not MULTI_TENANT and tenant_id == POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE:
         with Session(readonly_engine, expire_on_commit=False) as session:
             yield session

--- a/backend/onyx/db/engine/tenant_host_mapping.py
+++ b/backend/onyx/db/engine/tenant_host_mapping.py
@@ -1,0 +1,167 @@
+"""Resolve which Postgres host index a tenant lives on.
+
+Resolution order (for multi-tenant mode with >1 host):
+  1. In-process LRU cache
+  2. Redis  key ``tenant_host:{tenant_id}``
+  3. Control-plane ``GET /tenants/{tenant_id}/created-at`` → compute from cutoffs
+
+The mapping is effectively immutable (tenant creation time never changes), so
+Redis entries are stored without a TTL.
+"""
+
+import bisect
+from datetime import datetime
+from datetime import timezone
+from functools import lru_cache
+
+import requests
+from pydantic import BaseModel
+
+from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.configs.app_configs import POSTGRES_HOST_CUTOFFS
+from onyx.configs.app_configs import POSTGRES_HOSTS
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+REDIS_TENANT_HOST_KEY_PREFIX = "tenant_host:"
+
+_PARSED_CUTOFFS: list[datetime] | None = None
+
+
+def _get_parsed_cutoffs() -> list[datetime]:
+    global _PARSED_CUTOFFS
+    if _PARSED_CUTOFFS is None:
+        _PARSED_CUTOFFS = [
+            datetime.fromisoformat(c.replace("Z", "+00:00"))
+            for c in POSTGRES_HOST_CUTOFFS
+        ]
+    return _PARSED_CUTOFFS
+
+
+def compute_host_index(created_at: datetime) -> int:
+    """Pure function: given a tenant's creation time, return its host index."""
+    cutoffs = _get_parsed_cutoffs()
+    if not cutoffs:
+        return 0
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return bisect.bisect_right(cutoffs, created_at)
+
+
+class TenantCreatedAtResponse(BaseModel):
+    tenant_id: str
+    created_at: datetime
+
+
+def _fetch_created_at_from_control_plane(tenant_id: str) -> datetime:
+    from ee.onyx.server.tenants.access import generate_data_plane_token
+
+    token = generate_data_plane_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    response = requests.get(
+        f"{CONTROL_PLANE_API_BASE_URL}/tenants/{tenant_id}/created-at",
+        headers=headers,
+        timeout=10,
+    )
+    response.raise_for_status()
+    parsed = TenantCreatedAtResponse(**response.json())
+    return parsed.created_at
+
+
+def _only_one_host() -> bool:
+    return len(POSTGRES_HOSTS) <= 1
+
+
+def set_tenant_host_in_redis(tenant_id: str, host_index: int) -> None:
+    """Write the tenant→host mapping into Redis (no TTL — effectively permanent)."""
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    client = get_raw_redis_client()
+    client.set(f"{REDIS_TENANT_HOST_KEY_PREFIX}{tenant_id}", str(host_index))
+
+
+def get_host_index_from_redis(tenant_id: str) -> int | None:
+    """Read the host index from Redis only.  Returns None on miss.
+
+    Use this when the CP cannot be queried (e.g. the tenant hasn't been
+    registered with the CP yet, as is the case for pre-provisioned pool
+    tenants).
+    """
+    if not MULTI_TENANT or _only_one_host():
+        return 0
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    raw = get_raw_redis_client().get(f"{REDIS_TENANT_HOST_KEY_PREFIX}{tenant_id}")
+    if raw is not None:
+        return int(raw)
+    return None
+
+
+def get_host_index_for_tenant(tenant_id: str) -> int:
+    """Return the Postgres host index for *tenant_id*.
+
+    Fast-path: if there's only one configured host, always returns 0.
+    Otherwise checks the LRU cache, then Redis, then the control plane.
+    """
+    if not MULTI_TENANT or _only_one_host():
+        return 0
+
+    cached = _lru_get_host_index(tenant_id)
+    if cached is not None:
+        return cached
+
+    host_index = _resolve_and_cache(tenant_id)
+    return host_index
+
+
+@lru_cache(maxsize=16384)
+def _lru_get_host_index(tenant_id: str) -> int | None:
+    """Check Redis; return None on miss so the caller falls through to CP."""
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    client = get_raw_redis_client()
+    raw = client.get(f"{REDIS_TENANT_HOST_KEY_PREFIX}{tenant_id}")
+    if raw is not None:
+        return int(raw)
+    return None
+
+
+def _resolve_and_cache(tenant_id: str) -> int:
+    """Call the control plane, compute the host index, cache everywhere."""
+    created_at = _fetch_created_at_from_control_plane(tenant_id)
+    host_index = compute_host_index(created_at)
+
+    set_tenant_host_in_redis(tenant_id, host_index)
+
+    # Evict the sentinel None from the LRU so the next call hits the fresh value
+    _lru_get_host_index.cache_clear()
+
+    logger.info(
+        f"Resolved tenant {tenant_id} → host {host_index} "
+        f"(created_at={created_at.isoformat()})"
+    )
+    return host_index
+
+
+def warm_tenant_host_cache(tenant_ids_by_host: dict[int, list[str]]) -> int:
+    """Bulk-populate Redis with tenant→host mappings.
+
+    Returns the total number of keys written.
+    """
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    client = get_raw_redis_client()
+    pipe = client.pipeline(transaction=False)
+    count = 0
+    for host_index, tenant_ids in tenant_ids_by_host.items():
+        for tid in tenant_ids:
+            pipe.set(f"{REDIS_TENANT_HOST_KEY_PREFIX}{tid}", str(host_index))
+            count += 1
+    pipe.execute()
+    logger.info(f"Warmed {count} tenant→host Redis entries")
+    return count

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,14 +1,53 @@
 from sqlalchemy import text
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.engine.sql_engine import SqlEngine
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import TENANT_ID_PREFIX
 
 
+def _tenant_schemas_on_engine(host_index: int) -> list[str]:
+    """Return tenant schema names that physically exist on the given host."""
+    engine = SqlEngine.get_engine(host_index)
+    with engine.connect() as conn:
+        result = conn.execute(
+            text(
+                f"""
+                SELECT schema_name
+                FROM information_schema.schemata
+                WHERE schema_name NOT IN (
+                    'pg_catalog', 'information_schema', '{POSTGRES_DEFAULT_SCHEMA}'
+                )"""
+            )
+        )
+        schemas = [row[0] for row in result]
+    return [s for s in schemas if s.startswith(TENANT_ID_PREFIX)]
+
+
+def get_tenant_ids_by_host() -> dict[int, list[str]]:
+    """Return ``{host_index: [tenant_id, ...]}`` for every configured host."""
+    if not MULTI_TENANT:
+        return {0: [POSTGRES_DEFAULT_SCHEMA]}
+
+    result: dict[int, list[str]] = {}
+    for host_index in SqlEngine.get_all_engines():
+        result[host_index] = _tenant_schemas_on_engine(host_index)
+    return result
+
+
+def get_all_tenant_ids() -> list[str]:
+    """Flat list of all tenant IDs across every configured Postgres host."""
+    if not MULTI_TENANT:
+        return [POSTGRES_DEFAULT_SCHEMA]
+
+    all_ids: list[str] = []
+    for tenants in get_tenant_ids_by_host().values():
+        all_ids.extend(tenants)
+    return all_ids
+
+
 def get_schemas_needing_migration(
-    tenant_schemas: list[str], head_rev: str
+    tenant_schemas: list[str], head_rev: str, host_index: int = 0
 ) -> list[str]:
     """Return only schemas whose current alembic version is not at head.
 
@@ -20,12 +59,9 @@ def get_schemas_needing_migration(
     if not tenant_schemas:
         return []
 
-    engine = SqlEngine.get_engine()
+    engine = SqlEngine.get_engine(host_index)
 
     with engine.connect() as conn:
-        # Populate a temp input table with exactly the schemas we care about.
-        # The DO block reads from this table so it only iterates the requested
-        # schemas instead of every tenant_% schema in the database.
         conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
         conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
         conn.execute(text("CREATE TEMP TABLE _tenant_schemas_input (schema_name text)"))
@@ -65,12 +101,6 @@ def get_schemas_needing_migration(
                                 s, s
                             );
                         EXCEPTION
-                            -- undefined_table: schema exists but has no alembic_version
-                            --   table yet (new tenant, not yet migrated).
-                            -- invalid_schema_name: tenant is registered but its
-                            --   PostgreSQL schema does not exist yet (e.g. provisioning
-                            --   incomplete). Both cases mean no version is available and
-                            --   the schema will be included in the migration list.
                             WHEN undefined_table THEN NULL;
                             WHEN invalid_schema_name THEN NULL;
                         END;
@@ -89,34 +119,4 @@ def get_schemas_needing_migration(
         conn.execute(text("DROP TABLE IF EXISTS _alembic_version_snapshot"))
         conn.execute(text("DROP TABLE IF EXISTS _tenant_schemas_input"))
 
-    # Schemas missing from the snapshot have no alembic_version table yet and
-    # also need migration. version_by_schema.get(s) returns None for those,
-    # and None != head_rev, so they are included automatically.
     return [s for s in tenant_schemas if version_by_schema.get(s) != head_rev]
-
-
-def get_all_tenant_ids() -> list[str]:
-    """Returning [None] means the only tenant is the 'public' or self hosted tenant."""
-
-    tenant_ids: list[str]
-
-    if not MULTI_TENANT:
-        return [POSTGRES_DEFAULT_SCHEMA]
-
-    with get_session_with_shared_schema() as session:
-        result = session.execute(
-            text(
-                f"""
-                SELECT schema_name
-                FROM information_schema.schemata
-                WHERE schema_name NOT IN ('pg_catalog', 'information_schema', '{POSTGRES_DEFAULT_SCHEMA}')"""
-            )
-        )
-        tenant_ids = [row[0] for row in result]
-
-    valid_tenants = [
-        tenant
-        for tenant in tenant_ids
-        if tenant is None or tenant.startswith(TENANT_ID_PREFIX)
-    ]
-    return valid_tenants

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -318,13 +318,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
     SqlEngine.set_app_name(POSTGRES_WEB_APP_NAME)
 
-    SqlEngine.init_engine(
+    SqlEngine.init_all_engines(
         pool_size=POSTGRES_API_SERVER_POOL_SIZE,
         max_overflow=POSTGRES_API_SERVER_POOL_OVERFLOW,
     )
     SqlEngine.get_engine()
 
-    SqlEngine.init_readonly_engine(
+    SqlEngine.init_all_readonly_engines(
         pool_size=POSTGRES_API_SERVER_READ_ONLY_POOL_SIZE,
         max_overflow=POSTGRES_API_SERVER_READ_ONLY_POOL_OVERFLOW,
     )

--- a/backend/onyx/onyxbot/discord/client.py
+++ b/backend/onyx/onyxbot/discord/client.py
@@ -200,7 +200,7 @@ def main() -> None:
     logger.info("Starting Onyx Discord Bot...")
 
     # Initialize the database engine (required before any DB operations)
-    SqlEngine.init_engine(pool_size=20, max_overflow=5)
+    SqlEngine.init_all_engines(pool_size=20, max_overflow=5)
 
     # Initialize EE features based on environment
     set_is_ee_based_on_env_variable()

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -1199,7 +1199,7 @@ def _get_socket_client(
 
 if __name__ == "__main__":
     # Initialize the SqlEngine
-    SqlEngine.init_engine(pool_size=20, max_overflow=5)
+    SqlEngine.init_all_engines(pool_size=20, max_overflow=5)
 
     # Initialize the tenant handler which will manage tenant connections
     logger.info("Starting SlackbotHandler")

--- a/backend/scripts/warm_tenant_host_cache.py
+++ b/backend/scripts/warm_tenant_host_cache.py
@@ -1,0 +1,32 @@
+"""One-time script to warm the Redis tenant→host cache.
+
+Iterates every configured Postgres host, discovers tenant schemas via
+information_schema.schemata, and writes ``tenant_host:{tenant_id}`` = host_index
+into Redis for each.  This avoids a thundering herd of control-plane calls
+when multi-host routing is first enabled.
+
+Usage:
+    python scripts/warm_tenant_host_cache.py
+"""
+
+from onyx.db.engine.sql_engine import SqlEngine
+from onyx.db.engine.tenant_host_mapping import warm_tenant_host_cache
+from onyx.db.engine.tenant_utils import get_tenant_ids_by_host
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def main() -> None:
+    SqlEngine.init_all_engines(pool_size=5, max_overflow=2)
+
+    by_host = get_tenant_ids_by_host()
+    for host_index, tenants in by_host.items():
+        logger.info(f"Host {host_index}: {len(tenants)} tenants")
+
+    count = warm_tenant_host_cache(by_host)
+    logger.info(f"Done — wrote {count} Redis entries")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/onyx/db/engine/test_tenant_host_mapping.py
+++ b/backend/tests/unit/onyx/db/engine/test_tenant_host_mapping.py
@@ -1,0 +1,237 @@
+"""Unit tests for tenant host mapping / routing logic.
+
+These tests mock Redis and the control plane — no external services required.
+"""
+
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.db.engine.tenant_host_mapping import _lru_get_host_index
+from onyx.db.engine.tenant_host_mapping import compute_host_index
+from onyx.db.engine.tenant_host_mapping import get_host_index_for_tenant
+from onyx.db.engine.tenant_host_mapping import get_host_index_from_redis
+from onyx.db.engine.tenant_host_mapping import REDIS_TENANT_HOST_KEY_PREFIX
+
+
+# ── compute_host_index ─────────────────────────────────────────────
+
+
+class TestComputeHostIndex:
+    """Tests for the pure cutoff-bisect function."""
+
+    def setup_method(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS", [])
+    def test_no_cutoffs_always_zero(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        assert compute_host_index(datetime(2020, 1, 1, tzinfo=timezone.utc)) == 0
+        assert compute_host_index(datetime(2099, 1, 1, tzinfo=timezone.utc)) == 0
+
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_single_cutoff_before(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        dt = datetime(2026, 3, 15, tzinfo=timezone.utc)
+        assert compute_host_index(dt) == 0
+
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_single_cutoff_after(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        dt = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        assert compute_host_index(dt) == 1
+
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_single_cutoff_exact_boundary(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        dt = datetime(2026, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+        # bisect_right: equal goes right → host 1
+        assert compute_host_index(dt) == 1
+
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-01-01T00:00:00Z", "2026-06-01T00:00:00Z"],
+    )
+    def test_two_cutoffs_middle(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        assert compute_host_index(datetime(2025, 6, 1, tzinfo=timezone.utc)) == 0
+        assert compute_host_index(datetime(2026, 3, 1, tzinfo=timezone.utc)) == 1
+        assert compute_host_index(datetime(2026, 9, 1, tzinfo=timezone.utc)) == 2
+
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        dt = datetime(2026, 3, 15)
+        assert compute_host_index(dt) == 0
+
+
+# ── get_host_index_for_tenant ──────────────────────────────────────
+
+
+class TestGetHostIndexForTenant:
+    """Tests for the full resolution chain: LRU → Redis → CP."""
+
+    def setup_method(self) -> None:
+        _lru_get_host_index.cache_clear()
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", False)
+    def test_single_tenant_always_zero(self) -> None:
+        assert get_host_index_for_tenant("public") == 0
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0"])
+    def test_single_host_always_zero(self) -> None:
+        assert get_host_index_for_tenant("tenant_abc") == 0
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0", "host1"])
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_redis_hit(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        _lru_get_host_index.cache_clear()
+
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = b"1"
+
+        with patch(
+            "onyx.redis.redis_pool.get_raw_redis_client",
+            return_value=mock_redis,
+        ):
+            assert get_host_index_for_tenant("tenant_123") == 1
+            mock_redis.get.assert_called_once_with(
+                f"{REDIS_TENANT_HOST_KEY_PREFIX}tenant_123"
+            )
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0", "host1"])
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_redis_miss_calls_cp(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        _lru_get_host_index.cache_clear()
+
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+
+        cp_created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+        with (
+            patch(
+                "onyx.redis.redis_pool.get_raw_redis_client",
+                return_value=mock_redis,
+            ),
+            patch(
+                "onyx.db.engine.tenant_host_mapping._fetch_created_at_from_control_plane",
+                return_value=cp_created_at,
+            ),
+        ):
+            result = get_host_index_for_tenant("tenant_new")
+            assert result == 1
+
+            mock_redis.set.assert_called_once_with(
+                f"{REDIS_TENANT_HOST_KEY_PREFIX}tenant_new", "1"
+            )
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0", "host1"])
+    @patch(
+        "onyx.db.engine.tenant_host_mapping.POSTGRES_HOST_CUTOFFS",
+        ["2026-04-01T00:00:00Z"],
+    )
+    def test_cp_unreachable_raises(self) -> None:
+        import onyx.db.engine.tenant_host_mapping as mod
+
+        mod._PARSED_CUTOFFS = None
+        _lru_get_host_index.cache_clear()
+
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+
+        with (
+            patch(
+                "onyx.redis.redis_pool.get_raw_redis_client",
+                return_value=mock_redis,
+            ),
+            patch(
+                "onyx.db.engine.tenant_host_mapping._fetch_created_at_from_control_plane",
+                side_effect=Exception("CP down"),
+            ),
+        ):
+            with pytest.raises(Exception, match="CP down"):
+                get_host_index_for_tenant("tenant_unreachable")
+
+
+# ── get_host_index_from_redis ─────────────────────────────────────
+
+
+class TestGetHostIndexFromRedis:
+    """Tests for the Redis-only lookup (no CP fallback)."""
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", False)
+    def test_single_tenant_returns_zero(self) -> None:
+        assert get_host_index_from_redis("anything") == 0
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0"])
+    def test_single_host_returns_zero(self) -> None:
+        assert get_host_index_from_redis("tenant_x") == 0
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0", "host1"])
+    def test_redis_hit_returns_value(self) -> None:
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = b"1"
+        with patch(
+            "onyx.redis.redis_pool.get_raw_redis_client",
+            return_value=mock_redis,
+        ):
+            assert get_host_index_from_redis("tenant_pool") == 1
+
+    @patch("onyx.db.engine.tenant_host_mapping.MULTI_TENANT", True)
+    @patch("onyx.db.engine.tenant_host_mapping.POSTGRES_HOSTS", ["host0", "host1"])
+    def test_redis_miss_returns_none(self) -> None:
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+        with patch(
+            "onyx.redis.redis_pool.get_raw_redis_client",
+            return_value=mock_redis,
+        ):
+            assert get_host_index_from_redis("tenant_unknown") is None


### PR DESCRIPTION
## Description

Adds support for connecting to different RDS hosts in the cloud. Unfortunately the current approach doesn't scale well as tenants increase, so as a stopgap we need to allow new tenants to be created on a new RDS instance. 

## How Has This Been Tested?

new tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-RDS support for cloud by running one engine per Postgres host and routing each tenant to its host. Adds a Redis-backed tenant→host lookup with control-plane fallback; migrations, sessions, and workers are now host-aware.

- **New Features**
  - Multi-host engines: `SqlEngine.init_all_engines` (and async) create per-host engines; pool sizes split across hosts; connection warmup hits every host.
  - Tenant routing: `POSTGRES_HOSTS` and optional `POSTGRES_HOST_CUTOFFS`; runtime resolution uses LRU/Redis (`tenant_host:{tenant_id}`) with control-plane fallback; public schema always on host index 0.
  - Migrations & provisioning: Alembic envs iterate hosts for `-x upgrade_all_tenants=true`; specific-schema runs target the correct host via `sqlalchemy.url`; schema tools accept `host_index`; provisioning/pre-provisioning compute a host, create the schema there, seed Redis, run migrations; rollback drops schema on the right host.
  - Background jobs: all Celery apps, bots, and indexing workers initialize engines for all hosts.
  - Utility: `scripts/warm_tenant_host_cache.py` seeds Redis by discovering tenants on each host.

- **Migration**
  - Set `POSTGRES_HOSTS` (comma-separated) and, if splitting by time, `POSTGRES_HOST_CUTOFFS` (ISO-8601; length = hosts − 1). Ensure host 0 is the catalog/public host.
  - Run `python scripts/warm_tenant_host_cache.py` once to prefill Redis tenant→host mappings.
  - Redeploy and restart workers. Run Alembic with `-x upgrade_all_tenants=true` to migrate tenant schemas across all hosts.

<sup>Written for commit 140c62779d6c38142bb53e63c567a01af868f926. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

