### PR TITLE
fix(chat): loss of attachments on message edit/regeneration

### DIFF
--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1099,11 +1099,17 @@ export default function useChatController({
               ];
             } else {
               messagesToUpsertInLoop = [
-                {
-                  ...initialUserNode,
-                  messageId: newUserMessageId ?? undefined,
-                  files: files,
-                },
+                // Regeneration reuses the existing user node. Re-upserting a
+                // stale copy here can wipe attachments from the latest tree snapshot.
+                ...(!regenerationRequest
+                  ? [
+                      {
+                        ...initialUserNode,
+                        messageId: newUserMessageId ?? undefined,
+                        files: files,
+                      },
+                    ]
+                  : []),
                 {
                   ...initialAgentNode,
                   messageId: newAgentMessageId ?? undefined,
@@ -1150,16 +1156,20 @@ export default function useChatController({
       } catch (e: any) {
         console.log("Error:", e);
         const errorMsg = e.message;
-        const userErrorNode: Message = {
-          nodeId: initialUserNode.nodeId,
-          message: currMessage,
-          type: "user",
-          files: effectiveFileDescriptors,
-          toolCall: null,
-          parentNodeId: parentMessage?.nodeId || SYSTEM_NODE_ID,
-          packets: [],
-          packetCount: 0,
-        };
+        const userErrorNodes: Message[] = !regenerationRequest
+          ? [
+              {
+                nodeId: initialUserNode.nodeId,
+                message: currMessage,
+                type: "user",
+                files: effectiveFileDescriptors,
+                toolCall: null,
+                parentNodeId: parentMessage?.nodeId || SYSTEM_NODE_ID,
+                packets: [],
+                packetCount: 0,
+              },
+            ]
+          : [];
 
         // In multi-model mode, mark non-errored assistant nodes as errors.
         // Skip models that already have their own per-model error state.
@@ -1193,7 +1203,7 @@ export default function useChatController({
             ];
 
         currentMessageTreeLocal = upsertToCompleteMessageTree({
-          messages: [userErrorNode, ...errorAssistantNodes],
+          messages: [...userErrorNodes, ...errorAssistantNodes],
           completeMessageTreeOverride: currentMessageTreeLocal,
           chatSessionId: frozenSessionId,
         });

--- a/web/tests/e2e/chat/message_edit_regenerate.spec.ts
+++ b/web/tests/e2e/chat/message_edit_regenerate.spec.ts
@@ -1,6 +1,79 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { loginAsRandomUser } from "@tests/e2e/utils/auth";
 import { sendMessage, switchModel } from "@tests/e2e/utils/chatActions";
+
+function buildMockErrorStreamResponse(
+  userMessageId: number,
+  agentMessageId: number,
+  error: string
+): string {
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      error,
+      error_code: "mock_regeneration_failure",
+      is_retryable: true,
+      details: null,
+    },
+  ];
+
+  return `${packets.map((packet) => JSON.stringify(packet)).join("\n")}\n`;
+}
+
+async function uploadTextAttachment(
+  page: Page,
+  fileName: string,
+  fileContent: string
+): Promise<void> {
+  const fileInput = page.locator('input[type="file"]').first();
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await fileInput.dispatchEvent("click");
+  const fileChooser = await fileChooserPromise;
+
+  const uploadResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/user/projects/file/upload") &&
+      response.request().method() === "POST"
+  );
+
+  await fileChooser.setFiles({
+    name: fileName,
+    mimeType: "text/plain",
+    buffer: Buffer.from(fileContent, "utf-8"),
+  });
+
+  const uploadResponse = await uploadResponsePromise;
+  expect(uploadResponse.ok()).toBeTruthy();
+
+  await page.waitForLoadState("networkidle", { timeout: 10000 });
+  await expect(page.getByText(fileName).first()).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+async function selectModelFromRegenerateDialog(page: Page): Promise<void> {
+  await page.waitForSelector('[role="dialog"]', {
+    state: "visible",
+    timeout: 10000,
+  });
+
+  const dialog = page.locator('[role="dialog"]');
+  const alternateOptions = dialog.locator('[data-selected="false"]');
+
+  if ((await alternateOptions.count()) > 0) {
+    await alternateOptions.first().click();
+  } else {
+    await dialog.locator("[data-selected]").first().click();
+  }
+
+  await page.waitForSelector('[role="dialog"]', {
+    state: "hidden",
+    timeout: 10000,
+  });
+}
 
 test.describe("Message Edit and Regenerate Tests", () => {
   test.beforeEach(async ({ page }) => {
@@ -213,6 +286,100 @@ test.describe("Message Edit and Regenerate Tests", () => {
     switcherSpan = page.getByTestId("MessageSwitcher/container").first();
     await expect(switcherSpan).toBeVisible({ timeout: 5000 });
     await expect(switcherSpan).toContainText("2/2");
+  });
+
+  test("Message regeneration with files preserves attachments", async ({
+    page,
+  }) => {
+    const testFileName = `test-regen-${Date.now()}.txt`;
+    const testFileContent =
+      "This is a test file for regeneration attachment persistence.";
+
+    await uploadTextAttachment(page, testFileName, testFileContent);
+    await sendMessage(page, "Summarize this file");
+    await page.waitForSelector('[data-testid="AgentMessage/copy-button"]', {
+      state: "visible",
+      timeout: 30000,
+    });
+
+    const humanMessage = page.locator("#onyx-human-message").first();
+    const fileDisplay = humanMessage.locator("#onyx-file").first();
+    await expect(fileDisplay).toBeVisible();
+    await expect(fileDisplay.getByText(testFileName)).toBeVisible();
+
+    const aiMessage = page.locator('[data-testid="onyx-ai-message"]').first();
+    await aiMessage.hover();
+    await aiMessage.getByTestId("AgentMessage/regenerate").click();
+    await selectModelFromRegenerateDialog(page);
+
+    const messageSwitcher = page
+      .getByTestId("MessageSwitcher/container")
+      .first();
+    await expect(messageSwitcher).toBeVisible({ timeout: 15000 });
+    await expect(messageSwitcher).toContainText("2/2");
+
+    const regeneratedHumanMessage = page.locator("#onyx-human-message").first();
+    const regeneratedFileDisplay =
+      regeneratedHumanMessage.locator("#onyx-file").first();
+    await expect(regeneratedFileDisplay).toBeVisible();
+    await expect(regeneratedFileDisplay.getByText(testFileName)).toBeVisible();
+  });
+
+  test("Failed regeneration with files preserves attachments", async ({
+    page,
+  }) => {
+    const testFileName = `test-regen-error-${Date.now()}.txt`;
+    const testFileContent =
+      "This is a test file for failed regeneration attachment persistence.";
+    const regenerationError = "Forced regeneration failure";
+
+    await uploadTextAttachment(page, testFileName, testFileContent);
+    await sendMessage(page, "Summarize this file");
+    await page.waitForSelector('[data-testid="AgentMessage/copy-button"]', {
+      state: "visible",
+      timeout: 30000,
+    });
+
+    const humanMessage = page.locator("#onyx-human-message").first();
+    const fileDisplay = humanMessage.locator("#onyx-file").first();
+    await expect(fileDisplay).toBeVisible();
+    await expect(fileDisplay.getByText(testFileName)).toBeVisible();
+
+    await page.route("**/api/chat/send-chat-message", async (route) => {
+      const payload = route.request().postDataJSON() as {
+        parent_message_id: number | null;
+      };
+
+      if (!payload.parent_message_id) {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: buildMockErrorStreamResponse(
+          payload.parent_message_id,
+          payload.parent_message_id + 1000,
+          regenerationError
+        ),
+      });
+    });
+
+    const aiMessage = page.locator('[data-testid="onyx-ai-message"]').first();
+    await aiMessage.hover();
+    await aiMessage.getByTestId("AgentMessage/regenerate").click();
+    await selectModelFromRegenerateDialog(page);
+
+    await expect(page.getByText(regenerationError)).toBeVisible({
+      timeout: 15000,
+    });
+
+    const regeneratedHumanMessage = page.locator("#onyx-human-message").first();
+    const regeneratedFileDisplay =
+      regeneratedHumanMessage.locator("#onyx-file").first();
+    await expect(regeneratedFileDisplay).toBeVisible();
+    await expect(regeneratedFileDisplay.getByText(testFileName)).toBeVisible();
   });
 
   test("Message editing with files", async ({ page }) => {

--- a/web/tests/e2e/chat/message_edit_regenerate.spec.ts
+++ b/web/tests/e2e/chat/message_edit_regenerate.spec.ts
@@ -319,8 +319,9 @@ test.describe("Message Edit and Regenerate Tests", () => {
     await expect(messageSwitcher).toContainText("2/2");
 
     const regeneratedHumanMessage = page.locator("#onyx-human-message").first();
-    const regeneratedFileDisplay =
-      regeneratedHumanMessage.locator("#onyx-file").first();
+    const regeneratedFileDisplay = regeneratedHumanMessage
+      .locator("#onyx-file")
+      .first();
     await expect(regeneratedFileDisplay).toBeVisible();
     await expect(regeneratedFileDisplay.getByText(testFileName)).toBeVisible();
   });
@@ -376,8 +377,9 @@ test.describe("Message Edit and Regenerate Tests", () => {
     });
 
     const regeneratedHumanMessage = page.locator("#onyx-human-message").first();
-    const regeneratedFileDisplay =
-      regeneratedHumanMessage.locator("#onyx-file").first();
+    const regeneratedFileDisplay = regeneratedHumanMessage
+      .locator("#onyx-file")
+      .first();
     await expect(regeneratedFileDisplay).toBeVisible();
     await expect(regeneratedFileDisplay.getByText(testFileName)).toBeVisible();
   });


### PR DESCRIPTION
## Description

For a while, regeneration has caused attachments to become "lost." Meaning that they 1) no longer show in the UI but seem to still be readable if a regeneration was requested, not an edit. 2) If you edit the message with the attachment, the attachment seems to be essentially "deleted" and the LLM cannot see it unless you go to the original branch.

This patch resolves the core issue: during a regeneration, the user message is overwritten with a copy of itself by the frontend but lacking any attachments (the backend already seems to reuse the user message so frontend behavior just looks misaligned with backend.) Since files aren't included in that latest write they essentially get permanently unlinked from the chat on all future branches. We now avoid this by only updating the new assistant message and not overwriting the user message, fixing the issue.

## How Has This Been Tested?

Manually and with a new playwright test. The playwright test fails on main and succeeds with this PR.

Problem demo: https://github.com/user-attachments/assets/ddc84d1d-cdfa-4a47-9f3f-5014fb5a0171
Fixed: https://github.com/user-attachments/assets/4d74656c-86cd-4518-839e-7a3af17942a5

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost attachments when regenerating or editing messages by reusing the existing user message so files stay linked and visible to the model.

- **Bug Fixes**
  - On `regenerationRequest`, skip re-upserting the user node (including error paths) and only upsert the assistant node, preventing attachments from being wiped from the latest tree snapshot.
  - Added Playwright tests to verify attachments persist on regeneration, including failed regeneration.

<sup>Written for commit c7659e9d326b5e701d7a3186d3f027c0b327d683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

