### PR TITLE
fix(indexing): reset stall tracking when attempts start

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -243,6 +243,11 @@ def transition_attempt_to_in_progress(
 
         attempt.status = IndexingStatus.IN_PROGRESS
         attempt.time_started = attempt.time_started or func.now()  # type: ignore
+        # Reset stall tracking so time spent scheduled does not count against active work.
+        attempt.last_progress_time = None
+        attempt.last_batches_completed_count = 0
+        attempt.last_heartbeat_time = None
+        attempt.last_heartbeat_value = attempt.heartbeat_counter or 0
         db_session.commit()
         return attempt
     except Exception:

--- a/backend/tests/unit/onyx/db/test_index_attempt_progress.py
+++ b/backend/tests/unit/onyx/db/test_index_attempt_progress.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.db.enums import IndexingStatus
+from onyx.db.index_attempt import transition_attempt_to_in_progress
+from onyx.db.indexing_coordination import IndexingCoordination
+
+
+class _ScalarOneResult:
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def scalar_one(self) -> object:
+        return self._value
+
+
+def test_transition_attempt_to_in_progress_resets_stall_tracking() -> None:
+    old_time = datetime.now(timezone.utc) - timedelta(hours=7)
+    attempt = SimpleNamespace(
+        status=IndexingStatus.NOT_STARTED,
+        time_started=None,
+        last_progress_time=old_time,
+        last_batches_completed_count=3,
+        heartbeat_counter=11,
+        last_heartbeat_time=old_time,
+        last_heartbeat_value=5,
+    )
+    db_session = MagicMock()
+    db_session.execute.return_value = _ScalarOneResult(attempt)
+
+    result = transition_attempt_to_in_progress(17, db_session)
+
+    assert result is attempt
+    assert attempt.status == IndexingStatus.IN_PROGRESS
+    assert attempt.time_started is not None
+    assert attempt.last_progress_time is None
+    assert attempt.last_batches_completed_count == 0
+    assert attempt.last_heartbeat_time is None
+    assert attempt.last_heartbeat_value == 11
+    db_session.commit.assert_called_once()
+
+
+def test_update_progress_tracking_treats_reset_attempt_as_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(timezone.utc)
+    attempt = SimpleNamespace(
+        last_progress_time=now - timedelta(hours=7),
+        last_batches_completed_count=0,
+    )
+    db_session = MagicMock()
+
+    monkeypatch.setattr(
+        "onyx.db.indexing_coordination.get_index_attempt",
+        lambda _db_session, _attempt_id: attempt,
+    )
+    monkeypatch.setattr(
+        "onyx.db.indexing_coordination.get_db_current_time",
+        lambda _db_session: now,
+    )
+
+    assert (
+        IndexingCoordination.update_progress_tracking(
+            db_session,
+            index_attempt_id=17,
+            current_batches_completed=0,
+            timeout_hours=6,
+        )
+        is False
+    )
+
+    attempt.last_progress_time = None
+
+    assert (
+        IndexingCoordination.update_progress_tracking(
+            db_session,
+            index_attempt_id=17,
+            current_batches_completed=0,
+            timeout_hours=6,
+        )
+        is True
+    )
+    assert attempt.last_progress_time == now
+    assert attempt.last_batches_completed_count == 0
+    db_session.commit.assert_called_once()


### PR DESCRIPTION
## Description

This is part 2 of our indexing fixes (see https://github.com/onyx-dot-app/onyx/pull/10105.) Both of these should be merged to resolve the random `Stalled indexing` behavior.

This fix is more simple and addresses a design issue: if a connector is queued for longer than the stall threshold, it can be marked `Stalled` indexing almost immediately after real work begins. This doesn't make much sense because the connector itself is already in the middle of being indexed. Unless this is intentional, this is caused by queued time being treated as active work time, which makes the connector subject to the default 6 hour timeout before a Stall status is automatically set. To fix this we simply reset the stall-tracking fields (when the attempt transitions to `IN_PROGRESS`) to 0.

## How Has This Been Tested?

Unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false “Stalled indexing” by resetting stall tracking when an indexing attempt starts. Stall time now only counts during active work, not while queued.

- **Bug Fixes**
  - On transition to `IN_PROGRESS`, clear `last_progress_time`, `last_batches_completed_count`, `last_heartbeat_time`, and set `last_heartbeat_value` to the current `heartbeat_counter`.
  - Added unit tests to verify reset on start and that progress tracking treats a reset attempt as fresh.

<sup>Written for commit 0347364e1c4f663d42454ddea0f8e8d7c9d6faf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

