### PR TITLE
fix: use contextual RAG LLM for image summarization

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -71,6 +71,7 @@ from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LLMRateLimitError
 from onyx.llm.utils import llm_response_to_string
 from onyx.llm.utils import MAX_CONTEXT_TOKENS
+from onyx.llm.utils import model_supports_image_input
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.natural_language_processing.utils import tokenizer_trim_middle
@@ -509,7 +510,9 @@ def filter_documents(document_batch: list[Document]) -> list[Document]:
     return documents
 
 
-def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
+def process_image_sections(
+    documents: list[Document], llm: LLM | None = None
+) -> list[IndexingDocument]:
     """
     Process all sections in documents by:
     1. Converting both TextSection and ImageSection objects to base Section objects
@@ -518,15 +521,24 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
 
     Args:
         documents: List of documents with TextSection | ImageSection objects
+        llm: LLM to use for image summarization. If not provided, falls back to
+             the default vision-capable LLM.
 
     Returns:
         List of IndexingDocument objects with processed_sections as list[Section]
     """
-    # Check if image extraction and analysis is enabled before trying to get a vision LLM
     if not get_image_extraction_and_analysis_enabled():
         llm = None
-    else:
-        # Only get the vision LLM if image processing is enabled
+    elif llm is not None and not model_supports_image_input(
+        llm.config.model_name, llm.config.model_provider
+    ):
+        # Configured LLM lacks vision — fall back to default vision model
+        logger.warning(
+            "Model '%s' does not support vision, falling back to default vision model",
+            llm.config.model_name,
+        )
+        llm = get_default_llm_with_vision()
+    elif llm is None:
         llm = get_default_llm_with_vision()
 
     if not llm:
@@ -962,7 +974,7 @@ def index_doc_batch(
 
     # Convert documents to IndexingDocument objects with processed section
     # logger.debug("Processing image sections")
-    context.indexable_docs = process_image_sections(context.updatable_docs)
+    context.indexable_docs = process_image_sections(context.updatable_docs, llm=llm)
 
     doc_descriptors = [
         {


### PR DESCRIPTION
## Description

process_image_sections() in backend/onyx/indexing/indexing_pipeline.py always called get_default_llm_with_vision() internally, ignoring the contextual RAG LLM configured in search_settings.contextual_rag_llm_name / contextual_rag_llm_provider.

The indexing pipeline already resolves the contextual RAG LLM and passes it as llm into index_doc_batch, but process_image_sections had no way to receive it. It fetched its own LLM independently. This caused users who configured a specific model for contextual RAG to silently get a different (in our case more expensive) model used for image summarization.

Fix: process_image_sections now accepts an optional llm parameter. When called from index_doc_batch, the contextual RAG LLM is passed through. Falls back to get_default_llm_with_vision() if no LLM is provided (e.g. contextual RAG disabled).

## How Has This Been Tested?

Manually, enabled Contextual RAG with a specific LLM (gpt-4.1-mini), indexed a PDF containing images, and confirmed in openai console that image summarization used the configured model instead of the default.

## Additional Options
- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

btw: in our case, no model was set as the default vision model in the llm_model_flow table. It seems the frontend does not pass any model there. Our default LLM is configured via {onyx}/admin/configuration/llm. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the configured contextual RAG LLM for image summarization during indexing, instead of always using the default vision model. This respects `search_settings` and avoids unexpected, more expensive models.

- **Bug Fixes**
  - `process_image_sections()` now accepts an optional `llm` and is called from `index_doc_batch()` with the resolved contextual RAG LLM.
  - Falls back to the default vision LLM only when image analysis is disabled or the provided LLM lacks vision support (with a warning).
  - Added `model_supports_image_input` check to ensure the selected model can handle images.

<sup>Written for commit 11be72a0bc4690ebd5ba720fb7679ff840a62539. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

