### PR TITLE
chore(indexing): remove multilingual_expansion from search settings

### DIFF
--- a/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
+++ b/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
@@ -1,7 +1,7 @@
 """remove multilingual_expansion from search_settings
 
 Revision ID: a7c3e2b1d4f8
-Revises: a6fcd3d631f9
+Revises: 856bcbe14d79
 Create Date: 2026-04-16
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "a7c3e2b1d4f8"
-down_revision = "a6fcd3d631f9"
+down_revision = "856bcbe14d79"
 branch_labels: None = None
 depends_on: None = None
 

--- a/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
+++ b/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
@@ -1,0 +1,33 @@
+"""remove multilingual_expansion from search_settings
+
+Revision ID: a7c3e2b1d4f8
+Revises: d129f37b3d87
+Create Date: 2026-04-16
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a7c3e2b1d4f8"
+down_revision = "d129f37b3d87"
+branch_labels: None = None
+depends_on: None = None
+
+
+def upgrade() -> None:
+    op.drop_column("search_settings", "multilingual_expansion")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "search_settings",
+        sa.Column(
+            "multilingual_expansion",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )

--- a/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
+++ b/backend/alembic/versions/a7c3e2b1d4f8_remove_multilingual_expansion_from_search_settings.py
@@ -1,7 +1,7 @@
 """remove multilingual_expansion from search_settings
 
 Revision ID: a7c3e2b1d4f8
-Revises: d129f37b3d87
+Revises: a6fcd3d631f9
 Create Date: 2026-04-16
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "a7c3e2b1d4f8"
-down_revision = "d129f37b3d87"
+down_revision = "a6fcd3d631f9"
 branch_labels: None = None
 depends_on: None = None
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2100,10 +2100,6 @@ class SearchSettings(Base):
         String, nullable=True
     )
 
-    multilingual_expansion: Mapped[list[str]] = mapped_column(
-        postgresql.ARRAY(String), default=[]
-    )
-
     cloud_provider: Mapped["CloudEmbeddingProvider"] = relationship(
         "CloudEmbeddingProvider",
         back_populates="search_settings",

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from onyx.configs.model_configs import DEFAULT_DOCUMENT_ENCODER_MODEL
 from onyx.configs.model_configs import DOCUMENT_ENCODER_MODEL
 from onyx.context.search.models import SavedSearchSettings
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.llm import fetch_embedding_provider
 from onyx.db.models import CloudEmbeddingProvider
 from onyx.db.models import IndexAttempt
@@ -175,17 +174,6 @@ def get_all_search_settings(db_session: Session) -> list[SearchSettings]:
     result = db_session.execute(query)
     all_settings = result.scalars().all()
     return list(all_settings)
-
-
-def get_multilingual_expansion(db_session: Session | None = None) -> list[str]:
-    if db_session is None:
-        with get_session_with_current_tenant() as db_session:
-            search_settings = get_current_search_settings(db_session)
-    else:
-        search_settings = get_current_search_settings(db_session)
-    if not search_settings:
-        return []
-    return search_settings.multilingual_expansion
 
 
 def update_search_settings(

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -108,12 +108,6 @@ def setup_onyx(
         logger.notice(f'Query embedding prefix: "{search_settings.query_prefix}"')
         logger.notice(f'Passage embedding prefix: "{search_settings.passage_prefix}"')
 
-    if search_settings:
-        if search_settings.multilingual_expansion:
-            logger.notice(
-                f"Multilingual query expansion is enabled with {search_settings.multilingual_expansion}."
-            )
-
     # setup Postgres with default credential, llm providers, etc.
     setup_postgres(db_session)
 

--- a/web/src/app/admin/embeddings/interfaces.ts
+++ b/web/src/app/admin/embeddings/interfaces.ts
@@ -44,7 +44,6 @@ export interface AdvancedSearchConfiguration {
   enable_contextual_rag: boolean;
   contextual_rag_llm_name: string | null;
   contextual_rag_llm_provider: string | null;
-  multilingual_expansion: string[];
   disable_rerank_for_streaming: boolean;
   api_url: string | null;
   num_rerank: number;

--- a/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/AdvancedEmbeddingFormPage.tsx
@@ -101,7 +101,6 @@ const AdvancedEmbeddingFormPage = forwardRef<
             contextual_rag_llm: getCurrentLLMValue,
           }}
           validationSchema={Yup.object().shape({
-            multilingual_expansion: Yup.array().of(Yup.string()),
             multipass_indexing: Yup.boolean(),
             enable_contextual_rag: Yup.boolean(),
             contextual_rag_llm: Yup.string()
@@ -169,7 +168,6 @@ const AdvancedEmbeddingFormPage = forwardRef<
                 // Manually validate against the schema
                 Yup.object()
                   .shape({
-                    multilingual_expansion: Yup.array().of(Yup.string()),
                     multipass_indexing: Yup.boolean(),
                     enable_contextual_rag: Yup.boolean(),
                     contextual_rag_llm: Yup.string()

--- a/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
+++ b/web/src/app/admin/embeddings/pages/EmbeddingFormPage.tsx
@@ -53,7 +53,6 @@ export default function EmbeddingForm() {
       enable_contextual_rag: false,
       contextual_rag_llm_name: null,
       contextual_rag_llm_provider: null,
-      multilingual_expansion: [],
       disable_rerank_for_streaming: false,
       api_url: null,
       num_rerank: 0,
@@ -144,7 +143,6 @@ export default function EmbeddingForm() {
         enable_contextual_rag: searchSettings.enable_contextual_rag,
         contextual_rag_llm_name: searchSettings.contextual_rag_llm_name,
         contextual_rag_llm_provider: searchSettings.contextual_rag_llm_provider,
-        multilingual_expansion: searchSettings.multilingual_expansion,
         disable_rerank_for_streaming:
           searchSettings.disable_rerank_for_streaming,
         num_rerank: searchSettings.num_rerank,


### PR DESCRIPTION
## Description

Remove the unused `multilingual_expansion` field from `SearchSettings`. The column exists in the DB but is not exposed via `SavedSearchSettings` (the API model), and `get_multilingual_expansion()` is never called anywhere in the codebase — it's dead code.

**Changes:**
- Drop `multilingual_expansion` column from `search_settings` table (new alembic migration `a7c3e2b1d4f8`)
- Remove field from `SearchSettings` ORM model in `backend/onyx/db/models.py`
- Remove unused `get_multilingual_expansion()` helper from `backend/onyx/db/search_settings.py`
- Remove multilingual expansion logging block from `backend/onyx/setup.py`

Linear: [ENG-4028](https://linear.app/onyx-app/issue/ENG-4028)

## How Has This Been Tested?

- [ ] \`alembic upgrade head\` applies cleanly
- [ ] \`alembic downgrade -1 && alembic upgrade head\` round-trips cleanly
- [ ] Backend imports cleanly
- [ ] Unit tests pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check