### PR TITLE
chore(indexing): remove unstructured admin API endpoints

### DIFF
--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -27,9 +27,6 @@ from onyx.db.search_settings import update_current_search_settings
 from onyx.db.search_settings import update_search_settings_status
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.factory import get_default_document_index
-from onyx.file_processing.unstructured import delete_unstructured_api_key
-from onyx.file_processing.unstructured import get_unstructured_api_key
-from onyx.file_processing.unstructured import update_unstructured_api_key
 from onyx.natural_language_processing.search_nlp_models import clean_model_name
 from onyx.server.manage.embedding.models import SearchSettingsDeleteRequest
 from onyx.server.manage.models import FullModelVersionResponse
@@ -259,29 +256,6 @@ def update_saved_search_settings(
 
     # Re-sync default to match PRESENT search settings
     _sync_default_contextual_model(db_session)
-
-
-@router.get("/unstructured-api-key-set")
-def unstructured_api_key_set(
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
-) -> bool:
-    api_key = get_unstructured_api_key()
-    return api_key is not None
-
-
-@router.put("/upsert-unstructured-api-key")
-def upsert_unstructured_api_key(
-    unstructured_api_key: str,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
-) -> None:
-    update_unstructured_api_key(unstructured_api_key)
-
-
-@router.delete("/delete-unstructured-api-key")
-def delete_unstructured_api_key_endpoint(
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
-) -> None:
-    delete_unstructured_api_key()
 
 
 def validate_contextual_rag_model(


### PR DESCRIPTION
## Description

Remove the 3 admin API endpoints for managing the Unstructured API key. These endpoints powered the "Document Processing" admin page, which is being removed as part of the indexing settings simplification (ENG-3972).

**Changes:**
- Remove \`GET /search-settings/unstructured-api-key-set\`
- Remove \`PUT /search-settings/upsert-unstructured-api-key\`
- Remove \`DELETE /search-settings/delete-unstructured-api-key\`
- Remove associated imports from \`onyx.file_processing.unstructured\`

Linear: [ENG-4029](https://linear.app/onyx-app/issue/ENG-4029)

## How Has This Been Tested?

- [ ] Existing Unstructured API keys in the KV store still work during indexing (pipeline path unchanged)
- [ ] UI removal (ENG-3972) has shipped before merging this

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check