### PR TITLE
chore(indexing): default embedding_precision to FLOAT

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -126,25 +126,28 @@ _BASE_EMBEDDING_MODELS = [
 
 # Automatically generate both FLOAT and BFLOAT16 versions of all models
 SUPPORTED_EMBEDDING_MODELS = [
-    # BFLOAT16 precision versions
-    *[
-        SupportedEmbeddingModel(
-            name=model.name,
-            dim=model.dim,
-            index_name=f"{model.index_name}_bfloat16",
-            embedding_precision=EmbeddingPrecision.BFLOAT16,
-        )
-        for model in _BASE_EMBEDDING_MODELS
-    ],
     # FLOAT precision versions
-    # NOTE: need to keep this one for backwards compatibility. We now default to
-    # BFLOAT16.
+    # NOTE: FLOAT (float32) is the default. OpenSearch (the target document
+    # index) ignores embedding_precision and stores vectors as float32
+    # regardless.
     *[
         SupportedEmbeddingModel(
             name=model.name,
             dim=model.dim,
             index_name=model.index_name,
             embedding_precision=EmbeddingPrecision.FLOAT,
+        )
+        for model in _BASE_EMBEDDING_MODELS
+    ],
+    # BFLOAT16 precision versions
+    # NOTE: kept for backwards compatibility with existing Vespa deployments
+    # that configured BFLOAT16 for memory savings.
+    *[
+        SupportedEmbeddingModel(
+            name=model.name,
+            dim=model.dim,
+            index_name=f"{model.index_name}_bfloat16",
+            embedding_precision=EmbeddingPrecision.BFLOAT16,
         )
         for model in _BASE_EMBEDDING_MODELS
     ],

--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -127,8 +127,6 @@ _BASE_EMBEDDING_MODELS = [
 # Automatically generate both FLOAT and BFLOAT16 versions of all models
 SUPPORTED_EMBEDDING_MODELS = [
     # BFLOAT16 precision versions
-    # NOTE: kept for backwards compatibility with existing Vespa deployments
-    # that configured BFLOAT16 for memory savings.
     *[
         SupportedEmbeddingModel(
             name=model.name,
@@ -139,9 +137,8 @@ SUPPORTED_EMBEDDING_MODELS = [
         for model in _BASE_EMBEDDING_MODELS
     ],
     # FLOAT precision versions
-    # NOTE: FLOAT (float32) is the default. OpenSearch (the target document
-    # index) ignores embedding_precision and stores vectors as float32
-    # regardless.
+    # NOTE: need to keep this one for backwards compatibility. We now default to
+    # BFLOAT16.
     *[
         SupportedEmbeddingModel(
             name=model.name,

--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -126,6 +126,18 @@ _BASE_EMBEDDING_MODELS = [
 
 # Automatically generate both FLOAT and BFLOAT16 versions of all models
 SUPPORTED_EMBEDDING_MODELS = [
+    # BFLOAT16 precision versions
+    # NOTE: kept for backwards compatibility with existing Vespa deployments
+    # that configured BFLOAT16 for memory savings.
+    *[
+        SupportedEmbeddingModel(
+            name=model.name,
+            dim=model.dim,
+            index_name=f"{model.index_name}_bfloat16",
+            embedding_precision=EmbeddingPrecision.BFLOAT16,
+        )
+        for model in _BASE_EMBEDDING_MODELS
+    ],
     # FLOAT precision versions
     # NOTE: FLOAT (float32) is the default. OpenSearch (the target document
     # index) ignores embedding_precision and stores vectors as float32
@@ -136,18 +148,6 @@ SUPPORTED_EMBEDDING_MODELS = [
             dim=model.dim,
             index_name=model.index_name,
             embedding_precision=EmbeddingPrecision.FLOAT,
-        )
-        for model in _BASE_EMBEDDING_MODELS
-    ],
-    # BFLOAT16 precision versions
-    # NOTE: kept for backwards compatibility with existing Vespa deployments
-    # that configured BFLOAT16 for memory savings.
-    *[
-        SupportedEmbeddingModel(
-            name=model.name,
-            dim=model.dim,
-            index_name=f"{model.index_name}_bfloat16",
-            embedding_precision=EmbeddingPrecision.BFLOAT16,
         )
         for model in _BASE_EMBEDDING_MODELS
     ],

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2075,9 +2075,12 @@ class SearchSettings(Base):
         Enum(SwitchoverType, native_enum=False), default=SwitchoverType.REINDEX
     )
 
-    # allows for quantization -> less memory usage for a small performance hit
+    # allows for quantization -> less memory usage for a small performance hit.
+    # Defaults to FLOAT (float32). OpenSearch ignores this field and stores
+    # vectors as float32 regardless; BFLOAT16 is only honored by Vespa.
     embedding_precision: Mapped[EmbeddingPrecision] = mapped_column(
-        Enum(EmbeddingPrecision, native_enum=False)
+        Enum(EmbeddingPrecision, native_enum=False),
+        default=EmbeddingPrecision.FLOAT,
     )
 
     # can be used to reduce dimensionality of vectors and save memory with

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -189,7 +189,11 @@ class IndexingSetting(EmbeddingModelDetail):
     model_dim: int
     index_name: str | None
     multipass_indexing: bool
-    embedding_precision: EmbeddingPrecision
+    # Defaults to FLOAT (float32). OpenSearch ignores embedding_precision and
+    # stores vectors as float32 regardless — see
+    # onyx/document_index/opensearch/opensearch_document_index.py. BFLOAT16
+    # still works for existing Vespa deployments.
+    embedding_precision: EmbeddingPrecision = EmbeddingPrecision.FLOAT
     reduced_dimension: int | None = None
 
     switchover_type: SwitchoverType = SwitchoverType.REINDEX


### PR DESCRIPTION
## Description

Default \`embedding_precision\` to \`FLOAT\` (float32) instead of \`BFLOAT16\` on newly created \`SearchSettings\` rows.

OpenSearch ignores \`embedding_precision\` entirely. In \`backend/onyx/document_index/opensearch/opensearch_document_index.py\` the parameter is explicitly annotated \`# noqa: ARG002\` and vectors are stored as float32 regardless of the configured precision. Defaulting new rows to BFLOAT16 would create a lie in the DB (claimed BFLOAT16, actually stored as float32). Defaulting to FLOAT makes the DB match reality.

**Changes:**
- \`IndexingSetting.embedding_precision\` in \`backend/onyx/indexing/models.py\` — add default \`EmbeddingPrecision.FLOAT\`
- \`SearchSettings.embedding_precision\` in \`backend/onyx/db/models.py\` — add ORM default \`EmbeddingPrecision.FLOAT\`
- Update comments in \`backend/onyx/configs/embedding_configs.py\` and reorder generated variants so FLOAT is listed first

Linear: [ENG-4026](https://linear.app/onyx-app/issue/ENG-4026)

## How Has This Been Tested?

- [ ] Newly-created \`SearchSettings\` row without explicit \`embedding_precision\` defaults to \`FLOAT\` in the DB
- [ ] Existing rows with \`BFLOAT16\` remain unchanged after deploy
- [ ] Existing search_settings tests pass (fixtures set precision explicitly)
- [ ] Vespa-based tests pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check