### PR TITLE
feat(indexing): Add file_id to Document model

### DIFF
--- a/backend/alembic/versions/91d150c361f6_add_file_id_to_documents.py
+++ b/backend/alembic/versions/91d150c361f6_add_file_id_to_documents.py
@@ -1,7 +1,7 @@
 """Add file_id to documents
 
 Revision ID: 91d150c361f6
-Revises: d129f37b3d87
+Revises: a6fcd3d631f9
 Create Date: 2026-04-16 15:43:30.314823
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "91d150c361f6"
-down_revision = "d129f37b3d87"
+down_revision = "a6fcd3d631f9"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/91d150c361f6_add_file_id_to_documents.py
+++ b/backend/alembic/versions/91d150c361f6_add_file_id_to_documents.py
@@ -1,0 +1,27 @@
+"""Add file_id to documents
+
+Revision ID: 91d150c361f6
+Revises: d129f37b3d87
+Create Date: 2026-04-16 15:43:30.314823
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "91d150c361f6"
+down_revision = "d129f37b3d87"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "document",
+        sa.Column("file_id", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("document", "file_id")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -952,6 +952,7 @@ class Document(Base):
     semantic_id: Mapped[str] = mapped_column(NullFilteredString)
     # First Section's link
     link: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
+    file_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # The updated time is also used as a measure of the last successful state of the doc
     # pulled from the source (to help skip reindexing already updated docs in case of


### PR DESCRIPTION
## Description
Adds a file_id to Document model so that a document can optionally reference a saved file

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional file_id to the Document model to link documents to their source file. Includes an Alembic migration that adds a nullable String column to the document table.

- **Migration**
  - Run `alembic upgrade head` to apply the migration.
  - No backfill needed; the column is nullable.

<sup>Written for commit 90aa10e6987efc8199253ed09e4aeb39669500d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



