### PR TITLE
feat(indexing): Stage file callback for connectors

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -58,6 +58,8 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
 from onyx.file_store.document_batch_storage import get_document_batch_storage
+from onyx.file_store.staging import build_raw_file_callback
+from onyx.file_store.staging import RawFileCallback
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.redis.redis_hierarchy import cache_hierarchy_nodes_batch
@@ -90,6 +92,7 @@ def _get_connector_runner(
     end_time: datetime,
     include_permissions: bool,
     leave_connector_active: bool = LEAVE_CONNECTOR_ACTIVE_ON_INITIALIZATION_FAILURE,
+    raw_file_callback: RawFileCallback | None = None,
 ) -> ConnectorRunner:
     """
     NOTE: `start_time` and `end_time` are only used for poll connectors
@@ -108,6 +111,7 @@ def _get_connector_runner(
             input_type=task,
             connector_specific_config=attempt.connector_credential_pair.connector.connector_specific_config,
             credential=attempt.connector_credential_pair.credential,
+            raw_file_callback=raw_file_callback,
         )
 
         # validate the connector settings
@@ -275,6 +279,12 @@ def run_docfetching_entrypoint(
         f"credentials='{credential_id}'"
     )
 
+    raw_file_callback = build_raw_file_callback(
+        index_attempt_id=index_attempt_id,
+        cc_pair_id=connector_credential_pair_id,
+        tenant_id=tenant_id,
+    )
+
     connector_document_extraction(
         app,
         index_attempt_id,
@@ -282,6 +292,7 @@ def run_docfetching_entrypoint(
         attempt.search_settings_id,
         tenant_id,
         callback,
+        raw_file_callback=raw_file_callback,
     )
 
     logger.info(
@@ -301,6 +312,7 @@ def connector_document_extraction(
     search_settings_id: int,
     tenant_id: str,
     callback: IndexingHeartbeatInterface | None = None,
+    raw_file_callback: RawFileCallback | None = None,
 ) -> None:
     """Extract documents from connector and queue them for indexing pipeline processing.
 
@@ -451,6 +463,7 @@ def connector_document_extraction(
             start_time=window_start,
             end_time=window_end,
             include_permissions=should_fetch_permissions_during_indexing,
+            raw_file_callback=raw_file_callback,
         )
 
         # don't use a checkpoint if we're explicitly indexing from

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -372,6 +372,7 @@ class FileOrigin(str, Enum):
     CONNECTOR_METADATA = "connector_metadata"
     GENERATED_REPORT = "generated_report"
     INDEXING_CHECKPOINT = "indexing_checkpoint"
+    INDEXING_STAGING = "indexing_staging"
     PLAINTEXT_CACHE = "plaintext_cache"
     OTHER = "other"
     QUERY_HISTORY_CSV = "query_history_csv"

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -22,6 +22,7 @@ from onyx.db.credentials import backend_update_credential_json
 from onyx.db.credentials import fetch_credential_by_id
 from onyx.db.enums import AccessType
 from onyx.db.models import Credential
+from onyx.file_store.staging import RawFileCallback
 from shared_configs.contextvars import get_current_tenant_id
 
 
@@ -107,6 +108,7 @@ def instantiate_connector(
     input_type: InputType,
     connector_specific_config: dict[str, Any],
     credential: Credential,
+    raw_file_callback: RawFileCallback | None = None,
 ) -> BaseConnector:
     connector_class = identify_connector_class(source, input_type)
 
@@ -129,6 +131,9 @@ def instantiate_connector(
             backend_update_credential_json(credential, new_credentials, db_session)
 
     connector.set_allow_images(get_image_extraction_and_analysis_enabled())
+
+    if raw_file_callback is not None:
+        connector.set_raw_file_callback(raw_file_callback)
 
     return connector
 

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -15,6 +15,7 @@ from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
+from onyx.file_store.staging import RawFileCallback
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
@@ -41,6 +42,9 @@ class NormalizationResult(BaseModel):
 
 class BaseConnector(abc.ABC, Generic[CT]):
     REDIS_KEY_PREFIX = "da_connector_data:"
+
+    # Optional raw-file persistence hook to save original file
+    raw_file_callback: RawFileCallback | None = None
 
     @abc.abstractmethod
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -87,6 +91,15 @@ class BaseConnector(abc.ABC, Generic[CT]):
     def set_allow_images(self, value: bool) -> None:
         """Implement if the underlying connector wants to skip/allow image downloading
         based on the application level image analysis setting."""
+
+    def set_raw_file_callback(self, callback: RawFileCallback) -> None:
+        """Inject the per-attempt raw-file persistence callback.
+
+        Wired up by the docfetching entrypoint via `instantiate_connector`.
+        Connectors that don't care about persisting raw bytes can ignore this
+        — `raw_file_callback` simply stays `None`.
+        """
+        self.raw_file_callback = callback
 
     @classmethod
     def normalize_url(cls, url: str) -> "NormalizationResult":  # noqa: ARG003

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -10,7 +10,7 @@ logger = setup_logger()
 
 
 # (content, content_type) -> file_id
-RawFileCallback = Callable[[IO, str], str]
+RawFileCallback = Callable[[IO[bytes], str], str]
 
 
 def stage_raw_file(
@@ -53,7 +53,7 @@ def build_raw_file_callback(
         "tenant_id": tenant_id,
     }
 
-    def _callback(content: IO, content_type: str) -> str:
+    def _callback(content: IO[bytes], content_type: str) -> str:
         return stage_raw_file(
             content=content,
             content_type=content_type,

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -1,0 +1,63 @@
+from collections.abc import Callable
+from typing import Any
+from typing import IO
+
+from onyx.configs.constants import FileOrigin
+from onyx.file_store.file_store import get_default_file_store
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# (content, content_type) -> file_id
+RawFileCallback = Callable[[IO, str], str]
+
+
+def stage_raw_file(
+    content: IO,
+    content_type: str,
+    *,
+    metadata: dict[str, Any],
+) -> str:
+    """Persist raw bytes to the file store with FileOrigin.INDEXING_STAGING.
+
+    `metadata` is attached to the file_record so that downstream promotion
+    (in docprocessing) and orphan reaping (TTL janitor) can locate the file
+    by its originating context.
+    """
+    file_store = get_default_file_store()
+    file_id = file_store.save_file(
+        content=content,
+        display_name=None,
+        file_origin=FileOrigin.INDEXING_STAGING,
+        file_type=content_type,
+        file_metadata=metadata,
+    )
+    return file_id
+
+
+def build_raw_file_callback(
+    *,
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+) -> RawFileCallback:
+    """Build a per-attempt callback that connectors can invoke to opt in to
+    raw-file persistence. The closure binds the attempt-level context as the
+    staging metadata so the connector only needs to pass per-call info
+    (bytes, content_type) and gets back a file_id to attach to its Document.
+    """
+    metadata: dict[str, Any] = {
+        "index_attempt_id": index_attempt_id,
+        "cc_pair_id": cc_pair_id,
+        "tenant_id": tenant_id,
+    }
+
+    def _callback(content: IO, content_type: str) -> str:
+        return stage_raw_file(
+            content=content,
+            content_type=content_type,
+            metadata=metadata,
+        )
+
+    return _callback

--- a/backend/tests/external_dependency_unit/file_store/test_staging.py
+++ b/backend/tests/external_dependency_unit/file_store/test_staging.py
@@ -1,0 +1,130 @@
+"""External dependency tests for onyx.file_store.staging.
+
+Exercises the raw-file persistence hook used by the docfetching pipeline
+against a real file store (Postgres + MinIO/S3), since mocking the store
+would defeat the point of verifying that metadata round-trips through
+FileRecord.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import FileOrigin
+from onyx.connectors.interfaces import BaseConnector
+from onyx.db.file_record import delete_filerecord_by_file_id
+from onyx.db.file_record import get_filerecord_by_file_id
+from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.staging import build_raw_file_callback
+from onyx.file_store.staging import stage_raw_file
+
+
+@pytest.fixture(scope="function")
+def cleanup_file_ids(
+    db_session: Session,
+) -> Generator[list[str], None, None]:
+    created: list[str] = []
+    yield created
+    file_store = get_default_file_store()
+    for fid in created:
+        try:
+            file_store.delete_file(fid)
+        except Exception:
+            delete_filerecord_by_file_id(file_id=fid, db_session=db_session)
+            db_session.commit()
+
+
+def test_stage_raw_file_persists_with_origin_and_metadata(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    cleanup_file_ids: list[str],
+) -> None:
+    """stage_raw_file writes a FileRecord with INDEXING_STAGING origin and
+    round-trips the provided metadata verbatim."""
+    metadata: dict[str, Any] = {
+        "index_attempt_id": 42,
+        "cc_pair_id": 7,
+        "tenant_id": "tenant-abc",
+        "extra": "payload",
+    }
+    content_bytes = b"hello raw file"
+    content_type = "application/pdf"
+
+    file_id = stage_raw_file(
+        content=BytesIO(content_bytes),
+        content_type=content_type,
+        metadata=metadata,
+    )
+    cleanup_file_ids.append(file_id)
+    db_session.commit()
+
+    record = get_filerecord_by_file_id(file_id=file_id, db_session=db_session)
+    assert record.file_origin == FileOrigin.INDEXING_STAGING
+    assert record.file_type == content_type
+    assert record.file_metadata == metadata
+
+
+def test_build_raw_file_callback_binds_attempt_context_per_call(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    cleanup_file_ids: list[str],
+) -> None:
+    """The callback returned by build_raw_file_callback must bind the
+    attempt-level context into every FileRecord it produces, without
+    leaking state across invocations."""
+    callback = build_raw_file_callback(
+        index_attempt_id=1001,
+        cc_pair_id=202,
+        tenant_id="tenant-xyz",
+    )
+
+    file_id_a = callback(BytesIO(b"alpha"), "text/plain")
+    file_id_b = callback(BytesIO(b"beta"), "application/octet-stream")
+    cleanup_file_ids.extend([file_id_a, file_id_b])
+    db_session.commit()
+
+    assert file_id_a != file_id_b
+
+    for fid, expected_content_type in (
+        (file_id_a, "text/plain"),
+        (file_id_b, "application/octet-stream"),
+    ):
+        record = get_filerecord_by_file_id(file_id=fid, db_session=db_session)
+        assert record.file_origin == FileOrigin.INDEXING_STAGING
+        assert record.file_type == expected_content_type
+        assert record.file_metadata == {
+            "index_attempt_id": 1001,
+            "cc_pair_id": 202,
+            "tenant_id": "tenant-xyz",
+        }
+
+
+def test_set_raw_file_callback_on_base_connector() -> None:
+    """set_raw_file_callback must install the callback as an instance
+    attribute usable by the connector."""
+
+    class _MinimalConnector(BaseConnector):
+        def load_credentials(
+            self,
+            credentials: dict[str, Any],  # noqa: ARG002
+        ) -> dict[str, Any] | None:
+            return None
+
+    connector = _MinimalConnector()
+    assert connector.raw_file_callback is None
+
+    sentinel_file_id = f"sentinel-{uuid4().hex[:8]}"
+
+    def _fake_callback(_content: Any, _content_type: str) -> str:
+        return sentinel_file_id
+
+    connector.set_raw_file_callback(_fake_callback)
+
+    assert connector.raw_file_callback is _fake_callback
+    assert connector.raw_file_callback(BytesIO(b""), "text/plain") == sentinel_file_id


### PR DESCRIPTION
## Description
Provides a callback to connectors that enables files to be staged during doc-fetching. The callback will save a file to the filestore with the INDEXING_STAGING origin. 

## How Has This Been Tested?
Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a staging hook to save original files during doc-fetching so connectors can persist raw bytes for later processing and audit. Introduces `FileOrigin.INDEXING_STAGING` and wires a per-attempt `RawFileCallback` through the doc-fetching pipeline into connectors.

- **New Features**
  - Added `onyx.file_store.staging` with `stage_raw_file` and `build_raw_file_callback`; stores bytes with attempt metadata and returns a `file_id`.
  - Doc-fetching builds the callback per attempt (attempt, connector pair, tenant) and threads it through `connector_document_extraction` → `_get_connector_runner` → connector factory (`set_raw_file_callback`).
  - Connectors can optionally call `raw_file_callback(content, content_type)` to persist files; behavior is unchanged if unused.

<sup>Written for commit 7f80d1fed884a1110708ad6fd3359c920671961f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



