### PR TITLE
feat(slack): add per-channel toggle to hide Helpful / Not Helpful buttons

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3685,6 +3685,7 @@ class ChannelConfig(TypedDict):
     follow_up_tags: NotRequired[list[str]]
     show_continue_in_web_ui: NotRequired[bool]  # defaults to False
     disabled: NotRequired[bool]  # defaults to False
+    disable_ai_feedback: NotRequired[bool]  # defaults to False
 
 
 class SlackChannelConfig(Base):

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -152,6 +152,7 @@ def _build_ephemeral_publication_block(
             answer_filters=channel_conf.get("answer_filters"),
             follow_up_tags=channel_conf.get("follow_up_tags"),
             show_continue_in_web_ui=channel_conf.get("show_continue_in_web_ui", False),
+            disable_ai_feedback=channel_conf.get("disable_ai_feedback", False),
         )
     )
 

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -53,7 +53,6 @@ from onyx.server.query_and_chat.models import ChatMessageDetail
 from onyx.server.query_and_chat.streaming_models import CitationInfo
 from onyx.utils.logger import setup_logger
 
-
 logger = setup_logger()
 
 
@@ -287,7 +286,7 @@ def handle_publish_ephemeral_message_button(
             message_info=slack_message_info,
             channel_conf=channel_conf,
             feedback_reminder_id=feedback_reminder_id,
-            skip_ai_feedback=False,
+            skip_ai_feedback=bool(channel_conf and channel_conf.disable_ai_feedback),
             offer_ephemeral_publication=False,
             skip_restated_question=True,
         )
@@ -316,7 +315,7 @@ def handle_publish_ephemeral_message_button(
             message_info=slack_message_info,
             channel_conf=channel_conf,
             feedback_reminder_id=feedback_reminder_id,
-            skip_ai_feedback=False,
+            skip_ai_feedback=bool(channel_conf and channel_conf.disable_ai_feedback),
             offer_ephemeral_publication=False,
             skip_restated_question=True,
         )

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -385,6 +385,9 @@ def handle_regular_answer(
         offer_ephemeral_publication = False
         skip_ai_feedback = False
 
+    if channel_conf.get("disable_ai_feedback", False):
+        skip_ai_feedback = True
+
     all_blocks = build_slack_response_blocks(
         message_info=message_info,
         answer=answer,

--- a/backend/onyx/onyxbot/slack/models.py
+++ b/backend/onyx/onyxbot/slack/models.py
@@ -68,6 +68,7 @@ class ActionValuesEphemeralMessageChannelConfig(BaseModel):
     )
     follow_up_tags: list[str] | None
     show_continue_in_web_ui: bool
+    disable_ai_feedback: bool = False
 
 
 class ActionValuesEphemeralMessage(BaseModel):

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -30,7 +30,6 @@ from onyx.server.features.persona.models import PersonaSnapshot
 from onyx.server.models import FullUserSnapshot
 from onyx.server.models import InvitedUserSnapshot
 
-
 if TYPE_CHECKING:
     pass
 
@@ -318,6 +317,7 @@ class SlackChannelConfigCreationRequest(BaseModel):
     # XXX this is going away soon
     standard_answer_categories: list[int] = Field(default_factory=list)
     disabled: bool = False
+    disable_ai_feedback: bool = False
 
     @field_validator("answer_filters", mode="before")
     @classmethod

--- a/backend/onyx/server/manage/slack_bot.py
+++ b/backend/onyx/server/manage/slack_bot.py
@@ -107,6 +107,10 @@ def _form_channel_config(
 
     channel_config["disabled"] = slack_channel_config_creation_request.disabled
 
+    channel_config["disable_ai_feedback"] = (
+        slack_channel_config_creation_request.disable_ai_feedback
+    )
+
     return channel_config
 
 

--- a/backend/tests/unit/onyx/onyxbot/test_slack_feedback_toggle.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_feedback_toggle.py
@@ -1,0 +1,111 @@
+from slack_sdk.models.blocks import ActionsBlock
+
+from onyx.chat.models import ChatBasicResponse
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import SavedSearchDoc
+from onyx.context.search.models import SearchDoc
+from onyx.db.models import ChannelConfig
+from onyx.onyxbot.slack.blocks import build_slack_response_blocks
+from onyx.onyxbot.slack.constants import DISLIKE_BLOCK_ACTION_ID
+from onyx.onyxbot.slack.constants import LIKE_BLOCK_ACTION_ID
+from onyx.onyxbot.slack.models import SlackMessageInfo
+from onyx.onyxbot.slack.models import ThreadMessage
+
+
+def _make_doc(doc_id: str) -> SearchDoc:
+    return SavedSearchDoc(
+        db_doc_id=hash(doc_id) & 0xFFFFFF,
+        document_id=doc_id,
+        chunk_ind=0,
+        semantic_identifier=doc_id,
+        link=f"https://example.com/{doc_id}",
+        blurb="blurb",
+        source_type=DocumentSource.FILE,
+        boost=0,
+        hidden=False,
+        metadata={},
+        score=0.0,
+        match_highlights=[],
+        updated_at=None,
+        primary_owners=[],
+        secondary_owners=None,
+        is_relevant=None,
+        relevance_explanation=None,
+        is_internet=False,
+    )
+
+
+def _make_answer() -> ChatBasicResponse:
+    return ChatBasicResponse(
+        answer="some answer",
+        answer_citationless="some answer",
+        top_documents=[_make_doc("doc-1")],
+        error_msg=None,
+        message_id=42,
+        citation_info=[],
+    )
+
+
+def _make_slack_message_info() -> SlackMessageInfo:
+    return SlackMessageInfo(
+        thread_messages=[ThreadMessage(message="hello?")],
+        channel_to_respond="C123",
+        msg_to_respond="1.0",
+        thread_to_respond=None,
+        sender_id="U1",
+        email=None,
+        bypass_filters=False,
+        is_slash_command=False,
+        is_bot_dm=False,
+    )
+
+
+def _has_qa_feedback_buttons(blocks: list) -> bool:
+    for block in blocks:
+        if not isinstance(block, ActionsBlock):
+            continue
+        action_ids = {
+            element.action_id
+            for element in block.elements
+            if hasattr(element, "action_id")
+        }
+        if LIKE_BLOCK_ACTION_ID in action_ids and DISLIKE_BLOCK_ACTION_ID in action_ids:
+            return True
+    return False
+
+
+def test_feedback_buttons_rendered_when_skip_ai_feedback_false() -> None:
+    blocks = build_slack_response_blocks(
+        answer=_make_answer(),
+        message_info=_make_slack_message_info(),
+        channel_conf=None,
+        feedback_reminder_id=None,
+        skip_ai_feedback=False,
+        skip_restated_question=True,
+    )
+    assert _has_qa_feedback_buttons(blocks)
+
+
+def test_feedback_buttons_suppressed_when_skip_ai_feedback_true() -> None:
+    blocks = build_slack_response_blocks(
+        answer=_make_answer(),
+        message_info=_make_slack_message_info(),
+        channel_conf=None,
+        feedback_reminder_id=None,
+        skip_ai_feedback=True,
+        skip_restated_question=True,
+    )
+    assert not _has_qa_feedback_buttons(blocks)
+
+
+def test_channel_config_disable_ai_feedback_field_roundtrips() -> None:
+    """The `disable_ai_feedback` field is a valid ChannelConfig key and
+    can be read via .get() with a default like the handler does."""
+    config: ChannelConfig = {
+        "channel_name": "test",
+        "disable_ai_feedback": True,
+    }
+    assert config.get("disable_ai_feedback", False) is True
+
+    config_unset: ChannelConfig = {"channel_name": "test"}
+    assert config_unset.get("disable_ai_feedback", False) is False

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigCreationForm.tsx
@@ -121,6 +121,9 @@ export const SlackChannelConfigCreationForm = ({
               : "all_public",
           disabled:
             existingSlackChannelConfig?.channel_config?.disabled ?? false,
+          disable_ai_feedback:
+            existingSlackChannelConfig?.channel_config?.disable_ai_feedback ??
+            false,
         }}
         validationSchema={Yup.object().shape({
           slack_bot_id: Yup.number().required(),
@@ -169,6 +172,7 @@ export const SlackChannelConfigCreationForm = ({
             ])
             .required(),
           disabled: Yup.boolean().optional().default(false),
+          disable_ai_feedback: Yup.boolean().optional().default(false),
         })}
         onSubmit={async (values, formikHelpers) => {
           formikHelpers.setSubmitting(true);
@@ -195,6 +199,7 @@ export const SlackChannelConfigCreationForm = ({
             ),
             response_type: values.response_type as SlackBotResponseType,
             disabled: values.disabled ?? false,
+            disable_ai_feedback: values.disable_ai_feedback ?? false,
           };
 
           if (!cleanedValues.still_need_help_enabled) {

--- a/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/SlackChannelConfigFormFields.tsx
@@ -487,6 +487,12 @@ export function SlackChannelConfigFormFields({
               />
 
               <CheckboxField
+                name="disable_ai_feedback"
+                label="Hide Helpful / Not Helpful buttons"
+                tooltip="If set, OnyxBot responses in this channel will not include the 👍 Helpful / 👎 Not helpful feedback buttons."
+              />
+
+              <CheckboxField
                 name="still_need_help_enabled"
                 onChange={(checked: boolean) => {
                   setFieldValue("still_need_help_enabled", checked);

--- a/web/src/app/admin/bots/[bot-id]/lib.ts
+++ b/web/src/app/admin/bots/[bot-id]/lib.ts
@@ -19,6 +19,7 @@ interface SlackChannelConfigCreationRequest {
   response_type: SlackBotResponseType;
   standard_answer_categories: number[];
   disabled: boolean;
+  disable_ai_feedback: boolean;
 }
 
 const buildFiltersFromCreationRequest = (
@@ -54,6 +55,7 @@ const buildRequestBodyFromCreationRequest = (
     response_type: creationRequest.response_type,
     standard_answer_categories: creationRequest.standard_answer_categories,
     disabled: creationRequest.disabled,
+    disable_ai_feedback: creationRequest.disable_ai_feedback,
   });
 };
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -433,6 +433,7 @@ export interface ChannelConfig {
   answer_filters?: AnswerFilterOption[];
   follow_up_tags?: string[];
   disabled?: boolean;
+  disable_ai_feedback?: boolean;
 }
 
 export type SlackBotResponseType = "quotes" | "citations";


### PR DESCRIPTION
## Description

Adds a per-channel admin setting to suppress the 👍 Helpful / 👎 Not helpful feedback buttons that OnyxBot appends to its Slack responses. Customer-requested (Helsing); previously there was no UI or env var to disable the buttons.

Implementation:

- **Backend model**: new optional `disable_ai_feedback` field on `ChannelConfig` TypedDict. JSONB column, no Alembic migration — existing rows default to `False` via `.get("disable_ai_feedback", False)`.
- **Request/plumbing**: `SlackChannelConfigCreationRequest.disable_ai_feedback` + `_form_channel_config` copy it into the JSONB payload. Admin `POST`/`PATCH /admin/slack-app/channel` accepts and persists the field.
- **Runtime**: `handle_regular_answer.handle_regular_answer` ORs the flag into the existing `skip_ai_feedback` computation — the ephemeral-single-receiver gate still short-circuits, and the new flag just extends the set of conditions that hide the buttons.
- **Ephemeral Share / Keep-to-Yourself paths**: `handle_buttons.handle_publish_ephemeral_message_button` now forwards the flag through `ActionValuesEphemeralMessageChannelConfig` (new `disable_ai_feedback: bool = False` field) so the rebuilt blocks after a Share or Keep-to-Yourself click respect the toggle too.
- **Admin UI**: new `CheckboxField` in the "General Configuration" accordion of the channel config form (`Hide Helpful / Not Helpful buttons`). Formik initial values, Yup schema, cleaned-values plumbing, and request-body serialization all updated. Frontend `ChannelConfig` + `SlackChannelConfigCreationRequest` TypeScript interfaces gained the field.
- **Tests**: `backend/tests/unit/onyx/onyxbot/test_slack_feedback_toggle.py` covers the block-level gate (buttons present when `skip_ai_feedback=False`, absent when `True`) and confirms the `ChannelConfig` TypedDict accepts and roundtrips the field with `.get(..., False)` defaulting.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check