### PR TITLE
feat(indexing): Delete associated document files on doc delete

### DIFF
--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -15,7 +15,7 @@ from onyx.background.celery.tasks.shared.RetryDocumentIndex import RetryDocument
 from onyx.configs.constants import ONYX_CELERY_BEAT_HEARTBEAT_KEY
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.document import delete_document_by_connector_credential_pair__no_commit
-from onyx.db.document import delete_documents_complete__no_commit
+from onyx.db.document import delete_documents_complete
 from onyx.db.document import fetch_chunk_count_for_document
 from onyx.db.document import get_document
 from onyx.db.document import get_document_connector_count
@@ -129,11 +129,10 @@ def document_by_cc_pair_cleanup_task(
                     document_id=document_id,
                 )
 
-                delete_documents_complete__no_commit(
+                delete_documents_complete(
                     db_session=db_session,
                     document_ids=[document_id],
                 )
-                db_session.commit()
 
                 completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
             elif count > 1:

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -932,11 +932,7 @@ def get_file_ids_for_document_ids(
     db_session: Session,
     document_ids: list[str],
 ) -> list[str]:
-    """Return the non-null `file_id` values attached to the given documents.
-
-    Used at deletion time to enumerate raw files that need to be reaped from
-    the file store once their owning document rows are gone.
-    """
+    """Return the non-null `file_id` values attached to the given documents."""
     if not document_ids:
         return []
     rows = (
@@ -997,13 +993,8 @@ def delete_documents_complete(
 ) -> None:
     """Fully remove documents AND best-effort delete their attached files.
 
-    This is the canonical path for "I'm done with these docs" — it captures
-    file_ids, removes the rows + every FK they hold, commits, then reaps
-    files. The order matters: file deletion happens after commit so a DB
-    rollback can never leave a `document` row pointing at a missing file.
-
-    Use this instead of `delete_documents_complete__no_commit` unless you
-    specifically need to compose with other operations in one transaction.
+    To be used when a document is finished and should be disposed of.
+    Removes the row and the potentially associated file.
     """
     file_ids_to_delete = get_file_ids_for_document_ids(
         db_session=db_session,

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -52,6 +52,7 @@ from onyx.db.utils import DocumentRow
 from onyx.db.utils import model_to_dict
 from onyx.db.utils import SortOrder
 from onyx.document_index.interfaces import DocumentMetadata
+from onyx.file_store.staging import delete_files_best_effort
 from onyx.kg.models import KGStage
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.utils.logger import setup_logger
@@ -927,6 +928,26 @@ def delete_documents__no_commit(db_session: Session, document_ids: list[str]) ->
     db_session.execute(delete(DbDocument).where(DbDocument.id.in_(document_ids)))
 
 
+def get_file_ids_for_document_ids(
+    db_session: Session,
+    document_ids: list[str],
+) -> list[str]:
+    """Return the non-null `file_id` values attached to the given documents.
+
+    Used at deletion time to enumerate raw files that need to be reaped from
+    the file store once their owning document rows are gone.
+    """
+    if not document_ids:
+        return []
+    rows = (
+        db_session.query(DbDocument.file_id)
+        .filter(DbDocument.id.in_(document_ids))
+        .filter(DbDocument.file_id.isnot(None))
+        .all()
+    )
+    return [row.file_id for row in rows]
+
+
 def delete_documents_complete__no_commit(
     db_session: Session, document_ids: list[str]
 ) -> None:
@@ -970,6 +991,32 @@ def delete_documents_complete__no_commit(
     delete_documents__no_commit(db_session, document_ids)
 
 
+def delete_documents_complete(
+    db_session: Session,
+    document_ids: list[str],
+) -> None:
+    """Fully remove documents AND best-effort delete their attached files.
+
+    This is the canonical path for "I'm done with these docs" — it captures
+    file_ids, removes the rows + every FK they hold, commits, then reaps
+    files. The order matters: file deletion happens after commit so a DB
+    rollback can never leave a `document` row pointing at a missing file.
+
+    Use this instead of `delete_documents_complete__no_commit` unless you
+    specifically need to compose with other operations in one transaction.
+    """
+    file_ids_to_delete = get_file_ids_for_document_ids(
+        db_session=db_session,
+        document_ids=document_ids,
+    )
+    delete_documents_complete__no_commit(
+        db_session=db_session,
+        document_ids=document_ids,
+    )
+    db_session.commit()
+    delete_files_best_effort(file_ids_to_delete)
+
+
 def delete_all_documents_for_connector_credential_pair(
     db_session: Session,
     connector_id: int,
@@ -1001,10 +1048,9 @@ def delete_all_documents_for_connector_credential_pair(
         if not document_ids:
             break
 
-        delete_documents_complete__no_commit(
+        delete_documents_complete(
             db_session=db_session, document_ids=list(document_ids)
         )
-        db_session.commit()
 
         if time.monotonic() - start_time > timeout:
             raise RuntimeError("Timeout reached while deleting documents")

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -945,7 +945,7 @@ def get_file_ids_for_document_ids(
         .filter(DbDocument.file_id.isnot(None))
         .all()
     )
-    return [row.file_id for row in rows]
+    return [row.file_id for row in rows if row.file_id is not None]
 
 
 def delete_documents_complete__no_commit(

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -69,11 +69,6 @@ def build_raw_file_callback(
 def delete_files_best_effort(file_ids: list[str]) -> None:
     """Delete a list of files from the file store, logging individual
     failures rather than raising.
-
-    Used at document-deletion time to reap raw files attached via
-    `Document.file_id`. The corresponding document rows have already been
-    deleted by the caller, so a failure here just leaves a recoverable
-    orphan rather than a broken pointer.
     """
     if not file_ids:
         return

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -66,6 +66,27 @@ def build_raw_file_callback(
     return _callback
 
 
+def delete_files_best_effort(file_ids: list[str]) -> None:
+    """Delete a list of files from the file store, logging individual
+    failures rather than raising.
+
+    Used at document-deletion time to reap raw files attached via
+    `Document.file_id`. The corresponding document rows have already been
+    deleted by the caller, so a failure here just leaves a recoverable
+    orphan rather than a broken pointer.
+    """
+    if not file_ids:
+        return
+    file_store = get_default_file_store()
+    for file_id in file_ids:
+        try:
+            file_store.delete_file(file_id, error_on_missing=False)
+        except Exception:
+            logger.exception(
+                f"Failed to delete file_id={file_id} during document cleanup"
+            )
+
+
 def promote_staged_file(db_session: Session, file_id: str) -> None:
     """Mark a previously-staged file as `FileOrigin.CONNECTOR`."""
     update_filerecord_origin(

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -13,7 +13,7 @@ from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexAttemptMetadata
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
-from onyx.db.document import delete_documents_complete__no_commit
+from onyx.db.document import delete_documents_complete
 from onyx.db.document import get_document
 from onyx.db.document import get_documents_by_cc_pair
 from onyx.db.document import get_ingestion_documents
@@ -210,5 +210,4 @@ def delete_ingestion_doc(
         )
 
     # Delete from database
-    delete_documents_complete__no_commit(db_session, [document_id])
-    db_session.commit()
+    delete_documents_complete(db_session, [document_id])

--- a/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
@@ -1,0 +1,348 @@
+"""External dependency unit tests for the file_id cleanup that runs alongside
+document deletion across the three deletion paths:
+
+    1. `document_by_cc_pair_cleanup_task` (pruning + connector deletion)
+    2. `delete_ingestion_doc` (public ingestion API DELETE)
+    3. `delete_all_documents_for_connector_credential_pair` (index swap)
+
+Each path captures attached `Document.file_id`s before the row is removed and
+best-effort deletes the underlying files after the DB commit.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.shared.tasks import (
+    document_by_cc_pair_cleanup_task,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
+from onyx.connectors.models import Document
+from onyx.connectors.models import IndexAttemptMetadata
+from onyx.connectors.models import InputType
+from onyx.connectors.models import TextSection
+from onyx.db.document import delete_all_documents_for_connector_credential_pair
+from onyx.db.document import upsert_document_by_connector_credential_pair
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.file_record import get_filerecord_by_file_id_optional
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import Document as DBDocument
+from onyx.db.models import FileRecord
+from onyx.file_store.file_store import get_default_file_store
+from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+from onyx.server.onyx_api.ingestion import delete_ingestion_doc
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(
+    doc_id: str,
+    file_id: str | None = None,
+    from_ingestion_api: bool = False,
+) -> Document:
+    return Document(
+        id=doc_id,
+        source=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"semantic-{doc_id}",
+        sections=[TextSection(text="content", link=None)],
+        metadata={},
+        file_id=file_id,
+        from_ingestion_api=from_ingestion_api,
+    )
+
+
+def _stage_file(content: bytes = b"raw bytes") -> str:
+    return get_default_file_store().save_file(
+        content=BytesIO(content),
+        display_name=None,
+        file_origin=FileOrigin.INDEXING_STAGING,
+        file_type="application/octet-stream",
+        file_metadata={"test": True},
+    )
+
+
+def _get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
+    db_session.expire_all()
+    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
+
+
+def _get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
+    db_session.expire_all()
+    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
+
+
+def _index_doc(
+    db_session: Session,
+    doc: Document,
+    attempt_metadata: IndexAttemptMetadata,
+) -> None:
+    """Run the doc through the upsert pipeline so the row + cc_pair mapping
+    exist (so deletion paths have something to find)."""
+    index_doc_batch_prepare(
+        documents=[doc],
+        index_attempt_metadata=attempt_metadata,
+        db_session=db_session,
+        ignore_time_skip=True,
+    )
+    db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"test-connector-{uuid4().hex[:8]}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.MOCK_CONNECTOR,
+        credential_json={},
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"test-cc-pair-{uuid4().hex[:8]}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+        auto_sync_options=None,
+    )
+    db_session.add(pair)
+    db_session.commit()
+    db_session.refresh(pair)
+    return pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    yield _make_cc_pair(db_session)
+
+
+@pytest.fixture
+def second_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    """A second cc_pair, used to test the count > 1 branch."""
+    yield _make_cc_pair(db_session)
+
+
+@pytest.fixture
+def attempt_metadata(cc_pair: ConnectorCredentialPair) -> IndexAttemptMetadata:
+    return IndexAttemptMetadata(
+        connector_id=cc_pair.connector_id,
+        credential_id=cc_pair.credential_id,
+        attempt_id=None,
+        request_id="test-request",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllDocumentsForCcPair:
+    """Path 3: bulk delete during index swap (`INSTANT` switchover)."""
+
+    def test_cleans_up_files_for_all_docs(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+    ) -> None:
+        file_id_a = _stage_file(content=b"a")
+        file_id_b = _stage_file(content=b"b")
+        doc_a = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
+        doc_b = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
+
+        _index_doc(db_session, doc_a, attempt_metadata)
+        _index_doc(db_session, doc_b, attempt_metadata)
+
+        assert _get_filerecord(db_session, file_id_a) is not None
+        assert _get_filerecord(db_session, file_id_b) is not None
+
+        delete_all_documents_for_connector_credential_pair(
+            db_session=db_session,
+            connector_id=cc_pair.connector_id,
+            credential_id=cc_pair.credential_id,
+        )
+
+        assert _get_doc_row(db_session, doc_a.id) is None
+        assert _get_doc_row(db_session, doc_b.id) is None
+        assert _get_filerecord(db_session, file_id_a) is None
+        assert _get_filerecord(db_session, file_id_b) is None
+
+    def test_handles_mixed_docs_with_and_without_file_ids(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+    ) -> None:
+        """Docs without file_id should be cleanly removed — no errors,
+        no spurious file_store calls."""
+        file_id = _stage_file()
+        doc_with = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        doc_without = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+
+        _index_doc(db_session, doc_with, attempt_metadata)
+        _index_doc(db_session, doc_without, attempt_metadata)
+
+        delete_all_documents_for_connector_credential_pair(
+            db_session=db_session,
+            connector_id=cc_pair.connector_id,
+            credential_id=cc_pair.credential_id,
+        )
+
+        assert _get_doc_row(db_session, doc_with.id) is None
+        assert _get_doc_row(db_session, doc_without.id) is None
+        assert _get_filerecord(db_session, file_id) is None
+
+
+class TestDeleteIngestionDoc:
+    """Path 2: public ingestion API DELETE endpoint."""
+
+    def test_cleans_up_file_for_ingestion_api_doc(
+        self,
+        db_session: Session,
+        attempt_metadata: IndexAttemptMetadata,
+        tenant_context: None,  # noqa: ARG002
+        initialize_file_store: None,  # noqa: ARG002
+    ) -> None:
+        file_id = _stage_file()
+        doc = _make_doc(
+            f"doc-{uuid4().hex[:8]}",
+            file_id=file_id,
+            from_ingestion_api=True,
+        )
+
+        _index_doc(db_session, doc, attempt_metadata)
+        assert _get_filerecord(db_session, file_id) is not None
+
+        # Patch out Vespa — we're testing the file cleanup, not the document
+        # index integration.
+        with patch(
+            "onyx.server.onyx_api.ingestion.get_all_document_indices",
+            return_value=[],
+        ):
+            delete_ingestion_doc(
+                document_id=doc.id,
+                _=MagicMock(),  # auth dep — not used by the function body
+                db_session=db_session,
+            )
+
+        assert _get_doc_row(db_session, doc.id) is None
+        assert _get_filerecord(db_session, file_id) is None
+
+
+class TestDocumentByCcPairCleanupTask:
+    """Path 1: per-doc cleanup task fired by pruning / connector deletion."""
+
+    def test_count_1_branch_cleans_up_file(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        """When the doc has exactly one cc_pair reference, the full delete
+        path runs and the attached file is reaped."""
+        file_id = _stage_file()
+        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        _index_doc(db_session, doc, attempt_metadata)
+
+        assert _get_filerecord(db_session, file_id) is not None
+
+        # Patch out Vespa interaction — no chunks were ever written, and we're
+        # not testing the document index here.
+        with patch(
+            "onyx.background.celery.tasks.shared.tasks.get_all_document_indices",
+            return_value=[],
+        ):
+            result = document_by_cc_pair_cleanup_task.apply(
+                args=(
+                    doc.id,
+                    cc_pair.connector_id,
+                    cc_pair.credential_id,
+                    TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+        assert _get_doc_row(db_session, doc.id) is None
+        assert _get_filerecord(db_session, file_id) is None
+
+    def test_count_gt_1_branch_preserves_file(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        second_cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        """When the doc is referenced by another cc_pair, only the mapping
+        for the detaching cc_pair is removed. The file MUST stay because
+        the doc and its file are still owned by the remaining cc_pair."""
+        file_id = _stage_file()
+        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        _index_doc(db_session, doc, attempt_metadata)
+
+        # Attach the same doc to a second cc_pair so refcount becomes 2.
+        upsert_document_by_connector_credential_pair(
+            db_session,
+            second_cc_pair.connector_id,
+            second_cc_pair.credential_id,
+            [doc.id],
+        )
+        db_session.commit()
+
+        with patch(
+            "onyx.background.celery.tasks.shared.tasks.get_all_document_indices",
+            return_value=[],
+        ):
+            result = document_by_cc_pair_cleanup_task.apply(
+                args=(
+                    doc.id,
+                    cc_pair.connector_id,
+                    cc_pair.credential_id,
+                    TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+        # Document row still exists (other cc_pair owns it).
+        assert _get_doc_row(db_session, doc.id) is not None
+        # File MUST still exist.
+        record = _get_filerecord(db_session, file_id)
+        assert record is not None

--- a/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
@@ -10,7 +10,6 @@ best-effort deletes the underlying files after the DB commit.
 """
 
 from collections.abc import Generator
-from io import BytesIO
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from uuid import uuid4
@@ -21,67 +20,25 @@ from sqlalchemy.orm import Session
 from onyx.background.celery.tasks.shared.tasks import (
     document_by_cc_pair_cleanup_task,
 )
-from onyx.configs.constants import DocumentSource
-from onyx.configs.constants import FileOrigin
 from onyx.connectors.models import Document
 from onyx.connectors.models import IndexAttemptMetadata
-from onyx.connectors.models import InputType
-from onyx.connectors.models import TextSection
 from onyx.db.document import delete_all_documents_for_connector_credential_pair
 from onyx.db.document import upsert_document_by_connector_credential_pair
-from onyx.db.enums import AccessType
-from onyx.db.enums import ConnectorCredentialPairStatus
-from onyx.db.file_record import get_filerecord_by_file_id_optional
-from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
-from onyx.db.models import Credential
-from onyx.db.models import Document as DBDocument
-from onyx.db.models import FileRecord
-from onyx.file_store.file_store import get_default_file_store
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.server.onyx_api.ingestion import delete_ingestion_doc
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import get_doc_row
+from tests.external_dependency_unit.indexing_helpers import get_filerecord
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_doc
+from tests.external_dependency_unit.indexing_helpers import stage_file
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers (file-local)
 # ---------------------------------------------------------------------------
-
-
-def _make_doc(
-    doc_id: str,
-    file_id: str | None = None,
-    from_ingestion_api: bool = False,
-) -> Document:
-    return Document(
-        id=doc_id,
-        source=DocumentSource.MOCK_CONNECTOR,
-        semantic_identifier=f"semantic-{doc_id}",
-        sections=[TextSection(text="content", link=None)],
-        metadata={},
-        file_id=file_id,
-        from_ingestion_api=from_ingestion_api,
-    )
-
-
-def _stage_file(content: bytes = b"raw bytes") -> str:
-    return get_default_file_store().save_file(
-        content=BytesIO(content),
-        display_name=None,
-        file_origin=FileOrigin.INDEXING_STAGING,
-        file_type="application/octet-stream",
-        file_metadata={"test": True},
-    )
-
-
-def _get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
-    db_session.expire_all()
-    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
-
-
-def _get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
-    db_session.expire_all()
-    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
 
 
 def _index_doc(
@@ -105,47 +62,17 @@ def _index_doc(
 # ---------------------------------------------------------------------------
 
 
-def _make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
-    connector = Connector(
-        name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
-        input_type=InputType.LOAD_STATE,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=None,
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
-        credential_json={},
-    )
-    db_session.add(credential)
-    db_session.flush()
-
-    pair = ConnectorCredentialPair(
-        connector_id=connector.id,
-        credential_id=credential.id,
-        name=f"test-cc-pair-{uuid4().hex[:8]}",
-        status=ConnectorCredentialPairStatus.ACTIVE,
-        access_type=AccessType.PUBLIC,
-        auto_sync_options=None,
-    )
-    db_session.add(pair)
-    db_session.commit()
-    db_session.refresh(pair)
-    return pair
-
-
 @pytest.fixture
 def cc_pair(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     initialize_file_store: None,  # noqa: ARG001
 ) -> Generator[ConnectorCredentialPair, None, None]:
-    yield _make_cc_pair(db_session)
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
 
 
 @pytest.fixture
@@ -155,7 +82,11 @@ def second_cc_pair(
     initialize_file_store: None,  # noqa: ARG001
 ) -> Generator[ConnectorCredentialPair, None, None]:
     """A second cc_pair, used to test the count > 1 branch."""
-    yield _make_cc_pair(db_session)
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
 
 
 @pytest.fixture
@@ -182,16 +113,16 @@ class TestDeleteAllDocumentsForCcPair:
         cc_pair: ConnectorCredentialPair,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        file_id_a = _stage_file(content=b"a")
-        file_id_b = _stage_file(content=b"b")
-        doc_a = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
-        doc_b = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
+        file_id_a = stage_file(content=b"a")
+        file_id_b = stage_file(content=b"b")
+        doc_a = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
+        doc_b = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
 
         _index_doc(db_session, doc_a, attempt_metadata)
         _index_doc(db_session, doc_b, attempt_metadata)
 
-        assert _get_filerecord(db_session, file_id_a) is not None
-        assert _get_filerecord(db_session, file_id_b) is not None
+        assert get_filerecord(db_session, file_id_a) is not None
+        assert get_filerecord(db_session, file_id_b) is not None
 
         delete_all_documents_for_connector_credential_pair(
             db_session=db_session,
@@ -199,10 +130,10 @@ class TestDeleteAllDocumentsForCcPair:
             credential_id=cc_pair.credential_id,
         )
 
-        assert _get_doc_row(db_session, doc_a.id) is None
-        assert _get_doc_row(db_session, doc_b.id) is None
-        assert _get_filerecord(db_session, file_id_a) is None
-        assert _get_filerecord(db_session, file_id_b) is None
+        assert get_doc_row(db_session, doc_a.id) is None
+        assert get_doc_row(db_session, doc_b.id) is None
+        assert get_filerecord(db_session, file_id_a) is None
+        assert get_filerecord(db_session, file_id_b) is None
 
     def test_handles_mixed_docs_with_and_without_file_ids(
         self,
@@ -212,9 +143,9 @@ class TestDeleteAllDocumentsForCcPair:
     ) -> None:
         """Docs without file_id should be cleanly removed — no errors,
         no spurious file_store calls."""
-        file_id = _stage_file()
-        doc_with = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
-        doc_without = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+        file_id = stage_file()
+        doc_with = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        doc_without = make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
 
         _index_doc(db_session, doc_with, attempt_metadata)
         _index_doc(db_session, doc_without, attempt_metadata)
@@ -225,9 +156,9 @@ class TestDeleteAllDocumentsForCcPair:
             credential_id=cc_pair.credential_id,
         )
 
-        assert _get_doc_row(db_session, doc_with.id) is None
-        assert _get_doc_row(db_session, doc_without.id) is None
-        assert _get_filerecord(db_session, file_id) is None
+        assert get_doc_row(db_session, doc_with.id) is None
+        assert get_doc_row(db_session, doc_without.id) is None
+        assert get_filerecord(db_session, file_id) is None
 
 
 class TestDeleteIngestionDoc:
@@ -240,15 +171,15 @@ class TestDeleteIngestionDoc:
         tenant_context: None,  # noqa: ARG002
         initialize_file_store: None,  # noqa: ARG002
     ) -> None:
-        file_id = _stage_file()
-        doc = _make_doc(
+        file_id = stage_file()
+        doc = make_doc(
             f"doc-{uuid4().hex[:8]}",
             file_id=file_id,
             from_ingestion_api=True,
         )
 
         _index_doc(db_session, doc, attempt_metadata)
-        assert _get_filerecord(db_session, file_id) is not None
+        assert get_filerecord(db_session, file_id) is not None
 
         # Patch out Vespa — we're testing the file cleanup, not the document
         # index integration.
@@ -262,8 +193,8 @@ class TestDeleteIngestionDoc:
                 db_session=db_session,
             )
 
-        assert _get_doc_row(db_session, doc.id) is None
-        assert _get_filerecord(db_session, file_id) is None
+        assert get_doc_row(db_session, doc.id) is None
+        assert get_filerecord(db_session, file_id) is None
 
 
 class TestDocumentByCcPairCleanupTask:
@@ -278,11 +209,11 @@ class TestDocumentByCcPairCleanupTask:
     ) -> None:
         """When the doc has exactly one cc_pair reference, the full delete
         path runs and the attached file is reaped."""
-        file_id = _stage_file()
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        file_id = stage_file()
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
         _index_doc(db_session, doc, attempt_metadata)
 
-        assert _get_filerecord(db_session, file_id) is not None
+        assert get_filerecord(db_session, file_id) is not None
 
         # Patch out Vespa interaction — no chunks were ever written, and we're
         # not testing the document index here.
@@ -300,8 +231,8 @@ class TestDocumentByCcPairCleanupTask:
             )
 
         assert result.successful(), result.traceback
-        assert _get_doc_row(db_session, doc.id) is None
-        assert _get_filerecord(db_session, file_id) is None
+        assert get_doc_row(db_session, doc.id) is None
+        assert get_filerecord(db_session, file_id) is None
 
     def test_count_gt_1_branch_preserves_file(
         self,
@@ -314,8 +245,8 @@ class TestDocumentByCcPairCleanupTask:
         """When the doc is referenced by another cc_pair, only the mapping
         for the detaching cc_pair is removed. The file MUST stay because
         the doc and its file are still owned by the remaining cc_pair."""
-        file_id = _stage_file()
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        file_id = stage_file()
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
         _index_doc(db_session, doc, attempt_metadata)
 
         # Attach the same doc to a second cc_pair so refcount becomes 2.
@@ -342,7 +273,7 @@ class TestDocumentByCcPairCleanupTask:
 
         assert result.successful(), result.traceback
         # Document row still exists (other cc_pair owns it).
-        assert _get_doc_row(db_session, doc.id) is not None
+        assert get_doc_row(db_session, doc.id) is not None
         # File MUST still exist.
-        record = _get_filerecord(db_session, file_id)
+        record = get_filerecord(db_session, file_id)
         assert record is not None

--- a/backend/tests/external_dependency_unit/indexing/test_index_doc_batch_prepare.py
+++ b/backend/tests/external_dependency_unit/indexing/test_index_doc_batch_prepare.py
@@ -11,72 +11,21 @@ Uses real PostgreSQL + real S3/MinIO via the file store.
 """
 
 from collections.abc import Generator
-from io import BytesIO
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FileOrigin
-from onyx.connectors.models import Document
 from onyx.connectors.models import IndexAttemptMetadata
-from onyx.connectors.models import InputType
-from onyx.connectors.models import TextSection
-from onyx.db.enums import AccessType
-from onyx.db.enums import ConnectorCredentialPairStatus
-from onyx.db.file_record import get_filerecord_by_file_id_optional
-from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
-from onyx.db.models import Credential
-from onyx.db.models import Document as DBDocument
-from onyx.db.models import DocumentByConnectorCredentialPair
-from onyx.db.models import FileRecord
-from onyx.file_store.file_store import get_default_file_store
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_doc(doc_id: str, file_id: str | None = None) -> Document:
-    """Minimal Document for indexing-pipeline tests. MOCK_CONNECTOR avoids
-    triggering the hierarchy-node linking branch (NOTION/CONFLUENCE only)."""
-    return Document(
-        id=doc_id,
-        source=DocumentSource.MOCK_CONNECTOR,
-        semantic_identifier=f"semantic-{doc_id}",
-        sections=[TextSection(text="content", link=None)],
-        metadata={},
-        file_id=file_id,
-    )
-
-
-def _stage_file(content: bytes = b"raw bytes") -> str:
-    """Write bytes to the file store as INDEXING_STAGING and return the file_id.
-
-    Mirrors what the connector raw_file_callback would do during fetch.
-    """
-    return get_default_file_store().save_file(
-        content=BytesIO(content),
-        display_name=None,
-        file_origin=FileOrigin.INDEXING_STAGING,
-        file_type="application/octet-stream",
-        file_metadata={"test": True},
-    )
-
-
-def _get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
-    """Reload the document row fresh from DB so we see post-upsert state."""
-    db_session.expire_all()
-    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
-
-
-def _get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
-    db_session.expire_all()
-    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import get_doc_row
+from tests.external_dependency_unit.indexing_helpers import get_filerecord
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_doc
+from tests.external_dependency_unit.indexing_helpers import stage_file
 
 
 # ---------------------------------------------------------------------------
@@ -90,97 +39,11 @@ def cc_pair(
     tenant_context: None,  # noqa: ARG001
     initialize_file_store: None,  # noqa: ARG001
 ) -> Generator[ConnectorCredentialPair, None, None]:
-    """Create a connector + credential + cc_pair backing the index attempt.
-
-    Teardown sweeps everything the test created under this cc_pair: the
-    `document_by_connector_credential_pair` join rows, the `Document` rows
-    they point at, the `FileRecord` + blob for each doc's `file_id`, and
-    finally the cc_pair / connector / credential themselves. Without this,
-    every run would leave orphan rows in the dev DB and orphan blobs in
-    MinIO.
-    """
-    connector = Connector(
-        name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
-        input_type=InputType.LOAD_STATE,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=None,
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
-        credential_json={},
-    )
-    db_session.add(credential)
-    db_session.flush()
-
-    pair = ConnectorCredentialPair(
-        connector_id=connector.id,
-        credential_id=credential.id,
-        name=f"test-cc-pair-{uuid4().hex[:8]}",
-        status=ConnectorCredentialPairStatus.ACTIVE,
-        access_type=AccessType.PUBLIC,
-        auto_sync_options=None,
-    )
-    db_session.add(pair)
-    db_session.commit()
-    db_session.refresh(pair)
-
-    connector_id = pair.connector_id
-    credential_id = pair.credential_id
-
+    pair = make_cc_pair(db_session)
     try:
         yield pair
     finally:
-        db_session.expire_all()
-
-        # Collect every doc indexed under this cc_pair so we can delete its
-        # file_record + blob before dropping the Document row itself.
-        doc_ids: list[str] = [
-            row[0]
-            for row in db_session.query(DocumentByConnectorCredentialPair.id)
-            .filter(
-                DocumentByConnectorCredentialPair.connector_id == connector_id,
-                DocumentByConnectorCredentialPair.credential_id == credential_id,
-            )
-            .all()
-        ]
-        file_ids: list[str] = [
-            row[0]
-            for row in db_session.query(DBDocument.file_id)
-            .filter(DBDocument.id.in_(doc_ids), DBDocument.file_id.isnot(None))
-            .all()
-        ]
-
-        file_store = get_default_file_store()
-        for fid in file_ids:
-            try:
-                file_store.delete_file(fid, error_on_missing=False)
-            except Exception:
-                pass
-
-        if doc_ids:
-            db_session.query(DocumentByConnectorCredentialPair).filter(
-                DocumentByConnectorCredentialPair.id.in_(doc_ids)
-            ).delete(synchronize_session="fetch")
-            db_session.query(DBDocument).filter(DBDocument.id.in_(doc_ids)).delete(
-                synchronize_session="fetch"
-            )
-
-        db_session.query(ConnectorCredentialPair).filter(
-            ConnectorCredentialPair.id == pair.id
-        ).delete(synchronize_session="fetch")
-        db_session.query(Connector).filter(Connector.id == connector_id).delete(
-            synchronize_session="fetch"
-        )
-        db_session.query(Credential).filter(Credential.id == credential_id).delete(
-            synchronize_session="fetch"
-        )
-        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
 
 
 @pytest.fixture
@@ -206,7 +69,7 @@ class TestNewDocuments:
         db_session: Session,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
 
         index_doc_batch_prepare(
             documents=[doc],
@@ -216,7 +79,7 @@ class TestNewDocuments:
         )
         db_session.commit()
 
-        row = _get_doc_row(db_session, doc.id)
+        row = get_doc_row(db_session, doc.id)
         assert row is not None
         assert row.file_id is None
 
@@ -225,8 +88,8 @@ class TestNewDocuments:
         db_session: Session,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        file_id = _stage_file()
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        file_id = stage_file()
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
 
         index_doc_batch_prepare(
             documents=[doc],
@@ -236,10 +99,10 @@ class TestNewDocuments:
         )
         db_session.commit()
 
-        row = _get_doc_row(db_session, doc.id)
+        row = get_doc_row(db_session, doc.id)
         assert row is not None and row.file_id == file_id
 
-        record = _get_filerecord(db_session, file_id)
+        record = get_filerecord(db_session, file_id)
         assert record is not None
         assert record.file_origin == FileOrigin.CONNECTOR
 
@@ -252,8 +115,8 @@ class TestExistingDocuments:
         db_session: Session,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        file_id = _stage_file()
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        file_id = stage_file()
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
 
         # First pass: inserts the row + promotes the file.
         index_doc_batch_prepare(
@@ -273,11 +136,11 @@ class TestExistingDocuments:
         )
         db_session.commit()
 
-        record = _get_filerecord(db_session, file_id)
+        record = get_filerecord(db_session, file_id)
         assert record is not None
         assert record.file_origin == FileOrigin.CONNECTOR
 
-        row = _get_doc_row(db_session, doc.id)
+        row = get_doc_row(db_session, doc.id)
         assert row is not None and row.file_id == file_id
 
     def test_swapping_file_id_promotes_new_and_deletes_old(
@@ -285,8 +148,8 @@ class TestExistingDocuments:
         db_session: Session,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        old_file_id = _stage_file(content=b"old bytes")
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=old_file_id)
+        old_file_id = stage_file(content=b"old bytes")
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=old_file_id)
 
         index_doc_batch_prepare(
             documents=[doc],
@@ -297,8 +160,8 @@ class TestExistingDocuments:
         db_session.commit()
 
         # Re-fetch produces a new staged file_id for the same doc.
-        new_file_id = _stage_file(content=b"new bytes")
-        doc_v2 = _make_doc(doc.id, file_id=new_file_id)
+        new_file_id = stage_file(content=b"new bytes")
+        doc_v2 = make_doc(doc.id, file_id=new_file_id)
 
         index_doc_batch_prepare(
             documents=[doc_v2],
@@ -308,23 +171,23 @@ class TestExistingDocuments:
         )
         db_session.commit()
 
-        row = _get_doc_row(db_session, doc.id)
+        row = get_doc_row(db_session, doc.id)
         assert row is not None and row.file_id == new_file_id
 
-        new_record = _get_filerecord(db_session, new_file_id)
+        new_record = get_filerecord(db_session, new_file_id)
         assert new_record is not None
         assert new_record.file_origin == FileOrigin.CONNECTOR
 
         # Old file_record + S3 object are gone.
-        assert _get_filerecord(db_session, old_file_id) is None
+        assert get_filerecord(db_session, old_file_id) is None
 
     def test_clearing_file_id_deletes_old_and_nulls_column(
         self,
         db_session: Session,
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
-        old_file_id = _stage_file()
-        doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=old_file_id)
+        old_file_id = stage_file()
+        doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=old_file_id)
 
         index_doc_batch_prepare(
             documents=[doc],
@@ -335,7 +198,7 @@ class TestExistingDocuments:
         db_session.commit()
 
         # Connector opts out on next run — yields the doc without a file_id.
-        doc_v2 = _make_doc(doc.id, file_id=None)
+        doc_v2 = make_doc(doc.id, file_id=None)
 
         index_doc_batch_prepare(
             documents=[doc_v2],
@@ -345,9 +208,9 @@ class TestExistingDocuments:
         )
         db_session.commit()
 
-        row = _get_doc_row(db_session, doc.id)
+        row = get_doc_row(db_session, doc.id)
         assert row is not None and row.file_id is None
-        assert _get_filerecord(db_session, old_file_id) is None
+        assert get_filerecord(db_session, old_file_id) is None
 
 
 class TestBatchHandling:
@@ -359,8 +222,8 @@ class TestBatchHandling:
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
         # Pre-seed an existing doc with a file_id we'll swap.
-        existing_old_id = _stage_file(content=b"existing-old")
-        existing_doc = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=existing_old_id)
+        existing_old_id = stage_file(content=b"existing-old")
+        existing_doc = make_doc(f"doc-{uuid4().hex[:8]}", file_id=existing_old_id)
         index_doc_batch_prepare(
             documents=[existing_doc],
             index_attempt_metadata=attempt_metadata,
@@ -371,11 +234,11 @@ class TestBatchHandling:
 
         # Now: swap the existing one, add a brand-new doc with file_id, and a
         # brand-new doc without file_id.
-        swap_new_id = _stage_file(content=b"existing-new")
-        new_with_file_id = _stage_file(content=b"new-with-file")
-        existing_v2 = _make_doc(existing_doc.id, file_id=swap_new_id)
-        new_with = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=new_with_file_id)
-        new_without = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+        swap_new_id = stage_file(content=b"existing-new")
+        new_with_file_id = stage_file(content=b"new-with-file")
+        existing_v2 = make_doc(existing_doc.id, file_id=swap_new_id)
+        new_with = make_doc(f"doc-{uuid4().hex[:8]}", file_id=new_with_file_id)
+        new_without = make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
 
         index_doc_batch_prepare(
             documents=[existing_v2, new_with, new_without],
@@ -386,20 +249,20 @@ class TestBatchHandling:
         db_session.commit()
 
         # Existing doc was swapped: old file gone, new file promoted.
-        existing_row = _get_doc_row(db_session, existing_doc.id)
+        existing_row = get_doc_row(db_session, existing_doc.id)
         assert existing_row is not None and existing_row.file_id == swap_new_id
-        assert _get_filerecord(db_session, existing_old_id) is None
-        swap_record = _get_filerecord(db_session, swap_new_id)
+        assert get_filerecord(db_session, existing_old_id) is None
+        swap_record = get_filerecord(db_session, swap_new_id)
         assert swap_record is not None
         assert swap_record.file_origin == FileOrigin.CONNECTOR
 
         # New doc with file_id: row exists, file promoted.
-        new_with_row = _get_doc_row(db_session, new_with.id)
+        new_with_row = get_doc_row(db_session, new_with.id)
         assert new_with_row is not None and new_with_row.file_id == new_with_file_id
-        new_with_record = _get_filerecord(db_session, new_with_file_id)
+        new_with_record = get_filerecord(db_session, new_with_file_id)
         assert new_with_record is not None
         assert new_with_record.file_origin == FileOrigin.CONNECTOR
 
         # New doc without file_id: row exists, no file_record involvement.
-        new_without_row = _get_doc_row(db_session, new_without.id)
+        new_without_row = get_doc_row(db_session, new_without.id)
         assert new_without_row is not None and new_without_row.file_id is None

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -1,0 +1,190 @@
+"""Shared helpers for external-dependency indexing tests.
+
+Three test files exercise the `Document` / `cc_pair` / `file_store` surfaces
+against real Postgres + S3: `test_index_doc_batch_prepare`, `test_index_swap_workflow`,
+and `test_document_deletion_file_cleanup`. The setup + teardown logic is
+substantial and identical across all three, so it lives here.
+
+Tests keep their own `cc_pair` fixture (dependencies differ per file), but
+the body is just `make_cc_pair` + `cleanup_cc_pair`.
+"""
+
+from io import BytesIO
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
+from onyx.connectors.models import Document
+from onyx.connectors.models import InputType
+from onyx.connectors.models import TextSection
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.file_record import get_filerecord_by_file_id_optional
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import Document as DBDocument
+from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import FileRecord
+from onyx.file_store.file_store import get_default_file_store
+
+
+def make_doc(
+    doc_id: str,
+    file_id: str | None = None,
+    from_ingestion_api: bool = False,
+) -> Document:
+    """Minimal Document for indexing-pipeline tests. MOCK_CONNECTOR avoids
+    triggering the hierarchy-node linking branch (NOTION/CONFLUENCE only)."""
+    return Document(
+        id=doc_id,
+        source=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"semantic-{doc_id}",
+        sections=[TextSection(text="content", link=None)],
+        metadata={},
+        file_id=file_id,
+        from_ingestion_api=from_ingestion_api,
+    )
+
+
+def stage_file(content: bytes = b"raw bytes") -> str:
+    """Write bytes to the file store as INDEXING_STAGING and return the file_id.
+
+    Mirrors what the connector raw_file_callback would do during fetch.
+    The `{"test": True}` metadata tag lets manual cleanup scripts find
+    leftovers if a cleanup ever slips through.
+    """
+    return get_default_file_store().save_file(
+        content=BytesIO(content),
+        display_name=None,
+        file_origin=FileOrigin.INDEXING_STAGING,
+        file_type="application/octet-stream",
+        file_metadata={"test": True},
+    )
+
+
+def get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
+    """Reload the document row fresh from DB so we see post-upsert state."""
+    db_session.expire_all()
+    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
+
+
+def get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
+    db_session.expire_all()
+    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
+
+
+def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+    """Create a Connector + Credential + ConnectorCredentialPair for a test.
+
+    All names are UUID-suffixed so parallel test runs don't collide.
+    """
+    connector = Connector(
+        name=f"test-connector-{uuid4().hex[:8]}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.MOCK_CONNECTOR,
+        credential_json={},
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"test-cc-pair-{uuid4().hex[:8]}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+        auto_sync_options=None,
+    )
+    db_session.add(pair)
+    db_session.commit()
+    db_session.refresh(pair)
+    return pair
+
+
+def cleanup_cc_pair(db_session: Session, pair: ConnectorCredentialPair) -> None:
+    """Tear down everything created under `pair`.
+
+    Deletes own join rows first (FK to document has no cascade), then for any
+    doc that now has zero remaining cc_pair references, deletes its file +
+    the document row. Finally removes the cc_pair, connector, credential.
+    Safe against docs shared with other cc_pairs — those stay alive until
+    their last reference is torn down.
+    """
+    db_session.expire_all()
+
+    connector_id = pair.connector_id
+    credential_id = pair.credential_id
+
+    owned_doc_ids: list[str] = [
+        row[0]
+        for row in db_session.query(DocumentByConnectorCredentialPair.id)
+        .filter(
+            DocumentByConnectorCredentialPair.connector_id == connector_id,
+            DocumentByConnectorCredentialPair.credential_id == credential_id,
+        )
+        .all()
+    ]
+
+    db_session.query(DocumentByConnectorCredentialPair).filter(
+        DocumentByConnectorCredentialPair.connector_id == connector_id,
+        DocumentByConnectorCredentialPair.credential_id == credential_id,
+    ).delete(synchronize_session="fetch")
+    db_session.flush()
+
+    if owned_doc_ids:
+        orphan_doc_ids: list[str] = [
+            row[0]
+            for row in db_session.query(DBDocument.id)
+            .filter(DBDocument.id.in_(owned_doc_ids))
+            .filter(
+                ~db_session.query(DocumentByConnectorCredentialPair)
+                .filter(DocumentByConnectorCredentialPair.id == DBDocument.id)
+                .exists()
+            )
+            .all()
+        ]
+        orphan_file_ids: list[str] = [
+            row[0]
+            for row in db_session.query(DBDocument.file_id)
+            .filter(
+                DBDocument.id.in_(orphan_doc_ids),
+                DBDocument.file_id.isnot(None),
+            )
+            .all()
+        ]
+
+        file_store = get_default_file_store()
+        for fid in orphan_file_ids:
+            try:
+                file_store.delete_file(fid, error_on_missing=False)
+            except Exception:
+                pass
+
+        if orphan_doc_ids:
+            db_session.query(DBDocument).filter(
+                DBDocument.id.in_(orphan_doc_ids)
+            ).delete(synchronize_session="fetch")
+
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.id == pair.id
+    ).delete(synchronize_session="fetch")
+    db_session.query(Connector).filter(Connector.id == connector_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.query(Credential).filter(Credential.id == credential_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()

--- a/backend/tests/external_dependency_unit/search_settings/test_index_swap_workflow.py
+++ b/backend/tests/external_dependency_unit/search_settings/test_index_swap_workflow.py
@@ -10,105 +10,32 @@ file_store side effects of the swap, not the document index integration.
 """
 
 from collections.abc import Generator
-from io import BytesIO
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import DocumentSource
-from onyx.configs.constants import FileOrigin
-from onyx.connectors.models import Document
 from onyx.connectors.models import IndexAttemptMetadata
-from onyx.connectors.models import InputType
-from onyx.connectors.models import TextSection
 from onyx.context.search.models import SavedSearchSettings
-from onyx.db.enums import AccessType
-from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import EmbeddingPrecision
 from onyx.db.enums import SwitchoverType
-from onyx.db.file_record import get_filerecord_by_file_id_optional
-from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
-from onyx.db.models import Credential
-from onyx.db.models import Document as DBDocument
-from onyx.db.models import FileRecord
 from onyx.db.models import IndexModelStatus
 from onyx.db.search_settings import create_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
-from onyx.file_store.file_store import get_default_file_store
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import get_doc_row
+from tests.external_dependency_unit.indexing_helpers import get_filerecord
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_doc
+from tests.external_dependency_unit.indexing_helpers import stage_file
 
 
 # ---------------------------------------------------------------------------
-# Helpers (kept inline; extract to a shared conftest if a 4th test file shows up)
+# Helpers (file-local)
 # ---------------------------------------------------------------------------
-
-
-def _make_doc(doc_id: str, file_id: str | None = None) -> Document:
-    return Document(
-        id=doc_id,
-        source=DocumentSource.MOCK_CONNECTOR,
-        semantic_identifier=f"semantic-{doc_id}",
-        sections=[TextSection(text="content", link=None)],
-        metadata={},
-        file_id=file_id,
-    )
-
-
-def _stage_file(content: bytes = b"raw bytes") -> str:
-    return get_default_file_store().save_file(
-        content=BytesIO(content),
-        display_name=None,
-        file_origin=FileOrigin.INDEXING_STAGING,
-        file_type="application/octet-stream",
-        file_metadata={"test": True},
-    )
-
-
-def _get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
-    db_session.expire_all()
-    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
-
-
-def _get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
-    db_session.expire_all()
-    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
-
-
-def _make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
-    connector = Connector(
-        name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
-        input_type=InputType.LOAD_STATE,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=None,
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
-        credential_json={},
-    )
-    db_session.add(credential)
-    db_session.flush()
-
-    pair = ConnectorCredentialPair(
-        connector_id=connector.id,
-        credential_id=credential.id,
-        name=f"test-cc-pair-{uuid4().hex[:8]}",
-        status=ConnectorCredentialPairStatus.ACTIVE,
-        access_type=AccessType.PUBLIC,
-        auto_sync_options=None,
-    )
-    db_session.add(pair)
-    db_session.commit()
-    db_session.refresh(pair)
-    return pair
 
 
 def _make_saved_search_settings(
@@ -145,7 +72,11 @@ def cc_pair(
     initialize_file_store: None,  # noqa: ARG001
     full_deployment_setup: None,  # noqa: ARG001
 ) -> Generator[ConnectorCredentialPair, None, None]:
-    yield _make_cc_pair(db_session)
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
 
 
 @pytest.fixture
@@ -173,10 +104,10 @@ class TestInstantIndexSwap:
         attempt_metadata: IndexAttemptMetadata,
     ) -> None:
         # Index two docs with attached files via the normal pipeline.
-        file_id_a = _stage_file(content=b"alpha")
-        file_id_b = _stage_file(content=b"beta")
-        doc_a = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
-        doc_b = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
+        file_id_a = stage_file(content=b"alpha")
+        file_id_b = stage_file(content=b"beta")
+        doc_a = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
+        doc_b = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
 
         index_doc_batch_prepare(
             documents=[doc_a, doc_b],
@@ -187,10 +118,10 @@ class TestInstantIndexSwap:
         db_session.commit()
 
         # Sanity: docs and files exist before the swap.
-        assert _get_doc_row(db_session, doc_a.id) is not None
-        assert _get_doc_row(db_session, doc_b.id) is not None
-        assert _get_filerecord(db_session, file_id_a) is not None
-        assert _get_filerecord(db_session, file_id_b) is not None
+        assert get_doc_row(db_session, doc_a.id) is not None
+        assert get_doc_row(db_session, doc_b.id) is not None
+        assert get_filerecord(db_session, file_id_a) is not None
+        assert get_filerecord(db_session, file_id_b) is not None
 
         # Stage a FUTURE search settings with INSTANT switchover. The next
         # `check_and_perform_index_swap` call will see this and trigger the
@@ -214,13 +145,13 @@ class TestInstantIndexSwap:
         assert old_settings is not None, "INSTANT swap should have executed"
 
         # Documents are gone.
-        assert _get_doc_row(db_session, doc_a.id) is None
-        assert _get_doc_row(db_session, doc_b.id) is None
+        assert get_doc_row(db_session, doc_a.id) is None
+        assert get_doc_row(db_session, doc_b.id) is None
 
         # Files are gone — the workflow's bulk-delete path correctly
         # propagated through to file cleanup.
-        assert _get_filerecord(db_session, file_id_a) is None
-        assert _get_filerecord(db_session, file_id_b) is None
+        assert get_filerecord(db_session, file_id_a) is None
+        assert get_filerecord(db_session, file_id_b) is None
 
     def test_instant_swap_with_mixed_docs_does_not_break(
         self,
@@ -229,9 +160,9 @@ class TestInstantIndexSwap:
     ) -> None:
         """A mix of docs with and without file_ids must all be swept up
         without errors during the swap."""
-        file_id = _stage_file()
-        doc_with = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
-        doc_without = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+        file_id = stage_file()
+        doc_with = make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        doc_without = make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
 
         index_doc_batch_prepare(
             documents=[doc_with, doc_without],
@@ -257,6 +188,6 @@ class TestInstantIndexSwap:
 
         assert old_settings is not None
 
-        assert _get_doc_row(db_session, doc_with.id) is None
-        assert _get_doc_row(db_session, doc_without.id) is None
-        assert _get_filerecord(db_session, file_id) is None
+        assert get_doc_row(db_session, doc_with.id) is None
+        assert get_doc_row(db_session, doc_without.id) is None
+        assert get_filerecord(db_session, file_id) is None

--- a/backend/tests/external_dependency_unit/search_settings/test_index_swap_workflow.py
+++ b/backend/tests/external_dependency_unit/search_settings/test_index_swap_workflow.py
@@ -1,0 +1,262 @@
+"""Workflow-level test for the INSTANT index swap.
+
+When `check_and_perform_index_swap` runs against an `INSTANT` switchover, it
+calls `delete_all_documents_for_connector_credential_pair` for each cc_pair.
+This test exercises that full workflow end-to-end and asserts that the
+attached `Document.file_id`s are also reaped — not just the document rows.
+
+Mocks Vespa (`get_all_document_indices`) since this is testing the postgres +
+file_store side effects of the swap, not the document index integration.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
+from onyx.connectors.models import Document
+from onyx.connectors.models import IndexAttemptMetadata
+from onyx.connectors.models import InputType
+from onyx.connectors.models import TextSection
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import SwitchoverType
+from onyx.db.file_record import get_filerecord_by_file_id_optional
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import Document as DBDocument
+from onyx.db.models import FileRecord
+from onyx.db.models import IndexModelStatus
+from onyx.db.search_settings import create_search_settings
+from onyx.db.swap_index import check_and_perform_index_swap
+from onyx.file_store.file_store import get_default_file_store
+from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+
+
+# ---------------------------------------------------------------------------
+# Helpers (kept inline; extract to a shared conftest if a 4th test file shows up)
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(doc_id: str, file_id: str | None = None) -> Document:
+    return Document(
+        id=doc_id,
+        source=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"semantic-{doc_id}",
+        sections=[TextSection(text="content", link=None)],
+        metadata={},
+        file_id=file_id,
+    )
+
+
+def _stage_file(content: bytes = b"raw bytes") -> str:
+    return get_default_file_store().save_file(
+        content=BytesIO(content),
+        display_name=None,
+        file_origin=FileOrigin.INDEXING_STAGING,
+        file_type="application/octet-stream",
+        file_metadata={"test": True},
+    )
+
+
+def _get_doc_row(db_session: Session, doc_id: str) -> DBDocument | None:
+    db_session.expire_all()
+    return db_session.query(DBDocument).filter(DBDocument.id == doc_id).one_or_none()
+
+
+def _get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
+    db_session.expire_all()
+    return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
+
+
+def _make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"test-connector-{uuid4().hex[:8]}",
+        source=DocumentSource.MOCK_CONNECTOR,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.MOCK_CONNECTOR,
+        credential_json={},
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"test-cc-pair-{uuid4().hex[:8]}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+        auto_sync_options=None,
+    )
+    db_session.add(pair)
+    db_session.commit()
+    db_session.refresh(pair)
+    return pair
+
+
+def _make_saved_search_settings(
+    *,
+    switchover_type: SwitchoverType = SwitchoverType.REINDEX,
+) -> SavedSearchSettings:
+    return SavedSearchSettings(
+        model_name=f"test-embedding-model-{uuid4().hex[:8]}",
+        model_dim=768,
+        normalize=True,
+        query_prefix="",
+        passage_prefix="",
+        provider_type=None,
+        index_name=f"test_index_{uuid4().hex[:8]}",
+        multipass_indexing=False,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+        reduced_dimension=None,
+        enable_contextual_rag=False,
+        contextual_rag_llm_name=None,
+        contextual_rag_llm_provider=None,
+        switchover_type=switchover_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    full_deployment_setup: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    yield _make_cc_pair(db_session)
+
+
+@pytest.fixture
+def attempt_metadata(cc_pair: ConnectorCredentialPair) -> IndexAttemptMetadata:
+    return IndexAttemptMetadata(
+        connector_id=cc_pair.connector_id,
+        credential_id=cc_pair.credential_id,
+        attempt_id=None,
+        request_id="test-request",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInstantIndexSwap:
+    """`SwitchoverType.INSTANT` wipes all docs for every cc_pair as part of
+    the swap. The associated raw files must be reaped too."""
+
+    def test_instant_swap_deletes_docs_and_files(
+        self,
+        db_session: Session,
+        attempt_metadata: IndexAttemptMetadata,
+    ) -> None:
+        # Index two docs with attached files via the normal pipeline.
+        file_id_a = _stage_file(content=b"alpha")
+        file_id_b = _stage_file(content=b"beta")
+        doc_a = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_a)
+        doc_b = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id_b)
+
+        index_doc_batch_prepare(
+            documents=[doc_a, doc_b],
+            index_attempt_metadata=attempt_metadata,
+            db_session=db_session,
+            ignore_time_skip=True,
+        )
+        db_session.commit()
+
+        # Sanity: docs and files exist before the swap.
+        assert _get_doc_row(db_session, doc_a.id) is not None
+        assert _get_doc_row(db_session, doc_b.id) is not None
+        assert _get_filerecord(db_session, file_id_a) is not None
+        assert _get_filerecord(db_session, file_id_b) is not None
+
+        # Stage a FUTURE search settings with INSTANT switchover. The next
+        # `check_and_perform_index_swap` call will see this and trigger the
+        # bulk-delete path on every cc_pair.
+        create_search_settings(
+            search_settings=_make_saved_search_settings(
+                switchover_type=SwitchoverType.INSTANT
+            ),
+            db_session=db_session,
+            status=IndexModelStatus.FUTURE,
+        )
+
+        # Vespa is patched out — we're testing the postgres + file_store
+        # side effects, not the document-index integration.
+        with patch(
+            "onyx.db.swap_index.get_all_document_indices",
+            return_value=[],
+        ):
+            old_settings = check_and_perform_index_swap(db_session)
+
+        assert old_settings is not None, "INSTANT swap should have executed"
+
+        # Documents are gone.
+        assert _get_doc_row(db_session, doc_a.id) is None
+        assert _get_doc_row(db_session, doc_b.id) is None
+
+        # Files are gone — the workflow's bulk-delete path correctly
+        # propagated through to file cleanup.
+        assert _get_filerecord(db_session, file_id_a) is None
+        assert _get_filerecord(db_session, file_id_b) is None
+
+    def test_instant_swap_with_mixed_docs_does_not_break(
+        self,
+        db_session: Session,
+        attempt_metadata: IndexAttemptMetadata,
+    ) -> None:
+        """A mix of docs with and without file_ids must all be swept up
+        without errors during the swap."""
+        file_id = _stage_file()
+        doc_with = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_id)
+        doc_without = _make_doc(f"doc-{uuid4().hex[:8]}", file_id=None)
+
+        index_doc_batch_prepare(
+            documents=[doc_with, doc_without],
+            index_attempt_metadata=attempt_metadata,
+            db_session=db_session,
+            ignore_time_skip=True,
+        )
+        db_session.commit()
+
+        create_search_settings(
+            search_settings=_make_saved_search_settings(
+                switchover_type=SwitchoverType.INSTANT
+            ),
+            db_session=db_session,
+            status=IndexModelStatus.FUTURE,
+        )
+
+        with patch(
+            "onyx.db.swap_index.get_all_document_indices",
+            return_value=[],
+        ):
+            old_settings = check_and_perform_index_swap(db_session)
+
+        assert old_settings is not None
+
+        assert _get_doc_row(db_session, doc_with.id) is None
+        assert _get_doc_row(db_session, doc_without.id) is None
+        assert _get_filerecord(db_session, file_id) is None


### PR DESCRIPTION
## Description
When a document gets deleted, we want to also delete the stored file. This PR follows the document lifecycle to delete the stored file whenever the document gets deleted.

## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes attached files when documents are removed and manages the `file_id` lifecycle on upsert. Cleanup runs after the DB commit across all delete paths to avoid orphaned files.

- **New Features**
  - Upsert and store `file_id` via `index_doc_batch_prepare`; promote staged files to `CONNECTOR`. Swapping deletes the old file; unchanged is a no-op; clearing removes the old file and nulls the column.

- **Bug Fixes**
  - Added `delete_documents_complete` to commit and then delete files; switched callers: `document_by_cc_pair_cleanup_task` (count=1), `delete_ingestion_doc`, `delete_all_documents_for_connector_credential_pair`.
  - Added `get_file_ids_for_document_ids` and `delete_files_best_effort`; tests cover all delete paths and `INSTANT` index swaps, preserving files when documents are still referenced.

<sup>Written for commit 37c8b9eec8dfa8b1a6c2b4e44e63bcef2c303d65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



