### PR TITLE
feat(chart): allow extra manifests for chart flexibility

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.46
+version: 0.4.47
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/extra-manifests.yaml
+++ b/deployment/helm/charts/onyx/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraManifests }}
+---
+{{- if kindIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1316,3 +1316,26 @@ configMap:
   HARD_DELETE_CHATS: ""
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
+
+# -- Additional arbitrary manifests to render as part of the release. Each entry
+# may be either a YAML mapping (a single Kubernetes object) or a multi-line
+# string that will be passed through `tpl` so it can reference release values.
+# Useful for injecting resources not covered by the chart (e.g. NetworkPolicies,
+# ExternalSecrets, custom CRs) without forking the chart.
+extraManifests: []
+# extraManifests:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: my-extra-config
+#     data:
+#       key: value
+#   - |
+#     apiVersion: networking.k8s.io/v1
+#     kind: NetworkPolicy
+#     metadata:
+#       name: {{ include "onyx.fullname" . }}-extra
+#     spec:
+#       podSelector: {}
+#       policyTypes:
+#         - Ingress


### PR DESCRIPTION
## Description

Added an `extraManifests` value in the `values.yaml` of the onyx helm chart

## How Has This Been Tested?

Tested with the following comamnds:

```
cat > /tmp/extra-manifests-test.yaml <<'EOF'
auth:
  opensearch:
    values:
      opensearch_admin_password: "dummy-password-for-template-test"

extraManifests:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: my-extra-config
    data:
      key: value
  - |
    apiVersion: networking.k8s.io/v1
    kind: NetworkPolicy
    metadata:
      name: {{ include "onyx.fullname" . }}-extra
      labels:
        {{- include "onyx.labels" . | nindent 8 }}
    spec:
      podSelector: {}
      policyTypes:
        - Ingress
EOF
helm template test . -f /tmp/extra-manifests-test.yaml --show-only templates/extra-manifests.yaml 2>&1
```

renders the additional configmap and netpol

```
cat > /tmp/extra-manifests-empty.yaml <<'EOF'
auth:
  opensearch:
    values:
      opensearch_admin_password: "dummy"
EOF
helm template test . -f /tmp/extra-manifests-empty.yaml --show-only templates/extra-manifests.yaml 2>&1
```

Does not render any additional files

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `extraManifests` to the `onyx` Helm chart so users can include arbitrary Kubernetes resources in a release. Supports YAML objects and templated multi-line strings for flexible customization.

- **New Features**
  - New template `templates/extra-manifests.yaml` renders each item in `.Values.extraManifests` (string entries via `tpl`, object entries via `toYaml`).
  - `values.yaml` adds `extraManifests: []` with brief docs and examples (e.g., `ConfigMap`, `NetworkPolicy`) to inject resources not covered by the chart.
  - Bumps chart version to `0.4.47`.

<sup>Written for commit 8010bf7f1a93063a3d6bd921d5b14d632a35d80b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

