### PR TITLE
fix: include COMPLETED_WITH_ERRORS in poll range start calculation

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -348,7 +348,9 @@ def get_last_successful_attempt_poll_range_end(
         .filter(
             ConnectorCredentialPair.id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings.id,
-            IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.status.in_(
+                [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
+            ),
         )
         .order_by(IndexAttempt.poll_range_end.desc())
         .first()


### PR DESCRIPTION
Fixes #10059

## Problem

When a connector finishes with `COMPLETED_WITH_ERRORS`, `IndexingStatus.is_successful()` returns `True` and `last_successful_index_time` on the connector-credential pair is updated correctly. However, `get_last_successful_attempt_poll_range_end()` in `backend/onyx/db/connector_credential_pair.py` queried only attempts with `status == IndexingStatus.SUCCESS`, excluding `COMPLETED_WITH_ERRORS`.

As a result, connectors that consistently end with `COMPLETED_WITH_ERRORS` (like the Gong connector, which often has partial transcript failures) never find a "successful" attempt to anchor the next `poll_range_start`. Every run starts from epoch (`1970-01-01 00:00:00+00:00`), causing the connector to re-fetch and re-process all documents on every indexing cycle.

## Solution

Extend the status filter in `get_last_successful_attempt_poll_range_end()` to include both `IndexingStatus.SUCCESS` and `IndexingStatus.COMPLETED_WITH_ERRORS`, making it consistent with the `is_successful()` method used elsewhere in the codebase (including in `last_successful_index_time` update logic).

## Testing

- Existing integration tests in `backend/tests/integration/tests/indexing/test_polling.py` continue to pass, as they test `SUCCESS` status which is still included in the filter.
- The fix is a one-line logical extension of an existing filter, consistent with `IndexingStatus.is_successful()` semantics already used throughout the codebase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `COMPLETED_WITH_ERRORS` as a successful indexing attempt when calculating the poll range start to prevent connectors from resetting to epoch and reprocessing everything each run.

- **Bug Fixes**
  - Updated `get_last_successful_attempt_poll_range_end()` to include both `IndexingStatus.SUCCESS` and `IndexingStatus.COMPLETED_WITH_ERRORS`, aligning with `is_successful()` and `last_successful_index_time`.

<sup>Written for commit c74ce830a4bf76898bf1e50d4be1e3964955ffc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

