### PR TITLE
fix(db): add missing FK indexes for hot celery worker tables

### DIFF
--- a/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
+++ b/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
@@ -1,0 +1,68 @@
+"""add missing FK indexes for hot tables
+
+Adds indexes on foreign key columns that are frequently queried by celery
+worker tasks but were missing indexes, causing full sequential scans.
+
+Postgres does NOT automatically create indexes on foreign key columns
+(unlike MySQL). These four columns were identified via Aurora Performance
+Insights as the top contributors to primary-worker AAS after the
+ix_document_needs_sync partial index was deployed.
+
+- index_attempt_errors.index_attempt_id: #1 query in pg_stat_statements
+  (56ms mean on a 532K-row / 997MB table). Queried every check_for_indexing
+  cycle to load errors per attempt.
+- index_attempt_errors.connector_credential_pair_id: same table, queried
+  when filtering errors by cc_pair.
+- index_attempt.connector_credential_pair_id: queried by check_for_indexing
+  to find attempts for each cc_pair. 73ms mean on tenant_dev.
+- hierarchy_node.document_id: 18MB+ on large tenants, queried during
+  document deletion and hierarchy rebuilds.
+
+Revision ID: 856bcbe14d79
+Revises: a6fcd3d631f9
+Create Date: 2026-04-19 18:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "856bcbe14d79"
+down_revision = "a6fcd3d631f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_index_attempt_errors_attempt_id",
+        "index_attempt_errors",
+        ["index_attempt_id"],
+    )
+    op.create_index(
+        "ix_index_attempt_errors_cc_pair_id",
+        "index_attempt_errors",
+        ["connector_credential_pair_id"],
+    )
+    op.create_index(
+        "ix_index_attempt_cc_pair_id",
+        "index_attempt",
+        ["connector_credential_pair_id"],
+    )
+    op.create_index(
+        "ix_hierarchy_node_document_id",
+        "hierarchy_node",
+        ["document_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_hierarchy_node_document_id", table_name="hierarchy_node")
+    op.drop_index("ix_index_attempt_cc_pair_id", table_name="index_attempt")
+    op.drop_index(
+        "ix_index_attempt_errors_cc_pair_id", table_name="index_attempt_errors"
+    )
+    op.drop_index(
+        "ix_index_attempt_errors_attempt_id", table_name="index_attempt_errors"
+    )

--- a/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
+++ b/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
@@ -33,7 +33,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "856bcbe14d79"
-down_revision = "a6fcd3d631f9"
+down_revision = "91d150c361f6"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
+++ b/backend/alembic/versions/856bcbe14d79_add_missing_fk_indexes_for_hot_tables.py
@@ -18,6 +18,10 @@ ix_document_needs_sync partial index was deployed.
 - hierarchy_node.document_id: 18MB+ on large tenants, queried during
   document deletion and hierarchy rebuilds.
 
+Note: Index names follow SQLAlchemy's ix_<table>_<column> convention to match
+the `index=True` declarations in models.py. This prevents autogenerate from
+detecting a mismatch and creating duplicate indexes.
+
 Revision ID: 856bcbe14d79
 Revises: a6fcd3d631f9
 Create Date: 2026-04-19 18:00:00.000000
@@ -36,17 +40,17 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_index(
-        "ix_index_attempt_errors_attempt_id",
+        "ix_index_attempt_errors_index_attempt_id",
         "index_attempt_errors",
         ["index_attempt_id"],
     )
     op.create_index(
-        "ix_index_attempt_errors_cc_pair_id",
+        "ix_index_attempt_errors_connector_credential_pair_id",
         "index_attempt_errors",
         ["connector_credential_pair_id"],
     )
     op.create_index(
-        "ix_index_attempt_cc_pair_id",
+        "ix_index_attempt_connector_credential_pair_id",
         "index_attempt",
         ["connector_credential_pair_id"],
     )
@@ -59,10 +63,13 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index("ix_hierarchy_node_document_id", table_name="hierarchy_node")
-    op.drop_index("ix_index_attempt_cc_pair_id", table_name="index_attempt")
     op.drop_index(
-        "ix_index_attempt_errors_cc_pair_id", table_name="index_attempt_errors"
+        "ix_index_attempt_connector_credential_pair_id", table_name="index_attempt"
     )
     op.drop_index(
-        "ix_index_attempt_errors_attempt_id", table_name="index_attempt_errors"
+        "ix_index_attempt_errors_connector_credential_pair_id",
+        table_name="index_attempt_errors",
+    )
+    op.drop_index(
+        "ix_index_attempt_errors_index_attempt_id", table_name="index_attempt_errors"
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -894,7 +894,7 @@ class HierarchyNode(Base):
     # For hierarchy nodes that are also documents (e.g., Confluence pages)
     # SET NULL when document is deleted - node can exist without its document
     document_id: Mapped[str | None] = mapped_column(
-        ForeignKey("document.id", ondelete="SET NULL"), nullable=True
+        ForeignKey("document.id", ondelete="SET NULL"), nullable=True, index=True
     )
 
     # Self-referential FK for tree structure
@@ -2204,6 +2204,7 @@ class IndexAttempt(Base):
     connector_credential_pair_id: Mapped[int] = mapped_column(
         ForeignKey("connector_credential_pair.id"),
         nullable=False,
+        index=True,
     )
 
     # Some index attempts that run from beginning will still have this as False
@@ -2407,10 +2408,12 @@ class IndexAttemptError(Base):
     index_attempt_id: Mapped[int] = mapped_column(
         ForeignKey("index_attempt.id"),
         nullable=False,
+        index=True,
     )
     connector_credential_pair_id: Mapped[int] = mapped_column(
         ForeignKey("connector_credential_pair.id"),
         nullable=False,
+        index=True,
     )
 
     document_id: Mapped[str | None] = mapped_column(String, nullable=True)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
- Adds indexes on 4 foreign key columns that celery workers query frequently but had no indexes, causing full sequential scans
- `index_attempt_errors.index_attempt_id` — top query in Aurora PI (56ms mean, 532K rows, 997MB table)
- `index_attempt_errors.connector_credential_pair_id` — same table
- `index_attempt.connector_credential_pair_id` — 73ms mean on tenant_dev
- `hierarchy_node.document_id` — 18MB+ on large tenants
- Follows up on PR #10349 (partial index on document sync)

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing indexes on four hot foreign key columns to stop full scans by celery workers and cut query latency. Lowers Aurora load and speeds up indexing and document deletes on large tenants.

- **Bug Fixes**
  - Added indexes on index_attempt_errors.index_attempt_id, index_attempt_errors.connector_credential_pair_id, index_attempt.connector_credential_pair_id, and hierarchy_node.document_id via an `Alembic` migration and `index=True` in models.
  - Cleanup: renamed indexes to `SQLAlchemy`’s `ix_<table>_<column>` convention and chained the migration after `91d150c361f6` to avoid a fork.

<sup>Written for commit 6d38179c451a9f0b12ceb4ec6f4aae89ad3f4983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



