### PR TITLE
fix(external-group-sync): batch upsert + commit before API calls

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -506,6 +506,18 @@ def _perform_external_group_sync(
 
         ext_group_sync_func = sync_config.group_sync_config.group_sync_func
 
+        # Clean up stale rows from previous cycle BEFORE marking new ones.
+        # This ensures cleanup always runs regardless of whether the current
+        # sync succeeds — previously, cleanup only ran at the END of the sync,
+        # so if the sync failed (e.g. DB connection killed by
+        # idle_in_transaction_session_timeout during long API calls), stale
+        # rows would accumulate indefinitely.
+        logger.info(
+            f"Removing stale external groups from prior cycle for {source_type} "
+            f"for cc_pair: {cc_pair_id}"
+        )
+        remove_stale_external_groups(db_session, cc_pair_id)
+
         logger.info(
             f"Marking old external groups as stale for {source_type} for cc_pair: {cc_pair_id}"
         )

--- a/backend/ee/onyx/db/external_perm.py
+++ b/backend/ee/onyx/db/external_perm.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy import update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from onyx.access.utils import build_ext_group_name_for_onyx
@@ -77,6 +78,15 @@ def mark_old_external_groups_as_stale(
         .where(PublicExternalUserGroup.cc_pair_id == cc_pair_id)
         .values(stale=True)
     )
+    # Commit immediately so the transaction closes before potentially long
+    # external API calls (e.g. Google Drive folder iteration). Without this,
+    # the DB connection sits idle-in-transaction during API calls and gets
+    # killed by idle_in_transaction_session_timeout, causing the entire sync
+    # to fail and stale cleanup to never run.
+    db_session.commit()
+
+
+_UPSERT_BATCH_SIZE = 5000
 
 
 def upsert_external_groups(
@@ -86,91 +96,83 @@ def upsert_external_groups(
     source: DocumentSource,
 ) -> None:
     """
-    Performs a true upsert operation for external user groups:
-    - For existing groups (same user_id, external_user_group_id, cc_pair_id), updates the stale flag to False
-    - For new groups, inserts them with stale=False
-    - For public groups, uses upsert logic as well
+    Batch upsert external user groups using INSERT ... ON CONFLICT DO UPDATE.
+    - For existing rows (same user_id, external_user_group_id, cc_pair_id),
+      sets stale=False
+    - For new rows, inserts with stale=False
+    - Same logic for PublicExternalUserGroup
     """
-    # If there are no groups to add, return early
     if not external_groups:
         return
 
-    # collect all emails from all groups to batch add all users at once for efficiency
-    all_group_member_emails = set()
+    # Collect all emails from all groups to batch-add users at once
+    all_group_member_emails: set[str] = set()
     for external_group in external_groups:
-        for user_email in external_group.user_emails:
-            all_group_member_emails.add(user_email)
+        all_group_member_emails.update(external_group.user_emails)
 
-    # batch add users if they don't exist and get their ids
+    # Batch add users if they don't exist and get their ids
     all_group_members: list[User] = batch_add_ext_perm_user_if_not_exists(
         db_session=db_session,
-        # NOTE: this function handles case sensitivity for emails
         emails=list(all_group_member_emails),
     )
 
-    # map emails to ids
     email_id_map = {user.email.lower(): user.id for user in all_group_members}
 
-    # Process each external group
+    # Build all user-group mappings and public-group mappings
+    user_group_mappings: list[dict] = []
+    public_group_mappings: list[dict] = []
+
     for external_group in external_groups:
         external_group_id = build_ext_group_name_for_onyx(
             ext_group_name=external_group.id,
             source=source,
         )
 
-        # Handle user-group mappings
         for user_email in external_group.user_emails:
             user_id = email_id_map.get(user_email.lower())
             if user_id is None:
                 logger.warning(
-                    f"User in group {external_group.id} with email {user_email} not found"
+                    f"User in group {external_group.id}"
+                    f" with email {user_email} not found"
                 )
                 continue
 
-            # Check if the user-group mapping already exists
-            existing_user_group = db_session.scalar(
-                select(User__ExternalUserGroupId).where(
-                    User__ExternalUserGroupId.user_id == user_id,
-                    User__ExternalUserGroupId.external_user_group_id
-                    == external_group_id,
-                    User__ExternalUserGroupId.cc_pair_id == cc_pair_id,
-                )
+            user_group_mappings.append(
+                {
+                    "user_id": user_id,
+                    "external_user_group_id": external_group_id,
+                    "cc_pair_id": cc_pair_id,
+                    "stale": False,
+                }
             )
 
-            if existing_user_group:
-                # Update existing record
-                existing_user_group.stale = False
-            else:
-                # Insert new record
-                new_user_group = User__ExternalUserGroupId(
-                    user_id=user_id,
-                    external_user_group_id=external_group_id,
-                    cc_pair_id=cc_pair_id,
-                    stale=False,
-                )
-                db_session.add(new_user_group)
-
-        # Handle public group if needed
         if external_group.gives_anyone_access:
-            # Check if the public group already exists
-            existing_public_group = db_session.scalar(
-                select(PublicExternalUserGroup).where(
-                    PublicExternalUserGroup.external_user_group_id == external_group_id,
-                    PublicExternalUserGroup.cc_pair_id == cc_pair_id,
-                )
+            public_group_mappings.append(
+                {
+                    "external_user_group_id": external_group_id,
+                    "cc_pair_id": cc_pair_id,
+                    "stale": False,
+                }
             )
 
-            if existing_public_group:
-                # Update existing record
-                existing_public_group.stale = False
-            else:
-                # Insert new record
-                new_public_group = PublicExternalUserGroup(
-                    external_user_group_id=external_group_id,
-                    cc_pair_id=cc_pair_id,
-                    stale=False,
-                )
-                db_session.add(new_public_group)
+    # Batch upsert user-group mappings
+    for i in range(0, len(user_group_mappings), _UPSERT_BATCH_SIZE):
+        chunk = user_group_mappings[i : i + _UPSERT_BATCH_SIZE]
+        stmt = pg_insert(User__ExternalUserGroupId).values(chunk)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "external_user_group_id", "cc_pair_id"],
+            set_={"stale": False},
+        )
+        db_session.execute(stmt)
+
+    # Batch upsert public group mappings
+    if public_group_mappings:
+        stmt = pg_insert(PublicExternalUserGroup).values(public_group_mappings)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["external_user_group_id", "cc_pair_id"],
+            set_={"stale": False},
+        )
+        db_session.execute(stmt)
 
     db_session.commit()
 

--- a/backend/ee/onyx/db/external_perm.py
+++ b/backend/ee/onyx/db/external_perm.py
@@ -175,9 +175,17 @@ def upsert_external_groups(
         )
         db_session.execute(stmt)
 
+    # Deduplicate public group mappings as well
+    public_group_mappings_deduped = list(
+        {
+            (m["external_user_group_id"], m["cc_pair_id"]): m
+            for m in public_group_mappings
+        }.values()
+    )
+
     # Batch upsert public group mappings
-    for i in range(0, len(public_group_mappings), _UPSERT_BATCH_SIZE):
-        chunk = public_group_mappings[i : i + _UPSERT_BATCH_SIZE]
+    for i in range(0, len(public_group_mappings_deduped), _UPSERT_BATCH_SIZE):
+        chunk = public_group_mappings_deduped[i : i + _UPSERT_BATCH_SIZE]
         stmt = pg_insert(PublicExternalUserGroup).values(chunk)
         stmt = stmt.on_conflict_do_update(
             index_elements=["external_user_group_id", "cc_pair_id"],

--- a/backend/ee/onyx/db/external_perm.py
+++ b/backend/ee/onyx/db/external_perm.py
@@ -155,9 +155,19 @@ def upsert_external_groups(
                 }
             )
 
+    # Deduplicate to avoid "ON CONFLICT DO UPDATE command cannot affect row
+    # a second time" when duplicate emails or overlapping groups produce
+    # identical (user_id, external_user_group_id, cc_pair_id) tuples.
+    user_group_mappings_deduped = list(
+        {
+            (m["user_id"], m["external_user_group_id"], m["cc_pair_id"]): m
+            for m in user_group_mappings
+        }.values()
+    )
+
     # Batch upsert user-group mappings
-    for i in range(0, len(user_group_mappings), _UPSERT_BATCH_SIZE):
-        chunk = user_group_mappings[i : i + _UPSERT_BATCH_SIZE]
+    for i in range(0, len(user_group_mappings_deduped), _UPSERT_BATCH_SIZE):
+        chunk = user_group_mappings_deduped[i : i + _UPSERT_BATCH_SIZE]
         stmt = pg_insert(User__ExternalUserGroupId).values(chunk)
         stmt = stmt.on_conflict_do_update(
             index_elements=["user_id", "external_user_group_id", "cc_pair_id"],
@@ -166,8 +176,9 @@ def upsert_external_groups(
         db_session.execute(stmt)
 
     # Batch upsert public group mappings
-    if public_group_mappings:
-        stmt = pg_insert(PublicExternalUserGroup).values(public_group_mappings)
+    for i in range(0, len(public_group_mappings), _UPSERT_BATCH_SIZE):
+        chunk = public_group_mappings[i : i + _UPSERT_BATCH_SIZE]
+        stmt = pg_insert(PublicExternalUserGroup).values(chunk)
         stmt = stmt.on_conflict_do_update(
             index_elements=["external_user_group_id", "cc_pair_id"],
             set_={"stale": False},


### PR DESCRIPTION
## Description

- External group sync was silently failing for tenants with large Google Drive workspaces, causing `user__external_user_group_id` to accumulate ~20 GB of stale rows across 8 tenants (worst: 2.2M rows / 13 GB for one tenant)
- Root cause: `mark_old_external_groups_as_stale()` left a DB transaction open during Google API folder iteration (10+ min). `idle_in_transaction_session_timeout=60s` killed the connection, causing `remove_stale_external_groups()` to never run
- Three fixes: (1) commit after mark-stale so transaction closes before API calls, (2) batch upsert with `ON CONFLICT` replacing per-row SELECT+INSERT (400K queries/cycle → ~42), (3) run stale cleanup at the START of each sync so it runs regardless of current sync success

## Details

### Bug 1: DB connection death during long API calls
`_perform_external_group_sync` opens a single DB session and holds it for the entire sync. `mark_old_external_groups_as_stale()` runs an UPDATE without committing, then the Google Drive generator starts making API calls. The DB connection sits idle-in-transaction, and after 60s Postgres kills it. The sync exceptions with `InvalidTransactionError: Can't reconnect until invalid transaction is rolled back`, and `remove_stale_external_groups()` never runs.

**Fix:** Add `db_session.commit()` in `mark_old_external_groups_as_stale` so the transaction closes before API calls begin.

### Bug 2: N+1 query pattern
`upsert_external_groups` does one SELECT per user-group mapping to check existence, then INSERT or UPDATE. For 200K mappings, that's ~400K queries per cycle.

**Fix:** Replace with batch `INSERT ... ON CONFLICT DO UPDATE` in chunks of 5000.

### Bug 3: Cleanup only runs on success
`remove_stale_external_groups` was only called after the sync loop completes successfully. If the sync fails (timeout, API error, DB error), stale rows accumulate forever.

**Fix:** Also run `remove_stale_external_groups` at the START of each sync, cleaning up stale rows from the prior cycle before marking new ones.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Verify external group sync completes for a Google Drive tenant with SYNC access
Verify stale rows are cleaned up after a successful sync cycle

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes external group sync for large Google Drive tenants by committing before API calls, batching upserts, and running cleanup at the start. Prevents stale row buildup and slashes query load during syncs.

- **Bug Fixes**
  - Commit right after marking old groups as stale to avoid idle-in-transaction timeouts during long API calls.
  - Run stale cleanup at the start of each sync so it runs even if the prior or current sync fails.

- **Refactors**
  - Replace per-row checks with batch INSERT ... ON CONFLICT DO UPDATE (5k chunks) for user-group and public-group mappings. Deduplicate both mapping types before upsert to avoid conflict errors. Reduces ~400k queries per cycle to ~42.

<sup>Written for commit ec33e6489ec728c3bf83fdd05dc2a359e0540af9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



