### PR TITLE
fix: remove minio profile restriction to fix default docker deployment

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -520,7 +520,6 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
-    profiles: ["s3-filestore"]
     restart: unless-stopped
     # DEV: To expose ports, either:
     # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -156,6 +156,9 @@ services:
         condition: service_started
       indexing_model_server:
         condition: service_started
+      minio:
+        condition: service_started
+        required: false
     restart: unless-stopped
     environment:
       - FILE_STORE_BACKEND=${FILE_STORE_BACKEND:-s3}


### PR DESCRIPTION
## Description

Following the official deployment documentation, running `docker compose up -d` currently causes the API server to crash immediately with a `botocore.exceptions.EndpointConnectionError`. This happens because the `api_server` defaults to `FILE_STORE_BACKEND=s3` (which requires Minio), but the `minio` service was gated behind `profiles: ["s3-filestore"]` and never started.

This PR removes the `profiles: ["s3-filestore"]` line from the `minio` service in `deployment/docker_compose/docker-compose.yml`. Minio will now start by default alongside the rest of the stack, satisfying the S3 backend requirement and resolving the API server crash.

Closes #9793

## How Has This Been Tested?

1. Cloned the repository and navigated to `deployment/docker_compose/`
2. Ran `docker compose up -d`
3. Verified the `minio` container is successfully pulled and running via `docker compose ps`
4. Checked the API server logs (`docker logs onyx-api_server-1`) and confirmed the `EndpointConnectionError` for the S3 bucket is no longer present and the server continues its startup sequence.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check