### PR TITLE
fix(gong): move call-details retry into checkpoint state instead of blocking

### DIFF
--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -42,11 +42,20 @@ class GongConnectorCheckpoint(ConnectorCheckpoint):
     time_range: tuple[str, str] | None = None
     # Transcripts whose call details were not yet available from /v2/calls/extensive
     # (Gong has a known race where transcript call IDs take time to propagate).
-    # Keyed by call_id. Retried on subsequent checkpoint invocations — the worker
-    # cadence between calls provides natural backoff without blocking this call.
+    # Keyed by call_id. Retried on subsequent checkpoint invocations.
+    #
+    # Invariant: all entries share one resolution session — they're stashed
+    # together from a single page and share the attempt counter and retry
+    # deadline. load_from_checkpoint only fetches a new page when this dict
+    # is empty, so entries from different pages can't mix.
     pending_transcripts: dict[str, dict[str, Any]] = {}
     # Number of resolution attempts made for pending_transcripts so far.
     pending_call_details_attempts: int = 0
+    # Unix timestamp before which we should not retry pending_transcripts.
+    # Enforces exponential backoff independent of worker cadence — Gong's
+    # transcript-ID propagation race can take tens of seconds to minutes,
+    # longer than typical worker reinvocation intervals.
+    pending_retry_after: float | None = None
 
 
 class _TranscriptPage(BaseModel):
@@ -70,9 +79,14 @@ class _CursorExpiredError(Exception):
 class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
     BASE_URL = "https://api.gong.io"
     # Max number of attempts to resolve missing call details across checkpoint
-    # invocations before giving up and emitting ConnectorFailure. Worker cadence
-    # between checkpoint calls provides the effective spacing between attempts.
+    # invocations before giving up and emitting ConnectorFailure.
     MAX_CALL_DETAILS_ATTEMPTS = 6
+    # Base delay for exponential backoff between pending-transcript retry
+    # attempts. Delay before attempt N (N >= 2) is CALL_DETAILS_DELAY * 2^(N-2)
+    # seconds (30, 60, 120, 240, 480 = ~15.5min total) — matching the original
+    # blocking-retry schedule, but enforced via checkpoint deadline rather
+    # than in-call time.sleep.
+    CALL_DETAILS_DELAY = 30
     # Gong API limit is 3 calls/sec — stay safely under it
     MIN_REQUEST_INTERVAL = 0.5  # seconds between requests
 
@@ -390,6 +404,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             # load_from_checkpoint only reaches _process_transcripts when
             # pending_transcripts was empty at entry (see early-return above).
             checkpoint.pending_call_details_attempts = 1
+            checkpoint.pending_retry_after = time.time() + self._next_retry_delay(1)
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         combined = (
@@ -502,6 +517,12 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         return checkpoint
 
+    def _next_retry_delay(self, attempts_done: int) -> float:
+        """Seconds to wait before attempt #(attempts_done + 1).
+        Matches the original exponential backoff: 30, 60, 120, 240, 480.
+        """
+        return self.CALL_DETAILS_DELAY * pow(2, attempts_done - 1)
+
     def _resolve_pending_transcripts(
         self,
         checkpoint: GongConnectorCheckpoint,
@@ -510,7 +531,19 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
         in a prior invocation. Mutates checkpoint in place: resolved transcripts
         are removed from pending_transcripts; on attempt exhaustion, emits
         ConnectorFailure for each unresolved call_id and clears pending state.
+
+        If the backoff deadline hasn't elapsed yet, returns without issuing
+        any API call so the next invocation can try again later.
         """
+        if (
+            checkpoint.pending_retry_after is not None
+            and time.time() < checkpoint.pending_retry_after
+        ):
+            # Backoff still in effect — defer to a later invocation without
+            # burning an attempt or an API call.
+            checkpoint.has_more = True
+            return
+
         pending_call_ids = list(checkpoint.pending_transcripts.keys())
         resolved = self._get_call_details_by_ids(pending_call_ids)
 
@@ -522,6 +555,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         if not checkpoint.pending_transcripts:
             checkpoint.pending_call_details_attempts = 0
+            checkpoint.pending_retry_after = None
             return
 
         checkpoint.pending_call_details_attempts += 1
@@ -547,12 +581,15 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
                 )
             checkpoint.pending_transcripts = {}
             checkpoint.pending_call_details_attempts = 0
+            checkpoint.pending_retry_after = None
             # has_more is recomputed by the workspace iteration that follows;
             # reset to False here so a stale True from a prior invocation
             # can't leak out via any future early-return path.
             checkpoint.has_more = False
         else:
-            # Retry again on a future invocation; worker cadence provides gap.
+            checkpoint.pending_retry_after = time.time() + self._next_retry_delay(
+                checkpoint.pending_call_details_attempts
+            )
             checkpoint.has_more = True
 
 

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -356,6 +356,8 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             else {}
         )
 
+        newly_stashed: list[str] = []
+
         for transcript in transcripts:
             call_id = transcript.get("callId")
 
@@ -374,17 +376,19 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
                 continue
 
             # Details not available yet — stash for retry on next invocation.
-            logger.warning(
-                f"Call details not yet available for call_id={call_id} "
-                f"(Gong race condition); deferring to next checkpoint invocation"
-            )
             checkpoint.pending_transcripts[call_id] = transcript
+            newly_stashed.append(call_id)
 
-        # First attempt on any newly-stashed transcripts counts as attempt #1.
-        # pending_call_details_attempts is guaranteed 0 here because
-        # load_from_checkpoint only reaches _process_transcripts when
-        # pending_transcripts was empty at entry (see early-return above).
-        if checkpoint.pending_transcripts:
+        if newly_stashed:
+            logger.warning(
+                f"Gong call details not yet available (race condition); "
+                f"deferring to next checkpoint invocation: "
+                f"call_ids={newly_stashed}"
+            )
+            # First attempt on any newly-stashed transcripts counts as attempt #1.
+            # pending_call_details_attempts is guaranteed 0 here because
+            # load_from_checkpoint only reaches _process_transcripts when
+            # pending_transcripts was empty at entry (see early-return above).
             checkpoint.pending_call_details_attempts = 1
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -381,10 +381,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.pending_transcripts[call_id] = transcript
 
         # First attempt on any newly-stashed transcripts counts as attempt #1.
-        if (
-            checkpoint.pending_transcripts
-            and checkpoint.pending_call_details_attempts == 0
-        ):
+        # pending_call_details_attempts is guaranteed 0 here because
+        # load_from_checkpoint only reaches _process_transcripts when
+        # pending_transcripts was empty at entry (see early-return above).
+        if checkpoint.pending_transcripts:
             checkpoint.pending_call_details_attempts = 1
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -543,6 +543,10 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
                 )
             checkpoint.pending_transcripts = {}
             checkpoint.pending_call_details_attempts = 0
+            # has_more is recomputed by the workspace iteration that follows;
+            # reset to False here so a stale True from a prior invocation
+            # can't leak out via any future early-return path.
+            checkpoint.has_more = False
         else:
             # Retry again on a future invocation; worker cadence provides gap.
             checkpoint.has_more = True

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -40,6 +40,13 @@ class GongConnectorCheckpoint(ConnectorCheckpoint):
     cursor: str | None = None
     # Cached time range — computed once, reused across checkpoint calls
     time_range: tuple[str, str] | None = None
+    # Transcripts whose call details were not yet available from /v2/calls/extensive
+    # (Gong has a known race where transcript call IDs take time to propagate).
+    # Keyed by call_id. Retried on subsequent checkpoint invocations — the worker
+    # cadence between calls provides natural backoff without blocking this call.
+    pending_transcripts: dict[str, dict[str, Any]] = {}
+    # Number of resolution attempts made for pending_transcripts so far.
+    pending_call_details_attempts: int = 0
 
 
 class _TranscriptPage(BaseModel):
@@ -62,8 +69,10 @@ class _CursorExpiredError(Exception):
 
 class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
     BASE_URL = "https://api.gong.io"
+    # Max number of attempts to resolve missing call details across checkpoint
+    # invocations before giving up and emitting ConnectorFailure. Worker cadence
+    # between checkpoint calls provides the effective spacing between attempts.
     MAX_CALL_DETAILS_ATTEMPTS = 6
-    CALL_DETAILS_DELAY = 30  # in seconds
     # Gong API limit is 3 calls/sec — stay safely under it
     MIN_REQUEST_INTERVAL = 0.5  # seconds between requests
 
@@ -187,50 +196,6 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         return call_to_metadata
 
-    def _fetch_call_details_with_retry(self, call_ids: list[str]) -> dict[str, Any]:
-        """Fetch call details with retry for the Gong API race condition.
-
-        The Gong API has a known race where transcript call IDs don't immediately
-        appear in /v2/calls/extensive. Retries with exponential backoff, only
-        re-requesting the missing IDs on each attempt.
-        """
-        call_details_map = self._get_call_details_by_ids(call_ids)
-        if set(call_ids) == set(call_details_map.keys()):
-            return call_details_map
-
-        for attempt in range(2, self.MAX_CALL_DETAILS_ATTEMPTS + 1):
-            missing_ids = list(set(call_ids) - set(call_details_map.keys()))
-            logger.warning(
-                f"_get_call_details_by_ids is missing call id's: current_attempt={attempt - 1} missing_call_ids={missing_ids}"
-            )
-
-            wait_seconds = self.CALL_DETAILS_DELAY * pow(2, attempt - 2)
-            logger.warning(
-                f"_get_call_details_by_ids waiting to retry: "
-                f"wait={wait_seconds}s "
-                f"current_attempt={attempt - 1} "
-                f"next_attempt={attempt} "
-                f"max_attempts={self.MAX_CALL_DETAILS_ATTEMPTS}"
-            )
-            time.sleep(wait_seconds)
-
-            # Only re-fetch the missing IDs, merge into existing results
-            new_details = self._get_call_details_by_ids(missing_ids)
-            call_details_map.update(new_details)
-
-            if set(call_ids) == set(call_details_map.keys()):
-                return call_details_map
-
-        missing_ids = list(set(call_ids) - set(call_details_map.keys()))
-        logger.error(
-            f"Giving up on missing call id's after "
-            f"{self.MAX_CALL_DETAILS_ATTEMPTS} attempts: "
-            f"missing_call_ids={missing_ids} — "
-            f"proceeding with {len(call_details_map)} of "
-            f"{len(call_ids)} calls"
-        )
-        return call_details_map
-
     @staticmethod
     def _parse_parties(parties: list[dict]) -> dict[str, str]:
         id_mapping = {}
@@ -313,87 +278,114 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         return start_time, end_time
 
+    def _build_document(
+        self,
+        transcript: dict[str, Any],
+        call_details: dict[str, Any],
+    ) -> Document:
+        """Build a single Document from a transcript and its resolved call details."""
+        call_id = transcript["callId"]
+        call_metadata = call_details["metaData"]
+
+        call_time_str = call_metadata["started"]
+        call_title = call_metadata["title"]
+        logger.info(
+            f"Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
+        )
+
+        call_parties = cast(list[dict] | None, call_details.get("parties"))
+        if call_parties is None:
+            logger.error(f"Couldn't get parties for Call ID: {call_id}")
+            call_parties = []
+
+        id_to_name_map = self._parse_parties(call_parties)
+
+        speaker_to_name: dict[str, str] = {}
+
+        transcript_text = ""
+        call_purpose = call_metadata["purpose"]
+        if call_purpose:
+            transcript_text += f"Call Description: {call_purpose}\n\n"
+
+        contents = transcript["transcript"]
+        for segment in contents:
+            speaker_id = segment.get("speakerId", "")
+            if speaker_id not in speaker_to_name:
+                if self.hide_user_info:
+                    speaker_to_name[speaker_id] = f"User {len(speaker_to_name) + 1}"
+                else:
+                    speaker_to_name[speaker_id] = id_to_name_map.get(
+                        speaker_id, "Unknown"
+                    )
+
+            speaker_name = speaker_to_name[speaker_id]
+
+            sentences = segment.get("sentences", {})
+            monolog = " ".join([sentence.get("text", "") for sentence in sentences])
+            transcript_text += f"{speaker_name}: {monolog}\n\n"
+
+        return Document(
+            id=call_id,
+            sections=[TextSection(link=call_metadata["url"], text=transcript_text)],
+            source=DocumentSource.GONG,
+            semantic_identifier=call_title or "Untitled",
+            doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
+                timezone.utc
+            ),
+            metadata={"client": call_metadata.get("system")},
+        )
+
     def _process_transcripts(
         self,
         transcripts: list[dict[str, Any]],
+        checkpoint: GongConnectorCheckpoint,
     ) -> Generator[Document | ConnectorFailure, None, None]:
-        """Process a batch of transcripts into Documents or ConnectorFailures."""
+        """Fetch call details for a page of transcripts and yield resulting
+        Documents. Transcripts whose call details are missing (Gong race
+        condition) are stashed into `checkpoint.pending_transcripts` for retry
+        on a future checkpoint invocation rather than blocking here.
+        """
         transcript_call_ids = cast(
             list[str],
             [t.get("callId") for t in transcripts if t.get("callId")],
         )
 
-        call_details_map = self._fetch_call_details_with_retry(transcript_call_ids)
+        call_details_map = (
+            self._get_call_details_by_ids(transcript_call_ids)
+            if transcript_call_ids
+            else {}
+        )
 
         for transcript in transcripts:
             call_id = transcript.get("callId")
 
-            if not call_id or call_id not in call_details_map:
-                logger.error(f"Couldn't get call information for Call ID: {call_id}")
-                if call_id:
-                    logger.error(
-                        f"Call debug info: call_id={call_id} "
-                        f"call_ids={transcript_call_ids} "
-                        f"call_details_map={call_details_map.keys()}"
-                    )
+            if not call_id:
+                logger.error(
+                    "Couldn't get call information for transcript missing callId"
+                )
                 yield ConnectorFailure(
-                    failed_document=DocumentFailure(
-                        document_id=call_id or "unknown",
-                    ),
-                    failure_message=f"Couldn't get call information for Call ID: {call_id}",
+                    failed_document=DocumentFailure(document_id="unknown"),
+                    failure_message="Transcript missing callId",
                 )
                 continue
 
-            call_details = call_details_map[call_id]
-            call_metadata = call_details["metaData"]
+            if call_id in call_details_map:
+                yield self._build_document(transcript, call_details_map[call_id])
+                continue
 
-            call_time_str = call_metadata["started"]
-            call_title = call_metadata["title"]
-            logger.info(
-                f"Indexing Gong call id {call_id} from {call_time_str.split('T', 1)[0]}: {call_title}"
+            # Details not available yet — stash for retry on next invocation.
+            logger.warning(
+                f"Call details not yet available for call_id={call_id} "
+                f"(Gong race condition); deferring to next checkpoint invocation"
             )
+            checkpoint.pending_transcripts[call_id] = transcript
 
-            call_parties = cast(list[dict] | None, call_details.get("parties"))
-            if call_parties is None:
-                logger.error(f"Couldn't get parties for Call ID: {call_id}")
-                call_parties = []
-
-            id_to_name_map = self._parse_parties(call_parties)
-
-            speaker_to_name: dict[str, str] = {}
-
-            transcript_text = ""
-            call_purpose = call_metadata["purpose"]
-            if call_purpose:
-                transcript_text += f"Call Description: {call_purpose}\n\n"
-
-            contents = transcript["transcript"]
-            for segment in contents:
-                speaker_id = segment.get("speakerId", "")
-                if speaker_id not in speaker_to_name:
-                    if self.hide_user_info:
-                        speaker_to_name[speaker_id] = f"User {len(speaker_to_name) + 1}"
-                    else:
-                        speaker_to_name[speaker_id] = id_to_name_map.get(
-                            speaker_id, "Unknown"
-                        )
-
-                speaker_name = speaker_to_name[speaker_id]
-
-                sentences = segment.get("sentences", {})
-                monolog = " ".join([sentence.get("text", "") for sentence in sentences])
-                transcript_text += f"{speaker_name}: {monolog}\n\n"
-
-            yield Document(
-                id=call_id,
-                sections=[TextSection(link=call_metadata["url"], text=transcript_text)],
-                source=DocumentSource.GONG,
-                semantic_identifier=call_title or "Untitled",
-                doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
-                    timezone.utc
-                ),
-                metadata={"client": call_metadata.get("system")},
-            )
+        # First attempt on any newly-stashed transcripts counts as attempt #1.
+        if (
+            checkpoint.pending_transcripts
+            and checkpoint.pending_call_details_attempts == 0
+        ):
+            checkpoint.pending_call_details_attempts = 1
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
         combined = (
@@ -432,6 +424,18 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.has_more = True
             return checkpoint
 
+        # Step 2: Resolve any transcripts stashed by a prior invocation whose
+        # call details were missing due to Gong's propagation race. Worker
+        # cadence between checkpoint calls provides the spacing between retry
+        # attempts — no in-call sleep needed.
+        if checkpoint.pending_transcripts:
+            yield from self._resolve_pending_transcripts(checkpoint)
+            # If pending still exists and we haven't exhausted attempts, defer
+            # the rest of this invocation — _resolve_pending_transcripts set
+            # has_more=True for us.
+            if checkpoint.pending_transcripts:
+                return checkpoint
+
         workspace_ids = checkpoint.workspace_ids
 
         # If we've exhausted all workspaces, we're done
@@ -450,7 +454,7 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
 
         workspace_id = workspace_ids[checkpoint.workspace_index]
 
-        # Step 2: Fetch one page of transcripts
+        # Step 3: Fetch one page of transcripts
         try:
             page = self._fetch_transcript_page(
                 start_datetime=start_time,
@@ -473,22 +477,75 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             checkpoint.has_more = True
             return checkpoint
 
-        # Step 3: Process transcripts into documents
+        # Step 4: Process transcripts into documents. Missing-details
+        # transcripts get stashed into checkpoint.pending_transcripts.
         if page.transcripts:
-            yield from self._process_transcripts(page.transcripts)
+            yield from self._process_transcripts(page.transcripts, checkpoint)
 
-        # Step 4: Update checkpoint state
+        # Step 5: Update cursor/workspace state
         if page.next_cursor:
-            # More pages in this workspace
             checkpoint.cursor = page.next_cursor
             checkpoint.has_more = True
         else:
-            # This workspace is exhausted — advance to next
             checkpoint.workspace_index += 1
             checkpoint.cursor = None
             checkpoint.has_more = checkpoint.workspace_index < len(workspace_ids)
 
+        # If pending transcripts were stashed this invocation, we still have
+        # work to do on a future invocation even if pagination is exhausted.
+        if checkpoint.pending_transcripts:
+            checkpoint.has_more = True
+
         return checkpoint
+
+    def _resolve_pending_transcripts(
+        self,
+        checkpoint: GongConnectorCheckpoint,
+    ) -> Generator[Document | ConnectorFailure, None, None]:
+        """Attempt to resolve transcripts whose call details were unavailable
+        in a prior invocation. Mutates checkpoint in place: resolved transcripts
+        are removed from pending_transcripts; on attempt exhaustion, emits
+        ConnectorFailure for each unresolved call_id and clears pending state.
+        """
+        pending_call_ids = list(checkpoint.pending_transcripts.keys())
+        resolved = self._get_call_details_by_ids(pending_call_ids)
+
+        for call_id, details in resolved.items():
+            transcript = checkpoint.pending_transcripts.pop(call_id, None)
+            if transcript is None:
+                continue
+            yield self._build_document(transcript, details)
+
+        if not checkpoint.pending_transcripts:
+            checkpoint.pending_call_details_attempts = 0
+            return
+
+        checkpoint.pending_call_details_attempts += 1
+        logger.warning(
+            f"Gong call details still missing after "
+            f"{checkpoint.pending_call_details_attempts}/"
+            f"{self.MAX_CALL_DETAILS_ATTEMPTS} attempts: "
+            f"missing_call_ids={list(checkpoint.pending_transcripts.keys())}"
+        )
+
+        if checkpoint.pending_call_details_attempts >= self.MAX_CALL_DETAILS_ATTEMPTS:
+            logger.error(
+                f"Giving up on missing Gong call details after "
+                f"{self.MAX_CALL_DETAILS_ATTEMPTS} attempts: "
+                f"missing_call_ids={list(checkpoint.pending_transcripts.keys())}"
+            )
+            for call_id in list(checkpoint.pending_transcripts.keys()):
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(document_id=call_id),
+                    failure_message=(
+                        f"Couldn't get call details after {self.MAX_CALL_DETAILS_ATTEMPTS} attempts for Call ID: {call_id}"
+                    ),
+                )
+            checkpoint.pending_transcripts = {}
+            checkpoint.pending_call_details_attempts = 0
+        else:
+            # Retry again on a future invocation; worker cadence provides gap.
+            checkpoint.has_more = True
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -69,6 +69,8 @@ class TestGongConnectorCheckpoint:
             workspace_ids=["ws1", None],
             workspace_index=1,
             cursor="abc123",
+            pending_transcripts={"call1": _make_transcript("call1")},
+            pending_call_details_attempts=2,
         )
         json_str = original.model_dump_json()
         restored = connector.validate_checkpoint_json(json_str)
@@ -231,7 +233,10 @@ class TestGongConnectorCheckpoint:
         mock_request: MagicMock,
         connector: GongConnector,
     ) -> None:
-        """When call details are missing after retries, yield ConnectorFailure."""
+        """Missing call details persist across checkpoint invocations and
+        eventually yield ConnectorFailure once MAX_CALL_DETAILS_ATTEMPTS is hit.
+        No in-call sleep — retries happen on subsequent invocations.
+        """
         transcript_response = MagicMock()
         transcript_response.status_code = 200
         transcript_response.json.return_value = {
@@ -257,7 +262,12 @@ class TestGongConnectorCheckpoint:
         failures: list[ConnectorFailure] = []
         docs: list[Document] = []
 
-        with patch("onyx.connectors.gong.connector.time.sleep"):
+        # Each invocation tries pending once; loop until has_more=False.
+        # Safety cap: well beyond MAX_CALL_DETAILS_ATTEMPTS to catch runaways.
+        invocation_cap = GongConnector.MAX_CALL_DETAILS_ATTEMPTS + 5
+        for _ in range(invocation_cap):
+            if not checkpoint.has_more:
+                break
             generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
             try:
                 while True:
@@ -274,6 +284,12 @@ class TestGongConnectorCheckpoint:
         assert failures[0].failed_document is not None
         assert failures[0].failed_document.document_id == "call1"
         assert checkpoint.has_more is False
+        assert checkpoint.pending_transcripts == {}
+        assert checkpoint.pending_call_details_attempts == 0
+        # time.sleep should NOT have been used to pace retries — the point of
+        # this refactor is that worker cadence provides spacing, not in-call
+        # blocking.
+        assert mock_request.call_count == 1 + GongConnector.MAX_CALL_DETAILS_ATTEMPTS
 
     @patch.object(GongConnector, "_throttled_request")
     def test_multi_workspace_iteration(
@@ -381,12 +397,14 @@ class TestGongConnectorCheckpoint:
         assert checkpoint.workspace_index == 1
 
     @patch.object(GongConnector, "_throttled_request")
-    def test_retry_only_fetches_missing_ids(
+    def test_partial_details_defers_and_resolves_next_invocation(
         self,
         mock_request: MagicMock,
         connector: GongConnector,
     ) -> None:
-        """Retry for missing call details should only re-request the missing IDs."""
+        """A transcript whose call details are missing gets stashed into
+        pending_transcripts and resolves on a later checkpoint invocation.
+        Resolved docs are yielded in the order they become available."""
         transcript_response = MagicMock()
         transcript_response.status_code = 200
         transcript_response.json.return_value = {
@@ -404,7 +422,7 @@ class TestGongConnectorCheckpoint:
             "calls": [_make_call_detail("call1", "Call One")]
         }
 
-        # Second fetch (retry): returns call2
+        # Second fetch (next invocation): returns call2
         missing_details = MagicMock()
         missing_details.status_code = 200
         missing_details.json.return_value = {
@@ -424,25 +442,91 @@ class TestGongConnectorCheckpoint:
         )
 
         docs: list[Document] = []
-        with patch("onyx.connectors.gong.connector.time.sleep"):
-            generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
-            try:
-                while True:
-                    item = next(generator)
-                    if isinstance(item, Document):
-                        docs.append(item)
-            except StopIteration:
-                pass
+
+        # Invocation 1: fetches page + details, yields call1, stashes call2
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
+
+        assert len(docs) == 1
+        assert docs[0].semantic_identifier == "Call One"
+        assert "call2" in checkpoint.pending_transcripts
+        assert checkpoint.pending_call_details_attempts == 1
+        assert checkpoint.has_more is True
+
+        # Invocation 2: retries missing (only call2), yields it, clears pending
+        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+        try:
+            while True:
+                item = next(generator)
+                if isinstance(item, Document):
+                    docs.append(item)
+        except StopIteration as e:
+            checkpoint = e.value
 
         assert len(docs) == 2
-        assert docs[0].semantic_identifier == "Call One"
         assert docs[1].semantic_identifier == "Call Two"
+        assert checkpoint.pending_transcripts == {}
+        assert checkpoint.pending_call_details_attempts == 0
 
         # Verify: 3 API calls total (1 transcript + 1 full details + 1 retry for missing only)
         assert mock_request.call_count == 3
         # The retry call should only request call2, not both
         retry_call_body = mock_request.call_args_list[2][1]["json"]
         assert retry_call_body["filter"]["callIds"] == ["call2"]
+
+    @patch.object(GongConnector, "_throttled_request")
+    def test_pending_retry_does_not_block_on_time_sleep(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """Pending-transcript retry must never call time.sleep() with a
+        non-trivial delay — the whole point of the checkpoint-based retry is
+        that worker cadence provides spacing, not blocking."""
+        transcript_response = MagicMock()
+        transcript_response.status_code = 200
+        transcript_response.json.return_value = {
+            "callTranscripts": [_make_transcript("call1")],
+            "records": {},
+        }
+        empty_details = MagicMock()
+        empty_details.status_code = 200
+        empty_details.json.return_value = {"calls": []}
+
+        mock_request.side_effect = [transcript_response] + [
+            empty_details
+        ] * GongConnector.MAX_CALL_DETAILS_ATTEMPTS
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+        )
+
+        with patch("onyx.connectors.gong.connector.time.sleep") as mock_sleep:
+            invocation_cap = GongConnector.MAX_CALL_DETAILS_ATTEMPTS + 5
+            for _ in range(invocation_cap):
+                if not checkpoint.has_more:
+                    break
+                generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+                try:
+                    while True:
+                        next(generator)
+                except StopIteration as e:
+                    checkpoint = e.value
+
+            # The only legitimate sleep is the sub-second throttle in
+            # _throttled_request (<= MIN_REQUEST_INTERVAL). Assert we never
+            # sleep for anything close to the old per-retry delays (30s+).
+            for call in mock_sleep.call_args_list:
+                delay_arg = call.args[0] if call.args else 0
+                assert delay_arg <= GongConnector.MIN_REQUEST_INTERVAL
 
     @patch.object(GongConnector, "_throttled_request")
     def test_expired_cursor_restarts_workspace(

--- a/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
+++ b/backend/tests/unit/onyx/connectors/gong/test_gong_checkpoint.py
@@ -71,6 +71,7 @@ class TestGongConnectorCheckpoint:
             cursor="abc123",
             pending_transcripts={"call1": _make_transcript("call1")},
             pending_call_details_attempts=2,
+            pending_retry_after=1234567890.5,
         )
         json_str = original.model_dump_json()
         restored = connector.validate_checkpoint_json(json_str)
@@ -235,7 +236,8 @@ class TestGongConnectorCheckpoint:
     ) -> None:
         """Missing call details persist across checkpoint invocations and
         eventually yield ConnectorFailure once MAX_CALL_DETAILS_ATTEMPTS is hit.
-        No in-call sleep — retries happen on subsequent invocations.
+        No in-call sleep — retries happen on subsequent invocations, gated by
+        the wall-clock retry-after deadline on the checkpoint.
         """
         transcript_response = MagicMock()
         transcript_response.status_code = 200
@@ -262,22 +264,32 @@ class TestGongConnectorCheckpoint:
         failures: list[ConnectorFailure] = []
         docs: list[Document] = []
 
-        # Each invocation tries pending once; loop until has_more=False.
-        # Safety cap: well beyond MAX_CALL_DETAILS_ATTEMPTS to catch runaways.
+        # Jump the clock past any retry deadline on each invocation so we
+        # exercise the retry path without real sleeping. The test for the
+        # backoff-gate itself lives in test_backoff_gate_prevents_retry_too_soon.
+        fake_now = [1_000_000.0]
+
+        def _advance_clock() -> float:
+            fake_now[0] += 10_000.0
+            return fake_now[0]
+
         invocation_cap = GongConnector.MAX_CALL_DETAILS_ATTEMPTS + 5
-        for _ in range(invocation_cap):
-            if not checkpoint.has_more:
-                break
-            generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
-            try:
-                while True:
-                    item = next(generator)
-                    if isinstance(item, ConnectorFailure):
-                        failures.append(item)
-                    elif isinstance(item, Document):
-                        docs.append(item)
-            except StopIteration as e:
-                checkpoint = e.value
+        with patch(
+            "onyx.connectors.gong.connector.time.time", side_effect=_advance_clock
+        ):
+            for _ in range(invocation_cap):
+                if not checkpoint.has_more:
+                    break
+                generator = connector.load_from_checkpoint(0, fake_now[0], checkpoint)
+                try:
+                    while True:
+                        item = next(generator)
+                        if isinstance(item, ConnectorFailure):
+                            failures.append(item)
+                        elif isinstance(item, Document):
+                            docs.append(item)
+                except StopIteration as e:
+                    checkpoint = e.value
 
         assert len(docs) == 0
         assert len(failures) == 1
@@ -286,9 +298,7 @@ class TestGongConnectorCheckpoint:
         assert checkpoint.has_more is False
         assert checkpoint.pending_transcripts == {}
         assert checkpoint.pending_call_details_attempts == 0
-        # time.sleep should NOT have been used to pace retries — the point of
-        # this refactor is that worker cadence provides spacing, not in-call
-        # blocking.
+        assert checkpoint.pending_retry_after is None
         assert mock_request.call_count == 1 + GongConnector.MAX_CALL_DETAILS_ATTEMPTS
 
     @patch.object(GongConnector, "_throttled_request")
@@ -443,36 +453,47 @@ class TestGongConnectorCheckpoint:
 
         docs: list[Document] = []
 
-        # Invocation 1: fetches page + details, yields call1, stashes call2
-        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
-        try:
-            while True:
-                item = next(generator)
-                if isinstance(item, Document):
-                    docs.append(item)
-        except StopIteration as e:
-            checkpoint = e.value
+        fake_now = [1_000_000.0]
 
-        assert len(docs) == 1
-        assert docs[0].semantic_identifier == "Call One"
-        assert "call2" in checkpoint.pending_transcripts
-        assert checkpoint.pending_call_details_attempts == 1
-        assert checkpoint.has_more is True
+        def _advance_clock() -> float:
+            fake_now[0] += 10_000.0
+            return fake_now[0]
 
-        # Invocation 2: retries missing (only call2), yields it, clears pending
-        generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
-        try:
-            while True:
-                item = next(generator)
-                if isinstance(item, Document):
-                    docs.append(item)
-        except StopIteration as e:
-            checkpoint = e.value
+        with patch(
+            "onyx.connectors.gong.connector.time.time", side_effect=_advance_clock
+        ):
+            # Invocation 1: fetches page + details, yields call1, stashes call2
+            generator = connector.load_from_checkpoint(0, fake_now[0], checkpoint)
+            try:
+                while True:
+                    item = next(generator)
+                    if isinstance(item, Document):
+                        docs.append(item)
+            except StopIteration as e:
+                checkpoint = e.value
+
+            assert len(docs) == 1
+            assert docs[0].semantic_identifier == "Call One"
+            assert "call2" in checkpoint.pending_transcripts
+            assert checkpoint.pending_call_details_attempts == 1
+            assert checkpoint.pending_retry_after is not None
+            assert checkpoint.has_more is True
+
+            # Invocation 2: retries missing (only call2), yields it, clears pending
+            generator = connector.load_from_checkpoint(0, fake_now[0], checkpoint)
+            try:
+                while True:
+                    item = next(generator)
+                    if isinstance(item, Document):
+                        docs.append(item)
+            except StopIteration as e:
+                checkpoint = e.value
 
         assert len(docs) == 2
         assert docs[1].semantic_identifier == "Call Two"
         assert checkpoint.pending_transcripts == {}
         assert checkpoint.pending_call_details_attempts == 0
+        assert checkpoint.pending_retry_after is None
 
         # Verify: 3 API calls total (1 transcript + 1 full details + 1 retry for missing only)
         assert mock_request.call_count == 3
@@ -481,14 +502,56 @@ class TestGongConnectorCheckpoint:
         assert retry_call_body["filter"]["callIds"] == ["call2"]
 
     @patch.object(GongConnector, "_throttled_request")
+    def test_backoff_gate_prevents_retry_too_soon(
+        self,
+        mock_request: MagicMock,
+        connector: GongConnector,
+    ) -> None:
+        """If the retry-after deadline hasn't elapsed, _resolve_pending must
+        NOT issue a /v2/calls/extensive request. Prevents burning through
+        MAX_CALL_DETAILS_ATTEMPTS when workers re-invoke tightly.
+        """
+        pending_transcript = _make_transcript("call1")
+        fixed_now = 1_000_000.0
+        # Deadline is 30s in the future from fixed_now
+        retry_after = fixed_now + 30
+
+        checkpoint = GongConnectorCheckpoint(
+            has_more=True,
+            workspace_ids=[None],
+            workspace_index=0,
+            pending_transcripts={"call1": pending_transcript},
+            pending_call_details_attempts=1,
+            pending_retry_after=retry_after,
+        )
+
+        with patch("onyx.connectors.gong.connector.time.time", return_value=fixed_now):
+            generator = connector.load_from_checkpoint(0, fixed_now, checkpoint)
+            try:
+                while True:
+                    next(generator)
+            except StopIteration as e:
+                checkpoint = e.value
+
+        # No API calls should have been made — we were inside the backoff window
+        mock_request.assert_not_called()
+        # Pending state preserved for later retry
+        assert "call1" in checkpoint.pending_transcripts
+        assert checkpoint.pending_call_details_attempts == 1
+        assert checkpoint.pending_retry_after == retry_after
+        assert checkpoint.has_more is True
+
+    @patch.object(GongConnector, "_throttled_request")
     def test_pending_retry_does_not_block_on_time_sleep(
         self,
         mock_request: MagicMock,
         connector: GongConnector,
     ) -> None:
         """Pending-transcript retry must never call time.sleep() with a
-        non-trivial delay — the whole point of the checkpoint-based retry is
-        that worker cadence provides spacing, not blocking."""
+        non-trivial delay — spacing between retries is enforced via the
+        wall-clock retry-after deadline stored on the checkpoint, not by
+        blocking inside load_from_checkpoint.
+        """
         transcript_response = MagicMock()
         transcript_response.status_code = 200
         transcript_response.json.return_value = {
@@ -509,12 +572,23 @@ class TestGongConnectorCheckpoint:
             workspace_index=0,
         )
 
-        with patch("onyx.connectors.gong.connector.time.sleep") as mock_sleep:
+        fake_now = [1_000_000.0]
+
+        def _advance_clock() -> float:
+            fake_now[0] += 10_000.0
+            return fake_now[0]
+
+        with (
+            patch("onyx.connectors.gong.connector.time.sleep") as mock_sleep,
+            patch(
+                "onyx.connectors.gong.connector.time.time", side_effect=_advance_clock
+            ),
+        ):
             invocation_cap = GongConnector.MAX_CALL_DETAILS_ATTEMPTS + 5
             for _ in range(invocation_cap):
                 if not checkpoint.has_more:
                     break
-                generator = connector.load_from_checkpoint(0, time.time(), checkpoint)
+                generator = connector.load_from_checkpoint(0, fake_now[0], checkpoint)
                 try:
                     while True:
                         next(generator)
@@ -523,7 +597,7 @@ class TestGongConnectorCheckpoint:
 
             # The only legitimate sleep is the sub-second throttle in
             # _throttled_request (<= MIN_REQUEST_INTERVAL). Assert we never
-            # sleep for anything close to the old per-retry delays (30s+).
+            # sleep for anything close to the per-retry backoff delays.
             for call in mock_sleep.call_args_list:
                 delay_arg = call.args[0] if call.args else 0
                 assert delay_arg <= GongConnector.MIN_REQUEST_INTERVAL


### PR DESCRIPTION
## Description

Addresses the Greptile P2 raised on #10359 (and present on `main`): `_fetch_call_details_with_retry` could block a single `load_from_checkpoint` call for up to ~930s (30 + 60 + 120 + 240 + 480) while waiting out the Gong propagation race. That fights the CheckpointedConnector contract — the checkpoint can't be persisted while we sleep, and long blocks risk worker timeouts.

This PR moves the retry into checkpoint state:

- `GongConnectorCheckpoint` gains `pending_transcripts: dict[str, dict]` and `pending_call_details_attempts: int`. Transcripts whose `/v2/calls/extensive` details are missing get stashed under their `call_id`.
- On each subsequent `load_from_checkpoint` invocation, we retry only the missing IDs *before* fetching a new page. Worker cadence between invocations provides the effective spacing — no in-call `time.sleep()` beyond the existing sub-second per-request throttle.
- After `MAX_CALL_DETAILS_ATTEMPTS` (6) invocations still missing details, we emit `ConnectorFailure` for the unresolved call_ids and clear pending state so the run progresses.
- `_process_transcripts` now splits into a pure `_build_document` helper plus a page-processing generator that mutates the checkpoint to stash deferred work.

Behavior preserved:
- Gong-race tolerance: still up to 6 retry attempts.
- Cursor-expiry handling unchanged.
- Workspace iteration unchanged.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check