### PR TITLE
chore: [Running GitHub actions for #10356]

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.46
+version: 0.4.47
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/extra-manifests.yaml
+++ b/deployment/helm/charts/onyx/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraManifests }}
+---
+{{- if kindIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1316,3 +1316,26 @@ configMap:
   HARD_DELETE_CHATS: ""
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
+
+# -- Additional arbitrary manifests to render as part of the release. Each entry
+# may be either a YAML mapping (a single Kubernetes object) or a multi-line
+# string that will be passed through `tpl` so it can reference release values.
+# Useful for injecting resources not covered by the chart (e.g. NetworkPolicies,
+# ExternalSecrets, custom CRs) without forking the chart.
+extraManifests: []
+# extraManifests:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: my-extra-config
+#     data:
+#       key: value
+#   - |
+#     apiVersion: networking.k8s.io/v1
+#     kind: NetworkPolicy
+#     metadata:
+#       name: {{ include "onyx.fullname" . }}-extra
+#     spec:
+#       podSelector: {}
+#       policyTypes:
+#         - Ingress


### PR DESCRIPTION
This PR runs GitHub Actions CI for #10356.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `extraManifests` to the `onyx` Helm chart to render arbitrary Kubernetes resources via values, and bumps the chart to version 0.4.47.

- **New Features**
  - Adds `templates/extra-manifests.yaml` to render each item in `.Values.extraManifests`, accepting either YAML maps or multi-line strings processed with `tpl`.
  - Documents and enables `extraManifests` in `values.yaml` (defaults to `[]` so behavior is unchanged).

<sup>Written for commit 8010bf7f1a93063a3d6bd921d5b14d632a35d80b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

