### PR TITLE
feat: filestore delete missing error (#9878) to release v3.1

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -55,14 +55,20 @@ def perform_ttl_management_task(
             )
 
         for user_id, session_id in old_chat_sessions:
-            # one session per delete so that we don't blow up if a deletion fails.
-            with get_session_with_current_tenant() as db_session:
-                delete_chat_session(
-                    user_id,
-                    session_id,
-                    db_session,
-                    include_deleted=True,
-                    hard_delete=True,
+            try:
+                with get_session_with_current_tenant() as db_session:
+                    delete_chat_session(
+                        user_id,
+                        session_id,
+                        db_session,
+                        include_deleted=True,
+                        hard_delete=True,
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to delete chat session "
+                    f"user_id={user_id} session_id={session_id}, "
+                    "continuing with remaining sessions"
                 )
 
         with get_session_with_current_tenant() as db_session:

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -199,7 +199,7 @@ def delete_messages_and_files_from_chat_session(
     for _, files in messages_with_files:
         file_store = get_default_file_store()
         for file_info in files or []:
-            file_store.delete_file(file_id=file_info.get("id"))
+            file_store.delete_file(file_id=file_info.get("id"), error_on_missing=False)
 
     # Delete ChatMessage records - CASCADE constraints will automatically handle:
     # - ChatMessage__StandardAnswer relationship records

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -136,12 +136,14 @@ class FileStore(ABC):
         """
 
     @abstractmethod
-    def delete_file(self, file_id: str) -> None:
+    def delete_file(self, file_id: str, error_on_missing: bool = True) -> None:
         """
         Delete a file by its ID.
 
         Parameters:
-        - file_name: Name of file to delete
+        - file_id: ID of file to delete
+        - error_on_missing: If False, silently return when the file record
+          does not exist instead of raising.
         """
 
     @abstractmethod
@@ -452,12 +454,23 @@ class S3BackedFileStore(FileStore):
             logger.warning(f"Error getting file size for {file_id}: {e}")
             return None
 
-    def delete_file(self, file_id: str, db_session: Session | None = None) -> None:
+    def delete_file(
+        self,
+        file_id: str,
+        error_on_missing: bool = True,
+        db_session: Session | None = None,
+    ) -> None:
         with get_session_with_current_tenant_if_none(db_session) as db_session:
             try:
-                file_record = get_filerecord_by_file_id(
+                file_record = get_filerecord_by_file_id_optional(
                     file_id=file_id, db_session=db_session
                 )
+                if file_record is None:
+                    if error_on_missing:
+                        raise RuntimeError(
+                            f"File by id {file_id} does not exist or was deleted"
+                        )
+                    return
                 if not file_record.bucket_name:
                     logger.error(
                         f"File record {file_id} with key {file_record.object_key} "

--- a/backend/onyx/file_store/postgres_file_store.py
+++ b/backend/onyx/file_store/postgres_file_store.py
@@ -222,12 +222,23 @@ class PostgresBackedFileStore(FileStore):
             logger.warning(f"Error getting file size for {file_id}: {e}")
             return None
 
-    def delete_file(self, file_id: str, db_session: Session | None = None) -> None:
+    def delete_file(
+        self,
+        file_id: str,
+        error_on_missing: bool = True,
+        db_session: Session | None = None,
+    ) -> None:
         with get_session_with_current_tenant_if_none(db_session) as session:
             try:
-                file_content = get_file_content_by_file_id(
+                file_content = get_file_content_by_file_id_optional(
                     file_id=file_id, db_session=session
                 )
+                if file_content is None:
+                    if error_on_missing:
+                        raise RuntimeError(
+                            f"File content for file_id {file_id} does not exist or was deleted"
+                        )
+                    return
                 raw_conn = _get_raw_connection(session)
 
                 try:

--- a/backend/tests/unit/onyx/file_store/test_delete_file.py
+++ b/backend/tests/unit/onyx/file_store/test_delete_file.py
@@ -1,0 +1,91 @@
+"""Tests for FileStore.delete_file error_on_missing behavior."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+_S3_MODULE = "onyx.file_store.file_store"
+_PG_MODULE = "onyx.file_store.postgres_file_store"
+
+
+def _mock_db_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+# ── S3BackedFileStore ────────────────────────────────────────────────
+
+
+@patch(f"{_S3_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_S3_MODULE}.get_filerecord_by_file_id_optional", return_value=None)
+def test_s3_delete_missing_file_raises_by_default(
+    _mock_get_record: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    from onyx.file_store.file_store import S3BackedFileStore
+
+    mock_ctx.return_value = _mock_db_session()
+    store = S3BackedFileStore(bucket_name="b")
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        store.delete_file("nonexistent")
+
+
+@patch(f"{_S3_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_S3_MODULE}.get_filerecord_by_file_id_optional", return_value=None)
+@patch(f"{_S3_MODULE}.delete_filerecord_by_file_id")
+def test_s3_delete_missing_file_silent_when_error_on_missing_false(
+    mock_delete_record: MagicMock,
+    _mock_get_record: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    from onyx.file_store.file_store import S3BackedFileStore
+
+    mock_ctx.return_value = _mock_db_session()
+    store = S3BackedFileStore(bucket_name="b")
+
+    store.delete_file("nonexistent", error_on_missing=False)
+
+    mock_delete_record.assert_not_called()
+
+
+# ── PostgresBackedFileStore ──────────────────────────────────────────
+
+
+@patch(f"{_PG_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_PG_MODULE}.get_file_content_by_file_id_optional", return_value=None)
+def test_pg_delete_missing_file_raises_by_default(
+    _mock_get_content: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    from onyx.file_store.postgres_file_store import PostgresBackedFileStore
+
+    mock_ctx.return_value = _mock_db_session()
+    store = PostgresBackedFileStore()
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        store.delete_file("nonexistent")
+
+
+@patch(f"{_PG_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_PG_MODULE}.get_file_content_by_file_id_optional", return_value=None)
+@patch(f"{_PG_MODULE}.delete_file_content_by_file_id")
+@patch(f"{_PG_MODULE}.delete_filerecord_by_file_id")
+def test_pg_delete_missing_file_silent_when_error_on_missing_false(
+    mock_delete_record: MagicMock,
+    mock_delete_content: MagicMock,
+    _mock_get_content: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    from onyx.file_store.postgres_file_store import PostgresBackedFileStore
+
+    mock_ctx.return_value = _mock_db_session()
+    store = PostgresBackedFileStore()
+
+    store.delete_file("nonexistent", error_on_missing=False)
+
+    mock_delete_record.assert_not_called()
+    mock_delete_content.assert_not_called()


### PR DESCRIPTION
## Description

Cherry-picks #9878 (`feat: filestore delete missing error`, merge commit `a120add37b`) onto `release/v3.1` so the fix ships in a v3.1.X release.

Applied cleanly — no merge conflicts.

## How Has This Been Tested?

Relying on the unit tests added in the original PR (`backend/tests/unit/onyx/file_store/test_delete_file.py`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit errors when deleting missing files and make TTL cleanup more resilient. `delete_file` now supports an `error_on_missing` flag (default True) and tests cover both S3 and Postgres stores.

- **Migration**
  - If missing files are expected, call `delete_file(file_id, error_on_missing=False)`.
  - Update any custom `FileStore` implementations to accept `error_on_missing: bool = True` in `delete_file`.

<sup>Written for commit cde463ab0480d9c126feffd67bd867084e6bfbb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

