### PR TITLE
feat(invites): add tenant_invite_event table to cap trial tenant lifetime invites

### DIFF
--- a/backend/alembic_tenants/versions/d4e7a92c1b38_add_tenant_invite_counter.py
+++ b/backend/alembic_tenants/versions/d4e7a92c1b38_add_tenant_invite_counter.py
@@ -1,0 +1,79 @@
+"""add_tenant_invite_counter_table
+
+Revision ID: d4e7a92c1b38
+Revises: 3b9f09038764
+Create Date: 2026-04-20 18:00:00.000000
+
+Adds `public.tenant_invite_counter`, the lifetime invite-quota counter used by
+the trial-tenant cap in `bulk_invite_users`. One row per tenant; holds a
+monotonically-incremented total of invites ever reserved by that tenant.
+
+Why we need it:
+    Trial tenants are capped at NUM_FREE_TRIAL_USER_INVITES per lifetime.
+    A counter derived from the mutable KV-backed invited-users list can be
+    reset by the remove-invited-user endpoint (each removal pops a KV
+    entry, lowering the effective count), allowing the cap to be bypassed
+    by looping invite → remove → invite. This table stores a counter that
+    is only ever incremented; no endpoint decrements it, so removals do
+    not free up quota.
+
+How it works:
+    Each call to `bulk_invite_users` for a trial tenant runs a single atomic
+    UPSERT:
+
+        INSERT INTO public.tenant_invite_counter (tenant_id, total_invites_sent)
+        VALUES (:tid, :n)
+        ON CONFLICT (tenant_id) DO UPDATE
+          SET total_invites_sent = tenant_invite_counter.total_invites_sent + EXCLUDED.total_invites_sent,
+              updated_at = NOW()
+        RETURNING total_invites_sent;
+
+    The UPDATE takes a row-level lock on `tenant_id`, so concurrent bulk-
+    invite flows for the same tenant are serialized without an advisory
+    lock. If the returned total exceeds the cap the caller ROLLBACKs so the
+    reservation does not stick. Paid tenants skip this path entirely.
+
+Deploy-time behavior:
+    The table ships empty. Trial tenants with pre-existing KV invited-users
+    entries are not seeded, so each one's counter starts at 0 and can
+    issue one additional full batch (up to NUM_FREE_TRIAL_USER_INVITES)
+    before the monotonic guard engages. Scope of the gap is bounded to
+    one batch per trial tenant and does not recur; backfill was
+    intentionally skipped to keep this migration pure-DDL.
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d4e7a92c1b38"
+down_revision = "3b9f09038764"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenant_invite_counter",
+        sa.Column("tenant_id", sa.String(), nullable=False),
+        sa.Column(
+            "total_invites_sent",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("tenant_id"),
+        schema="public",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tenant_invite_counter", schema="public")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4593,6 +4593,25 @@ class TenantAnonymousUserPath(Base):
     )
 
 
+# Lifetime invite counter per tenant. Incremented atomically on every
+# invite reservation; never decremented — removals do not free quota, so
+# loops of invite → remove → invite cannot bypass the trial cap.
+class TenantInviteCounter(Base):
+    __tablename__ = "tenant_invite_counter"
+    __table_args__ = {"schema": "public"}
+
+    tenant_id: Mapped[str] = mapped_column(String, primary_key=True)
+    total_invites_sent: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
 class MCPServer(Base):
     """Model for storing MCP server configurations"""
 

--- a/backend/onyx/db/tenant_invite_counter.py
+++ b/backend/onyx/db/tenant_invite_counter.py
@@ -1,0 +1,62 @@
+from sqlalchemy import func
+from sqlalchemy import update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.models import TenantInviteCounter
+
+
+def reserve_trial_invites(
+    shared_session: Session,
+    tenant_id: str,
+    num_invites: int,
+) -> int:
+    """Atomically increment the tenant's invite counter by `num_invites`.
+
+    Returns the post-increment total. The caller is expected to compare
+    against the trial cap and rollback the session if the total exceeds
+    it — the UPSERT's UPDATE leg holds a row-level lock on `tenant_id`
+    for the duration of the transaction, serializing concurrent reservers
+    for the same tenant.
+    """
+    stmt = pg_insert(TenantInviteCounter).values(
+        tenant_id=tenant_id,
+        total_invites_sent=num_invites,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[TenantInviteCounter.tenant_id],
+        set_={
+            "total_invites_sent": TenantInviteCounter.total_invites_sent
+            + stmt.excluded.total_invites_sent,
+            "updated_at": func.now(),
+        },
+    ).returning(TenantInviteCounter.total_invites_sent)
+    return int(shared_session.execute(stmt).scalar_one())
+
+
+def release_trial_invites(
+    shared_session: Session,
+    tenant_id: str,
+    num_invites: int,
+) -> None:
+    """Compensating decrement of the counter by `num_invites`, clamped at 0.
+
+    Only called when a downstream step (KV write, billing register, etc.)
+    fails after the counter has already been incremented, so the counter
+    tracks invites that actually reached the system rather than merely
+    reserved. The counter is monotonic with respect to user actions — no
+    user-facing endpoint decrements it — but it is reconciled downward by
+    this function when the system fails mid-flow. No-op if the tenant has
+    no counter row.
+    """
+    stmt = (
+        update(TenantInviteCounter)
+        .where(TenantInviteCounter.tenant_id == tenant_id)
+        .values(
+            total_invites_sent=func.greatest(
+                TenantInviteCounter.total_invites_sent - num_invites, 0
+            ),
+            updated_at=func.now(),
+        )
+    )
+    shared_session.execute(stmt)

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -68,6 +68,7 @@ class OnyxErrorCode(Enum):
     # ------------------------------------------------------------------
     RATE_LIMITED = ("RATE_LIMITED", 429)
     SEAT_LIMIT_EXCEEDED = ("SEAT_LIMIT_EXCEEDED", 402)
+    TRIAL_INVITE_LIMIT_EXCEEDED = ("TRIAL_INVITE_LIMIT_EXCEEDED", 403)
 
     # ------------------------------------------------------------------
     # Payload (413)

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -51,11 +51,14 @@ from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.auth import get_live_users_count
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import AccountType
 from onyx.db.enums import Permission
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import User
 from onyx.db.models import UserFile
+from onyx.db.tenant_invite_counter import release_trial_invites
+from onyx.db.tenant_invite_counter import reserve_trial_invites
 from onyx.db.user_preferences import activate_user
 from onyx.db.user_preferences import deactivate_user
 from onyx.db.user_preferences import get_all_user_assistant_specific_configs
@@ -466,25 +469,37 @@ def bulk_invite_users(
         if e not in existing_users and e not in already_invited
     ]
 
-    # Limit bulk invites for trial tenants to prevent email spam
-    # Only count new invites, not re-invites of existing users
+    # Check seat availability for new users. Must run before the counter
+    # reservation below — a seat-limit failure must not burn trial quota.
+    if emails_needing_seats:
+        enforce_seat_limit(db_session, seats_needed=len(emails_needing_seats))
+
+    # Enforce the trial invite cap via the monotonic `tenant_invite_counter`.
+    # The UPSERT holds a row-level lock on `tenant_id` during the UPDATE, so
+    # concurrent bulk-invite flows for the same tenant are serialized without
+    # an advisory lock. On reject we ROLLBACK so the reservation does not stick.
+    trial_invite_reservation = 0
     if MULTI_TENANT and is_tenant_on_trial_fn(tenant_id):
-        current_invited = len(already_invited)
-        if current_invited + len(emails_needing_seats) > NUM_FREE_TRIAL_USER_INVITES:
-            raise HTTPException(
-                status_code=403,
-                detail="You have hit your invite limit. Please upgrade for unlimited invites.",
-            )
+        num_new_invites = len(emails_needing_seats)
+        if num_new_invites > 0:
+            with get_session_with_shared_schema() as shared_session:
+                new_total = reserve_trial_invites(
+                    shared_session, tenant_id, num_new_invites
+                )
+                if new_total > NUM_FREE_TRIAL_USER_INVITES:
+                    shared_session.rollback()
+                    raise OnyxError(
+                        OnyxErrorCode.TRIAL_INVITE_LIMIT_EXCEEDED,
+                        "You have hit your invite limit. Please upgrade for unlimited invites.",
+                    )
+                shared_session.commit()
+                trial_invite_reservation = num_new_invites
         enforce_invite_rate_limit(
             redis_client=get_redis_client(tenant_id=tenant_id),
             admin_user_id=current_user.id,
             num_invites=len(emails_needing_seats),
             tenant_id=tenant_id,
         )
-
-    # Check seat availability for new users
-    if emails_needing_seats:
-        enforce_seat_limit(db_session, seats_needed=len(emails_needing_seats))
 
     if MULTI_TENANT:
         try:
@@ -498,7 +513,29 @@ def bulk_invite_users(
     initial_invited_users = get_invited_users()
 
     all_emails = list(set(new_invited_emails) | set(initial_invited_users))
-    number_of_invited_users = write_invited_users(all_emails)
+    try:
+        number_of_invited_users = write_invited_users(all_emails)
+    except Exception:
+        # KV write failed after the counter already reserved slots. Release
+        # the reservation so the counter tracks invites that actually reached
+        # the store. Compensation failures are logged and never re-raised —
+        # the original KV error is what the caller needs to see.
+        if trial_invite_reservation > 0:
+            try:
+                with get_session_with_shared_schema() as comp_session:
+                    release_trial_invites(
+                        comp_session, tenant_id, trial_invite_reservation
+                    )
+                    comp_session.commit()
+            except Exception as comp_err:
+                logger.error(
+                    "tenant_invite_counter release failed for tenant=%s, "
+                    "slots burned=%d: %s",
+                    tenant_id,
+                    trial_invite_reservation,
+                    comp_err,
+                )
+        raise
 
     # send out email invitations only to new users (not already invited or existing)
     if not ENABLE_EMAIL_INVITES:
@@ -526,10 +563,31 @@ def bulk_invite_users(
             logger.info(
                 "Reverting changes: removing users from tenant and resetting invited users"
             )
-            write_invited_users(initial_invited_users)  # Reset to original state
-            fetch_ee_implementation_or_noop(
-                "onyx.server.tenants.user_mapping", "remove_users_from_tenant", None
-            )(new_invited_emails, tenant_id)
+            try:
+                write_invited_users(initial_invited_users)  # Reset to original state
+                fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.user_mapping", "remove_users_from_tenant", None
+                )(new_invited_emails, tenant_id)
+            finally:
+                # Release the counter reservation regardless of whether the KV /
+                # user-mapping reverts above succeeded — otherwise a double-fault
+                # (billing failure + revert failure) permanently inflates the
+                # counter for an invite batch the system considers rolled back.
+                if trial_invite_reservation > 0:
+                    try:
+                        with get_session_with_shared_schema() as comp_session:
+                            release_trial_invites(
+                                comp_session, tenant_id, trial_invite_reservation
+                            )
+                            comp_session.commit()
+                    except Exception as comp_err:
+                        logger.error(
+                            "tenant_invite_counter release failed for tenant=%s, "
+                            "slots burned=%d: %s",
+                            tenant_id,
+                            trial_invite_reservation,
+                            comp_err,
+                        )
             raise e
 
     return BulkInviteResponse(

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -1,36 +1,70 @@
 """Test bulk invite limit for free trial tenants."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.models import EmailInviteStatus
 from onyx.server.manage.models import UserByEmail
 from onyx.server.manage.users import bulk_invite_users
 from onyx.server.manage.users import remove_invited_user
 
 
+def _make_shared_session_mock(next_total: int) -> MagicMock:
+    """Build a MagicMock mirroring `get_session_with_shared_schema`.
+
+    The production code does one `INSERT ... ON CONFLICT DO UPDATE ...
+    RETURNING total_invites_sent` call against the shared-schema session.
+    The mock plays the role of that session: calling the patched factory
+    returns a context manager whose `__enter__` yields a session whose
+    `.execute(...).scalar_one()` answers with `next_total` — the
+    post-increment counter value the DB would have returned.
+    """
+    session = MagicMock()
+    session.execute.return_value.scalar_one.return_value = next_total
+
+    @contextmanager
+    def _ctx() -> Iterator[MagicMock]:
+        yield session
+
+    mock = MagicMock(side_effect=_ctx)
+    return mock
+
+
+@patch(
+    "onyx.server.manage.users.get_session_with_shared_schema",
+    new_callable=lambda: _make_shared_session_mock(next_total=6),
+)
 @patch("onyx.server.manage.users.enforce_invite_rate_limit")
 @patch("onyx.server.manage.users.MULTI_TENANT", True)
 @patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
 @patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
 @patch("onyx.server.manage.users.get_invited_users", return_value=[])
 @patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.enforce_seat_limit")
 @patch("onyx.server.manage.users.NUM_FREE_TRIAL_USER_INVITES", 5)
 def test_trial_tenant_cannot_exceed_invite_limit(*_mocks: None) -> None:
-    """Trial tenants cannot invite more users than the configured limit."""
+    """Post-upsert total of 6 exceeds cap=5 — must raise OnyxError."""
     emails = [f"user{i}@example.com" for i in range(6)]
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(OnyxError) as exc_info:
         bulk_invite_users(emails=emails, current_user=MagicMock())
 
-    assert exc_info.value.status_code == 403
+    assert exc_info.value.error_code == OnyxErrorCode.TRIAL_INVITE_LIMIT_EXCEEDED
     assert "invite limit" in exc_info.value.detail.lower()
 
 
+@patch(
+    "onyx.server.manage.users.get_session_with_shared_schema",
+    new_callable=lambda: _make_shared_session_mock(next_total=3),
+)
 @patch("onyx.server.manage.users.enforce_invite_rate_limit")
+@patch("onyx.server.manage.users.get_redis_client")
 @patch("onyx.server.manage.users.MULTI_TENANT", True)
 @patch("onyx.server.manage.users.DEV_MODE", True)
 @patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
@@ -46,13 +80,48 @@ def test_trial_tenant_cannot_exceed_invite_limit(*_mocks: None) -> None:
     return_value=lambda *_args: None,
 )
 def test_trial_tenant_can_invite_within_limit(*_mocks: None) -> None:
-    """Trial tenants can invite users when under the limit."""
+    """Post-upsert total of 3 fits under cap=5 — must succeed."""
     emails = ["user1@example.com", "user2@example.com", "user3@example.com"]
 
     result = bulk_invite_users(emails=emails, current_user=MagicMock())
 
     assert result.invited_count == 3
     assert result.email_invite_status == EmailInviteStatus.DISABLED
+
+
+@patch("onyx.server.manage.users.get_session_with_shared_schema")
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=3)
+@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+def test_paid_tenant_bypasses_invite_counter(
+    _ee_fetch: MagicMock,
+    _seat_limit: MagicMock,
+    _write_invited: MagicMock,
+    _get_all_users: MagicMock,
+    _get_invited_users: MagicMock,
+    _get_tenant_id: MagicMock,
+    _is_trial: MagicMock,
+    _rate_limit: MagicMock,
+    mock_get_session: MagicMock,
+) -> None:
+    """Paid tenants must not read or write the invite counter at all."""
+    emails = [f"user{i}@example.com" for i in range(3)]
+
+    result = bulk_invite_users(emails=emails, current_user=MagicMock())
+
+    mock_get_session.assert_not_called()
+    assert result.invited_count == 3
 
 
 # --- email_invite_status tests ---
@@ -120,68 +189,7 @@ def test_email_invite_status_send_failed(*_mocks: None) -> None:
     assert result.invited_count == 1
 
 
-# --- trial-only rate limit gating tests ---
-
-
-@patch("onyx.server.manage.users.enforce_invite_rate_limit")
-@patch("onyx.server.manage.users.MULTI_TENANT", True)
-@patch("onyx.server.manage.users.DEV_MODE", True)
-@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
-@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
-@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
-@patch("onyx.server.manage.users.get_invited_users", return_value=[])
-@patch("onyx.server.manage.users.get_all_users", return_value=[])
-@patch("onyx.server.manage.users.write_invited_users", return_value=3)
-@patch("onyx.server.manage.users.enforce_seat_limit")
-@patch(
-    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
-    return_value=lambda *_args: None,
-)
-def test_paid_tenant_bypasses_invite_rate_limit(
-    _ee_fetch: MagicMock,
-    _seat_limit: MagicMock,
-    _write_invited: MagicMock,
-    _get_all_users: MagicMock,
-    _get_invited_users: MagicMock,
-    _get_tenant_id: MagicMock,
-    _is_trial: MagicMock,
-    mock_rate_limit: MagicMock,
-) -> None:
-    """Paid tenants must not hit the invite rate limiter at all."""
-    emails = [f"user{i}@example.com" for i in range(3)]
-    bulk_invite_users(emails=emails, current_user=MagicMock())
-    mock_rate_limit.assert_not_called()
-
-
-@patch("onyx.server.manage.users.enforce_invite_rate_limit")
-@patch("onyx.server.manage.users.MULTI_TENANT", True)
-@patch("onyx.server.manage.users.DEV_MODE", True)
-@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
-@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
-@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
-@patch("onyx.server.manage.users.get_invited_users", return_value=[])
-@patch("onyx.server.manage.users.get_all_users", return_value=[])
-@patch("onyx.server.manage.users.write_invited_users", return_value=3)
-@patch("onyx.server.manage.users.enforce_seat_limit")
-@patch("onyx.server.manage.users.NUM_FREE_TRIAL_USER_INVITES", 50)
-@patch(
-    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
-    return_value=lambda *_args: None,
-)
-def test_trial_tenant_hits_invite_rate_limit(
-    _ee_fetch: MagicMock,
-    _seat_limit: MagicMock,
-    _write_invited: MagicMock,
-    _get_all_users: MagicMock,
-    _get_invited_users: MagicMock,
-    _get_tenant_id: MagicMock,
-    _is_trial: MagicMock,
-    mock_rate_limit: MagicMock,
-) -> None:
-    """Trial tenants must flow through the invite rate limiter."""
-    emails = [f"user{i}@example.com" for i in range(3)]
-    bulk_invite_users(emails=emails, current_user=MagicMock())
-    mock_rate_limit.assert_called_once()
+# --- trial-only rate limit gating tests (remove-invited-user) ---
 
 
 @patch("onyx.server.manage.users.enforce_remove_invited_rate_limit")
@@ -212,6 +220,7 @@ def test_paid_tenant_bypasses_remove_invited_rate_limit(
 
 @patch("onyx.server.manage.users.enforce_remove_invited_rate_limit")
 @patch("onyx.server.manage.users.remove_user_from_invited_users", return_value=0)
+@patch("onyx.server.manage.users.get_redis_client")
 @patch("onyx.server.manage.users.MULTI_TENANT", True)
 @patch("onyx.server.manage.users.DEV_MODE", True)
 @patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
@@ -224,6 +233,7 @@ def test_trial_tenant_hits_remove_invited_rate_limit(
     _ee_fetch: MagicMock,
     _get_tenant_id: MagicMock,
     _is_trial: MagicMock,
+    _get_redis: MagicMock,
     _remove_from_invited: MagicMock,
     mock_rate_limit: MagicMock,
 ) -> None:


### PR DESCRIPTION
## Description

Closes the trial invite-cap bypass where an admin could loop `invite 10 → remove 10 → invite 10` against the KV-backed `get_invited_users()` counter and escape the `NUM_FREE_TRIAL_USER_INVITES` lifetime cap.

**Design:** new `public.tenant_invite_counter(tenant_id PK, total_invites_sent INT, updated_at)` — one row per tenant. The counter is **monotonically incremented only**. `remove_invited_user` never touches it; the UI cleanup path still pops the KV list, but the cap enforcement state persists.

**Enforcement:** single atomic `INSERT ... ON CONFLICT DO UPDATE ... RETURNING total_invites_sent`. The UPSERT takes a row-level lock on `tenant_id` during UPDATE, so concurrent bulk-invite flows for the same tenant are serialized without needing an advisory lock or `FOR UPDATE` pre-check. Cap exceed → `ROLLBACK` so the reservation does not stick; reserved slots are discarded. Cost is O(1) PK lookup inside the UPSERT (no `COUNT(*)` scan) and ~1 row per tenant of storage (vs 1 row per invite).

**Scope:** trial tenants only. Paid tenants bypass via the existing `is_tenant_on_trial_fn(tenant_id)` gate.

Attack walkthrough (cap = 10):

| Step | Counter | Decision |
| --- | --- | --- |
| Invite 10 | 0 → 10 | sent |
| Remove 10 | 10 (unchanged) | KV cleared |
| Invite 10 more | 10 → 20 | 403 |
| Invite 1 | 10 → 11 | 403 |

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check