### PR TITLE
chore(sentry): make trace sample rates env-configurable, default celery to 0

### DIFF
--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -27,6 +27,7 @@ from shared_configs.configs import MIN_THREADS_ML_MODELS
 from shared_configs.configs import MODEL_SERVER_ALLOWED_HOST
 from shared_configs.configs import MODEL_SERVER_PORT
 from shared_configs.configs import SENTRY_DSN
+from shared_configs.configs import SENTRY_TRACES_SAMPLE_RATE
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["HF_HUB_DISABLE_TELEMETRY"] = "1"
@@ -101,7 +102,7 @@ def get_model_app() -> FastAPI:
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
-            traces_sample_rate=0.1,
+            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
             release=__version__,
             before_send=_add_instance_tags,
         )

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -55,6 +55,7 @@ from onyx.utils.logger import setup_logger
 from shared_configs.configs import DEV_LOGGING_ENABLED
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE
 from shared_configs.configs import SENTRY_DSN
 from shared_configs.configs import TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
@@ -69,7 +70,7 @@ if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[CeleryIntegration()],
-        traces_sample_rate=0.1,
+        traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE,
         release=__version__,
         before_send=_add_instance_tags,
     )

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -37,6 +37,7 @@ from onyx.redis.redis_connector import RedisConnector
 from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import global_version
+from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE
 from shared_configs.configs import SENTRY_DSN
 
 logger = setup_logger()
@@ -140,7 +141,7 @@ def _docfetching_task(
 
         sentry_sdk.init(
             dsn=SENTRY_DSN,
-            traces_sample_rate=0.1,
+            traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE,
             release=__version__,
             before_send=_add_instance_tags,
         )

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -166,6 +166,7 @@ from shared_configs.configs import CORS_ALLOWED_ORIGIN
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 from shared_configs.configs import SENTRY_DSN
+from shared_configs.configs import SENTRY_TRACES_SAMPLE_RATE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 warnings.filterwarnings(
@@ -439,7 +440,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[StarletteIntegration(), FastApiIntegration()],
-            traces_sample_rate=0.1,
+            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
             release=__version__,
             before_send=_add_instance_tags,
         )

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -99,6 +99,14 @@ STRICT_CHUNK_TOKEN_LIMIT = (
 # Set up Sentry integration (for error logging)
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
 
+# Celery task spans dominate ingestion volume (~94%), so default celery
+# tracing to 0. Web/API traces stay at a small non-zero rate so http.server
+# traces remain available. Both are env-tunable without a code change.
+SENTRY_TRACES_SAMPLE_RATE = float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", "0.01"))
+SENTRY_CELERY_TRACES_SAMPLE_RATE = float(
+    os.environ.get("SENTRY_CELERY_TRACES_SAMPLE_RATE", "0.0")
+)
+
 
 # Fields which should only be set on new search setting
 PRESERVED_SEARCH_FIELDS = [


### PR DESCRIPTION
## Description

We're burning through Sentry's monthly span quota. Investigation shows celery task spans account for ~94% of ingested span volume (28.5M celery spans vs 1.7M http.server spans over 7 days), and the resulting performance-detector issues have been almost entirely noise — 46 unresolved perf issues, 0 error events, all concentrated in `docprocessing_task`, `monitor_background_processes`, and `connector_doc_fetching_task`.

This PR:

- Splits the Sentry trace sample rate into two env vars so celery can be dialed down independently of web/API traces:
  - `SENTRY_TRACES_SAMPLE_RATE` — used by the API server and model server (default `0.01`, down from `0.1`)
  - `SENTRY_CELERY_TRACES_SAMPLE_RATE` — used by celery workers and the docfetching subprocess (default `0.0`, down from `0.1`)
- Leaves error capture, `release`, and the `before_send` instance-tagging hook unchanged.
- Expected result: ~99% reduction in span ingestion, keeping us inside quota for the rest of the month while preserving a small fraction of http.server traces for debugging.

If a specific celery transaction needs to be investigated mid-month, `SENTRY_CELERY_TRACES_SAMPLE_RATE` can be bumped to `0.001` via env var without a code change.

## How Has This Been Tested?

- Verified all four `sentry_sdk.init` call sites (`backend/onyx/main.py`, `backend/model_server/main.py`, `backend/onyx/background/celery/apps/app_base.py`, `backend/onyx/background/celery/tasks/docfetching/tasks.py`) read the new config values.
- Pre-commit passes (black, ruff, ty, import ordering).
- No behavior change when `SENTRY_DSN` is unset.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sentry trace sampling env-configurable and default Celery tracing to 0 to cut span ingestion. Keep a small sample for web/API traces; error capture and tagging stay the same.

- **New Features**
  - Two env vars: `SENTRY_TRACES_SAMPLE_RATE` (API/model servers, default 0.01) and `SENTRY_CELERY_TRACES_SAMPLE_RATE` (Celery workers/docfetching, default 0.0).
  - All `sentry_sdk.init` call sites now read these values.
  - Expected impact: ~99% fewer spans while preserving `http.server` visibility.

<sup>Written for commit fb61572608fc042b05415511b7bad83ba720cf5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

