### PR TITLE
fix(xlsx): Stream excel extraction to reduce peak memory

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -12,6 +12,7 @@ from email.parser import Parser as EmailParser
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from typing import cast
 from typing import IO
 from typing import NamedTuple
 from typing import Optional
@@ -20,7 +21,7 @@ from zipfile import BadZipFile
 
 import chardet
 import openpyxl
-from openpyxl.worksheet.worksheet import Worksheet
+from openpyxl.worksheet._read_only import ReadOnlyWorksheet
 from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
@@ -448,104 +449,68 @@ def pptx_to_text(file: IO[Any], file_name: str = "") -> str:
     return presentation.markdown
 
 
-def _worksheet_to_matrix(
-    worksheet: Worksheet,
-) -> list[list[str]]:
-    """
-    Converts a singular worksheet to a matrix of values.
-
-    Rows are padded to a uniform width. In openpyxl's read_only mode,
-    iter_rows can yield rows of differing lengths (trailing empty cells
-    are sometimes omitted), and downstream column cleanup assumes a
-    rectangular matrix.
-    """
-    rows: list[list[str]] = []
-    max_len = 0
-    for worksheet_row in worksheet.iter_rows(min_row=1, values_only=True):
-        row = ["" if cell is None else str(cell) for cell in worksheet_row]
-        if len(row) > max_len:
-            max_len = len(row)
-        rows.append(row)
-
-    for row in rows:
-        if len(row) < max_len:
-            row.extend([""] * (max_len - len(row)))
-
-    return rows
-
-
-def _clean_worksheet_matrix(matrix: list[list[str]]) -> list[list[str]]:
-    """
-    Cleans a worksheet matrix by removing rows if there are N consecutive empty
-    rows and removing cols if there are M consecutive empty columns
-    """
-    MAX_EMPTY_ROWS = 2  # Runs longer than this are capped to max_empty; shorter runs are preserved as-is
-    MAX_EMPTY_COLS = 2
-
-    # Row cleanup
-    matrix = _remove_empty_runs(matrix, max_empty=MAX_EMPTY_ROWS)
-
-    if not matrix:
-        return matrix
-
-    # Column cleanup — determine which columns to keep without transposing.
-    num_cols = len(matrix[0])
-    keep_cols = _columns_to_keep(matrix, num_cols, max_empty=MAX_EMPTY_COLS)
-    if len(keep_cols) < num_cols:
-        matrix = [[row[c] for c in keep_cols] for row in matrix]
-
-    return matrix
-
-
-def _columns_to_keep(
-    matrix: list[list[str]], num_cols: int, max_empty: int
-) -> list[int]:
-    """Return the indices of columns to keep after removing empty-column runs.
-
-    Uses the same logic as ``_remove_empty_runs`` but operates on column
-    indices so no transpose is needed.
-    """
+def _columns_to_keep(col_has_data: bytearray, max_empty: int) -> list[int]:
+    """Keep non-empty columns, plus runs of up to ``max_empty`` empty columns
+    between them. Trailing empty columns are dropped."""
     kept: list[int] = []
     empty_buffer: list[int] = []
-
-    for col_idx in range(num_cols):
-        col_is_empty = all(not row[col_idx] for row in matrix)
-        if col_is_empty:
-            empty_buffer.append(col_idx)
-        else:
+    for c, has in enumerate(col_has_data):
+        if has:
             kept.extend(empty_buffer[:max_empty])
-            kept.append(col_idx)
+            kept.append(c)
             empty_buffer = []
-
+        else:
+            empty_buffer.append(c)
     return kept
 
 
-def _remove_empty_runs(
-    rows: list[list[str]],
-    max_empty: int,
-) -> list[list[str]]:
-    """Removes entire runs of empty rows when the run length exceeds max_empty.
+def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
+    """Stream worksheet rows into CSV text without materializing a dense matrix.
 
-    Leading empty runs are capped to max_empty, just like interior runs.
-    Trailing empty rows are always dropped since there is no subsequent
-    non-empty row to flush them.
+    Empty rows are never stored. Column occupancy is tracked as a ``bytearray``
+    bitmap so column trimming needs no transpose or copy. Runs of empty
+    rows/columns longer than 2 are collapsed; shorter runs are preserved.
     """
-    result: list[list[str]] = []
-    empty_buffer: list[list[str]] = []
+    MAX_EMPTY_ROWS_IN_OUTPUT = 2
+    MAX_EMPTY_COLS_IN_OUTPUT = 2
 
-    for row in rows:
-        # Check if empty
-        if not any(row):
-            if len(empty_buffer) < max_empty:
-                empty_buffer.append(row)
-        else:
-            # Add upto max empty rows onto the result - that's what we allow
-            result.extend(empty_buffer[:max_empty])
-            # Add the new non-empty row
-            result.append(row)
-            empty_buffer = []
+    non_empty_rows: list[tuple[int, list[str]]] = []
+    col_has_data = bytearray()
 
-    return result
+    for row_idx, row_vals in enumerate(rows):
+        # Fast-reject empty rows before allocating a list of "".
+        if not any(v is not None and v != "" for v in row_vals):
+            continue
+
+        cells = ["" if v is None else str(v) for v in row_vals]
+        non_empty_rows.append((row_idx, cells))
+
+        if len(cells) > len(col_has_data):
+            col_has_data.extend(b"\x00" * (len(cells) - len(col_has_data)))
+        for i, v in enumerate(cells):
+            if v:
+                col_has_data[i] = 1
+
+    if not non_empty_rows:
+        return ""
+
+    keep_cols = _columns_to_keep(col_has_data, MAX_EMPTY_COLS_IN_OUTPUT)
+    if not keep_cols:
+        return ""
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    blank_row = [""] * len(keep_cols)
+    last_idx = -1
+    for row_idx, cells in non_empty_rows:
+        gap = row_idx - last_idx - 1
+        if gap > 0:
+            for _ in range(min(gap, MAX_EMPTY_ROWS_IN_OUTPUT)):
+                writer.writerow(blank_row)
+        writer.writerow([cells[c] if c < len(cells) else "" for c in keep_cols])
+        last_idx = row_idx
+
+    return buf.getvalue().rstrip("\n")
 
 
 def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str, str]]:
@@ -573,14 +538,16 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
         raise
 
     sheets: list[tuple[str, str]] = []
-    for sheet in workbook.worksheets:
-        sheet_matrix = _clean_worksheet_matrix(_worksheet_to_matrix(sheet))
-        buf = io.StringIO()
-        writer = csv.writer(buf, lineterminator="\n")
-        writer.writerows(sheet_matrix)
-        csv_text = buf.getvalue().rstrip("\n")
-        if csv_text.strip():
-            sheets.append((csv_text, sheet.title))
+    try:
+        for sheet in workbook.worksheets:
+            # Declared dimensions can be different to what is actually there
+            ro_sheet = cast(ReadOnlyWorksheet, sheet)
+            ro_sheet.reset_dimensions()
+            csv_text = _sheet_to_csv(ro_sheet.iter_rows(values_only=True))
+            sheets.append((csv_text.strip(), ro_sheet.title))
+    finally:
+        workbook.close()
+
     return sheets
 
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -553,7 +553,9 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
 
 def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
     sheets = xlsx_sheet_extraction(file, file_name)
-    return TEXT_SECTION_SEPARATOR.join(csv_text for csv_text, _title in sheets)
+    return TEXT_SECTION_SEPARATOR.join(
+        csv_text for csv_text, _title in sheets if csv_text
+    )
 
 
 def eml_to_text(file: IO[Any]) -> str:

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -6,8 +6,7 @@ from unittest.mock import patch
 import openpyxl
 from openpyxl.worksheet.worksheet import Worksheet
 
-from onyx.file_processing.extract_file_text import _clean_worksheet_matrix
-from onyx.file_processing.extract_file_text import _worksheet_to_matrix
+from onyx.file_processing.extract_file_text import _sheet_to_csv
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.extract_file_text import xlsx_to_text
 
@@ -203,50 +202,143 @@ class TestXlsxToText:
         assert "r3c1" in lines[2] and "r3c2" in lines[2]
 
 
-class TestWorksheetToMatrixJaggedRows:
-    """openpyxl read_only mode can yield rows of differing widths when
-    trailing cells are empty. The matrix must be padded to a rectangle
-    so downstream column cleanup can index safely."""
+class TestSheetToCsvJaggedRows:
+    """openpyxl's read-only mode yields rows of differing widths when
+    trailing cells are empty. These tests exercise ``_sheet_to_csv``
+    directly because ``_make_xlsx`` (via ``ws.append``) normalizes row
+    widths, so jagged input can only be produced in-memory."""
 
-    def test_pads_shorter_trailing_rows(self) -> None:
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A", "B", "C"),
-                ("X", "Y"),
-                ("P",),
-            ]
+    def test_shorter_trailing_rows_padded_in_output(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B", "C"),
+                    ("X", "Y"),
+                    ("P",),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        assert matrix == [["A", "B", "C"], ["X", "Y", ""], ["P", "", ""]]
+        assert csv_text.split("\n") == ["A,B,C", "X,Y,", "P,,"]
 
-    def test_pads_when_first_row_is_shorter(self) -> None:
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A",),
-                ("X", "Y", "Z"),
-            ]
+    def test_shorter_leading_row_padded_in_output(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A",),
+                    ("X", "Y", "Z"),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        assert matrix == [["A", "", ""], ["X", "Y", "Z"]]
+        assert csv_text.split("\n") == ["A,,", "X,Y,Z"]
 
-    def test_clean_worksheet_matrix_no_index_error_on_jagged_rows(self) -> None:
-        """Regression: previously raised IndexError when a later row was
-        shorter than the first row and the out-of-range column on the
-        first row was empty (so the short-circuit in `all()` did not
-        save us)."""
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A", "", "", "B"),
-                ("X", "Y"),
-            ]
+    def test_no_index_error_on_jagged_rows(self) -> None:
+        """Regression: the original dense-matrix version raised IndexError
+        when a later row was shorter than an earlier row whose out-of-range
+        columns happened to be empty."""
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "", "", "B"),
+                    ("X", "Y"),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        # Must not raise.
-        cleaned = _clean_worksheet_matrix(matrix)
-        assert cleaned == [["A", "", "", "B"], ["X", "Y", "", ""]]
+        assert csv_text.split("\n") == ["A,,,B", "X,Y,,"]
+
+
+class TestSheetToCsvStreaming:
+    """Pin the memory-safe streaming contract: empty rows are skipped
+    cheaply, empty-row/column runs are collapsed to at most 2, and sheets
+    with no data return the empty string."""
+
+    def test_empty_rows_between_data_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    ("C", "D"),
+                ]
+            )
+        )
+        # 5 empty rows collapsed to 2
+        assert csv_text.split("\n") == ["A,B", ",", ",", "C,D"]
+
+    def test_empty_rows_at_or_below_cap_preserved(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    (None, None),
+                    (None, None),
+                    ("C", "D"),
+                ]
+            )
+        )
+        assert csv_text.split("\n") == ["A,B", ",", ",", "C,D"]
+
+    def test_empty_column_run_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", None, None, None, None, "B"),
+                    ("C", None, None, None, None, "D"),
+                ]
+            )
+        )
+        # 4 empty cols between A and B collapsed to 2
+        assert csv_text.split("\n") == ["A,,,B", "C,,,D"]
+
+    def test_completely_empty_stream_returns_empty_string(self) -> None:
+        assert _sheet_to_csv(iter([])) == ""
+
+    def test_all_rows_empty_returns_empty_string(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    (None, None),
+                    ("", ""),
+                    (None,),
+                ]
+            )
+        )
+        assert csv_text == ""
+
+    def test_trailing_empty_rows_dropped(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A",),
+                    ("B",),
+                    (None,),
+                    (None,),
+                    (None,),
+                ]
+            )
+        )
+        # Trailing empties are never emitted (no subsequent non-empty row
+        # to flush them against).
+        assert csv_text.split("\n") == ["A", "B"]
+
+    def test_leading_empty_rows_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    ("A", "B"),
+                ]
+            )
+        )
+        # 5 leading empty rows collapsed to 2
+        assert csv_text.split("\n") == [",", ",", "A,B"]
 
 
 class TestXlsxSheetExtraction:
@@ -281,10 +373,9 @@ class TestXlsxSheetExtraction:
         assert "a" in csv_text
         assert "b" in csv_text
 
-    def test_empty_sheet_is_skipped(self) -> None:
-        """A sheet whose CSV output is empty/whitespace-only should NOT
-        appear in the result — the `if csv_text.strip():` guard filters
-        it out."""
+    def test_empty_sheet_included_with_empty_csv(self) -> None:
+        """Every sheet in the workbook appears in the result; an empty
+        sheet contributes an empty csv_text alongside its title."""
         xlsx = _make_xlsx(
             {
                 "Data": [["a", "b"]],
@@ -292,14 +383,17 @@ class TestXlsxSheetExtraction:
             }
         )
         sheets = xlsx_sheet_extraction(xlsx)
-        assert len(sheets) == 1
-        assert sheets[0][1] == "Data"
+        assert len(sheets) == 2
+        titles = [title for _csv, title in sheets]
+        assert titles == ["Data", "Empty"]
+        empty_csv = next(csv_text for csv_text, title in sheets if title == "Empty")
+        assert empty_csv == ""
 
-    def test_empty_workbook_returns_empty_list(self) -> None:
-        """All sheets empty → empty list (not a list of empty tuples)."""
+    def test_empty_workbook_returns_one_tuple_per_sheet(self) -> None:
+        """All sheets empty → one empty-csv tuple per sheet."""
         xlsx = _make_xlsx({"Sheet1": [], "Sheet2": []})
         sheets = xlsx_sheet_extraction(xlsx)
-        assert sheets == []
+        assert sheets == [("", "Sheet1"), ("", "Sheet2")]
 
     def test_single_sheet(self) -> None:
         xlsx = _make_xlsx({"Only": [["x", "y"], ["1", "2"]]})

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -1,6 +1,5 @@
 import io
 from typing import cast
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import openpyxl

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,11 +25,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@tests/*": ["./tests/*"],
-      "@public/*": ["./public/*"],
-      "@opal/*": ["./lib/opal/src/*"],
-      "@opal/types/*": ["./lib/opal/src/types/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ],
+      "@public/*": [
+        "./public/*"
+      ],
+      "@opal/*": [
+        "./lib/opal/src/*"
+      ],
+      "@opal/types/*": [
+        "./lib/opal/src/types/*"
+      ]
     }
   },
   "include": [
@@ -35,5 +49,8 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "lib/opal"]
+  "exclude": [
+    "node_modules",
+    "lib/opal"
+  ]
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -25,21 +25,11 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@tests/*": [
-        "./tests/*"
-      ],
-      "@public/*": [
-        "./public/*"
-      ],
-      "@opal/*": [
-        "./lib/opal/src/*"
-      ],
-      "@opal/types/*": [
-        "./lib/opal/src/types/*"
-      ]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"],
+      "@public/*": ["./public/*"],
+      "@opal/*": ["./lib/opal/src/*"],
+      "@opal/types/*": ["./lib/opal/src/types/*"]
     }
   },
   "include": [
@@ -49,8 +39,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "lib/opal"
-  ]
+  "exclude": ["node_modules", "lib/opal"]
 }


### PR DESCRIPTION
## Description
Switches excel extraction to utilise a more memory safe pattern by streaming vs batching. Also uses actual dimension size rather than excel metadata defined dimension size.

## How Has This Been Tested?
Manual + Unit

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch XLSX text extraction to a streaming, memory-safe path using `openpyxl` read-only worksheets that outputs CSV per sheet. Prevents OOMs on large files, handles jagged rows, and collapses long empty row/column runs.

- **Bug Fixes**
  - Stream rows via `_sheet_to_csv` from `ReadOnlyWorksheet.iter_rows`; cap empty row/column runs at 2 and drop trailing empty rows.
  - Handle jagged rows without IndexError; reset sheet dimensions with `reset_dimensions` and always close the workbook.

- **Migration**
  - `xlsx_sheet_extraction` now returns all sheets; empty sheets produce empty `csv_text`. Update any logic that assumed only non-empty sheets are returned.

<sup>Written for commit 806e38bfc4b9faaab722b3094358f74e6b8e49db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



