### PR TITLE
fix(pruning): Google Drive Connector - cache orphaned ancestor paths to skip redundant folder walks

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -578,8 +578,18 @@ class GoogleDriveConnector(
                     current_id, file.user_email, field_type, failed_folder_ids_by_email
                 )
                 if not folder:
-                    # Can't access this folder - stop climbing
-                    # Don't mark as fully walked since we didn't reach root
+                    # Can't access this folder - stop climbing.
+                    # If the terminal node is a confirmed orphan, backfill all
+                    # intermediate folders into failed_folder_ids_by_email so
+                    # future files short-circuit via _get_folder_metadata's
+                    # cache check instead of re-climbing the whole chain.
+                    if failed_folder_ids_by_email is not None:
+                        for email in {file.user_email, self.primary_admin_email}:
+                            email_failed_ids = failed_folder_ids_by_email.get(email)
+                            if email_failed_ids and current_id in email_failed_ids:
+                                failed_folder_ids_by_email.setdefault(
+                                    email, ThreadSafeSet()
+                                ).update(set(node_ids_in_walk))
                     break
 
                 folder_parent_id = _get_parent_id_from_file(folder)

--- a/backend/onyx/connectors/google_drive/models.py
+++ b/backend/onyx/connectors/google_drive/models.py
@@ -167,9 +167,12 @@ class GoogleDriveCheckpoint(ConnectorCheckpoint):
         default_factory=ThreadSafeSet
     )
 
-    # Maps email → set of IDs of folders where that email confirmed no accessible parent.
-    # Avoids redundant API calls when the same (folder, email) pair is
-    # encountered again within the same retrieval run.
+    # Maps email → set of folder IDs that email should skip when walking the
+    # parent chain. Covers two cases:
+    #   1. Folders where that email confirmed no accessible parent (true orphans).
+    #   2. Intermediate folders on a path that dead-ended at a confirmed orphan —
+    #      backfilled so future walks short-circuit earlier in the chain.
+    # In both cases _get_folder_metadata skips the API call and returns None.
     failed_folder_ids_by_email: ThreadSafeDict[str, ThreadSafeSet[str]] = Field(
         default_factory=ThreadSafeDict
     )

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -287,3 +287,140 @@ class TestFailedFolderIdsByEmail:
             )
 
         assert len(failed_map) == 0
+
+
+class TestOrphanedPathBackfill:
+    def _make_failed_map(
+        self, entries: dict[str, set[str]]
+    ) -> ThreadSafeDict[str, ThreadSafeSet[str]]:
+        return ThreadSafeDict({k: ThreadSafeSet(v) for k, v in entries.items()})
+
+    def _make_file(self, parent_id: str) -> MagicMock:
+        file = MagicMock()
+        file.user_email = "retriever@example.com"
+        file.drive_file = {"parents": [parent_id]}
+        return file
+
+    def test_backfills_intermediate_folders_into_failed_map(self) -> None:
+        """When a walk dead-ends at a confirmed orphan, all intermediate folder
+        IDs must be added to failed_folder_ids_by_email for both emails so
+        future files short-circuit via _get_folder_metadata's cache check."""
+        connector = _make_connector()
+
+        # Chain: folderA -> folderB -> folderC (confirmed orphan)
+        failed_map = self._make_failed_map(
+            {
+                "retriever@example.com": {"folderC"},
+                "admin@example.com": {"folderC"},
+            }
+        )
+
+        folder_a = {"id": "folderA", "name": "A", "parents": ["folderB"]}
+        folder_b = {"id": "folderB", "name": "B", "parents": ["folderC"]}
+
+        def mock_get_folder(
+            _service: MagicMock, folder_id: str, _field_type: DriveFileFieldType
+        ) -> dict | None:
+            if folder_id == "folderA":
+                return folder_a
+            if folder_id == "folderB":
+                return folder_b
+            return None
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_folder_metadata",
+                side_effect=mock_get_folder,
+            ),
+        ):
+            connector._get_new_ancestors_for_files(
+                files=[self._make_file("folderA")],
+                seen_hierarchy_node_raw_ids=ThreadSafeSet(),
+                fully_walked_hierarchy_node_raw_ids=ThreadSafeSet(),
+                failed_folder_ids_by_email=failed_map,
+            )
+
+        # Both emails confirmed folderC as orphan, so both get the backfill
+        for email in ("retriever@example.com", "admin@example.com"):
+            cached = failed_map.get(email, ThreadSafeSet())
+            assert "folderA" in cached
+            assert "folderB" in cached
+            assert "folderC" in cached
+
+    def test_backfills_only_for_confirming_email(self) -> None:
+        """Only the email that confirmed the orphan gets the path backfilled."""
+        connector = _make_connector()
+
+        # Only retriever confirmed folderC as orphan; admin has no entry
+        failed_map = self._make_failed_map({"retriever@example.com": {"folderC"}})
+
+        folder_a = {"id": "folderA", "name": "A", "parents": ["folderB"]}
+        folder_b = {"id": "folderB", "name": "B", "parents": ["folderC"]}
+
+        def mock_get_folder(
+            _service: MagicMock, folder_id: str, _field_type: DriveFileFieldType
+        ) -> dict | None:
+            if folder_id == "folderA":
+                return folder_a
+            if folder_id == "folderB":
+                return folder_b
+            return None
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_folder_metadata",
+                side_effect=mock_get_folder,
+            ),
+        ):
+            connector._get_new_ancestors_for_files(
+                files=[self._make_file("folderA")],
+                seen_hierarchy_node_raw_ids=ThreadSafeSet(),
+                fully_walked_hierarchy_node_raw_ids=ThreadSafeSet(),
+                failed_folder_ids_by_email=failed_map,
+            )
+
+        retriever_cached = failed_map.get("retriever@example.com", ThreadSafeSet())
+        assert "folderA" in retriever_cached
+        assert "folderB" in retriever_cached
+
+        # admin did not confirm the orphan — must not get the backfill
+        assert failed_map.get("admin@example.com") is None
+
+    def test_short_circuits_on_backfilled_intermediate(self) -> None:
+        """A second file whose parent is already in failed_folder_ids_by_email
+        must not trigger any folder metadata API calls."""
+        connector = _make_connector()
+
+        # folderA already in the failed map from a previous walk
+        failed_map = self._make_failed_map(
+            {
+                "retriever@example.com": {"folderA"},
+                "admin@example.com": {"folderA"},
+            }
+        )
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_folder_metadata"
+            ) as mock_api,
+        ):
+            connector._get_new_ancestors_for_files(
+                files=[self._make_file("folderA")],
+                seen_hierarchy_node_raw_ids=ThreadSafeSet(),
+                fully_walked_hierarchy_node_raw_ids=ThreadSafeSet(),
+                failed_folder_ids_by_email=failed_map,
+            )
+
+        mock_api.assert_not_called()


### PR DESCRIPTION
## Description

Summary
PR [#10304](https://github.com/onyx-dot-app/onyx/pull/10304) cached orphaned terminal folders but not the intermediate folders leading to them. Every file sharing an orphaned ancestor still re-climbed the full chain — one API call per intermediate folder — causing 6-hour pruning timeouts in production.

Fix
When a walk dead-ends at a confirmed orphan, backfill all traversed intermediate folder IDs into failed_folder_ids_by_email (per-email, only for the email that confirmed the orphan). Future files short-circuit at the first step via the existing _get_folder_metadata cache check.

https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?pli=1&tab=t.ozuz6m1l9an2
https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
Updated unit tests
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Google Drive pruning now caches entire orphaned ancestor paths, not just the terminal folder. Files that share an orphaned ancestor short-circuit early and skip redundant API calls. Addresses Linear ENG-3954 and reduces pruning timeouts.

- **Bug Fixes**
  - When a walk dead-ends at a confirmed orphan, backfill all traversed folder IDs into failed_folder_ids_by_email, but only for the emails that confirmed the orphan (retriever and/or admin).
  - Subsequent files stop at the first cached ancestor via _get_folder_metadata, avoiding folder-walk API calls; added unit tests for dual-email backfill, single-email backfill, and short-circuiting.

<sup>Written for commit 6c20d91b9a276c89b1f27035525d5639885f7392. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

