### PR TITLE
fix(xlsx): Hard limit on num cells

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -868,6 +868,15 @@ MAX_EMBEDDED_IMAGES_PER_UPLOAD = max(
     0, int(os.environ.get("MAX_EMBEDDED_IMAGES_PER_UPLOAD") or 1000)
 )
 
+# Maximum non-empty cells to extract from a single xlsx worksheet. Protects
+# from OOM on honestly-huge spreadsheets: memory cost in the extractor is
+# roughly proportional to this count. Once exceeded, the scan stops and a
+# truncation marker row is appended to the sheet's CSV.
+# Peak Memory ~= 100 B * MAX_CELLS
+MAX_XLSX_CELLS_PER_SHEET = max(
+    0, int(os.environ.get("MAX_XLSX_CELLS_PER_SHEET") or 10_000_000)
+)
+
 # Use document summary for contextual rag
 USE_DOCUMENT_SUMMARY = os.environ.get("USE_DOCUMENT_SUMMARY", "true").lower() == "true"
 # Use chunk summary for contextual rag

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -25,6 +25,7 @@ from openpyxl.worksheet._read_only import ReadOnlyWorksheet
 from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
+from onyx.configs.app_configs import MAX_XLSX_CELLS_PER_SHEET
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -470,12 +471,19 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
     Empty rows are never stored. Column occupancy is tracked as a ``bytearray``
     bitmap so column trimming needs no transpose or copy. Runs of empty
     rows/columns longer than 2 are collapsed; shorter runs are preserved.
+
+    Scanning stops once ``MAX_CELLS_PER_SHEET`` non-empty cells have been
+    seen; the output gets a truncation marker row appended so downstream
+    indexing sees that the sheet was cut off.
     """
     MAX_EMPTY_ROWS_IN_OUTPUT = 2
     MAX_EMPTY_COLS_IN_OUTPUT = 2
+    TRUNCATION_MARKER = "[truncated: sheet exceeded cell limit]"
 
     non_empty_rows: list[tuple[int, list[str]]] = []
     col_has_data = bytearray()
+    total_non_empty = 0
+    truncated = False
 
     for row_idx, row_vals in enumerate(rows):
         # Fast-reject empty rows before allocating a list of "".
@@ -490,6 +498,11 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
         for i, v in enumerate(cells):
             if v:
                 col_has_data[i] = 1
+                total_non_empty += 1
+
+        if total_non_empty > MAX_XLSX_CELLS_PER_SHEET:
+            truncated = True
+            break
 
     if not non_empty_rows:
         return ""
@@ -509,6 +522,9 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
                 writer.writerow(blank_row)
         writer.writerow([cells[c] if c < len(cells) else "" for c in keep_cols])
         last_idx = row_idx
+
+    if truncated:
+        writer.writerow([TRUNCATION_MARKER])
 
     return buf.getvalue().rstrip("\n")
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -472,7 +472,7 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
     bitmap so column trimming needs no transpose or copy. Runs of empty
     rows/columns longer than 2 are collapsed; shorter runs are preserved.
 
-    Scanning stops once ``MAX_CELLS_PER_SHEET`` non-empty cells have been
+    Scanning stops once ``MAX_XLSX_CELLS_PER_SHEET`` non-empty cells have been
     seen; the output gets a truncation marker row appended so downstream
     indexing sees that the sheet was cut off.
     """

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -339,6 +339,42 @@ class TestSheetToCsvStreaming:
         # 5 leading empty rows collapsed to 2
         assert csv_text.split("\n") == [",", ",", "A,B"]
 
+    def test_cell_cap_truncates_and_appends_marker(self) -> None:
+        """When total non-empty cells exceeds the cap, scanning stops and
+        a truncation marker row is appended so downstream indexing sees
+        the sheet was cut off."""
+        with patch(
+            "onyx.file_processing.extract_file_text.MAX_XLSX_CELLS_PER_SHEET", 5
+        ):
+            csv_text = _sheet_to_csv(
+                iter(
+                    [
+                        ("A", "B", "C"),
+                        ("D", "E", "F"),
+                        ("G", "H", "I"),
+                        ("J", "K", "L"),
+                    ]
+                )
+            )
+        lines = csv_text.split("\n")
+        assert lines[-1] == "[truncated: sheet exceeded cell limit]"
+        # First two rows (6 cells) trip the cap=5 check after row 2; the
+        # third and fourth rows are never scanned.
+        assert "G" not in csv_text
+        assert "J" not in csv_text
+
+    def test_cell_cap_not_hit_no_marker(self) -> None:
+        """Under the cap, no truncation marker is appended."""
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    ("C", "D"),
+                ]
+            )
+        )
+        assert "[truncated" not in csv_text
+
 
 class TestXlsxSheetExtraction:
     def test_one_tuple_per_sheet(self) -> None:

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,11 +25,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@tests/*": ["./tests/*"],
-      "@public/*": ["./public/*"],
-      "@opal/*": ["./lib/opal/src/*"],
-      "@opal/types/*": ["./lib/opal/src/types/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ],
+      "@public/*": [
+        "./public/*"
+      ],
+      "@opal/*": [
+        "./lib/opal/src/*"
+      ],
+      "@opal/types/*": [
+        "./lib/opal/src/types/*"
+      ]
     }
   },
   "include": [
@@ -35,5 +49,8 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "lib/opal"]
+  "exclude": [
+    "node_modules",
+    "lib/opal"
+  ]
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -25,21 +25,11 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@tests/*": [
-        "./tests/*"
-      ],
-      "@public/*": [
-        "./public/*"
-      ],
-      "@opal/*": [
-        "./lib/opal/src/*"
-      ],
-      "@opal/types/*": [
-        "./lib/opal/src/types/*"
-      ]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"],
+      "@public/*": ["./public/*"],
+      "@opal/*": ["./lib/opal/src/*"],
+      "@opal/types/*": ["./lib/opal/src/types/*"]
     }
   },
   "include": [
@@ -49,8 +39,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "lib/opal"
-  ]
+  "exclude": ["node_modules", "lib/opal"]
 }


### PR DESCRIPTION
## Description
Adds a hard limit to the number of cells that can be extracted from an excel file. This is configurable via environment variable.

This is introduced due to exploding cell counts resulting in the docfetching pod OOMing. We anticipate excel memory peak to be approximately 100B * num cells

## How Has This Been Tested?
Manual + Unit

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent OOM on huge Excel files by capping non-empty cells processed per worksheet. If the limit is exceeded, scanning stops and a truncation marker row is appended to the sheet’s CSV.

- **Bug Fixes**
  - Configurable via `MAX_XLSX_CELLS_PER_SHEET` (default 10,000,000).
  - Early stop in `_sheet_to_csv`; appends `[truncated: sheet exceeded cell limit]`.
  - Unit tests cover truncation and normal flow.

<sup>Written for commit bde61787d21485663b9b794fca2c4dc0bb9c800f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



