### PR TITLE
feat(security): redis-backed rate limits for admin invite endpoints

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1063,26 +1063,6 @@ ENABLE_EMAIL_INVITES = os.environ.get("ENABLE_EMAIL_INVITES", "").lower() == "tr
 # Limit on number of users a free trial tenant can invite (cloud only)
 NUM_FREE_TRIAL_USER_INVITES = int(os.environ.get("NUM_FREE_TRIAL_USER_INVITES", "10"))
 
-# Redis-backed rate limits for admin invite + remove-invited endpoints.
-# These guard against compromised-admin invite-spam / email-bomb abuse
-# where nginx IP-keyed limits are insufficient (per-pod counters, IP rotation).
-# Set any of the below to 0 to disable that specific tier.
-INVITE_RATE_LIMIT_ADMIN_PER_MIN = int(
-    os.environ.get("INVITE_RATE_LIMIT_ADMIN_PER_MIN", "5")
-)
-INVITE_RATE_LIMIT_ADMIN_PER_DAY = int(
-    os.environ.get("INVITE_RATE_LIMIT_ADMIN_PER_DAY", "50")
-)
-INVITE_RATE_LIMIT_TENANT_PER_DAY = int(
-    os.environ.get("INVITE_RATE_LIMIT_TENANT_PER_DAY", "500")
-)
-INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN = int(
-    os.environ.get("INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN", "10")
-)
-INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY = int(
-    os.environ.get("INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY", "100")
-)
-
 # Security and authentication
 DATA_PLANE_SECRET = os.environ.get(
     "DATA_PLANE_SECRET", ""

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1063,6 +1063,26 @@ ENABLE_EMAIL_INVITES = os.environ.get("ENABLE_EMAIL_INVITES", "").lower() == "tr
 # Limit on number of users a free trial tenant can invite (cloud only)
 NUM_FREE_TRIAL_USER_INVITES = int(os.environ.get("NUM_FREE_TRIAL_USER_INVITES", "10"))
 
+# Redis-backed rate limits for admin invite + remove-invited endpoints.
+# These guard against compromised-admin invite-spam / email-bomb abuse
+# where nginx IP-keyed limits are insufficient (per-pod counters, IP rotation).
+# Set any of the below to 0 to disable that specific tier.
+INVITE_RATE_LIMIT_ADMIN_PER_MIN = int(
+    os.environ.get("INVITE_RATE_LIMIT_ADMIN_PER_MIN", "5")
+)
+INVITE_RATE_LIMIT_ADMIN_PER_DAY = int(
+    os.environ.get("INVITE_RATE_LIMIT_ADMIN_PER_DAY", "50")
+)
+INVITE_RATE_LIMIT_TENANT_PER_DAY = int(
+    os.environ.get("INVITE_RATE_LIMIT_TENANT_PER_DAY", "500")
+)
+INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN = int(
+    os.environ.get("INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN", "10")
+)
+INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY = int(
+    os.environ.get("INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY", "100")
+)
+
 # Security and authentication
 DATA_PLANE_SECRET = os.environ.get(
     "DATA_PLANE_SECRET", ""

--- a/backend/onyx/server/manage/invite_rate_limit.py
+++ b/backend/onyx/server/manage/invite_rate_limit.py
@@ -5,13 +5,21 @@ nginx IP-keyed `limit_req` cannot stop (per-pod counters in multi-replica
 deployments, trivial IP rotation). Counters live in tenant-prefixed Redis
 so multi-pod api-server instances share state and per-admin / per-tenant
 quotas are enforced cluster-wide.
+
+Check+increment is performed in a single Redis Lua script so two
+concurrent replicas cannot both pass the pre-check and both increment
+past the limit. When Redis is unavailable (e.g. Onyx Lite deployments
+where Redis is an opt-in `--profile redis` service), the rate limiter
+fails open with a logged warning so core invite flows continue to work.
 """
 
 from dataclasses import dataclass
-from typing import cast
 from uuid import UUID
 
 from redis import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_DAY
 from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_MIN
@@ -33,6 +41,41 @@ _INVITE_PUT_TENANT_DAY_KEY = "ratelimit:invite_put:tenant:day"
 _INVITE_REMOVE_ADMIN_MIN_KEY = "ratelimit:invite_remove:admin:{user_id}:min"
 _INVITE_REMOVE_ADMIN_DAY_KEY = "ratelimit:invite_remove:admin:{user_id}:day"
 
+# Atomic multi-bucket check+increment.
+# ARGV[1] = N (bucket count). For each bucket i=1..N, ARGV[2+(i-1)*3..4+(i-1)*3]
+# carry increment, limit, ttl. KEYS[i] is the bucket's Redis key.
+#
+# Buckets with limit <= 0 or increment <= 0 are skipped (a disabled tier).
+# On reject, returns the 1-indexed bucket number that failed so the caller
+# can report which scope tripped; on success returns 0. TTL is set with NX
+# semantics so pre-existing keys without a TTL are still given one, but
+# fresh increments do not reset the window (fixed-window, not sliding).
+_CHECK_AND_INCREMENT_SCRIPT = """
+local n = tonumber(ARGV[1])
+for i = 1, n do
+    local key = KEYS[i]
+    local increment = tonumber(ARGV[2 + (i - 1) * 3])
+    local limit = tonumber(ARGV[3 + (i - 1) * 3])
+    if limit > 0 and increment > 0 then
+        local current = tonumber(redis.call('get', key)) or 0
+        if current + increment > limit then
+            return i
+        end
+    end
+end
+for i = 1, n do
+    local key = KEYS[i]
+    local increment = tonumber(ARGV[2 + (i - 1) * 3])
+    local limit = tonumber(ARGV[3 + (i - 1) * 3])
+    local ttl = tonumber(ARGV[4 + (i - 1) * 3])
+    if limit > 0 and increment > 0 then
+        redis.call('incrby', key, increment)
+        redis.call('expire', key, ttl, 'NX')
+    end
+end
+return 0
+"""
+
 
 @dataclass(frozen=True)
 class _Bucket:
@@ -43,33 +86,58 @@ class _Bucket:
     increment: int
 
 
-def _raise_if_exceeded(redis_client: Redis, bucket: _Bucket) -> None:
-    if bucket.limit <= 0 or bucket.increment <= 0:
+def _run_atomic(redis_client: Redis, buckets: list[_Bucket]) -> None:
+    """Run the check+increment Lua script. Raise OnyxError on rejection.
+
+    On Redis connection / timeout errors the rate limiter fails open: the
+    request is allowed through and the failure is logged. This keeps the
+    invite flow usable on Onyx Lite deployments (Redis is opt-in there)
+    and during transient Redis outages in full deployments.
+    """
+    if not buckets:
         return
 
-    raw_current = cast(bytes | None, redis_client.get(bucket.key))
-    current = int(raw_current) if raw_current is not None else 0
-    if current + bucket.increment > bucket.limit:
+    keys = [b.key for b in buckets]
+    argv: list[str] = [str(len(buckets))]
+    for b in buckets:
+        argv.extend([str(b.increment), str(b.limit), str(b.ttl_seconds)])
+
+    try:
+        result = redis_client.eval(  # type: ignore[no-untyped-call]
+            _CHECK_AND_INCREMENT_SCRIPT,
+            len(keys),
+            *keys,
+            *argv,
+        )
+    except (RedisConnectionError, RedisTimeoutError) as e:
         logger.warning(
-            "Invite rate limit hit: scope=%s key=%s current=%d adding=%d limit=%d",
-            bucket.scope,
-            bucket.key,
-            current,
-            bucket.increment,
-            bucket.limit,
+            "Invite rate limiter skipped — Redis unavailable: %s. Rate limiting is disabled for this request.",
+            e,
         )
-        raise OnyxError(
-            OnyxErrorCode.RATE_LIMITED,
-            f"Invite rate limit exceeded ({bucket.scope}). Try again later.",
-        )
-
-
-def _record(redis_client: Redis, bucket: _Bucket) -> None:
-    if bucket.limit <= 0 or bucket.increment <= 0:
         return
-    new_value = redis_client.incrby(bucket.key, bucket.increment)
-    if new_value == bucket.increment:
-        redis_client.expire(bucket.key, bucket.ttl_seconds)
+    except RedisError as e:
+        logger.error(
+            "Invite rate limiter Redis error, failing open: %s",
+            e,
+        )
+        return
+
+    failed_index = int(result) if isinstance(result, (int, str, bytes)) else 0
+    if failed_index <= 0:
+        return
+
+    failed_bucket = buckets[failed_index - 1]
+    logger.warning(
+        "Invite rate limit hit: scope=%s key=%s adding=%d limit=%d",
+        failed_bucket.scope,
+        failed_bucket.key,
+        failed_bucket.increment,
+        failed_bucket.limit,
+    )
+    raise OnyxError(
+        OnyxErrorCode.RATE_LIMITED,
+        f"Invite rate limit exceeded ({failed_bucket.scope}). Try again later.",
+    )
 
 
 def enforce_invite_rate_limit(
@@ -116,11 +184,7 @@ def enforce_invite_rate_limit(
             increment=1,
         ),
     ]
-
-    for bucket in buckets:
-        _raise_if_exceeded(redis_client, bucket)
-    for bucket in buckets:
-        _record(redis_client, bucket)
+    _run_atomic(redis_client, buckets)
 
 
 def enforce_remove_invited_rate_limit(
@@ -151,8 +215,4 @@ def enforce_remove_invited_rate_limit(
             increment=1,
         ),
     ]
-
-    for bucket in buckets:
-        _raise_if_exceeded(redis_client, bucket)
-    for bucket in buckets:
-        _record(redis_client, bucket)
+    _run_atomic(redis_client, buckets)

--- a/backend/onyx/server/manage/invite_rate_limit.py
+++ b/backend/onyx/server/manage/invite_rate_limit.py
@@ -30,16 +30,20 @@ logger = setup_logger()
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_DAY = 24 * 60 * 60
 
-# These limits primarily matter for multi-tenant cloud. Self-hosted / Lite
-# deployments fail open when Redis is unavailable, so the limits are
-# effectively no-ops there. Tuned for the invite-spam attack pattern where
-# a compromised admin sends ~30/min of PUT+PATCH cycles; caps are well
-# above any legitimate human invite cadence.
-_INVITE_ADMIN_PER_MIN = 5
-_INVITE_ADMIN_PER_DAY = 50
-_INVITE_TENANT_PER_DAY = 500
-_REMOVE_ADMIN_PER_MIN = 10
-_REMOVE_ADMIN_PER_DAY = 100
+# Rate limits apply to trial tenants only (enforced at call site). Paid
+# tenants bypass entirely — their guardrails are seat limits and the
+# per-admin lifetime counter. Self-hosted / Lite deployments fail open
+# when Redis is unavailable. Values are sized against the trial lifetime
+# cap `NUM_FREE_TRIAL_USER_INVITES=10` and the invite→remove→invite
+# bypass attack: per-day caps stay tight so a compromised or scripted
+# trial admin cannot exceed the lifetime cap even across window rolls,
+# and per-minute caps block burst automation while leaving headroom for
+# a human typing emails by hand.
+_INVITE_ADMIN_PER_MIN = 3
+_INVITE_ADMIN_PER_DAY = 10
+_INVITE_TENANT_PER_DAY = 15
+_REMOVE_ADMIN_PER_MIN = 3
+_REMOVE_ADMIN_PER_DAY = 30
 
 _INVITE_PUT_ADMIN_MIN_KEY = "ratelimit:invite_put:admin:{user_id}:min"
 _INVITE_PUT_ADMIN_DAY_KEY = "ratelimit:invite_put:admin:{user_id}:day"

--- a/backend/onyx/server/manage/invite_rate_limit.py
+++ b/backend/onyx/server/manage/invite_rate_limit.py
@@ -21,11 +21,6 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_DAY
-from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_MIN
-from onyx.configs.app_configs import INVITE_RATE_LIMIT_TENANT_PER_DAY
-from onyx.configs.app_configs import INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY
-from onyx.configs.app_configs import INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -34,6 +29,17 @@ logger = setup_logger()
 
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_DAY = 24 * 60 * 60
+
+# These limits primarily matter for multi-tenant cloud. Self-hosted / Lite
+# deployments fail open when Redis is unavailable, so the limits are
+# effectively no-ops there. Tuned for the invite-spam attack pattern where
+# a compromised admin sends ~30/min of PUT+PATCH cycles; caps are well
+# above any legitimate human invite cadence.
+_INVITE_ADMIN_PER_MIN = 5
+_INVITE_ADMIN_PER_DAY = 50
+_INVITE_TENANT_PER_DAY = 500
+_REMOVE_ADMIN_PER_MIN = 10
+_REMOVE_ADMIN_PER_DAY = 100
 
 _INVITE_PUT_ADMIN_MIN_KEY = "ratelimit:invite_put:admin:{user_id}:min"
 _INVITE_PUT_ADMIN_DAY_KEY = "ratelimit:invite_put:admin:{user_id}:day"
@@ -164,21 +170,21 @@ def enforce_invite_rate_limit(
     buckets = [
         _Bucket(
             key=_INVITE_PUT_TENANT_DAY_KEY,
-            limit=INVITE_RATE_LIMIT_TENANT_PER_DAY,
+            limit=_INVITE_TENANT_PER_DAY,
             ttl_seconds=_SECONDS_PER_DAY,
             scope="tenant/day",
             increment=daily_increment,
         ),
         _Bucket(
             key=_INVITE_PUT_ADMIN_DAY_KEY.format(user_id=user_key),
-            limit=INVITE_RATE_LIMIT_ADMIN_PER_DAY,
+            limit=_INVITE_ADMIN_PER_DAY,
             ttl_seconds=_SECONDS_PER_DAY,
             scope="admin/day",
             increment=daily_increment,
         ),
         _Bucket(
             key=_INVITE_PUT_ADMIN_MIN_KEY.format(user_id=user_key),
-            limit=INVITE_RATE_LIMIT_ADMIN_PER_MIN,
+            limit=_INVITE_ADMIN_PER_MIN,
             ttl_seconds=_SECONDS_PER_MINUTE,
             scope="admin/minute",
             increment=1,
@@ -202,14 +208,14 @@ def enforce_remove_invited_rate_limit(
     buckets = [
         _Bucket(
             key=_INVITE_REMOVE_ADMIN_DAY_KEY.format(user_id=user_key),
-            limit=INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY,
+            limit=_REMOVE_ADMIN_PER_DAY,
             ttl_seconds=_SECONDS_PER_DAY,
             scope="admin/day",
             increment=1,
         ),
         _Bucket(
             key=_INVITE_REMOVE_ADMIN_MIN_KEY.format(user_id=user_key),
-            limit=INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN,
+            limit=_REMOVE_ADMIN_PER_MIN,
             ttl_seconds=_SECONDS_PER_MINUTE,
             scope="admin/minute",
             increment=1,

--- a/backend/onyx/server/manage/invite_rate_limit.py
+++ b/backend/onyx/server/manage/invite_rate_limit.py
@@ -1,0 +1,158 @@
+"""Redis-backed rate limits for admin invite + remove-invited-user endpoints.
+
+Defends against compromised-admin invite-spam and email-bomb abuse that
+nginx IP-keyed `limit_req` cannot stop (per-pod counters in multi-replica
+deployments, trivial IP rotation). Counters live in tenant-prefixed Redis
+so multi-pod api-server instances share state and per-admin / per-tenant
+quotas are enforced cluster-wide.
+"""
+
+from dataclasses import dataclass
+from typing import cast
+from uuid import UUID
+
+from redis import Redis
+
+from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_DAY
+from onyx.configs.app_configs import INVITE_RATE_LIMIT_ADMIN_PER_MIN
+from onyx.configs.app_configs import INVITE_RATE_LIMIT_TENANT_PER_DAY
+from onyx.configs.app_configs import INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY
+from onyx.configs.app_configs import INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_DAY = 24 * 60 * 60
+
+_INVITE_PUT_ADMIN_MIN_KEY = "ratelimit:invite_put:admin:{user_id}:min"
+_INVITE_PUT_ADMIN_DAY_KEY = "ratelimit:invite_put:admin:{user_id}:day"
+_INVITE_PUT_TENANT_DAY_KEY = "ratelimit:invite_put:tenant:day"
+_INVITE_REMOVE_ADMIN_MIN_KEY = "ratelimit:invite_remove:admin:{user_id}:min"
+_INVITE_REMOVE_ADMIN_DAY_KEY = "ratelimit:invite_remove:admin:{user_id}:day"
+
+
+@dataclass(frozen=True)
+class _Bucket:
+    key: str
+    limit: int
+    ttl_seconds: int
+    scope: str
+    increment: int
+
+
+def _raise_if_exceeded(redis_client: Redis, bucket: _Bucket) -> None:
+    if bucket.limit <= 0 or bucket.increment <= 0:
+        return
+
+    raw_current = cast(bytes | None, redis_client.get(bucket.key))
+    current = int(raw_current) if raw_current is not None else 0
+    if current + bucket.increment > bucket.limit:
+        logger.warning(
+            "Invite rate limit hit: scope=%s key=%s current=%d adding=%d limit=%d",
+            bucket.scope,
+            bucket.key,
+            current,
+            bucket.increment,
+            bucket.limit,
+        )
+        raise OnyxError(
+            OnyxErrorCode.RATE_LIMITED,
+            f"Invite rate limit exceeded ({bucket.scope}). Try again later.",
+        )
+
+
+def _record(redis_client: Redis, bucket: _Bucket) -> None:
+    if bucket.limit <= 0 or bucket.increment <= 0:
+        return
+    new_value = redis_client.incrby(bucket.key, bucket.increment)
+    if new_value == bucket.increment:
+        redis_client.expire(bucket.key, bucket.ttl_seconds)
+
+
+def enforce_invite_rate_limit(
+    redis_client: Redis,
+    admin_user_id: UUID | str,
+    num_invites: int,
+) -> None:
+    """Check+record invite quotas for an admin user within their tenant.
+
+    Three tiers. Daily tiers track invite volume (so bulk invite of 20
+    users counts as 20); the minute tier tracks request cadence (so a
+    single legitimate bulk call does not trip the burst guard while an
+    attacker spamming single-email requests does).
+
+    Raises OnyxError(RATE_LIMITED) without recording if any tier would be
+    exceeded, so repeated rejected attempts do not consume budget.
+    `num_invites` MUST be the count of new invites the request will send
+    (not total emails in the body — deduplicate already-invited first).
+    Zero-invite calls still tick the minute bucket so probe-floods of
+    already-invited emails cannot bypass the burst guard.
+    """
+    user_key = str(admin_user_id)
+    daily_increment = max(0, num_invites)
+    buckets = [
+        _Bucket(
+            key=_INVITE_PUT_TENANT_DAY_KEY,
+            limit=INVITE_RATE_LIMIT_TENANT_PER_DAY,
+            ttl_seconds=_SECONDS_PER_DAY,
+            scope="tenant/day",
+            increment=daily_increment,
+        ),
+        _Bucket(
+            key=_INVITE_PUT_ADMIN_DAY_KEY.format(user_id=user_key),
+            limit=INVITE_RATE_LIMIT_ADMIN_PER_DAY,
+            ttl_seconds=_SECONDS_PER_DAY,
+            scope="admin/day",
+            increment=daily_increment,
+        ),
+        _Bucket(
+            key=_INVITE_PUT_ADMIN_MIN_KEY.format(user_id=user_key),
+            limit=INVITE_RATE_LIMIT_ADMIN_PER_MIN,
+            ttl_seconds=_SECONDS_PER_MINUTE,
+            scope="admin/minute",
+            increment=1,
+        ),
+    ]
+
+    for bucket in buckets:
+        _raise_if_exceeded(redis_client, bucket)
+    for bucket in buckets:
+        _record(redis_client, bucket)
+
+
+def enforce_remove_invited_rate_limit(
+    redis_client: Redis,
+    admin_user_id: UUID | str,
+) -> None:
+    """Check+record remove-invited-user quotas for an admin user.
+
+    Two tiers: per-admin per-day and per-admin per-minute. Removal itself
+    does not send email, so there is no tenant-wide cap — the goal is to
+    detect the PUT→PATCH abuse pattern by throttling PATCHes to roughly
+    the cadence of legitimate administrative mistake correction.
+    """
+    user_key = str(admin_user_id)
+    buckets = [
+        _Bucket(
+            key=_INVITE_REMOVE_ADMIN_DAY_KEY.format(user_id=user_key),
+            limit=INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY,
+            ttl_seconds=_SECONDS_PER_DAY,
+            scope="admin/day",
+            increment=1,
+        ),
+        _Bucket(
+            key=_INVITE_REMOVE_ADMIN_MIN_KEY.format(user_id=user_key),
+            limit=INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN,
+            ttl_seconds=_SECONDS_PER_MINUTE,
+            scope="admin/minute",
+            increment=1,
+        ),
+    ]
+
+    for bucket in buckets:
+        _raise_if_exceeded(redis_client, bucket)
+    for bucket in buckets:
+        _record(redis_client, bucket)

--- a/backend/onyx/server/manage/invite_rate_limit.py
+++ b/backend/onyx/server/manage/invite_rate_limit.py
@@ -45,9 +45,16 @@ _INVITE_TENANT_PER_DAY = 15
 _REMOVE_ADMIN_PER_MIN = 3
 _REMOVE_ADMIN_PER_DAY = 30
 
+# Per-admin buckets are accidentally safe without an explicit tenant
+# prefix because admin UUIDs are globally unique. The tenant/day bucket
+# MUST embed the tenant_id directly: TenantRedis.__getattribute__ only
+# prefixes commands in an explicit allowlist and `eval` is not on it, so
+# keys passed to the Lua script reach Redis bare. A key of
+# "ratelimit:invite_put:tenant:day" would be shared across every trial
+# tenant, exhausting one global counter for the whole cluster.
 _INVITE_PUT_ADMIN_MIN_KEY = "ratelimit:invite_put:admin:{user_id}:min"
 _INVITE_PUT_ADMIN_DAY_KEY = "ratelimit:invite_put:admin:{user_id}:day"
-_INVITE_PUT_TENANT_DAY_KEY = "ratelimit:invite_put:tenant:day"
+_INVITE_PUT_TENANT_DAY_KEY = "ratelimit:invite_put:tenant:{tenant_id}:day"
 _INVITE_REMOVE_ADMIN_MIN_KEY = "ratelimit:invite_remove:admin:{user_id}:min"
 _INVITE_REMOVE_ADMIN_DAY_KEY = "ratelimit:invite_remove:admin:{user_id}:day"
 
@@ -154,6 +161,7 @@ def enforce_invite_rate_limit(
     redis_client: Redis,
     admin_user_id: UUID | str,
     num_invites: int,
+    tenant_id: str,
 ) -> None:
     """Check+record invite quotas for an admin user within their tenant.
 
@@ -173,7 +181,7 @@ def enforce_invite_rate_limit(
     daily_increment = max(0, num_invites)
     buckets = [
         _Bucket(
-            key=_INVITE_PUT_TENANT_DAY_KEY,
+            key=_INVITE_PUT_TENANT_DAY_KEY.format(tenant_id=tenant_id),
             limit=_INVITE_TENANT_PER_DAY,
             ttl_seconds=_SECONDS_PER_DAY,
             scope="tenant/day",

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -476,6 +476,7 @@ def bulk_invite_users(
             redis_client=get_redis_client(tenant_id=tenant_id),
             admin_user_id=current_user.id,
             num_invites=len(emails_needing_seats),
+            tenant_id=tenant_id,
         )
 
     # Check seat availability for new users

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -83,8 +83,11 @@ from onyx.db.users import get_user_counts_by_role_and_status
 from onyx.db.users import validate_user_role_update
 from onyx.key_value_store.factory import get_kv_store
 from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.features.projects.models import UserFileSnapshot
+from onyx.server.manage.invite_rate_limit import enforce_invite_rate_limit
+from onyx.server.manage.invite_rate_limit import enforce_remove_invited_rate_limit
 from onyx.server.manage.models import AllUsersResponse
 from onyx.server.manage.models import AutoScrollRequest
 from onyx.server.manage.models import BulkInviteResponse
@@ -470,6 +473,12 @@ def bulk_invite_users(
                 detail="You have hit your invite limit. Please upgrade for unlimited invites.",
             )
 
+    enforce_invite_rate_limit(
+        redis_client=get_redis_client(tenant_id=tenant_id),
+        admin_user_id=current_user.id,
+        num_invites=len(emails_needing_seats),
+    )
+
     # Check seat availability for new users
     if emails_needing_seats:
         enforce_seat_limit(db_session, seats_needed=len(emails_needing_seats))
@@ -529,10 +538,16 @@ def bulk_invite_users(
 @router.patch("/manage/admin/remove-invited-user", tags=PUBLIC_API_TAGS)
 def remove_invited_user(
     user_email: UserByEmail,
-    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    current_user: User = Depends(
+        require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
+    ),
     db_session: Session = Depends(get_session),
 ) -> int:
     tenant_id = get_current_tenant_id()
+    enforce_remove_invited_rate_limit(
+        redis_client=get_redis_client(tenant_id=tenant_id),
+        admin_user_id=current_user.id,
+    )
     if MULTI_TENANT:
         fetch_ee_implementation_or_noop(
             "onyx.server.tenants.user_mapping", "remove_users_from_tenant", None

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -472,12 +472,11 @@ def bulk_invite_users(
                 status_code=403,
                 detail="You have hit your invite limit. Please upgrade for unlimited invites.",
             )
-
-    enforce_invite_rate_limit(
-        redis_client=get_redis_client(tenant_id=tenant_id),
-        admin_user_id=current_user.id,
-        num_invites=len(emails_needing_seats),
-    )
+        enforce_invite_rate_limit(
+            redis_client=get_redis_client(tenant_id=tenant_id),
+            admin_user_id=current_user.id,
+            num_invites=len(emails_needing_seats),
+        )
 
     # Check seat availability for new users
     if emails_needing_seats:
@@ -544,10 +543,11 @@ def remove_invited_user(
     db_session: Session = Depends(get_session),
 ) -> int:
     tenant_id = get_current_tenant_id()
-    enforce_remove_invited_rate_limit(
-        redis_client=get_redis_client(tenant_id=tenant_id),
-        admin_user_id=current_user.id,
-    )
+    if MULTI_TENANT and is_tenant_on_trial_fn(tenant_id):
+        enforce_remove_invited_rate_limit(
+            redis_client=get_redis_client(tenant_id=tenant_id),
+            admin_user_id=current_user.id,
+        )
     if MULTI_TENANT:
         fetch_ee_implementation_or_noop(
             "onyx.server.tenants.user_mapping", "remove_users_from_tenant", None

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -10,6 +10,7 @@ from onyx.server.manage.models import EmailInviteStatus
 from onyx.server.manage.users import bulk_invite_users
 
 
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
 @patch("onyx.server.manage.users.MULTI_TENANT", True)
 @patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
 @patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
@@ -21,12 +22,13 @@ def test_trial_tenant_cannot_exceed_invite_limit(*_mocks: None) -> None:
     emails = [f"user{i}@example.com" for i in range(6)]
 
     with pytest.raises(HTTPException) as exc_info:
-        bulk_invite_users(emails=emails)
+        bulk_invite_users(emails=emails, current_user=MagicMock())
 
     assert exc_info.value.status_code == 403
     assert "invite limit" in exc_info.value.detail.lower()
 
 
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
 @patch("onyx.server.manage.users.MULTI_TENANT", True)
 @patch("onyx.server.manage.users.DEV_MODE", True)
 @patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
@@ -45,7 +47,7 @@ def test_trial_tenant_can_invite_within_limit(*_mocks: None) -> None:
     """Trial tenants can invite users when under the limit."""
     emails = ["user1@example.com", "user2@example.com", "user3@example.com"]
 
-    result = bulk_invite_users(emails=emails)
+    result = bulk_invite_users(emails=emails, current_user=MagicMock())
 
     assert result.invited_count == 3
     assert result.email_invite_status == EmailInviteStatus.DISABLED
@@ -60,6 +62,7 @@ _COMMON_PATCHES = [
     patch("onyx.server.manage.users.get_all_users", return_value=[]),
     patch("onyx.server.manage.users.write_invited_users", return_value=1),
     patch("onyx.server.manage.users.enforce_seat_limit"),
+    patch("onyx.server.manage.users.enforce_invite_rate_limit"),
 ]
 
 
@@ -73,7 +76,7 @@ def _with_common_patches(fn: object) -> object:
 @patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
 def test_email_invite_status_disabled(*_mocks: None) -> None:
     """When email invites are disabled, status is disabled."""
-    result = bulk_invite_users(emails=["user@example.com"])
+    result = bulk_invite_users(emails=["user@example.com"], current_user=MagicMock())
 
     assert result.email_invite_status == EmailInviteStatus.DISABLED
 
@@ -83,7 +86,7 @@ def test_email_invite_status_disabled(*_mocks: None) -> None:
 @patch("onyx.server.manage.users.EMAIL_CONFIGURED", False)
 def test_email_invite_status_not_configured(*_mocks: None) -> None:
     """When email invites are enabled but no server is configured, status is not_configured."""
-    result = bulk_invite_users(emails=["user@example.com"])
+    result = bulk_invite_users(emails=["user@example.com"], current_user=MagicMock())
 
     assert result.email_invite_status == EmailInviteStatus.NOT_CONFIGURED
 
@@ -94,7 +97,7 @@ def test_email_invite_status_not_configured(*_mocks: None) -> None:
 @patch("onyx.server.manage.users.send_user_email_invite")
 def test_email_invite_status_sent(mock_send: MagicMock, *_mocks: None) -> None:
     """When email invites are enabled and configured, status is sent."""
-    result = bulk_invite_users(emails=["user@example.com"])
+    result = bulk_invite_users(emails=["user@example.com"], current_user=MagicMock())
 
     mock_send.assert_called_once()
     assert result.email_invite_status == EmailInviteStatus.SENT
@@ -109,7 +112,7 @@ def test_email_invite_status_sent(mock_send: MagicMock, *_mocks: None) -> None:
 )
 def test_email_invite_status_send_failed(*_mocks: None) -> None:
     """When email sending throws, status is send_failed and invite is still saved."""
-    result = bulk_invite_users(emails=["user@example.com"])
+    result = bulk_invite_users(emails=["user@example.com"], current_user=MagicMock())
 
     assert result.email_invite_status == EmailInviteStatus.SEND_FAILED
     assert result.invited_count == 1

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -7,7 +7,9 @@ import pytest
 from fastapi import HTTPException
 
 from onyx.server.manage.models import EmailInviteStatus
+from onyx.server.manage.models import UserByEmail
 from onyx.server.manage.users import bulk_invite_users
+from onyx.server.manage.users import remove_invited_user
 
 
 @patch("onyx.server.manage.users.enforce_invite_rate_limit")
@@ -116,3 +118,119 @@ def test_email_invite_status_send_failed(*_mocks: None) -> None:
 
     assert result.email_invite_status == EmailInviteStatus.SEND_FAILED
     assert result.invited_count == 1
+
+
+# --- trial-only rate limit gating tests ---
+
+
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=3)
+@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+def test_paid_tenant_bypasses_invite_rate_limit(
+    _ee_fetch: MagicMock,
+    _seat_limit: MagicMock,
+    _write_invited: MagicMock,
+    _get_all_users: MagicMock,
+    _get_invited_users: MagicMock,
+    _get_tenant_id: MagicMock,
+    _is_trial: MagicMock,
+    mock_rate_limit: MagicMock,
+) -> None:
+    """Paid tenants must not hit the invite rate limiter at all."""
+    emails = [f"user{i}@example.com" for i in range(3)]
+    bulk_invite_users(emails=emails, current_user=MagicMock())
+    mock_rate_limit.assert_not_called()
+
+
+@patch("onyx.server.manage.users.enforce_invite_rate_limit")
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.ENABLE_EMAIL_INVITES", False)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch("onyx.server.manage.users.get_invited_users", return_value=[])
+@patch("onyx.server.manage.users.get_all_users", return_value=[])
+@patch("onyx.server.manage.users.write_invited_users", return_value=3)
+@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch("onyx.server.manage.users.NUM_FREE_TRIAL_USER_INVITES", 50)
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+def test_trial_tenant_hits_invite_rate_limit(
+    _ee_fetch: MagicMock,
+    _seat_limit: MagicMock,
+    _write_invited: MagicMock,
+    _get_all_users: MagicMock,
+    _get_invited_users: MagicMock,
+    _get_tenant_id: MagicMock,
+    _is_trial: MagicMock,
+    mock_rate_limit: MagicMock,
+) -> None:
+    """Trial tenants must flow through the invite rate limiter."""
+    emails = [f"user{i}@example.com" for i in range(3)]
+    bulk_invite_users(emails=emails, current_user=MagicMock())
+    mock_rate_limit.assert_called_once()
+
+
+@patch("onyx.server.manage.users.enforce_remove_invited_rate_limit")
+@patch("onyx.server.manage.users.remove_user_from_invited_users", return_value=0)
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=False)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+def test_paid_tenant_bypasses_remove_invited_rate_limit(
+    _ee_fetch: MagicMock,
+    _get_tenant_id: MagicMock,
+    _is_trial: MagicMock,
+    _remove_from_invited: MagicMock,
+    mock_rate_limit: MagicMock,
+) -> None:
+    """Paid tenants must not hit the remove-invited rate limiter at all."""
+    remove_invited_user(
+        user_email=UserByEmail(user_email="user@example.com"),
+        current_user=MagicMock(),
+        db_session=MagicMock(),
+    )
+    mock_rate_limit.assert_not_called()
+
+
+@patch("onyx.server.manage.users.enforce_remove_invited_rate_limit")
+@patch("onyx.server.manage.users.remove_user_from_invited_users", return_value=0)
+@patch("onyx.server.manage.users.MULTI_TENANT", True)
+@patch("onyx.server.manage.users.DEV_MODE", True)
+@patch("onyx.server.manage.users.is_tenant_on_trial_fn", return_value=True)
+@patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
+@patch(
+    "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+    return_value=lambda *_args: None,
+)
+def test_trial_tenant_hits_remove_invited_rate_limit(
+    _ee_fetch: MagicMock,
+    _get_tenant_id: MagicMock,
+    _is_trial: MagicMock,
+    _remove_from_invited: MagicMock,
+    mock_rate_limit: MagicMock,
+) -> None:
+    """Trial tenants must flow through the remove-invited rate limiter."""
+    remove_invited_user(
+        user_email=UserByEmail(user_email="user@example.com"),
+        current_user=MagicMock(),
+        db_session=MagicMock(),
+    )
+    mock_rate_limit.assert_called_once()

--- a/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
@@ -1,0 +1,288 @@
+"""Unit tests for the Redis-backed invite + remove-invited rate limits."""
+
+from typing import cast
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from redis import Redis
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.invite_rate_limit import enforce_invite_rate_limit
+from onyx.server.manage.invite_rate_limit import enforce_remove_invited_rate_limit
+
+
+class _StubRedis:
+    """Minimal in-memory stand-in for the Redis methods the rate limiter uses."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+        self.ttls: dict[str, int] = {}
+
+    def get(self, key: str) -> bytes | None:
+        if key not in self.store:
+            return None
+        return str(self.store[key]).encode()
+
+    def incrby(self, key: str, amount: int) -> int:
+        self.store[key] = self.store.get(key, 0) + amount
+        return self.store[key]
+
+    def expire(self, key: str, ttl: int) -> bool:
+        self.ttls[key] = ttl
+        return True
+
+
+def _stub() -> Redis:
+    return cast(Redis, _StubRedis())
+
+
+def test_invite_allows_under_all_tiers() -> None:
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 500
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.store[f"ratelimit:invite_put:admin:{user_id}:day"] == 10
+    assert stub.store["ratelimit:invite_put:tenant:day"] == 10
+    assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
+
+
+def test_invite_minute_bucket_blocks_request_flood() -> None:
+    """Attacker firing single-email invites rapidly must trip admin/minute."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            5000,
+        ),
+    ):
+        for _ in range(5):
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+
+        with pytest.raises(OnyxError) as exc_info:
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+
+    assert exc_info.value.error_code == OnyxErrorCode.RATE_LIMITED
+
+
+def test_invite_bulk_call_does_not_trip_minute_bucket() -> None:
+    """Legitimate one-shot bulk call for many users should not hit minute cap."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 500
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=20)
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
+
+
+def test_invite_admin_daily_cap_enforced() -> None:
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1000
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            5000,
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=50)
+        with pytest.raises(OnyxError):
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+
+
+def test_invite_tenant_daily_cap_enforced_across_admins() -> None:
+    """Tenant cap should trip even when traffic comes from multiple admins."""
+    redis_client = _stub()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1000
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 1000
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 10
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, uuid4(), num_invites=6)
+        enforce_invite_rate_limit(redis_client, uuid4(), num_invites=4)
+        with pytest.raises(OnyxError):
+            enforce_invite_rate_limit(redis_client, uuid4(), num_invites=1)
+
+
+def test_invite_rejected_request_does_not_consume_budget() -> None:
+    """A request that violates a tier must not increment the surviving tiers."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 10
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+        with pytest.raises(OnyxError):
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=5)
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.store[f"ratelimit:invite_put:admin:{user_id}:day"] == 10
+    assert stub.store["ratelimit:invite_put:tenant:day"] == 10
+    assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
+
+
+def test_invite_zero_new_invites_still_ticks_minute_bucket() -> None:
+    """Probes against already-invited emails must still tick the burst guard."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 2
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            5000,
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
+        with pytest.raises(OnyxError):
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.store.get(f"ratelimit:invite_put:admin:{user_id}:day", 0) == 0
+    assert stub.store.get("ratelimit:invite_put:tenant:day", 0) == 0
+
+
+def test_invite_limit_zero_disables_tier() -> None:
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 0
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 0
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 0
+        ),
+    ):
+        for _ in range(100):
+            enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+
+
+def test_remove_minute_bucket_blocks_pattern_attack() -> None:
+    """PUT→PATCH spam must trip the remove-invited minute bucket."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN",
+            3,
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY",
+            100,
+        ),
+    ):
+        for _ in range(3):
+            enforce_remove_invited_rate_limit(redis_client, user_id)
+        with pytest.raises(OnyxError):
+            enforce_remove_invited_rate_limit(redis_client, user_id)
+
+
+def test_remove_daily_cap_enforced() -> None:
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN",
+            1000,
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY",
+            5,
+        ),
+    ):
+        for _ in range(5):
+            enforce_remove_invited_rate_limit(redis_client, user_id)
+        with pytest.raises(OnyxError):
+            enforce_remove_invited_rate_limit(redis_client, user_id)
+
+
+def test_ttls_set_on_first_increment_only() -> None:
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 100
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            5000,
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=3)
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:day"] == 24 * 60 * 60
+    assert stub.ttls["ratelimit:invite_put:tenant:day"] == 24 * 60 * 60
+    assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] == 60

--- a/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
@@ -71,11 +71,13 @@ def test_invite_allows_under_all_tiers() -> None:
             500,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=10, tenant_id="tenant_a"
+        )
 
     stub = cast(_StubRedis, redis_client)
     assert stub.store[f"ratelimit:invite_put:admin:{user_id}:day"] == 10
-    assert stub.store["ratelimit:invite_put:tenant:day"] == 10
+    assert stub.store["ratelimit:invite_put:tenant:tenant_a:day"] == 10
     assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
 
 
@@ -93,10 +95,14 @@ def test_invite_minute_bucket_blocks_request_flood() -> None:
         ),
     ):
         for _ in range(5):
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=1, tenant_id="tenant_a"
+            )
 
         with pytest.raises(OnyxError) as exc_info:
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=1, tenant_id="tenant_a"
+            )
 
     assert exc_info.value.error_code == OnyxErrorCode.RATE_LIMITED
 
@@ -114,7 +120,9 @@ def test_invite_bulk_call_does_not_trip_minute_bucket() -> None:
             500,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=20)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=20, tenant_id="tenant_a"
+        )
 
     stub = cast(_StubRedis, redis_client)
     assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
@@ -135,9 +143,13 @@ def test_invite_admin_daily_cap_enforced() -> None:
             5000,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=50)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=50, tenant_id="tenant_a"
+        )
         with pytest.raises(OnyxError):
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=1)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=1, tenant_id="tenant_a"
+            )
 
 
 def test_invite_tenant_daily_cap_enforced_across_admins() -> None:
@@ -155,10 +167,16 @@ def test_invite_tenant_daily_cap_enforced_across_admins() -> None:
         ),
         patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 10),
     ):
-        enforce_invite_rate_limit(redis_client, uuid4(), num_invites=6)
-        enforce_invite_rate_limit(redis_client, uuid4(), num_invites=4)
+        enforce_invite_rate_limit(
+            redis_client, uuid4(), num_invites=6, tenant_id="tenant_a"
+        )
+        enforce_invite_rate_limit(
+            redis_client, uuid4(), num_invites=4, tenant_id="tenant_a"
+        )
         with pytest.raises(OnyxError):
-            enforce_invite_rate_limit(redis_client, uuid4(), num_invites=1)
+            enforce_invite_rate_limit(
+                redis_client, uuid4(), num_invites=1, tenant_id="tenant_a"
+            )
 
 
 def test_invite_rejected_request_does_not_consume_budget() -> None:
@@ -171,13 +189,17 @@ def test_invite_rejected_request_does_not_consume_budget() -> None:
         patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 50),
         patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 10),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=10, tenant_id="tenant_a"
+        )
         with pytest.raises(OnyxError):
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=5)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=5, tenant_id="tenant_a"
+            )
 
     stub = cast(_StubRedis, redis_client)
     assert stub.store[f"ratelimit:invite_put:admin:{user_id}:day"] == 10
-    assert stub.store["ratelimit:invite_put:tenant:day"] == 10
+    assert stub.store["ratelimit:invite_put:tenant:tenant_a:day"] == 10
     assert stub.store[f"ratelimit:invite_put:admin:{user_id}:min"] == 1
 
 
@@ -194,14 +216,20 @@ def test_invite_zero_new_invites_still_ticks_minute_bucket() -> None:
             5000,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=0, tenant_id="tenant_a"
+        )
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=0, tenant_id="tenant_a"
+        )
         with pytest.raises(OnyxError):
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=0)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=0, tenant_id="tenant_a"
+            )
 
     stub = cast(_StubRedis, redis_client)
     assert stub.store.get(f"ratelimit:invite_put:admin:{user_id}:day", 0) == 0
-    assert stub.store.get("ratelimit:invite_put:tenant:day", 0) == 0
+    assert stub.store.get("ratelimit:invite_put:tenant:tenant_a:day", 0) == 0
 
 
 def test_invite_limit_zero_disables_tier() -> None:
@@ -214,7 +242,40 @@ def test_invite_limit_zero_disables_tier() -> None:
         patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 0),
     ):
         for _ in range(100):
-            enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=10, tenant_id="tenant_a"
+            )
+
+
+def test_invite_tenant_bucket_is_isolated_across_tenants() -> None:
+    """Regression guard: tenants MUST NOT share the tenant/day counter.
+    TenantRedis does not prefix keys passed to `eval`, so the tenant_id is
+    baked into the key string itself."""
+    redis_client = _stub()
+    user_id = uuid4()
+
+    with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 1000),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 1000),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 10),
+    ):
+        # Tenant A exhausts its own cap.
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=10, tenant_id="tenant_a"
+        )
+        with pytest.raises(OnyxError):
+            enforce_invite_rate_limit(
+                redis_client, user_id, num_invites=1, tenant_id="tenant_a"
+            )
+
+        # Tenant B must still have its full budget.
+        enforce_invite_rate_limit(
+            redis_client, uuid4(), num_invites=10, tenant_id="tenant_b"
+        )
+
+    stub = cast(_StubRedis, redis_client)
+    assert stub.store["ratelimit:invite_put:tenant:tenant_a:day"] == 10
+    assert stub.store["ratelimit:invite_put:tenant:tenant_b:day"] == 10
 
 
 def test_invite_fails_open_when_redis_unavailable() -> None:
@@ -229,7 +290,9 @@ def test_invite_fails_open_when_redis_unavailable() -> None:
         patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 1),
         patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 1),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=1_000_000)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=1_000_000, tenant_id="tenant_a"
+        )
 
 
 def test_remove_minute_bucket_blocks_pattern_attack() -> None:
@@ -286,11 +349,13 @@ def test_ttls_set_on_first_increment_and_not_reset() -> None:
             5000,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=3)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=3, tenant_id="tenant_a"
+        )
 
     stub = cast(_StubRedis, redis_client)
     assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:day"] == 24 * 60 * 60
-    assert stub.ttls["ratelimit:invite_put:tenant:day"] == 24 * 60 * 60
+    assert stub.ttls["ratelimit:invite_put:tenant:tenant_a:day"] == 24 * 60 * 60
     assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] == 60
 
     stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] = 999
@@ -302,6 +367,8 @@ def test_ttls_set_on_first_increment_and_not_reset() -> None:
             5000,
         ),
     ):
-        enforce_invite_rate_limit(redis_client, user_id, num_invites=3)
+        enforce_invite_rate_limit(
+            redis_client, user_id, num_invites=3, tenant_id="tenant_a"
+        )
 
     assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] == 999

--- a/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
@@ -64,14 +64,10 @@ def test_invite_allows_under_all_tiers() -> None:
     user_id = uuid4()
 
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 5),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 50),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             500,
         ),
     ):
@@ -89,14 +85,10 @@ def test_invite_minute_bucket_blocks_request_flood() -> None:
     user_id = uuid4()
 
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 5),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 500),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             5000,
         ),
     ):
@@ -115,14 +107,10 @@ def test_invite_bulk_call_does_not_trip_minute_bucket() -> None:
     user_id = uuid4()
 
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 5),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 50),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             500,
         ),
     ):
@@ -138,14 +126,12 @@ def test_invite_admin_daily_cap_enforced() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN",
+            "onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN",
             1000,
         ),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 50),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             5000,
         ),
     ):
@@ -160,16 +146,14 @@ def test_invite_tenant_daily_cap_enforced_across_admins() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN",
+            "onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN",
             1000,
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY",
             1000,
         ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 10
-        ),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 10),
     ):
         enforce_invite_rate_limit(redis_client, uuid4(), num_invites=6)
         enforce_invite_rate_limit(redis_client, uuid4(), num_invites=4)
@@ -183,15 +167,9 @@ def test_invite_rejected_request_does_not_consume_budget() -> None:
     user_id = uuid4()
 
     with (
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 5
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 10
-        ),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 5),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 50),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 10),
     ):
         enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
         with pytest.raises(OnyxError):
@@ -209,14 +187,10 @@ def test_invite_zero_new_invites_still_ticks_minute_bucket() -> None:
     user_id = uuid4()
 
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 2),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 500),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 2
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             5000,
         ),
     ):
@@ -235,15 +209,9 @@ def test_invite_limit_zero_disables_tier() -> None:
     user_id = uuid4()
 
     with (
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 0
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 0
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 0
-        ),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 0),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 0),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 0),
     ):
         for _ in range(100):
             enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
@@ -257,15 +225,9 @@ def test_invite_fails_open_when_redis_unavailable() -> None:
     user_id = uuid4()
 
     with (
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 1
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 1
-        ),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 1),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 1),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY", 1),
     ):
         enforce_invite_rate_limit(redis_client, user_id, num_invites=1_000_000)
 
@@ -277,11 +239,11 @@ def test_remove_minute_bucket_blocks_pattern_attack() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN",
+            "onyx.server.manage.invite_rate_limit._REMOVE_ADMIN_PER_MIN",
             3,
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._REMOVE_ADMIN_PER_DAY",
             100,
         ),
     ):
@@ -297,11 +259,11 @@ def test_remove_daily_cap_enforced() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_MIN",
+            "onyx.server.manage.invite_rate_limit._REMOVE_ADMIN_PER_MIN",
             1000,
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_REMOVE_RATE_LIMIT_ADMIN_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._REMOVE_ADMIN_PER_DAY",
             5,
         ),
     ):
@@ -317,14 +279,10 @@ def test_ttls_set_on_first_increment_and_not_reset() -> None:
     user_id = uuid4()
 
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 100),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 500),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 100
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             5000,
         ),
     ):
@@ -337,14 +295,10 @@ def test_ttls_set_on_first_increment_and_not_reset() -> None:
 
     stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] = 999
     with (
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_MIN", 100),
+        patch("onyx.server.manage.invite_rate_limit._INVITE_ADMIN_PER_DAY", 500),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 100
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
-        ),
-        patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            "onyx.server.manage.invite_rate_limit._INVITE_TENANT_PER_DAY",
             5000,
         ),
     ):

--- a/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py
@@ -1,11 +1,13 @@
 """Unit tests for the Redis-backed invite + remove-invited rate limits."""
 
+from typing import Any
 from typing import cast
 from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from redis import Redis
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -14,24 +16,43 @@ from onyx.server.manage.invite_rate_limit import enforce_remove_invited_rate_lim
 
 
 class _StubRedis:
-    """Minimal in-memory stand-in for the Redis methods the rate limiter uses."""
+    """In-memory stand-in that mirrors the Lua script's semantics.
+
+    The production rate limiter drives all state via a single EVAL call.
+    The stub reimplements that logic in Python so unit tests can assert
+    behavior without a live Redis — matching semantics including the
+    NX-style TTL that leaves existing TTLs intact on re-increment.
+    """
 
     def __init__(self) -> None:
         self.store: dict[str, int] = {}
         self.ttls: dict[str, int] = {}
+        self.eval_fail: Exception | None = None
 
-    def get(self, key: str) -> bytes | None:
-        if key not in self.store:
-            return None
-        return str(self.store[key]).encode()
-
-    def incrby(self, key: str, amount: int) -> int:
-        self.store[key] = self.store.get(key, 0) + amount
-        return self.store[key]
-
-    def expire(self, key: str, ttl: int) -> bool:
-        self.ttls[key] = ttl
-        return True
+    def eval(self, _script: str, num_keys: int, *args: Any) -> int:
+        if self.eval_fail is not None:
+            raise self.eval_fail
+        keys = list(args[:num_keys])
+        argv = list(args[num_keys:])
+        n = int(argv[0])
+        for i in range(n):
+            key = keys[i]
+            increment = int(argv[1 + i * 3])
+            limit = int(argv[2 + i * 3])
+            if limit > 0 and increment > 0:
+                current = self.store.get(key, 0)
+                if current + increment > limit:
+                    return i + 1
+        for i in range(n):
+            key = keys[i]
+            increment = int(argv[1 + i * 3])
+            limit = int(argv[2 + i * 3])
+            ttl = int(argv[3 + i * 3])
+            if limit > 0 and increment > 0:
+                self.store[key] = self.store.get(key, 0) + increment
+                if key not in self.ttls:
+                    self.ttls[key] = ttl
+        return 0
 
 
 def _stub() -> Redis:
@@ -50,7 +71,8 @@ def test_invite_allows_under_all_tiers() -> None:
             "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 500
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            500,
         ),
     ):
         enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
@@ -100,7 +122,8 @@ def test_invite_bulk_call_does_not_trip_minute_bucket() -> None:
             "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 500
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            500,
         ),
     ):
         enforce_invite_rate_limit(redis_client, user_id, num_invites=20)
@@ -115,7 +138,8 @@ def test_invite_admin_daily_cap_enforced() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1000
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN",
+            1000,
         ),
         patch(
             "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 50
@@ -136,10 +160,12 @@ def test_invite_tenant_daily_cap_enforced_across_admins() -> None:
 
     with (
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1000
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN",
+            1000,
         ),
         patch(
-            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 1000
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY",
+            1000,
         ),
         patch(
             "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 10
@@ -223,6 +249,27 @@ def test_invite_limit_zero_disables_tier() -> None:
             enforce_invite_rate_limit(redis_client, user_id, num_invites=10)
 
 
+def test_invite_fails_open_when_redis_unavailable() -> None:
+    """Onyx Lite deployments ship without Redis; invite flow must still work."""
+    stub = _StubRedis()
+    stub.eval_fail = RedisConnectionError("Redis not reachable")
+    redis_client = cast(Redis, stub)
+    user_id = uuid4()
+
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 1
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 1
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY", 1
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=1_000_000)
+
+
 def test_remove_minute_bucket_blocks_pattern_attack() -> None:
     """PUT→PATCH spam must trip the remove-invited minute bucket."""
     redis_client = _stub()
@@ -264,7 +311,8 @@ def test_remove_daily_cap_enforced() -> None:
             enforce_remove_invited_rate_limit(redis_client, user_id)
 
 
-def test_ttls_set_on_first_increment_only() -> None:
+def test_ttls_set_on_first_increment_and_not_reset() -> None:
+    """TTL must be set on the first increment and must not be reset on later ones."""
     redis_client = _stub()
     user_id = uuid4()
 
@@ -286,3 +334,20 @@ def test_ttls_set_on_first_increment_only() -> None:
     assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:day"] == 24 * 60 * 60
     assert stub.ttls["ratelimit:invite_put:tenant:day"] == 24 * 60 * 60
     assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] == 60
+
+    stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] = 999
+    with (
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_MIN", 100
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_ADMIN_PER_DAY", 500
+        ),
+        patch(
+            "onyx.server.manage.invite_rate_limit.INVITE_RATE_LIMIT_TENANT_PER_DAY",
+            5000,
+        ),
+    ):
+        enforce_invite_rate_limit(redis_client, user_id, num_invites=3)
+
+    assert stub.ttls[f"ratelimit:invite_put:admin:{user_id}:min"] == 999


### PR DESCRIPTION
## Description

Adds tenant-prefixed Redis counters that enforce per-admin-per-minute, per-admin-per-day, and per-tenant-per-day limits on `PUT /api/manage/admin/users` and per-admin limits on `PATCH /api/manage/admin/remove-invited-user`.

The existing nginx `limit_req` config works but doesnt completely cover multi-replica deployments because `limit_req_zone` shared memory is per-pod, so 3 nginx replicas yield 3x the intended rate ceiling. Nginx-side keys are also IP-only, trivially bypassable via `X-Forwarded-For` rotation. Redis counters close both gaps: counters are cluster-wide and scoped to admin user + tenant.

Daily buckets count invite volume while the minute bucket counts request cadence, so legitimate bulk calls (one request, many emails) do not trip the burst guard while attackers firing single-email requests do. Rejected requests do not consume budget on surviving tiers.

## Scope — trial tenants only

Rate limits apply **only** to trial tenants (`is_tenant_on_trial_fn(tenant_id) == True`). Paid tenants bypass entirely — their guardrails are seat limits plus the per-admin lifetime counter. This keeps the limits tight against the abuse pattern (trial signup → spam invites) while leaving legitimate paid team onboarding unaffected.

## Limits (trial tenants)

| Scope | Limit |
| --- | --- |
| invite — admin/minute | 3 |
| invite — admin/day | 10 |
| invite — tenant/day | 15 |
| remove-invited — admin/minute | 3 |
| remove-invited — admin/day | 30 |

Constants live inline in `backend/onyx/server/manage/invite_rate_limit.py` (no env vars). Per-day caps sit at/below `NUM_FREE_TRIAL_USER_INVITES=10` so they backstop the lifetime cap across window rolls; per-minute caps block scripted burst while allowing human bulk invites.

## Atomicity + resilience

Check + increment is performed in a single Redis Lua script (`EVAL`) so two concurrent replicas cannot both pass the pre-check and both increment past the limit. TTL is set via `EXPIRE ... NX`, so pre-existing keys without a TTL still get one, and fresh increments do not reset the window (fixed-window, not sliding).

On Redis connection or timeout errors the limiter fails open with a logged warning — keeps the invite flow usable on Onyx Lite (Redis is opt-in there) and during transient Redis outages in full deployments. The rate-limit call itself is also guarded at the call site by the trial check, so a single-tenant self-hosted deployment never enters the limiter at all.

## Tests

- `backend/tests/unit/onyx/server/manage/test_invite_rate_limit.py` — internals of the limiter: per-tier caps, burst vs bulk, zero-invite probes still tick minute bucket, rejected requests preserve budget, `limit=0` disables tier, fail-open on Redis errors, TTL NX semantics.
- `backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py` — call-site gating: paid tenant bypasses both invite + remove-invited limiters, trial tenant flows through them.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check