### PR TITLE
fix(files): harden authorization on chat file downloads (#10380) to release v3.1

### DIFF
--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -2,11 +2,17 @@ import datetime
 from uuid import UUID
 
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import FileOrigin
+from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
+from onyx.db.models import ChatSessionSharedStatus
+from onyx.db.models import FileRecord
 from onyx.db.models import Persona
 from onyx.db.models import Project__UserFile
 from onyx.db.models import UserFile
@@ -108,11 +114,71 @@ def update_last_accessed_at_for_user_files(
     db_session.commit()
 
 
-def get_file_id_by_user_file_id(user_file_id: str, db_session: Session) -> str | None:
-    user_file = db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
+def get_file_id_by_user_file_id(
+    user_file_id: str, user_id: UUID, db_session: Session
+) -> str | None:
+    user_file = (
+        db_session.query(UserFile)
+        .filter(UserFile.id == user_file_id, UserFile.user_id == user_id)
+        .first()
+    )
     if user_file:
         return user_file.file_id
     return None
+
+
+def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) -> bool:
+    """Return True if `user_id` is allowed to read the raw `file_id` served by
+    `GET /chat/file/{file_id}`. Access is granted when any of:
+
+    - The `file_id` is the storage id of a `UserFile` owned by the user.
+    - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
+      are visible to any authenticated user.
+    - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
+      session the user owns or a session publicly shared via
+      `ChatSessionSharedStatus.PUBLIC`.
+    """
+    owns_user_file = db_session.query(
+        select(UserFile.id)
+        .where(UserFile.file_id == file_id, UserFile.user_id == user_id)
+        .exists()
+    ).scalar()
+    if owns_user_file:
+        return True
+
+    # TODO: move persona avatars to a dedicated endpoint (e.g.
+    # /assistants/{id}/avatar) so this branch can be removed. /chat/file is
+    # currently overloaded with multiple asset classes (user files, chat
+    # attachments, tool outputs, avatars), forcing this access-check fan-out.
+    #
+    # Restrict the avatar path to CHAT_UPLOAD-origin files so an attacker
+    # cannot bind another user's USER_FILE (or any other origin) to their
+    # own persona and read it through this check.
+    is_persona_avatar = db_session.query(
+        select(Persona.id)
+        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
+        .where(
+            Persona.uploaded_image_id == file_id,
+            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
+        )
+        .exists()
+    ).scalar()
+    if is_persona_avatar:
+        return True
+
+    chat_file_stmt = (
+        select(ChatMessage.id)
+        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
+        .where(ChatMessage.files.op("@>")([{"id": file_id}]))
+        .where(
+            or_(
+                ChatSession.user_id == user_id,
+                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
+            )
+        )
+        .limit(1)
+    )
+    return db_session.execute(chat_file_stmt).first() is not None
 
 
 def get_file_ids_by_user_file_ids(

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -60,6 +60,9 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.usage import increment_usage
 from onyx.db.usage import UsageType
 from onyx.db.user_file import get_file_id_by_user_file_id
+from onyx.db.user_file import user_can_access_chat_file
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.factory import get_default_llm
@@ -796,14 +799,18 @@ def seed_chat_from_slack(
 def fetch_chat_file(
     file_id: str,
     request: Request,
-    _: User = Depends(current_user),
+    user: User = Depends(current_user),
     db_session: Session = Depends(get_session),
 ) -> Response:
 
     # For user files, we need to get the file id from the user file id
-    file_id_from_user_file = get_file_id_by_user_file_id(file_id, db_session)
+    file_id_from_user_file = get_file_id_by_user_file_id(file_id, user.id, db_session)
     if file_id_from_user_file:
         file_id = file_id_from_user_file
+    elif not user_can_access_chat_file(file_id, user.id, db_session):
+        # Return 404 (rather than 403) so callers cannot probe for file
+        # existence across ownership boundaries.
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "File not found")
 
     file_store = get_default_file_store()
     file_record = file_store.read_file_record(file_id)

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -8,8 +8,10 @@ import io
 from typing import NamedTuple
 
 import pytest
+import requests
 
 from onyx.file_store.models import FileDescriptor
+from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
@@ -119,3 +121,31 @@ def test_public_assistant_with_user_files(
     assert (
         len(chat_history) >= 2
     ), "Expected at least 2 messages (user message and assistant response)"
+
+
+def test_cannot_download_other_users_file_via_chat_file_endpoint(
+    user_file_setup: UserFileTestSetup,
+) -> None:
+    storage_file_id = user_file_setup.user1_file_descriptor["id"]
+    user_file_id = user_file_setup.user1_file_id
+
+    owner_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{storage_file_id}",
+        headers=user_file_setup.user1_file_owner.headers,
+    )
+    assert owner_response.status_code == 200
+    assert owner_response.content, "Owner should receive the file contents"
+
+    for file_id in (storage_file_id, user_file_id):
+        user2_response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=user_file_setup.user2_non_owner.headers,
+        )
+        assert user2_response.status_code in (
+            403,
+            404,
+        ), (
+            f"Expected access denied for non-owner, got {user2_response.status_code} "
+            f"when fetching file_id={file_id}"
+        )
+        assert user2_response.content != owner_response.content


### PR DESCRIPTION
Cherry-pick of commit a7a5b66d6d83d1c9f089acd2629880da1b3e4c51 to release/v3.1 branch.

Original PR: #10380

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened authorization on `/chat/file/{file_id}` to block downloads of other users’ files and prevent file-ID probing. Backport to `v3.1`.

- **Bug Fixes**
  - Require user ownership when resolving `user_file_id` → storage `file_id`.
  - Gate file access via `user_can_access_chat_file`: allow if the user owns the file, it’s a persona avatar from `CHAT_UPLOAD`, or it’s attached to a message in the user’s session or a public session.
  - Return 404 on unauthorized access to avoid existence probing.
  - Added integration test to ensure non-owners cannot download files by either storage ID or `user_file_id`.

<sup>Written for commit eebb066f7309c356095ec5bc27ef4b5a2693353f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

