### PR TITLE
fix(pdf): Allowing Image Extraction from PDF files

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -60,6 +60,7 @@ from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import MilestoneRecordType
+from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import SearchDoc
 from onyx.db.chat import create_new_chat_message
@@ -80,6 +81,10 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import log_onyx_error
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.extract_file_text import extract_file_text
+from onyx.file_processing.extract_file_text import extract_text_and_images
+from onyx.file_processing.image_summarization import (
+    summarize_image_with_error_handling,
+)
 from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile
 from onyx.file_store.utils import load_in_memory_chat_files
@@ -89,6 +94,7 @@ from onyx.hooks.executor import HookSkipped
 from onyx.hooks.executor import HookSoftFailed
 from onyx.hooks.points.query_processing import QueryProcessingPayload
 from onyx.hooks.points.query_processing import QueryProcessingResponse
+from onyx.llm.factory import get_default_llm_with_vision
 from onyx.llm.factory import get_llm_for_persona
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
@@ -127,6 +133,11 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 ERROR_TYPE_CANCELLED = "cancelled"
 APPROX_CHARS_PER_TOKEN = 4
+# Cap for inline vision-LLM summarization of image-only files at chat time.
+# Each summary is a serial vision-LLM call (~seconds), so we bound latency for
+# files with many embedded images. Upload-time extraction/indexing summarizes
+# every embedded image (up to MAX_EMBEDDED_IMAGES_PER_FILE).
+_CHAT_TIME_IMAGE_SUMMARIZATION_CAP = 20
 
 
 def _collect_available_file_ids(
@@ -251,15 +262,57 @@ def _extract_text_from_in_memory_file(f: InMemoryChatFile) -> str | None:
     ingestion — decode directly.
     DOC / CSV / other text types: the content is the original file bytes —
     use extract_file_text which handles encoding detection and format parsing.
+    When image extraction is enabled and the file has no extractable text
+    (e.g. a scanned PDF), embedded images are summarized inline via a vision
+    LLM so the content survives into the chat context. Files that already
+    have text are left untouched to avoid adding vision-LLM latency to the
+    common case.
     """
     try:
         if f.file_type == ChatFileType.PLAIN_TEXT:
             return f.content.decode("utf-8", errors="ignore").replace("\x00", "")
-        return extract_file_text(
+
+        filename = f.filename or ""
+        if not get_image_extraction_and_analysis_enabled():
+            return extract_file_text(
+                file=io.BytesIO(f.content),
+                file_name=filename,
+                break_on_unprocessable=False,
+            )
+
+        extraction = extract_text_and_images(
             file=io.BytesIO(f.content),
-            file_name=f.filename or "",
-            break_on_unprocessable=False,
+            file_name=filename,
         )
+
+        if extraction.text_content.strip():
+            return extraction.text_content
+
+        if not extraction.embedded_images:
+            return None
+
+        images = extraction.embedded_images[:_CHAT_TIME_IMAGE_SUMMARIZATION_CAP]
+        truncated = len(extraction.embedded_images) > len(images)
+
+        vision_llm = get_default_llm_with_vision()
+        parts: list[str] = []
+        for idx, (img_bytes, img_name) in enumerate(images, start=1):
+            summary = summarize_image_with_error_handling(
+                llm=vision_llm,
+                image_data=img_bytes,
+                context_name=img_name,
+            )
+            if summary:
+                parts.append(f"[Image {idx} — {img_name}]\n{summary}")
+
+        if truncated and parts:
+            parts.append(
+                f"[Note: only the first {len(images)} of "
+                f"{len(extraction.embedded_images)} embedded images were "
+                f"summarized at chat time.]"
+            )
+
+        return "\n\n".join(parts).strip() or None
     except Exception:
         logger.warning(f"Failed to extract text from file {f.file_id}", exc_info=True)
         return None

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -330,6 +330,16 @@ def _extract_text_from_in_memory_file(
         has_text = bool(text.strip())
         has_images = bool(extraction.embedded_images)
 
+        if not has_text and not has_images:
+            # extract_text_and_images has no is_text_file() fallback for
+            # unknown extensions (.py/.rs/.md without a dedicated handler).
+            # Defer to the legacy path so those files remain readable.
+            return extract_file_text(
+                file=io.BytesIO(f.content),
+                file_name=filename,
+                break_on_unprocessable=False,
+            )
+
         if not has_images:
             return text if has_text else None
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -87,9 +87,6 @@ from onyx.error_handling.exceptions import log_onyx_error
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import extract_text_and_images
-from onyx.file_processing.image_summarization import (
-    summarize_image_with_error_handling,
-)
 from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile
 from onyx.file_store.utils import load_in_memory_chat_files
@@ -99,7 +96,6 @@ from onyx.hooks.executor import HookSkipped
 from onyx.hooks.executor import HookSoftFailed
 from onyx.hooks.points.query_processing import QueryProcessingPayload
 from onyx.hooks.points.query_processing import QueryProcessingResponse
-from onyx.llm.factory import get_default_llm_with_vision
 from onyx.llm.factory import get_llm_for_persona
 from onyx.llm.factory import get_llm_token_counter
 from onyx.llm.interfaces import LLM
@@ -133,16 +129,12 @@ from onyx.tools.tool_constructor import SearchToolConfig
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
 from onyx.utils.timing import log_function_time
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 ERROR_TYPE_CANCELLED = "cancelled"
 APPROX_CHARS_PER_TOKEN = 4
-# Cap for inline vision-LLM summarization of image-only files at chat time.
-# Each summary is a serial vision-LLM call (~seconds), so we bound latency for
-# files with many embedded images. Upload-time extraction/indexing summarizes
-# every embedded image (up to MAX_EMBEDDED_IMAGES_PER_FILE).
-_CHAT_TIME_IMAGE_SUMMARIZATION_CAP = 20
 
 
 def _collect_available_file_ids(
@@ -277,7 +269,10 @@ def _fetch_cached_image_captions(
     try:
         chunks = document_index.id_based_retrieval(
             chunk_requests=[VespaChunkRequest(document_id=str(user_file.id))],
-            filters=IndexFilters(access_control_list=None),
+            filters=IndexFilters(
+                access_control_list=None,
+                tenant_id=get_current_tenant_id() if MULTI_TENANT else None,
+            ),
         )
     except Exception:
         logger.warning(
@@ -285,10 +280,16 @@ def _fetch_cached_image_captions(
             exc_info=True,
         )
         return []
+
+    # An image can be spread across multiple chunks; combine by image_file_id
+    # so a single caption appears once in the context.
+    combined: dict[str, list[str]] = {}
+    for chunk in chunks:
+        if chunk.image_file_id and chunk.content:
+            combined.setdefault(chunk.image_file_id, []).append(chunk.content)
     return [
-        f"[Image — {chunk.image_file_id}]\n{chunk.content}"
-        for chunk in chunks
-        if chunk.image_file_id and chunk.content
+        f"[Image — {image_file_id}]\n" + "\n".join(contents)
+        for image_file_id, contents in combined.items()
     ]
 
 
@@ -305,10 +306,10 @@ def _extract_text_from_in_memory_file(
     use extract_file_text which handles encoding detection and format parsing.
     When image extraction is enabled and the file has embedded images, cached
     captions are pulled from the document index and appended to the text.
-    The index fetch is skipped for files with no embedded images. If nothing
-    is cached yet (e.g. indexing is still in flight) and there is no text, a
-    bounded number of images are summarized inline via a vision LLM so the
-    chat turn still has something meaningful.
+    The index fetch is skipped for files with no embedded images. We do not
+    re-summarize images inline here — this path is hot and the indexing
+    pipeline writes chunks atomically, so a missed caption means the file
+    is mid-indexing and will be picked up on the next turn.
     """
     try:
         if f.file_type == ChatFileType.PLAIN_TEXT:
@@ -350,33 +351,7 @@ def _extract_text_from_in_memory_file(
             parts.append(text)
         parts.extend(cached_captions)
 
-        if parts:
-            return "\n\n".join(parts).strip() or None
-
-        # Nothing cached and no text — file is likely mid-indexing. Fall
-        # back to inline vision summarization for a bounded number of
-        # images so the chat turn still has something meaningful.
-        images = extraction.embedded_images[:_CHAT_TIME_IMAGE_SUMMARIZATION_CAP]
-        truncated = len(extraction.embedded_images) > len(images)
-        vision_llm = get_default_llm_with_vision()
-        inline_parts: list[str] = []
-        for idx, (img_bytes, img_name) in enumerate(images, start=1):
-            summary = summarize_image_with_error_handling(
-                llm=vision_llm,
-                image_data=img_bytes,
-                context_name=img_name,
-            )
-            if summary:
-                inline_parts.append(f"[Image {idx} — {img_name}]\n{summary}")
-
-        if truncated and inline_parts:
-            inline_parts.append(
-                f"[Note: only the first {len(images)} of "
-                f"{len(extraction.embedded_images)} embedded images were "
-                f"summarized at chat time.]"
-            )
-
-        return "\n\n".join(inline_parts).strip() or None
+        return "\n\n".join(parts).strip() or None
     except Exception:
         logger.warning(f"Failed to extract text from file {f.file_id}", exc_info=True)
         return None

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -62,6 +62,7 @@ from onyx.configs.constants import MessageType
 from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import SearchDoc
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_chat_session_by_id
@@ -75,8 +76,12 @@ from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.projects import get_user_files_from_project
+from onyx.db.search_settings import get_active_search_settings
 from onyx.db.tools import get_tools
 from onyx.deep_research.dr_loop import run_deep_research_llm_loop
+from onyx.document_index.factory import get_default_document_index
+from onyx.document_index.interfaces import DocumentIndex
+from onyx.document_index.interfaces import VespaChunkRequest
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import log_onyx_error
 from onyx.error_handling.exceptions import OnyxError
@@ -255,18 +260,55 @@ def _empty_extracted_context_files() -> ExtractedContextFiles:
     )
 
 
-def _extract_text_from_in_memory_file(f: InMemoryChatFile) -> str | None:
+def _fetch_cached_image_captions(
+    user_file: UserFile | None,
+    document_index: DocumentIndex | None,
+) -> list[str]:
+    """Read image-caption chunks for a user file from the document index.
+
+    During indexing, embedded images are summarized via a vision LLM and
+    those summaries are stored as chunks whose `image_file_id` is set. Reading
+    them back at chat time avoids re-running vision-LLM calls per turn.
+    Returns an empty list if the index has no chunks yet (e.g. indexing is
+    still in flight) or on any fetch failure.
+    """
+    if user_file is None or document_index is None:
+        return []
+    try:
+        chunks = document_index.id_based_retrieval(
+            chunk_requests=[VespaChunkRequest(document_id=str(user_file.id))],
+            filters=IndexFilters(access_control_list=None),
+        )
+    except Exception:
+        logger.warning(
+            f"Failed to fetch cached captions for user_file {user_file.id}",
+            exc_info=True,
+        )
+        return []
+    return [
+        f"[Image — {chunk.image_file_id}]\n{chunk.content}"
+        for chunk in chunks
+        if chunk.image_file_id and chunk.content
+    ]
+
+
+def _extract_text_from_in_memory_file(
+    f: InMemoryChatFile,
+    user_file: UserFile | None = None,
+    document_index: DocumentIndex | None = None,
+) -> str | None:
     """Extract text content from an InMemoryChatFile.
 
     PLAIN_TEXT: the content is pre-extracted UTF-8 plaintext stored during
     ingestion — decode directly.
     DOC / CSV / other text types: the content is the original file bytes —
     use extract_file_text which handles encoding detection and format parsing.
-    When image extraction is enabled and the file has no extractable text
-    (e.g. a scanned PDF), embedded images are summarized inline via a vision
-    LLM so the content survives into the chat context. Files that already
-    have text are left untouched to avoid adding vision-LLM latency to the
-    common case.
+    When image extraction is enabled and the file has embedded images, cached
+    captions are pulled from the document index and appended to the text.
+    The index fetch is skipped for files with no embedded images. If nothing
+    is cached yet (e.g. indexing is still in flight) and there is no text, a
+    bounded number of images are summarized inline via a vision LLM so the
+    chat turn still has something meaningful.
     """
     try:
         if f.file_type == ChatFileType.PLAIN_TEXT:
@@ -284,18 +326,30 @@ def _extract_text_from_in_memory_file(f: InMemoryChatFile) -> str | None:
             file=io.BytesIO(f.content),
             file_name=filename,
         )
+        text = extraction.text_content
+        has_text = bool(text.strip())
+        has_images = bool(extraction.embedded_images)
 
-        if extraction.text_content.strip():
-            return extraction.text_content
+        if not has_images:
+            return text if has_text else None
 
-        if not extraction.embedded_images:
-            return None
+        cached_captions = _fetch_cached_image_captions(user_file, document_index)
 
+        parts: list[str] = []
+        if has_text:
+            parts.append(text)
+        parts.extend(cached_captions)
+
+        if parts:
+            return "\n\n".join(parts).strip() or None
+
+        # Nothing cached and no text — file is likely mid-indexing. Fall
+        # back to inline vision summarization for a bounded number of
+        # images so the chat turn still has something meaningful.
         images = extraction.embedded_images[:_CHAT_TIME_IMAGE_SUMMARIZATION_CAP]
         truncated = len(extraction.embedded_images) > len(images)
-
         vision_llm = get_default_llm_with_vision()
-        parts: list[str] = []
+        inline_parts: list[str] = []
         for idx, (img_bytes, img_name) in enumerate(images, start=1):
             summary = summarize_image_with_error_handling(
                 llm=vision_llm,
@@ -303,16 +357,16 @@ def _extract_text_from_in_memory_file(f: InMemoryChatFile) -> str | None:
                 context_name=img_name,
             )
             if summary:
-                parts.append(f"[Image {idx} — {img_name}]\n{summary}")
+                inline_parts.append(f"[Image {idx} — {img_name}]\n{summary}")
 
-        if truncated and parts:
-            parts.append(
+        if truncated and inline_parts:
+            inline_parts.append(
                 f"[Note: only the first {len(images)} of "
                 f"{len(extraction.embedded_images)} embedded images were "
                 f"summarized at chat time.]"
             )
 
-        return "\n\n".join(parts).strip() or None
+        return "\n\n".join(inline_parts).strip() or None
     except Exception:
         logger.warning(f"Failed to extract text from file {f.file_id}", exc_info=True)
         return None
@@ -394,6 +448,23 @@ def extract_context_files(
         db_session=db_session,
     )
 
+    # The document index is used at chat time to read cached image captions
+    # (produced during indexing) so vision-LLM calls don't re-run per turn.
+    document_index: DocumentIndex | None = None
+    if not DISABLE_VECTOR_DB and get_image_extraction_and_analysis_enabled():
+        try:
+            active_search_settings = get_active_search_settings(db_session)
+            document_index = get_default_document_index(
+                search_settings=active_search_settings.primary,
+                secondary_search_settings=None,
+                db_session=db_session,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to construct document index for caption lookup",
+                exc_info=True,
+            )
+
     file_texts: list[str] = []
     image_files: list[ChatLoadedFile] = []
     file_metadata: list[ContextFileMetadata] = []
@@ -414,7 +485,9 @@ def extract_context_files(
                 continue
             tool_metadata.append(_build_tool_metadata(uf))
         elif f.file_type.is_text_file():
-            text_content = _extract_text_from_in_memory_file(f)
+            text_content = _extract_text_from_in_memory_file(
+                f, user_file=uf, document_index=document_index
+            )
             if not text_content:
                 continue
             if not uf:

--- a/backend/onyx/configs/llm_configs.py
+++ b/backend/onyx/configs/llm_configs.py
@@ -3,7 +3,14 @@ from onyx.server.settings.store import load_settings
 
 
 def get_image_extraction_and_analysis_enabled() -> bool:
-    """Get image extraction and analysis enabled setting from workspace settings or fallback to True"""
+    """Return the workspace setting for image extraction/analysis.
+
+    The pydantic `Settings` model defaults this field to True, so production
+    tenants get the feature on by default on first read. The fallback here
+    stays False so environments where settings cannot be loaded at all
+    (e.g. unit tests with no DB/Redis) don't trigger downstream vision-LLM
+    code paths that assume the DB is reachable.
+    """
     try:
         settings = load_settings()
         if settings.image_extraction_and_analysis_enabled is not None:
@@ -11,7 +18,7 @@ def get_image_extraction_and_analysis_enabled() -> bool:
     except Exception:
         pass
 
-    return True
+    return False
 
 
 def get_search_time_image_analysis_enabled() -> bool:

--- a/backend/onyx/configs/llm_configs.py
+++ b/backend/onyx/configs/llm_configs.py
@@ -3,7 +3,7 @@ from onyx.server.settings.store import load_settings
 
 
 def get_image_extraction_and_analysis_enabled() -> bool:
-    """Get image extraction and analysis enabled setting from workspace settings or fallback to False"""
+    """Get image extraction and analysis enabled setting from workspace settings or fallback to True"""
     try:
         settings = load_settings()
         if settings.image_extraction_and_analysis_enabled is not None:
@@ -11,7 +11,7 @@ def get_image_extraction_and_analysis_enabled() -> bool:
     except Exception:
         pass
 
-    return False
+    return True
 
 
 def get_search_time_image_analysis_enabled() -> bool:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -367,6 +367,40 @@ def extract_docx_images(docx_bytes: IO[Any]) -> Iterator[tuple[bytes, str]]:
         logger.exception("Failed to extract all docx images")
 
 
+def count_docx_embedded_images(file: IO[Any], cap: int) -> int:
+    """Return the number of embedded images in a docx, short-circuiting at cap+1.
+
+    Mirrors count_pdf_embedded_images so upload validation can apply the same
+    per-file/per-batch caps. Returns a value > cap once the count exceeds the
+    cap so callers do not iterate every media entry just to report a number.
+    Always restores the file pointer to its original position before returning.
+    """
+    try:
+        start_pos = file.tell()
+    except Exception:
+        start_pos = None
+    try:
+        if start_pos is not None:
+            file.seek(0)
+        count = 0
+        with zipfile.ZipFile(file) as z:
+            for name in z.namelist():
+                if name.startswith("word/media/"):
+                    count += 1
+                    if count > cap:
+                        return count
+        return count
+    except Exception:
+        logger.warning("Failed to count embedded images in docx", exc_info=True)
+        return 0
+    finally:
+        if start_pos is not None:
+            try:
+                file.seek(start_pos)
+            except Exception:
+                pass
+
+
 def read_docx_file(
     file: IO[Any],
     file_name: str = "",

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -30,6 +30,7 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import IndexAttemptMetadata
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
+from onyx.connectors.models import SectionType
 from onyx.connectors.models import TextSection
 from onyx.db.document import get_documents_by_ids
 from onyx.db.document import upsert_document_by_connector_credential_pair
@@ -530,9 +531,11 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
     Returns:
         List of IndexingDocument objects with processed_sections as list[Section]
     """
-    # Check if image extraction and analysis is enabled before trying to get a vision LLM
+    # Check if image extraction and analysis is enabled before trying to get a vision LLM.
+    # Use section.type rather than isinstance because sections can round-trip
+    # through pydantic as base Section instances (not the concrete subclass).
     has_image_section = any(
-        isinstance(section, ImageSection)
+        section.type == SectionType.IMAGE
         for document in documents
         for section in document.sections
     )

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -531,7 +531,12 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         List of IndexingDocument objects with processed_sections as list[Section]
     """
     # Check if image extraction and analysis is enabled before trying to get a vision LLM
-    if not get_image_extraction_and_analysis_enabled():
+    has_image_section = any(
+        isinstance(section, ImageSection)
+        for document in documents
+        for section in document.sections
+    )
+    if not get_image_extraction_and_analysis_enabled() or not has_image_section:
         llm = None
     else:
         # Only get the vision LLM if image processing is enabled

--- a/backend/onyx/server/features/projects/projects_file_utils.py
+++ b/backend/onyx/server/features/projects/projects_file_utils.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_UPLOAD
+from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.db.llm import fetch_default_llm_model
 from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.file_processing.extract_file_text import extract_file_text
@@ -265,6 +266,7 @@ def categorize_uploaded_files(
                 # A PDF with thousands of embedded images can OOM the
                 # user-file-processing celery worker because every image is
                 # decoded with PIL and then sent to the vision LLM.
+                count = 0
                 if extension == ".pdf":
                     file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
                     batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
@@ -308,6 +310,24 @@ def categorize_uploaded_files(
                     extension=extension,
                 )
                 if not text_content:
+                    # PDFs with embedded images (e.g. scans) have no extractable
+                    # text but can still be indexed via the vision-LLM
+                    # captioning path when image analysis is enabled.
+                    if (
+                        extension == ".pdf"
+                        and count > 0
+                        and get_image_extraction_and_analysis_enabled()
+                    ):
+                        results.acceptable.append(upload)
+                        results.acceptable_file_to_token_count[filename] = 0
+                        try:
+                            upload.file.seek(0)
+                        except Exception as e:
+                            logger.warning(
+                                f"Failed to reset file pointer for '{filename}': {str(e)}"
+                            )
+                        continue
+
                     logger.warning(f"No text content extracted from '{filename}'")
                     results.rejected.append(
                         RejectedFile(

--- a/backend/onyx/server/features/projects/projects_file_utils.py
+++ b/backend/onyx/server/features/projects/projects_file_utils.py
@@ -199,6 +199,9 @@ def categorize_uploaded_files(
     # rejected even if they'd individually fit under MAX_EMBEDDED_IMAGES_PER_FILE.
     batch_image_total = 0
 
+    # Hoisted out of the loop to avoid a KV-store lookup per file.
+    image_extraction_enabled = get_image_extraction_and_analysis_enabled()
+
     for upload in files:
         try:
             filename = get_safe_filename(upload)
@@ -266,7 +269,7 @@ def categorize_uploaded_files(
                 # A PDF with thousands of embedded images can OOM the
                 # user-file-processing celery worker because every image is
                 # decoded with PIL and then sent to the vision LLM.
-                count = 0
+                count: int = 0
                 if extension == ".pdf":
                     file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
                     batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
@@ -313,11 +316,7 @@ def categorize_uploaded_files(
                     # PDFs with embedded images (e.g. scans) have no extractable
                     # text but can still be indexed via the vision-LLM
                     # captioning path when image analysis is enabled.
-                    if (
-                        extension == ".pdf"
-                        and count > 0
-                        and get_image_extraction_and_analysis_enabled()
-                    ):
+                    if extension == ".pdf" and count > 0 and image_extraction_enabled:
                         results.acceptable.append(upload)
                         results.acceptable_file_to_token_count[filename] = 0
                         try:

--- a/backend/onyx/server/features/projects/projects_file_utils.py
+++ b/backend/onyx/server/features/projects/projects_file_utils.py
@@ -13,6 +13,7 @@ from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_UPLOAD
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.db.llm import fetch_default_llm_model
+from onyx.file_processing.extract_file_text import count_docx_embedded_images
 from onyx.file_processing.extract_file_text import count_pdf_embedded_images
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
@@ -264,29 +265,33 @@ def categorize_uploaded_files(
                     )
                     continue
 
-                # Reject PDFs with an unreasonable number of embedded images
-                # (either per-file or accumulated across this upload batch).
-                # A PDF with thousands of embedded images can OOM the
+                # Reject documents with an unreasonable number of embedded
+                # images (either per-file or accumulated across this upload
+                # batch). A file with thousands of embedded images can OOM the
                 # user-file-processing celery worker because every image is
                 # decoded with PIL and then sent to the vision LLM.
                 count: int = 0
-                if extension == ".pdf":
+                image_bearing_ext = extension in (".pdf", ".docx")
+                if image_bearing_ext:
                     file_cap = MAX_EMBEDDED_IMAGES_PER_FILE
                     batch_cap = MAX_EMBEDDED_IMAGES_PER_UPLOAD
                     # Use the larger of the two caps as the short-circuit
                     # threshold so we get a useful count for both checks.
-                    # count_pdf_embedded_images restores the stream position.
-                    count = count_pdf_embedded_images(
-                        upload.file, max(file_cap, batch_cap)
+                    # These helpers restore the stream position.
+                    counter = (
+                        count_pdf_embedded_images
+                        if extension == ".pdf"
+                        else count_docx_embedded_images
                     )
+                    count = counter(upload.file, max(file_cap, batch_cap))
                     if count > file_cap:
                         results.rejected.append(
                             RejectedFile(
                                 filename=filename,
                                 reason=(
-                                    f"PDF contains too many embedded images "
-                                    f"(more than {file_cap}). Try splitting "
-                                    f"the document into smaller files."
+                                    f"Document contains too many embedded "
+                                    f"images (more than {file_cap}). Try "
+                                    f"splitting it into smaller files."
                                 ),
                             )
                         )
@@ -313,10 +318,11 @@ def categorize_uploaded_files(
                     extension=extension,
                 )
                 if not text_content:
-                    # PDFs with embedded images (e.g. scans) have no extractable
-                    # text but can still be indexed via the vision-LLM
-                    # captioning path when image analysis is enabled.
-                    if extension == ".pdf" and count > 0 and image_extraction_enabled:
+                    # Documents with embedded images (e.g. scans) have no
+                    # extractable text but can still be indexed via the
+                    # vision-LLM captioning path when image analysis is
+                    # enabled.
+                    if image_bearing_ext and count > 0 and image_extraction_enabled:
                         results.acceptable.append(upload)
                         results.acceptable_file_to_token_count[filename] = 0
                         try:

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -80,7 +80,7 @@ class Settings(BaseModel):
     query_history_type: QueryHistoryType | None = None
 
     # Image processing settings
-    image_extraction_and_analysis_enabled: bool | None = False
+    image_extraction_and_analysis_enabled: bool | None = True
     search_time_image_analysis_enabled: bool | None = False
     image_analysis_max_size_mb: int | None = 20
 

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -247,7 +247,7 @@ class DATestSettings(BaseModel):
     gpu_enabled: bool | None = None
     product_gating: DATestGatingType = DATestGatingType.NONE
     anonymous_user_enabled: bool | None = None
-    image_extraction_and_analysis_enabled: bool | None = False
+    image_extraction_and_analysis_enabled: bool | None = True
     search_time_image_analysis_enabled: bool | None = False
 
 

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -997,6 +997,23 @@ export default function ChatPreferencesPage() {
                 </Card>
 
                 <Card border="solid" rounding="lg">
+                  <InputHorizontal
+                    title="Image Extraction & Analysis"
+                    description="Extract embedded images from uploaded files (PDFs, DOCX, etc.) and summarize them with a vision-capable LLM so image-only documents become searchable and answerable. Requires a vision-capable default LLM."
+                    withLabel
+                  >
+                    <Switch
+                      checked={s.image_extraction_and_analysis_enabled ?? true}
+                      onCheckedChange={(checked) => {
+                        void saveSettings({
+                          image_extraction_and_analysis_enabled: checked,
+                        });
+                      }}
+                    />
+                  </InputHorizontal>
+                </Card>
+
+                <Card border="solid" rounding="lg">
                   <Section>
                     <InputHorizontal
                       title="Allow Anonymous Users"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Historically if we had a PDF with images that was a user file upload, it would not parse the image and it would not extract any information from the file. This now has changed and we will try to get semantic meaning from the images if there is a vision model that is available. 

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally. Validated that the toggle exists, is set by default and the fake text was extracted from the file. 

<img width="870" height="583" alt="Screenshot 2026-04-20 at 2 12 22 PM" src="https://github.com/user-attachments/assets/ecc6700e-efef-4fad-ab10-970c9c0aeec0" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables image extraction and vision-LLM captioning for PDFs and DOCX so image-only uploads become searchable and can answer questions. Defaults on with an admin toggle; chat reads cached captions from the index and avoids re-running vision models.

- **New Features**
  - Indexes embedded images and stores captions; chat pulls cached captions from the document index and merges them with any file text.
  - Accepts scanned/image-only PDFs and DOCX for indexing when enabled, even if text extraction is empty.
  - Enforces embedded-image caps for DOCX like PDF and improves rejection messages.
  - Loads the document index/vision LLM only when needed; adds “Image Extraction & Analysis” toggle in Chat Preferences (default on).

<sup>Written for commit 495669b3d250f662e0098f8d07f0ab22145cdca5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

