### PR TITLE
chore(devtools): set env which allows `api_server` to run

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,10 @@
   "containerEnv": {
     "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
     "POSTGRES_HOST": "relational_db",
+    "VESPA_HOST": "index",
+    "OPENSEARCH_HOST": "opensearch",
+    "MODEL_SERVER_HOST": "inference_model_server",
+    "S3_ENDPOINT_URL": "http://minio:9000",
     "REDIS_HOST": "cache"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,13 +16,13 @@
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
   ],
   "containerEnv": {
-    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
-    "POSTGRES_HOST": "relational_db",
-    "VESPA_HOST": "index",
-    "OPENSEARCH_HOST": "opensearch",
     "MODEL_SERVER_HOST": "inference_model_server",
+    "OPENSEARCH_HOST": "opensearch",
+    "POSTGRES_HOST": "relational_db",
+    "REDIS_HOST": "cache",
     "S3_ENDPOINT_URL": "http://minio:9000",
-    "REDIS_HOST": "cache"
+    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
+    "VESPA_HOST": "index"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",
   "updateRemoteUserUID": false,

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -40,6 +40,7 @@ ALLOWED_DOMAINS=(
     "api.anthropic.com"
     "api-staging.anthropic.com"
     "files.anthropic.com"
+    "huggingface.co"
     "sentry.io"
     "update.code.visualstudio.com"
     "pypi.org"


### PR DESCRIPTION
## Description

This allows the api server to be started from within the devcontainer similar to how it's started via the docker-compose service definition.

## How Has This Been Tested?

```
ods dev rebuild
ods dev exec ods backend api
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable running `api_server` inside the devcontainer by setting required service env vars and S3 endpoint. Also allows outbound requests to `huggingface.co` for model downloads.

- **Migration**
  - Rebuild the devcontainer: `ods dev rebuild`
  - Start the API: `ods dev exec ods backend api`

<sup>Written for commit 7580a8bf0943babeac838e37646aa0f70a0fc79e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

