### PR TITLE
fix(pruning): SharePoint Connector - fix pruning crash on site page 401 + permission validation

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -75,6 +75,8 @@ from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException
+from onyx.utils.url import validate_outbound_http_url
 
 logger = setup_logger()
 SLIM_BATCH_SIZE = 1000
@@ -981,6 +983,42 @@ class SharepointConnector(
                 raise ConnectorValidationError(
                     "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
                 )
+            try:
+                validate_outbound_http_url(site_url, https_only=True)
+            except (SSRFException, ValueError) as e:
+                raise ConnectorValidationError(
+                    f"Invalid site URL '{site_url}': {e}"
+                ) from e
+
+        # Probe RoleAssignments permission — required for permission sync.
+        # Only runs when credentials have been loaded.
+        if self.msal_app and self.sp_tenant_domain and self.sites:
+            try:
+                token_response = acquire_token_for_rest(
+                    self.msal_app,
+                    self.sp_tenant_domain,
+                    self.sharepoint_domain_suffix,
+                )
+                probe_url = (
+                    f"{self.sites[0].rstrip('/')}/_api/web/roleassignments?$top=1"
+                )
+                resp = requests.get(
+                    probe_url,
+                    headers={"Authorization": f"Bearer {token_response.accessToken}"},
+                    timeout=10,
+                )
+                if resp.status_code in (401, 403):
+                    raise ConnectorValidationError(
+                        "The Azure AD app registration is missing the required SharePoint permission "
+                        "to read role assignments. Please grant 'Sites.FullControl.All' "
+                        "(application permission) in the Azure portal and re-run admin consent."
+                    )
+            except ConnectorValidationError:
+                raise
+            except Exception as e:
+                logger.warning(
+                    f"RoleAssignments permission probe failed (non-blocking): {e}"
+                )
 
     def _extract_tenant_domain_from_sites(self) -> str | None:
         """Extract the tenant domain from configured site URLs.
@@ -1876,16 +1914,22 @@ class SharepointConnector(
                     logger.debug(
                         f"Processing site page: {site_page.get('webUrl', site_page.get('name', 'Unknown'))}"
                     )
-                    ctx = self._create_rest_client_context(site_descriptor.url)
-                    doc_batch.append(
-                        _convert_sitepage_to_slim_document(
-                            site_page,
-                            ctx,
-                            self.graph_client,
-                            parent_hierarchy_raw_node_id=site_descriptor.url,
-                            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                    try:
+                        ctx = self._create_rest_client_context(site_descriptor.url)
+                        doc_batch.append(
+                            _convert_sitepage_to_slim_document(
+                                site_page,
+                                ctx,
+                                self.graph_client,
+                                parent_hierarchy_raw_node_id=site_descriptor.url,
+                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                            )
                         )
-                    )
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to process site page "
+                            f"{site_page.get('webUrl', site_page.get('name', 'Unknown'))}: {e}"
+                        )
                     if len(doc_batch) >= SLIM_BATCH_SIZE:
                         yield doc_batch
                         doc_batch = []

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -1,0 +1,194 @@
+"""Unit tests for SharepointConnector site-page slim resilience and
+validate_connector_settings RoleAssignments permission probe."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.sharepoint.connector import SharepointConnector
+
+SITE_URL = "https://tenant.sharepoint.com/sites/MySite"
+
+
+def _make_connector() -> SharepointConnector:
+    connector = SharepointConnector(sites=[SITE_URL])
+    connector.msal_app = MagicMock()
+    connector.sp_tenant_domain = "tenant"
+    connector._credential_json = {"sp_client_id": "x", "sp_directory_id": "y"}
+    connector._graph_client = MagicMock()
+    return connector
+
+
+# ---------------------------------------------------------------------------
+# _fetch_slim_documents_from_sharepoint — site page error resilience
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.connectors.sharepoint.connector._convert_sitepage_to_slim_document")
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._create_rest_client_context"
+)
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_site_pages")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_driveitems")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector.fetch_sites")
+def test_site_page_error_does_not_crash(
+    mock_fetch_sites: MagicMock,
+    mock_fetch_driveitems: MagicMock,
+    mock_fetch_site_pages: MagicMock,
+    _mock_create_ctx: MagicMock,
+    mock_convert: MagicMock,
+) -> None:
+    """A 401 (or any exception) on a site page is caught; remaining pages are processed."""
+    from onyx.connectors.models import SlimDocument
+
+    connector = _make_connector()
+    connector.include_site_documents = False
+    connector.include_site_pages = True
+
+    site = MagicMock()
+    site.url = SITE_URL
+    mock_fetch_sites.return_value = [site]
+    mock_fetch_driveitems.return_value = iter([])
+
+    page_ok = {"id": "1", "webUrl": SITE_URL + "/SitePages/Good.aspx"}
+    page_bad = {"id": "2", "webUrl": SITE_URL + "/SitePages/Bad.aspx"}
+    mock_fetch_site_pages.return_value = [page_bad, page_ok]
+
+    good_slim = SlimDocument(id="1")
+
+    def _convert_side_effect(
+        page: dict, *_args: object, **_kwargs: object
+    ) -> SlimDocument:  # noqa: ANN001
+        if page["id"] == "2":
+            from office365.runtime.client_request import ClientRequestException
+
+            raise ClientRequestException(MagicMock(status_code=401), None)
+        return good_slim
+
+    mock_convert.side_effect = _convert_side_effect
+
+    results = [
+        doc
+        for batch in connector._fetch_slim_documents_from_sharepoint()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    ]
+
+    # Only the good page makes it through; bad page is skipped, no exception raised.
+    assert any(d.id == "1" for d in results)
+    assert not any(d.id == "2" for d in results)
+
+
+@patch("onyx.connectors.sharepoint.connector._convert_sitepage_to_slim_document")
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._create_rest_client_context"
+)
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_site_pages")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_driveitems")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector.fetch_sites")
+def test_all_site_pages_fail_does_not_crash(
+    mock_fetch_sites: MagicMock,
+    mock_fetch_driveitems: MagicMock,
+    mock_fetch_site_pages: MagicMock,
+    _mock_create_ctx: MagicMock,
+    mock_convert: MagicMock,
+) -> None:
+    """When every site page fails, the generator completes without raising."""
+    connector = _make_connector()
+    connector.include_site_documents = False
+    connector.include_site_pages = True
+
+    site = MagicMock()
+    site.url = SITE_URL
+    mock_fetch_sites.return_value = [site]
+    mock_fetch_driveitems.return_value = iter([])
+    mock_fetch_site_pages.return_value = [
+        {"id": "1", "webUrl": SITE_URL + "/SitePages/A.aspx"},
+        {"id": "2", "webUrl": SITE_URL + "/SitePages/B.aspx"},
+    ]
+    mock_convert.side_effect = RuntimeError("context error")
+
+    from onyx.connectors.models import SlimDocument
+
+    # Should not raise; no SlimDocuments in output (only hierarchy nodes).
+    slim_results = [
+        doc
+        for batch in connector._fetch_slim_documents_from_sharepoint()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    ]
+    assert slim_results == []
+
+
+# ---------------------------------------------------------------------------
+# validate_connector_settings — RoleAssignments permission probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_validate_raises_on_401_or_403(
+    mock_acquire: MagicMock,
+    _mock_validate_url: MagicMock,
+    mock_get: MagicMock,
+    status_code: int,
+) -> None:
+    """validate_connector_settings raises ConnectorValidationError when probe returns 401 or 403."""
+    mock_acquire.return_value = MagicMock(accessToken="tok")
+    mock_get.return_value = MagicMock(status_code=status_code)
+
+    connector = _make_connector()
+
+    with pytest.raises(ConnectorValidationError, match="Sites.FullControl.All"):
+        connector.validate_connector_settings()
+
+
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_validate_passes_on_200(
+    mock_acquire: MagicMock,
+    _mock_validate_url: MagicMock,
+    mock_get: MagicMock,
+) -> None:
+    """validate_connector_settings does not raise when probe returns 200."""
+    mock_acquire.return_value = MagicMock(accessToken="tok")
+    mock_get.return_value = MagicMock(status_code=200)
+
+    connector = _make_connector()
+    connector.validate_connector_settings()  # should not raise
+
+
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_validate_passes_on_network_error(
+    mock_acquire: MagicMock,
+    _mock_validate_url: MagicMock,
+    mock_get: MagicMock,
+) -> None:
+    """Network errors during the probe are non-blocking (logged as warning only)."""
+    mock_acquire.return_value = MagicMock(accessToken="tok")
+    mock_get.side_effect = Exception("timeout")
+
+    connector = _make_connector()
+    connector.validate_connector_settings()  # should not raise
+
+
+@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_validate_skips_probe_without_credentials(
+    mock_acquire: MagicMock,
+    _mock_validate_url: MagicMock,
+) -> None:
+    """Probe is skipped when credentials have not been loaded."""
+    connector = SharepointConnector(sites=[SITE_URL])
+    # msal_app and sp_tenant_domain are None — probe must be skipped.
+    connector.validate_connector_settings()  # should not raise
+    mock_acquire.assert_not_called()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Problem: SharePoint pruning tasks were crashing when the Azure AD app lacked Sites.FullControl.All — RoleAssignments calls on site pages returned 401, which propagated unhandled and killed the entire task. Drive items already had a guard; site pages did not.

Changes:

- Wrap site page conversion in try/except to match existing drive item behavior — 401s log a warning and pruning continues
- Add a RoleAssignments probe in validate_connector_settings — surfaces a clear error at connector setup time if the permission is missing


https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness


TODO:
Customer outreach
## How Has This Been Tested?
Added 6 unit tests
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SharePoint pruning from crashing on site pages that return 401/403 by logging and skipping them, and adds strict URL and permission validation to fail fast during setup (ENG-3954). The permission probe runs only when credentials are loaded and flags missing `Sites.FullControl.All`.

- **Bug Fixes**
  - Wrap site page processing in try/except; log and skip failures so pruning continues, matching the existing drive item guard.

- **New Features**
  - In validate_connector_settings, enforce full HTTPS SharePoint URLs using `validate_outbound_http_url` and block invalid/SSRF-prone URLs.
  - Probe site RoleAssignments and raise a clear error if `Sites.FullControl.All` is missing; network errors are non-blocking and the probe is skipped without credentials.

<sup>Written for commit f8e37f5460604f57e36a6aa4657fec4ae52a870f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



