### PR TITLE
fix(llm): Model reasoning returning None

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -743,7 +743,12 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
             model_name,
         )
         if model_obj and "supports_reasoning" in model_obj:
-            return model_obj.get("supports_reasoning", False)
+            reasoning = model_obj.get("supports_reasoning")
+            if reasoning is None:
+                logger.error(
+                    f"Cannot find reasoning for name={model_name} and provider={model_provider}"
+                )
+            return reasoning or False
 
         # Fallback: try using litellm.supports_reasoning() for newer models
         try:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -743,7 +743,7 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
             model_name,
         )
         if model_obj and "supports_reasoning" in model_obj:
-            return model_obj["supports_reasoning"]
+            return model_obj.get("supports_reasoning", False)
 
         # Fallback: try using litellm.supports_reasoning() for newer models
         try:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -748,7 +748,8 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
                 logger.error(
                     f"Cannot find reasoning for name={model_name} and provider={model_provider}"
                 )
-            return reasoning or False
+                reasoning = False
+            return reasoning
 
         # Fallback: try using litellm.supports_reasoning() for newer models
         try:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -743,7 +743,7 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
             model_name,
         )
         if model_obj and "supports_reasoning" in model_obj:
-            reasoning = model_obj.get("supports_reasoning")
+            reasoning = model_obj["supports_reasoning"]
             if reasoning is None:
                 logger.error(
                     f"Cannot find reasoning for name={model_name} and provider={model_provider}"


### PR DESCRIPTION
## Description
There is possibly an error where supports_reasoning does not exist and is returning None. This explicitly handles that case where supports_reasoning is None.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `model_is_reasoning_model` to treat `supports_reasoning: None` as `False` and log the model and provider. Fallback to `litellm.supports_reasoning()` stays the same.

- **Bug Fixes**
  - Log an error and return `False` when `supports_reasoning` is `None`.

<sup>Written for commit 551a3ed42aaeab1cefa3727653271baae275d74c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

