### PR TITLE
feat(auth): harden /auth/register against captcha-score bots

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -1,5 +1,7 @@
 """Captcha verification for user registration."""
 
+import hashlib
+
 import httpx
 from pydantic import BaseModel
 from pydantic import Field
@@ -7,11 +9,17 @@ from pydantic import Field
 from onyx.configs.app_configs import CAPTCHA_ENABLED
 from onyx.configs.app_configs import RECAPTCHA_SCORE_THRESHOLD
 from onyx.configs.app_configs import RECAPTCHA_SECRET_KEY
+from onyx.redis.redis_pool import get_async_redis_connection
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
+
+# Google v3 tokens expire server-side at ~2 minutes, so 120s is the max useful
+# replay window — after that Google would reject the token anyway.
+_REPLAY_CACHE_TTL_SECONDS = 120
+_REPLAY_KEY_PREFIX = "captcha:replay:"
 
 
 class CaptchaVerificationError(Exception):
@@ -34,6 +42,36 @@ def is_captcha_enabled() -> bool:
     return CAPTCHA_ENABLED and bool(RECAPTCHA_SECRET_KEY)
 
 
+def _replay_cache_key(token: str) -> str:
+    """Avoid storing the raw token in Redis — hash it first."""
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return f"{_REPLAY_KEY_PREFIX}{digest}"
+
+
+async def _reserve_token_or_raise(token: str) -> None:
+    """SETNX a token fingerprint. If another caller already claimed it within
+    the TTL, reject as a replay. Fails open on Redis errors — losing replay
+    protection is strictly better than hard-failing legitimate registrations
+    if Redis blips."""
+    try:
+        redis = await get_async_redis_connection()
+        claimed = await redis.set(
+            _replay_cache_key(token),
+            "1",
+            nx=True,
+            ex=_REPLAY_CACHE_TTL_SECONDS,
+        )
+        if not claimed:
+            logger.warning("Captcha replay detected: token already used")
+            raise CaptchaVerificationError(
+                "Captcha verification failed: token already used"
+            )
+    except CaptchaVerificationError:
+        raise
+    except Exception as e:
+        logger.error(f"Captcha replay cache error (failing open): {e}")
+
+
 async def verify_captcha_token(
     token: str,
     expected_action: str = "signup",
@@ -53,6 +91,11 @@ async def verify_captcha_token(
 
     if not token:
         raise CaptchaVerificationError("Captcha token is required")
+
+    # Claim the token first so a concurrent replay of the same value cannot
+    # slip through the Google round-trip window. Done BEFORE calling Google
+    # because even a still-valid token should only redeem once.
+    await _reserve_token_or_raise(token)
 
     try:
         async with httpx.AsyncClient() as client:
@@ -76,24 +119,34 @@ async def verify_captcha_token(
                     f"Captcha verification failed: {', '.join(error_codes)}"
                 )
 
-            # For reCAPTCHA v3, also check the score
-            if result.score is not None:
-                if result.score < RECAPTCHA_SCORE_THRESHOLD:
-                    logger.warning(
-                        f"Captcha score too low: {result.score} < {RECAPTCHA_SCORE_THRESHOLD}"
-                    )
-                    raise CaptchaVerificationError(
-                        "Captcha verification failed: suspicious activity detected"
-                    )
+            # Require v3 score. Google's public test secret returns no score
+            # — that path must not be active in prod since it skips the only
+            # human-vs-bot signal. If score is missing here captcha is
+            # misconfigured (test secret in prod, or v2 response slipped in
+            # via an action mismatch).
+            if result.score is None:
+                logger.warning(
+                    "Captcha verification failed: siteverify returned no score (likely test secret in prod)"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: missing score"
+                )
 
-                # Optionally verify the action matches
-                if result.action and result.action != expected_action:
-                    logger.warning(
-                        f"Captcha action mismatch: {result.action} != {expected_action}"
-                    )
-                    raise CaptchaVerificationError(
-                        "Captcha verification failed: action mismatch"
-                    )
+            if result.score < RECAPTCHA_SCORE_THRESHOLD:
+                logger.warning(
+                    f"Captcha score too low: {result.score} < {RECAPTCHA_SCORE_THRESHOLD}"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: suspicious activity detected"
+                )
+
+            if result.action and result.action != expected_action:
+                logger.warning(
+                    f"Captcha action mismatch: {result.action} != {expected_action}"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: action mismatch"
+                )
 
             logger.debug(
                 f"Captcha verification passed: score={result.score}, action={result.action}"
@@ -101,6 +154,4 @@ async def verify_captcha_token(
 
     except httpx.HTTPError as e:
         logger.error(f"Captcha API request failed: {e}")
-        # In case of API errors, we might want to allow registration
-        # to prevent blocking legitimate users. This is a policy decision.
         raise CaptchaVerificationError("Captcha verification service unavailable")

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -1,0 +1,96 @@
+"""Per-IP rate limit on email/password signup.
+
+Orthogonal to reCAPTCHA. Even when bots pass a v3 score >= threshold (real
+browser automation + residential proxies routinely do) the cost of each
+rotated IP still limits throughput. Cloud-only: self-hosted deployments
+skip this entirely.
+
+Uses Redis INCR + EXPIRE so counters are cluster-wide. Keys are hour-bucketed
+on wall-clock so the "per hour" window is a fixed tumbling window — fine for
+this use case since we're not trying to be precise, we're raising cost.
+"""
+
+import time
+
+from fastapi import Request
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+# Hardcoded tunables. Registration is a rare legitimate event — humans sign
+# up once. 5/hour/IP still accommodates shared-NAT offices while forcing
+# bot farms to rotate IPs (which costs real money on residential proxies).
+_PER_IP_PER_HOUR = 5
+_BUCKET_SECONDS = 3600
+_REDIS_KEY_PREFIX = "signup_rate:"
+
+
+def _client_ip(request: Request) -> str:
+    """Prefer the real client IP from X-Forwarded-For. Nginx and the AWS LB
+    both set it; ``request.client.host`` is the proxy hop, which is the same
+    for every request and useless as a rate-limit key."""
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        # First entry is the originating client per RFC 7239 convention.
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _bucket_key(ip: str) -> str:
+    bucket = int(time.time() // _BUCKET_SECONDS)
+    return f"{_REDIS_KEY_PREFIX}{ip}:{bucket}"
+
+
+def is_signup_rate_limit_enabled() -> bool:
+    """Only active on multi-tenant cloud deployments. Self-hosted signup is
+    typically admin-invite-only and doesn't see the spray-registration
+    threat model."""
+    return MULTI_TENANT
+
+
+async def enforce_signup_rate_limit(request: Request) -> None:
+    """Raise OnyxError(TOO_MANY_REQUESTS) if this client has exceeded the
+    hourly signup cap. Fails open on Redis errors so a Redis blip cannot
+    block legitimate registrations."""
+    if not is_signup_rate_limit_enabled():
+        return
+
+    ip = _client_ip(request)
+    key = _bucket_key(ip)
+
+    try:
+        redis = await get_async_redis_connection()
+        # INCR returns the post-increment value; if this is the first hit in
+        # the bucket we also set TTL so the key self-cleans.
+        count = await redis.incr(key)
+        if count == 1:
+            await redis.expire(key, _BUCKET_SECONDS)
+    except Exception as e:
+        logger.error(f"Signup rate-limit Redis error (failing open): {e}")
+        return
+
+    if count > _PER_IP_PER_HOUR:
+        logger.warning(
+            f"Signup rate limit exceeded for ip={ip} count={count} limit={_PER_IP_PER_HOUR}"
+        )
+        raise OnyxError(
+            OnyxErrorCode.RATE_LIMITED,
+            "Too many signup attempts from this network. Please wait before trying again.",
+        )
+
+
+# Exported for tests that want to reason about the bucket shape without
+# re-deriving the constants.
+__all__ = [
+    "enforce_signup_rate_limit",
+    "is_signup_rate_limit_enabled",
+    "_PER_IP_PER_HOUR",
+    "_BUCKET_SECONDS",
+    "_client_ip",
+    "_bucket_key",
+]

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -72,6 +72,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
+from onyx.auth.captcha import CaptchaVerificationError
+from onyx.auth.captcha import is_captcha_enabled
+from onyx.auth.captcha import verify_captcha_token
 from onyx.auth.disposable_email_validator import is_disposable_email
 from onyx.auth.email_utils import send_forgot_password_email
 from onyx.auth.email_utils import send_user_verification_email
@@ -82,6 +85,7 @@ from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
+from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
 from onyx.configs.app_configs import AUTH_TYPE
@@ -380,11 +384,28 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         safe: bool = False,
         request: Optional[Request] = None,
     ) -> User:
-        # Verify captcha if enabled (for cloud signup protection)
-        from onyx.auth.captcha import CaptchaVerificationError
-        from onyx.auth.captcha import is_captcha_enabled
-        from onyx.auth.captcha import verify_captcha_token
+        # Run cheap, non-network checks first so bots on disposable domains or
+        # over the rate limit never reach Google siteverify.
+        try:
+            verify_email_domain(user_create.email, is_registration=True)
+        except OnyxError as e:
+            # Log blocked disposable email attempts
+            if "Disposable email" in e.detail:
+                domain = (
+                    user_create.email.split("@")[-1]
+                    if "@" in user_create.email
+                    else "unknown"
+                )
+                logger.warning(
+                    f"Blocked disposable email registration attempt: {domain}",
+                    extra={"email_domain": domain},
+                )
+            raise
 
+        if request is not None:
+            await enforce_signup_rate_limit(request)
+
+        # Verify captcha if enabled (for cloud signup protection)
         if is_captcha_enabled() and request is not None:
             # Get captcha token from request body or headers
             captcha_token = None
@@ -406,24 +427,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         await self.validate_password(
             user_create.password, cast(schemas.UC, user_create)
         )
-
-        # Check for disposable emails BEFORE provisioning tenant
-        # This prevents creating tenants for throwaway email addresses
-        try:
-            verify_email_domain(user_create.email, is_registration=True)
-        except OnyxError as e:
-            # Log blocked disposable email attempts
-            if "Disposable email" in e.detail:
-                domain = (
-                    user_create.email.split("@")[-1]
-                    if "@" in user_create.email
-                    else "unknown"
-                )
-                logger.warning(
-                    f"Blocked disposable email registration attempt: {domain}",
-                    extra={"email_domain": domain},
-                )
-            raise
 
         user_count: int | None = None
         referral_source = (
@@ -620,8 +623,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 sync_db.commit()
             else:
                 logger.warning(
-                    "User %s not found in sync session during upgrade to standard; "
-                    "skipping upgrade",
+                    "User %s not found in sync session during upgrade to standard; skipping upgrade",
                     user_id,
                 )
 
@@ -1614,7 +1616,6 @@ async def optional_user(
     async_db_session: AsyncSession = Depends(get_async_session),
     user: User | None = Depends(optional_fastapi_current_user),
 ) -> User | None:
-
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
         return user

--- a/backend/tests/unit/onyx/auth/test_captcha_replay.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_replay.py
@@ -1,0 +1,133 @@
+"""Unit tests for the reCAPTCHA token replay cache + require-score check."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth import captcha as captcha_module
+from onyx.auth.captcha import _replay_cache_key
+from onyx.auth.captcha import _reserve_token_or_raise
+from onyx.auth.captcha import CaptchaVerificationError
+from onyx.auth.captcha import verify_captcha_token
+
+
+# ---------- replay cache ----------
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_succeeds_on_first_use() -> None:
+    """First SETNX claims the token; no exception."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    with patch.object(
+        captcha_module, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+    ):
+        await _reserve_token_or_raise("some-token")
+    fake_redis.set.assert_awaited_once()
+    # Verify SETNX + TTL args went through.
+    await_args = fake_redis.set.await_args
+    assert await_args is not None
+    assert await_args.kwargs["nx"] is True
+    assert await_args.kwargs["ex"] == 120
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_rejects_replay() -> None:
+    """Second use of the same token within TTL → CaptchaVerificationError."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=False)
+    with patch.object(
+        captcha_module, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+    ):
+        with pytest.raises(CaptchaVerificationError, match="token already used"):
+            await _reserve_token_or_raise("replayed-token")
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_fails_open_on_redis_error() -> None:
+    """A Redis blip must NOT block legitimate registrations."""
+    with patch.object(
+        captcha_module,
+        "get_async_redis_connection",
+        AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        # No exception raised — replay protection is gracefully skipped.
+        await _reserve_token_or_raise("any-token")
+
+
+def test_replay_cache_key_is_sha256_prefixed() -> None:
+    """The stored key never contains the raw token."""
+    key = _replay_cache_key("raw-value")
+    assert key.startswith("captcha:replay:")
+    assert "raw-value" not in key
+    # Length = prefix + 64 hex chars.
+    assert len(key) == len("captcha:replay:") + 64
+
+
+# ---------- require-score check ----------
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_when_score_missing() -> None:
+    """A siteverify response with no score field is rejected outright —
+    closes the accidental 'test secret in prod' bypass path."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+
+    fake_httpx_response = MagicMock()
+    fake_httpx_response.raise_for_status = MagicMock()
+    fake_httpx_response.json = MagicMock(
+        return_value={"success": True, "hostname": "testkey.google.com"}
+    )
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_httpx_response)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=fake_redis),
+        ),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=fake_client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="missing score"):
+            await verify_captcha_token("test-token", expected_action="signup")
+
+
+@pytest.mark.asyncio
+async def test_verify_accepts_when_score_present_and_above_threshold() -> None:
+    """Sanity check the happy path still works with the tighter score rule."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+
+    fake_httpx_response = MagicMock()
+    fake_httpx_response.raise_for_status = MagicMock()
+    fake_httpx_response.json = MagicMock(
+        return_value={
+            "success": True,
+            "score": 0.9,
+            "action": "signup",
+            "hostname": "cloud.onyx.app",
+        }
+    )
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_httpx_response)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=fake_redis),
+        ),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=fake_client),
+    ):
+        # Should not raise.
+        await verify_captcha_token("fresh-token", expected_action="signup")

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -1,0 +1,143 @@
+"""Unit tests for the per-IP signup rate limiter."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastapi import Request
+
+from onyx.auth import signup_rate_limit as rl
+from onyx.auth.signup_rate_limit import _bucket_key
+from onyx.auth.signup_rate_limit import _client_ip
+from onyx.auth.signup_rate_limit import _PER_IP_PER_HOUR
+from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
+from onyx.error_handling.exceptions import OnyxError
+
+
+def _make_request(
+    xff: str | None = None, client_host: str | None = "1.2.3.4"
+) -> Request:
+    scope: dict = {
+        "type": "http",
+        "method": "POST",
+        "path": "/auth/register",
+        "headers": [],
+    }
+    if xff is not None:
+        scope["headers"].append((b"x-forwarded-for", xff.encode()))
+    if client_host is not None:
+        scope["client"] = (client_host, 54321)
+    return Request(scope)
+
+
+# ---------- IP extraction ----------
+
+
+def test_client_ip_prefers_xff_first_entry() -> None:
+    req = _make_request(xff="203.0.113.9, 10.0.0.1, 10.0.0.2")
+    assert _client_ip(req) == "203.0.113.9"
+
+
+def test_client_ip_falls_back_to_request_client_host() -> None:
+    req = _make_request(xff=None, client_host="198.51.100.7")
+    assert _client_ip(req) == "198.51.100.7"
+
+
+def test_client_ip_handles_no_client() -> None:
+    req = _make_request(xff=None, client_host=None)
+    assert _client_ip(req) == "unknown"
+
+
+# ---------- enforce_signup_rate_limit ----------
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_not_multitenant() -> None:
+    """Self-hosted (MULTI_TENANT=False) should never call Redis."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", False),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ) as conn,
+    ):
+        await enforce_signup_rate_limit(req)
+    conn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allows_when_under_limit() -> None:
+    """Counts at or below the hourly cap do not raise."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR)  # exactly at cap
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        await enforce_signup_rate_limit(req)
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_over_limit() -> None:
+    """Strictly above the cap → OnyxError.RATE_LIMITED (HTTP 429)."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR + 1)
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            await enforce_signup_rate_limit(req)
+    assert exc_info.value.error_code.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_sets_ttl_only_on_first_hit() -> None:
+    """Every non-first INCR must not reset the bucket TTL."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=3)  # not the first hit
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        await enforce_signup_rate_limit(req)
+    fake_redis.expire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_redis_error() -> None:
+    """Redis blip must NOT block legitimate signups."""
+    req = _make_request(client_host="1.2.3.4")
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl,
+            "get_async_redis_connection",
+            AsyncMock(side_effect=RuntimeError("redis down")),
+        ),
+    ):
+        # Does not raise.
+        await enforce_signup_rate_limit(req)
+
+
+def test_bucket_keys_differ_across_ips() -> None:
+    """Two different IPs in the same hour must not share a counter."""
+    a = _bucket_key("1.1.1.1")
+    b = _bucket_key("2.2.2.2")
+    assert a != b
+    assert a.startswith("signup_rate:1.1.1.1:")
+    assert b.startswith("signup_rate:2.2.2.2:")


### PR DESCRIPTION
## Description

Follow-up to PR #10381 (reCAPTCHA on OAuth callback). The post-mortem investigation showed the 2026-04-17 bot tenants all used email/password signup with disposable domains (zero Google-OAuth emails in the 1,677-tenant dataset). On cloud, `CAPTCHA_ENABLED=true` and `RECAPTCHA_SCORE_THRESHOLD=0.8` were active during the attack — meaning the bots passed Google v3 at score ≥ 0.8. v3 alone, even at 0.8, is not enough against sophisticated bots with residential proxies + real-browser automation.

This PR stacks four orthogonal defenses on top of v3:

### 1. Token replay cache (`backend/onyx/auth/captcha.py`)

Before calling Google siteverify, `verify_captcha_token` SETNX-claims `captcha:replay:<sha256(token)>` in Redis with a 120s TTL (Google's own token expiry). A second attempt to redeem the same token fails fast:

```
Captcha verification failed: token already used
```

Closes the "solve once, spray N registrations" attack where a single human-solved token is re-submitted across many registration attempts. Fails open on Redis errors — a Redis blip cannot hard-fail legitimate signups.

### 2. Per-IP signup rate limit (`backend/onyx/auth/signup_rate_limit.py`, new)

Hour-bucketed Redis `INCR` on `signup_rate:<ip>:<hour>`. Hard cap **5 registrations per IP per hour**. Only active on `MULTI_TENANT` deployments — self-hosted keeps today's behavior. Over-limit requests get `OnyxError(RATE_LIMITED)` → HTTP 429.

Closes the vector where a bot farm with real v3 scores tries to register hundreds of accounts from the same IP (or narrow IP pool). Raises attacker cost by forcing IP rotation.

Uses `X-Forwarded-For` for the real client IP (AWS LB / nginx pass-through); falls back to `request.client.host`.

### 3. Require v3 score field (`captcha.py`)

Google's public test secret returns `{success:true}` with **no score field**. Old code:

```python
if result.score is not None:      # skipped entirely when score missing
    if result.score < RECAPTCHA_SCORE_THRESHOLD:
        raise ...
```

That's an accidental bypass if a test secret ever leaks into prod config. New code rejects outright when the score is absent:

```python
if result.score is None:
    raise CaptchaVerificationError("Captcha verification failed: missing score")
```

### 4. Reorder `UserManager.create` — cheap checks first

Before: `captcha → validate_password → verify_email_domain`. Bots on disposable domains burn a Google API call before being rejected.

After: `verify_email_domain → enforce_signup_rate_limit → captcha → validate_password`. Disposable domains and rate-limited IPs get a fast 400/429 with no Google round-trip. Reduces siteverify load and tightens the failure fast-path.

### Item 5 deferred

The original plan included "v3 score between threshold and 1.0 → step up to v2 visible checkbox." That's larger — needs:

- Frontend: new `Recaptchav2Challenge` component + signup-page wiring
- Backend: accept v2 token path on `/auth/register` and call siteverify without action/score constraints
- UX decision: when exactly to show the checkbox, how to phrase it

Scoped for a follow-up PR so it can be reviewed on its own UX merits.

### No new env vars

Everything beyond the existing `CAPTCHA_ENABLED` / `RECAPTCHA_*` is hardcoded inside the modules:

- Replay TTL: `_REPLAY_CACHE_TTL_SECONDS = 120` (matches Google)
- Signup cap: `_PER_IP_PER_HOUR = 5`
- Bucket size: `_BUCKET_SECONDS = 3600`

Signup rate limit is gated on `MULTI_TENANT` so self-hosted is untouched.

## How Has This Been Tested?

### 31 unit tests pass

**15 new tests:**

```bash
$ pytest -xv backend/tests/unit/onyx/auth/test_captcha_replay.py \
              backend/tests/unit/onyx/auth/test_signup_rate_limit.py
# ============================== 15 passed in 0.06s ==============================
```

Covers:
- Replay cache: first-use success, second-use rejection, fail-open on Redis error, SHA-256-prefixed key (raw token never stored)
- Require-score: missing-score rejection, passing with score present
- Signup rate-limit IP extraction: XFF first-entry, client.host fallback, `"unknown"` when no client
- Rate-limit behavior: disabled when not multi-tenant, under-cap allowed, over-cap raises 429, TTL only on first hit, fail-open, cross-IP isolation

**16 existing tests still pass** after the `UserManager.create` reorder:

```bash
$ pytest -xv backend/tests/unit/onyx/auth/test_user_registration.py
# ============================== 16 passed in 0.29s ==============================
```

### Type checks

```bash
$ mypy onyx/auth/captcha.py onyx/auth/signup_rate_limit.py \
        tests/unit/onyx/auth/test_captcha_replay.py \
        tests/unit/onyx/auth/test_signup_rate_limit.py
# Success: no issues found in 4 source files
```

`onyx/auth/users.py` has 7 pre-existing mypy errors unrelated to this PR (verified by stashing my changes and re-running — same 7 errors on clean main).

### Manual smoke — replay cache

With a real local reCAPTCHA token reused twice via curl to `/auth/captcha/oauth-verify`: first call returns 200, second returns 403 with detail `"Captcha verification failed: token already used"`. Same mechanism applies to `/auth/register` since both paths go through `verify_captcha_token`.

### Manual smoke — rate limit

Simulated 6 POSTs to `/auth/register` within the hour bucket from the same X-Forwarded-For. Hit 6 returned 429 with detail `"Too many signup attempts from this network..."`.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check