### PR TITLE
feat(auth): Redis replay cache on captcha tokens

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -27,12 +27,18 @@ from onyx.configs.app_configs import CAPTCHA_ENABLED
 from onyx.configs.app_configs import RECAPTCHA_SCORE_THRESHOLD
 from onyx.configs.app_configs import RECAPTCHA_SECRET_KEY
 from onyx.configs.app_configs import USER_AUTH_SECRET
+from onyx.redis.redis_pool import get_async_redis_connection
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 RECAPTCHA_VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
 CAPTCHA_COOKIE_NAME = "onyx_captcha_verified"
+
+# Google v3 tokens expire server-side at ~2 minutes, so 120s is the max useful
+# replay window — after that Google would reject the token anyway.
+_REPLAY_CACHE_TTL_SECONDS = 120
+_REPLAY_KEY_PREFIX = "captcha:replay:"
 
 
 class CaptchaVerificationError(Exception):
@@ -55,6 +61,36 @@ def is_captcha_enabled() -> bool:
     return CAPTCHA_ENABLED and bool(RECAPTCHA_SECRET_KEY)
 
 
+def _replay_cache_key(token: str) -> str:
+    """Avoid storing the raw token in Redis — hash it first."""
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    return f"{_REPLAY_KEY_PREFIX}{digest}"
+
+
+async def _reserve_token_or_raise(token: str) -> None:
+    """SETNX a token fingerprint. If another caller already claimed it within
+    the TTL, reject as a replay. Fails open on Redis errors — losing replay
+    protection is strictly better than hard-failing legitimate registrations
+    if Redis blips."""
+    try:
+        redis = await get_async_redis_connection()
+        claimed = await redis.set(
+            _replay_cache_key(token),
+            "1",
+            nx=True,
+            ex=_REPLAY_CACHE_TTL_SECONDS,
+        )
+        if not claimed:
+            logger.warning("Captcha replay detected: token already used")
+            raise CaptchaVerificationError(
+                "Captcha verification failed: token already used"
+            )
+    except CaptchaVerificationError:
+        raise
+    except Exception as e:
+        logger.error(f"Captcha replay cache error (failing open): {e}")
+
+
 async def verify_captcha_token(
     token: str,
     expected_action: str = "signup",
@@ -74,6 +110,11 @@ async def verify_captcha_token(
 
     if not token:
         raise CaptchaVerificationError("Captcha token is required")
+
+    # Claim the token first so a concurrent replay of the same value cannot
+    # slip through the Google round-trip window. Done BEFORE calling Google
+    # because even a still-valid token should only redeem once.
+    await _reserve_token_or_raise(token)
 
     try:
         async with httpx.AsyncClient() as client:

--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -91,6 +91,21 @@ async def _reserve_token_or_raise(token: str) -> None:
         logger.error(f"Captcha replay cache error (failing open): {e}")
 
 
+async def _release_token(token: str) -> None:
+    """Unclaim a previously-reserved token so a retry with the same still-valid
+    token is not blocked. Called when WE fail (network error talking to
+    Google), not when Google rejects the token — Google rejections mean the
+    token is permanently invalid and must stay claimed."""
+    try:
+        redis = await get_async_redis_connection()
+        await redis.delete(_replay_cache_key(token))
+    except Exception as e:
+        # Worst case: the user must wait up to 120s before the TTL expires
+        # on its own and they can retry. Still strictly better than failing
+        # open on the reservation side.
+        logger.error(f"Captcha replay cache release error (ignored): {e}")
+
+
 async def verify_captcha_token(
     token: str,
     expected_action: str = "signup",
@@ -173,8 +188,11 @@ async def verify_captcha_token(
 
     except httpx.HTTPError as e:
         logger.error(f"Captcha API request failed: {e}")
-        # In case of API errors, we might want to allow registration
-        # to prevent blocking legitimate users. This is a policy decision.
+        # Google itself was unreachable — the user's token is not invalid,
+        # we just couldn't verify it. Release the replay reservation so a
+        # retry with the same still-valid token is accepted instead of
+        # rejected as "already used" for the next ~120s.
+        await _release_token(token)
         raise CaptchaVerificationError("Captcha verification service unavailable")
 
 

--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -186,12 +186,18 @@ async def verify_captcha_token(
                 f"Captcha verification passed: score={result.score}, action={result.action}"
             )
 
-    except httpx.HTTPError as e:
-        logger.error(f"Captcha API request failed: {e}")
-        # Google itself was unreachable — the user's token is not invalid,
-        # we just couldn't verify it. Release the replay reservation so a
-        # retry with the same still-valid token is accepted instead of
-        # rejected as "already used" for the next ~120s.
+    except CaptchaVerificationError:
+        # Definitively-bad token (Google rejected it, score too low, action
+        # mismatch). Keep the reservation so the same token cannot be
+        # retried elsewhere during the TTL window.
+        raise
+    except Exception as e:
+        # Anything else — network failure, JSON decode error, Pydantic
+        # validation error on an unexpected siteverify response shape — is
+        # OUR inability to verify the token, not proof the token is bad.
+        # Release the reservation so the user can retry with the same
+        # still-valid token instead of being locked out for ~120s.
+        logger.error(f"Captcha verification failed unexpectedly: {e}")
         await _release_token(token)
         raise CaptchaVerificationError("Captcha verification service unavailable")
 

--- a/backend/tests/unit/onyx/auth/test_captcha_replay.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_replay.py
@@ -4,12 +4,14 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from onyx.auth import captcha as captcha_module
 from onyx.auth.captcha import _replay_cache_key
 from onyx.auth.captcha import _reserve_token_or_raise
 from onyx.auth.captcha import CaptchaVerificationError
+from onyx.auth.captcha import verify_captcha_token
 
 
 @pytest.mark.asyncio
@@ -63,3 +65,34 @@ def test_replay_cache_key_is_sha256_prefixed() -> None:
     assert "raw-value" not in key
     # Length = prefix + 64 hex chars.
     assert len(key) == len("captcha:replay:") + 64
+
+
+@pytest.mark.asyncio
+async def test_reservation_released_when_google_unreachable() -> None:
+    """If Google's siteverify itself errors (our side, not the token's), the
+    replay reservation must be released so the user can retry with the same
+    still-valid token instead of getting 'already used' for 120s."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock(return_value=1)
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(side_effect=httpx.ConnectError("network down"))
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=fake_redis),
+        ),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=fake_client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="service unavailable"):
+            await verify_captcha_token("valid-token", expected_action="signup")
+
+    # The reservation was claimed and then released.
+    fake_redis.set.assert_awaited_once()
+    fake_redis.delete.assert_awaited_once()

--- a/backend/tests/unit/onyx/auth/test_captcha_replay.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_replay.py
@@ -96,3 +96,77 @@ async def test_reservation_released_when_google_unreachable() -> None:
     # The reservation was claimed and then released.
     fake_redis.set.assert_awaited_once()
     fake_redis.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reservation_released_on_unexpected_response_shape() -> None:
+    """Non-HTTP errors during response parsing (malformed JSON, pydantic
+    validation failure) also release the reservation — they mean WE couldn't
+    verify the token, not that the token is definitively invalid."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock(return_value=1)
+
+    # Simulate Google returning something that json() still succeeds on but
+    # fails RecaptchaResponse validation (e.g. success=true but with a wrong
+    # shape that Pydantic rejects when coerced).
+    fake_httpx_response = MagicMock()
+    fake_httpx_response.raise_for_status = MagicMock()
+    fake_httpx_response.json = MagicMock(side_effect=ValueError("not valid JSON"))
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_httpx_response)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=fake_redis),
+        ),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=fake_client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="service unavailable"):
+            await verify_captcha_token("valid-token", expected_action="signup")
+
+    fake_redis.set.assert_awaited_once()
+    fake_redis.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reservation_kept_when_google_rejects_token() -> None:
+    """If Google itself says the token is invalid (success=false, or score
+    too low), the reservation must NOT be released — that token is known-bad
+    for its entire lifetime and shouldn't be retryable."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    fake_redis.delete = AsyncMock(return_value=1)
+
+    fake_httpx_response = MagicMock()
+    fake_httpx_response.raise_for_status = MagicMock()
+    fake_httpx_response.json = MagicMock(
+        return_value={
+            "success": False,
+            "error-codes": ["invalid-input-response"],
+        }
+    )
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=fake_httpx_response)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_module,
+            "get_async_redis_connection",
+            AsyncMock(return_value=fake_redis),
+        ),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=fake_client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="invalid-input-response"):
+            await verify_captcha_token("bad-token", expected_action="signup")
+
+    fake_redis.set.assert_awaited_once()
+    fake_redis.delete.assert_not_awaited()

--- a/backend/tests/unit/onyx/auth/test_captcha_replay.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_replay.py
@@ -1,0 +1,65 @@
+"""Unit tests for the reCAPTCHA token replay cache."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth import captcha as captcha_module
+from onyx.auth.captcha import _replay_cache_key
+from onyx.auth.captcha import _reserve_token_or_raise
+from onyx.auth.captcha import CaptchaVerificationError
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_succeeds_on_first_use() -> None:
+    """First SETNX claims the token; no exception."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    with patch.object(
+        captcha_module,
+        "get_async_redis_connection",
+        AsyncMock(return_value=fake_redis),
+    ):
+        await _reserve_token_or_raise("some-token")
+    fake_redis.set.assert_awaited_once()
+    await_args = fake_redis.set.await_args
+    assert await_args is not None
+    assert await_args.kwargs["nx"] is True
+    assert await_args.kwargs["ex"] == 120
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_rejects_replay() -> None:
+    """Second use of the same token within TTL → CaptchaVerificationError."""
+    fake_redis = MagicMock()
+    fake_redis.set = AsyncMock(return_value=False)
+    with patch.object(
+        captcha_module,
+        "get_async_redis_connection",
+        AsyncMock(return_value=fake_redis),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="token already used"):
+            await _reserve_token_or_raise("replayed-token")
+
+
+@pytest.mark.asyncio
+async def test_reserve_token_fails_open_on_redis_error() -> None:
+    """A Redis blip must NOT block legitimate registrations."""
+    with patch.object(
+        captcha_module,
+        "get_async_redis_connection",
+        AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        # No exception raised — replay protection is gracefully skipped.
+        await _reserve_token_or_raise("any-token")
+
+
+def test_replay_cache_key_is_sha256_prefixed() -> None:
+    """The stored key never contains the raw token."""
+    key = _replay_cache_key("raw-value")
+    assert key.startswith("captcha:replay:")
+    assert "raw-value" not in key
+    # Length = prefix + 64 hex chars.
+    assert len(key) == len("captcha:replay:") + 64


### PR DESCRIPTION
## Description

Closes the "solve one reCAPTCHA token, spray N registrations" pattern. Before calling Google siteverify, `verify_captcha_token` SETNX-claims a SHA-256 fingerprint of the token in Redis with a 120s TTL (Google's own token lifetime). A second redeem of the same token fails fast with `Captcha verification failed: token already used`.

Raw token is never stored — only the hash. Fails open on Redis errors so a Redis blip cannot hard-fail legitimate signups.

TTL is a hardcoded module constant (`_REPLAY_CACHE_TTL_SECONDS = 120`). No new env vars.

Applies automatically to both existing callers: email/password `/auth/register` via `UserManager.create`, and `/auth/captcha/oauth-verify` from #10381.

## How Has This Been Tested?

4 unit tests — first-use success, replay rejection, fail-open on Redis error, SHA-256 key shape (raw token never leaked).

```bash
$ pytest -xv backend/tests/unit/onyx/auth/test_captcha_replay.py
# 4 passed
$ mypy onyx/auth/captcha.py tests/unit/onyx/auth/test_captcha_replay.py
# Success
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check