### PR TITLE
feat(auth): require v3 score in captcha verification

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -76,24 +76,34 @@ async def verify_captcha_token(
                     f"Captcha verification failed: {', '.join(error_codes)}"
                 )
 
-            # For reCAPTCHA v3, also check the score
-            if result.score is not None:
-                if result.score < RECAPTCHA_SCORE_THRESHOLD:
-                    logger.warning(
-                        f"Captcha score too low: {result.score} < {RECAPTCHA_SCORE_THRESHOLD}"
-                    )
-                    raise CaptchaVerificationError(
-                        "Captcha verification failed: suspicious activity detected"
-                    )
+            # Require v3 score. Google's public test secret returns no score
+            # — that path must not be active in prod since it skips the only
+            # human-vs-bot signal. A missing score here means captcha is
+            # misconfigured (test secret in prod, or a v2 response slipped in
+            # via an action mismatch).
+            if result.score is None:
+                logger.warning(
+                    "Captcha verification failed: siteverify returned no score (likely test secret in prod)"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: missing score"
+                )
 
-                # Optionally verify the action matches
-                if result.action and result.action != expected_action:
-                    logger.warning(
-                        f"Captcha action mismatch: {result.action} != {expected_action}"
-                    )
-                    raise CaptchaVerificationError(
-                        "Captcha verification failed: action mismatch"
-                    )
+            if result.score < RECAPTCHA_SCORE_THRESHOLD:
+                logger.warning(
+                    f"Captcha score too low: {result.score} < {RECAPTCHA_SCORE_THRESHOLD}"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: suspicious activity detected"
+                )
+
+            if result.action and result.action != expected_action:
+                logger.warning(
+                    f"Captcha action mismatch: {result.action} != {expected_action}"
+                )
+                raise CaptchaVerificationError(
+                    "Captcha verification failed: action mismatch"
+                )
 
             logger.debug(
                 f"Captcha verification passed: score={result.score}, action={result.action}"

--- a/backend/tests/unit/onyx/auth/test_captcha_require_score.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_require_score.py
@@ -1,0 +1,78 @@
+"""Unit tests for the require-score check in verify_captcha_token."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth import captcha as captcha_module
+from onyx.auth.captcha import CaptchaVerificationError
+from onyx.auth.captcha import verify_captcha_token
+
+
+def _fake_httpx_client_returning(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    client = MagicMock()
+    client.post = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_score_missing() -> None:
+    """Siteverify response with no score field is rejected outright —
+    closes the accidental 'test secret in prod' bypass path."""
+    client = _fake_httpx_client_returning(
+        {"success": True, "hostname": "testkey.google.com"}
+    )
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="missing score"):
+            await verify_captcha_token("test-token", expected_action="signup")
+
+
+@pytest.mark.asyncio
+async def test_accepts_when_score_present_and_above_threshold() -> None:
+    """Sanity check the happy path still works with the tighter score rule."""
+    client = _fake_httpx_client_returning(
+        {
+            "success": True,
+            "score": 0.9,
+            "action": "signup",
+            "hostname": "cloud.onyx.app",
+        }
+    )
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=client),
+    ):
+        # Should not raise.
+        await verify_captcha_token("fresh-token", expected_action="signup")
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_score_below_threshold() -> None:
+    """A score present but below threshold still rejects (existing behavior,
+    guarding against regression from this PR's restructure)."""
+    client = _fake_httpx_client_returning(
+        {
+            "success": True,
+            "score": 0.1,
+            "action": "signup",
+            "hostname": "cloud.onyx.app",
+        }
+    )
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=client),
+    ):
+        with pytest.raises(
+            CaptchaVerificationError, match="suspicious activity detected"
+        ):
+            await verify_captcha_token("low-score-token", expected_action="signup")


### PR DESCRIPTION
## Description

Google's public reCAPTCHA test secret (`6LeIxAcT...`) returns `{success: true}` with no `score` field. Old code treated a missing score as "skip the check":

```python
if result.score is not None:          # silent no-op when missing
    if result.score < RECAPTCHA_SCORE_THRESHOLD:
        raise ...
```

Two concrete risks:

1. **Test-secret-in-prod bypass.** If the test secret ever reaches `RECAPTCHA_SECRET_KEY` in a real deployment, every registration passes the threshold check regardless of the configured value.
2. **Threshold tuning is untestable with public test keys.** Can set `RECAPTCHA_SCORE_THRESHOLD=1.01` (should reject all) and local signup still succeeds.

After this PR, a missing score rejects outright: `Captcha verification failed: missing score`.

## How Has This Been Tested?

3 unit tests — missing-score rejected, score >= threshold passes, score < threshold still rejects (restructure regression guard).

```bash
$ pytest -xv backend/tests/unit/onyx/auth/test_captcha_require_score.py
# 3 passed
$ mypy onyx/auth/captcha.py tests/unit/onyx/auth/test_captcha_require_score.py
# Success
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check