### PR TITLE
feat(auth): per-IP rate limit on /auth/register

### DIFF
--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -1,74 +1,11 @@
-"""Per-IP rate limit on email/password signup.
-
-Orthogonal to reCAPTCHA. Even when bots pass a v3 score >= threshold (real
-browser automation + residential proxies routinely do) the cost of each
-rotated IP still limits throughput. Cloud-only: self-hosted deployments
-skip this entirely.
-
-Uses Redis INCR + EXPIRE (in a pipeline for atomicity) so counters are
-cluster-wide. Keys are hour-bucketed on wall-clock so the "per hour" window
-is a fixed tumbling window — fine for this use case since we're not trying
-to be precise, we're raising cost.
-
-### IP extraction in Onyx cloud
-
-The multi-tenant cloud topology is:
-
-    client  ──(TCP)──▶  AWS NLB  ──(TCP)──▶  ingress-nginx
-                                                    │
-                                                    ▼
-                                             internal nginx
-                                                    │
-                                                    ▼
-                                                api-server
-
-- The NLB is **Layer 4** and does not touch HTTP — it does NOT add
-  X-Forwarded-For. With `externalTrafficPolicy: Local` set on the ingress
-  service, NLB preserves the source IP at the TCP level.
-- ingress-nginx-controller with default config (no `use-forwarded-headers`)
-  **ignores any client-supplied X-Forwarded-For** and overwrites it with
-  its own `$remote_addr` — which is the real client IP, preserved through
-  NLB. So by the time the request leaves ingress-nginx, X-Forwarded-For
-  carries exactly one trustworthy entry: the real client.
-- internal nginx then appends its own `$remote_addr` (the ingress-nginx
-  pod IP, a private RFC-1918 address) via `$proxy_add_x_forwarded_for`.
-
-At the api-server we therefore see:
-
-    X-Forwarded-For: <real_client_ip>, <ingress_nginx_pod_ip>
-
-Taking `parts[0]` matches what the existing nginx-side `limit_req_zone`
-already does (`map $http_x_forwarded_for $real_client_ip` in
-`onyx-nginx-conf`). It is safe *because* ingress-nginx overwrites XFF —
-not because XFF is inherently trustworthy.
-
-Defense in depth: if ingress-nginx is ever reconfigured with
-`use-forwarded-headers: true` (making the leftmost entry spoofable again),
-we reject leftmost entries that are private / loopback / reserved and
-fall through to `request.client.host`. That prevents an attacker from
-trivially bucketing all their requests under `10.0.0.1` via an
-`X-Forwarded-For: 10.0.0.1` header.
-
-### Prerequisite: ingress-nginx must NOT run with `--enable-ssl-passthrough`
-
-Pre-2026-04-20, the ingress-nginx deployment ran with
-`--enable-ssl-passthrough`, which wraps the main nginx in an internal
-TCP proxy on `127.0.0.1:442`. That made `$remote_addr` at ingress-nginx
-always `127.0.0.1`, so XFF carried loopback for every request. The arg
-was removed in `cloud-deployment-yamls#256`. If it is ever re-added,
-`parts[0]` will be `127.0.0.1` and `is_global` will correctly reject it
-— every signup will bucket under the TCP peer (ingress pod IP), which
-degrades rate limiting to a single cluster-wide counter. Safe-fails
-(over-rate-limits rather than under-rate-limits) but bad UX, so this
-flag must stay off.
-"""
+"""Per-IP rate limit on email/password signup."""
 
 import ipaddress
-import os
 import time
 
 from fastapi import Request
 
+from onyx.configs.app_configs import SIGNUP_RATE_LIMIT_ENABLED
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_async_redis_connection
@@ -77,32 +14,12 @@ from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
-# Hardcoded tunables. Registration is a rare legitimate event — humans sign
-# up once. 5/hour/IP still accommodates shared-NAT offices while forcing
-# bot farms to rotate IPs (which costs real money on residential proxies).
 _PER_IP_PER_HOUR = 5
 _BUCKET_SECONDS = 3600
 _REDIS_KEY_PREFIX = "signup_rate:"
 
-# Opt-in enable flag. MULTI_TENANT alone is insufficient — integration
-# tests run in multi-tenant mode from a single shared runner IP and would
-# trip the cap after a handful of signup-flow tests. Cloud sets this to
-# "true" explicitly; CI / local dev leave it unset.
-SIGNUP_RATE_LIMIT_ENABLED = (
-    os.environ.get("SIGNUP_RATE_LIMIT_ENABLED", "").lower() == "true"
-)
-
 
 def _is_usable_client_ip(ip_str: str) -> bool:
-    """Only accept a parseable, globally-routable IP as the rate-limit key.
-
-    `is_global` is True iff the address is in public-internet space —
-    it rules out RFC-1918 private ranges, loopback, link-local,
-    multicast, and the RFC-5737 documentation ranges in one check. Any
-    non-global address reaching `parts[0]` in Onyx cloud is either a
-    kubernetes-internal hop (misconfigured ingress) or an attacker
-    spoofing the header, and we fall back to the TCP peer instead.
-    """
     try:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
@@ -111,17 +28,6 @@ def _is_usable_client_ip(ip_str: str) -> bool:
 
 
 def _client_ip(request: Request) -> str:
-    """Extract the real client IP for the rate-limit key.
-
-    Onyx cloud: the first X-Forwarded-For entry is the real client,
-    written by ingress-nginx from its own `$remote_addr` (safe because
-    ingress-nginx overwrites, not appends). Later entries are internal
-    kubernetes proxy hops. See module docstring for the full rationale.
-
-    Falls back to `request.client.host` (TCP peer) when XFF is absent,
-    malformed, or yields an internal-only address — i.e. local dev,
-    tests, or a misconfigured ingress.
-    """
     xff = request.headers.get("x-forwarded-for")
     if xff:
         parts = [p.strip() for p in xff.split(",") if p.strip()]
@@ -136,11 +42,7 @@ def _bucket_key(ip: str) -> str:
 
 
 async def enforce_signup_rate_limit(request: Request) -> None:
-    """Raise OnyxError(RATE_LIMITED) if this client has exceeded the hourly
-    signup cap. Only active when both MULTI_TENANT and
-    SIGNUP_RATE_LIMIT_ENABLED are true — self-hosted and CI deployments
-    skip this path. Fails open on Redis errors so a Redis blip cannot
-    block legitimate registrations."""
+    """Raise OnyxError(RATE_LIMITED) when the client exceeds the signup cap."""
     if not (MULTI_TENANT and SIGNUP_RATE_LIMIT_ENABLED):
         return
 
@@ -149,31 +51,23 @@ async def enforce_signup_rate_limit(request: Request) -> None:
 
     try:
         redis = await get_async_redis_connection()
-        # INCR + EXPIRE must be atomic: if INCR created the key but EXPIRE
-        # then failed separately, the key would live forever with no TTL,
-        # permanently blocking that IP after it crossed the threshold.
-        # A single pipeline round-trip guarantees both or neither.
         pipe = redis.pipeline()
         pipe.incr(key)
         pipe.expire(key, _BUCKET_SECONDS)
         incr_result, _ = await pipe.execute()
         count = int(incr_result)
     except Exception as e:
-        logger.error(f"Signup rate-limit Redis error (failing open): {e}")
+        logger.error(f"Signup rate-limit Redis error: {e}")
         return
 
     if count > _PER_IP_PER_HOUR:
-        logger.warning(
-            f"Signup rate limit exceeded for ip={ip} count={count} limit={_PER_IP_PER_HOUR}"
-        )
+        logger.warning(f"Signup rate limit exceeded for ip={ip} count={count}")
         raise OnyxError(
             OnyxErrorCode.RATE_LIMITED,
             "Too many signup attempts from this network. Please wait before trying again.",
         )
 
 
-# Exported for tests that want to reason about the bucket shape without
-# re-deriving the constants.
 __all__ = [
     "enforce_signup_rate_limit",
     "_PER_IP_PER_HOUR",

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -126,18 +126,12 @@ def _bucket_key(ip: str) -> str:
     return f"{_REDIS_KEY_PREFIX}{ip}:{bucket}"
 
 
-def is_signup_rate_limit_enabled() -> bool:
-    """Only active on multi-tenant cloud deployments. Self-hosted signup is
-    typically admin-invite-only and doesn't see the spray-registration
-    threat model."""
-    return MULTI_TENANT
-
-
 async def enforce_signup_rate_limit(request: Request) -> None:
     """Raise OnyxError(RATE_LIMITED) if this client has exceeded the hourly
-    signup cap. Fails open on Redis errors so a Redis blip cannot block
-    legitimate registrations."""
-    if not is_signup_rate_limit_enabled():
+    signup cap. Cloud-only: self-hosted signup is typically admin-invite-only
+    and doesn't see the spray-registration threat model. Fails open on Redis
+    errors so a Redis blip cannot block legitimate registrations."""
+    if not MULTI_TENANT:
         return
 
     ip = _client_ip(request)
@@ -172,7 +166,6 @@ async def enforce_signup_rate_limit(request: Request) -> None:
 # re-deriving the constants.
 __all__ = [
     "enforce_signup_rate_limit",
-    "is_signup_rate_limit_enabled",
     "_PER_IP_PER_HOUR",
     "_BUCKET_SECONDS",
     "_client_ip",

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -48,6 +48,19 @@ we reject leftmost entries that are private / loopback / reserved and
 fall through to `request.client.host`. That prevents an attacker from
 trivially bucketing all their requests under `10.0.0.1` via an
 `X-Forwarded-For: 10.0.0.1` header.
+
+### Prerequisite: ingress-nginx must NOT run with `--enable-ssl-passthrough`
+
+Pre-2026-04-20, the ingress-nginx deployment ran with
+`--enable-ssl-passthrough`, which wraps the main nginx in an internal
+TCP proxy on `127.0.0.1:442`. That made `$remote_addr` at ingress-nginx
+always `127.0.0.1`, so XFF carried loopback for every request. The arg
+was removed in `cloud-deployment-yamls#256`. If it is ever re-added,
+`parts[0]` will be `127.0.0.1` and `is_global` will correctly reject it
+— every signup will bucket under the TCP peer (ingress pod IP), which
+degrades rate limiting to a single cluster-wide counter. Safe-fails
+(over-rate-limits rather than under-rate-limits) but bad UX, so this
+flag must stay off.
 """
 
 import ipaddress

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -64,6 +64,7 @@ flag must stay off.
 """
 
 import ipaddress
+import os
 import time
 
 from fastapi import Request
@@ -82,6 +83,14 @@ logger = setup_logger()
 _PER_IP_PER_HOUR = 5
 _BUCKET_SECONDS = 3600
 _REDIS_KEY_PREFIX = "signup_rate:"
+
+# Opt-in enable flag. MULTI_TENANT alone is insufficient — integration
+# tests run in multi-tenant mode from a single shared runner IP and would
+# trip the cap after a handful of signup-flow tests. Cloud sets this to
+# "true" explicitly; CI / local dev leave it unset.
+SIGNUP_RATE_LIMIT_ENABLED = (
+    os.environ.get("SIGNUP_RATE_LIMIT_ENABLED", "").lower() == "true"
+)
 
 
 def _is_usable_client_ip(ip_str: str) -> bool:
@@ -128,10 +137,11 @@ def _bucket_key(ip: str) -> str:
 
 async def enforce_signup_rate_limit(request: Request) -> None:
     """Raise OnyxError(RATE_LIMITED) if this client has exceeded the hourly
-    signup cap. Cloud-only: self-hosted signup is typically admin-invite-only
-    and doesn't see the spray-registration threat model. Fails open on Redis
-    errors so a Redis blip cannot block legitimate registrations."""
-    if not MULTI_TENANT:
+    signup cap. Only active when both MULTI_TENANT and
+    SIGNUP_RATE_LIMIT_ENABLED are true — self-hosted and CI deployments
+    skip this path. Fails open on Redis errors so a Redis blip cannot
+    block legitimate registrations."""
+    if not (MULTI_TENANT and SIGNUP_RATE_LIMIT_ENABLED):
         return
 
     ip = _client_ip(request)

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -1,0 +1,96 @@
+"""Per-IP rate limit on email/password signup.
+
+Orthogonal to reCAPTCHA. Even when bots pass a v3 score >= threshold (real
+browser automation + residential proxies routinely do) the cost of each
+rotated IP still limits throughput. Cloud-only: self-hosted deployments
+skip this entirely.
+
+Uses Redis INCR + EXPIRE so counters are cluster-wide. Keys are hour-bucketed
+on wall-clock so the "per hour" window is a fixed tumbling window — fine for
+this use case since we're not trying to be precise, we're raising cost.
+"""
+
+import time
+
+from fastapi import Request
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+# Hardcoded tunables. Registration is a rare legitimate event — humans sign
+# up once. 5/hour/IP still accommodates shared-NAT offices while forcing
+# bot farms to rotate IPs (which costs real money on residential proxies).
+_PER_IP_PER_HOUR = 5
+_BUCKET_SECONDS = 3600
+_REDIS_KEY_PREFIX = "signup_rate:"
+
+
+def _client_ip(request: Request) -> str:
+    """Prefer the real client IP from X-Forwarded-For. Nginx and the AWS LB
+    both set it; ``request.client.host`` is the proxy hop, which is the same
+    for every request and useless as a rate-limit key."""
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        # First entry is the originating client per RFC 7239 convention.
+        return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _bucket_key(ip: str) -> str:
+    bucket = int(time.time() // _BUCKET_SECONDS)
+    return f"{_REDIS_KEY_PREFIX}{ip}:{bucket}"
+
+
+def is_signup_rate_limit_enabled() -> bool:
+    """Only active on multi-tenant cloud deployments. Self-hosted signup is
+    typically admin-invite-only and doesn't see the spray-registration
+    threat model."""
+    return MULTI_TENANT
+
+
+async def enforce_signup_rate_limit(request: Request) -> None:
+    """Raise OnyxError(RATE_LIMITED) if this client has exceeded the hourly
+    signup cap. Fails open on Redis errors so a Redis blip cannot block
+    legitimate registrations."""
+    if not is_signup_rate_limit_enabled():
+        return
+
+    ip = _client_ip(request)
+    key = _bucket_key(ip)
+
+    try:
+        redis = await get_async_redis_connection()
+        # INCR returns the post-increment value; if this is the first hit in
+        # the bucket we also set TTL so the key self-cleans.
+        count = await redis.incr(key)
+        if count == 1:
+            await redis.expire(key, _BUCKET_SECONDS)
+    except Exception as e:
+        logger.error(f"Signup rate-limit Redis error (failing open): {e}")
+        return
+
+    if count > _PER_IP_PER_HOUR:
+        logger.warning(
+            f"Signup rate limit exceeded for ip={ip} count={count} limit={_PER_IP_PER_HOUR}"
+        )
+        raise OnyxError(
+            OnyxErrorCode.RATE_LIMITED,
+            "Too many signup attempts from this network. Please wait before trying again.",
+        )
+
+
+# Exported for tests that want to reason about the bucket shape without
+# re-deriving the constants.
+__all__ = [
+    "enforce_signup_rate_limit",
+    "is_signup_rate_limit_enabled",
+    "_PER_IP_PER_HOUR",
+    "_BUCKET_SECONDS",
+    "_client_ip",
+    "_bucket_key",
+]

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -5,11 +5,52 @@ browser automation + residential proxies routinely do) the cost of each
 rotated IP still limits throughput. Cloud-only: self-hosted deployments
 skip this entirely.
 
-Uses Redis INCR + EXPIRE so counters are cluster-wide. Keys are hour-bucketed
-on wall-clock so the "per hour" window is a fixed tumbling window — fine for
-this use case since we're not trying to be precise, we're raising cost.
+Uses Redis INCR + EXPIRE (in a pipeline for atomicity) so counters are
+cluster-wide. Keys are hour-bucketed on wall-clock so the "per hour" window
+is a fixed tumbling window — fine for this use case since we're not trying
+to be precise, we're raising cost.
+
+### IP extraction in Onyx cloud
+
+The multi-tenant cloud topology is:
+
+    client  ──(TCP)──▶  AWS NLB  ──(TCP)──▶  ingress-nginx
+                                                    │
+                                                    ▼
+                                             internal nginx
+                                                    │
+                                                    ▼
+                                                api-server
+
+- The NLB is **Layer 4** and does not touch HTTP — it does NOT add
+  X-Forwarded-For. With `externalTrafficPolicy: Local` set on the ingress
+  service, NLB preserves the source IP at the TCP level.
+- ingress-nginx-controller with default config (no `use-forwarded-headers`)
+  **ignores any client-supplied X-Forwarded-For** and overwrites it with
+  its own `$remote_addr` — which is the real client IP, preserved through
+  NLB. So by the time the request leaves ingress-nginx, X-Forwarded-For
+  carries exactly one trustworthy entry: the real client.
+- internal nginx then appends its own `$remote_addr` (the ingress-nginx
+  pod IP, a private RFC-1918 address) via `$proxy_add_x_forwarded_for`.
+
+At the api-server we therefore see:
+
+    X-Forwarded-For: <real_client_ip>, <ingress_nginx_pod_ip>
+
+Taking `parts[0]` matches what the existing nginx-side `limit_req_zone`
+already does (`map $http_x_forwarded_for $real_client_ip` in
+`onyx-nginx-conf`). It is safe *because* ingress-nginx overwrites XFF —
+not because XFF is inherently trustworthy.
+
+Defense in depth: if ingress-nginx is ever reconfigured with
+`use-forwarded-headers: true` (making the leftmost entry spoofable again),
+we reject leftmost entries that are private / loopback / reserved and
+fall through to `request.client.host`. That prevents an attacker from
+trivially bucketing all their requests under `10.0.0.1` via an
+`X-Forwarded-For: 10.0.0.1` header.
 """
 
+import ipaddress
 import time
 
 from fastapi import Request
@@ -29,37 +70,41 @@ _PER_IP_PER_HOUR = 5
 _BUCKET_SECONDS = 3600
 _REDIS_KEY_PREFIX = "signup_rate:"
 
-# Number of infrastructure hops between the public internet and the api-server
-# that each *append* to X-Forwarded-For. Onyx cloud: AWS ALB + ingress-nginx =
-# 2. Adjust if the deployment topology changes. This is what lets us safely
-# ignore any client-supplied prefix of the XFF header: the trusted proxy that
-# sits _TRUSTED_PROXY_HOPS from the right always appended the actual client
-# IP, so we count from the end.
-_TRUSTED_PROXY_HOPS = 2
+
+def _is_usable_client_ip(ip_str: str) -> bool:
+    """Only accept a parseable, globally-routable IP as the rate-limit key.
+
+    `is_global` is True iff the address is in public-internet space —
+    it rules out RFC-1918 private ranges, loopback, link-local,
+    multicast, and the RFC-5737 documentation ranges in one check. Any
+    non-global address reaching `parts[0]` in Onyx cloud is either a
+    kubernetes-internal hop (misconfigured ingress) or an attacker
+    spoofing the header, and we fall back to the TCP peer instead.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    return ip.is_global
 
 
 def _client_ip(request: Request) -> str:
-    """Extract the real client IP in a way that is not trivially spoofable.
+    """Extract the real client IP for the rate-limit key.
 
-    AWS ALB and nginx *append* to any pre-existing X-Forwarded-For header —
-    they do not replace it. A bot can send `X-Forwarded-For: fake-ip`; the
-    LB appends the real client IP; nginx appends the ALB's IP. The FIRST
-    entry is therefore client-controlled and useless. The REAL client IP is
-    the entry written by the outermost trusted proxy, counted from the
-    right.
+    Onyx cloud: the first X-Forwarded-For entry is the real client,
+    written by ingress-nginx from its own `$remote_addr` (safe because
+    ingress-nginx overwrites, not appends). Later entries are internal
+    kubernetes proxy hops. See module docstring for the full rationale.
 
-    Falls back to request.client.host (direct TCP peer) only when there is
-    no trust chain — self-hosted single-nginx deployments, local dev, tests.
+    Falls back to `request.client.host` (TCP peer) when XFF is absent,
+    malformed, or yields an internal-only address — i.e. local dev,
+    tests, or a misconfigured ingress.
     """
     xff = request.headers.get("x-forwarded-for")
     if xff:
         parts = [p.strip() for p in xff.split(",") if p.strip()]
-        # Take the entry written by the outermost trusted proxy. If the chain
-        # is shorter than expected (misconfiguration, or a proxy we don't
-        # know about), fall through to the TCP peer rather than reading from
-        # the client-controlled prefix.
-        if len(parts) >= _TRUSTED_PROXY_HOPS:
-            return parts[-_TRUSTED_PROXY_HOPS]
+        if parts and _is_usable_client_ip(parts[0]):
+            return parts[0]
     return request.client.host if request.client else "unknown"
 
 

--- a/backend/onyx/auth/signup_rate_limit.py
+++ b/backend/onyx/auth/signup_rate_limit.py
@@ -29,15 +29,37 @@ _PER_IP_PER_HOUR = 5
 _BUCKET_SECONDS = 3600
 _REDIS_KEY_PREFIX = "signup_rate:"
 
+# Number of infrastructure hops between the public internet and the api-server
+# that each *append* to X-Forwarded-For. Onyx cloud: AWS ALB + ingress-nginx =
+# 2. Adjust if the deployment topology changes. This is what lets us safely
+# ignore any client-supplied prefix of the XFF header: the trusted proxy that
+# sits _TRUSTED_PROXY_HOPS from the right always appended the actual client
+# IP, so we count from the end.
+_TRUSTED_PROXY_HOPS = 2
+
 
 def _client_ip(request: Request) -> str:
-    """Prefer the real client IP from X-Forwarded-For. Nginx and the AWS LB
-    both set it; ``request.client.host`` is the proxy hop, which is the same
-    for every request and useless as a rate-limit key."""
+    """Extract the real client IP in a way that is not trivially spoofable.
+
+    AWS ALB and nginx *append* to any pre-existing X-Forwarded-For header —
+    they do not replace it. A bot can send `X-Forwarded-For: fake-ip`; the
+    LB appends the real client IP; nginx appends the ALB's IP. The FIRST
+    entry is therefore client-controlled and useless. The REAL client IP is
+    the entry written by the outermost trusted proxy, counted from the
+    right.
+
+    Falls back to request.client.host (direct TCP peer) only when there is
+    no trust chain — self-hosted single-nginx deployments, local dev, tests.
+    """
     xff = request.headers.get("x-forwarded-for")
     if xff:
-        # First entry is the originating client per RFC 7239 convention.
-        return xff.split(",")[0].strip()
+        parts = [p.strip() for p in xff.split(",") if p.strip()]
+        # Take the entry written by the outermost trusted proxy. If the chain
+        # is shorter than expected (misconfiguration, or a proxy we don't
+        # know about), fall through to the TCP peer rather than reading from
+        # the client-controlled prefix.
+        if len(parts) >= _TRUSTED_PROXY_HOPS:
+            return parts[-_TRUSTED_PROXY_HOPS]
     return request.client.host if request.client else "unknown"
 
 
@@ -65,11 +87,15 @@ async def enforce_signup_rate_limit(request: Request) -> None:
 
     try:
         redis = await get_async_redis_connection()
-        # INCR returns the post-increment value; if this is the first hit in
-        # the bucket we also set TTL so the key self-cleans.
-        count = await redis.incr(key)
-        if count == 1:
-            await redis.expire(key, _BUCKET_SECONDS)
+        # INCR + EXPIRE must be atomic: if INCR created the key but EXPIRE
+        # then failed separately, the key would live forever with no TTL,
+        # permanently blocking that IP after it crossed the threshold.
+        # A single pipeline round-trip guarantees both or neither.
+        pipe = redis.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, _BUCKET_SECONDS)
+        incr_result, _ = await pipe.execute()
+        count = int(incr_result)
     except Exception as e:
         logger.error(f"Signup rate-limit Redis error (failing open): {e}")
         return

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -172,9 +172,13 @@ def verify_auth_setting() -> None:
     raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
 
     if raw_auth_type == "cloud":
-        raise ValueError("'cloud' is not a valid auth type for self-hosted deployments.")
+        raise ValueError(
+            "'cloud' is not a valid auth type for self-hosted deployments."
+        )
     if raw_auth_type == "disabled":
-        logger.warning("AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration.")
+        logger.warning(
+            "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
+        )
 
     logger.notice(f"Using Auth Type: {AUTH_TYPE.value}")
 
@@ -265,7 +269,9 @@ def verify_email_is_invited(email: str) -> None:
         try:
             # normalized emails are now being inserted into the db
             # we can remove this normalization on read after some time has passed
-            email_info_whitelist = validate_email(email_whitelist, check_deliverability=False)
+            email_info_whitelist = validate_email(
+                email_whitelist, check_deliverability=False
+            )
         except EmailNotValidError:
             continue
 
@@ -337,9 +343,9 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
     if MULTI_TENANT:
         return
 
-    result = fetch_ee_implementation_or_noop("onyx.db.license", "check_seat_availability", None)(
-        db_session, seats_needed=seats_needed
-    )
+    result = fetch_ee_implementation_or_noop(
+        "onyx.db.license", "check_seat_availability", None
+    )(db_session, seats_needed=seats_needed)
 
     if result is not None and not result.available:
         raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message)
@@ -352,12 +358,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     user_db: SQLAlchemyUserDatabase[User, uuid.UUID]
 
     async def get_by_email(self, user_email: str) -> User:
-        tenant_id = fetch_ee_implementation_or_noop("onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None)(
-            user_email
-        )
+        tenant_id = fetch_ee_implementation_or_noop(
+            "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
+        )(user_email)
         async with get_async_session_context_manager(tenant_id) as db_session:
             if MULTI_TENANT:
-                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
+                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
+                    db_session, User, OAuthAccount
+                )
                 user = await tenant_user_db.get_by_email(user_email)
             else:
                 user = await self.user_db.get_by_email(user_email)
@@ -380,7 +388,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         except OnyxError as e:
             # Log blocked disposable email attempts
             if "Disposable email" in e.detail:
-                domain = user_create.email.split("@")[-1] if "@" in user_create.email else "unknown"
+                domain = (
+                    user_create.email.split("@")[-1]
+                    if "@" in user_create.email
+                    else "unknown"
+                )
                 logger.warning(
                     f"Blocked disposable email registration attempt: {domain}",
                     extra={"email_domain": domain},
@@ -408,15 +420,23 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 captcha_token = request.headers.get("X-Captcha-Token")
 
             try:
-                await verify_captcha_token(captcha_token or "", expected_action="signup")
+                await verify_captcha_token(
+                    captcha_token or "", expected_action="signup"
+                )
             except CaptchaVerificationError as e:
                 raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
 
         # We verify the password here to make sure it's valid before we proceed
-        await self.validate_password(user_create.password, cast(schemas.UC, user_create))
+        await self.validate_password(
+            user_create.password, cast(schemas.UC, user_create)
+        )
 
         user_count: int | None = None
-        referral_source = request.cookies.get("referral_source", None) if request is not None else None
+        referral_source = (
+            request.cookies.get("referral_source", None)
+            if request is not None
+            else None
+        )
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
@@ -444,14 +464,19 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # Single-tenant: Check invite list (skips if SAML/OIDC or no list configured)
                     verify_email_is_invited(user_create.email)
                 if MULTI_TENANT:
-                    tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
+                    tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
+                        db_session, User, OAuthAccount
+                    )
                     self.user_db = tenant_user_db
 
                 if hasattr(user_create, "role"):
                     user_create.role = UserRole.BASIC  # ty: ignore[invalid-assignment]
 
                     user_count = await get_user_count()
-                    if user_count == 0 or user_create.email in get_default_admin_user_emails():
+                    if (
+                        user_count == 0
+                        or user_create.email in get_default_admin_user_emails()
+                    ):
                         user_create.role = (  # ty: ignore[invalid-assignment]
                             UserRole.ADMIN
                         )
@@ -541,7 +566,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
         return user
 
-    async def _assign_default_pinned_assistants(self, user: User, db_session: AsyncSession) -> None:
+    async def _assign_default_pinned_assistants(
+        self, user: User, db_session: AsyncSession
+    ) -> None:
         if user.pinned_assistants is not None:
             return
 
@@ -585,7 +612,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 .first()
             )
             if sync_user:
-                sync_user.hashed_password = self.password_helper.hash(user_create.password)
+                sync_user.hashed_password = self.password_helper.hash(
+                    user_create.password
+                )
                 sync_user.is_verified = user_create.is_verified or False
                 sync_user.role = user_create.role
                 sync_user.account_type = AccountType.STANDARD
@@ -606,16 +635,28 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     ) -> None:
         # Validate password according to configurable security policy (defined via environment variables)
         if len(password) < PASSWORD_MIN_LENGTH:
-            raise exceptions.InvalidPasswordException(reason=f"Password must be at least {PASSWORD_MIN_LENGTH} characters long.")
+            raise exceptions.InvalidPasswordException(
+                reason=f"Password must be at least {PASSWORD_MIN_LENGTH} characters long."
+            )
         if len(password) > PASSWORD_MAX_LENGTH:
-            raise exceptions.InvalidPasswordException(reason=f"Password must not exceed {PASSWORD_MAX_LENGTH} characters.")
+            raise exceptions.InvalidPasswordException(
+                reason=f"Password must not exceed {PASSWORD_MAX_LENGTH} characters."
+            )
         if PASSWORD_REQUIRE_UPPERCASE and not any(char.isupper() for char in password):
-            raise exceptions.InvalidPasswordException(reason="Password must contain at least one uppercase letter.")
+            raise exceptions.InvalidPasswordException(
+                reason="Password must contain at least one uppercase letter."
+            )
         if PASSWORD_REQUIRE_LOWERCASE and not any(char.islower() for char in password):
-            raise exceptions.InvalidPasswordException(reason="Password must contain at least one lowercase letter.")
+            raise exceptions.InvalidPasswordException(
+                reason="Password must contain at least one lowercase letter."
+            )
         if PASSWORD_REQUIRE_DIGIT and not any(char.isdigit() for char in password):
-            raise exceptions.InvalidPasswordException(reason="Password must contain at least one number.")
-        if PASSWORD_REQUIRE_SPECIAL_CHAR and not any(char in PASSWORD_SPECIAL_CHARS for char in password):
+            raise exceptions.InvalidPasswordException(
+                reason="Password must contain at least one number."
+            )
+        if PASSWORD_REQUIRE_SPECIAL_CHAR and not any(
+            char in PASSWORD_SPECIAL_CHARS for char in password
+        ):
             raise exceptions.InvalidPasswordException(
                 reason=f"Password must contain at least one special character from the following set: {PASSWORD_SPECIAL_CHARS}."
             )
@@ -635,7 +676,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> User:
-        referral_source = getattr(request.state, "referral_source", None) if request else None
+        referral_source = (
+            getattr(request.state, "referral_source", None) if request else None
+        )
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
@@ -661,7 +704,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # NOTE(rkuo): If this UserManager is instantiated per connection
             # should we even be doing this here?
             if MULTI_TENANT:
-                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
+                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
+                    db_session, User, OAuthAccount
+                )
                 self.user_db = tenant_user_db
 
             oauth_account_dict = {
@@ -688,7 +733,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
                     # Make sure user is not None before adding OAuth account
                     if user is not None:
-                        user = await self.user_db.add_oauth_account(user, oauth_account_dict)
+                        user = await self.user_db.add_oauth_account(
+                            user, oauth_account_dict
+                        )
                     else:
                         # This shouldn't happen since get_by_email would raise UserNotExists
                         # but adding as a safeguard
@@ -718,7 +765,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 # User exists, update OAuth account if needed
                 if user is not None:  # Add explicit check
                     for existing_oauth_account in user.oauth_accounts:
-                        if existing_oauth_account.account_id == account_id and existing_oauth_account.oauth_name == oauth_name:
+                        if (
+                            existing_oauth_account.account_id == account_id
+                            and existing_oauth_account.oauth_name == oauth_name
+                        ):
                             user = await self.user_db.update_oauth_account(
                                 user,
                                 # NOTE: OAuthAccount DOES implement the OAuthAccountProtocol
@@ -731,7 +781,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # re-authenticate that frequently, so by default this is disabled
             if expires_at and TRACK_EXTERNAL_IDP_EXPIRY:
                 oidc_expiry = datetime.fromtimestamp(expires_at, tz=timezone.utc)
-                await self.user_db.update(user, update_dict={"oidc_expiry": oidc_expiry})
+                await self.user_db.update(
+                    user, update_dict={"oidc_expiry": oidc_expiry}
+                )
 
             # Handle case where user has used product outside of web and is now creating an account through web
             if not user.account_type.is_web_login():
@@ -817,7 +869,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             properties={"email": user.email, "tenant_id": tenant_id},
         )
 
-    async def on_after_register(self, user: User, request: Optional[Request] = None) -> None:
+    async def on_after_register(
+        self, user: User, request: Optional[Request] = None
+    ) -> None:
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
             "get_or_provision_tenant",
@@ -862,7 +916,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # otherwise get_session_with_current_tenant() targets the wrong schema.
             is_admin = user_count == 1 or user.email in get_default_admin_user_emails()
             with get_session_with_current_tenant() as db_session:
-                assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
+                assign_user_to_default_groups__no_commit(
+                    db_session, user, is_admin=is_admin
+                )
                 db_session.commit()
 
         finally:
@@ -892,9 +948,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             and (marketing_cookie_value := request.cookies.get(marketing_cookie_name))
             and (parsed_cookie := parse_posthog_cookie(marketing_cookie_value))
         ):
-            marketing_anonymous_id = parsed_cookie[  # ty: ignore[possibly-unresolved-reference]
-                "distinct_id"
-            ]
+            marketing_anonymous_id = (
+                parsed_cookie[  # ty: ignore[possibly-unresolved-reference]
+                    "distinct_id"
+                ]
+            )
 
             # Technically, USER_SIGNED_UP is only fired from the cloud site when
             # it is the first user in a tenant. However, it is semantically correct
@@ -938,7 +996,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         request: Optional[Request] = None,  # noqa: ARG002
     ) -> None:
         if not EMAIL_CONFIGURED:
-            logger.error("Email is not configured. Please configure email in the admin panel")
+            logger.error(
+                "Email is not configured. Please configure email in the admin panel"
+            )
             raise HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 "Your admin has not enabled this feature.",
@@ -959,12 +1019,18 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     ) -> None:
         verify_email_domain(user.email)
 
-        logger.notice(f"Verification requested for user {user.id}. Verification token: {token}")
+        logger.notice(
+            f"Verification requested for user {user.id}. Verification token: {token}"
+        )
         user_count = await get_user_count()
-        send_user_verification_email(user.email, token, new_organization=user_count == 1)
+        send_user_verification_email(
+            user.email, token, new_organization=user_count == 1
+        )
 
     @log_function_time(print_only=True)
-    async def authenticate(self, credentials: OAuth2PasswordRequestForm) -> Optional[User]:
+    async def authenticate(
+        self, credentials: OAuth2PasswordRequestForm
+    ) -> Optional[User]:
         email = credentials.username
 
         tenant_id: str | None = None
@@ -977,7 +1043,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 email=email,
             )
         except Exception as e:
-            logger.warning(f"User attempted to login with invalid credentials: {str(e)}")
+            logger.warning(
+                f"User attempted to login with invalid credentials: {str(e)}"
+            )
 
         if not tenant_id:
             # User not found in mapping
@@ -986,7 +1054,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         # Create a tenant-specific session
         async with get_async_session_context_manager(tenant_id) as tenant_session:
-            tenant_user_db: SQLAlchemyUserDatabase = SQLAlchemyUserDatabase(tenant_session, User)
+            tenant_user_db: SQLAlchemyUserDatabase = SQLAlchemyUserDatabase(
+                tenant_session, User
+            )
             self.user_db = tenant_user_db
 
             # Proceed with authentication
@@ -1002,12 +1072,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     detail="NO_WEB_LOGIN_AND_HAS_NO_PASSWORD",
                 )
 
-            verified, updated_password_hash = self.password_helper.verify_and_update(credentials.password, user.hashed_password)
+            verified, updated_password_hash = self.password_helper.verify_and_update(
+                credentials.password, user.hashed_password
+            )
             if not verified:
                 return None
 
             if updated_password_hash is not None:
-                await self.user_db.update(user, {"hashed_password": updated_password_hash})
+                await self.user_db.update(
+                    user, {"hashed_password": updated_password_hash}
+                )
 
             return user
 
@@ -1018,12 +1092,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         await self._update(user, {"password": new_password})
         return new_password
 
-    async def change_password_if_old_matches(self, user: User, old_password: str, new_password: str) -> None:
+    async def change_password_if_old_matches(
+        self, user: User, old_password: str, new_password: str
+    ) -> None:
         """
         For normal users to change password if they know the old one.
         Raises 400 if old password doesn't match.
         """
-        verified, updated_password_hash = self.password_helper.verify_and_update(old_password, user.hashed_password)
+        verified, updated_password_hash = self.password_helper.verify_and_update(
+            old_password, user.hashed_password
+        )
         if not verified:
             # Raise some HTTPException (or your custom exception) if old password is invalid:
             from fastapi import HTTPException, status
@@ -1105,7 +1183,9 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
         )
         return token
 
-    async def read_token(self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]) -> Optional[User]:
+    async def read_token(
+        self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]
+    ) -> Optional[User]:
         redis = await get_async_redis_connection()
         token_data_str = await redis.get(f"{self.key_prefix}{token}")
         if not token_data_str:
@@ -1174,7 +1254,9 @@ class RefreshableDatabaseStrategy(DatabaseStrategy[User, uuid.UUID, AccessToken]
             return await self.write_token(user)
 
         # Update expiration time
-        new_expires = datetime.now(timezone.utc) + timedelta(seconds=float(self.lifetime_seconds or SESSION_EXPIRE_TIME_SECONDS))
+        new_expires = datetime.now(timezone.utc) + timedelta(
+            seconds=float(self.lifetime_seconds or SESSION_EXPIRE_TIME_SECONDS)
+        )
         await self._access_token_db.update(access_token, {"expires": new_expires})
 
         return token
@@ -1215,7 +1297,9 @@ class SingleTenantJWTStrategy(JWTStrategy[User, uuid.UUID]):
             "aud": self.token_audience,
             "iat": int(datetime.now(timezone.utc).timestamp()),
         }
-        return generate_jwt(data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm)
+        return generate_jwt(
+            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm
+        )
 
     async def destroy_token(self, token: str, user: User) -> None:  # noqa: ARG002
         # JWTs are stateless — nothing to invalidate server-side.
@@ -1242,7 +1326,9 @@ def get_redis_strategy() -> TenantAwareRedisStrategy:
 def get_database_strategy(
     access_token_db: AccessTokenDatabase[AccessToken] = Depends(get_access_token_db),
 ) -> RefreshableDatabaseStrategy:
-    return RefreshableDatabaseStrategy(access_token_db, lifetime_seconds=SESSION_EXPIRE_TIME_SECONDS)
+    return RefreshableDatabaseStrategy(
+        access_token_db, lifetime_seconds=SESSION_EXPIRE_TIME_SECONDS
+    )
 
 
 def get_jwt_strategy() -> SingleTenantJWTStrategy:
@@ -1261,11 +1347,17 @@ if AUTH_BACKEND == AuthBackend.JWT:
         raise ValueError("USER_AUTH_SECRET is required for JWT auth backend.")
 
 if AUTH_BACKEND == AuthBackend.REDIS:
-    auth_backend = AuthenticationBackend(name="redis", transport=cookie_transport, get_strategy=get_redis_strategy)
+    auth_backend = AuthenticationBackend(
+        name="redis", transport=cookie_transport, get_strategy=get_redis_strategy
+    )
 elif AUTH_BACKEND == AuthBackend.POSTGRES:
-    auth_backend = AuthenticationBackend(name="postgres", transport=cookie_transport, get_strategy=get_database_strategy)
+    auth_backend = AuthenticationBackend(
+        name="postgres", transport=cookie_transport, get_strategy=get_database_strategy
+    )
 elif AUTH_BACKEND == AuthBackend.JWT:
-    auth_backend = AuthenticationBackend(name="jwt", transport=cookie_transport, get_strategy=get_jwt_strategy)
+    auth_backend = AuthenticationBackend(
+        name="jwt", transport=cookie_transport, get_strategy=get_jwt_strategy
+    )
 else:
     raise ValueError(f"Invalid auth backend: {AUTH_BACKEND}")
 
@@ -1282,14 +1374,22 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
         """
         router = APIRouter()
 
-        get_current_user_token = self.authenticator.current_user_token(active=True, verified=requires_verification)
+        get_current_user_token = self.authenticator.current_user_token(
+            active=True, verified=requires_verification
+        )
 
         logout_responses: OpenAPIResponseType = {
-            **{status.HTTP_401_UNAUTHORIZED: {"description": "Missing token or inactive user."}},
+            **{
+                status.HTTP_401_UNAUTHORIZED: {
+                    "description": "Missing token or inactive user."
+                }
+            },
             **backend.transport.get_openapi_logout_responses_success(),
         }
 
-        @router.post("/logout", name=f"auth:{backend.name}.logout", responses=logout_responses)
+        @router.post(
+            "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
+        )
         async def logout(
             user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
             strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
@@ -1312,18 +1412,28 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
 
         router = APIRouter()
 
-        get_current_user_token = self.authenticator.current_user_token(active=True, verified=requires_verification)
+        get_current_user_token = self.authenticator.current_user_token(
+            active=True, verified=requires_verification
+        )
 
         refresh_responses: OpenAPIResponseType = {
-            **{status.HTTP_401_UNAUTHORIZED: {"description": "Missing token or inactive user."}},
+            **{
+                status.HTTP_401_UNAUTHORIZED: {
+                    "description": "Missing token or inactive user."
+                }
+            },
             **backend.transport.get_openapi_login_responses_success(),
         }
 
-        @router.post("/refresh", name=f"auth:{backend.name}.refresh", responses=refresh_responses)
+        @router.post(
+            "/refresh", name=f"auth:{backend.name}.refresh", responses=refresh_responses
+        )
         async def refresh(
             user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
             strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
-            user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+            user_manager: BaseUserManager[models.UP, models.ID] = Depends(
+                get_user_manager
+            ),
             db_session: AsyncSession = Depends(get_async_session),
         ) -> Response:
             try:
@@ -1338,13 +1448,17 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
                 )
 
                 # Check if strategy supports refreshing
-                supports_refresh = hasattr(strategy, "refresh_token") and callable(getattr(strategy, "refresh_token"))
+                supports_refresh = hasattr(strategy, "refresh_token") and callable(
+                    getattr(strategy, "refresh_token")
+                )
 
                 if supports_refresh:
                     try:
                         refresh_method = getattr(strategy, "refresh_token")
                         new_token = await refresh_method(token, user)
-                        logger.info(f"Successfully refreshed session token for user {user.email}")
+                        logger.info(
+                            f"Successfully refreshed session token for user {user.email}"
+                        )
                         return await backend.transport.get_login_response(new_token)
                     except Exception as e:
                         logger.error(f"Error refreshing session token: {str(e)}")
@@ -1353,7 +1467,9 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
                         return await backend.login(strategy, user)
 
                 # Fallback: logout and login again
-                logger.info("Strategy doesn't support refresh - using logout/login flow")
+                logger.info(
+                    "Strategy doesn't support refresh - using logout/login flow"
+                )
                 await backend.logout(strategy, user, token)
                 return await backend.login(strategy, user)
             except Exception as e:
@@ -1366,7 +1482,9 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
         return router
 
 
-fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](get_user_manager, [auth_backend])
+fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](
+    get_user_manager, [auth_backend]
+)
 
 
 # NOTE: verified=REQUIRE_EMAIL_VERIFICATION is not used here since we
@@ -1393,7 +1511,9 @@ def _extract_email_from_jwt(payload: dict[str, Any]) -> str | None:
     return None
 
 
-async def _sync_jwt_oidc_expiry(user_manager: UserManager, user: User, payload: dict[str, Any]) -> None:
+async def _sync_jwt_oidc_expiry(
+    user_manager: UserManager, user: User, payload: dict[str, Any]
+) -> None:
     if TRACK_EXTERNAL_IDP_EXPIRY:
         expires_at = payload.get("exp")
         if expires_at is None:
@@ -1424,14 +1544,18 @@ async def _get_or_create_user_from_jwt(
 ) -> User | None:
     email = _extract_email_from_jwt(payload)
     if email is None:
-        logger.warning("JWT token decoded successfully but no email claim found; skipping auth")
+        logger.warning(
+            "JWT token decoded successfully but no email claim found; skipping auth"
+        )
         return None
 
     # Enforce the same allowlist/domain policies as other auth flows
     verify_email_is_invited(email)
     verify_email_domain(email)
 
-    user_db: SQLAlchemyUserAdminDB[User, uuid.UUID] = SQLAlchemyUserAdminDB(async_db_session, User, OAuthAccount)
+    user_db: SQLAlchemyUserAdminDB[User, uuid.UUID] = SQLAlchemyUserAdminDB(
+        async_db_session, User, OAuthAccount
+    )
     user_manager = UserManager(user_db)
 
     try:
@@ -1483,7 +1607,9 @@ async def _check_for_saml_and_jwt(
             token = auth_header[len("Bearer ") :].strip()
             payload = await verify_jwt_token(token)
             if payload is not None:
-                user = await _get_or_create_user_from_jwt(payload, request, async_db_session)
+                user = await _get_or_create_user_from_jwt(
+                    payload, request, async_db_session
+                )
 
     return user
 
@@ -1539,7 +1665,11 @@ async def double_check_user(
                 detail="Access denied. User is not verified.",
             )
 
-        if user.oidc_expiry and user.oidc_expiry < datetime.now(timezone.utc) and not include_expired:
+        if (
+            user.oidc_expiry
+            and user.oidc_expiry < datetime.now(timezone.utc)
+            and not include_expired
+        ):
             raise BasicAuthenticationError(
                 detail="Access denied. User's OIDC token has expired.",
             )
@@ -1571,7 +1701,9 @@ async def current_chat_accessible_user(
 ) -> User:
     tenant_id = get_current_tenant_id()
 
-    return await double_check_user(user, allow_anonymous_access=anonymous_user_enabled(tenant_id=tenant_id))
+    return await double_check_user(
+        user, allow_anonymous_access=anonymous_user_enabled(tenant_id=tenant_id)
+    )
 
 
 async def current_user(
@@ -1684,18 +1816,24 @@ async def current_user_from_websocket(
     try:
         token_data = await retrieve_ws_token_data(token)
         if token_data is None:
-            raise BasicAuthenticationError(detail="Access denied. Invalid or expired authentication token.")
+            raise BasicAuthenticationError(
+                detail="Access denied. Invalid or expired authentication token."
+            )
     except BasicAuthenticationError:
         raise
     except Exception as e:
         logger.error(f"WS auth: error during token validation: {e}")
-        raise BasicAuthenticationError(detail="Authentication verification failed.") from e
+        raise BasicAuthenticationError(
+            detail="Authentication verification failed."
+        ) from e
 
     # Get user from token data
     user = await _get_user_from_token_data(token_data)
     if user is None:
         logger.warning(f"WS auth: user not found for id={token_data.get('sub')}")
-        raise BasicAuthenticationError(detail="Access denied. User not found or inactive.")
+        raise BasicAuthenticationError(
+            detail="Access denied. User not found or inactive."
+        )
 
     # Apply same checks as HTTP auth (verification, OIDC expiry, role)
     user = await double_check_user(user)
@@ -1813,7 +1951,9 @@ def get_oauth_router(
     async def null_access_token_state() -> tuple[OAuth2Token, Optional[str]] | None:
         return None
 
-    access_token_state_dependency = oauth2_authorize_callback if not enable_pkce else null_access_token_state
+    access_token_state_dependency = (
+        oauth2_authorize_callback if not enable_pkce else null_access_token_state
+    )
 
     if csrf_token_cookie_secure is None:
         csrf_token_cookie_secure = WEB_DOMAIN.startswith("https")
@@ -1871,7 +2011,9 @@ def get_oauth_router(
 
         # For Google OAuth, add parameters to request refresh tokens
         if oauth_client.name == "google":
-            authorization_url = add_url_params(authorization_url, {"access_type": "offline", "prompt": "consent"})
+            authorization_url = add_url_params(
+                authorization_url, {"access_type": "offline", "prompt": "consent"}
+            )
 
         def set_oauth_cookie(
             target_response: Response,
@@ -1941,7 +2083,9 @@ def get_oauth_router(
     )
     async def callback(
         request: Request,
-        access_token_state: Tuple[OAuth2Token, Optional[str]] | None = Depends(access_token_state_dependency),
+        access_token_state: Tuple[OAuth2Token, Optional[str]] | None = Depends(
+            access_token_state_dependency
+        ),
         code: Optional[str] = None,
         state: Optional[str] = None,
         error: Optional[str] = None,
@@ -1969,7 +2113,9 @@ def get_oauth_router(
 
         def decode_and_validate_state(state_value: str) -> Dict[str, str]:
             try:
-                state_data = decode_jwt(state_value, state_secret, [STATE_TOKEN_AUDIENCE])
+                state_data = decode_jwt(
+                    state_value, state_secret, [STATE_TOKEN_AUDIENCE]
+                )
             except jwt.DecodeError:
                 raise OnyxError(
                     OnyxErrorCode.VALIDATION_ERROR,
@@ -2000,7 +2146,11 @@ def get_oauth_router(
 
             cookie_csrf_token = request.cookies.get(csrf_token_cookie_name)
             state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
-            if not cookie_csrf_token or not state_csrf_token or not secrets.compare_digest(cookie_csrf_token, state_csrf_token):
+            if (
+                not cookie_csrf_token
+                or not state_csrf_token
+                or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
+            ):
                 raise OnyxError(
                     OnyxErrorCode.VALIDATION_ERROR,
                     getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
@@ -2062,7 +2212,9 @@ def get_oauth_router(
                 return build_error_response(e)
 
             try:
-                token = await oauth_client.get_access_token(code, callback_redirect_url, code_verifier)
+                token = await oauth_client.get_access_token(
+                    code, callback_redirect_url, code_verifier
+                )
             except GetAccessTokenError:
                 return build_error_response(
                     OnyxError(
@@ -2072,7 +2224,9 @@ def get_oauth_router(
                 )
         else:
             if access_token_state is None:
-                raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Missing OAuth callback state")
+                raise OnyxError(
+                    OnyxErrorCode.INTERNAL_ERROR, "Missing OAuth callback state"
+                )
             token, callback_state = access_token_state
             if callback_state is None:
                 raise OnyxError(
@@ -2081,8 +2235,12 @@ def get_oauth_router(
                 )
             state_data = decode_and_validate_state(callback_state)
 
-        async def complete_login_flow(token: OAuth2Token, state_data: Dict[str, str]) -> RedirectResponse:
-            account_id, account_email = await oauth_client.get_id_email(token["access_token"])
+        async def complete_login_flow(
+            token: OAuth2Token, state_data: Dict[str, str]
+        ) -> RedirectResponse:
+            account_id, account_email = await oauth_client.get_id_email(
+                token["access_token"]
+            )
 
             if account_email is None:
                 raise OnyxError(
@@ -2093,9 +2251,9 @@ def get_oauth_router(
             next_url = state_data.get("next_url", "/")
             referral_source = state_data.get("referral_source", None)
             try:
-                tenant_id = fetch_ee_implementation_or_noop("onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None)(
-                    account_email
-                )
+                tenant_id = fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
+                )(account_email)
             except exceptions.UserNotExists:
                 tenant_id = None
 
@@ -2134,7 +2292,9 @@ def get_oauth_router(
             if tenant_id is None:
                 # Use URL utility to add parameters
                 redirect_destination = add_url_params(next_url, {"new_team": "true"})
-                redirect_response = RedirectResponse(redirect_destination, status_code=302)
+                redirect_response = RedirectResponse(
+                    redirect_destination, status_code=302
+                )
             else:
                 # No parameters to add
                 redirect_response = RedirectResponse(next_url, status_code=302)

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -399,8 +399,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 )
             raise
 
-        # Per-IP rate limit (cloud only). Runs before captcha so over-limit
-        # clients don't consume a Google siteverify call.
         if request is not None:
             await enforce_signup_rate_limit(request)
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -82,6 +82,7 @@ from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
+from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
 from onyx.configs.app_configs import AUTH_TYPE
@@ -171,13 +172,9 @@ def verify_auth_setting() -> None:
     raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
 
     if raw_auth_type == "cloud":
-        raise ValueError(
-            "'cloud' is not a valid auth type for self-hosted deployments."
-        )
+        raise ValueError("'cloud' is not a valid auth type for self-hosted deployments.")
     if raw_auth_type == "disabled":
-        logger.warning(
-            "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
-        )
+        logger.warning("AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration.")
 
     logger.notice(f"Using Auth Type: {AUTH_TYPE.value}")
 
@@ -268,9 +265,7 @@ def verify_email_is_invited(email: str) -> None:
         try:
             # normalized emails are now being inserted into the db
             # we can remove this normalization on read after some time has passed
-            email_info_whitelist = validate_email(
-                email_whitelist, check_deliverability=False
-            )
+            email_info_whitelist = validate_email(email_whitelist, check_deliverability=False)
         except EmailNotValidError:
             continue
 
@@ -342,9 +337,9 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
     if MULTI_TENANT:
         return
 
-    result = fetch_ee_implementation_or_noop(
-        "onyx.db.license", "check_seat_availability", None
-    )(db_session, seats_needed=seats_needed)
+    result = fetch_ee_implementation_or_noop("onyx.db.license", "check_seat_availability", None)(
+        db_session, seats_needed=seats_needed
+    )
 
     if result is not None and not result.available:
         raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message)
@@ -357,14 +352,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     user_db: SQLAlchemyUserDatabase[User, uuid.UUID]
 
     async def get_by_email(self, user_email: str) -> User:
-        tenant_id = fetch_ee_implementation_or_noop(
-            "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
-        )(user_email)
+        tenant_id = fetch_ee_implementation_or_noop("onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None)(
+            user_email
+        )
         async with get_async_session_context_manager(tenant_id) as db_session:
             if MULTI_TENANT:
-                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
-                    db_session, User, OAuthAccount
-                )
+                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
                 user = await tenant_user_db.get_by_email(user_email)
             else:
                 user = await self.user_db.get_by_email(user_email)
@@ -387,16 +380,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         except OnyxError as e:
             # Log blocked disposable email attempts
             if "Disposable email" in e.detail:
-                domain = (
-                    user_create.email.split("@")[-1]
-                    if "@" in user_create.email
-                    else "unknown"
-                )
+                domain = user_create.email.split("@")[-1] if "@" in user_create.email else "unknown"
                 logger.warning(
                     f"Blocked disposable email registration attempt: {domain}",
                     extra={"email_domain": domain},
                 )
             raise
+
+        # Per-IP rate limit (cloud only). Runs before captcha so over-limit
+        # clients don't consume a Google siteverify call.
+        if request is not None:
+            await enforce_signup_rate_limit(request)
 
         # Verify captcha if enabled (for cloud signup protection)
         from onyx.auth.captcha import CaptchaVerificationError
@@ -414,23 +408,15 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 captcha_token = request.headers.get("X-Captcha-Token")
 
             try:
-                await verify_captcha_token(
-                    captcha_token or "", expected_action="signup"
-                )
+                await verify_captcha_token(captcha_token or "", expected_action="signup")
             except CaptchaVerificationError as e:
                 raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
 
         # We verify the password here to make sure it's valid before we proceed
-        await self.validate_password(
-            user_create.password, cast(schemas.UC, user_create)
-        )
+        await self.validate_password(user_create.password, cast(schemas.UC, user_create))
 
         user_count: int | None = None
-        referral_source = (
-            request.cookies.get("referral_source", None)
-            if request is not None
-            else None
-        )
+        referral_source = request.cookies.get("referral_source", None) if request is not None else None
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
@@ -458,19 +444,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # Single-tenant: Check invite list (skips if SAML/OIDC or no list configured)
                     verify_email_is_invited(user_create.email)
                 if MULTI_TENANT:
-                    tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
-                        db_session, User, OAuthAccount
-                    )
+                    tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
                     self.user_db = tenant_user_db
 
                 if hasattr(user_create, "role"):
                     user_create.role = UserRole.BASIC  # ty: ignore[invalid-assignment]
 
                     user_count = await get_user_count()
-                    if (
-                        user_count == 0
-                        or user_create.email in get_default_admin_user_emails()
-                    ):
+                    if user_count == 0 or user_create.email in get_default_admin_user_emails():
                         user_create.role = (  # ty: ignore[invalid-assignment]
                             UserRole.ADMIN
                         )
@@ -560,9 +541,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
         return user
 
-    async def _assign_default_pinned_assistants(
-        self, user: User, db_session: AsyncSession
-    ) -> None:
+    async def _assign_default_pinned_assistants(self, user: User, db_session: AsyncSession) -> None:
         if user.pinned_assistants is not None:
             return
 
@@ -606,9 +585,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 .first()
             )
             if sync_user:
-                sync_user.hashed_password = self.password_helper.hash(
-                    user_create.password
-                )
+                sync_user.hashed_password = self.password_helper.hash(user_create.password)
                 sync_user.is_verified = user_create.is_verified or False
                 sync_user.role = user_create.role
                 sync_user.account_type = AccountType.STANDARD
@@ -629,28 +606,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     ) -> None:
         # Validate password according to configurable security policy (defined via environment variables)
         if len(password) < PASSWORD_MIN_LENGTH:
-            raise exceptions.InvalidPasswordException(
-                reason=f"Password must be at least {PASSWORD_MIN_LENGTH} characters long."
-            )
+            raise exceptions.InvalidPasswordException(reason=f"Password must be at least {PASSWORD_MIN_LENGTH} characters long.")
         if len(password) > PASSWORD_MAX_LENGTH:
-            raise exceptions.InvalidPasswordException(
-                reason=f"Password must not exceed {PASSWORD_MAX_LENGTH} characters."
-            )
+            raise exceptions.InvalidPasswordException(reason=f"Password must not exceed {PASSWORD_MAX_LENGTH} characters.")
         if PASSWORD_REQUIRE_UPPERCASE and not any(char.isupper() for char in password):
-            raise exceptions.InvalidPasswordException(
-                reason="Password must contain at least one uppercase letter."
-            )
+            raise exceptions.InvalidPasswordException(reason="Password must contain at least one uppercase letter.")
         if PASSWORD_REQUIRE_LOWERCASE and not any(char.islower() for char in password):
-            raise exceptions.InvalidPasswordException(
-                reason="Password must contain at least one lowercase letter."
-            )
+            raise exceptions.InvalidPasswordException(reason="Password must contain at least one lowercase letter.")
         if PASSWORD_REQUIRE_DIGIT and not any(char.isdigit() for char in password):
-            raise exceptions.InvalidPasswordException(
-                reason="Password must contain at least one number."
-            )
-        if PASSWORD_REQUIRE_SPECIAL_CHAR and not any(
-            char in PASSWORD_SPECIAL_CHARS for char in password
-        ):
+            raise exceptions.InvalidPasswordException(reason="Password must contain at least one number.")
+        if PASSWORD_REQUIRE_SPECIAL_CHAR and not any(char in PASSWORD_SPECIAL_CHARS for char in password):
             raise exceptions.InvalidPasswordException(
                 reason=f"Password must contain at least one special character from the following set: {PASSWORD_SPECIAL_CHARS}."
             )
@@ -670,9 +635,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
     ) -> User:
-        referral_source = (
-            getattr(request.state, "referral_source", None) if request else None
-        )
+        referral_source = getattr(request.state, "referral_source", None) if request else None
 
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
@@ -698,9 +661,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # NOTE(rkuo): If this UserManager is instantiated per connection
             # should we even be doing this here?
             if MULTI_TENANT:
-                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
-                    db_session, User, OAuthAccount
-                )
+                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](db_session, User, OAuthAccount)
                 self.user_db = tenant_user_db
 
             oauth_account_dict = {
@@ -727,9 +688,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
                     # Make sure user is not None before adding OAuth account
                     if user is not None:
-                        user = await self.user_db.add_oauth_account(
-                            user, oauth_account_dict
-                        )
+                        user = await self.user_db.add_oauth_account(user, oauth_account_dict)
                     else:
                         # This shouldn't happen since get_by_email would raise UserNotExists
                         # but adding as a safeguard
@@ -759,10 +718,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 # User exists, update OAuth account if needed
                 if user is not None:  # Add explicit check
                     for existing_oauth_account in user.oauth_accounts:
-                        if (
-                            existing_oauth_account.account_id == account_id
-                            and existing_oauth_account.oauth_name == oauth_name
-                        ):
+                        if existing_oauth_account.account_id == account_id and existing_oauth_account.oauth_name == oauth_name:
                             user = await self.user_db.update_oauth_account(
                                 user,
                                 # NOTE: OAuthAccount DOES implement the OAuthAccountProtocol
@@ -775,9 +731,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # re-authenticate that frequently, so by default this is disabled
             if expires_at and TRACK_EXTERNAL_IDP_EXPIRY:
                 oidc_expiry = datetime.fromtimestamp(expires_at, tz=timezone.utc)
-                await self.user_db.update(
-                    user, update_dict={"oidc_expiry": oidc_expiry}
-                )
+                await self.user_db.update(user, update_dict={"oidc_expiry": oidc_expiry})
 
             # Handle case where user has used product outside of web and is now creating an account through web
             if not user.account_type.is_web_login():
@@ -863,9 +817,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             properties={"email": user.email, "tenant_id": tenant_id},
         )
 
-    async def on_after_register(
-        self, user: User, request: Optional[Request] = None
-    ) -> None:
+    async def on_after_register(self, user: User, request: Optional[Request] = None) -> None:
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
             "get_or_provision_tenant",
@@ -910,9 +862,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             # otherwise get_session_with_current_tenant() targets the wrong schema.
             is_admin = user_count == 1 or user.email in get_default_admin_user_emails()
             with get_session_with_current_tenant() as db_session:
-                assign_user_to_default_groups__no_commit(
-                    db_session, user, is_admin=is_admin
-                )
+                assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
                 db_session.commit()
 
         finally:
@@ -942,11 +892,9 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             and (marketing_cookie_value := request.cookies.get(marketing_cookie_name))
             and (parsed_cookie := parse_posthog_cookie(marketing_cookie_value))
         ):
-            marketing_anonymous_id = (
-                parsed_cookie[  # ty: ignore[possibly-unresolved-reference]
-                    "distinct_id"
-                ]
-            )
+            marketing_anonymous_id = parsed_cookie[  # ty: ignore[possibly-unresolved-reference]
+                "distinct_id"
+            ]
 
             # Technically, USER_SIGNED_UP is only fired from the cloud site when
             # it is the first user in a tenant. However, it is semantically correct
@@ -990,9 +938,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         request: Optional[Request] = None,  # noqa: ARG002
     ) -> None:
         if not EMAIL_CONFIGURED:
-            logger.error(
-                "Email is not configured. Please configure email in the admin panel"
-            )
+            logger.error("Email is not configured. Please configure email in the admin panel")
             raise HTTPException(
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
                 "Your admin has not enabled this feature.",
@@ -1013,18 +959,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     ) -> None:
         verify_email_domain(user.email)
 
-        logger.notice(
-            f"Verification requested for user {user.id}. Verification token: {token}"
-        )
+        logger.notice(f"Verification requested for user {user.id}. Verification token: {token}")
         user_count = await get_user_count()
-        send_user_verification_email(
-            user.email, token, new_organization=user_count == 1
-        )
+        send_user_verification_email(user.email, token, new_organization=user_count == 1)
 
     @log_function_time(print_only=True)
-    async def authenticate(
-        self, credentials: OAuth2PasswordRequestForm
-    ) -> Optional[User]:
+    async def authenticate(self, credentials: OAuth2PasswordRequestForm) -> Optional[User]:
         email = credentials.username
 
         tenant_id: str | None = None
@@ -1037,9 +977,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 email=email,
             )
         except Exception as e:
-            logger.warning(
-                f"User attempted to login with invalid credentials: {str(e)}"
-            )
+            logger.warning(f"User attempted to login with invalid credentials: {str(e)}")
 
         if not tenant_id:
             # User not found in mapping
@@ -1048,9 +986,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         # Create a tenant-specific session
         async with get_async_session_context_manager(tenant_id) as tenant_session:
-            tenant_user_db: SQLAlchemyUserDatabase = SQLAlchemyUserDatabase(
-                tenant_session, User
-            )
+            tenant_user_db: SQLAlchemyUserDatabase = SQLAlchemyUserDatabase(tenant_session, User)
             self.user_db = tenant_user_db
 
             # Proceed with authentication
@@ -1066,16 +1002,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     detail="NO_WEB_LOGIN_AND_HAS_NO_PASSWORD",
                 )
 
-            verified, updated_password_hash = self.password_helper.verify_and_update(
-                credentials.password, user.hashed_password
-            )
+            verified, updated_password_hash = self.password_helper.verify_and_update(credentials.password, user.hashed_password)
             if not verified:
                 return None
 
             if updated_password_hash is not None:
-                await self.user_db.update(
-                    user, {"hashed_password": updated_password_hash}
-                )
+                await self.user_db.update(user, {"hashed_password": updated_password_hash})
 
             return user
 
@@ -1086,16 +1018,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         await self._update(user, {"password": new_password})
         return new_password
 
-    async def change_password_if_old_matches(
-        self, user: User, old_password: str, new_password: str
-    ) -> None:
+    async def change_password_if_old_matches(self, user: User, old_password: str, new_password: str) -> None:
         """
         For normal users to change password if they know the old one.
         Raises 400 if old password doesn't match.
         """
-        verified, updated_password_hash = self.password_helper.verify_and_update(
-            old_password, user.hashed_password
-        )
+        verified, updated_password_hash = self.password_helper.verify_and_update(old_password, user.hashed_password)
         if not verified:
             # Raise some HTTPException (or your custom exception) if old password is invalid:
             from fastapi import HTTPException, status
@@ -1177,9 +1105,7 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
         )
         return token
 
-    async def read_token(
-        self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]
-    ) -> Optional[User]:
+    async def read_token(self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]) -> Optional[User]:
         redis = await get_async_redis_connection()
         token_data_str = await redis.get(f"{self.key_prefix}{token}")
         if not token_data_str:
@@ -1248,9 +1174,7 @@ class RefreshableDatabaseStrategy(DatabaseStrategy[User, uuid.UUID, AccessToken]
             return await self.write_token(user)
 
         # Update expiration time
-        new_expires = datetime.now(timezone.utc) + timedelta(
-            seconds=float(self.lifetime_seconds or SESSION_EXPIRE_TIME_SECONDS)
-        )
+        new_expires = datetime.now(timezone.utc) + timedelta(seconds=float(self.lifetime_seconds or SESSION_EXPIRE_TIME_SECONDS))
         await self._access_token_db.update(access_token, {"expires": new_expires})
 
         return token
@@ -1291,9 +1215,7 @@ class SingleTenantJWTStrategy(JWTStrategy[User, uuid.UUID]):
             "aud": self.token_audience,
             "iat": int(datetime.now(timezone.utc).timestamp()),
         }
-        return generate_jwt(
-            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm
-        )
+        return generate_jwt(data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm)
 
     async def destroy_token(self, token: str, user: User) -> None:  # noqa: ARG002
         # JWTs are stateless — nothing to invalidate server-side.
@@ -1320,9 +1242,7 @@ def get_redis_strategy() -> TenantAwareRedisStrategy:
 def get_database_strategy(
     access_token_db: AccessTokenDatabase[AccessToken] = Depends(get_access_token_db),
 ) -> RefreshableDatabaseStrategy:
-    return RefreshableDatabaseStrategy(
-        access_token_db, lifetime_seconds=SESSION_EXPIRE_TIME_SECONDS
-    )
+    return RefreshableDatabaseStrategy(access_token_db, lifetime_seconds=SESSION_EXPIRE_TIME_SECONDS)
 
 
 def get_jwt_strategy() -> SingleTenantJWTStrategy:
@@ -1341,17 +1261,11 @@ if AUTH_BACKEND == AuthBackend.JWT:
         raise ValueError("USER_AUTH_SECRET is required for JWT auth backend.")
 
 if AUTH_BACKEND == AuthBackend.REDIS:
-    auth_backend = AuthenticationBackend(
-        name="redis", transport=cookie_transport, get_strategy=get_redis_strategy
-    )
+    auth_backend = AuthenticationBackend(name="redis", transport=cookie_transport, get_strategy=get_redis_strategy)
 elif AUTH_BACKEND == AuthBackend.POSTGRES:
-    auth_backend = AuthenticationBackend(
-        name="postgres", transport=cookie_transport, get_strategy=get_database_strategy
-    )
+    auth_backend = AuthenticationBackend(name="postgres", transport=cookie_transport, get_strategy=get_database_strategy)
 elif AUTH_BACKEND == AuthBackend.JWT:
-    auth_backend = AuthenticationBackend(
-        name="jwt", transport=cookie_transport, get_strategy=get_jwt_strategy
-    )
+    auth_backend = AuthenticationBackend(name="jwt", transport=cookie_transport, get_strategy=get_jwt_strategy)
 else:
     raise ValueError(f"Invalid auth backend: {AUTH_BACKEND}")
 
@@ -1368,22 +1282,14 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
         """
         router = APIRouter()
 
-        get_current_user_token = self.authenticator.current_user_token(
-            active=True, verified=requires_verification
-        )
+        get_current_user_token = self.authenticator.current_user_token(active=True, verified=requires_verification)
 
         logout_responses: OpenAPIResponseType = {
-            **{
-                status.HTTP_401_UNAUTHORIZED: {
-                    "description": "Missing token or inactive user."
-                }
-            },
+            **{status.HTTP_401_UNAUTHORIZED: {"description": "Missing token or inactive user."}},
             **backend.transport.get_openapi_logout_responses_success(),
         }
 
-        @router.post(
-            "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
-        )
+        @router.post("/logout", name=f"auth:{backend.name}.logout", responses=logout_responses)
         async def logout(
             user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
             strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
@@ -1406,28 +1312,18 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
 
         router = APIRouter()
 
-        get_current_user_token = self.authenticator.current_user_token(
-            active=True, verified=requires_verification
-        )
+        get_current_user_token = self.authenticator.current_user_token(active=True, verified=requires_verification)
 
         refresh_responses: OpenAPIResponseType = {
-            **{
-                status.HTTP_401_UNAUTHORIZED: {
-                    "description": "Missing token or inactive user."
-                }
-            },
+            **{status.HTTP_401_UNAUTHORIZED: {"description": "Missing token or inactive user."}},
             **backend.transport.get_openapi_login_responses_success(),
         }
 
-        @router.post(
-            "/refresh", name=f"auth:{backend.name}.refresh", responses=refresh_responses
-        )
+        @router.post("/refresh", name=f"auth:{backend.name}.refresh", responses=refresh_responses)
         async def refresh(
             user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
             strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
-            user_manager: BaseUserManager[models.UP, models.ID] = Depends(
-                get_user_manager
-            ),
+            user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
             db_session: AsyncSession = Depends(get_async_session),
         ) -> Response:
             try:
@@ -1442,17 +1338,13 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
                 )
 
                 # Check if strategy supports refreshing
-                supports_refresh = hasattr(strategy, "refresh_token") and callable(
-                    getattr(strategy, "refresh_token")
-                )
+                supports_refresh = hasattr(strategy, "refresh_token") and callable(getattr(strategy, "refresh_token"))
 
                 if supports_refresh:
                     try:
                         refresh_method = getattr(strategy, "refresh_token")
                         new_token = await refresh_method(token, user)
-                        logger.info(
-                            f"Successfully refreshed session token for user {user.email}"
-                        )
+                        logger.info(f"Successfully refreshed session token for user {user.email}")
                         return await backend.transport.get_login_response(new_token)
                     except Exception as e:
                         logger.error(f"Error refreshing session token: {str(e)}")
@@ -1461,9 +1353,7 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
                         return await backend.login(strategy, user)
 
                 # Fallback: logout and login again
-                logger.info(
-                    "Strategy doesn't support refresh - using logout/login flow"
-                )
+                logger.info("Strategy doesn't support refresh - using logout/login flow")
                 await backend.logout(strategy, user, token)
                 return await backend.login(strategy, user)
             except Exception as e:
@@ -1476,9 +1366,7 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
         return router
 
 
-fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](
-    get_user_manager, [auth_backend]
-)
+fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](get_user_manager, [auth_backend])
 
 
 # NOTE: verified=REQUIRE_EMAIL_VERIFICATION is not used here since we
@@ -1505,9 +1393,7 @@ def _extract_email_from_jwt(payload: dict[str, Any]) -> str | None:
     return None
 
 
-async def _sync_jwt_oidc_expiry(
-    user_manager: UserManager, user: User, payload: dict[str, Any]
-) -> None:
+async def _sync_jwt_oidc_expiry(user_manager: UserManager, user: User, payload: dict[str, Any]) -> None:
     if TRACK_EXTERNAL_IDP_EXPIRY:
         expires_at = payload.get("exp")
         if expires_at is None:
@@ -1538,18 +1424,14 @@ async def _get_or_create_user_from_jwt(
 ) -> User | None:
     email = _extract_email_from_jwt(payload)
     if email is None:
-        logger.warning(
-            "JWT token decoded successfully but no email claim found; skipping auth"
-        )
+        logger.warning("JWT token decoded successfully but no email claim found; skipping auth")
         return None
 
     # Enforce the same allowlist/domain policies as other auth flows
     verify_email_is_invited(email)
     verify_email_domain(email)
 
-    user_db: SQLAlchemyUserAdminDB[User, uuid.UUID] = SQLAlchemyUserAdminDB(
-        async_db_session, User, OAuthAccount
-    )
+    user_db: SQLAlchemyUserAdminDB[User, uuid.UUID] = SQLAlchemyUserAdminDB(async_db_session, User, OAuthAccount)
     user_manager = UserManager(user_db)
 
     try:
@@ -1601,9 +1483,7 @@ async def _check_for_saml_and_jwt(
             token = auth_header[len("Bearer ") :].strip()
             payload = await verify_jwt_token(token)
             if payload is not None:
-                user = await _get_or_create_user_from_jwt(
-                    payload, request, async_db_session
-                )
+                user = await _get_or_create_user_from_jwt(payload, request, async_db_session)
 
     return user
 
@@ -1659,11 +1539,7 @@ async def double_check_user(
                 detail="Access denied. User is not verified.",
             )
 
-        if (
-            user.oidc_expiry
-            and user.oidc_expiry < datetime.now(timezone.utc)
-            and not include_expired
-        ):
+        if user.oidc_expiry and user.oidc_expiry < datetime.now(timezone.utc) and not include_expired:
             raise BasicAuthenticationError(
                 detail="Access denied. User's OIDC token has expired.",
             )
@@ -1695,9 +1571,7 @@ async def current_chat_accessible_user(
 ) -> User:
     tenant_id = get_current_tenant_id()
 
-    return await double_check_user(
-        user, allow_anonymous_access=anonymous_user_enabled(tenant_id=tenant_id)
-    )
+    return await double_check_user(user, allow_anonymous_access=anonymous_user_enabled(tenant_id=tenant_id))
 
 
 async def current_user(
@@ -1810,24 +1684,18 @@ async def current_user_from_websocket(
     try:
         token_data = await retrieve_ws_token_data(token)
         if token_data is None:
-            raise BasicAuthenticationError(
-                detail="Access denied. Invalid or expired authentication token."
-            )
+            raise BasicAuthenticationError(detail="Access denied. Invalid or expired authentication token.")
     except BasicAuthenticationError:
         raise
     except Exception as e:
         logger.error(f"WS auth: error during token validation: {e}")
-        raise BasicAuthenticationError(
-            detail="Authentication verification failed."
-        ) from e
+        raise BasicAuthenticationError(detail="Authentication verification failed.") from e
 
     # Get user from token data
     user = await _get_user_from_token_data(token_data)
     if user is None:
         logger.warning(f"WS auth: user not found for id={token_data.get('sub')}")
-        raise BasicAuthenticationError(
-            detail="Access denied. User not found or inactive."
-        )
+        raise BasicAuthenticationError(detail="Access denied. User not found or inactive.")
 
     # Apply same checks as HTTP auth (verification, OIDC expiry, role)
     user = await double_check_user(user)
@@ -1945,9 +1813,7 @@ def get_oauth_router(
     async def null_access_token_state() -> tuple[OAuth2Token, Optional[str]] | None:
         return None
 
-    access_token_state_dependency = (
-        oauth2_authorize_callback if not enable_pkce else null_access_token_state
-    )
+    access_token_state_dependency = oauth2_authorize_callback if not enable_pkce else null_access_token_state
 
     if csrf_token_cookie_secure is None:
         csrf_token_cookie_secure = WEB_DOMAIN.startswith("https")
@@ -2005,9 +1871,7 @@ def get_oauth_router(
 
         # For Google OAuth, add parameters to request refresh tokens
         if oauth_client.name == "google":
-            authorization_url = add_url_params(
-                authorization_url, {"access_type": "offline", "prompt": "consent"}
-            )
+            authorization_url = add_url_params(authorization_url, {"access_type": "offline", "prompt": "consent"})
 
         def set_oauth_cookie(
             target_response: Response,
@@ -2077,9 +1941,7 @@ def get_oauth_router(
     )
     async def callback(
         request: Request,
-        access_token_state: Tuple[OAuth2Token, Optional[str]] | None = Depends(
-            access_token_state_dependency
-        ),
+        access_token_state: Tuple[OAuth2Token, Optional[str]] | None = Depends(access_token_state_dependency),
         code: Optional[str] = None,
         state: Optional[str] = None,
         error: Optional[str] = None,
@@ -2107,9 +1969,7 @@ def get_oauth_router(
 
         def decode_and_validate_state(state_value: str) -> Dict[str, str]:
             try:
-                state_data = decode_jwt(
-                    state_value, state_secret, [STATE_TOKEN_AUDIENCE]
-                )
+                state_data = decode_jwt(state_value, state_secret, [STATE_TOKEN_AUDIENCE])
             except jwt.DecodeError:
                 raise OnyxError(
                     OnyxErrorCode.VALIDATION_ERROR,
@@ -2140,11 +2000,7 @@ def get_oauth_router(
 
             cookie_csrf_token = request.cookies.get(csrf_token_cookie_name)
             state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
-            if (
-                not cookie_csrf_token
-                or not state_csrf_token
-                or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
-            ):
+            if not cookie_csrf_token or not state_csrf_token or not secrets.compare_digest(cookie_csrf_token, state_csrf_token):
                 raise OnyxError(
                     OnyxErrorCode.VALIDATION_ERROR,
                     getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
@@ -2206,9 +2062,7 @@ def get_oauth_router(
                 return build_error_response(e)
 
             try:
-                token = await oauth_client.get_access_token(
-                    code, callback_redirect_url, code_verifier
-                )
+                token = await oauth_client.get_access_token(code, callback_redirect_url, code_verifier)
             except GetAccessTokenError:
                 return build_error_response(
                     OnyxError(
@@ -2218,9 +2072,7 @@ def get_oauth_router(
                 )
         else:
             if access_token_state is None:
-                raise OnyxError(
-                    OnyxErrorCode.INTERNAL_ERROR, "Missing OAuth callback state"
-                )
+                raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Missing OAuth callback state")
             token, callback_state = access_token_state
             if callback_state is None:
                 raise OnyxError(
@@ -2229,12 +2081,8 @@ def get_oauth_router(
                 )
             state_data = decode_and_validate_state(callback_state)
 
-        async def complete_login_flow(
-            token: OAuth2Token, state_data: Dict[str, str]
-        ) -> RedirectResponse:
-            account_id, account_email = await oauth_client.get_id_email(
-                token["access_token"]
-            )
+        async def complete_login_flow(token: OAuth2Token, state_data: Dict[str, str]) -> RedirectResponse:
+            account_id, account_email = await oauth_client.get_id_email(token["access_token"])
 
             if account_email is None:
                 raise OnyxError(
@@ -2245,9 +2093,9 @@ def get_oauth_router(
             next_url = state_data.get("next_url", "/")
             referral_source = state_data.get("referral_source", None)
             try:
-                tenant_id = fetch_ee_implementation_or_noop(
-                    "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
-                )(account_email)
+                tenant_id = fetch_ee_implementation_or_noop("onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None)(
+                    account_email
+                )
             except exceptions.UserNotExists:
                 tenant_id = None
 
@@ -2286,9 +2134,7 @@ def get_oauth_router(
             if tenant_id is None:
                 # Use URL utility to add parameters
                 redirect_destination = add_url_params(next_url, {"new_team": "true"})
-                redirect_response = RedirectResponse(
-                    redirect_destination, status_code=302
-                )
+                redirect_response = RedirectResponse(redirect_destination, status_code=302)
             else:
                 # No parameters to add
                 redirect_response = RedirectResponse(next_url, status_code=302)

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1155,6 +1155,11 @@ RECAPTCHA_SECRET_KEY = os.environ.get("RECAPTCHA_SECRET_KEY", "")
 # 0.5 is the recommended default
 RECAPTCHA_SCORE_THRESHOLD = float(os.environ.get("RECAPTCHA_SCORE_THRESHOLD", "0.5"))
 
+# Opt-in per-IP rate limit on /auth/register.
+SIGNUP_RATE_LIMIT_ENABLED = (
+    os.environ.get("SIGNUP_RATE_LIMIT_ENABLED", "").lower() == "true"
+)
+
 MOCK_CONNECTOR_FILE_PATH = os.environ.get("MOCK_CONNECTOR_FILE_PATH")
 
 # Set to true to mock LLM responses for testing purposes

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -31,12 +31,45 @@ def _make_request(
     return Request(scope)
 
 
+def _fake_pipeline_redis(incr_return: int) -> MagicMock:
+    """Build a Redis mock whose pipeline().execute() yields [incr_return, ok]."""
+    pipeline = MagicMock()
+    pipeline.incr = MagicMock()
+    pipeline.expire = MagicMock()
+    pipeline.execute = AsyncMock(return_value=[incr_return, 1])
+    redis = MagicMock()
+    redis.pipeline = MagicMock(return_value=pipeline)
+    # Stash the pipeline for assertions
+    redis._pipeline = pipeline  # type: ignore[attr-defined]
+    return redis
+
+
 # ---------- IP extraction ----------
 
 
-def test_client_ip_prefers_xff_first_entry() -> None:
-    req = _make_request(xff="203.0.113.9, 10.0.0.1, 10.0.0.2")
-    assert _client_ip(req) == "203.0.113.9"
+def test_client_ip_picks_entry_written_by_outermost_trusted_proxy() -> None:
+    """With 2 trusted proxies (ALB + nginx), XFF looks like
+    ``<client-prefix>, real-client-ip, alb-ip``. Take the second-to-last,
+    NOT the leftmost (which is attacker-controlled)."""
+    req = _make_request(
+        xff="spoofed-by-bot, 198.51.100.99, 10.0.0.1",
+    )
+    assert _client_ip(req) == "198.51.100.99"
+
+
+def test_client_ip_ignores_client_controlled_prefix() -> None:
+    """A bot-prepended entry at the start of XFF must never be used."""
+    req = _make_request(xff="99.99.99.99, 203.0.113.7, 10.0.0.1")
+    # With _TRUSTED_PROXY_HOPS=2 the outermost trusted hop wrote
+    # 203.0.113.7; the attacker's 99.99.99.99 is ignored.
+    assert _client_ip(req) == "203.0.113.7"
+
+
+def test_client_ip_falls_back_to_tcp_peer_when_xff_too_short() -> None:
+    """If the XFF chain is shorter than the expected trust depth, we don't
+    trust any of it — fall through to the TCP peer."""
+    req = _make_request(xff="only-one-entry", client_host="198.51.100.7")
+    assert _client_ip(req) == "198.51.100.7"
 
 
 def test_client_ip_falls_back_to_request_client_host() -> None:
@@ -71,9 +104,7 @@ async def test_disabled_when_not_multitenant() -> None:
 async def test_allows_when_under_limit() -> None:
     """Counts at or below the hourly cap do not raise."""
     req = _make_request(client_host="1.2.3.4")
-    fake_redis = MagicMock()
-    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR)  # exactly at cap
-    fake_redis.expire = AsyncMock()
+    fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR)
     with (
         patch.object(rl, "MULTI_TENANT", True),
         patch.object(
@@ -87,9 +118,7 @@ async def test_allows_when_under_limit() -> None:
 async def test_rejects_when_over_limit() -> None:
     """Strictly above the cap → OnyxError.RATE_LIMITED (HTTP 429)."""
     req = _make_request(client_host="1.2.3.4")
-    fake_redis = MagicMock()
-    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR + 1)
-    fake_redis.expire = AsyncMock()
+    fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR + 1)
     with (
         patch.object(rl, "MULTI_TENANT", True),
         patch.object(
@@ -102,12 +131,12 @@ async def test_rejects_when_over_limit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sets_ttl_only_on_first_hit() -> None:
-    """Every non-first INCR must not reset the bucket TTL."""
+async def test_pipeline_expire_runs_on_every_hit() -> None:
+    """INCR and EXPIRE must go through the same pipeline so the TTL is
+    set atomically — even on the 2nd, 3rd, ... hit. This closes the
+    'key with no TTL → permanent block' class of bugs."""
     req = _make_request(client_host="1.2.3.4")
-    fake_redis = MagicMock()
-    fake_redis.incr = AsyncMock(return_value=3)  # not the first hit
-    fake_redis.expire = AsyncMock()
+    fake_redis = _fake_pipeline_redis(incr_return=3)
     with (
         patch.object(rl, "MULTI_TENANT", True),
         patch.object(
@@ -115,7 +144,8 @@ async def test_sets_ttl_only_on_first_hit() -> None:
         ),
     ):
         await enforce_signup_rate_limit(req)
-    fake_redis.expire.assert_not_awaited()
+    # EXPIRE is always queued into the pipeline — no branch on count == 1.
+    fake_redis._pipeline.expire.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -1,0 +1,143 @@
+"""Unit tests for the per-IP signup rate limiter."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from fastapi import Request
+
+from onyx.auth import signup_rate_limit as rl
+from onyx.auth.signup_rate_limit import _bucket_key
+from onyx.auth.signup_rate_limit import _client_ip
+from onyx.auth.signup_rate_limit import _PER_IP_PER_HOUR
+from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
+from onyx.error_handling.exceptions import OnyxError
+
+
+def _make_request(
+    xff: str | None = None, client_host: str | None = "1.2.3.4"
+) -> Request:
+    scope: dict = {
+        "type": "http",
+        "method": "POST",
+        "path": "/auth/register",
+        "headers": [],
+    }
+    if xff is not None:
+        scope["headers"].append((b"x-forwarded-for", xff.encode()))
+    if client_host is not None:
+        scope["client"] = (client_host, 54321)
+    return Request(scope)
+
+
+# ---------- IP extraction ----------
+
+
+def test_client_ip_prefers_xff_first_entry() -> None:
+    req = _make_request(xff="203.0.113.9, 10.0.0.1, 10.0.0.2")
+    assert _client_ip(req) == "203.0.113.9"
+
+
+def test_client_ip_falls_back_to_request_client_host() -> None:
+    req = _make_request(xff=None, client_host="198.51.100.7")
+    assert _client_ip(req) == "198.51.100.7"
+
+
+def test_client_ip_handles_no_client() -> None:
+    req = _make_request(xff=None, client_host=None)
+    assert _client_ip(req) == "unknown"
+
+
+# ---------- enforce_signup_rate_limit ----------
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_not_multitenant() -> None:
+    """Self-hosted (MULTI_TENANT=False) should never call Redis."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", False),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ) as conn,
+    ):
+        await enforce_signup_rate_limit(req)
+    conn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allows_when_under_limit() -> None:
+    """Counts at or below the hourly cap do not raise."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR)  # exactly at cap
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        await enforce_signup_rate_limit(req)
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_over_limit() -> None:
+    """Strictly above the cap → OnyxError.RATE_LIMITED (HTTP 429)."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=_PER_IP_PER_HOUR + 1)
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        with pytest.raises(OnyxError) as exc_info:
+            await enforce_signup_rate_limit(req)
+    assert exc_info.value.error_code.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_sets_ttl_only_on_first_hit() -> None:
+    """Every non-first INCR must not reset the bucket TTL."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    fake_redis.incr = AsyncMock(return_value=3)  # not the first hit
+    fake_redis.expire = AsyncMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ),
+    ):
+        await enforce_signup_rate_limit(req)
+    fake_redis.expire.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fails_open_on_redis_error() -> None:
+    """Redis blip must NOT block legitimate signups."""
+    req = _make_request(client_host="1.2.3.4")
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(
+            rl,
+            "get_async_redis_connection",
+            AsyncMock(side_effect=RuntimeError("redis down")),
+        ),
+    ):
+        # Does not raise.
+        await enforce_signup_rate_limit(req)
+
+
+def test_bucket_keys_differ_across_ips() -> None:
+    """Two different IPs in the same hour must not share a counter."""
+    a = _bucket_key("1.1.1.1")
+    b = _bucket_key("2.2.2.2")
+    assert a != b
+    assert a.startswith("signup_rate:1.1.1.1:")
+    assert b.startswith("signup_rate:2.2.2.2:")

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -100,11 +100,31 @@ def test_client_ip_handles_no_client() -> None:
 
 @pytest.mark.asyncio
 async def test_disabled_when_not_multitenant() -> None:
-    """Self-hosted (MULTI_TENANT=False) should never call Redis."""
+    """Self-hosted (MULTI_TENANT=False) should never call Redis, even if
+    SIGNUP_RATE_LIMIT_ENABLED is on."""
     req = _make_request(client_host="1.2.3.4")
     fake_redis = MagicMock()
     with (
         patch.object(rl, "MULTI_TENANT", False),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", True),
+        patch.object(
+            rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
+        ) as conn,
+    ):
+        await enforce_signup_rate_limit(req)
+    conn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_enable_flag_off() -> None:
+    """MULTI_TENANT alone is not enough — CI runs multi-tenant but must
+    not trip the rate limit. SIGNUP_RATE_LIMIT_ENABLED is the explicit
+    opt-in."""
+    req = _make_request(client_host="1.2.3.4")
+    fake_redis = MagicMock()
+    with (
+        patch.object(rl, "MULTI_TENANT", True),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", False),
         patch.object(
             rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
         ) as conn,
@@ -120,6 +140,7 @@ async def test_allows_when_under_limit() -> None:
     fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR)
     with (
         patch.object(rl, "MULTI_TENANT", True),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", True),
         patch.object(
             rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
         ),
@@ -134,6 +155,7 @@ async def test_rejects_when_over_limit() -> None:
     fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR + 1)
     with (
         patch.object(rl, "MULTI_TENANT", True),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", True),
         patch.object(
             rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
         ),
@@ -151,6 +173,7 @@ async def test_pipeline_expire_runs_on_every_hit() -> None:
     fake_redis = _fake_pipeline_redis(incr_return=3)
     with (
         patch.object(rl, "MULTI_TENANT", True),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", True),
         patch.object(
             rl, "get_async_redis_connection", AsyncMock(return_value=fake_redis)
         ),
@@ -165,6 +188,7 @@ async def test_fails_open_on_redis_error() -> None:
     req = _make_request(xff="1.2.3.4, 10.0.0.1")
     with (
         patch.object(rl, "MULTI_TENANT", True),
+        patch.object(rl, "SIGNUP_RATE_LIMIT_ENABLED", True),
         patch.object(
             rl,
             "get_async_redis_connection",

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -43,32 +43,12 @@ def _fake_pipeline_redis(incr_return: int) -> MagicMock:
     return redis
 
 
-# ---------- IP extraction (Onyx cloud topology) ----------
-#
-# In cloud: NLB (L4) → ingress-nginx → internal nginx → api-server.
-# ingress-nginx OVERWRITES X-Forwarded-For with its own $remote_addr (the
-# real client IP, preserved through NLB). internal nginx then APPENDS its
-# own pod IP via $proxy_add_x_forwarded_for. So a typical request arrives
-# at the api-server with:
-#
-#     X-Forwarded-For: <real_client_ip>, <ingress_nginx_pod_ip>
-#
-# The real client is parts[0]. The rightmost entry is always a
-# private/internal pod IP.
-
-
 def test_client_ip_uses_leftmost_when_first_entry_is_public() -> None:
-    """Cloud production shape: public real client IP, private internal hop."""
     req = _make_request(xff="1.2.3.4, 10.0.0.42")
     assert _client_ip(req) == "1.2.3.4"
 
 
 def test_client_ip_falls_back_when_leftmost_is_private() -> None:
-    """If the leftmost entry is private (indicates either a spoof attempt
-    or a misconfigured ingress that no longer overwrites XFF), we refuse
-    to use it and fall back to the TCP peer. Prevents an attacker from
-    trivially bucketing all their traffic under e.g. `10.0.0.1` by
-    sending that in a raw XFF header."""
     req = _make_request(xff="10.0.0.1, 1.2.3.4", client_host="5.6.7.8")
     assert _client_ip(req) == "5.6.7.8"
 
@@ -79,9 +59,7 @@ def test_client_ip_falls_back_when_leftmost_is_loopback() -> None:
 
 
 def test_client_ip_falls_back_when_xff_is_malformed() -> None:
-    """Non-IP entries (e.g. injected garbage) are not usable keys."""
     req = _make_request(xff="not-an-ip, 1.2.3.4", client_host="10.0.0.1")
-    # We don't walk past parts[0]; if it's unparseable, fall through.
     assert _client_ip(req) == "10.0.0.1"
 
 
@@ -95,13 +73,8 @@ def test_client_ip_handles_no_client() -> None:
     assert _client_ip(req) == "unknown"
 
 
-# ---------- enforce_signup_rate_limit ----------
-
-
 @pytest.mark.asyncio
 async def test_disabled_when_not_multitenant() -> None:
-    """Self-hosted (MULTI_TENANT=False) should never call Redis, even if
-    SIGNUP_RATE_LIMIT_ENABLED is on."""
     req = _make_request(client_host="1.2.3.4")
     fake_redis = MagicMock()
     with (
@@ -117,9 +90,6 @@ async def test_disabled_when_not_multitenant() -> None:
 
 @pytest.mark.asyncio
 async def test_disabled_when_enable_flag_off() -> None:
-    """MULTI_TENANT alone is not enough — CI runs multi-tenant but must
-    not trip the rate limit. SIGNUP_RATE_LIMIT_ENABLED is the explicit
-    opt-in."""
     req = _make_request(client_host="1.2.3.4")
     fake_redis = MagicMock()
     with (
@@ -167,8 +137,7 @@ async def test_rejects_when_over_limit() -> None:
 
 @pytest.mark.asyncio
 async def test_pipeline_expire_runs_on_every_hit() -> None:
-    """INCR and EXPIRE go through the same pipeline so TTL is always set
-    atomically — closes the 'key with no TTL → permanent block' bug."""
+    """INCR and EXPIRE run in a single pipeline for atomicity."""
     req = _make_request(xff="1.2.3.4, 10.0.0.1")
     fake_redis = _fake_pipeline_redis(incr_return=3)
     with (

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -39,42 +39,55 @@ def _fake_pipeline_redis(incr_return: int) -> MagicMock:
     pipeline.execute = AsyncMock(return_value=[incr_return, 1])
     redis = MagicMock()
     redis.pipeline = MagicMock(return_value=pipeline)
-    # Stash the pipeline for assertions
     redis._pipeline = pipeline  # type: ignore[attr-defined]
     return redis
 
 
-# ---------- IP extraction ----------
+# ---------- IP extraction (Onyx cloud topology) ----------
+#
+# In cloud: NLB (L4) → ingress-nginx → internal nginx → api-server.
+# ingress-nginx OVERWRITES X-Forwarded-For with its own $remote_addr (the
+# real client IP, preserved through NLB). internal nginx then APPENDS its
+# own pod IP via $proxy_add_x_forwarded_for. So a typical request arrives
+# at the api-server with:
+#
+#     X-Forwarded-For: <real_client_ip>, <ingress_nginx_pod_ip>
+#
+# The real client is parts[0]. The rightmost entry is always a
+# private/internal pod IP.
 
 
-def test_client_ip_picks_entry_written_by_outermost_trusted_proxy() -> None:
-    """With 2 trusted proxies (ALB + nginx), XFF looks like
-    ``<client-prefix>, real-client-ip, alb-ip``. Take the second-to-last,
-    NOT the leftmost (which is attacker-controlled)."""
-    req = _make_request(
-        xff="spoofed-by-bot, 198.51.100.99, 10.0.0.1",
-    )
-    assert _client_ip(req) == "198.51.100.99"
+def test_client_ip_uses_leftmost_when_first_entry_is_public() -> None:
+    """Cloud production shape: public real client IP, private internal hop."""
+    req = _make_request(xff="1.2.3.4, 10.0.0.42")
+    assert _client_ip(req) == "1.2.3.4"
 
 
-def test_client_ip_ignores_client_controlled_prefix() -> None:
-    """A bot-prepended entry at the start of XFF must never be used."""
-    req = _make_request(xff="99.99.99.99, 203.0.113.7, 10.0.0.1")
-    # With _TRUSTED_PROXY_HOPS=2 the outermost trusted hop wrote
-    # 203.0.113.7; the attacker's 99.99.99.99 is ignored.
-    assert _client_ip(req) == "203.0.113.7"
+def test_client_ip_falls_back_when_leftmost_is_private() -> None:
+    """If the leftmost entry is private (indicates either a spoof attempt
+    or a misconfigured ingress that no longer overwrites XFF), we refuse
+    to use it and fall back to the TCP peer. Prevents an attacker from
+    trivially bucketing all their traffic under e.g. `10.0.0.1` by
+    sending that in a raw XFF header."""
+    req = _make_request(xff="10.0.0.1, 1.2.3.4", client_host="5.6.7.8")
+    assert _client_ip(req) == "5.6.7.8"
 
 
-def test_client_ip_falls_back_to_tcp_peer_when_xff_too_short() -> None:
-    """If the XFF chain is shorter than the expected trust depth, we don't
-    trust any of it — fall through to the TCP peer."""
-    req = _make_request(xff="only-one-entry", client_host="198.51.100.7")
-    assert _client_ip(req) == "198.51.100.7"
+def test_client_ip_falls_back_when_leftmost_is_loopback() -> None:
+    req = _make_request(xff="127.0.0.1", client_host="5.6.7.8")
+    assert _client_ip(req) == "5.6.7.8"
 
 
-def test_client_ip_falls_back_to_request_client_host() -> None:
-    req = _make_request(xff=None, client_host="198.51.100.7")
-    assert _client_ip(req) == "198.51.100.7"
+def test_client_ip_falls_back_when_xff_is_malformed() -> None:
+    """Non-IP entries (e.g. injected garbage) are not usable keys."""
+    req = _make_request(xff="not-an-ip, 1.2.3.4", client_host="10.0.0.1")
+    # We don't walk past parts[0]; if it's unparseable, fall through.
+    assert _client_ip(req) == "10.0.0.1"
+
+
+def test_client_ip_falls_back_to_tcp_peer_when_xff_absent() -> None:
+    req = _make_request(xff=None, client_host="5.6.7.8")
+    assert _client_ip(req) == "5.6.7.8"
 
 
 def test_client_ip_handles_no_client() -> None:
@@ -103,7 +116,7 @@ async def test_disabled_when_not_multitenant() -> None:
 @pytest.mark.asyncio
 async def test_allows_when_under_limit() -> None:
     """Counts at or below the hourly cap do not raise."""
-    req = _make_request(client_host="1.2.3.4")
+    req = _make_request(xff="1.2.3.4, 10.0.0.1")
     fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR)
     with (
         patch.object(rl, "MULTI_TENANT", True),
@@ -117,7 +130,7 @@ async def test_allows_when_under_limit() -> None:
 @pytest.mark.asyncio
 async def test_rejects_when_over_limit() -> None:
     """Strictly above the cap → OnyxError.RATE_LIMITED (HTTP 429)."""
-    req = _make_request(client_host="1.2.3.4")
+    req = _make_request(xff="1.2.3.4, 10.0.0.1")
     fake_redis = _fake_pipeline_redis(incr_return=_PER_IP_PER_HOUR + 1)
     with (
         patch.object(rl, "MULTI_TENANT", True),
@@ -132,10 +145,9 @@ async def test_rejects_when_over_limit() -> None:
 
 @pytest.mark.asyncio
 async def test_pipeline_expire_runs_on_every_hit() -> None:
-    """INCR and EXPIRE must go through the same pipeline so the TTL is
-    set atomically — even on the 2nd, 3rd, ... hit. This closes the
-    'key with no TTL → permanent block' class of bugs."""
-    req = _make_request(client_host="1.2.3.4")
+    """INCR and EXPIRE go through the same pipeline so TTL is always set
+    atomically — closes the 'key with no TTL → permanent block' bug."""
+    req = _make_request(xff="1.2.3.4, 10.0.0.1")
     fake_redis = _fake_pipeline_redis(incr_return=3)
     with (
         patch.object(rl, "MULTI_TENANT", True),
@@ -144,14 +156,13 @@ async def test_pipeline_expire_runs_on_every_hit() -> None:
         ),
     ):
         await enforce_signup_rate_limit(req)
-    # EXPIRE is always queued into the pipeline — no branch on count == 1.
     fake_redis._pipeline.expire.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_fails_open_on_redis_error() -> None:
     """Redis blip must NOT block legitimate signups."""
-    req = _make_request(client_host="1.2.3.4")
+    req = _make_request(xff="1.2.3.4, 10.0.0.1")
     with (
         patch.object(rl, "MULTI_TENANT", True),
         patch.object(
@@ -160,7 +171,6 @@ async def test_fails_open_on_redis_error() -> None:
             AsyncMock(side_effect=RuntimeError("redis down")),
         ),
     ):
-        # Does not raise.
         await enforce_signup_rate_limit(req)
 
 


### PR DESCRIPTION
## Description

Adds per-IP rate limiting to `POST /auth/register` to cap signup throughput on top of the existing reCAPTCHA check.

New module `onyx.auth.signup_rate_limit`, called from `UserManager.create`:

- Redis `INCR` + `EXPIRE` in a single pipeline (atomic)
- Hour-bucketed key `signup_rate:<ip>:<bucket>` (cluster-wide)
- Cap: 5 registrations per IP per hour (hardcoded)
- Client IP from X-Forwarded-For first entry when globally-routable, else `request.client.host`
- Gated on `MULTI_TENANT` + new `SIGNUP_RATE_LIMIT_ENABLED` env flag
- `OnyxError(RATE_LIMITED)` → HTTP 429
- Fails open on Redis errors

Config addition: `SIGNUP_RATE_LIMIT_ENABLED` in `onyx/configs/app_configs.py` (same pattern as `CAPTCHA_ENABLED`). Default unset — cloud opts in by setting it to `"true"`; CI and local dev leave it off.

## How Has This Been Tested?

13 unit tests covering IP extraction (public leftmost, private/loopback/malformed/absent fallbacks, no-client), both gating flags independently, under/over cap, pipeline atomicity, fail-open, cross-IP bucket isolation. Existing 16-test registration suite still green.

```bash
$ pytest -xv backend/tests/unit/onyx/auth/test_signup_rate_limit.py \
              backend/tests/unit/onyx/auth/test_user_registration.py
# 29 passed

$ mypy backend/onyx/auth/signup_rate_limit.py \
        backend/onyx/configs/app_configs.py \
        backend/tests/unit/onyx/auth/test_signup_rate_limit.py
# Success
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check