### PR TITLE
chore(opensearch): Debug script can get and set settings from/to, and open, close an index

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -519,8 +519,21 @@ class OpenSearchIndexClient(OpenSearchClient):
         logger.debug(f"Settings of index {self._index_name} updated successfully.")
 
     @log_function_time(print_only=True, debug_only=True)
-    def get_settings(self) -> dict[str, Any]:
+    def get_settings(
+        self,
+        include_defaults: bool = False,
+        flat_settings: bool = False,
+        pretty: bool = False,
+    ) -> dict[str, Any]:
         """Gets the settings of the index.
+
+        Args:
+            include_defaults: Whether to include default settings which have not
+                been explicitly set. Defaults to False.
+            flat_settings: Whether to return settings in flat format vs nested
+                dictionaries. Defaults to False.
+            pretty: Whether to pretty-format the returned JSON response.
+                Defaults to False.
 
         Returns:
             The settings of the index.
@@ -529,7 +542,14 @@ class OpenSearchIndexClient(OpenSearchClient):
             Exception: There was an error getting the settings of the index.
         """
         logger.debug(f"Getting settings of index {self._index_name}.")
-        response = self._client.indices.get_settings(index=self._index_name)
+        params = {
+            "include_defaults": include_defaults,
+            "flat_settings": flat_settings,
+            "pretty": pretty,
+        }
+        response = self._client.indices.get_settings(
+            index=self._index_name, params=params
+        )
         return response[self._index_name]["settings"]
 
     @log_function_time(print_only=True, debug_only=True)

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -524,7 +524,8 @@ class OpenSearchIndexClient(OpenSearchClient):
         include_defaults: bool = False,
         flat_settings: bool = False,
         pretty: bool = False,
-    ) -> dict[str, Any]:
+        human: bool = False,
+    ) -> tuple[dict[str, Any], dict[str, Any] | None]:
         """Gets the settings of the index.
 
         Args:
@@ -534,23 +535,29 @@ class OpenSearchIndexClient(OpenSearchClient):
                 dictionaries. Defaults to False.
             pretty: Whether to pretty-format the returned JSON response.
                 Defaults to False.
+            human: Whether to return statistics in human-readable format.
+                Defaults to False.
 
         Returns:
-            The settings of the index.
+            The settings of the index, and optionally the default settings. If
+                include_defaults is False, the default settings will be None.
 
         Raises:
             Exception: There was an error getting the settings of the index.
         """
         logger.debug(f"Getting settings of index {self._index_name}.")
         params = {
-            "include_defaults": include_defaults,
-            "flat_settings": flat_settings,
-            "pretty": pretty,
+            "include_defaults": "true" if include_defaults else "false",
+            "flat_settings": "true" if flat_settings else "false",
+            "pretty": "true" if pretty else "false",
+            "human": "true" if human else "false",
         }
         response = self._client.indices.get_settings(
             index=self._index_name, params=params
         )
-        return response[self._index_name]["settings"]
+        return response[self._index_name]["settings"], response[self._index_name].get(
+            "defaults", None
+        )
 
     @log_function_time(print_only=True, debug_only=True)
     def open_index(self) -> None:

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -547,10 +547,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         """
         logger.debug(f"Getting settings of index {self._index_name}.")
         params = {
-            "include_defaults": "true" if include_defaults else "false",
-            "flat_settings": "true" if flat_settings else "false",
-            "pretty": "true" if pretty else "false",
-            "human": "true" if human else "false",
+            "include_defaults": str(include_defaults).lower(),
+            "flat_settings": str(flat_settings).lower(),
+            "pretty": str(pretty).lower(),
+            "human": str(human).lower(),
         }
         response = self._client.indices.get_settings(
             index=self._index_name, params=params

--- a/backend/scripts/debugging/opensearch/opensearch_debug.py
+++ b/backend/scripts/debugging/opensearch/opensearch_debug.py
@@ -257,7 +257,7 @@ def main() -> None:
                 human=args.human,
             )
         elif args.command == "set":
-            set_settings(client, args.settings)
+            set_settings(client, json.loads(args.settings))
         elif args.command == "open":
             open_index(client)
         elif args.command == "close":

--- a/backend/scripts/debugging/opensearch/opensearch_debug.py
+++ b/backend/scripts/debugging/opensearch/opensearch_debug.py
@@ -5,7 +5,8 @@ Usage:
     source .venv/bin/activate
     python backend/scripts/debugging/opensearch/opensearch_debug.py --help
     python backend/scripts/debugging/opensearch/opensearch_debug.py list
-    python backend/scripts/debugging/opensearch/opensearch_debug.py delete <index_name>
+    python backend/scripts/debugging/opensearch/opensearch_debug.py delete
+        <index_name>
 
 Environment Variables:
     OPENSEARCH_HOST: OpenSearch host
@@ -17,10 +18,11 @@ Dependencies:
     backend/shared_configs/configs.py
     backend/onyx/document_index/opensearch/client.py
 """
-
 import argparse
+import json
 import os
 import sys
+from typing import Any
 
 from onyx.document_index.opensearch.client import OpenSearchClient
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
@@ -61,6 +63,33 @@ def delete_index(client: OpenSearchIndexClient) -> None:
         print(f"Failed to delete index '{client._index_name}' for an unknown reason.")
 
 
+def get_settings(
+    client: OpenSearchIndexClient,
+    include_defaults: bool = False,
+    flat_settings: bool = False,
+    pretty: bool = False,
+) -> None:
+    settings = client.get_settings(
+        include_defaults=include_defaults, flat_settings=flat_settings, pretty=pretty
+    )
+    print(json.dumps(settings, indent=4))
+
+
+def set_settings(client: OpenSearchIndexClient, settings: dict[str, Any]) -> None:
+    client.update_settings(settings)
+    print(f"Updated settings for index '{client._index_name}'.")
+
+
+def open_index(client: OpenSearchIndexClient) -> None:
+    client.open_index()
+    print(f"Index '{client._index_name}' opened.")
+
+
+def close_index(client: OpenSearchIndexClient) -> None:
+    client.close_index()
+    print(f"Index '{client._index_name}' closed.")
+
+
 def main() -> None:
     def add_standard_arguments(parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -77,13 +106,19 @@ def main() -> None:
         )
         parser.add_argument(
             "--username",
-            help="OpenSearch username. If not provided, will fall back to OPENSEARCH_ADMIN_USERNAME, then prompt for input.",
+            help=(
+                "OpenSearch username. If not provided, will fall back to OPENSEARCH_ADMIN_USERNAME, then prompt for "
+                "input."
+            ),
             type=str,
             default=os.environ.get("OPENSEARCH_ADMIN_USERNAME", ""),
         )
         parser.add_argument(
             "--password",
-            help="OpenSearch password. If not provided, will fall back to OPENSEARCH_ADMIN_PASSWORD, then prompt for input.",
+            help=(
+                "OpenSearch password. If not provided, will fall back to OPENSEARCH_ADMIN_PASSWORD, then prompt for "
+                "input."
+            ),
             type=str,
             default=os.environ.get("OPENSEARCH_ADMIN_PASSWORD", ""),
         )
@@ -118,6 +153,41 @@ def main() -> None:
     delete_parser = subparsers.add_parser("delete", help="Delete an index.")
     delete_parser.add_argument("index", help="Index name.", type=str)
 
+    get_settings_parser = subparsers.add_parser(
+        "get-settings", help="Get settings for an index."
+    )
+    get_settings_parser.add_argument("index", help="Index name.", type=str)
+    get_settings_parser.add_argument(
+        "--include-defaults",
+        help="Include default settings.",
+        action="store_true",
+        default=False,
+    )
+    get_settings_parser.add_argument(
+        "--flat-settings",
+        help="Return settings in flat format.",
+        action="store_true",
+        default=False,
+    )
+    get_settings_parser.add_argument(
+        "--pretty",
+        help="Pretty-format the returned JSON response.",
+        action="store_true",
+        default=False,
+    )
+
+    set_settings_parser = subparsers.add_parser(
+        "set-settings", help="Set settings for an index."
+    )
+    set_settings_parser.add_argument("index", help="Index name.", type=str)
+    set_settings_parser.add_argument("settings", help="Settings to set.", type=str)
+
+    open_index_parser = subparsers.add_parser("open-index", help="Open an index.")
+    open_index_parser.add_argument("index", help="Index name.", type=str)
+
+    close_index_parser = subparsers.add_parser("close-index", help="Close an index.")
+    close_index_parser.add_argument("index", help="Index name.", type=str)
+
     args = parser.parse_args()
 
     if not (host := args.host or input("Enter the OpenSearch host: ")):
@@ -136,16 +206,16 @@ def main() -> None:
     print(f"MULTI_TENANT: {MULTI_TENANT}")
 
     with (
-        OpenSearchIndexClient(
-            index_name=args.index,
+        OpenSearchClient(
             host=host,
             port=port,
             auth=(username, password),
             use_ssl=not args.no_ssl,
             verify_certs=not args.no_verify_certs,
         )
-        if args.command == "delete"
-        else OpenSearchClient(
+        if args.command == "list"
+        else OpenSearchIndexClient(
+            index_name=args.index,
             host=host,
             port=port,
             auth=(username, password),
@@ -161,6 +231,14 @@ def main() -> None:
             list_indices(client)
         elif args.command == "delete":
             delete_index(client)
+        elif args.command == "get-settings":
+            get_settings(client, args.include_defaults, args.flat_settings, args.pretty)
+        elif args.command == "set-settings":
+            set_settings(client, args.settings)
+        elif args.command == "open-index":
+            open_index(client)
+        elif args.command == "close-index":
+            close_index(client)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/debugging/opensearch/opensearch_debug.py
+++ b/backend/scripts/debugging/opensearch/opensearch_debug.py
@@ -68,11 +68,21 @@ def get_settings(
     include_defaults: bool = False,
     flat_settings: bool = False,
     pretty: bool = False,
+    human: bool = False,
 ) -> None:
-    settings = client.get_settings(
-        include_defaults=include_defaults, flat_settings=flat_settings, pretty=pretty
+    settings, default_settings = client.get_settings(
+        include_defaults=include_defaults,
+        flat_settings=flat_settings,
+        pretty=pretty,
+        human=human,
     )
+    print("Settings:")
     print(json.dumps(settings, indent=4))
+    print("-" * 80)
+    if default_settings:
+        print("Default settings:")
+        print(json.dumps(default_settings, indent=4))
+        print("-" * 80)
 
 
 def set_settings(client: OpenSearchIndexClient, settings: dict[str, Any]) -> None:
@@ -154,7 +164,7 @@ def main() -> None:
     delete_parser.add_argument("index", help="Index name.", type=str)
 
     get_settings_parser = subparsers.add_parser(
-        "get-settings", help="Get settings for an index."
+        "get", help="Get settings for an index."
     )
     get_settings_parser.add_argument("index", help="Index name.", type=str)
     get_settings_parser.add_argument(
@@ -175,17 +185,23 @@ def main() -> None:
         action="store_true",
         default=False,
     )
+    get_settings_parser.add_argument(
+        "--human",
+        help="Return statistics in human-readable format.",
+        action="store_true",
+        default=False,
+    )
 
     set_settings_parser = subparsers.add_parser(
-        "set-settings", help="Set settings for an index."
+        "set", help="Set settings for an index."
     )
     set_settings_parser.add_argument("index", help="Index name.", type=str)
     set_settings_parser.add_argument("settings", help="Settings to set.", type=str)
 
-    open_index_parser = subparsers.add_parser("open-index", help="Open an index.")
+    open_index_parser = subparsers.add_parser("open", help="Open an index.")
     open_index_parser.add_argument("index", help="Index name.", type=str)
 
-    close_index_parser = subparsers.add_parser("close-index", help="Close an index.")
+    close_index_parser = subparsers.add_parser("close", help="Close an index.")
     close_index_parser.add_argument("index", help="Index name.", type=str)
 
     args = parser.parse_args()
@@ -204,6 +220,7 @@ def main() -> None:
         sys.exit(1)
     print("Using AWS-managed OpenSearch: ", args.use_aws_managed_opensearch)
     print(f"MULTI_TENANT: {MULTI_TENANT}")
+    print()
 
     with (
         OpenSearchClient(
@@ -231,14 +248,23 @@ def main() -> None:
             list_indices(client)
         elif args.command == "delete":
             delete_index(client)
-        elif args.command == "get-settings":
-            get_settings(client, args.include_defaults, args.flat_settings, args.pretty)
-        elif args.command == "set-settings":
+        elif args.command == "get":
+            get_settings(
+                client,
+                include_defaults=args.include_defaults,
+                flat_settings=args.flat_settings,
+                pretty=args.pretty,
+                human=args.human,
+            )
+        elif args.command == "set":
             set_settings(client, args.settings)
-        elif args.command == "open-index":
+        elif args.command == "open":
             open_index(client)
-        elif args.command == "close-index":
+        elif args.command == "close":
             close_index(client)
+        else:
+            print(f"Unknown command: {args.command}")
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -456,7 +456,7 @@ class TestOpenSearchClient:
         # Assert that the current number of replicas is not the desired test
         # number we are updating to.
         test_num_replicas = 0
-        current_settings = test_client.get_settings()
+        current_settings, _ = test_client.get_settings()
         assert current_settings["index"]["number_of_replicas"] != f"{test_num_replicas}"
 
         # Under test.
@@ -467,7 +467,7 @@ class TestOpenSearchClient:
         )
 
         # Postcondition.
-        current_settings = test_client.get_settings()
+        current_settings, _ = test_client.get_settings()
         assert current_settings["index"]["number_of_replicas"] == f"{test_num_replicas}"
 
     def test_update_settings_on_nonexistent_index(
@@ -488,7 +488,7 @@ class TestOpenSearchClient:
         test_client.create_index(mappings=mappings, settings=settings)
 
         # Under test.
-        current_settings = test_client.get_settings()
+        current_settings, _ = test_client.get_settings()
 
         # Postcondition.
         assert "index" in current_settings


### PR DESCRIPTION
## Description
Added additional functionality to the OpenSearch index debug script.

## How Has This Been Tested?
Ran `get`, `set`, `open`, `close` against a local index.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded the OpenSearch debug script with commands to get/set index settings and to open/close an index. Updated `OpenSearchIndexClient.get_settings` to accept query options and return settings plus defaults when requested.

- **New Features**
  - Added CLI commands: `get`, `set`, `open`, `close`.
  - `get` supports `--include-defaults`, `--flat-settings`, `--pretty`, `--human`; pretty-prints settings and defaults.
  - `set` accepts JSON settings.

- **Migration**
  - `OpenSearchIndexClient.get_settings` now returns `(settings, defaults_or_none)`; update call sites to unpack the tuple.

<sup>Written for commit 285c62b07572533f5633b2bc3f849b479d8e5989. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

