### PR TITLE
test(auth): add permission gating tests and fix implied permissions

### DIFF
--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -107,7 +107,7 @@ def get_user_group_permissions(
 def set_user_group_permissions(
     user_group_id: int,
     request: BulkSetPermissionsRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> list[Permission]:
     group = fetch_user_group(db_session, user_group_id)

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -53,6 +53,9 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
         Permission.READ_AGENTS.value,
         Permission.READ_USERS.value,
     },
+    Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS.value: {
+        Permission.READ_USER_GROUPS.value,
+    },
 }
 
 # Permissions that cannot be toggled via the group-permission API.

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -19,6 +19,7 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import global_version
 
 logger = setup_logger()
 
@@ -65,6 +66,16 @@ NON_TOGGLEABLE_PERMISSIONS: frozenset[Permission] = frozenset(
         Permission.READ_AGENTS,
         Permission.READ_USERS,
         Permission.READ_USER_GROUPS,
+    }
+)
+
+# Permissions auto-granted to all users in Community Edition.
+# In CE there is no group-permission UI, so these capabilities must be
+# available without explicit grants.  In EE they are controlled normally
+# via group permissions.
+CE_UNGATED_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        Permission.ADD_AGENTS,
     }
 )
 
@@ -222,6 +233,10 @@ def get_effective_permissions(user: User) -> set[Permission]:
             logger.warning(f"Skipping unknown permission '{p}' for user {user.id}")
     if Permission.FULL_ADMIN_PANEL_ACCESS in granted:
         return set(Permission)
+
+    if not global_version.is_ee_version():
+        granted |= CE_UNGATED_PERMISSIONS
+
     expanded = resolve_effective_permissions({p.value for p in granted})
     return {Permission(p) for p in expanded}
 

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -36,6 +36,7 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
     Permission.MANAGE_DOCUMENT_SETS.value: {
         Permission.READ_DOCUMENT_SETS.value,
         Permission.READ_CONNECTORS.value,
+        Permission.READ_USER_GROUPS.value,
     },
     Permission.MANAGE_CONNECTORS.value: {
         Permission.READ_CONNECTORS.value,

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -49,6 +49,7 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
     Permission.MANAGE_LLMS.value: {
         Permission.READ_USER_GROUPS.value,
         Permission.READ_AGENTS.value,
+        Permission.READ_USERS.value,
     },
 }
 

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -1050,7 +1050,7 @@ def get_currently_failed_indexing_status(
 
 @router.get("/admin/connector/status", tags=PUBLIC_API_TAGS)
 def get_connector_status(
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(require_permission(Permission.READ_CONNECTORS)),
     db_session: Session = Depends(get_session),
 ) -> list[ConnectorStatus]:
     # This method is only used document set and group creation/editing

--- a/backend/tests/integration/tests/permissions/_access_matrix.py
+++ b/backend/tests/integration/tests/permissions/_access_matrix.py
@@ -1,0 +1,148 @@
+"""Shared helpers for per-permission access-matrix tests.
+
+Each custom-permission test file exercises the same 7-user matrix:
+
+  admin          → allowed (FULL_ADMIN_PANEL_ACCESS bypass)
+  holder         → allowed (group grants only the permission under test)
+  basic          → denied
+  service_account→ denied
+  bot            → denied
+  ext_perm       → denied
+  anonymous      → denied (401 or 403)
+
+"Allowed" is interpreted permissively: any response code that is *not*
+401/403 means the permission gate was reached. We don't require 2xx
+because several gated endpoints need path parameters pointing at real
+resources (e.g. ``PATCH /admin/persona/{id}/listed``) and returning 404
+on a bogus ID is fine — we only care that the caller was not blocked by
+the gate.
+"""
+
+from typing import Any
+
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+
+# (method, path, json body or None)
+Endpoint = tuple[str, str, dict[str, Any] | None]
+
+
+# User-kind + expected-outcome pairs parametrized into every test file.
+# Each test file's local ``holder_user`` fixture supplies the "holder" kind.
+USER_KINDS: list[tuple[str, str]] = [
+    ("admin", "allowed"),
+    ("holder", "allowed"),
+    ("service_account_holder", "allowed"),
+    ("basic", "denied"),
+    ("service_account", "denied"),
+    ("bot", "denied"),
+    ("ext_perm", "denied"),
+    ("anonymous", "anon_denied"),
+]
+
+
+def call_endpoint(
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    headers: dict[str, str] | None,
+    cookies: Any = None,
+) -> requests.Response:
+    kwargs: dict[str, Any] = {"headers": headers or {}, "timeout": 30}
+    if cookies is not None:
+        kwargs["cookies"] = cookies
+    if body is not None:
+        kwargs["json"] = body
+    return requests.request(method, f"{API_SERVER_URL}{path}", **kwargs)
+
+
+def resolve_credentials(
+    user_kind: str, request: pytest.FixtureRequest
+) -> tuple[dict[str, str], Any]:
+    """Map a user-kind string to (headers, cookies) by pulling the matching
+    shared fixture from ``conftest.py``. Per-file ``holder_user`` /
+    ``holder_service_account`` fixtures are looked up by well-known names."""
+    if user_kind == "anonymous":
+        return {}, None
+    if user_kind == "service_account":
+        sa = request.getfixturevalue("limited_service_account")
+        return sa.headers, None
+    if user_kind == "service_account_holder":
+        sa = request.getfixturevalue("holder_service_account")
+        return sa.headers, None
+    if user_kind == "bot":
+        return request.getfixturevalue("bot_user_headers"), None
+    if user_kind == "ext_perm":
+        return request.getfixturevalue("ext_perm_user_headers"), None
+
+    fixture_map = {
+        "admin": "permission_admin_user",
+        "basic": "permission_basic_user",
+        "holder": "holder_user",
+    }
+    user = request.getfixturevalue(fixture_map[user_kind])
+    return user.headers, user.cookies
+
+
+_LIMITED_USER_DETAIL = "Access denied. User has limited permissions."
+
+
+def _is_gate_denial(resp: requests.Response) -> bool:
+    """True iff the 403 came from an auth-layer gate, not the handler.
+
+    Two auth-layer shapes exist:
+
+    1. ``require_permission`` → ``OnyxError(INSUFFICIENT_PERMISSIONS)``
+       serialised as ``{"error_code": "INSUFFICIENT_PERMISSIONS", ...}``.
+    2. ``current_user`` rejects a user whose effective_permissions list is
+       empty via ``BasicAuthenticationError`` → plain
+       ``{"detail": "Access denied. User has limited permissions."}``.
+
+    A handler-level 403 (e.g. persona handlers re-raising ``ValueError`` as
+    ``HTTPException(403)``) matches neither shape.
+    """
+    if resp.status_code != 403:
+        return False
+    try:
+        body = resp.json()
+    except ValueError:
+        return False
+    if not isinstance(body, dict):
+        return False
+    if body.get("error_code") == "INSUFFICIENT_PERMISSIONS":
+        return True
+    if body.get("detail") == _LIMITED_USER_DETAIL:
+        return True
+    return False
+
+
+def assert_response(
+    resp: requests.Response,
+    method: str,
+    path: str,
+    user_kind: str,
+    expected: str,
+) -> None:
+    if expected == "allowed":
+        # A caller who cleared the gate may still hit a handler-level 403
+        # (e.g. persona-not-found paths that reuse 403). We only care that
+        # the permission gate itself did not reject the request.
+        assert resp.status_code != 401 and not _is_gate_denial(resp), (
+            f"{user_kind} should not be blocked by permission gate on "
+            f"{method} {path}, got {resp.status_code} "
+            f"(body={resp.text[:200]})"
+        )
+    elif expected == "denied":
+        assert resp.status_code == 403 and _is_gate_denial(resp), (
+            f"{user_kind} should be denied by permission gate on "
+            f"{method} {path}, got {resp.status_code} "
+            f"(body={resp.text[:200]})"
+        )
+    elif expected == "anon_denied":
+        assert resp.status_code in (401, 403), (
+            f"Anonymous should be denied on {method} {path}, " f"got {resp.status_code}"
+        )
+    else:
+        raise ValueError(f"Unknown expected value: {expected}")

--- a/backend/tests/integration/tests/permissions/conftest.py
+++ b/backend/tests/integration/tests/permissions/conftest.py
@@ -4,14 +4,21 @@ Creates six user types that cover the full access spectrum:
   - admin_user:               STANDARD account, Admin group
   - basic_user:               STANDARD account, Basic group
   - limited_service_account:  SERVICE_ACCOUNT, no groups
-  - bot_user:                 BOT account, SLACK_USER role
-  - ext_perm_user:            EXT_PERM_USER account, EXT_PERM_USER role
+  - bot_user:                 BOT account type (no web login)
+  - ext_perm_user:            EXT_PERM_USER account type (no web login)
   - anonymous (no fixture):   unauthenticated request (empty headers)
+
+Plus a ``permission_holder_user_factory`` fixture used by the custom-
+permission test files to materialize a 7th user type per test module:
+a STANDARD user whose only non-BASIC permission is the one under test,
+granted via a fresh user group.
 
 All fixtures are module-scoped because permission tests are read-only
 (GET requests checking status codes) and don't mutate state between tests.
 This avoids a costly full reset per test.
 """
+
+from collections.abc import Callable
 
 import pytest
 
@@ -21,9 +28,37 @@ from onyx.db.users import add_slack_user_if_not_exists
 from onyx.db.users import batch_add_ext_perm_user_if_not_exists
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.reset import reset_all
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
+
+
+def _attach_group_with_permission(
+    *,
+    permission: str,
+    admin_user: DATestUser,
+    user_ids: list[str],
+    group_name: str,
+) -> None:
+    """Create a fresh user group containing ``user_ids`` and grant it exactly
+    one permission. Synchronous: permission is written to every member's
+    ``effective_permissions`` column before this returns — no celery sync
+    needed because ``set_group_permissions_bulk__no_commit`` calls
+    ``recompute_permissions_for_group__no_commit`` in-process.
+    """
+    group = UserGroupManager.create(
+        name=group_name,
+        user_ids=user_ids,
+        cc_pair_ids=[],
+        user_performing_action=admin_user,
+    )
+    set_resp = UserGroupManager.set_permissions(
+        user_group=group,
+        permissions=[permission],
+        user_performing_action=admin_user,
+    )
+    set_resp.raise_for_status()
 
 
 @pytest.fixture(scope="module")
@@ -34,7 +69,7 @@ def module_reset() -> None:
 
 @pytest.fixture(scope="module")
 def permission_admin_user(module_reset: None) -> DATestUser:  # noqa: ARG001
-    """First registered user — automatically gets ADMIN role."""
+    """First registered user — automatically promoted to admin (full_admin_panel_access)."""
     return UserManager.create(name="perm_admin")
 
 
@@ -42,7 +77,7 @@ def permission_admin_user(module_reset: None) -> DATestUser:  # noqa: ARG001
 def permission_basic_user(
     permission_admin_user: DATestUser,  # noqa: ARG001
 ) -> DATestUser:
-    """Second registered user — gets BASIC role."""
+    """Second registered user — joins the default Basic user group with only basic permissions."""
     return UserManager.create(name="perm_basic")
 
 
@@ -62,10 +97,9 @@ def limited_service_account(
 def bot_user_headers(
     permission_admin_user: DATestUser,  # noqa: ARG001
 ) -> dict[str, str]:
-    """BOT account (SLACK_USER role) authenticated via PAT.
+    """Authorization headers that authenticate as a BOT account type user.
 
-    BOT users can't log in via web — we create one in the DB directly
-    and issue a PAT for authentication.
+    BOT users can't log in via web, so we create one in the DB directly.
     """
     with get_session_with_current_tenant() as db_session:
         user = add_slack_user_if_not_exists(db_session, email="bot_test@example.com")
@@ -82,10 +116,9 @@ def bot_user_headers(
 def ext_perm_user_headers(
     permission_admin_user: DATestUser,  # noqa: ARG001
 ) -> dict[str, str]:
-    """EXT_PERM_USER account authenticated via PAT.
+    """Authorization headers that authenticate as an EXT_PERM_USER account type user.
 
-    EXT_PERM_USER users can't log in via web — we create one in the DB
-    directly and issue a PAT for authentication.
+    EXT_PERM_USER users can't log in via web, so we create one in the DB directly.
     """
     with get_session_with_current_tenant() as db_session:
         users = batch_add_ext_perm_user_if_not_exists(
@@ -98,3 +131,80 @@ def ext_perm_user_headers(
             expiration_days=None,
         )
     return {"Authorization": f"Bearer {raw_token}"}
+
+
+@pytest.fixture(scope="module")
+def permission_holder_user_factory(
+    permission_admin_user: DATestUser,
+) -> Callable[[str], DATestUser]:
+    """Factory: STANDARD user whose only non-BASIC permission is ``permission``.
+
+    Each call creates a fresh user group containing only that user and
+    grants the group exactly one permission. This is the end-to-end path a
+    real admin uses to delegate a capability, so the test exercises the
+    group → effective_permissions expansion rather than stubbing it.
+
+    Module-scoped and memoized by permission string. Requires the
+    user-group permission API (Enterprise-only) — callers must guard their
+    module with the ``ENABLE_PAID_ENTERPRISE_EDITION_FEATURES`` skipif.
+    """
+
+    cache: dict[str, DATestUser] = {}
+
+    def _make(permission: str) -> DATestUser:
+        if permission in cache:
+            return cache[permission]
+
+        slug = permission.replace(":", "_")
+        user = UserManager.create(name=f"perm_{slug}_holder")
+        _attach_group_with_permission(
+            permission=permission,
+            admin_user=permission_admin_user,
+            user_ids=[user.id],
+            group_name=f"perm-{slug}",
+        )
+        cache[permission] = user
+        return user
+
+    return _make
+
+
+@pytest.fixture(scope="module")
+def permission_holder_service_account_factory(
+    permission_admin_user: DATestUser,
+) -> Callable[[str], DATestAPIKey]:
+    """Factory: SERVICE_ACCOUNT whose only non-BASIC permission is ``permission``.
+
+    Service accounts are part of the same group-based permission model as
+    standard users. We create an API key (which creates a backing SA User)
+    and add that User to a fresh group granting exactly one permission.
+
+    Module-scoped and memoized by permission string. EE-only, same guard
+    as ``permission_holder_user_factory``.
+    """
+
+    cache: dict[str, DATestAPIKey] = {}
+
+    def _make(permission: str) -> DATestAPIKey:
+        if permission in cache:
+            return cache[permission]
+
+        slug = permission.replace(":", "_")
+        # Create SA with no initial group membership; we add it to a
+        # custom group immediately afterwards to avoid a 2-step API flow
+        # of (create with group, then set permissions on that group).
+        api_key = APIKeyManager.create(
+            group_ids=[],
+            user_performing_action=permission_admin_user,
+            name=f"perm_{slug}_sa",
+        )
+        _attach_group_with_permission(
+            permission=permission,
+            admin_user=permission_admin_user,
+            user_ids=[str(api_key.user_id)],
+            group_name=f"perm-sa-{slug}",
+        )
+        cache[permission] = api_key
+        return api_key
+
+    return _make

--- a/backend/tests/integration/tests/permissions/test_add_agents.py
+++ b/backend/tests/integration/tests/permissions/test_add_agents.py
@@ -1,0 +1,65 @@
+"""Integration tests for ADD_AGENTS permission gate.
+
+ADD_AGENTS gates the "create / edit my own agent" endpoints on the
+basic_router (prefix ``/persona``) and agents_router (prefix
+``/agents``) in ``backend/onyx/server/features/persona/api.py``.
+
+We target PATCH/DELETE endpoints with bogus persona IDs. The permission
+check runs before the DB lookup, so allowed callers receive 404 and
+denied callers receive 403.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.ADD_AGENTS.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("PATCH", "/persona/999999/public", {"is_public": True}),
+    ("PATCH", "/persona/999999/share", {"user_ids": []}),
+    ("DELETE", "/persona/999999", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_create_user_api_keys.py
+++ b/backend/tests/integration/tests/permissions/test_create_user_api_keys.py
@@ -1,0 +1,65 @@
+"""Integration tests for CREATE_USER_API_KEYS permission gate.
+
+Covers the personal-access-token creation endpoint in
+``backend/onyx/server/pat/api.py`` (router prefix ``/user/pats``).
+The basic-access GET endpoints on the same router are covered by
+``test_basic_access.py`` — this file only exercises the CREATE token.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.CREATE_USER_API_KEYS.value
+
+_CREATE_PAT_BODY: dict[str, Any] = {
+    "name": "perm-test-pat",
+    "expiration_days": 7,
+}
+
+ENDPOINTS: list[Endpoint] = [
+    ("POST", "/user/pats", _CREATE_PAT_BODY),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_file_connector_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_file_connector_permissions.py
@@ -86,15 +86,16 @@ def _create_connector_managers_group(
     group_user: DATestUser,
     name: str,
 ) -> None:
-    """Create a non-default group that grants its members manage:connectors."""
+    """Create a non-default group that grants its members manage:connectors.
+
+    User effective permissions are recomputed synchronously when group
+    permissions are set, so this does not need to wait for the slower document
+    index user-group sync marker.
+    """
     group = UserGroupManager.create(
         name=name,
         user_ids=[group_user.id],
         cc_pair_ids=[],
-        user_performing_action=admin_user,
-    )
-    UserGroupManager.wait_for_sync(
-        user_groups_to_check=[group],
         user_performing_action=admin_user,
     )
     set_perms_response = UserGroupManager.set_permissions(

--- a/backend/tests/integration/tests/permissions/test_manage_actions.py
+++ b/backend/tests/integration/tests/permissions/test_manage_actions.py
@@ -1,0 +1,71 @@
+"""Integration tests for MANAGE_ACTIONS permission gate.
+
+MANAGE_ACTIONS protects custom-tool + MCP admin endpoints in
+``backend/onyx/server/features/tool/api.py`` (admin_router prefix
+``/admin/tool``) and ``backend/onyx/server/features/mcp/api.py``
+(admin_router prefix ``/admin/mcp``).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_ACTIONS.value
+
+_VALIDATE_TOOL_BODY: dict[str, Any] = {
+    "definition": {
+        "openapi": "3.0.0",
+        "info": {"title": "t", "version": "1.0.0"},
+        "paths": {},
+    },
+}
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/admin/mcp/server/999999/tools", None),
+    ("GET", "/admin/mcp/servers/999999", None),
+    ("DELETE", "/admin/tool/custom/999999", None),
+    ("POST", "/admin/tool/custom/validate", _VALIDATE_TOOL_BODY),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_agents.py
+++ b/backend/tests/integration/tests/permissions/test_manage_agents.py
@@ -1,0 +1,62 @@
+"""Integration tests for MANAGE_AGENTS permission gate.
+
+MANAGE_AGENTS gates persona-admin PATCH endpoints in
+``backend/onyx/server/features/persona/api.py`` (admin_router prefix
+``/admin/persona``). Because the persona IDs are bogus the allowed
+callers will receive 404 — fine, we only assert the gate was not the
+blocker.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_AGENTS.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("PATCH", "/admin/persona/999999/listed", {"is_listed": True}),
+    ("PATCH", "/admin/persona/999999/featured", {"is_featured": True}),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_bots.py
+++ b/backend/tests/integration/tests/permissions/test_manage_bots.py
@@ -1,0 +1,63 @@
+"""Integration tests for MANAGE_BOTS permission gate.
+
+MANAGE_BOTS protects the Slack-bot admin endpoints in
+``backend/onyx/server/manage/slack_bot.py`` (router prefix ``/manage``)
+and the Discord-bot admin endpoints in
+``backend/onyx/server/manage/discord_bot/api.py`` (router prefix
+``/manage/admin/discord-bot``).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_BOTS.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/manage/admin/slack-app/channel", None),
+    ("GET", "/manage/admin/slack-app/bots", None),
+    ("GET", "/manage/admin/discord-bot/guilds", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_connectors.py
+++ b/backend/tests/integration/tests/permissions/test_manage_connectors.py
@@ -1,0 +1,63 @@
+"""Integration tests for MANAGE_CONNECTORS permission gate.
+
+Complements ``test_file_connector_permissions.py`` (which exercises the
+file-connector flow in depth) by asserting the breadth of general
+connector management endpoints in
+``backend/onyx/server/documents/connector.py`` (router prefix ``/manage``).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_CONNECTORS.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/manage/admin/connector", None),
+    ("GET", "/manage/admin/connector/status", None),
+    ("GET", "/manage/admin/connector/failed-indexing-status", None),
+    ("GET", "/manage/admin/connector/google-drive/app-credential", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_document_sets.py
+++ b/backend/tests/integration/tests/permissions/test_manage_document_sets.py
@@ -1,0 +1,82 @@
+"""Integration tests for MANAGE_DOCUMENT_SETS permission gate.
+
+Document-set admin endpoints live in
+``backend/onyx/server/features/document_set/api.py`` (router prefix
+``/manage``). Only mutating endpoints exist; the access matrix therefore
+sends valid-shape bodies and tolerates 404 on a bogus DELETE path.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_DOCUMENT_SETS.value
+
+_VALID_CREATE_BODY: dict[str, Any] = {
+    "name": "perm-test-doc-set",
+    "description": "created by test_manage_document_sets",
+    "cc_pair_ids": [],
+    "is_public": True,
+    "users": [],
+    "groups": [],
+    "federated_connectors": [],
+}
+
+_VALID_UPDATE_BODY: dict[str, Any] = {
+    "id": 999999,
+    "description": "irrelevant",
+    "cc_pair_ids": [],
+    "is_public": True,
+    "users": [],
+    "groups": [],
+    "federated_connectors": [],
+}
+
+ENDPOINTS: list[Endpoint] = [
+    ("POST", "/manage/admin/document-set", _VALID_CREATE_BODY),
+    ("PATCH", "/manage/admin/document-set", _VALID_UPDATE_BODY),
+    ("DELETE", "/manage/admin/document-set/999999", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_llms.py
+++ b/backend/tests/integration/tests/permissions/test_manage_llms.py
@@ -1,0 +1,61 @@
+"""Integration tests for MANAGE_LLMS permission gate.
+
+LLM admin endpoints live in ``backend/onyx/server/manage/llm/api.py`` on
+the admin_router (prefix ``/admin/llm``).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_LLMS.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/admin/llm/built-in/options", None),
+    ("GET", "/admin/llm/provider", None),
+    ("GET", "/admin/llm/auto-config", None),
+    ("GET", "/admin/llm/vision-providers", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_service_account_api_keys.py
+++ b/backend/tests/integration/tests/permissions/test_manage_service_account_api_keys.py
@@ -1,0 +1,65 @@
+"""Integration tests for MANAGE_SERVICE_ACCOUNT_API_KEYS permission gate.
+
+Covers the service-account API-key admin endpoints in
+``backend/onyx/server/api_key/api.py`` (router prefix ``/admin/api-key``).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Custom group permission assignment is enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS.value
+
+_CREATE_API_KEY_BODY: dict[str, Any] = {
+    "name": "perm-test-api-key",
+    "group_ids": [],
+}
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/admin/api-key", None),
+    ("POST", "/admin/api-key", _CREATE_API_KEY_BODY),
+    ("DELETE", "/admin/api-key/999999", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions/test_manage_user_groups.py
@@ -1,0 +1,70 @@
+"""Integration tests for MANAGE_USER_GROUPS permission gate (Enterprise).
+
+MANAGE_USER_GROUPS protects the user-group admin endpoints in
+``backend/ee/onyx/server/user_group/api.py`` (router prefix ``/manage``).
+
+Note: ``GET /manage/admin/user-group`` is guarded by READ_USER_GROUPS
+(implied by MANAGE_USER_GROUPS) so we deliberately exclude it here —
+this file only covers endpoints that require the MANAGE token directly.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User-group permission tests are enterprise only",
+)
+
+PERMISSION = Permission.MANAGE_USER_GROUPS.value
+
+_CREATE_GROUP_BODY: dict[str, Any] = {
+    "name": "perm-test-user-group",
+    "user_ids": [],
+    "cc_pair_ids": [],
+}
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/manage/admin/user-group/999999/permissions", None),
+    ("POST", "/manage/admin/user-group", _CREATE_GROUP_BODY),
+    ("DELETE", "/manage/admin/user-group/999999", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions/test_manage_user_groups.py
@@ -68,3 +68,35 @@ def test_access_matrix(
     headers, cookies = resolve_credentials(user_kind, request)
     resp = call_endpoint(method, path, body, headers, cookies)
     assert_response(resp, method, path, user_kind, expected)
+
+
+# PUT /manage/admin/user-group/{id}/permissions is admin-only (not
+# MANAGE_USER_GROUPS) to prevent privilege escalation — a group manager
+# could otherwise grant their own group any toggleable permission. The
+# endpoint must remain gated on FULL_ADMIN_PANEL_ACCESS, so holders of
+# MANAGE_USER_GROUPS are expected to be denied here.
+_SET_PERMISSIONS_USER_KINDS: list[tuple[str, str]] = [
+    ("admin", "allowed"),
+    ("holder", "denied"),
+    ("service_account_holder", "denied"),
+    ("basic", "denied"),
+    ("service_account", "denied"),
+    ("bot", "denied"),
+    ("ext_perm", "denied"),
+    ("anonymous", "anon_denied"),
+]
+
+
+@pytest.mark.parametrize("user_kind,expected", _SET_PERMISSIONS_USER_KINDS)
+def test_set_permissions_requires_full_admin(
+    user_kind: str,
+    expected: str,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    method = "PUT"
+    path = "/manage/admin/user-group/999999/permissions"
+    body: dict[str, Any] = {"permissions": []}
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/integration/tests/permissions/test_read_query_history.py
+++ b/backend/tests/integration/tests/permissions/test_read_query_history.py
@@ -1,0 +1,59 @@
+"""Integration tests for READ_QUERY_HISTORY permission gate (Enterprise).
+
+Covers the query-history admin endpoints in
+``backend/ee/onyx/server/query_history/api.py`` (router has no prefix).
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+from tests.integration.tests.permissions._access_matrix import Endpoint
+from tests.integration.tests.permissions._access_matrix import resolve_credentials
+from tests.integration.tests.permissions._access_matrix import USER_KINDS
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Query-history endpoints are enterprise only",
+)
+
+PERMISSION = Permission.READ_QUERY_HISTORY.value
+
+ENDPOINTS: list[Endpoint] = [
+    ("GET", "/admin/query-history/list", None),
+    ("GET", "/admin/query-history/export-status?request_id=nonexistent", None),
+]
+
+
+@pytest.fixture(scope="module")
+def holder_user(permission_holder_user_factory: Any) -> DATestUser:
+    return permission_holder_user_factory(PERMISSION)
+
+
+@pytest.fixture(scope="module")
+def holder_service_account(
+    permission_holder_service_account_factory: Any,
+) -> DATestAPIKey:
+    return permission_holder_service_account_factory(PERMISSION)
+
+
+@pytest.mark.parametrize("user_kind,expected", USER_KINDS)
+@pytest.mark.parametrize("method,path,body", ENDPOINTS)
+def test_access_matrix(
+    user_kind: str,
+    expected: str,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+    request: pytest.FixtureRequest,
+    permission_admin_user: DATestUser,  # noqa: ARG001 -- ensures module_reset ran
+) -> None:
+    headers, cookies = resolve_credentials(user_kind, request)
+    resp = call_endpoint(method, path, body, headers, cookies)
+    assert_response(resp, method, path, user_kind, expected)

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -7,12 +7,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.auth.permissions import ALL_PERMISSIONS
+from onyx.auth.permissions import CE_UNGATED_PERMISSIONS
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import require_permission
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.variable_functionality import global_version
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +111,13 @@ class TestResolveEffectivePermissions:
 
 
 class TestGetEffectivePermissions:
+    def setup_method(self) -> None:
+        """Ensure EE mode is set so CE ungating does not interfere."""
+        global_version.set_ee()
+
+    def teardown_method(self) -> None:
+        global_version.unset_ee()
+
     def test_expands_implied_permissions(self) -> None:
         """Column stores only granted; get_effective_permissions expands implied."""
         user = MagicMock()
@@ -122,17 +131,59 @@ class TestGetEffectivePermissions:
         result = get_effective_permissions(user)
         assert result == set(Permission)
 
-    def test_basic_stays_basic(self) -> None:
+    def test_basic_stays_basic_in_ee(self) -> None:
         user = MagicMock()
         user.effective_permissions = ["basic"]
         result = get_effective_permissions(user)
         assert result == {Permission.BASIC_ACCESS}
 
-    def test_empty_column(self) -> None:
+    def test_empty_column_in_ee(self) -> None:
         user = MagicMock()
         user.effective_permissions = []
         result = get_effective_permissions(user)
         assert result == set()
+
+
+class TestCEUngatedPermissions:
+    """Verify CE_UNGATED_PERMISSIONS are auto-granted in CE but not in EE."""
+
+    def setup_method(self) -> None:
+        global_version.unset_ee()
+
+    def teardown_method(self) -> None:
+        global_version.unset_ee()
+
+    def test_basic_user_gets_ungated_permissions_in_ce(self) -> None:
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+        result = get_effective_permissions(user)
+        assert Permission.ADD_AGENTS in result
+        assert Permission.READ_AGENTS in result
+        assert Permission.BASIC_ACCESS in result
+
+    def test_empty_user_gets_ungated_permissions_in_ce(self) -> None:
+        user = MagicMock()
+        user.effective_permissions = []
+        result = get_effective_permissions(user)
+        assert Permission.ADD_AGENTS in result
+        assert Permission.READ_AGENTS in result
+
+    def test_basic_user_does_not_get_ungated_permissions_in_ee(self) -> None:
+        global_version.set_ee()
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+        result = get_effective_permissions(user)
+        assert Permission.ADD_AGENTS not in result
+        assert result == {Permission.BASIC_ACCESS}
+
+    def test_admin_unaffected_by_ce_ungating(self) -> None:
+        user = MagicMock()
+        user.effective_permissions = ["admin"]
+        result = get_effective_permissions(user)
+        assert result == set(Permission)
+
+    def test_ce_ungated_set_contains_add_agents(self) -> None:
+        assert Permission.ADD_AGENTS in CE_UNGATED_PERMISSIONS
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +192,12 @@ class TestGetEffectivePermissions:
 
 
 class TestRequirePermission:
+    def setup_method(self) -> None:
+        global_version.set_ee()
+
+    def teardown_method(self) -> None:
+        global_version.unset_ee()
+
     @pytest.mark.asyncio
     async def test_admin_bypass(self) -> None:
         """Admin stored in column should pass any permission check."""

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -32,14 +32,19 @@ class TestResolveEffectivePermissions:
         result = resolve_effective_permissions({"add:agents"})
         assert result == {"add:agents", "read:agents"}
 
-    def test_manage_agents_implies_add_and_read(self) -> None:
-        """manage:agents directly maps to {add:agents, read:agents}."""
+    def test_manage_agents_implies_add_and_reads(self) -> None:
+        """manage:agents implies add:agents, read:agents, and read:document_sets."""
         result = resolve_effective_permissions({"manage:agents"})
-        assert result == {"manage:agents", "add:agents", "read:agents"}
+        assert result == {
+            "manage:agents",
+            "add:agents",
+            "read:agents",
+            "read:document_sets",
+        }
 
     def test_manage_connectors_chain(self) -> None:
         result = resolve_effective_permissions({"manage:connectors"})
-        assert result == {"manage:connectors", "add:connectors", "read:connectors"}
+        assert result == {"manage:connectors", "read:connectors"}
 
     def test_manage_document_sets(self) -> None:
         result = resolve_effective_permissions({"manage:document_sets"})
@@ -55,6 +60,16 @@ class TestResolveEffectivePermissions:
             "manage:user_groups",
             "read:connectors",
             "read:document_sets",
+            "read:agents",
+            "read:users",
+            "read:user_groups",
+        }
+
+    def test_manage_llms_implies_reads(self) -> None:
+        result = resolve_effective_permissions({"manage:llms"})
+        assert result == {
+            "manage:llms",
+            "read:user_groups",
             "read:agents",
             "read:users",
         }
@@ -76,7 +91,6 @@ class TestResolveEffectivePermissions:
             "add:agents",
             "read:agents",
             "manage:connectors",
-            "add:connectors",
             "read:connectors",
         }
 

--- a/web/src/components/ConnectorMultiSelect.tsx
+++ b/web/src/components/ConnectorMultiSelect.tsx
@@ -138,6 +138,7 @@ export const ConnectorMultiSelect = ({
           }}
           onKeyDown={handleKeyDown}
           className="rounded-12"
+          data-testid="connector-search-input"
         />
 
         {open && (

--- a/web/src/components/GenericMultiSelect.tsx
+++ b/web/src/components/GenericMultiSelect.tsx
@@ -133,6 +133,7 @@ export function GenericMultiSelect<
               }))}
             strict
             leftSearchIcon
+            data-testid={`${fieldName}-search-input`}
           />
         </div>
       </Disabled>

--- a/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
@@ -26,6 +26,7 @@ import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupRe
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
+import { useUser } from "@/providers/UserProvider";
 
 function CreateGroupPage() {
   const router = useRouter();
@@ -43,6 +44,7 @@ function CreateGroupPage() {
     { tokenBudget: null, periodHours: null },
   ]);
 
+  const { isAdmin } = useUser();
   const { rows: allRows, isLoading, error } = useGroupMemberCandidates();
 
   async function handleCreate() {
@@ -59,7 +61,9 @@ function CreateGroupPage() {
         selectedUserIds,
         selectedCcPairIds
       );
-      await saveGroupPermissions(groupId, enabledPermissions);
+      if (isAdmin) {
+        await saveGroupPermissions(groupId, enabledPermissions);
+      }
       await updateAgentGroupSharing(groupId, [], selectedAgentIds);
       await updateDocSetGroupSharing(groupId, [], selectedDocSetIds);
       await saveTokenLimits(groupId, tokenLimits, []);
@@ -159,10 +163,12 @@ function CreateGroupPage() {
             />
           </Section>
         )}
-        <GroupPermissionsSection
-          enabledPermissions={enabledPermissions}
-          onPermissionsChange={setEnabledPermissions}
-        />
+        {isAdmin && (
+          <GroupPermissionsSection
+            enabledPermissions={enabledPermissions}
+            onPermissionsChange={setEnabledPermissions}
+          />
+        )}
 
         <SharedGroupResources
           selectedCcPairIds={selectedCcPairIds}

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -37,6 +37,7 @@ import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupRe
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
+import { useUser } from "@/providers/UserProvider";
 
 const addModeColumns = memberTableColumns;
 
@@ -51,6 +52,7 @@ interface EditGroupPageProps {
 function EditGroupPage({ groupId }: EditGroupPageProps) {
   const router = useRouter();
   const { mutate } = useSWRConfig();
+  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -77,10 +79,13 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     TokenRateLimitDisplay[]
   >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher);
 
-  // Fetch permissions for this group
+  // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
-  >(SWR_KEYS.userGroupPermissions(groupId), errorHandlingFetcher);
+  >(
+    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    errorHandlingFetcher
+  );
 
   // Form state
   const [groupName, setGroupName] = useState("");
@@ -254,8 +259,10 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save permissions (bulk desired-state)
-      await saveGroupPermissions(groupId, enabledPermissions);
+      // Save permissions (bulk desired-state, admin only)
+      if (isAdmin) {
+        await saveGroupPermissions(groupId, enabledPermissions);
+      }
 
       // Save token rate limits (create/update/delete)
       await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
@@ -266,7 +273,9 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      mutate(SWR_KEYS.userGroupPermissions(groupId));
+      if (isAdmin) {
+        mutate(SWR_KEYS.userGroupPermissions(groupId));
+      }
       toast.success(`Group "${trimmed}" updated`);
       router.push("/admin/groups");
     } catch (e) {
@@ -456,10 +465,12 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              <GroupPermissionsSection
-                enabledPermissions={enabledPermissions}
-                onPermissionsChange={setEnabledPermissions}
-              />
+              {isAdmin && (
+                <GroupPermissionsSection
+                  enabledPermissions={enabledPermissions}
+                  onPermissionsChange={setEnabledPermissions}
+                />
+              )}
 
               <SharedGroupResources
                 selectedCcPairIds={selectedCcPairIds}

--- a/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
+++ b/web/src/refresh-pages/admin/ServiceAccountsPage/ApiKeyFormModal.tsx
@@ -170,6 +170,7 @@ export default function ApiKeyFormModal({
                         <Popover.Trigger asChild>
                           <div>
                             <InputTypeIn
+                              data-testid="groups-search-input"
                               value={searchTerm}
                               onChange={(e) => setSearchTerm(e.target.value)}
                               placeholder="Search groups..."

--- a/web/tests/e2e/admin/permissions/fixtures.ts
+++ b/web/tests/e2e/admin/permissions/fixtures.ts
@@ -1,0 +1,62 @@
+import { test as base, expect, type Page } from "@playwright/test";
+import { loginAs, apiLogin } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+
+const TEST_PASSWORD = "PermGating123!";
+
+function uniqueId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export interface TestUserContext {
+  userId: string;
+  groupId: number;
+  email: string;
+  password: string;
+}
+
+async function softCleanup(fn: () => Promise<unknown>): Promise<void> {
+  await fn().catch((e) => console.warn("cleanup:", e));
+}
+
+export const test = base.extend<{
+  adminClient: OnyxApiClient;
+  testUserContext: TestUserContext;
+}>({
+  adminClient: async ({ page }, use) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    await use(new OnyxApiClient(page.request));
+  },
+
+  testUserContext: async ({ page }, use) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    const adminClient = new OnyxApiClient(page.request);
+
+    const email = `e2e-perm-gating-${uniqueId("user")}@example.com`;
+    const groupName = `e2e-perm-gating-${uniqueId("group")}`;
+    let userId: string | undefined;
+    let groupId: number | undefined;
+
+    try {
+      const user = await adminClient.registerUser(email, TEST_PASSWORD);
+      userId = user.id;
+      groupId = await adminClient.createUserGroup(groupName, [userId]);
+
+      await use({ userId, groupId, email, password: TEST_PASSWORD });
+    } finally {
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanup = new OnyxApiClient(page.request);
+
+      if (groupId !== undefined) {
+        await softCleanup(() => cleanup.deleteUserGroup(groupId!));
+      }
+      await softCleanup(() => cleanup.deactivateUser(email));
+      await softCleanup(() => cleanup.deleteUser(email));
+    }
+  },
+});
+
+export { expect };

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "./fixtures";
+import { Permission } from "@/lib/types";
+import { apiLogin, loginAs } from "@tests/e2e/utils/auth";
+
+test.describe("Permission gating — ADD_AGENTS", () => {
+  test("New Agent button is disabled without ADD_AGENTS and enabled after granting it", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Phase 1: Without permission — button should be disabled
+    await page.context().clearCookies();
+    await apiLogin(page, email, password);
+    await page.goto("/app/agents");
+    await page.waitForLoadState("networkidle");
+
+    const newAgentButton = page.getByLabel("AgentsPage/new-agent-button");
+    await expect(newAgentButton).toBeVisible();
+    await expect(newAgentButton).toBeDisabled();
+
+    // Phase 2: Grant ADD_AGENTS — button should become enabled
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    await adminClient.setUserGroupPermissions(groupId, [Permission.ADD_AGENTS]);
+
+    await page.context().clearCookies();
+    await apiLogin(page, email, password);
+    await page.goto("/app/agents");
+    await page.waitForLoadState("networkidle");
+
+    await expect(newAgentButton).toBeVisible();
+    await expect(newAgentButton).toBeEnabled();
+
+    // Phase 3: Revoke ADD_AGENTS — button should be disabled again
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    await adminClient.setUserGroupPermissions(groupId, []);
+
+    await page.context().clearCookies();
+    await apiLogin(page, email, password);
+    await page.goto("/app/agents");
+    await page.waitForLoadState("networkidle");
+
+    await expect(newAgentButton).toBeVisible();
+    await expect(newAgentButton).toBeDisabled();
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -269,3 +269,124 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
+  test("Admin panel and /admin/documents/sets are gated behind MANAGE_DOCUMENT_SETS, with implied READ_CONNECTORS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a public file connector
+    const connectorName = `E2E DocSet Connector ${Date.now()}`;
+    const ccPairId = await adminClient.createFileConnector(
+      connectorName,
+      "public"
+    );
+
+    // Admin creates a second user group (user is already in fixture group;
+    // having 2 groups causes the full group selector to render)
+    const extraGroupName = `E2E DocSet Group ${Date.now()}`;
+    const extraGroupId = await adminClient.createUserGroup(extraGroupName, [
+      testUserContext.userId,
+    ]);
+
+    try {
+      // Phase 1: Without MANAGE_DOCUMENT_SETS — /admin/documents/sets should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/documents/sets");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Also verify /admin/documents/sets/new redirects
+      await page.goto("/admin/documents/sets/new");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_DOCUMENT_SETS — pages should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_DOCUMENT_SETS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/documents/sets");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/documents/sets");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Document Sets")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText("New Document Set")).toBeVisible();
+
+      // Navigate to creation page to verify implied READ_CONNECTORS
+      await page.goto("/admin/documents/sets/new");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/documents/sets/new");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("New Document Set")
+      ).toBeVisible({ timeout: 10000 });
+
+      // Open the connector dropdown and verify the admin-created connector is listed
+      const connectorSearchInput = page.getByTestId("connector-search-input");
+      await expect(connectorSearchInput).toBeVisible({ timeout: 10000 });
+      await connectorSearchInput.click();
+
+      // Verify the connector is visible (proves implied READ_CONNECTORS)
+      await expect(page.getByText(connectorName)).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Verify group selector loaded successfully (proves implied READ_USER_GROUPS)
+      await expect(
+        page.getByText("Assign group access for this document set")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.getByText(
+          "Failed to load assign group access for this document set"
+        )
+      ).not.toBeVisible();
+
+      // Open the group dropdown and verify the extra group is listed
+      const groupSearchInput = page.getByTestId("groups-search-input");
+      await expect(groupSearchInput).toBeVisible({ timeout: 10000 });
+      await groupSearchInput.click();
+      await expect(
+        page.getByRole("option", { name: extraGroupName })
+      ).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Phase 3: Revoke MANAGE_DOCUMENT_SETS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/documents/sets");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the connector and extra group
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteCCPair(ccPairId);
+      await cleanupClient.deleteUserGroup(extraGroupId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -503,11 +503,9 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
     const accountName = `E2E Service Account ${Date.now()}`;
     const apiKeyId = await adminClient.createServiceAccount(accountName);
 
-    // Admin creates a second user group (having 2 groups causes the full group selector to render)
+    // Admin creates a second user group (so the groups dropdown has content to render)
     const extraGroupName = `E2E SvcAcct Group ${Date.now()}`;
-    const extraGroupId = await adminClient.createUserGroup(extraGroupName, [
-      testUserContext.userId,
-    ]);
+    const extraGroupId = await adminClient.createUserGroup(extraGroupName);
 
     try {
       // Phase 1: Without MANAGE_SERVICE_ACCOUNT_API_KEYS — /admin/service-accounts should redirect to /app
@@ -548,7 +546,7 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
       const groupsSearchInput = page.getByTestId("groups-search-input");
       await expect(groupsSearchInput).toBeVisible({ timeout: 10000 });
       await groupsSearchInput.click();
-      await expect(page.getByText(extraGroupName)).toBeVisible({
+      await expect(page.getByText(extraGroupName).first()).toBeVisible({
         timeout: 10000,
       });
 

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -482,3 +482,93 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
+  test("Admin panel /admin/service-accounts is gated behind MANAGE_SERVICE_ACCOUNT_API_KEYS, with implied READ_USER_GROUPS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a service account
+    const accountName = `E2E Service Account ${Date.now()}`;
+    const apiKeyId = await adminClient.createServiceAccount(accountName);
+
+    // Admin creates a second user group (having 2 groups causes the full group selector to render)
+    const extraGroupName = `E2E SvcAcct Group ${Date.now()}`;
+    const extraGroupId = await adminClient.createUserGroup(extraGroupName, [
+      testUserContext.userId,
+    ]);
+
+    try {
+      // Phase 1: Without MANAGE_SERVICE_ACCOUNT_API_KEYS — /admin/service-accounts should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/service-accounts");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_SERVICE_ACCOUNT_API_KEYS — /admin/service-accounts should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_SERVICE_ACCOUNT_API_KEYS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/service-accounts");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/service-accounts");
+      await expect(
+        page
+          .getByLabel("admin-page-title")
+          .getByText("Service Accounts", { exact: true })
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText(accountName)).toBeVisible();
+
+      // Click "New Service Account" to open the creation modal
+      await page.getByText("New Service Account").click();
+      await expect(
+        page.getByText("Create Service Account", { exact: true })
+      ).toBeVisible({ timeout: 10000 });
+
+      // Open the groups search dropdown and verify the extra group is listed
+      // (proves implied READ_USER_GROUPS)
+      const groupsSearchInput = page.getByTestId("groups-search-input");
+      await expect(groupsSearchInput).toBeVisible({ timeout: 10000 });
+      await groupsSearchInput.click();
+      await expect(page.getByText(extraGroupName)).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Phase 3: Revoke MANAGE_SERVICE_ACCOUNT_API_KEYS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/service-accounts");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the service account and extra group
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteServiceAccount(apiKeyId);
+      await cleanupClient.deleteUserGroup(extraGroupId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -655,3 +655,69 @@ test.describe("Permission gating — MANAGE_BOTS", () => {
     }
   });
 });
+
+test.describe("Permission gating — READ_QUERY_HISTORY", () => {
+  test("Admin panel /admin/performance/query-history is gated behind READ_QUERY_HISTORY", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a chat session so the query history table has data
+    const sessionDescription = `E2E Query History ${Date.now()}`;
+    const chatSessionId =
+      await adminClient.createChatSession(sessionDescription);
+
+    try {
+      // Phase 1: Without READ_QUERY_HISTORY — /admin/performance/query-history should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/performance/query-history");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant READ_QUERY_HISTORY — /admin/performance/query-history should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.READ_QUERY_HISTORY,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/performance/query-history");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/performance/query-history");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Query History")
+      ).toBeVisible({ timeout: 10000 });
+
+      // Phase 3: Revoke READ_QUERY_HISTORY — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/performance/query-history");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the chat session
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteChatSession(chatSessionId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -721,3 +721,96 @@ test.describe("Permission gating — READ_QUERY_HISTORY", () => {
     }
   });
 });
+
+test.describe("Permission gating — CREATE_USER_API_KEYS", () => {
+  test("Access Tokens section and New Access Token button are gated behind CREATE_USER_API_KEYS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+    let createdPatId: number | undefined;
+
+    try {
+      // Phase 1: Without permission and no tokens — section should be hidden entirely
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/app/settings/accounts-access");
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByText("Access Tokens", { exact: true })
+      ).not.toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "New Access Token" })
+      ).not.toBeVisible();
+
+      // Phase 2: Grant CREATE_USER_API_KEYS — section visible, button enabled
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.CREATE_USER_API_KEYS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/app/settings/accounts-access");
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByText("Access Tokens", { exact: true })
+      ).toBeVisible({ timeout: 10000 });
+
+      const newTokenButton = page.getByRole("button", {
+        name: "New Access Token",
+      });
+      await expect(newTokenButton).toBeVisible({ timeout: 10000 });
+      await expect(newTokenButton).toBeEnabled();
+
+      // Create a PAT via API so Phase 3 can test "token exists but no permission"
+      const createResponse = await page.request.post("/api/user/pats", {
+        data: {
+          name: `E2E PAT ${Date.now()}`,
+          expiration_days: 30,
+        },
+      });
+      expect(createResponse.ok()).toBeTruthy();
+      const patData = await createResponse.json();
+      createdPatId = patData.id;
+
+      // Phase 3: Revoke permission — section stays (token exists) but button disabled
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/app/settings/accounts-access");
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByText("Access Tokens", { exact: true })
+      ).toBeVisible({ timeout: 10000 });
+
+      await expect(newTokenButton).toBeVisible({ timeout: 10000 });
+      await expect(newTokenButton).toBeDisabled();
+    } finally {
+      // Cleanup: delete the PAT (only requires BASIC_ACCESS)
+      if (createdPatId !== undefined) {
+        await page.context().clearCookies();
+        await apiLogin(page, email, password);
+        await page.request
+          .delete(`/api/user/pats/${createdPatId}`)
+          .catch(() => {});
+      }
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -390,3 +390,95 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_ACTIONS", () => {
+  test("Admin panel /admin/actions/mcp and /admin/actions/open-api are gated behind MANAGE_ACTIONS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates an OpenAPI custom tool and an MCP server
+    const toolName = `E2E Manage Tool ${Date.now()}`;
+    const toolId = await adminClient.createCustomTool(toolName);
+
+    const mcpName = `E2E Manage MCP ${Date.now()}`;
+    const mcpServerId = await adminClient.createMcpServer(mcpName);
+
+    try {
+      // Phase 1: Without MANAGE_ACTIONS — both pages should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/actions/open-api");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      await page.goto("/admin/actions/mcp");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_ACTIONS — both pages should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_ACTIONS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+
+      // Verify OpenAPI Actions page and created tool visibility
+      await page.goto("/admin/actions/open-api");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/admin/actions/open-api");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("OpenAPI Actions")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.getByLabel(`${toolName} OpenAPI action card`)
+      ).toBeVisible({ timeout: 10000 });
+
+      // Verify MCP Actions page and created server visibility
+      await page.goto("/admin/actions/mcp");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/admin/actions/mcp");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("MCP Actions")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByLabel(`${mcpName} MCP server card`)).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Phase 3: Revoke MANAGE_ACTIONS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/actions/open-api");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      await page.goto("/admin/actions/mcp");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the tool and MCP server
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteCustomTool(toolId);
+      await cleanupClient.deleteMcpServer(mcpServerId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -122,3 +122,150 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_LLMS", () => {
+  test("Admin panel and /admin/configuration/llm are gated behind MANAGE_LLMS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates an LLM provider
+    const providerName = `E2E Manage LLM ${Date.now()}`;
+    const providerId = await adminClient.createProvider(providerName);
+
+    try {
+      // Phase 1: Without MANAGE_LLMS — /admin/configuration/llm should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/configuration/llm");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_LLMS — /admin/configuration/llm should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_LLMS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/configuration/llm");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/configuration/llm");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Language Models")
+      ).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByText(providerName)).toBeVisible();
+
+      // Phase 3: Revoke MANAGE_LLMS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/configuration/llm");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the provider
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteProvider(providerId);
+    }
+  });
+});
+
+test.describe("Permission gating — MANAGE_CONNECTORS", () => {
+  test("Admin panel and /admin/indexing/status are gated behind MANAGE_CONNECTORS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a file connector
+    const connectorName = `E2E Manage Connector ${Date.now()}`;
+    const ccPairId = await adminClient.createFileConnector(connectorName);
+
+    try {
+      // Phase 1: Without MANAGE_CONNECTORS — /admin/indexing/status should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/indexing/status");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Also verify /admin/add-connector redirects
+      await page.goto("/admin/add-connector");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_CONNECTORS — /admin/indexing/status should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_CONNECTORS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/indexing/status");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/indexing/status");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Existing Connectors")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByRole("table")).toBeVisible();
+
+      // Also verify /admin/add-connector is accessible
+      await page.goto("/admin/add-connector");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/admin/add-connector");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Add Connector")
+      ).toBeVisible({ timeout: 10000 });
+
+      // Phase 3: Revoke MANAGE_CONNECTORS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/indexing/status");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the connector
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteCCPair(ccPairId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./fixtures";
 import { Permission } from "@/lib/types";
 import { apiLogin, loginAs } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
 
 test.describe("Permission gating — ADD_AGENTS", () => {
   test("New Agent button is disabled without ADD_AGENTS and enabled after granting it", async ({
@@ -53,5 +54,71 @@ test.describe("Permission gating — ADD_AGENTS", () => {
 
     await expect(newAgentButton).toBeVisible();
     await expect(newAgentButton).toBeDisabled();
+  });
+});
+
+test.describe("Permission gating — MANAGE_AGENTS", () => {
+  test("Admin panel and /admin/agents are gated behind MANAGE_AGENTS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a custom agent
+    const agentName = `E2E Manage Agent ${Date.now()}`;
+    const agentId = await adminClient.createAgent(agentName, "Test agent");
+
+    try {
+      // Phase 1: Without MANAGE_AGENTS — /admin/agents should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/agents");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_AGENTS — /admin/agents should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_AGENTS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/agents");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/agents");
+      await expect(page.getByRole("link", { name: "New Agent" })).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByText(agentName)).toBeVisible();
+
+      // Phase 3: Revoke MANAGE_AGENTS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/agents");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the agent
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteAgent(agentId);
+    }
   });
 });

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -570,3 +570,88 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_BOTS", () => {
+  test("Admin panel /admin/bots and /admin/discord-bot are gated behind MANAGE_BOTS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates a Discord guild (Slack bot skipped — creation requires real Slack API tokens)
+    const guild = await adminClient.createDiscordGuild();
+
+    try {
+      // Phase 1: Without MANAGE_BOTS — both pages should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/bots");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      await page.goto("/admin/discord-bot");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_BOTS — both pages should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_BOTS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+
+      // Verify Slack Integration page
+      await page.goto("/admin/bots");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/admin/bots");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Slack Integration")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.getByRole("button", { name: "New Slack Bot" })
+      ).toBeVisible();
+
+      // Verify Discord Integration page
+      await page.goto("/admin/discord-bot");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/admin/discord-bot");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Discord Integration")
+      ).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText("Add Server")).toBeVisible();
+
+      // Phase 3: Revoke MANAGE_BOTS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/bots");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      await page.goto("/admin/discord-bot");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete the Discord guild
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteDiscordGuild(guild.id);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -814,3 +814,132 @@ test.describe("Permission gating — CREATE_USER_API_KEYS", () => {
     }
   });
 });
+
+test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
+  test("Admin panel /admin/groups and /admin/groups/create are gated behind MANAGE_USER_GROUPS, with implied READ_CONNECTORS, READ_DOCUMENT_SETS, and READ_AGENTS", async ({
+    page,
+    adminClient,
+    testUserContext,
+  }) => {
+    const registryResponse = await page.request.get(
+      "/api/manage/admin/permissions/registry"
+    );
+    test.skip(
+      registryResponse.status() === 404,
+      "Permission registry unavailable (CE environment)"
+    );
+
+    const { groupId, email, password } = testUserContext;
+
+    // Admin creates test data for implied permission verification
+    const connectorName = `E2E ManageGroups Connector ${Date.now()}`;
+    const ccPairId = await adminClient.createFileConnector(
+      connectorName,
+      "public"
+    );
+
+    const agentName = `E2E ManageGroups Agent ${Date.now()}`;
+    const agentId = await adminClient.createAgent(agentName, "Test agent");
+
+    const docSetName = `E2E ManageGroups DocSet ${Date.now()}`;
+    const docSetId = await adminClient.createDocumentSet(docSetName, [
+      ccPairId,
+    ]);
+
+    // Extra user group so the groups list has a visible custom group card
+    const extraGroupName = `E2E ManageGroups Group ${Date.now()}`;
+    const extraGroupId = await adminClient.createUserGroup(extraGroupName, [
+      testUserContext.userId,
+    ]);
+
+    try {
+      // Phase 1: Without MANAGE_USER_GROUPS — /admin/groups should redirect to /app
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/groups");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Also verify /admin/groups/create redirects
+      await page.goto("/admin/groups/create");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+
+      // Phase 2: Grant MANAGE_USER_GROUPS — pages should be accessible
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, [
+        Permission.MANAGE_USER_GROUPS,
+      ]);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+
+      // Verify groups list page
+      await page.goto("/admin/groups");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/groups");
+      await expect(page.getByTestId("groups-page-heading")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.getByRole("button", { name: "New Group" })
+      ).toBeVisible();
+      await expect(page.getByText(extraGroupName)).toBeVisible();
+
+      // Navigate to create page to verify implied permissions
+      await page.goto("/admin/groups/create");
+      await page.waitForLoadState("networkidle");
+
+      expect(page.url()).toContain("/admin/groups/create");
+      await expect(
+        page.getByLabel("admin-page-title").getByText("Create Group")
+      ).toBeVisible({ timeout: 10000 });
+
+      // Open connectors & document sets popover and verify items (proves READ_CONNECTORS + READ_DOCUMENT_SETS)
+      const connectorDocSetInput = page.getByPlaceholder(
+        "Add connectors, document sets"
+      );
+      await expect(connectorDocSetInput).toBeVisible({ timeout: 10000 });
+      await connectorDocSetInput.click();
+      await expect(page.getByText(connectorName).first()).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByText(docSetName).first()).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Dismiss the connectors popover by pressing Escape before opening agents
+      await page.keyboard.press("Escape");
+
+      // Open agents popover and verify item (proves READ_AGENTS)
+      const agentsInput = page.getByPlaceholder("Add agents");
+      await expect(agentsInput).toBeVisible({ timeout: 10000 });
+      await agentsInput.click();
+      await expect(page.getByText(agentName).first()).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Phase 3: Revoke MANAGE_USER_GROUPS — should redirect again
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      await adminClient.setUserGroupPermissions(groupId, []);
+
+      await page.context().clearCookies();
+      await apiLogin(page, email, password);
+      await page.goto("/admin/groups");
+      await page.waitForLoadState("networkidle");
+      expect(page.url()).toContain("/app");
+    } finally {
+      // Cleanup: delete resources (doc set before connector since it references it)
+      await page.context().clearCookies();
+      await loginAs(page, "admin");
+      const cleanupClient = new OnyxApiClient(page.request);
+      await cleanupClient.deleteDocumentSet(docSetId);
+      await cleanupClient.deleteCCPair(ccPairId);
+      await cleanupClient.deleteAgent(agentId);
+      await cleanupClient.deleteUserGroup(extraGroupId);
+    }
+  });
+});

--- a/web/tests/e2e/admin/permissions/permission_system.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_system.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type APIResponse } from "@playwright/test";
+import { Permission } from "@/lib/types";
+import { apiLogin, loginAs } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+
+const TEST_PASSWORD = "PermissionSystem123!";
+
+function uniqueEmail(prefix: string): string {
+  return `e2e-permissions-${prefix}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}@example.com`;
+}
+
+async function softCleanup(fn: () => Promise<unknown>): Promise<void> {
+  await fn().catch((e) => console.warn("cleanup:", e));
+}
+
+async function expectOk(response: APIResponse, message: string): Promise<void> {
+  if (!response.ok()) {
+    throw new Error(
+      `${message}: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+test("group permissions apply immediately when a user is added to the group", async ({
+  page,
+}) => {
+  const email = uniqueEmail("llm");
+  const groupName = `e2e-permissions-llm-${Date.now()}`;
+  let groupId: number | undefined;
+
+  await page.context().clearCookies();
+  await loginAs(page, "admin");
+  const adminClient = new OnyxApiClient(page.request);
+
+  const registryResponse = await page.request.get(
+    "/api/manage/admin/permissions/registry"
+  );
+  test.skip(
+    registryResponse.status() === 404,
+    "Group permission registry is unavailable in this environment"
+  );
+  await expectOk(registryResponse, "Failed to fetch permission registry");
+
+  try {
+    const user = await adminClient.registerUser(email, TEST_PASSWORD);
+    groupId = await adminClient.createUserGroup(groupName);
+    await adminClient.setUserGroupPermissions(groupId, [
+      Permission.MANAGE_LLMS,
+    ]);
+
+    // This is intentionally not followed by waitForGroupSync. Auth permission
+    // recomputation is expected to complete before add-users returns.
+    await adminClient.addUsersToGroup(groupId, [user.id]);
+
+    await page.context().clearCookies();
+    await apiLogin(page, email, TEST_PASSWORD);
+
+    const userClient = new OnyxApiClient(page.request);
+    const permissions = await userClient.getCurrentUserPermissions();
+    expect(permissions).toEqual(
+      expect.arrayContaining([
+        Permission.BASIC_ACCESS,
+        Permission.MANAGE_LLMS,
+        Permission.READ_USERS,
+        Permission.READ_USER_GROUPS,
+        Permission.READ_AGENTS,
+      ])
+    );
+    expect(permissions).not.toContain(Permission.FULL_ADMIN_PANEL_ACCESS);
+    expect(permissions).not.toContain(Permission.MANAGE_USER_GROUPS);
+
+    const usersResponse = await page.request.get(
+      "/api/manage/users?include_api_keys=false"
+    );
+    await expectOk(
+      usersResponse,
+      "manage:llms should imply read:users for LLM sharing UI"
+    );
+
+    await page.goto("/admin/configuration/llm");
+    await expect(page.getByLabel("admin-page-title")).toContainText(
+      "Language Models"
+    );
+    await expect(
+      page.getByRole("link", { name: "Language Models" })
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Groups" })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Users" })).toHaveCount(0);
+
+    await page.goto("/admin/users");
+    await expect(page).toHaveURL(/\/admin\/configuration\/llm/);
+  } finally {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+    const cleanupClient = new OnyxApiClient(page.request);
+
+    if (groupId !== undefined) {
+      await softCleanup(() => cleanupClient.deleteUserGroup(groupId!));
+    }
+    await softCleanup(() => cleanupClient.deactivateUser(email));
+    await softCleanup(() => cleanupClient.deleteUser(email));
+  }
+});

--- a/web/tests/e2e/agents/create_and_edit_agent.spec.ts
+++ b/web/tests/e2e/agents/create_and_edit_agent.spec.ts
@@ -2,6 +2,11 @@ import { test, expect, Page, Browser } from "@playwright/test";
 import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
 import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+import { Permission } from "@/lib/types";
+import {
+  grantWorkerPermissions,
+  cleanupPermissionGroup,
+} from "@tests/e2e/utils/permissions";
 
 // --- Locator Helper Functions ---
 const getNameInput = (page: Page) => page.locator('input[name="name"]');
@@ -121,6 +126,7 @@ test.describe("Assistant Creation and Edit Verification", () => {
 
   test.describe("User Files Only", () => {
     let userFilesAssistantId: number | null = null;
+    let permGroupId: number | undefined;
 
     test.afterAll(async ({ browser }: { browser: Browser }) => {
       if (userFilesAssistantId !== null) {
@@ -135,11 +141,16 @@ test.describe("Assistant Creation and Edit Verification", () => {
           "[test] Cleanup completed - deleted User Files Only assistant"
         );
       }
+      await cleanupPermissionGroup(browser, permGroupId);
     });
 
     test("should create assistant with user files when no connectors exist @exclusive", async ({
       page,
     }, testInfo) => {
+      permGroupId = await grantWorkerPermissions(page, testInfo.workerIndex, [
+        Permission.ADD_AGENTS,
+      ]);
+
       await page.context().clearCookies();
       await loginAsWorkerUser(page, testInfo.workerIndex);
 
@@ -193,6 +204,7 @@ test.describe("Assistant Creation and Edit Verification", () => {
     let ccPairId: number;
     let documentSetId: number;
     let knowledgeAssistantId: number | null = null;
+    let permGroupId: number | undefined;
 
     test.afterAll(async ({ browser }: { browser: Browser }) => {
       // Cleanup using browser fixture (worker-scoped) to avoid per-test fixture limitation
@@ -214,11 +226,17 @@ test.describe("Assistant Creation and Edit Verification", () => {
       console.log(
         "[test] Cleanup completed - deleted assistant, connector, and document set"
       );
+      await cleanupPermissionGroup(browser, permGroupId);
     });
 
     test("should create and edit assistant with Knowledge enabled", async ({
       page,
     }, testInfo) => {
+      permGroupId = await grantWorkerPermissions(page, testInfo.workerIndex, [
+        Permission.ADD_AGENTS,
+        Permission.MANAGE_DOCUMENT_SETS,
+      ]);
+
       // Login as admin to create connector and document set (requires admin permissions)
       await page.context().clearCookies();
       await loginAs(page, "admin");

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -774,6 +774,58 @@ export class OnyxApiClient {
     return success;
   }
 
+  async createCustomTool(
+    name: string,
+    description: string = "E2E test tool"
+  ): Promise<number> {
+    const response = await this.post("/admin/tool/custom", {
+      name,
+      description,
+      definition: {
+        openapi: "3.0.0",
+        info: { title: name, description: description, version: "1.0.0" },
+        paths: {
+          "/test": {
+            get: {
+              operationId: "testOp",
+              summary: "Test endpoint",
+              responses: { "200": { description: "OK" } },
+            },
+          },
+        },
+        servers: [{ url: "https://example.com" }],
+      },
+      passthrough_auth: false,
+    });
+
+    const data = await this.handleResponse<{ id: number }>(
+      response,
+      "Failed to create custom tool"
+    );
+    this.log(`Created custom tool: ${name} (ID: ${data.id})`);
+    return data.id;
+  }
+
+  async createMcpServer(
+    name: string,
+    serverUrl: string = "https://example.com/mcp"
+  ): Promise<number> {
+    const response = await this.post("/admin/mcp/servers/create", {
+      name,
+      description: "E2E test MCP server",
+      server_url: serverUrl,
+      auth_type: "NONE",
+      auth_performer: "ADMIN",
+    });
+
+    const data = await this.handleResponse<{ server_id: number }>(
+      response,
+      "Failed to create MCP server"
+    );
+    this.log(`Created MCP server: ${name} (ID: ${data.server_id})`);
+    return data.server_id;
+  }
+
   async deleteCustomTool(toolId: number): Promise<boolean> {
     const response = await this.request.delete(
       `${this.baseUrl}/admin/tool/custom/${toolId}`

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -364,12 +364,16 @@ export class OnyxApiClient {
   }
 
   /**
-   * Deletes a connector-credential pair and waits for deletion to complete.
-   * Fetches the CC pair details to get connector/credential IDs, then initiates deletion
-   * and polls until the deletion is confirmed (waits for 404 response).
+   * Initiates deletion of a connector-credential pair.
+   *
+   * Fetches the CC pair details to get connector/credential IDs, then fires
+   * the deletion-attempt endpoint. Deletion runs asynchronously on a Celery
+   * worker; this method does NOT wait for it to finish, so the pair may
+   * still appear briefly after this resolves. Intended for test-teardown
+   * fire-and-forget cleanup — use `waitForDeletion` directly if a caller
+   * needs to observe the deleted state.
    *
    * @param ccPairId - The connector-credential pair ID to delete
-   * @returns Promise that resolves when deletion is confirmed, or rejects on timeout
    */
   async deleteCCPair(ccPairId: number): Promise<void> {
     // Get CC pair details to extract connector_id and credential_id

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -44,6 +44,8 @@ const E2E_IMAGE_GEN_API_KEY =
  * **User Groups:**
  * - `getUserGroups()` - Lists all user groups (including default system groups)
  * - `createUserGroup(name)` - Creates a user group
+ * - `addUsersToGroup(groupId, userIds)` - Adds users to a user group
+ * - `setUserGroupPermissions(groupId, permissions)` - Replaces group permission grants
  * - `deleteUserGroup(id)` - Deletes a user group
  *
  * **Tool Providers:**
@@ -590,6 +592,50 @@ export class OnyxApiClient {
   }
 
   /**
+   * Adds users to an existing user group.
+   *
+   * This endpoint recomputes effective permissions for the added users before
+   * returning, so callers do not need to wait for document-index group sync
+   * when they only need auth permissions.
+   */
+  async addUsersToGroup(groupId: number, userIds: string[]): Promise<void> {
+    const response = await this.post(
+      `/manage/admin/user-group/${groupId}/add-users`,
+      {
+        user_ids: userIds,
+      }
+    );
+
+    await this.handleResponse(
+      response,
+      `Failed to add users to group ${groupId}`
+    );
+    this.log(`Added ${userIds.length} user(s) to user group: ${groupId}`);
+  }
+
+  /**
+   * Replaces the toggleable permissions granted to a user group.
+   */
+  async setUserGroupPermissions(
+    groupId: number,
+    permissions: string[]
+  ): Promise<string[]> {
+    const response = await this.put(
+      `/manage/admin/user-group/${groupId}/permissions`,
+      {
+        permissions,
+      }
+    );
+
+    const updatedPermissions = await this.handleResponse<string[]>(
+      response,
+      `Failed to set permissions for user group ${groupId}`
+    );
+    this.log(`Set permissions for user group ${groupId}`);
+    return updatedPermissions;
+  }
+
+  /**
    * Polls until a user group has finished syncing (is_up_to_date === true).
    * Newly created groups start syncing immediately; many mutation endpoints
    * reject requests while the group is still syncing.
@@ -643,6 +689,14 @@ export class OnyxApiClient {
       "/manage/admin/user-group?include_default=true"
     );
     return response.json();
+  }
+
+  async getCurrentUserPermissions(): Promise<string[]> {
+    const response = await this.get("/me/permissions");
+    return await this.handleResponse(
+      response,
+      "Failed to fetch current user permissions"
+    );
   }
 
   async addUserToAdminGroup(email: string): Promise<void> {

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -58,6 +58,10 @@ const E2E_IMAGE_GEN_API_KEY =
  * - `createChatSession(description, personaId?)` - Creates a chat session with a description
  * - `deleteChatSession(chatId)` - Deletes a chat session
  *
+ * **Service Accounts:**
+ * - `createServiceAccount(name, groupIds?)` - Creates a service account API key
+ * - `deleteServiceAccount(apiKeyId)` - Deletes a service account API key
+ *
  * **Projects:**
  * - `createProject(name)` - Creates a project with a name
  * - `deleteProject(projectId)` - Deletes a project
@@ -824,6 +828,37 @@ export class OnyxApiClient {
     );
     this.log(`Created MCP server: ${name} (ID: ${data.server_id})`);
     return data.server_id;
+  }
+
+  async createServiceAccount(
+    name: string,
+    groupIds: number[] = []
+  ): Promise<number> {
+    const response = await this.post("/admin/api-key", {
+      name,
+      group_ids: groupIds,
+    });
+
+    const data = await this.handleResponse<{ api_key_id: number }>(
+      response,
+      "Failed to create service account"
+    );
+    this.log(`Created service account: ${name} (ID: ${data.api_key_id})`);
+    return data.api_key_id;
+  }
+
+  async deleteServiceAccount(apiKeyId: number): Promise<boolean> {
+    const response = await this.request.delete(
+      `${this.baseUrl}/admin/api-key/${apiKeyId}`
+    );
+    const success = await this.handleResponseSoft(
+      response,
+      `Failed to delete service account ${apiKeyId}`
+    );
+    if (success) {
+      this.log(`Deleted service account ${apiKeyId}`);
+    }
+    return success;
   }
 
   async deleteCustomTool(toolId: number): Promise<boolean> {

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -404,12 +404,6 @@ export class OnyxApiClient {
     this.log(
       `Initiated deletion for CC pair: ${ccPairId} (connector: ${connectorId}, credential: ${credentialId})`
     );
-    await this.waitForDeletion(
-      `/manage/admin/cc-pair/${ccPairId}`,
-      "CC pair",
-      ccPairId
-    );
-    this.log(`CC pair ${ccPairId} deletion confirmed`);
   }
 
   /**
@@ -447,6 +441,37 @@ export class OnyxApiClient {
     this.log(
       `Created restricted LLM provider: ${providerName} (ID: ${responseData.id}, Group: ${groupId})`
     );
+    return responseData.id;
+  }
+
+  /**
+   * Creates a public LLM provider and returns its ID.
+   *
+   * @param providerName - Display name for the provider
+   * @returns The provider ID
+   */
+  async createProvider(providerName: string): Promise<number> {
+    const response = await this.request.put(
+      `${this.baseUrl}/admin/llm/provider?is_creation=true`,
+      {
+        data: {
+          name: providerName,
+          provider: "openai",
+          api_key: E2E_LLM_PROVIDER_API_KEY,
+          is_public: true,
+          groups: [],
+          personas: [],
+          model_configurations: [{ name: "gpt-4o", is_visible: true }],
+        },
+      }
+    );
+
+    const responseData = await this.handleResponse<{ id: number }>(
+      response,
+      "Failed to create LLM provider"
+    );
+
+    this.log(`Created LLM provider: ${providerName} (ID: ${responseData.id})`);
     return responseData.id;
   }
 

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -777,6 +777,25 @@ export class OnyxApiClient {
     return tools.find((tool) => tool.name === name) ?? null;
   }
 
+  async createAgent(name: string, description: string = ""): Promise<number> {
+    const response = await this.post("/persona", {
+      name,
+      description,
+      system_prompt: "",
+      task_prompt: "",
+      datetime_aware: false,
+      document_set_ids: [],
+      is_public: true,
+      tool_ids: [],
+    });
+    const data = await this.handleResponse<{ id: number }>(
+      response,
+      "Failed to create agent"
+    );
+    this.log(`Created agent: ${name} (ID: ${data.id})`);
+    return data.id;
+  }
+
   async deleteAgent(agentId: number): Promise<boolean> {
     const response = await this.request.delete(
       `${this.baseUrl}/persona/${agentId}`

--- a/web/tests/e2e/utils/permissions.ts
+++ b/web/tests/e2e/utils/permissions.ts
@@ -49,7 +49,16 @@ export async function grantWorkerPermissions(
   const registryRes = await page.request.get(
     "/api/manage/admin/permissions/registry"
   );
-  if (!registryRes.ok()) return undefined;
+  // 404 is the expected CE-mode signal that the permission registry is
+  // disabled; anything else is a real setup failure we want to surface.
+  if (registryRes.status() === 404) return undefined;
+  if (!registryRes.ok()) {
+    const body = await registryRes.text().catch(() => "");
+    throw new Error(
+      `Unexpected /manage/admin/permissions/registry status ` +
+        `${registryRes.status()}: ${body.slice(0, 200)}`
+    );
+  }
 
   const { email } = workerUserCredentials(workerIndex % WORKER_USER_POOL_SIZE);
   const user = await adminClient.getUserByEmail(email);

--- a/web/tests/e2e/utils/permissions.ts
+++ b/web/tests/e2e/utils/permissions.ts
@@ -1,0 +1,84 @@
+import type { Browser, Page } from "@playwright/test";
+import { Permission } from "@/lib/types";
+import { loginAs } from "./auth";
+import { OnyxApiClient } from "./onyxApiClient";
+import {
+  WORKER_USER_POOL_SIZE,
+  workerUserCredentials,
+} from "@tests/e2e/constants";
+
+/**
+ * Grant permissions to a worker user via a temporary group.
+ *
+ * In EE mode: creates a group, adds the worker, sets the requested
+ * permissions, and returns the group ID (for cleanup).
+ *
+ * In CE mode: permissions like ADD_AGENTS are auto-granted, so this
+ * is a no-op that returns `undefined`.
+ *
+ * Leaves the page authenticated as admin — callers should clear
+ * cookies and re-login as the worker afterwards.
+ *
+ * Usage:
+ * ```ts
+ * let permGroupId: number | undefined;
+ *
+ * test("my test", async ({ page }, testInfo) => {
+ *   permGroupId = await grantWorkerPermissions(page, testInfo.workerIndex, [
+ *     Permission.ADD_AGENTS,
+ *   ]);
+ *   await page.context().clearCookies();
+ *   await loginAsWorkerUser(page, testInfo.workerIndex);
+ *   // ... test body
+ * });
+ *
+ * test.afterAll(async ({ browser }) => {
+ *   await cleanupPermissionGroup(browser, permGroupId);
+ * });
+ * ```
+ */
+export async function grantWorkerPermissions(
+  page: Page,
+  workerIndex: number,
+  permissions: Permission[]
+): Promise<number | undefined> {
+  await page.context().clearCookies();
+  await loginAs(page, "admin");
+  const adminClient = new OnyxApiClient(page.request);
+
+  const registryRes = await page.request.get(
+    "/api/manage/admin/permissions/registry"
+  );
+  if (!registryRes.ok()) return undefined;
+
+  const { email } = workerUserCredentials(workerIndex % WORKER_USER_POOL_SIZE);
+  const user = await adminClient.getUserByEmail(email);
+  if (!user) throw new Error(`Worker user ${email} not found`);
+
+  const groupId = await adminClient.createUserGroup(
+    `e2e-perm-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    [user.id]
+  );
+  await adminClient.setUserGroupPermissions(groupId, permissions);
+  return groupId;
+}
+
+/**
+ * Delete a temporary permission group created by `grantWorkerPermissions`.
+ * Safe to call with `undefined` (CE mode no-op).
+ */
+export async function cleanupPermissionGroup(
+  browser: Browser,
+  groupId: number | undefined
+): Promise<void> {
+  if (groupId === undefined) return;
+  const context = await browser.newContext({
+    storageState: "admin_auth.json",
+  });
+  const page = await context.newPage();
+  const client = new OnyxApiClient(page.request);
+  await client
+    .deleteUserGroup(groupId)
+    .catch((e: unknown) => console.warn("permission group cleanup:", e));
+  await context.close();
+}


### PR DESCRIPTION
## Summary

- Adds comprehensive integration and E2E tests for the new group-based permission system, covering every toggleable permission gate (MANAGE_AGENTS, MANAGE_CONNECTORS, MANAGE_LLMS, MANAGE_DOCUMENT_SETS, MANAGE_ACTIONS, MANAGE_BOTS, MANAGE_SERVICE_ACCOUNT_API_KEYS, MANAGE_USER_GROUPS, READ_QUERY_HISTORY, CREATE_USER_API_KEYS, ADD_AGENTS)
- Introduces a shared access matrix (`_access_matrix.py`) and test fixtures for systematically testing that workers (users with specific group permissions) can access permitted endpoints and are blocked from others
- Adds Playwright E2E tests for permission gating across admin UI pages, verifying sidebar visibility and page access based on group permissions
- Fixes CreateGroupPage and EditGroupPage to require admin-level permissions, preventing non-admin users with MANAGE_USER_GROUPS from escalating privileges
- Extends `OnyxApiClient` with helper methods for creating agents, custom tools, MCP servers, service accounts, and managing group permissions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added comprehensive tests for the group-based permission system, made group permission changes admin-only, aligned connector status with `READ_CONNECTORS`, and defined ungated permissions for Community Edition.

- **New Features**
  - Integration tests for all gates using `_access_matrix.py` and shared fixtures.
  - `Playwright` E2E tests covering UI gating (sidebar visibility and page access).
  - Extended `OnyxApiClient` with helpers for agents, custom tools, MCP servers, service accounts, and group permissions.
  - Test utilities for granting worker permissions and `data-testid` selectors for stable inputs.

- **Bug Fixes**
  - Require `FULL_ADMIN_PANEL_ACCESS` to change group permissions via API and gate `CreateGroupPage`/`EditGroupPage` permission updates behind `isAdmin` to prevent escalation.
  - Change `GET /admin/connector/status` to require `READ_CONNECTORS`.
  - Introduce `CE_UNGATED_PERMISSIONS` and unit tests; fix implied permissions (e.g., `MANAGE_DOCUMENT_SETS` ⇒ `READ_USER_GROUPS`, `MANAGE_LLMS` ⇒ `READ_USERS`, `MANAGE_SERVICE_ACCOUNT_API_KEYS` ⇒ `READ_USER_GROUPS`).

<sup>Written for commit ee3ebb6d971772cb9794245807afc8d9b6aa55dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



