### PR TITLE
fix(security): enforce chat session ownership on stop endpoint

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -986,11 +986,21 @@ async def search_chats(
 @router.post("/stop-chat-session/{chat_session_id}", tags=PUBLIC_API_TAGS)
 def stop_chat_session(
     chat_session_id: UUID,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),  # noqa: ARG001
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
 ) -> dict[str, str]:
     """
     Stop a chat session by setting a stop signal.
     This endpoint is called by the frontend when the user clicks the stop button.
     """
+    try:
+        get_chat_session_by_id(
+            chat_session_id=chat_session_id,
+            user_id=user.id,
+            db_session=db_session,
+        )
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Chat session not found")
+
     set_fence(chat_session_id, get_cache_backend(), True)
     return {"message": "Chat session stopped"}

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -183,3 +183,30 @@ def test_chat_session_not_found_returns_404(basic_user: DATestUser) -> None:
     """Verify unknown IDs return 404."""
     response = _get_chat_session(str(uuid4()), basic_user)
     assert response.status_code == 404
+
+
+def _stop_chat_session(chat_session_id: str, user: DATestUser) -> requests.Response:
+    return requests.post(
+        f"{API_SERVER_URL}/chat/stop-chat-session/{chat_session_id}",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def test_stop_chat_session_rejects_non_owner(
+    basic_user: DATestUser, second_user: DATestUser
+) -> None:
+    """Non-owner callers must not be able to stop another user's chat session."""
+    chat_session = ChatSessionManager.create(user_performing_action=basic_user)
+
+    # Owner can stop their own session.
+    response = _stop_chat_session(str(chat_session.id), basic_user)
+    assert response.status_code == 200
+
+    # A different authenticated user must not be able to stop it.
+    response = _stop_chat_session(str(chat_session.id), second_user)
+    assert response.status_code == 404
+
+    # Unknown session IDs are also rejected.
+    response = _stop_chat_session(str(uuid4()), second_user)
+    assert response.status_code == 404


### PR DESCRIPTION
## Description
- The `POST /chat/stop-chat-session/{chat_session_id}` handler now resolves the target session through the same ownership-scoped lookup (`get_chat_session_by_id` filtered by `user.id`) used by the other session-scoped endpoints before setting the stop signal.
- Callers who do not own (or admin-access) the session receive a 404 and cannot affect its state.

## How Has This Been Tested?
- [x] New integration regression test (`test_stop_chat_session_rejects_non_owner`) verifies owner can stop, non-owner gets 404, unknown IDs get 404.
- [x] `pre-commit` clean on the changed files (black, ty, ruff, autoflake, reorder-python-imports).
- [x] Security review performed on the diff — no new findings.

- [x] Override Linear Check