### PR TITLE
fix(security): enforce chat session ownership on stop endpoint (#10413) to release v3.0

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -918,11 +918,21 @@ async def search_chats(
 @router.post("/stop-chat-session/{chat_session_id}", tags=PUBLIC_API_TAGS)
 def stop_chat_session(
     chat_session_id: UUID,
-    user: User = Depends(current_user),  # noqa: ARG001
+    user: User = Depends(current_user),
+    db_session: Session = Depends(get_session),
 ) -> dict[str, str]:
     """
     Stop a chat session by setting a stop signal.
     This endpoint is called by the frontend when the user clicks the stop button.
     """
+    try:
+        get_chat_session_by_id(
+            chat_session_id=chat_session_id,
+            user_id=user.id,
+            db_session=db_session,
+        )
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Chat session not found")
+
     set_fence(chat_session_id, get_cache_backend(), True)
     return {"message": "Chat session stopped"}

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -183,3 +183,30 @@ def test_chat_session_not_found_returns_404(basic_user: DATestUser) -> None:
     """Verify unknown IDs return 404."""
     response = _get_chat_session(str(uuid4()), basic_user)
     assert response.status_code == 404
+
+
+def _stop_chat_session(chat_session_id: str, user: DATestUser) -> requests.Response:
+    return requests.post(
+        f"{API_SERVER_URL}/chat/stop-chat-session/{chat_session_id}",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+
+
+def test_stop_chat_session_rejects_non_owner(
+    basic_user: DATestUser, second_user: DATestUser
+) -> None:
+    """Non-owner callers must not be able to stop another user's chat session."""
+    chat_session = ChatSessionManager.create(user_performing_action=basic_user)
+
+    # Owner can stop their own session.
+    response = _stop_chat_session(str(chat_session.id), basic_user)
+    assert response.status_code == 200
+
+    # A different authenticated user must not be able to stop it.
+    response = _stop_chat_session(str(chat_session.id), second_user)
+    assert response.status_code == 404
+
+    # Unknown session IDs are also rejected.
+    response = _stop_chat_session(str(uuid4()), second_user)
+    assert response.status_code == 404


### PR DESCRIPTION
Cherry-pick of commit ec97ed0a735a6e3ab18a293fce8662c5eb6c23e3 to release/v3.0 branch.

Original PR: #10413

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce chat session ownership on the stop endpoint to prevent users from stopping sessions they don’t own. Returns 404 for unknown session IDs or non-owner requests.

- **Bug Fixes**
  - Validate session exists and is owned by the caller via `get_chat_session_by_id` with `user.id` and `db_session`.
  - Raise a session-not-found error to return 404 for non-owner or unknown IDs.
  - Add integration tests: owner can stop; non-owner and unknown IDs return 404.

<sup>Written for commit b490a81c75fca17556946a3a4c18b2c0e61a0950. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

