### PR TITLE
fix: unchanged client id not set in backend

### DIFF
--- a/backend/onyx/db/federated.py
+++ b/backend/onyx/db/federated.py
@@ -8,14 +8,13 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FederatedConnectorSource
-from onyx.configs.constants import MASK_CREDENTIAL_CHAR
-from onyx.configs.constants import MASK_CREDENTIAL_LONG_RE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import DocumentSet
 from onyx.db.models import FederatedConnector
 from onyx.db.models import FederatedConnector__DocumentSet
 from onyx.db.models import FederatedConnectorOAuthToken
 from onyx.federated_connectors.factory import get_federated_connector
+from onyx.utils.encryption import reject_masked_credentials
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -47,23 +46,6 @@ def fetch_all_federated_connectors_parallel() -> list[FederatedConnector]:
         return fetch_all_federated_connectors(db_session)
 
 
-def _reject_masked_credentials(credentials: dict[str, Any]) -> None:
-    """Raise if any credential string value contains mask placeholder characters.
-
-    mask_string() has two output formats:
-    - Short strings (< 14 chars): "••••••••••••" (U+2022 BULLET)
-    - Long strings (>= 14 chars): "abcd...wxyz" (first4 + "..." + last4)
-    Both must be rejected.
-    """
-    for key, val in credentials.items():
-        if isinstance(val, str) and (
-            MASK_CREDENTIAL_CHAR in val or MASK_CREDENTIAL_LONG_RE.match(val)
-        ):
-            raise ValueError(
-                f"Credential field '{key}' contains masked placeholder characters. Please provide the actual credential value."
-            )
-
-
 def validate_federated_connector_credentials(
     source: FederatedConnectorSource,
     credentials: dict[str, Any],
@@ -85,7 +67,7 @@ def create_federated_connector(
     config: dict[str, Any] | None = None,
 ) -> FederatedConnector:
     """Create a new federated connector with credential and config validation."""
-    _reject_masked_credentials(credentials)
+    reject_masked_credentials(credentials)
 
     # Validate credentials before creating
     if not validate_federated_connector_credentials(source, credentials):
@@ -298,7 +280,7 @@ def update_federated_connector(
     )
 
     if credentials is not None:
-        _reject_masked_credentials(credentials)
+        reject_masked_credentials(credentials)
 
         # Validate credentials before updating
         if not validate_federated_connector_credentials(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -151,7 +151,7 @@ def _build_oauth_admin_config_data(
         redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
         grant_types=["authorization_code", "refresh_token"],
         response_types=["code"],
-        scope=REQUESTED_SCOPE,  # TODO: allow specifying scopes?
+        scope=REQUESTED_SCOPE,  # TODO(evan): allow specifying scopes?
         token_endpoint_auth_method=token_endpoint_auth_method,
     )
     config_data[MCPOAuthKeys.CLIENT_INFO.value] = client_info.model_dump(mode="json")

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -82,6 +82,7 @@ from onyx.tools.tool_implementations.mcp.mcp_client import discover_mcp_tools
 from onyx.tools.tool_implementations.mcp.mcp_client import initialize_mcp_client
 from onyx.tools.tool_implementations.mcp.mcp_client import log_exception_group
 from onyx.utils.encryption import mask_string
+from onyx.utils.encryption import reject_masked_credentials
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -96,30 +97,65 @@ def _truncate_description(description: str | None, max_length: int = 500) -> str
     return description[: max_length - 3] + "..."
 
 
-# TODO: Replace mask-comparison approach with an explicit Unset sentinel from the
-# frontend indicating whether each credential field was actually modified. The current
-# approach is brittle (e.g. short credentials produce a fixed-length mask that could
-# collide) and mutates request values, which is surprising. The frontend should signal
-# "unchanged" vs "new value" directly rather than relying on masked-string equality.
-def _restore_masked_oauth_credentials(
+def _resolve_oauth_credentials(
+    *,
     request_client_id: str | None,
+    request_client_id_changed: bool,
     request_client_secret: str | None,
-    existing_client: OAuthClientInformationFull,
+    request_client_secret_changed: bool,
+    existing_client: OAuthClientInformationFull | None,
 ) -> tuple[str | None, str | None]:
-    """If the frontend sent back masked credentials, restore the real stored values."""
-    if (
-        request_client_id
-        and existing_client.client_id
-        and request_client_id == mask_string(existing_client.client_id)
-    ):
-        request_client_id = existing_client.client_id
-    if (
-        request_client_secret
-        and existing_client.client_secret
-        and request_client_secret == mask_string(existing_client.client_secret)
-    ):
-        request_client_secret = existing_client.client_secret
-    return request_client_id, request_client_secret
+    """Pick the effective client_id / client_secret for an upsert/connect.
+
+    Mirrors the LLM-provider `api_key_changed` pattern: when the frontend
+    flags a field as unchanged, ignore whatever value it sent (it is most
+    likely a masked placeholder) and reuse the stored value. When the
+    frontend flags a field as changed, take the request value as-is, but
+    defensively reject masked placeholders so a buggy client can't write
+    a mask to the database.
+    """
+    resolved_id = request_client_id
+    if not request_client_id_changed:
+        resolved_id = existing_client.client_id if existing_client else None
+    elif resolved_id:
+        reject_masked_credentials({"oauth_client_id": resolved_id})
+
+    resolved_secret = request_client_secret
+    if not request_client_secret_changed:
+        resolved_secret = existing_client.client_secret if existing_client else None
+    elif resolved_secret:
+        reject_masked_credentials({"oauth_client_secret": resolved_secret})
+
+    return resolved_id, resolved_secret
+
+
+def _build_oauth_admin_config_data(
+    *,
+    client_id: str | None,
+    client_secret: str | None,
+) -> MCPConnectionData:
+    """Construct the admin connection config payload for an OAuth client.
+
+    A public client legitimately has no `client_secret`, so we only require
+    a `client_id` to seed `client_info`. When no client_id is available we
+    fall through to an empty config (the OAuth provider will rely on
+    Dynamic Client Registration to obtain credentials).
+    """
+    config_data = MCPConnectionData(headers={})
+    if not client_id:
+        return config_data
+    token_endpoint_auth_method = "client_secret_post" if client_secret else "none"
+    client_info = OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        scope=REQUESTED_SCOPE,  # TODO: allow specifying scopes?
+        token_endpoint_auth_method=token_endpoint_auth_method,
+    )
+    config_data[MCPOAuthKeys.CLIENT_INFO.value] = client_info.model_dump(mode="json")
+    return config_data
 
 
 router = APIRouter(prefix="/mcp")
@@ -420,8 +456,10 @@ async def _connect_oauth(
             detail=f"Server was configured with authentication type {auth_type_str}",
         )
 
-    # If the frontend sent back masked credentials (unchanged by the user),
-    # restore the real stored values so we don't overwrite them with masks.
+    # Resolve the effective OAuth credentials, falling back to the stored
+    # values for any field the frontend marked as unchanged. This protects
+    # against the resubmit case where the form replays masked placeholders.
+    existing_client: OAuthClientInformationFull | None = None
     if mcp_server.admin_connection_config:
         existing_data = extract_connection_data(
             mcp_server.admin_connection_config, apply_mask=False
@@ -431,31 +469,19 @@ async def _connect_oauth(
             existing_client = OAuthClientInformationFull.model_validate(
                 existing_client_raw
             )
-            (
-                request.oauth_client_id,
-                request.oauth_client_secret,
-            ) = _restore_masked_oauth_credentials(
-                request.oauth_client_id,
-                request.oauth_client_secret,
-                existing_client,
-            )
 
-    # Create admin config with client info if provided
-    config_data = MCPConnectionData(headers={})
-    if request.oauth_client_id and request.oauth_client_secret:
-        client_info = OAuthClientInformationFull(
-            client_id=request.oauth_client_id,
-            client_secret=request.oauth_client_secret,
-            redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
-            grant_types=["authorization_code", "refresh_token"],
-            response_types=["code"],
-            scope=REQUESTED_SCOPE,  # TODO: allow specifying scopes?
-            # Must specify auth method so client_secret is actually sent during token exchange
-            token_endpoint_auth_method="client_secret_post",
-        )
-        config_data[MCPOAuthKeys.CLIENT_INFO.value] = client_info.model_dump(
-            mode="json"
-        )
+    request.oauth_client_id, request.oauth_client_secret = _resolve_oauth_credentials(
+        request_client_id=request.oauth_client_id,
+        request_client_id_changed=request.oauth_client_id_changed,
+        request_client_secret=request.oauth_client_secret,
+        request_client_secret_changed=request.oauth_client_secret_changed,
+        existing_client=existing_client,
+    )
+
+    config_data = _build_oauth_admin_config_data(
+        client_id=request.oauth_client_id,
+        client_secret=request.oauth_client_secret,
+    )
 
     if mcp_server.admin_connection_config_id is None:
         if not is_admin:
@@ -1404,17 +1430,20 @@ def _upsert_mcp_server(
             if client_info_raw:
                 client_info = OAuthClientInformationFull.model_validate(client_info_raw)
 
-        # If the frontend sent back masked credentials (unchanged by the user),
-        # restore the real stored values so the comparison below sees no change
-        # and the credentials aren't overwritten with masked strings.
+        # Resolve the effective OAuth credentials, falling back to the stored
+        # values for any field the frontend marked as unchanged. This protects
+        # the change-detection comparison below from spurious diffs caused by
+        # masked placeholders being replayed.
         if client_info and request.auth_type == MCPAuthenticationType.OAUTH:
             (
                 request.oauth_client_id,
                 request.oauth_client_secret,
-            ) = _restore_masked_oauth_credentials(
-                request.oauth_client_id,
-                request.oauth_client_secret,
-                client_info,
+            ) = _resolve_oauth_credentials(
+                request_client_id=request.oauth_client_id,
+                request_client_id_changed=request.oauth_client_id_changed,
+                request_client_secret=request.oauth_client_secret,
+                request_client_secret_changed=request.oauth_client_secret_changed,
+                existing_client=client_info,
             )
 
         changing_connection_config = (

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -75,6 +75,23 @@ class MCPToolCreateRequest(BaseModel):
     )
     oauth_client_id: Optional[str] = Field(None, description="OAuth client ID")
     oauth_client_secret: Optional[str] = Field(None, description="OAuth client secret")
+    oauth_client_id_changed: bool = Field(
+        default=False,
+        description=(
+            "True if `oauth_client_id` was edited by the user. When False on an "
+            "update of an existing server, the stored value is reused and the "
+            "request value is ignored. Defaults to False for backward "
+            "compatibility with older clients that don't send the flag."
+        ),
+    )
+    oauth_client_secret_changed: bool = Field(
+        default=False,
+        description=(
+            "True if `oauth_client_secret` was edited by the user. When False on "
+            "an update of an existing server, the stored value is reused and the "
+            "request value is ignored."
+        ),
+    )
     transport: MCPTransport | None = Field(
         None, description="MCP transport type (STREAMABLE_HTTP or SSE)"
     )
@@ -203,6 +220,21 @@ class MCPUserOAuthConnectRequest(BaseModel):
     )
     oauth_client_secret: str | None = Field(
         None, description="OAuth client secret (optional for DCR)"
+    )
+    oauth_client_id_changed: bool = Field(
+        default=False,
+        description=(
+            "True if `oauth_client_id` was edited by the user. When False, "
+            "the stored value is reused and the request value is ignored. "
+            "Defaults to False for backward compatibility."
+        ),
+    )
+    oauth_client_secret_changed: bool = Field(
+        default=False,
+        description=(
+            "True if `oauth_client_secret` was edited by the user. When False, "
+            "the stored value is reused and the request value is ignored."
+        ),
     )
 
     @model_validator(mode="after")

--- a/backend/onyx/utils/encryption.py
+++ b/backend/onyx/utils/encryption.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from onyx.configs.app_configs import ENCRYPTION_KEY_SECRET
+from onyx.configs.constants import MASK_CREDENTIAL_CHAR
+from onyx.configs.constants import MASK_CREDENTIAL_LONG_RE
 from onyx.connectors.google_utils.shared_constants import (
     DB_CREDENTIALS_AUTHENTICATION_METHOD,
 )
@@ -40,6 +42,30 @@ def mask_string(sensitive_str: str) -> str:
         return "••••••••••••"
 
     return f"{sensitive_str[:visible_start]}...{sensitive_str[-visible_end:]}"
+
+
+def is_masked_credential(value: str) -> bool:
+    """Return True if the string looks like a `mask_string` placeholder.
+
+    `mask_string` has two output formats:
+    - Short strings (< 14 chars): "••••••••••••" (U+2022 BULLET)
+    - Long strings (>= 14 chars): "abcd...wxyz" (first4 + "..." + last4)
+    """
+    return MASK_CREDENTIAL_CHAR in value or bool(MASK_CREDENTIAL_LONG_RE.match(value))
+
+
+def reject_masked_credentials(credentials: dict[str, Any]) -> None:
+    """Raise if any credential string value contains mask placeholder characters.
+
+    Used as a defensive net at write boundaries so that masked values
+    round-tripped from `mask_string` are never persisted as real credentials.
+    """
+    for key, val in credentials.items():
+        if isinstance(val, str) and is_masked_credential(val):
+            raise ValueError(
+                f"Credential field '{key}' contains masked placeholder "
+                "characters. Please provide the actual credential value."
+            )
 
 
 MASK_CREDENTIALS_WHITELIST = {

--- a/backend/onyx/utils/encryption.py
+++ b/backend/onyx/utils/encryption.py
@@ -59,13 +59,35 @@ def reject_masked_credentials(credentials: dict[str, Any]) -> None:
 
     Used as a defensive net at write boundaries so that masked values
     round-tripped from `mask_string` are never persisted as real credentials.
+
+    Recurses into nested dicts and lists to stay symmetric with
+    `mask_credential_dict`, which masks nested string values. The error
+    message includes a dotted path like `oauth.client_secret` or
+    `keys[2]` so callers can pinpoint the offending field.
     """
+    _reject_masked_in_dict(credentials, path="")
+
+
+def _reject_masked_in_dict(credentials: dict[str, Any], path: str) -> None:
     for key, val in credentials.items():
-        if isinstance(val, str) and is_masked_credential(val):
+        field_path = f"{path}.{key}" if path else key
+        _reject_masked_in_value(val, field_path)
+
+
+def _reject_masked_in_value(val: Any, path: str) -> None:
+    if isinstance(val, str):
+        if is_masked_credential(val):
             raise ValueError(
-                f"Credential field '{key}' contains masked placeholder "
+                f"Credential field '{path}' contains masked placeholder "
                 "characters. Please provide the actual credential value."
             )
+        return
+    if isinstance(val, dict):
+        _reject_masked_in_dict(val, path=path)
+        return
+    if isinstance(val, list):
+        for index, item in enumerate(val):
+            _reject_masked_in_value(item, f"{path}[{index}]")
 
 
 MASK_CREDENTIALS_WHITELIST = {

--- a/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
+++ b/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
@@ -56,3 +56,52 @@ class TestRejectMaskedCredentials:
                 "some_flag": True,
             }
         )
+
+    def test_rejects_masked_value_inside_nested_dict(self) -> None:
+        """`mask_credential_dict` recurses into nested dicts; the rejection
+        helper must do the same so a masked nested string can't slip
+        through on resubmit."""
+        with pytest.raises(ValueError, match=r"oauth\.client_secret"):
+            reject_masked_credentials(
+                {
+                    "name": "fine",
+                    "oauth": {
+                        "client_id": "1234567890.1234567890",
+                        "client_secret": "abcd...wxyz",
+                    },
+                }
+            )
+
+    def test_rejects_masked_value_inside_list(self) -> None:
+        """`_mask_list` masks string elements; the rejection helper must
+        catch them too."""
+        with pytest.raises(ValueError, match=r"keys\[1\]"):
+            reject_masked_credentials(
+                {
+                    "keys": ["real-key-aaaa", "abcd...wxyz", "real-key-bbbb"],
+                }
+            )
+
+    def test_rejects_masked_value_inside_list_of_dicts(self) -> None:
+        with pytest.raises(ValueError, match=r"sessions\[0\]\.token"):
+            reject_masked_credentials(
+                {
+                    "sessions": [
+                        {"token": "abcd...wxyz"},
+                        {"token": "real-token-value"},
+                    ],
+                }
+            )
+
+    def test_accepts_deeply_nested_real_values(self) -> None:
+        reject_masked_credentials(
+            {
+                "oauth": {
+                    "client_id": "real-id-value-1234",
+                    "extras": {
+                        "scopes": ["read", "write"],
+                        "metadata": {"region": "us-east-1"},
+                    },
+                },
+            }
+        )

--- a/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
+++ b/backend/tests/unit/federated_connector/test_reject_masked_credentials.py
@@ -1,7 +1,7 @@
 import pytest
 
 from onyx.configs.constants import MASK_CREDENTIAL_CHAR
-from onyx.db.federated import _reject_masked_credentials
+from onyx.utils.encryption import reject_masked_credentials
 
 
 class TestRejectMaskedCredentials:
@@ -10,24 +10,24 @@ class TestRejectMaskedCredentials:
     mask_string() has two output formats:
     - Short strings (< 14 chars): "••••••••••••" (U+2022 BULLET)
     - Long strings (>= 14 chars): "abcd...wxyz" (first4 + "..." + last4)
-    _reject_masked_credentials must catch both.
+    reject_masked_credentials must catch both.
     """
 
     def test_rejects_fully_masked_value(self) -> None:
         masked = MASK_CREDENTIAL_CHAR * 12  # "••••••••••••"
         with pytest.raises(ValueError, match="masked placeholder"):
-            _reject_masked_credentials({"client_id": masked})
+            reject_masked_credentials({"client_id": masked})
 
     def test_rejects_long_string_masked_value(self) -> None:
         """mask_string returns 'first4...last4' for long strings — the real
         format used for OAuth credentials like client_id and client_secret."""
         with pytest.raises(ValueError, match="masked placeholder"):
-            _reject_masked_credentials({"client_id": "1234...7890"})
+            reject_masked_credentials({"client_id": "1234...7890"})
 
     def test_rejects_when_any_field_is_masked(self) -> None:
         """Even if client_id is real, a masked client_secret must be caught."""
         with pytest.raises(ValueError, match="client_secret"):
-            _reject_masked_credentials(
+            reject_masked_credentials(
                 {
                     "client_id": "1234567890.1234567890",
                     "client_secret": MASK_CREDENTIAL_CHAR * 12,
@@ -36,7 +36,7 @@ class TestRejectMaskedCredentials:
 
     def test_accepts_real_credentials(self) -> None:
         # Should not raise
-        _reject_masked_credentials(
+        reject_masked_credentials(
             {
                 "client_id": "1234567890.1234567890",
                 "client_secret": "test_client_secret_value",
@@ -45,11 +45,11 @@ class TestRejectMaskedCredentials:
 
     def test_accepts_empty_dict(self) -> None:
         # Should not raise — empty credentials are handled elsewhere
-        _reject_masked_credentials({})
+        reject_masked_credentials({})
 
     def test_ignores_non_string_values(self) -> None:
         # Non-string values (None, bool, int) should pass through
-        _reject_masked_credentials(
+        reject_masked_credentials(
             {
                 "client_id": "real_value",
                 "redirect_uri": None,

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
@@ -1,0 +1,207 @@
+"""Unit tests for the MCP OAuth credentials resolver and config builder.
+
+These tests cover the fix for the "resubmit unchanged wipes client_info" bug
+described in `plans/mcp-oauth-resubmit-empty-secret-fix.md`. The resolver
+mirrors the LLM-provider `api_key_changed` pattern: when the frontend marks a
+credential field as unchanged, the backend reuses the stored value instead of
+overwriting it with whatever (likely masked) string the form replayed.
+"""
+
+import pytest
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+from onyx.server.features.mcp.api import _build_oauth_admin_config_data
+from onyx.server.features.mcp.api import _resolve_oauth_credentials
+from onyx.server.features.mcp.models import MCPOAuthKeys
+from onyx.utils.encryption import mask_string
+
+
+def _make_existing_client(
+    *,
+    client_id: str = "stored-client-id",
+    client_secret: str | None = "stored-secret",
+) -> OAuthClientInformationFull:
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uris=[AnyUrl("https://example.com/callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method=("client_secret_post" if client_secret else "none"),
+    )
+
+
+class TestResolveOAuthCredentials:
+    def test_public_client_unchanged_resubmit_keeps_stored_values(self) -> None:
+        existing = _make_existing_client(client_id="abc", client_secret=None)
+
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id=mask_string("abc") if len("abc") >= 14 else "abc",
+            request_client_id_changed=False,
+            request_client_secret="",
+            request_client_secret_changed=False,
+            existing_client=existing,
+        )
+
+        assert resolved_id == "abc"
+        assert resolved_secret is None
+
+    def test_confidential_client_unchanged_resubmit_keeps_stored_values(self) -> None:
+        stored_id = "long-client-id-123456"
+        stored_secret = "long-client-secret-abcdef"
+        existing = _make_existing_client(
+            client_id=stored_id,
+            client_secret=stored_secret,
+        )
+
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id=mask_string(stored_id),
+            request_client_id_changed=False,
+            request_client_secret=mask_string(stored_secret),
+            request_client_secret_changed=False,
+            existing_client=existing,
+        )
+
+        assert resolved_id == stored_id
+        assert resolved_secret == stored_secret
+
+    def test_only_client_id_changed_keeps_stored_secret(self) -> None:
+        existing = _make_existing_client(
+            client_id="stored-id",
+            client_secret="stored-secret-value",
+        )
+
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id="brand-new-id",
+            request_client_id_changed=True,
+            request_client_secret=mask_string("stored-secret-value"),
+            request_client_secret_changed=False,
+            existing_client=existing,
+        )
+
+        assert resolved_id == "brand-new-id"
+        assert resolved_secret == "stored-secret-value"
+
+    def test_only_client_secret_changed_keeps_stored_id(self) -> None:
+        existing = _make_existing_client(
+            client_id="stored-client-id-1234",
+            client_secret="stored-secret",
+        )
+
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id=mask_string("stored-client-id-1234"),
+            request_client_id_changed=False,
+            request_client_secret="brand-new-secret",
+            request_client_secret_changed=True,
+            existing_client=existing,
+        )
+
+        assert resolved_id == "stored-client-id-1234"
+        assert resolved_secret == "brand-new-secret"
+
+    def test_changed_flag_with_long_masked_value_is_rejected(self) -> None:
+        existing = _make_existing_client(
+            client_id="real-stored-id-1234",
+            client_secret="real-stored-secret-1234",
+        )
+
+        with pytest.raises(ValueError, match="oauth_client_id"):
+            _resolve_oauth_credentials(
+                request_client_id=mask_string("some-other-long-string"),
+                request_client_id_changed=True,
+                request_client_secret="anything-else",
+                request_client_secret_changed=True,
+                existing_client=existing,
+            )
+
+        with pytest.raises(ValueError, match="oauth_client_secret"):
+            _resolve_oauth_credentials(
+                request_client_id="totally-fresh-id",
+                request_client_id_changed=True,
+                request_client_secret=mask_string("another-long-secret"),
+                request_client_secret_changed=True,
+                existing_client=existing,
+            )
+
+    def test_changed_flag_with_short_mask_placeholder_is_rejected(self) -> None:
+        # mask_string returns "••••••••••••" for short inputs; verify both
+        # mask formats trip the safety net, not just the long form.
+        short_mask = mask_string("short")
+        existing = _make_existing_client()
+
+        with pytest.raises(ValueError, match="oauth_client_secret"):
+            _resolve_oauth_credentials(
+                request_client_id="something",
+                request_client_id_changed=True,
+                request_client_secret=short_mask,
+                request_client_secret_changed=True,
+                existing_client=existing,
+            )
+
+    def test_no_existing_client_passes_request_values_through(self) -> None:
+        # Create flow: nothing is stored yet; both flags are False (the default)
+        # but there's nothing to fall back to. The resolver should resolve to
+        # None for both fields, leaving the caller to handle the create path
+        # explicitly (which `_upsert_mcp_server` does by only invoking the
+        # resolver when an `existing_client` is present).
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id="user-typed-id",
+            request_client_id_changed=False,
+            request_client_secret="user-typed-secret",
+            request_client_secret_changed=False,
+            existing_client=None,
+        )
+
+        assert resolved_id is None
+        assert resolved_secret is None
+
+    def test_no_existing_client_with_changed_flags_uses_request_values(self) -> None:
+        resolved_id, resolved_secret = _resolve_oauth_credentials(
+            request_client_id="user-typed-id",
+            request_client_id_changed=True,
+            request_client_secret="user-typed-secret",
+            request_client_secret_changed=True,
+            existing_client=None,
+        )
+
+        assert resolved_id == "user-typed-id"
+        assert resolved_secret == "user-typed-secret"
+
+
+class TestBuildOAuthAdminConfigData:
+    def test_no_client_id_returns_empty_headers_only(self) -> None:
+        config_data = _build_oauth_admin_config_data(
+            client_id=None,
+            client_secret=None,
+        )
+
+        assert config_data == {"headers": {}}
+        assert MCPOAuthKeys.CLIENT_INFO.value not in config_data
+
+    def test_public_client_with_no_secret_still_seeds_client_info(self) -> None:
+        # Regression for the original bug: a public client (id present, secret
+        # absent) used to fall through the gate and silently wipe the stored
+        # client_info on resubmit.
+        config_data = _build_oauth_admin_config_data(
+            client_id="public-client-id",
+            client_secret=None,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["client_id"] == "public-client-id"
+        assert client_info_dict.get("client_secret") is None
+        assert client_info_dict["token_endpoint_auth_method"] == "none"
+
+    def test_confidential_client_uses_client_secret_post(self) -> None:
+        config_data = _build_oauth_admin_config_data(
+            client_id="confidential-id",
+            client_secret="confidential-secret",
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["client_id"] == "confidential-id"
+        assert client_info_dict["client_secret"] == "confidential-secret"
+        assert client_info_dict["token_endpoint_auth_method"] == "client_secret_post"

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -183,6 +183,11 @@ export async function upsertMCPServer(serverData: {
   api_token?: string;
   oauth_client_id?: string;
   oauth_client_secret?: string;
+  // Mirrors the LLM-provider `api_key_changed` pattern: explicitly signal
+  // whether the OAuth credential fields were edited so the backend doesn't
+  // overwrite stored values with masked placeholders on resubmit.
+  oauth_client_id_changed?: boolean;
+  oauth_client_secret_changed?: boolean;
   auth_template?: any;
   admin_credentials?: Record<string, string>;
   existing_server_id?: number;

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -199,9 +199,30 @@ export default function MCPAuthenticationModal({
     };
   }, [fullServer, mcpServer?.server_url]);
 
+  // Mirrors the LLM-provider `api_key_changed` pattern in
+  // `web/src/sections/modals/llmConfig/svc.ts`. The backend uses these flags
+  // to decide whether to overwrite the stored OAuth credentials or to leave
+  // them untouched, which prevents masked placeholders sent back from the
+  // GET response from accidentally wiping out the real stored values.
+  const computeOAuthChangedFlags = (values: MCPAuthFormValues) => {
+    if (values.auth_type !== MCPAuthenticationType.OAUTH) {
+      return {
+        oauth_client_id_changed: false,
+        oauth_client_secret_changed: false,
+      };
+    }
+    return {
+      oauth_client_id_changed:
+        values.oauth_client_id !== initialValues.oauth_client_id,
+      oauth_client_secret_changed:
+        values.oauth_client_secret !== initialValues.oauth_client_secret,
+    };
+  };
+
   const constructServerData = (values: MCPAuthFormValues) => {
     if (!mcpServer) return null;
     const authType = values.auth_type;
+    const oauthChangedFlags = computeOAuthChangedFlags(values);
 
     return {
       name: mcpServer.name,
@@ -233,6 +254,7 @@ export default function MCPAuthenticationModal({
         authType === MCPAuthenticationType.OAUTH
           ? values.oauth_client_secret
           : undefined,
+      ...oauthChangedFlags,
       existing_server_id: mcpServer.id,
     };
   };
@@ -263,6 +285,7 @@ export default function MCPAuthenticationModal({
 
       // Step 3: For OAuth, initiate the OAuth flow
       if (authType === MCPAuthenticationType.OAUTH) {
+        const oauthChangedFlags = computeOAuthChangedFlags(values);
         const oauthResponse = await fetch("/api/admin/mcp/oauth/connect", {
           method: "POST",
           headers: {
@@ -272,6 +295,7 @@ export default function MCPAuthenticationModal({
             server_id: mcpServer.id.toString(),
             oauth_client_id: values.oauth_client_id,
             oauth_client_secret: values.oauth_client_secret,
+            ...oauthChangedFlags,
             return_path: `/admin/actions/mcp/?server_id=${mcpServer.id}&trigger_fetch=true`,
             include_resource_param: true,
           }),


### PR DESCRIPTION
## Description

When client_secret was None, we were incorrectly treating client_id as changed and setting a masked value in the backend. We now use the standardized changed_* pattern to avoid this.

Closes https://linear.app/onyx-app/issue/ENG-4069/mcp-oauth-client-id-masked-value-persisted-when-client-secret-is-null

## How Has This Been Tested?

unit tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth credential updates so we don’t overwrite an unchanged `client_id` with a masked value when `client_secret` is empty, and blocks saving masked placeholders. Aligns with ENG-4069.

- **Bug Fixes**
  - Added `oauth_client_id_changed` and `oauth_client_secret_changed` to request models and web UI for upsert and OAuth connect; backend reuses stored values when flags are false.
  - Resolves OAuth credentials on upsert/connect, ignoring unchanged fields and rejecting masked placeholders to prevent wiping `client_info` on resubmit.
  - Builds admin config when only a `client_id` is given; uses `token_endpoint_auth_method` = `none` for public clients or `client_secret_post` when a secret exists.
  - Centralized masked-credential detection in `onyx.utils.encryption` (`reject_masked_credentials`) with nested dict/list support; federated connectors and MCP OAuth flows use it.
  - Added unit tests for the resolver/config builder and masked-credential rejection, including nested cases.

<sup>Written for commit 3d0ee2489ca63b58f8132bce2cc1f37707e5a180. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

