### PR TITLE
fix(opal): keep expandable card separator line default border color

### DIFF
--- a/web/lib/opal/src/components/cards/card/styles.css
+++ b/web/lib/opal/src/components/cards/card/styles.css
@@ -81,6 +81,16 @@
   @apply border;
 }
 
+/* When expanded, the header's bottom border acts as a separator between
+   header and body. It should always remain the default border color,
+   regardless of any status borderColor applied to the card. */
+
+.opal-card-expandable-header:has(
+    + .opal-card-expandable-wrapper[data-expanded="true"]
+  ) {
+  @apply border-b-border-01;
+}
+
 /* ── Content wrapper: grid 0fr↔1fr animation ─────────────────────────── */
 
 .opal-card-expandable-wrapper {


### PR DESCRIPTION
## Description

Force the expandable card header's bottom border to `border-01` when expanded content is visible. This ensures the separator between header and body stays neutral regardless of any status `borderColor` applied to the card.

Uses a `:has(+ .wrapper[data-expanded="true"])` sibling selector so it only applies when the expandable content is shown — when collapsed, the full status border color applies normally.

## Screenshots + Videos

### Before

<img width="870" height="603" alt="image" src="https://github.com/user-attachments/assets/eb32e4fd-7638-4c85-a9f6-f01adc46908c" />

<br>

<img width="865" height="68" alt="image" src="https://github.com/user-attachments/assets/baadb086-442f-4dfb-8b16-8cb7cf7e9e90" />

### After

<img width="871" height="613" alt="image" src="https://github.com/user-attachments/assets/51ad8adf-63d0-49cf-881e-504da54a8f81" />

<br>

<img width="874" height="44" alt="image" src="https://github.com/user-attachments/assets/5236428e-4d30-4075-a20b-24226b7dce91" />

Notice how, now, the line between the `expandedContent` and the `mainContent` is NOT colour-matched with the exterior border.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the expandable card header’s bottom border at the default separator color when the card is expanded, so status `borderColor` only affects outer borders.

- **Bug Fixes**
  - Added a CSS rule using `:has(+ .opal-card-expandable-wrapper[data-expanded="true"])` to apply `border-b-border-01` on `.opal-card-expandable-header` only when expanded.

<sup>Written for commit 1fd41d4a6c9cc6c28f6841fc116d97117d5b4a6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->