### PR TITLE
feat(opal): add `headerPadding` prop + wire status border on `MessageCard`

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/README.md
+++ b/web/lib/opal/src/components/cards/message-card/README.md
@@ -14,6 +14,8 @@ and border colors.
 | `icon` | `IconFunctionComponent` | per variant | Override the default variant icon |
 | `title` | `string \| RichStr` | — | Main title text |
 | `description` | `string \| RichStr` | — | Description below the title |
+| `padding` | `"sm" \| "xs"` | `"sm"` | Padding preset for the outer card |
+| `headerPadding` | `PaddingVariants` | `"fit"` | Padding around the header Content area. `"fit"` → no padding; `"sm"` → `p-2`. |
 | `bottomChildren` | `ReactNode` | — | Content below a divider, under the main content |
 | `rightChildren` | `ReactNode` | — | Content on the right side. Mutually exclusive with `onClose`. |
 | `onClose` | `() => void` | — | Close button callback. When omitted, no close button is rendered. |

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -38,7 +38,7 @@ interface MessageCardBaseProps {
   /** Padding preset. @default "sm" */
   padding?: Extract<PaddingVariants, "sm" | "xs">;
 
-  /** Padding around the header Content area. @default "sm" */
+  /** Padding around the header Content area. @default "fit" */
   headerPadding?: PaddingVariants;
 
   /**
@@ -125,7 +125,7 @@ function MessageCard({
   title,
   description,
   padding = "sm",
-  headerPadding = "sm",
+  headerPadding = "fit",
   bottomChildren,
   rightChildren,
   onClose,

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -169,7 +169,7 @@ function MessageCard({
 
       {bottomChildren && (
         <>
-          <Divider paddingParallel="sm" paddingPerpendicular="fit" />
+          <Divider paddingParallel="sm" paddingPerpendicular="xs" />
           {bottomChildren}
         </>
       )}

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -38,6 +38,9 @@ interface MessageCardBaseProps {
   /** Padding preset. @default "sm" */
   padding?: Extract<PaddingVariants, "sm" | "xs">;
 
+  /** Padding around the header Content area. @default "sm" */
+  headerPadding?: PaddingVariants;
+
   /**
    * Content rendered below a divider, under the main content area.
    * When provided, a `Divider` is inserted between the `ContentAction` and this node.
@@ -122,6 +125,7 @@ function MessageCard({
   title,
   description,
   padding = "sm",
+  headerPadding = "sm",
   bottomChildren,
   rightChildren,
   onClose,
@@ -146,23 +150,26 @@ function MessageCard({
     <div
       className={cn("opal-message-card", paddingVariants[padding])}
       data-variant={variant}
+      data-opal-status-border={variant}
       ref={ref}
     >
-      <ContentAction
-        icon={(props) => (
-          <Icon {...props} className={cn(props.className, iconClass)} />
-        )}
-        title={title}
-        description={description}
-        sizePreset="main-ui"
-        variant="section"
-        padding="md"
-        rightChildren={right}
-      />
+      <div className={paddingVariants[headerPadding]}>
+        <ContentAction
+          icon={(props) => (
+            <Icon {...props} className={cn(props.className, iconClass)} />
+          )}
+          title={title}
+          description={description}
+          sizePreset="main-ui"
+          variant="section"
+          padding="fit"
+          rightChildren={right}
+        />
+      </div>
 
       {bottomChildren && (
         <>
-          <Divider paddingParallel="sm" paddingPerpendicular="xs" />
+          <Divider paddingParallel="sm" paddingPerpendicular="fit" />
           {bottomChildren}
         </>
       )}

--- a/web/lib/opal/src/components/cards/message-card/styles.css
+++ b/web/lib/opal/src/components/cards/message-card/styles.css
@@ -1,25 +1,26 @@
 .opal-message-card {
-  @apply flex flex-col w-full self-stretch rounded-16 border;
+  @apply flex flex-col gap-1 w-full self-stretch rounded-16 border;
 }
 
-/* Variant colors */
+/* Variant background colors. Border *color* lives in `cards/shared.css` and
+   is keyed off the `data-opal-status-border` attribute. */
 
 .opal-message-card[data-variant="default"] {
-  @apply bg-background-tint-01 border-border-01;
+  @apply bg-background-tint-01;
 }
 
 .opal-message-card[data-variant="info"] {
-  @apply bg-status-info-00 border-status-info-02;
+  @apply bg-status-info-00;
 }
 
 .opal-message-card[data-variant="success"] {
-  @apply bg-status-success-00 border-status-success-02;
+  @apply bg-status-success-00;
 }
 
 .opal-message-card[data-variant="warning"] {
-  @apply bg-status-warning-00 border-status-warning-02;
+  @apply bg-status-warning-00;
 }
 
 .opal-message-card[data-variant="error"] {
-  @apply bg-status-error-00 border-status-error-02;
+  @apply bg-status-error-00;
 }


### PR DESCRIPTION
## Description

- Add `headerPadding` prop (`PaddingVariants`, default `"sm"`) to `MessageCard` for controlling padding around the header `ContentAction` independently from the outer card padding
- Wire `data-opal-status-border={variant}` on the root element so variant-specific border colors from `cards/shared.css` apply correctly (previously all variants had a plain gray border)
- Add `gap-1` (0.25rem) to `.opal-message-card` for consistent spacing between header, divider, and `bottomChildren`
- Move border-color declarations from inline styles to the shared `data-opal-status-border` system

## Screenshots + Videos

No UI changes; screenshots / videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `headerPadding` prop to `MessageCard` for independent header spacing and wires `data-opal-status-border` on the root for correct variant border colors. Keeps vertical spacing between header, divider, and bottom content consistent.

- **New Features**
  - `headerPadding` (default `fit`) controls header padding independently from the card.
  - Consistent vertical spacing via root `gap-1`; divider uses `paddingPerpendicular="xs"`.

- **Bug Fixes**
  - Variant borders show correct colors for default/info/success/warning/error via `data-opal-status-border`; border colors moved to the shared system.

<sup>Written for commit 73eee947cdae103ab3175a8a0167549204a96023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

