### PR TITLE
refactor(opal): add headerPadding prop to Card.Header layout

### DIFF
--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Button } from "@opal/components";
 import {
   SvgArrowExchange,
@@ -39,12 +39,16 @@ export const Default: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Google Search"
-        description="Web search provider"
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Google Search"
+            description="Web search provider"
+          />
+        }
+        topRightChildren={
           <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
             Connect
           </Button>
@@ -58,12 +62,16 @@ export const WithBothSlots: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Google Search"
-        description="Currently the default provider."
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Google Search"
+            description="Currently the default provider."
+          />
+        }
+        topRightChildren={
           <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
             Current Default
           </Button>
@@ -93,12 +101,16 @@ export const RightChildrenOnly: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="OpenAI"
-        description="Not configured"
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="OpenAI"
+            description="Not configured"
+          />
+        }
+        topRightChildren={
           <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
             Connect
           </Button>
@@ -112,11 +124,15 @@ export const NoRightChildren: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Section Header"
-        description="No actions on the right."
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Section Header"
+            description="No actions on the right."
+          />
+        }
       />
     </div>
   ),
@@ -126,12 +142,16 @@ export const LongContent: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgGlobe}
-        title="Very Long Provider Name That Should Truncate"
-        description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
-        rightChildren={
+        headerChildren={
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={SvgGlobe}
+            title="Very Long Provider Name That Should Truncate"
+            description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
+          />
+        }
+        topRightChildren={
           <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
             Current Default
           </Button>

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -19,6 +19,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
+| `headerPadding` | `"sm" \| "fit"` | `"sm"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
 | `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
 | `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
@@ -37,7 +38,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
-- Left column (headerChildren wrapper): `self-start p-2 grow min-w-0` — grows to fill available space
+- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-2`) — grows to fill available space
 - Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -6,56 +6,61 @@ A namespace of card layout primitives. Each sub-component handles a specific reg
 
 ## Card.Header
 
-A card header layout that pairs a [`Content`](../content/README.md) block with a right-side column and an optional full-width children slot.
+A flexible card header with one slot for the main header content, two stacked slots in a right-side column, and a full-width slot below.
 
 ### Why Card.Header?
 
-[`ContentAction`](../content-action/README.md) provides a single `rightChildren` slot. Card headers typically need two distinct right-side regions — a primary action on top and secondary actions on the bottom. `Card.Header` provides this with `rightChildren` and `bottomRightChildren` slots, plus a `children` slot for full-width content below the header row (e.g., search bars, expandable tool lists).
+[`ContentAction`](../content-action/README.md) provides a single right-side slot. Card headers typically need more — a primary action on top, secondary actions on the bottom, and sometimes a full-width region beneath the entire row (e.g. expandable details, search bars, secondary info).
+
+`Card.Header` is layout-only — it intentionally doesn't bake in `Content` props. Pass a `<Content />` (or any other element) into `headerChildren` for the icon/title/description region.
 
 ### Props
 
-Inherits **all** props from [`Content`](../content/README.md) (icon, title, description, sizePreset, variant, editable, onTitleChange, suffix, etc.) plus:
-
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `rightChildren` | `ReactNode` | `undefined` | Content rendered to the right of the Content block (top of right column). |
-| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `rightChildren` in the same column. Laid out as `flex flex-row`. |
-| `children` | `ReactNode` | `undefined` | Content rendered below the full header row, spanning the entire width. |
+| `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
+| `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
+| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
+| `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
 
 ### Layout Structure
 
 ```
-+---------------------------------------------------------+
-| [Content (p-2, self-start)]    [rightChildren]          |
-|  icon + title + description    [bottomRightChildren]    |
-+---------------------------------------------------------+
-| [children — full width]                                 |
-+---------------------------------------------------------+
++------------------+----------------+
+| headerChildren   | topRight       |
++                  +----------------+
+|                  | bottomRight    |
++------------------+----------------+
+| bottomChildren (full width)       |
++-----------------------------------+
 ```
 
 - Outer wrapper: `flex flex-col w-full`
-- Header row: `flex flex-row items-stretch w-full`
-- Content area: `flex-1 min-w-0 self-start p-2` — top-aligned with fixed padding
-- Right column: `flex flex-col items-end shrink-0` — no padding, no gap
-- `bottomRightChildren` wrapper: `flex flex-row` — lays children out horizontally
-- `children` wrapper: `w-full` — only rendered when children are provided
+- Header row: `flex flex-row items-start w-full` — columns are independent in height
+- Left column (headerChildren wrapper): `self-start p-2 grow min-w-0` — grows to fill available space
+- Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
+- `bottomChildren` wrapper: `w-full` — only rendered when provided
 
 ### Usage
 
 #### Card with primary and secondary actions
 
 ```tsx
-import { Card } from "@opal/layouts";
+import { Card, Content } from "@opal/layouts";
 import { Button } from "@opal/components";
 import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 <Card.Header
-  icon={SvgGlobe}
-  title="Google Search"
-  description="Web search provider"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={
+  headerChildren={
+    <Content
+      icon={SvgGlobe}
+      title="Google Search"
+      description="Web search provider"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={
     <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
       Current Default
     </Button>
@@ -73,12 +78,16 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
-  icon={SvgCloud}
-  title="OpenAI"
-  description="Not configured"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={
+  headerChildren={
+    <Content
+      icon={SvgCloud}
+      title="OpenAI"
+      description="Not configured"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={
     <Button rightIcon={SvgArrowExchange} prominence="tertiary">
       Connect
     </Button>
@@ -86,31 +95,36 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 />
 ```
 
-#### Card with expandable children
+#### Card with extra info beneath the header
 
 ```tsx
 <Card.Header
-  icon={SvgServer}
-  title="MCP Server"
-  description="12 tools available"
-  sizePreset="main-ui"
-  variant="section"
-  rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
->
-  <SearchBar placeholder="Search tools..." />
-</Card.Header>
-```
-
-#### No right children
-
-```tsx
-<Card.Header
-  icon={SvgInfo}
-  title="Section Header"
-  description="Description text"
-  sizePreset="main-content"
-  variant="section"
+  headerChildren={
+    <Content
+      icon={SvgServer}
+      title="MCP Server"
+      description="12 tools available"
+      sizePreset="main-ui"
+      variant="section"
+    />
+  }
+  topRightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
+  bottomChildren={<SearchBar placeholder="Search tools..." />}
 />
 ```
 
-When both `rightChildren` and `bottomRightChildren` are omitted and no `children` are provided, the component renders only the padded `Content`.
+#### No slots
+
+```tsx
+<Card.Header
+  headerChildren={
+    <Content
+      icon={SvgInfo}
+      title="Section Header"
+      description="Description text"
+      sizePreset="main-content"
+      variant="section"
+    />
+  }
+/>
+```

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -19,7 +19,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
-| `headerPadding` | `"sm" \| "fit"` | `"fit"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
+| `headerPadding` | `"sm" \| "fit"` | `"sm"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
 | `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
 | `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
@@ -38,7 +38,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
-- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-0`) — grows to fill available space
+- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-2`) — grows to fill available space
 - Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -19,7 +19,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
-| `headerPadding` | `"sm" \| "fit"` | `"sm"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
+| `headerPadding` | `"sm" \| "fit"` | `"fit"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
 | `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
 | `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
@@ -38,7 +38,7 @@ A flexible card header with one slot for the main header content, two stacked sl
 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
-- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-2`) — grows to fill available space
+- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-0`) — grows to fill available space
 - Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -10,7 +10,7 @@ interface CardHeaderProps {
   /** Content rendered in the top-left header slot — typically a {@link Content} block. */
   headerChildren?: React.ReactNode;
 
-  /** Padding applied around `headerChildren`. @default "sm" */
+  /** Padding applied around `headerChildren`. @default "fit" */
   headerPadding?: Extract<PaddingVariants, "sm" | "fit">;
 
   /** Content rendered to the right of `headerChildren` (top of right column). */
@@ -75,7 +75,7 @@ interface CardHeaderProps {
  */
 function Header({
   headerChildren,
-  headerPadding = "sm",
+  headerPadding = "fit",
   topRightChildren,
   bottomRightChildren,
   bottomChildren,

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -10,7 +10,7 @@ interface CardHeaderProps {
   /** Content rendered in the top-left header slot — typically a {@link Content} block. */
   headerChildren?: React.ReactNode;
 
-  /** Padding applied around `headerChildren`. @default "fit" */
+  /** Padding applied around `headerChildren`. @default "sm" */
   headerPadding?: Extract<PaddingVariants, "sm" | "fit">;
 
   /** Content rendered to the right of `headerChildren` (top of right column). */
@@ -75,7 +75,7 @@ interface CardHeaderProps {
  */
 function Header({
   headerChildren,
-  headerPadding = "fit",
+  headerPadding = "sm",
   topRightChildren,
   bottomRightChildren,
   bottomChildren,

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -2,9 +2,15 @@
 // Types
 // ---------------------------------------------------------------------------
 
+import { paddingVariants } from "@opal/shared";
+import { SizeVariants } from "@opal/types";
+import { cn } from "@opal/utils";
+
 interface CardHeaderProps {
   /** Content rendered in the top-left header slot — typically a {@link Content} block. */
   headerChildren?: React.ReactNode;
+
+  headerPadding?: Extract<SizeVariants, "sm" | "fit">;
 
   /** Content rendered to the right of `headerChildren` (top of right column). */
   topRightChildren?: React.ReactNode;
@@ -68,6 +74,7 @@ interface CardHeaderProps {
  */
 function Header({
   headerChildren,
+  headerPadding = "sm",
   topRightChildren,
   bottomRightChildren,
   bottomChildren,
@@ -78,7 +85,14 @@ function Header({
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
         {headerChildren != null && (
-          <div className="self-start p-2 grow min-w-0">{headerChildren}</div>
+          <div
+            className={cn(
+              "self-start grow min-w-0",
+              paddingVariants[headerPadding]
+            )}
+          >
+            {headerChildren}
+          </div>
         )}
         {hasRight && (
           <div className="flex flex-col items-end shrink-0">

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -3,14 +3,15 @@
 // ---------------------------------------------------------------------------
 
 import { paddingVariants } from "@opal/shared";
-import { SizeVariants } from "@opal/types";
+import type { PaddingVariants } from "@opal/types";
 import { cn } from "@opal/utils";
 
 interface CardHeaderProps {
   /** Content rendered in the top-left header slot — typically a {@link Content} block. */
   headerChildren?: React.ReactNode;
 
-  headerPadding?: Extract<SizeVariants, "sm" | "fit">;
+  /** Padding applied around `headerChildren`. @default "sm" */
+  headerPadding?: Extract<PaddingVariants, "sm" | "fit">;
 
   /** Content rendered to the right of `headerChildren` (top of right column). */
   topRightChildren?: React.ReactNode;

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -114,6 +114,7 @@ export default function CodeInterpreterPage() {
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header
+                headerPadding="sm"
                 headerChildren={
                   <Content
                     sizePreset="main-ui"
@@ -166,6 +167,7 @@ export default function CodeInterpreterPage() {
             onClick={() => handleToggle(true)}
           >
             <Card.Header
+              headerPadding="sm"
               headerChildren={
                 <Content
                   sizePreset="main-ui"

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -256,6 +256,7 @@ export default function ImageGenerationContent() {
                     }
                   >
                     <Card.Header
+                      headerPadding="sm"
                       headerChildren={
                         <Content
                           sizePreset="main-ui"

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -277,6 +277,7 @@ function ProviderCard({
         }
       >
         <Card.Header
+          headerPadding="sm"
           headerChildren={
             <Content
               sizePreset="main-ui"

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -93,6 +93,7 @@ export default function ProviderCard({
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
       <Card.Header
+        headerPadding="sm"
         headerChildren={
           <Content
             sizePreset="main-ui"


### PR DESCRIPTION
## Description

Add `headerPadding` prop to `Card.Header` for controlling padding around the `headerChildren` slot. Uses `paddingVariants` with `"fit"` default.

Update stories and README to reflect the slot-based API (`headerChildren`, `topRightChildren`, `bottomRightChildren`, `bottomChildren`).

## Screenshots + Videos

No UI changes; screenshots + videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `headerPadding` prop to `Card.Header` and completes the slot-based, layout‑only API. Default is `"fit"` (`p-0`); existing usages now pass `headerPadding="sm"` to keep the old spacing.

- **New Features**
  - `headerPadding`: `"sm"` or `"fit"` (default), mapped via `paddingVariants`, applied to the `headerChildren` wrapper.

- **Migration**
  - Pass `<Content />` via `headerChildren` instead of `Card.Header` `Content` props.
  - Rename `rightChildren` → `topRightChildren`, and `children` → `bottomChildren`.
  - To keep previous `p-2` spacing, set `headerPadding="sm"`.

<sup>Written for commit 9372411032185c395c047d12b1f7ea3214a92762. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

