### PR TITLE
refactor(opal): add root.css with library-owned size tokens

### DIFF
--- a/web/lib/opal/src/root.css
+++ b/web/lib/opal/src/root.css
@@ -1,0 +1,19 @@
+/**
+ * @opal/root — Root-level design tokens for the opal design system.
+ *
+ * Import this file once at the top of the component tree (or from shared.ts)
+ * to make all opal CSS custom properties available globally.
+ *
+ * App-level tokens (container widths, page widths, etc.) live in the app's
+ * own CSS — this file is strictly for library-owned tokens.
+ */
+
+:root {
+  /* ── Line heights / container sizes ──────────────────────────────────── */
+
+  --opal-line-height-lg: 2.25rem;
+  --opal-line-height-md: 1.75rem;
+  --opal-line-height-sm: 1.5rem;
+  --opal-line-height-xs: 1.25rem;
+  --opal-line-height-2xs: 1rem;
+}

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -6,6 +6,8 @@
  * circular imports and gives every consumer a single source of truth.
  */
 
+import "@opal/root.css";
+
 import type {
   SizeVariants,
   OverridableExtremaSizeVariants,
@@ -21,14 +23,16 @@ import type {
  * Each entry maps a named preset to Tailwind utility classes for
  * `height`, `min-width`, and `padding`.
  *
- * | Key   | Height        | Padding  |
- * |-------|---------------|----------|
- * | `lg`  | 2.25rem (36px)| `p-2`   |
- * | `md`  | 1.75rem (28px)| `p-1`   |
- * | `sm`  | 1.5rem (24px) | `p-1`   |
- * | `xs`  | 1.25rem (20px)| `p-0.5` |
- * | `2xs` | 1rem (16px)   | `p-0.5` |
- * | `fit` | h-fit         | `p-0`   |
+ * Heights are driven by CSS custom properties defined in `@opal/root.css`.
+ *
+ * | Key   | Height                      | Padding  |
+ * |-------|-----------------------------|----------|
+ * | `lg`  | `--opal-line-height-lg`     | `p-2`   |
+ * | `md`  | `--opal-line-height-md`     | `p-1`   |
+ * | `sm`  | `--opal-line-height-sm`     | `p-1`   |
+ * | `xs`  | `--opal-line-height-xs`     | `p-0.5` |
+ * | `2xs` | `--opal-line-height-2xs`    | `p-0.5` |
+ * | `fit` | `h-fit`                     | `p-0`   |
  */
 type ContainerProperties = {
   height: string;
@@ -40,15 +44,31 @@ const containerSizeVariants: Record<
   ContainerProperties
 > = {
   fit: { height: "h-fit", minWidth: "", padding: "p-0" },
-  lg: { height: "h-[2.25rem]", minWidth: "min-w-[2.25rem]", padding: "p-2" },
-  md: { height: "h-[1.75rem]", minWidth: "min-w-[1.75rem]", padding: "p-1" },
-  sm: { height: "h-[1.5rem]", minWidth: "min-w-[1.5rem]", padding: "p-1" },
+  lg: {
+    height: "h-[var(--opal-line-height-lg)]",
+    minWidth: "min-w-[var(--opal-line-height-lg)]",
+    padding: "p-2",
+  },
+  md: {
+    height: "h-[var(--opal-line-height-md)]",
+    minWidth: "min-w-[var(--opal-line-height-md)]",
+    padding: "p-1",
+  },
+  sm: {
+    height: "h-[var(--opal-line-height-sm)]",
+    minWidth: "min-w-[var(--opal-line-height-sm)]",
+    padding: "p-1",
+  },
   xs: {
-    height: "h-[1.25rem]",
-    minWidth: "min-w-[1.25rem]",
+    height: "h-[var(--opal-line-height-xs)]",
+    minWidth: "min-w-[var(--opal-line-height-xs)]",
     padding: "p-0.5",
   },
-  "2xs": { height: "h-[1rem]", minWidth: "min-w-[1rem]", padding: "p-0.5" },
+  "2xs": {
+    height: "h-[var(--opal-line-height-2xs)]",
+    minWidth: "min-w-[var(--opal-line-height-2xs)]",
+    padding: "p-0.5",
+  },
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Create `web/lib/opal/src/root.css` as the single entry point for opal-level CSS custom properties. Replace hardcoded rem values in `shared.ts` containerSizeVariants with `--opal-line-height-*` CSS variables.

This separates library tokens (owned by opal) from app-level tokens (container widths, toast width, etc.) which remain in the app's `sizes.css`.

New variables:
- `--opal-line-height-lg`: 2.25rem
- `--opal-line-height-md`: 1.75rem
- `--opal-line-height-sm`: 1.5rem
- `--opal-line-height-xs`: 1.25rem
- `--opal-line-height-2xs`: 1rem

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `web/lib/opal/src/root.css` as the single entry for opal CSS variables and move container heights to `--opal-line-height-*` tokens. This separates library-owned tokens from app styles and keeps sizing identical.

- **Refactors**
  - Added `--opal-line-height-{lg,md,sm,xs,2xs}` in `root.css`.
  - Imported `@opal/root.css` in `shared.ts`; `containerSizeVariants` now use these variables.
  - App-level sizes (e.g., widths) remain in the app’s `sizes.css`.

<sup>Written for commit e0ed53073afa4763880a3ba13f5a0464e5fb34ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->