### PR TITLE
refactor(refresh-components): underline `Tab` variant, `Text` color inherit, `LineItem` `wrapDescription`

### DIFF
--- a/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
+++ b/web/src/components/dateRangeSelectors/SearchDateRangeSelector.tsx
@@ -23,7 +23,7 @@ export function SearchDateRangeSelector({
           <TimeRangeSelector
             value={value}
             className={cn(
-              "border border-border bg-background rounded-lg flex flex-col w-64 max-h-96 overflow-y-auto flex overscroll-contain",
+              "border border-border bg-background rounded-lg flex flex-col w-64 max-h-96 overflow-y-auto overscroll-contain",
               className
             )}
             timeRangeValues={timeRangeValues}

--- a/web/src/refresh-components/SimpleTabs.tsx
+++ b/web/src/refresh-components/SimpleTabs.tsx
@@ -19,7 +19,7 @@ export interface TabDefinition {
   /** Optional tooltip text to display on hover */
   tooltip?: string;
   /** Optional tooltip side */
-  side?: "top" | "bottom" | "left" | "right";
+  tooltipSide?: "top" | "bottom" | "left" | "right";
   /** Whether the tab is disabled */
   disabled?: boolean;
 }
@@ -103,7 +103,7 @@ export default function SimpleTabs({
             value={key}
             icon={tab.icon}
             tooltip={tab.tooltip}
-            tooltipSide={tab.side}
+            tooltipSide={tab.tooltipSide}
             disabled={tab.disabled}
           >
             {tab.name}

--- a/web/src/refresh-components/SimpleTabs.tsx
+++ b/web/src/refresh-components/SimpleTabs.tsx
@@ -19,7 +19,7 @@ export interface TabDefinition {
   /** Optional tooltip text to display on hover */
   tooltip?: string;
   /** Optional tooltip side */
-  tooltipSide?: "top" | "bottom" | "left" | "right";
+  side?: "top" | "bottom" | "left" | "right";
   /** Whether the tab is disabled */
   disabled?: boolean;
 }
@@ -103,7 +103,7 @@ export default function SimpleTabs({
             value={key}
             icon={tab.icon}
             tooltip={tab.tooltip}
-            tooltipSide={tab.tooltipSide}
+            tooltipSide={tab.side}
             disabled={tab.disabled}
           >
             {tab.name}

--- a/web/src/refresh-components/Tabs.stories.tsx
+++ b/web/src/refresh-components/Tabs.stories.tsx
@@ -149,3 +149,20 @@ export const LoadingTab: Story = {
     </Tabs>
   ),
 };
+
+// ---------------------------------------------------------------------------
+// Underline variant
+// ---------------------------------------------------------------------------
+
+export const Underline: Story = {
+  render: () => (
+    <Tabs defaultValue="cloud">
+      <Tabs.List variant="underline">
+        <Tabs.Trigger value="cloud">Cloud-based</Tabs.Trigger>
+        <Tabs.Trigger value="self">Self-hosted</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="cloud">Cloud-based models</Tabs.Content>
+      <Tabs.Content value="self">Self-hosted models</Tabs.Content>
+    </Tabs>
+  ),
+};

--- a/web/src/refresh-components/Tabs.tsx
+++ b/web/src/refresh-components/Tabs.tsx
@@ -8,21 +8,19 @@ import React, {
   useCallback,
 } from "react";
 import * as TabsPrimitive from "@radix-ui/react-tabs";
-import { cn, mergeRefs } from "@/lib/utils";
-import { Tooltip } from "@opal/components";
-import { WithoutStyles } from "@/types";
+import { mergeRefs } from "@/lib/utils";
+import { cn } from "@opal/utils";
 import { Section, SectionProps } from "@/layouts/general-layouts";
-import { IconProps } from "@opal/types";
+import { IconProps, WithoutStyles } from "@opal/types";
 import { SvgChevronLeft, SvgChevronRight } from "@opal/icons";
-import Text from "./texts/Text";
-import { Button } from "@opal/components";
+import { Tooltip, Button, Text } from "@opal/components";
 
 /* =============================================================================
    CONTEXT
    ============================================================================= */
 
 interface TabsContextValue {
-  variant: "contained" | "pill";
+  variant: "contained" | "pill" | "underline";
 }
 
 const TabsContext = React.createContext<TabsContextValue | undefined>(
@@ -52,6 +50,11 @@ const useTabsContext = () => {
  * ─────────────╨═════╨─────────────────────────────
  *              ↑ sliding indicator under active tab
  *
+ * Underline (like pill, but no base line):
+ *    Tab 1      Tab 2      Tab 3
+ *              ═══════
+ *              ↑ sliding indicator only, no base border
+ *
  * @example
  * <Tabs defaultValue="tab1">
  *   <Tabs.List variant="pill">
@@ -72,18 +75,22 @@ const useTabsContext = () => {
 const listVariants = {
   contained: "grid w-full rounded-08 bg-background-tint-03",
   pill: "relative flex w-full items-center pb-[5px] bg-background-tint-00 overflow-hidden",
+  underline:
+    "relative flex w-full items-center pb-[5px] bg-background-tint-00 overflow-hidden",
 } as const;
 
 /** Base style classes for TabsTrigger variants */
 const triggerBaseStyles = {
   contained: "p-2 gap-2",
   pill: "p-1 font-secondary-action transition-all duration-200 ease-out",
+  underline: "p-1 font-secondary-action transition-all duration-200 ease-out",
 } as const;
 
 /** Icon style classes for TabsTrigger variants */
 const iconVariants = {
   contained: "stroke-text-03",
   pill: "stroke-current",
+  underline: "stroke-current",
 } as const;
 
 /* =============================================================================
@@ -297,16 +304,20 @@ function useHorizontalScroll(
 function PillIndicator({
   style,
   rightOffset = 0,
+  hideBaseLine = false,
 }: {
   style: IndicatorStyle;
   rightOffset?: number;
+  hideBaseLine?: boolean;
 }) {
   return (
     <>
-      <div
-        className="absolute bottom-0 left-0 h-px bg-border-02 pointer-events-none"
-        style={{ right: rightOffset }}
-      />
+      {!hideBaseLine && (
+        <div
+          className="absolute bottom-0 left-0 h-px bg-border-02 pointer-events-none"
+          style={{ right: rightOffset }}
+        />
+      )}
       <div
         className="absolute bottom-0 h-[2px] bg-background-tint-inverted-03 z-10 pointer-events-none transition-all duration-200 ease-out"
         style={{
@@ -357,10 +368,15 @@ interface TabsListProps
    * - `contained` (default): Rounded background with equal-width tabs in a grid.
    *   Best for primary navigation where tabs should fill available space.
    *
-   * - `pill`: Transparent background with a sliding underline indicator.
-   *   Best for secondary navigation or filter-style tabs with flexible widths.
+   * - `pill`: Transparent background with a sliding underline indicator and
+   *   dark inverted active state. Best for secondary navigation or filter-style
+   *   tabs with flexible widths.
+   *
+   * - `underline`: Like `pill` but without the base border line. Active tab
+   *   gets a text-only highlight (no inverted background). Best for inline
+   *   tab groups within cards or sections.
    */
-  variant?: "contained" | "pill";
+  variant?: "contained" | "pill" | "underline";
 
   /**
    * Content to render on the right side of the tab list.
@@ -415,7 +431,7 @@ const TabsList = React.forwardRef<
     const scrollArrowsRef = useRef<HTMLDivElement>(null);
     const rightContentRef = useRef<HTMLDivElement>(null);
     const [rightOffset, setRightOffset] = useState(0);
-    const isPill = variant === "pill";
+    const isPill = variant === "pill" || variant === "underline";
     const { style: indicatorStyle } = usePillIndicator(
       listRef,
       isPill,
@@ -529,7 +545,11 @@ const TabsList = React.forwardRef<
           )}
 
           {isPill && (
-            <PillIndicator style={indicatorStyle} rightOffset={rightOffset} />
+            <PillIndicator
+              style={indicatorStyle}
+              rightOffset={rightOffset}
+              hideBaseLine={variant === "underline"}
+            />
           )}
         </TabsContext.Provider>
       </TabsPrimitive.List>
@@ -557,8 +577,9 @@ interface TabsTriggerProps
    *
    * - `contained` (default): White background with shadow when active
    * - `pill`: Dark pill background when active, transparent when inactive
+   * - `underline`: Text-only highlight when active, muted when inactive
    */
-  variant?: "contained" | "pill";
+  variant?: "contained" | "pill" | "underline";
 
   /** Optional tooltip text to display on hover */
   tooltip?: string;
@@ -617,7 +638,7 @@ const TabsTrigger = React.forwardRef<
         )}
         {typeof children === "string" ? (
           <div className="px-0.5">
-            <Text>{children}</Text>
+            <Text color="inherit">{children}</Text>
           </div>
         ) : (
           children
@@ -649,6 +670,7 @@ const TabsTrigger = React.forwardRef<
             "data-[state=active]:bg-background-tint-inverted-03",
             "data-[state=active]:text-text-inverted-05",
           ],
+          variant === "underline" && ["data-[state=active]:text-text-05"],
           variant === "contained" && [
             "data-[state=inactive]:text-text-03",
             "data-[state=inactive]:bg-transparent",
@@ -658,7 +680,8 @@ const TabsTrigger = React.forwardRef<
           variant === "pill" && [
             "data-[state=inactive]:bg-background-tint-00",
             "data-[state=inactive]:text-text-03",
-          ]
+          ],
+          variant === "underline" && ["data-[state=inactive]:text-text-03"]
         )}
         {...props}
       >
@@ -705,11 +728,14 @@ TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   SectionProps & { value: string }
->(({ children, value, ...props }, ref) => (
+>(({ children, value, className, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}
     value={value}
-    className="pt-4 focus:outline-none focus:border-theme-primary-05 w-full"
+    className={cn(
+      "pt-4 focus:outline-none focus:border-theme-primary-05 w-full",
+      className
+    )}
   >
     <Section padding={0} {...props}>
       {children}

--- a/web/src/refresh-components/Tabs.tsx
+++ b/web/src/refresh-components/Tabs.tsx
@@ -50,11 +50,6 @@ const useTabsContext = () => {
  * ─────────────╨═════╨─────────────────────────────
  *              ↑ sliding indicator under active tab
  *
- * Underline (like pill, but no base line):
- *    Tab 1      Tab 2      Tab 3
- *              ═══════
- *              ↑ sliding indicator only, no base border
- *
  * @example
  * <Tabs defaultValue="tab1">
  *   <Tabs.List variant="pill">
@@ -72,25 +67,29 @@ const useTabsContext = () => {
    ============================================================================= */
 
 /** Style classes for TabsList variants */
+const PILL_LIST =
+  "relative flex w-full items-center pb-[5px] bg-background-tint-00 overflow-hidden";
 const listVariants = {
   contained: "grid w-full rounded-08 bg-background-tint-03",
-  pill: "relative flex w-full items-center pb-[5px] bg-background-tint-00 overflow-hidden",
-  underline:
-    "relative flex w-full items-center pb-[5px] bg-background-tint-00 overflow-hidden",
+  pill: PILL_LIST,
+  underline: PILL_LIST,
 } as const;
 
 /** Base style classes for TabsTrigger variants */
+const PILL_TRIGGER =
+  "p-1 font-secondary-action transition-all duration-200 ease-out";
 const triggerBaseStyles = {
   contained: "p-2 gap-2",
-  pill: "p-1 font-secondary-action transition-all duration-200 ease-out",
-  underline: "p-1 font-secondary-action transition-all duration-200 ease-out",
+  pill: PILL_TRIGGER,
+  underline: PILL_TRIGGER,
 } as const;
 
 /** Icon style classes for TabsTrigger variants */
+const PILL_ICON = "stroke-current";
 const iconVariants = {
   contained: "stroke-text-03",
-  pill: "stroke-current",
-  underline: "stroke-current",
+  pill: PILL_ICON,
+  underline: PILL_ICON,
 } as const;
 
 /* =============================================================================
@@ -368,13 +367,8 @@ interface TabsListProps
    * - `contained` (default): Rounded background with equal-width tabs in a grid.
    *   Best for primary navigation where tabs should fill available space.
    *
-   * - `pill`: Transparent background with a sliding underline indicator and
-   *   dark inverted active state. Best for secondary navigation or filter-style
-   *   tabs with flexible widths.
-   *
-   * - `underline`: Like `pill` but without the base border line. Active tab
-   *   gets a text-only highlight (no inverted background). Best for inline
-   *   tab groups within cards or sections.
+   * - `pill`: Transparent background with a sliding underline indicator.
+   *   Best for secondary navigation or filter-style tabs with flexible widths.
    */
   variant?: "contained" | "pill" | "underline";
 
@@ -577,7 +571,6 @@ interface TabsTriggerProps
    *
    * - `contained` (default): White background with shadow when active
    * - `pill`: Dark pill background when active, transparent when inactive
-   * - `underline`: Text-only highlight when active, muted when inactive
    */
   variant?: "contained" | "pill" | "underline";
 

--- a/web/src/refresh-components/buttons/LineItem.stories.tsx
+++ b/web/src/refresh-components/buttons/LineItem.stories.tsx
@@ -105,6 +105,16 @@ export const WithRightChildren: Story = {
   },
 };
 
+export const WithWrappedDescription: Story = {
+  args: {
+    icon: SvgSettings,
+    children: "Re-index All Connectors",
+    description:
+      "Safest option. Continue using the current document index with existing settings until all connectors have completed a successful index attempt.",
+    wrapDescription: true,
+  },
+};
+
 export const MenuExample: Story = {
   render: () => (
     <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>

--- a/web/src/refresh-components/buttons/LineItem.tsx
+++ b/web/src/refresh-components/buttons/LineItem.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 import type { IconProps } from "@opal/types";
+import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import Link from "next/link";
 import type { Route } from "next";
@@ -84,6 +85,8 @@ export interface LineItemProps
   icon?: React.FunctionComponent<IconProps>;
   strokeIcon?: boolean;
   description?: string;
+  /** When true, the description text wraps instead of truncating. @default false */
+  wrapDescription?: boolean;
   rightChildren?: React.ReactNode;
   href?: string;
   rel?: string;
@@ -157,6 +160,7 @@ export default function LineItem({
   icon: Icon,
   strokeIcon = true,
   description,
+  wrapDescription,
   children,
   rightChildren,
   href,
@@ -271,17 +275,28 @@ export default function LineItem({
                 </Section>
               )}
             </Section>
-            {description && (
+            {description &&
+              (wrapDescription ? (
+                <Text as="p" secondaryBody text03 className="text-left w-full">
+                  {description}
+                </Text>
+              ) : (
+                <Truncated secondaryBody text03 className="text-left w-full">
+                  {description}
+                </Truncated>
+              ))}
+          </>
+        ) : description ? (
+          <Section flexDirection="row" gap={0.5}>
+            {wrapDescription ? (
+              <Text as="p" secondaryBody text03 className="text-left w-full">
+                {description}
+              </Text>
+            ) : (
               <Truncated secondaryBody text03 className="text-left w-full">
                 {description}
               </Truncated>
             )}
-          </>
-        ) : description ? (
-          <Section flexDirection="row" gap={0.5}>
-            <Truncated secondaryBody text03 className="text-left w-full">
-              {description}
-            </Truncated>
             {rightChildren && (
               <Section alignItems="end" width="fit">
                 {rightChildren}


### PR DESCRIPTION
## Description

**Tabs** (`Tabs.tsx`):
- Add `"underline"` variant — like `pill` but without the base border line. Active tab gets a text-only highlight (no inverted background). Best for inline tab groups within cards or sections.
- Fix `Text` inside `TabsTrigger` to use `color="inherit"` so `data-[state=active]` / `data-[state=inactive]` color classes on the parent trigger apply correctly. Previously, `Text` defaulted to `text-05` which overrode the inactive `text-03` color.
- Support `className` passthrough on `TabsContent` (was being dropped before).

**SimpleTabs** (`SimpleTabs.tsx`):
- Rename `tooltipSide` to `side` in `TabDefinition` interface for consistency.

**LineItem** (`buttons/LineItem.tsx`):
- Add `wrapDescription` prop (default `false`). When `true`, renders description with `Text` (wrapping) instead of `Truncated` (single-line ellipsis). Useful in dropdowns with long descriptions.

## Screenshots + Videos

### Tabs

https://github.com/user-attachments/assets/aebc4923-ef5c-4052-a717-b1777e1041df

### Line Item

<img width="550" height="340" alt="image" src="https://github.com/user-attachments/assets/0ea3e1ca-7da7-41b6-b5c6-f6c19965dac8" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an underline tab variant with a text-only active state, fixes `TabsTrigger` color inheritance, and lets `LineItem` descriptions wrap. `TabsContent` now accepts `className`, and Storybook includes examples.

- **New Features**
  - `Tabs`: New `underline` variant with a sliding indicator and no base line; `TabsContent` supports `className` passthrough.
  - `LineItem`: `wrapDescription` prop to render wrapping `Text` instead of single-line `Truncated`.

- **Refactors**
  - Deduplicated shared styles for `pill` and `underline` variants to keep them in sync.
  - Removed duplicate `flex` class in `SearchDateRangeSelector`.

<sup>Written for commit bf6dafa27e83a37671991a4fd3fd80141ec99de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

