### PR TITLE
fix: add missing headerPadding="sm" to all CardLayout.Header consumers

### DIFF
--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -347,7 +347,6 @@ function MCPServerCard({
             <Disabled key={tool.id} disabled={toolDisabled}>
               <Card border="solid" rounding="lg" padding="sm">
                 <CardLayout.Header
-                  headerPadding="sm"
                   headerChildren={
                     <ContentAction
                       icon={tool.icon ?? SvgSliders}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -1480,6 +1480,8 @@ export default function AgentEditorPage({
                               </Card>
                             </Disabled>
 
+                            {/* TODO(@raunakab): Consolidate the UI rendering logic of MCP-Server and OpenAPI cards
+                               (in `ChatPreferencesPage` and `AgentEditorPage`) together. */}
                             {/* Tools */}
                             <>
                               {/* render the separator if there is at least one mcp-server or open-api-tool */}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -281,6 +281,7 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
   return (
     <Card border="solid" rounding="lg" padding="sm">
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={SvgActions}
@@ -346,6 +347,7 @@ function MCPServerCard({
             <Disabled key={tool.id} disabled={toolDisabled}>
               <Card border="solid" rounding="lg" padding="sm">
                 <CardLayout.Header
+                  headerPadding="sm"
                   headerChildren={
                     <ContentAction
                       icon={tool.icon ?? SvgSliders}
@@ -381,6 +383,7 @@ function MCPServerCard({
       expandedContent={cardContent}
     >
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={getActionIcon(server.server_url, server.name)}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -279,21 +279,14 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
   const toolFieldName = `openapi_tool_${tool.id}`;
 
   return (
-    <Card border="solid" rounding="lg" padding="sm">
-      <CardLayout.Header
-        headerPadding="sm"
-        headerChildren={
-          <ContentAction
-            icon={SvgActions}
-            title={tool.display_name || tool.name}
-            description={tool.description}
-            sizePreset="main-ui"
-            variant="section"
-            padding="fit"
-          />
-        }
-        topRightChildren={<SwitchField name={toolFieldName} />}
-      />
+    <Card border="solid" rounding="lg">
+      <InputHorizontal
+        title={tool.display_name || tool.name}
+        description={tool.description}
+        withLabel={toolFieldName}
+      >
+        <SwitchField name={toolFieldName} />
+      </InputHorizontal>
     </Card>
   );
 }
@@ -345,7 +338,7 @@ function MCPServerCard({
             !getFieldMeta<boolean>(`${serverFieldName}.enabled`).value;
           return (
             <Disabled key={tool.id} disabled={toolDisabled}>
-              <Card border="solid" rounding="lg" padding="sm">
+              <Card border="solid" rounding="md" padding="sm">
                 <CardLayout.Header
                   headerChildren={
                     <ContentAction

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -1480,8 +1480,6 @@ export default function AgentEditorPage({
                               </Card>
                             </Disabled>
 
-                            {/* TODO(@raunakab): Consolidate the UI rendering logic of MCP-Server and OpenAPI cards
-                               (in `ChatPreferencesPage` and `AgentEditorPage`) together. */}
                             {/* Tools */}
                             <>
                               {/* render the separator if there is at least one mcp-server or open-api-tool */}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -279,14 +279,20 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
   const toolFieldName = `openapi_tool_${tool.id}`;
 
   return (
-    <Card border="solid" rounding="lg">
-      <InputHorizontal
-        title={tool.display_name || tool.name}
-        description={tool.description}
-        withLabel={toolFieldName}
-      >
-        <SwitchField name={toolFieldName} />
-      </InputHorizontal>
+    <Card border="solid" rounding="lg" padding="md">
+      <CardLayout.Header
+        headerChildren={
+          <ContentAction
+            icon={SvgActions}
+            title={tool.display_name || tool.name}
+            description={tool.description}
+            sizePreset="main-ui"
+            variant="section"
+            padding="fit"
+          />
+        }
+        topRightChildren={<SwitchField name={toolFieldName} />}
+      />
     </Card>
   );
 }
@@ -331,7 +337,7 @@ function MCPServerCard({
     );
   } else if (hasTools) {
     cardContent = (
-      <div className="flex flex-col gap-2 p-2">
+      <GeneralLayouts.Section gap={0.5} padding={0.5}>
         {filteredTools.map((tool) => {
           const toolDisabled =
             !tool.isAvailable ||
@@ -361,7 +367,7 @@ function MCPServerCard({
             </Disabled>
           );
         })}
-      </div>
+      </GeneralLayouts.Section>
     );
   }
 
@@ -375,7 +381,6 @@ function MCPServerCard({
       expandedContent={cardContent}
     >
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={getActionIcon(server.server_url, server.name)}
@@ -411,6 +416,7 @@ function MCPServerCard({
             }
           />
         }
+        headerPadding="sm"
         bottomChildren={
           <GeneralLayouts.Section flexDirection="row" gap={0.5}>
             <InputTypeIn

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -121,6 +121,7 @@ function MCPServerCard({
             {filteredTools.map((tool) => (
               <Card key={tool.id} border="solid" rounding="lg" padding="sm">
                 <CardLayout.Header
+                  headerPadding="sm"
                   headerChildren={
                     <Content
                       icon={tool.icon}
@@ -149,6 +150,7 @@ function MCPServerCard({
       }
     >
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={getActionIcon(server.server_url, server.name)}
@@ -894,6 +896,7 @@ export default function ChatPreferencesPage() {
                           padding="sm"
                         >
                           <CardLayout.Header
+                            headerPadding="sm"
                             headerChildren={
                               <Content
                                 icon={SvgActions}

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -121,7 +121,6 @@ function MCPServerCard({
             {filteredTools.map((tool) => (
               <Card key={tool.id} border="solid" rounding="lg" padding="sm">
                 <CardLayout.Header
-                  headerPadding="sm"
                   headerChildren={
                     <Content
                       icon={tool.icon}

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -875,6 +875,8 @@ export default function ChatPreferencesPage() {
                       />
                     )}
 
+                    {/* TODO(@raunakab): Consolidate the UI rendering logic of MCP-Server and OpenAPI cards
+                       (in `ChatPreferencesPage` and `AgentEditorPage`) together. */}
                     {/* MCP Servers & OpenAPI Tools */}
                     <Section gap={0.5}>
                       {mcpServersWithTools.map(({ server, tools }) => (
@@ -888,32 +890,19 @@ export default function ChatPreferencesPage() {
                         />
                       ))}
                       {openApiTools.map((tool) => (
-                        <Card
-                          key={tool.id}
-                          border="solid"
-                          rounding="lg"
-                          padding="sm"
-                        >
-                          <CardLayout.Header
-                            headerPadding="sm"
-                            headerChildren={
-                              <Content
-                                icon={SvgActions}
-                                title={tool.display_name || tool.name}
-                                description={tool.description}
-                                sizePreset="main-ui"
-                                variant="section"
-                              />
-                            }
-                            topRightChildren={
-                              <Switch
-                                checked={isToolEnabled(tool.id)}
-                                onCheckedChange={(checked) =>
-                                  toggleTool(tool.id, checked)
-                                }
-                              />
-                            }
-                          />
+                        <Card key={tool.id} border="solid" rounding="lg">
+                          <InputHorizontal
+                            title={tool.display_name || tool.name}
+                            description={tool.description}
+                            withLabel
+                          >
+                            <Switch
+                              checked={isToolEnabled(tool.id)}
+                              onCheckedChange={(checked) =>
+                                toggleTool(tool.id, checked)
+                              }
+                            />
+                          </InputHorizontal>
                         </Card>
                       ))}
                     </Section>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -875,8 +875,6 @@ export default function ChatPreferencesPage() {
                       />
                     )}
 
-                    {/* TODO(@raunakab): Consolidate the UI rendering logic of MCP-Server and OpenAPI cards
-                       (in `ChatPreferencesPage` and `AgentEditorPage`) together. */}
                     {/* MCP Servers & OpenAPI Tools */}
                     <Section gap={0.5}>
                       {mcpServersWithTools.map(({ server, tools }) => (
@@ -890,19 +888,32 @@ export default function ChatPreferencesPage() {
                         />
                       ))}
                       {openApiTools.map((tool) => (
-                        <Card key={tool.id} border="solid" rounding="lg">
-                          <InputHorizontal
-                            title={tool.display_name || tool.name}
-                            description={tool.description}
-                            withLabel
-                          >
-                            <Switch
-                              checked={isToolEnabled(tool.id)}
-                              onCheckedChange={(checked) =>
-                                toggleTool(tool.id, checked)
-                              }
-                            />
-                          </InputHorizontal>
+                        <Card
+                          key={tool.id}
+                          border="solid"
+                          rounding="lg"
+                          padding="sm"
+                        >
+                          <CardLayout.Header
+                            headerPadding="sm"
+                            headerChildren={
+                              <Content
+                                icon={SvgActions}
+                                title={tool.display_name || tool.name}
+                                description={tool.description}
+                                sizePreset="main-ui"
+                                variant="section"
+                              />
+                            }
+                            topRightChildren={
+                              <Switch
+                                checked={isToolEnabled(tool.id)}
+                                onCheckedChange={(checked) =>
+                                  toggleTool(tool.id, checked)
+                                }
+                              />
+                            }
+                          />
                         </Card>
                       ))}
                     </Section>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -117,9 +117,9 @@ function MCPServerCard({
       padding="sm"
       expandedContent={
         hasContent ? (
-          <div className="flex flex-col gap-2 p-2">
+          <Section gap={0.5} padding={0.5}>
             {filteredTools.map((tool) => (
-              <Card key={tool.id} border="solid" rounding="lg" padding="sm">
+              <Card key={tool.id} border="solid" rounding="md" padding="sm">
                 <CardLayout.Header
                   headerChildren={
                     <Content
@@ -144,7 +144,7 @@ function MCPServerCard({
                 />
               </Card>
             ))}
-          </div>
+          </Section>
         ) : undefined
       }
     >
@@ -892,10 +892,9 @@ export default function ChatPreferencesPage() {
                           key={tool.id}
                           border="solid"
                           rounding="lg"
-                          padding="sm"
+                          padding="md"
                         >
                           <CardLayout.Header
-                            headerPadding="sm"
                             headerChildren={
                               <Content
                                 icon={SvgActions}

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -141,6 +141,7 @@ function ExistingProviderCard({
           onClick={() => setIsOpen(true)}
         >
           <CardLayout.Header
+            headerPadding="sm"
             headerChildren={
               <Content
                 icon={icon}
@@ -211,6 +212,7 @@ function NewProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <Content
             icon={icon}
@@ -262,6 +264,7 @@ function NewCustomProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <Content
             icon={icon}

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -383,7 +383,6 @@ export default function AgentViewerModal({ agent }: AgentViewerModalProps) {
                 <InputHorizontal
                   title="Overwrite System Prompts"
                   description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
-                  withLabel
                 >
                   <Switch disabled checked={agent.replace_base_system_prompt} />
                 </InputHorizontal>

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -81,6 +81,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
       }
     >
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={serverIcon}
@@ -113,6 +114,7 @@ function ViewerOpenApiToolCard({ tool }: { tool: ToolSnapshot }) {
   return (
     <Card border="solid" rounding="lg" padding="sm">
       <CardLayout.Header
+        headerPadding="sm"
         headerChildren={
           <Content
             icon={SvgActions}


### PR DESCRIPTION
## Description

Hotfix for #10425. The `Card.Header` default changed from `"sm"` to `"fit"` but only `Card.Header` consumers were updated with explicit `headerPadding="sm"`. `CardLayout.Header` consumers (same component, different import alias via `import { Card as CardLayout }`) were missed, causing padding loss on:

- `AgentEditorPage.tsx` (3 instances)
- `LLMConfigurationPage.tsx` (3 instances)
- `ChatPreferencesPage.tsx` (3 instances)
- `AgentViewerModal.tsx` (2 instances)

All 11 instances now have explicit `headerPadding="sm"`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore consistent card header padding by adding explicit `headerPadding="sm"` to all `CardLayout.Header` usages after the default switched to `fit`, across Agent Editor, LLM Configuration, Chat Preferences, and the Agent Viewer modal. Also tightened nested card spacing/rounding and removed an unused label.

- **Bug Fixes**
  - UI tweaks: Agent Editor OpenAPI tool card uses `padding="md"`; nested tool cards use `rounding="md"`; replaced wrapper divs with `Section` components for consistent spacing.
  - Clean-up: removed unused `withLabel` in the Agent Viewer modal.

<sup>Written for commit de9c0e90fab5d7c5fb9678e2f8e3c474388bdbe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

