### PR TITLE
feat(auth): gate /auth/login with captcha

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -59,6 +59,7 @@ class CaptchaAction(StrEnum):
     one endpoint cannot be replayed against another."""
 
     SIGNUP = "signup"
+    LOGIN = "login"
     OAUTH = "oauth"
 
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -65,6 +65,7 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.hooks.registry import validate_registry
 from onyx.server.api_key.api import router as api_key_router
 from onyx.server.auth.captcha_api import CaptchaCookieMiddleware
+from onyx.server.auth.captcha_api import LoginCaptchaMiddleware
 from onyx.server.auth.captcha_api import router as captcha_router
 from onyx.server.auth_check import check_router_auth
 from onyx.server.documents.cc_pair import router as cc_pair_router
@@ -662,6 +663,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     # before the Google redirect. No-op unless is_captcha_enabled() is true
     # (requires CAPTCHA_ENABLED=true and RECAPTCHA_SECRET_KEY set).
     application.add_middleware(CaptchaCookieMiddleware)
+    application.add_middleware(LoginCaptchaMiddleware)
     if LOG_ENDPOINT_LATENCY:
         add_latency_logging_middleware(application, logger)
 

--- a/backend/onyx/server/auth/captcha_api.py
+++ b/backend/onyx/server/auth/captcha_api.py
@@ -1,15 +1,15 @@
-"""API + middleware for the reCAPTCHA pre-OAuth cookie flow.
+"""API + middleware for the reCAPTCHA cookie and header flows.
 
-The frontend solves a reCAPTCHA v3 challenge before clicking "Continue
-with Google", POSTs the token to ``/auth/captcha/oauth-verify``, and the
-backend verifies it with Google and sets a signed HttpOnly cookie. The
-cookie rides along on the subsequent Google OAuth callback redirect,
-where ``CaptchaCookieMiddleware`` checks it. Without this cookie flow
-the OAuth callback is un-gated because Google (not our frontend) issues
-the request and we cannot attach a header at the redirect hop.
+Three entry points are gated:
 
-Email/password signup has its own captcha enforcement inside
-``UserManager.create``, so this module only gates the OAuth callback.
+1. ``/auth/oauth/callback`` — the frontend pre-verifies a token and gets
+   a signed HttpOnly cookie (``/auth/captcha/oauth-verify``) that rides
+   along on the Google redirect, where ``CaptchaCookieMiddleware``
+   checks it.
+2. ``/auth/login`` — ``LoginCaptchaMiddleware`` verifies an
+   ``X-Captcha-Token`` header before the fastapi-users handler runs.
+3. ``/auth/register`` — captcha is enforced inside
+   ``UserManager.create`` via the body's ``captcha_token`` field.
 """
 
 from fastapi import APIRouter
@@ -117,3 +117,34 @@ class CaptchaCookieMiddleware(BaseHTTPMiddleware):
         if is_guarded_callback:
             response.delete_cookie(CAPTCHA_COOKIE_NAME, path="/")
         return response
+
+
+GUARDED_LOGIN_PATHS = frozenset({"/auth/login"})
+LOGIN_CAPTCHA_HEADER = "X-Captcha-Token"
+
+
+class LoginCaptchaMiddleware(BaseHTTPMiddleware):
+    """Reject ``/auth/login`` requests without a valid captcha token.
+
+    Enforced before the fastapi-users handler runs, so credential-stuffing
+    attempts cost the attacker a fresh captcha token per try. No-op when
+    ``is_captcha_enabled()`` is false.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if (
+            request.method == "POST"
+            and request.url.path in GUARDED_LOGIN_PATHS
+            and is_captcha_enabled()
+        ):
+            token = request.headers.get(LOGIN_CAPTCHA_HEADER, "")
+            try:
+                await verify_captcha_token(token, CaptchaAction.LOGIN)
+            except CaptchaVerificationError as exc:
+                return onyx_error_to_json_response(
+                    OnyxError(OnyxErrorCode.UNAUTHORIZED, str(exc))
+                )
+
+        return await call_next(request)

--- a/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
+++ b/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
@@ -1,0 +1,117 @@
+"""Unit tests for LoginCaptchaMiddleware."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from onyx.auth.captcha import CaptchaAction
+from onyx.auth.captcha import CaptchaVerificationError
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server.auth import captcha_api as captcha_api_module
+from onyx.server.auth.captcha_api import LoginCaptchaMiddleware
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.add_middleware(LoginCaptchaMiddleware)
+
+    @app.post("/auth/login")
+    async def _login() -> dict[str, str]:
+        return {"status": "logged-in"}
+
+    @app.post("/auth/register")
+    async def _register() -> dict[str, str]:
+        return {"status": "created"}
+
+    @app.get("/auth/login")
+    async def _login_get() -> dict[str, str]:
+        return {"status": "get-ignored"}
+
+    return app
+
+
+def test_passes_through_when_captcha_disabled() -> None:
+    app = build_app()
+    client = TestClient(app)
+    with patch.object(captcha_api_module, "is_captcha_enabled", return_value=False):
+        res = client.post("/auth/login")
+    assert res.status_code == 200
+    assert res.json() == {"status": "logged-in"}
+
+
+def test_rejects_when_header_missing() -> None:
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(
+                side_effect=CaptchaVerificationError(
+                    "Captcha verification failed: Captcha token is required"
+                )
+            ),
+        ),
+    ):
+        res = client.post("/auth/login")
+    assert res.status_code == 403
+    assert "Captcha" in res.json()["detail"]
+
+
+def test_rejects_on_bad_token() -> None:
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(
+                side_effect=CaptchaVerificationError(
+                    "Captcha verification failed: AUTOMATION"
+                )
+            ),
+        ) as verify_mock,
+    ):
+        res = client.post("/auth/login", headers={"X-Captcha-Token": "bad-token"})
+    assert res.status_code == 403
+    verify_mock.assert_awaited_once_with("bad-token", CaptchaAction.LOGIN)
+
+
+def test_passes_on_valid_token() -> None:
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(return_value=None),
+        ) as verify_mock,
+    ):
+        res = client.post("/auth/login", headers={"X-Captcha-Token": "good-token"})
+    assert res.status_code == 200
+    verify_mock.assert_awaited_once_with("good-token", CaptchaAction.LOGIN)
+
+
+def test_does_not_gate_other_endpoints() -> None:
+    """Only POST /auth/login is guarded. /auth/register and GET /auth/login pass."""
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(),
+        ) as verify_mock,
+    ):
+        register_res = client.post("/auth/register")
+        get_login_res = client.get("/auth/login")
+    assert register_res.status_code == 200
+    assert get_login_res.status_code == 200
+    verify_mock.assert_not_awaited()

--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -130,9 +130,7 @@ export default function EmailPasswordForm({
             }
           }
 
-          const loginCaptchaToken = isSignup
-            ? undefined
-            : await getCaptchaToken("login");
+          const loginCaptchaToken = await getCaptchaToken("login");
           const loginResponse = await basicLogin(
             email,
             values.password,

--- a/web/src/app/auth/login/EmailPasswordForm.tsx
+++ b/web/src/app/auth/login/EmailPasswordForm.tsx
@@ -130,7 +130,14 @@ export default function EmailPasswordForm({
             }
           }
 
-          const loginResponse = await basicLogin(email, values.password);
+          const loginCaptchaToken = isSignup
+            ? undefined
+            : await getCaptchaToken("login");
+          const loginResponse = await basicLogin(
+            email,
+            values.password,
+            loginCaptchaToken
+          );
           if (loginResponse.ok) {
             setApiStatus("success");
             if (isSignup && shouldVerify) {

--- a/web/src/lib/user.ts
+++ b/web/src/lib/user.ts
@@ -25,19 +25,25 @@ export const logout = async (): Promise<Response> => {
 
 export const basicLogin = async (
   email: string,
-  password: string
+  password: string,
+  captchaToken?: string
 ): Promise<Response> => {
   const params = new URLSearchParams([
     ["username", email],
     ["password", password],
   ]);
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+  };
+  if (captchaToken) {
+    headers["X-Captcha-Token"] = captchaToken;
+  }
+
   const response = await fetch("/api/auth/login", {
     method: "POST",
     credentials: "include",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+    headers,
     body: params,
   });
   return response;


### PR DESCRIPTION
## Description

Stacks on #10428. Adds `LoginCaptchaMiddleware` which verifies an `X-Captcha-Token` header against the reCAPTCHA Enterprise Assessment API before the fastapi-users login handler runs. Credential-stuffing attempts now cost the attacker a fresh captcha token per try.

New `CaptchaAction.LOGIN` value is checked for strict action equality against the Enterprise response, so a token minted for signup or OAuth cannot be replayed against login.

Frontend `basicLogin` gains an optional `captchaToken` parameter and sends it as `X-Captcha-Token`. `EmailPasswordForm` always calls `getCaptchaToken("login")` before `basicLogin` — including the auto-login that follows a successful signup.

No-op when `is_captcha_enabled()` is false, so self-hosted and dev deployments without the Enterprise envs set pass through unchanged.

## How Has This Been Tested?

### Unit
5/5 passing in `test_login_captcha_middleware.py`: captcha-disabled pass-through, missing header rejected, bad token rejected, valid token passes with correct `CaptchaAction.LOGIN` argument, other endpoints (`POST /auth/register`, `GET /auth/login`) not touched.

### End-to-end against real Google Enterprise API (dev1 worktree, localhost:3010)

**Login happy path (UI):** logged in via `/auth/login`; backend log shows one successful assessment `action=login`.

**Login — no captcha header:**
```bash
$ curl -i -X POST http://localhost:3010/api/auth/login \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    --data-urlencode 'username=you@example.com' --data-urlencode 'password=whatever'
HTTP/1.1 403 Forbidden
{"error_code":"UNAUTHORIZED","detail":"Captcha token is required"}
```
Fires **before** the password is checked — credential stuffing is blocked at the captcha gate.

**Login — malformed token:**
```bash
$ curl -i -X POST http://localhost:3010/api/auth/login \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    -H 'X-Captcha-Token: bogus' \
    --data-urlencode 'username=you@example.com' --data-urlencode 'password=whatever'
HTTP/1.1 403 Forbidden
{"error_code":"UNAUTHORIZED","detail":"Captcha verification failed: MALFORMED"}
```

**Signup happy path (UI):** proved the `basicLogin` auto-login now gets its own `action=login` token and succeeds (initial discovery bug — the signup form was previously calling `basicLogin` with `undefined` captcha, tripping the new middleware).

### Skipped e2e paths (covered by unit tests)

- Action mismatch (signup token redeemed at `/auth/login`) → replay cache fires first in practice; action check covered by `test_captcha_enterprise.py::test_action_mismatch_rejects_strictly`
- Middleware bypass on disabled / non-POST / wrong path → `test_login_captcha_middleware.py::test_passes_through_when_captcha_disabled` + `test_does_not_gate_other_endpoints`

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check