### PR TITLE
chore(tests): run `test_run_multitenant_migrations.py` w/ database tests

### DIFF
--- a/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
@@ -6,7 +6,7 @@ The script is invoked as a subprocess — the same way it would be used in
 production.  Tests verify exit codes and stdout messages.
 
 Usage:
-    pytest tests/integration/tests/migrations/test_run_multitenant_migrations.py -v
+    pytest -m alembic tests/integration/tests/migrations/test_run_multitenant_migrations.py -v
 """
 
 from __future__ import annotations
@@ -23,6 +23,8 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 from onyx.db.engine.sql_engine import SqlEngine
+
+pytestmark = pytest.mark.alembic
 
 # Resolve the backend/ directory once so every helper can use it as cwd.
 _BACKEND_DIR = os.path.normpath(

--- a/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
@@ -45,14 +45,13 @@ def _run_script(
     env_override: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run ``python alembic/run_multitenant_migrations.py`` from the backend/ directory."""
-    env = {**os.environ, **(env_override or {})}
     return subprocess.run(
         [sys.executable, "alembic/run_multitenant_migrations.py", *extra_args],
         cwd=_BACKEND_DIR,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
-        env=env,
+        env={**os.environ, "PYTHONPATH": _BACKEND_DIR, **(env_override or {})},
     )
 
 
@@ -112,6 +111,7 @@ def current_head_rev() -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        env={**os.environ, "PYTHONPATH": _BACKEND_DIR},
     )
     assert (
         result.returncode == 0


### PR DESCRIPTION
## Description

The multitenant integration tests are noisy, so move these to the smaller `pr-database-tests.yml` which are more focused on testing migrations anyways.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the multitenant migration integration test to run with the database test job and mark it with `pytest`’s `alembic` marker to reduce CI noise. Subprocess calls now set `PYTHONPATH` to ensure migrations run reliably.

- **Refactors**
  - Renamed to `tests/integration/tests/migrations/test_run_multitenant_migrations.py`.
  - Added `pytestmark = pytest.mark.alembic` so it runs with `-m alembic`.
  - Updated usage to `pytest -m alembic tests/integration/tests/migrations/test_run_multitenant_migrations.py -v`.
  - Set `PYTHONPATH` in subprocess env for both the migration script and `alembic` CLI calls.

<sup>Written for commit 8dea4cd63db9a0b1f0477d9f3bc374854b3acaa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



