### PR TITLE
fix: kill hung task from watchdog

### DIFF
--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -24,6 +24,7 @@ from onyx.background.indexing.job_client import SimpleJobClient
 from onyx.background.indexing.job_client import SimpleJobException
 from onyx.background.indexing.run_docfetching import run_docfetching_entrypoint
 from onyx.configs.constants import CELERY_INDEXING_WATCHDOG_CONNECTOR_TIMEOUT
+from onyx.configs.constants import CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
@@ -519,8 +520,10 @@ def docfetching_proxy_task(
                     )
                     last_memory_emit_time = current_time
 
-            # if the spawned task is still running, restart the check once again
-            # if the index attempt is not in a finished status
+            # if the IndexAttempt row has been marked terminal (failed/canceled/
+            # succeeded) by anyone else, the spawned subprocess is no longer doing
+            # work that anyone cares about. Kill it so the worker thread is freed
+            # up and a fresh attempt can be scheduled with a clean slate.
             try:
                 with get_session_with_current_tenant() as db_session:
                     index_attempt = get_index_attempt(
@@ -533,6 +536,7 @@ def docfetching_proxy_task(
                     if not index_attempt.is_finished():
                         continue
 
+                    attempt_status = index_attempt.status
             except Exception:
                 task_logger.exception(
                     log_builder.build(
@@ -540,6 +544,30 @@ def docfetching_proxy_task(
                     )
                 )
                 continue
+
+            task_logger.warning(
+                log_builder.build(
+                    "Indexing watchdog - IndexAttempt reached terminal status while "
+                    "subprocess was still running; terminating subprocess",
+                    attempt_status=str(attempt_status.value),
+                    pid=str(job.process.pid),
+                )
+            )
+            result.status = (
+                IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
+            )
+            try:
+                job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+            except Exception:
+                task_logger.exception(
+                    log_builder.build(
+                        "Indexing watchdog - exception while terminating subprocess "
+                        "after attempt finalization"
+                    )
+                )
+            if job.process is not None:
+                result.exit_code = job.process.exitcode
+            break
 
     except Exception as e:
         result.status = IndexingWatchdogTerminalStatus.WATCHDOG_EXCEPTIONED
@@ -613,7 +641,7 @@ def docfetching_proxy_task(
                 )
             )
 
-        job.cancel()
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
     elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ACTIVITY_TIMEOUT:
         try:
             with get_session_with_current_tenant() as db_session:
@@ -630,7 +658,16 @@ def docfetching_proxy_task(
                     "Indexing watchdog - transient exception marking index attempt as failed"
                 )
             )
-        job.cancel()
+        job.terminate_and_wait(CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS)
+    elif (
+        result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_ATTEMPT_FINALIZED
+    ):
+        # the IndexAttempt row was already marked terminal by whoever finalized it
+        # (e.g. heartbeat watchdog marking it FAILED, user requesting cancellation,
+        # successful completion in the spawned process before we noticed). The
+        # subprocess has been killed in the watchdog loop above; no further DB
+        # writes are needed here.
+        pass
     else:
         pass
 

--- a/backend/onyx/background/celery/tasks/models.py
+++ b/backend/onyx/background/celery/tasks/models.py
@@ -49,6 +49,12 @@ class IndexingWatchdogTerminalStatus(str, Enum):
     # the watchdog terminated the task due to no activity
     TERMINATED_BY_ACTIVITY_TIMEOUT = "terminated_by_activity_timeout"
 
+    # the watchdog terminated the task because the IndexAttempt reached a terminal
+    # status (failed/canceled/succeeded) outside of the spawned subprocess. We kill
+    # the subprocess so it can't keep doing work for an attempt that no longer exists
+    # logically. The DB row already reflects the real outcome, so we don't touch it.
+    TERMINATED_BY_ATTEMPT_FINALIZED = "terminated_by_attempt_finalized"
+
     # NOTE: this may actually be the same as SIGKILL, but parsed differently by python
     # consolidate once we know more
     OUT_OF_MEMORY = "out_of_memory"

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -125,6 +125,36 @@ class SimpleJob:
             return True
         return False
 
+    def terminate_and_wait(self, sigterm_grace_seconds: float) -> bool:
+        """Best-effort hard-kill of the spawned process.
+
+        Sends SIGTERM, waits up to `sigterm_grace_seconds` for the process to exit,
+        then escalates to SIGKILL if the process is still alive. Joins after each
+        signal so the OS can reap the child. Returns True if the process was alive
+        when this was called (i.e. we actually had to do something).
+        """
+        if self.process is None:
+            return False
+        if not self.process.is_alive():
+            return False
+
+        pid = self.process.pid
+        logger.warning(
+            f"SimpleJob.terminate_and_wait - sending SIGTERM to job: id={self.id} pid={pid}"
+        )
+        self.process.terminate()
+        self.process.join(timeout=sigterm_grace_seconds)
+
+        if self.process.is_alive():
+            logger.warning(
+                f"SimpleJob.terminate_and_wait - SIGTERM grace exceeded, sending SIGKILL: "
+                f"id={self.id} pid={pid} grace={sigterm_grace_seconds}s"
+            )
+            self.process.kill()
+            self.process.join()
+
+        return True
+
     @property
     def status(self) -> JobStatusType:
         if not self.process:

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -644,12 +644,15 @@ REDIS_SOCKET_KEEPALIVE_OPTIONS = {}
 REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPINTVL] = 15
 REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPCNT] = 3
 
+# TCP_KEEPALIVE only exists on Darwin and TCP_KEEPIDLE only exists on Linux/BSD.
+# getattr keeps both branches type-checkable on either platform; any per-line
+# ty suppression (scoped or bare) would itself be flagged as unused on the
+# platform where the attribute actually resolves, since ty analyzes one
+# platform at a time and can't model cross-platform conditional unused-ignores.
 if platform.system() == "Darwin":
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPALIVE] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPALIVE")] = 60
 else:
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[
-        socket.TCP_KEEPIDLE  # ty: ignore[unresolved-attribute]
-    ] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[getattr(socket, "TCP_KEEPIDLE")] = 60
 
 
 class OnyxCallTypes(str, Enum):

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -138,6 +138,11 @@ CELERY_PRIMARY_WORKER_LOCK_TIMEOUT = 120
 # to handle hung connectors
 CELERY_INDEXING_WATCHDOG_CONNECTOR_TIMEOUT = 3 * 60 * 60  # 3 hours (in seconds)
 
+# how long the indexing watchdog waits for a spawned subprocess to exit after
+# SIGTERM before escalating to SIGKILL. Kept short because we only fall into this
+# code path once we have already decided the process needs to die.
+CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS = 10  # seconds
+
 # soft timeout for the lock taken by the indexing connector run
 # allows the lock to eventually expire if the managing code around it dies
 # if we can get callbacks as object bytes download, we could lower this a lot.
@@ -640,11 +645,11 @@ REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPINTVL] = 15
 REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPCNT] = 3
 
 if platform.system() == "Darwin":
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[
-        socket.TCP_KEEPALIVE  # ty: ignore[unresolved-attribute]
-    ] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPALIVE] = 60
 else:
-    REDIS_SOCKET_KEEPALIVE_OPTIONS[socket.TCP_KEEPIDLE] = 60
+    REDIS_SOCKET_KEEPALIVE_OPTIONS[
+        socket.TCP_KEEPIDLE  # ty: ignore[unresolved-attribute]
+    ] = 60
 
 
 class OnyxCallTypes(str, Enum):

--- a/backend/tests/unit/onyx/background/indexing/test_simple_job_terminate.py
+++ b/backend/tests/unit/onyx/background/indexing/test_simple_job_terminate.py
@@ -1,0 +1,126 @@
+"""Unit tests for `SimpleJob.terminate_and_wait`.
+
+These tests do NOT exercise the full indexing watchdog. They only validate the
+small primitive added so the watchdog can hard-kill a stuck spawned process
+when its IndexAttempt has been finalized.
+
+We need real OS processes here (multiprocessing.Process) - mocking would
+defeat the purpose of testing termination semantics.
+"""
+
+import multiprocessing as mp
+import os
+import signal
+import time
+
+import pytest
+
+from onyx.background.indexing.job_client import SimpleJob
+
+
+def _ignore_sigterm_and_sleep_forever(ready_path: str) -> None:
+    """Child entry point that ignores SIGTERM, simulating a hung connector
+    that is not responsive to graceful shutdown signals.
+
+    Writes to `ready_path` once SIGTERM is masked so the parent can avoid a
+    race where it sends SIGTERM before the child has installed its handler.
+    """
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    with open(ready_path, "w") as f:
+        f.write("ready")
+    while True:
+        time.sleep(0.1)
+
+
+def _exit_quickly_on_sigterm(ready_path: str) -> None:
+    """Child entry point that handles SIGTERM by exiting cleanly."""
+
+    def _handler(_signum: int, _frame: object) -> None:
+        os._exit(0)
+
+    signal.signal(signal.SIGTERM, _handler)
+    with open(ready_path, "w") as f:
+        f.write("ready")
+    while True:
+        time.sleep(0.1)
+
+
+def _wait_for_ready_file(path: str, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if os.path.exists(path):
+            return
+        time.sleep(0.05)
+    raise TimeoutError(f"child never wrote ready file: {path}")
+
+
+@pytest.fixture()
+def ready_file(tmp_path) -> str:  # type: ignore[no-untyped-def]
+    return str(tmp_path / "child_ready.txt")
+
+
+def test_terminate_and_wait_returns_false_when_no_process() -> None:
+    """A SimpleJob with no spawned process should be a no-op."""
+    job = SimpleJob(id=0, process=None, queue=None)
+    assert job.terminate_and_wait(sigterm_grace_seconds=1.0) is False
+
+
+def test_terminate_and_wait_returns_false_when_process_already_exited(
+    ready_file: str,
+) -> None:
+    """If the child already exited cleanly, terminate_and_wait shouldn't error
+    and should report that there was nothing to do."""
+    ctx = mp.get_context("spawn")
+    process = ctx.Process(target=_exit_quickly_on_sigterm, args=(ready_file,))
+    process.start()
+    _wait_for_ready_file(ready_file)
+    assert process.pid is not None
+    os.kill(process.pid, signal.SIGTERM)
+    process.join(timeout=5.0)
+    assert not process.is_alive()
+
+    job = SimpleJob(id=1, process=process, queue=None)
+    assert job.terminate_and_wait(sigterm_grace_seconds=1.0) is False
+
+
+def test_terminate_and_wait_kills_responsive_child_with_sigterm(
+    ready_file: str,
+) -> None:
+    """A responsive child should be reaped by the SIGTERM stage; we should
+    not need to escalate to SIGKILL."""
+    ctx = mp.get_context("spawn")
+    process = ctx.Process(target=_exit_quickly_on_sigterm, args=(ready_file,))
+    process.start()
+    _wait_for_ready_file(ready_file)
+
+    job = SimpleJob(id=2, process=process, queue=None)
+    assert job.terminate_and_wait(sigterm_grace_seconds=5.0) is True
+    assert not process.is_alive()
+    assert process.exitcode == 0
+
+
+def test_terminate_and_wait_escalates_to_sigkill_for_unresponsive_child(
+    ready_file: str,
+) -> None:
+    """If the child ignores SIGTERM, terminate_and_wait must escalate to SIGKILL
+    so we never leave an orphaned subprocess attached to a worker thread.
+
+    This is the exact scenario that motivated this change: a connector
+    subprocess that is hung and unresponsive to SIGTERM was tying up a
+    docfetching worker thread indefinitely.
+    """
+    ctx = mp.get_context("spawn")
+    process = ctx.Process(target=_ignore_sigterm_and_sleep_forever, args=(ready_file,))
+    process.start()
+    _wait_for_ready_file(ready_file)
+
+    job = SimpleJob(id=3, process=process, queue=None)
+    start = time.monotonic()
+    grace = 0.5
+    assert job.terminate_and_wait(sigterm_grace_seconds=grace) is True
+    elapsed = time.monotonic() - start
+
+    assert not process.is_alive()
+    assert process.exitcode == -signal.SIGKILL
+    assert elapsed >= grace
+    assert elapsed < grace + 5.0


### PR DESCRIPTION
## Description

It was possible to get into a state where the watchdog for docfetching ran forever while supervising a hung task. Most critically, when the index attempt was marked as failed/cancelled for any reason (i.e. Stalled Indexing which is meant to catch issues like these), the watchdog continued to poll the hung process indefinitely. This PR makes it so we _use_ the status of the index attempt, and clean up the hung child process and allow the watchdog to exit once an attempt has failed.

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the docfetching watchdog from polling a hung subprocess forever by killing it once the related `IndexAttempt` is finalized (failed/canceled/succeeded). This frees the worker thread and lets a fresh attempt start cleanly.

- **Bug Fixes**
  - Watchdog checks `IndexAttempt` status and terminates the subprocess when the attempt is finished; sets `TERMINATED_BY_ATTEMPT_FINALIZED`.
  - Added `SimpleJob.terminate_and_wait(sigterm_grace_seconds)` to send SIGTERM, wait briefly, then escalate to SIGKILL; used instead of `job.cancel()` in watchdog cleanup paths.
  - Introduced `CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS` (10s) to control the SIGTERM grace period.
  - Fixed Redis TCP keepalive option selection to be cross-platform (Darwin/Linux) using `getattr`, avoiding type-checker issues.
  - Added unit tests validating termination behavior (responsive and unresponsive children).

<sup>Written for commit f1386ba680f82e015b3744dcbb16e2cfa44aff32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

