### PR TITLE
feat: add accessbility testing groundwork

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -95,6 +95,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.39.0",
         "@storybook/addon-essentials": "^8.6.18",
         "@storybook/addon-themes": "^8.6.18",
@@ -190,6 +191,19 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -8207,7 +8221,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -113,6 +113,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.39.0",
     "@storybook/addon-essentials": "^8.6.18",
     "@storybook/addon-themes": "^8.6.18",

--- a/web/tests/e2e/accessibility/README.md
+++ b/web/tests/e2e/accessibility/README.md
@@ -1,0 +1,185 @@
+# Accessibility Tests
+
+Automated accessibility (a11y) testing for the Onyx frontend using
+[axe-core](https://github.com/dequelabs/axe-core) via
+[@axe-core/playwright](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/playwright).
+
+## How it works
+
+axe-core is the industry-standard accessibility rules engine maintained by Deque Systems.
+`@axe-core/playwright` injects it into a live Playwright browser page and evaluates the
+rendered DOM against WCAG success criteria. Every violation includes the rule ID, impact
+level, affected elements, and a link to remediation guidance.
+
+Tests target **WCAG 2.1 Level AA** by default — the conformance level required by most
+accessibility regulations (ADA, Section 508, EN 301 549).
+
+## Strict vs. warning mode (the ratchet)
+
+Not all violations fail CI immediately. The system uses a **ratchet** — rules graduate
+from warning to strict as they are fixed:
+
+- **Warning rules** (default): violations are logged as test annotations visible in the
+  Playwright HTML report, but the test passes. This gives visibility without blocking PRs.
+- **Strict rules**: violations fail the test. Once a rule has zero violations across the
+  entire app, it gets added to `STRICT_RULES` in `utils/accessibility.ts`. CI then
+  prevents regressions.
+
+The ratchet only tightens — once a rule is strict, it stays strict.
+
+### Promoting a rule to strict
+
+1. Fix all instances of the rule across the app (e.g. add `aria-label` to every icon-only
+   button for `button-name`).
+2. Add the rule ID to `STRICT_RULES` in `tests/e2e/utils/accessibility.ts`:
+   ```ts
+   export const STRICT_RULES: string[] = [
+     "button-name",
+   ];
+   ```
+3. Run the tests to confirm zero violations for that rule.
+4. Merge. CI now blocks any PR that reintroduces that violation.
+
+## Directory structure
+
+```
+accessibility/
+├── README.md                  # You are here
+├── public_pages.spec.ts       # Unauthenticated pages (login, signup)
+├── app_pages.spec.ts          # Core authenticated pages (chat, search)
+├── admin_pages.spec.ts        # All admin pages (auto-discovered from sidebar)
+└── settings_pages.spec.ts     # All settings tabs (auto-discovered from nav)
+
+utils/
+└── accessibility.ts           # scanAccessibility(), STRICT_RULES, formatViolations()
+
+fixtures/
+└── accessibility.ts           # Playwright fixture: expectAccessible(), a11yScan()
+```
+
+## Philosophy
+
+**Scan the real app, not mocks.** These tests run against a full Onyx deployment — the
+same pages users see. axe-core evaluates the actual rendered DOM, catching issues that
+static analysis and component-level tests miss (z-index stacking, dynamic content, focus
+management, color contrast with real theme variables).
+
+**Auto-discover pages.** Admin and settings tests scrape the sidebar/nav for links rather
+than hardcoding routes. When someone adds a new admin page, it gets tested automatically.
+
+**Start permissive, tighten progressively.** The ratchet approach means the initial merge
+doesn't block anyone. Each rule fix is a small, focused PR. Once fixed, it never regresses.
+
+**Fix by rule, not by page.** Group fixes by violation type (`button-name`, `link-name`,
+`color-contrast`) rather than by page. Each rule type usually involves the same pattern
+applied across many components — fixing the component fixes every page that uses it.
+
+## CI integration
+
+These tests run automatically as part of the `admin` Playwright project in
+`pr-playwright-tests.yml`. No additional CI configuration is needed — they use the same
+global setup, auth fixtures, retry/worker settings, and artifact uploads as all other
+E2E tests.
+
+Warning-mode violations appear in the Playwright HTML report as test annotations.
+Strict-mode violations fail the test and block the PR.
+
+## Running locally
+
+```bash
+# Run all accessibility tests
+npx playwright test accessibility/
+
+# Run a specific file
+npx playwright test accessibility/public_pages.spec.ts
+
+# Run with the HTML reporter for a browsable results page
+npx playwright test accessibility/ --reporter=html
+npx playwright show-report
+```
+
+## Writing new tests
+
+### Simple: scan a page
+
+```ts
+import { test } from "@tests/e2e/fixtures/accessibility";
+
+test("my page is accessible", async ({ page, expectAccessible }) => {
+  await page.goto("/my-page");
+  await page.waitForLoadState("networkidle");
+  await expectAccessible();
+});
+```
+
+### Scoping: include/exclude regions
+
+```ts
+await expectAccessible({
+  include: ["main"],                // Only scan <main>
+  exclude: ["#third-party-widget"], // Skip a known-bad embed
+});
+```
+
+### Disabling specific rules
+
+```ts
+await expectAccessible({
+  disableRules: ["label"], // Third-party datepicker, can't fix
+});
+```
+
+### Using raw results
+
+When you need programmatic access to violations (filtering, counting by impact):
+
+```ts
+import { test, expect } from "@tests/e2e/fixtures/accessibility";
+
+test("no critical violations", async ({ page, a11yScan }) => {
+  await page.goto("/my-page");
+  await page.waitForLoadState("networkidle");
+
+  const results = await a11yScan();
+  const critical = results.violations.filter((v) => v.impact === "critical");
+  expect(critical).toHaveLength(0);
+});
+```
+
+### Adjusting WCAG level
+
+```ts
+// Stricter: WCAG 2.1 Level AAA
+await expectAccessible({ level: "wcag-aaa" });
+
+// Broadest: all axe rules including best-practice checks
+await expectAccessible({ level: "all" });
+```
+
+## Current violations to fix
+
+Prioritized by impact. Each row is a single focused PR.
+
+| Priority | Rule | Impact | Scope | Fix |
+|----------|------|--------|-------|-----|
+| 1 | `button-name` | Critical | 7 icon-only buttons | Add `aria-label` to icon-only `<Button>` components |
+| 2 | `aria-roles` | Critical | Chat input textarea | Fix invalid ARIA role on `#onyx-chat-input-textarea` |
+| 3 | `link-name` | Serious | 57+ sidebar links | Add accessible text to sidebar agent/page links |
+| 4 | `nested-interactive` | Serious | 53 sortable items | Restructure DnD sortable items to avoid nesting interactive elements |
+| 5 | `color-contrast` | Serious | Sidebar section labels | Adjust `text-text-02` color token or use `text-text-03`+ |
+| 6 | `aria-allowed-attr` | Critical | Radix collapsibles | Investigate `aria-controls` on Radix components (may need upstream fix or wrapper) |
+| 7 | `scrollable-region-focusable` | Serious | Admin sidebar | Add `tabindex="0"` to scrollable sidebar container |
+| 8 | `meta-viewport` | Moderate | Next.js viewport config | Remove `maximum-scale=1` / `user-scalable=no` from viewport meta |
+
+## Common violations reference
+
+| Rule | What it checks | Typical fix |
+|------|---------------|-------------|
+| `color-contrast` | Text has 4.5:1 contrast ratio | Use design system color tokens (text-03+ on neutral backgrounds) |
+| `label` | Form inputs have accessible labels | Add `<label>`, `aria-label`, or `aria-labelledby` |
+| `button-name` | Buttons have discernible text | Add text content or `aria-label` to icon-only buttons |
+| `image-alt` | Images have alt text | Add `alt` attribute; decorative images get `alt=""` |
+| `link-name` | Links have discernible text | Ensure link text is not empty |
+| `region` | Content is within landmark regions | Wrap page sections in `<main>`, `<nav>`, `<aside>` |
+
+Full rule reference: https://dequeuniversity.com/rules/axe/4.10

--- a/web/tests/e2e/accessibility/admin_pages.spec.ts
+++ b/web/tests/e2e/accessibility/admin_pages.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Accessibility scan for every admin page discovered from the sidebar.
+ *
+ * Uses the same dynamic discovery approach as the visual regression admin
+ * tests — scrapes sidebar links so the test automatically picks up new pages.
+ */
+
+import { test, expect } from "@tests/e2e/fixtures/accessibility";
+import type { Page } from "@playwright/test";
+
+test.use({ storageState: "admin_auth.json" });
+
+async function discoverAdminPages(page: Page): Promise<string[]> {
+  await page.goto("/admin/configuration/language-models");
+  await page.waitForLoadState("networkidle");
+
+  return page.evaluate(() => {
+    const sidebar = document.querySelector('[class*="group/SidebarWrapper"]');
+    if (!sidebar) return [];
+
+    const hrefs = new Set<string>();
+    sidebar
+      .querySelectorAll<HTMLAnchorElement>('a[href^="/admin/"]')
+      .forEach((a) => hrefs.add(a.getAttribute("href")!));
+    return Array.from(hrefs);
+  });
+}
+
+test("Accessibility — all admin pages", async ({ page, expectAccessible }) => {
+  const adminHrefs = await discoverAdminPages(page);
+  expect(
+    adminHrefs.length,
+    "Expected to discover at least one admin page"
+  ).toBeGreaterThan(0);
+
+  for (const href of adminHrefs) {
+    const slug = href.replace(/^\/admin\//, "").replace(/\//g, "--");
+
+    await test.step(`/admin/${slug}`, async () => {
+      await page.goto(href);
+      await page.waitForLoadState("networkidle");
+
+      await expectAccessible({
+        exclude: [
+          // Dynamic date content that may not be accessible by default
+          '[data-testid="admin-date-range-selector-button"]',
+        ],
+      });
+    });
+  }
+});

--- a/web/tests/e2e/accessibility/app_pages.spec.ts
+++ b/web/tests/e2e/accessibility/app_pages.spec.ts
@@ -5,16 +5,11 @@
  */
 
 import { test, expect } from "@tests/e2e/fixtures/accessibility";
-import { loginAs } from "@tests/e2e/utils/auth";
 
 test.use({ storageState: "admin_auth.json" });
 test.describe.configure({ mode: "parallel" });
 
 test.describe("Accessibility — app pages", () => {
-  test.beforeEach(async ({ page }) => {
-    await loginAs(page, "admin");
-  });
-
   test("chat welcome page (/app)", async ({ page, expectAccessible }) => {
     await page.goto("/app");
     await page.waitForLoadState("networkidle");

--- a/web/tests/e2e/accessibility/app_pages.spec.ts
+++ b/web/tests/e2e/accessibility/app_pages.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Accessibility tests for authenticated app pages.
+ *
+ * Covers the core user-facing routes: chat welcome, search, and settings.
+ */
+
+import { test, expect } from "@tests/e2e/fixtures/accessibility";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+test.use({ storageState: "admin_auth.json" });
+test.describe.configure({ mode: "parallel" });
+
+test.describe("Accessibility — app pages", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, "admin");
+  });
+
+  test("chat welcome page (/app)", async ({ page, expectAccessible }) => {
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await expectAccessible();
+  });
+
+  test("search page", async ({ page, expectAccessible }) => {
+    await page.goto("/search");
+    await page.waitForLoadState("networkidle");
+    await expectAccessible();
+  });
+});

--- a/web/tests/e2e/accessibility/public_pages.spec.ts
+++ b/web/tests/e2e/accessibility/public_pages.spec.ts
@@ -5,7 +5,7 @@
  * evaluated by external auditors or automated compliance scanners.
  */
 
-import { test, expect } from "@tests/e2e/fixtures/accessibility";
+import { test } from "@tests/e2e/fixtures/accessibility";
 
 test.describe("Accessibility — public pages", () => {
   test.describe.configure({ mode: "parallel" });

--- a/web/tests/e2e/accessibility/public_pages.spec.ts
+++ b/web/tests/e2e/accessibility/public_pages.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Accessibility tests for unauthenticated (public) pages.
+ *
+ * These pages are the first thing users encounter and are most likely to be
+ * evaluated by external auditors or automated compliance scanners.
+ */
+
+import { test, expect } from "@tests/e2e/fixtures/accessibility";
+
+test.describe("Accessibility — public pages", () => {
+  test.describe.configure({ mode: "parallel" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+  });
+
+  test("login page", async ({ page, expectAccessible }) => {
+    await page.goto("/auth/login");
+    await page.waitForLoadState("networkidle");
+    await expectAccessible();
+  });
+
+  test("signup page", async ({ page, expectAccessible }) => {
+    await page.goto("/auth/signup");
+    await page.waitForLoadState("networkidle");
+    await expectAccessible();
+  });
+});

--- a/web/tests/e2e/accessibility/settings_pages.spec.ts
+++ b/web/tests/e2e/accessibility/settings_pages.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Accessibility scan for every settings tab.
+ *
+ * Navigates to /app/settings, discovers tabs from the left nav, then scans
+ * each one.
+ */
+
+import { test, expect } from "@tests/e2e/fixtures/accessibility";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+test.use({ storageState: "admin_auth.json" });
+
+test("Accessibility — all settings pages", async ({
+  page,
+  expectAccessible,
+}) => {
+  await loginAs(page, "admin");
+  await page.goto("/app/settings/general");
+
+  const nav = page.getByTestId("settings-left-tab-navigation");
+  await nav.waitFor({ state: "visible", timeout: 10_000 });
+
+  const tabs = nav.locator("a");
+  await expect(tabs.first()).toBeVisible({ timeout: 10_000 });
+  const count = await tabs.count();
+
+  for (let i = 0; i < count; i++) {
+    const tab = tabs.nth(i);
+    const href = await tab.getAttribute("href");
+    const slug = href ? href.replace("/app/settings/", "") : `tab-${i}`;
+
+    await test.step(`settings/${slug}`, async () => {
+      await tab.click();
+      await page.waitForLoadState("networkidle");
+      await expectAccessible();
+    });
+  }
+});

--- a/web/tests/e2e/accessibility/settings_pages.spec.ts
+++ b/web/tests/e2e/accessibility/settings_pages.spec.ts
@@ -6,7 +6,6 @@
  */
 
 import { test, expect } from "@tests/e2e/fixtures/accessibility";
-import { loginAs } from "@tests/e2e/utils/auth";
 
 test.use({ storageState: "admin_auth.json" });
 
@@ -14,7 +13,6 @@ test("Accessibility — all settings pages", async ({
   page,
   expectAccessible,
 }) => {
-  await loginAs(page, "admin");
   await page.goto("/app/settings/general");
 
   const nav = page.getByTestId("settings-left-tab-navigation");

--- a/web/tests/e2e/fixtures/accessibility.ts
+++ b/web/tests/e2e/fixtures/accessibility.ts
@@ -1,0 +1,72 @@
+/**
+ * Playwright fixture that provides accessibility scanning helpers to any test.
+ *
+ * Usage:
+ * ```ts
+ * import { test, expect } from "@tests/e2e/fixtures/accessibility";
+ *
+ * test("page is accessible", async ({ page, expectAccessible }) => {
+ *   await page.goto("/app");
+ *   await page.waitForLoadState("networkidle");
+ *   await expectAccessible();
+ * });
+ * ```
+ *
+ * Behavior:
+ * - Violations of rules listed in STRICT_RULES → test fails (regressions blocked)
+ * - All other violations → logged as test warnings (visible in reports, non-blocking)
+ *
+ * As rules are fixed across the app, add their IDs to STRICT_RULES in
+ * `utils/accessibility.ts` to lock in the fix and prevent regressions.
+ */
+
+import { test as base, expect } from "@playwright/test";
+import type { TestInfo } from "@playwright/test";
+import type { AxeResults } from "axe-core";
+import {
+  scanAccessibility,
+  partitionViolations,
+  formatViolations,
+  formatWarnings,
+  type A11yScanOptions,
+} from "@tests/e2e/utils/accessibility";
+
+interface A11yFixtures {
+  /** Scan the page; fail on strict rule violations, warn on the rest. */
+  expectAccessible: (options?: A11yScanOptions) => Promise<void>;
+  /** Run an axe scan and return raw results for custom handling. */
+  a11yScan: (options?: A11yScanOptions) => Promise<AxeResults>;
+}
+
+export const test = base.extend<A11yFixtures>({
+  expectAccessible: async ({ page }, use, testInfo: TestInfo) => {
+    await use(async (options?: A11yScanOptions) => {
+      const results = await scanAccessibility(page, options);
+      const { strict, warnings } = partitionViolations(results.violations);
+
+      if (warnings.length > 0) {
+        testInfo.annotations.push({
+          type: "a11y-warnings",
+          description: `${
+            warnings.length
+          } non-strict a11y violation(s):\n${formatWarnings(warnings)}`,
+        });
+      }
+
+      expect(
+        strict,
+        strict.length > 0
+          ? `Strict a11y rule regression:\n${formatViolations(strict)}`
+          : ""
+      ).toHaveLength(0);
+    });
+  },
+
+  a11yScan: async ({ page }, use) => {
+    await use(async (options?: A11yScanOptions) => {
+      return scanAccessibility(page, options);
+    });
+  },
+});
+
+export { expect };

--- a/web/tests/e2e/utils/accessibility.ts
+++ b/web/tests/e2e/utils/accessibility.ts
@@ -14,7 +14,14 @@ export type WcagLevel = "wcag-aa" | "wcag-aaa" | "all";
 
 const WCAG_TAGS: Record<WcagLevel, string[]> = {
   "wcag-aa": ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
-  "wcag-aaa": ["wcag2a", "wcag2aa", "wcag2aaa", "wcag21a", "wcag21aa"],
+  "wcag-aaa": [
+    "wcag2a",
+    "wcag2aa",
+    "wcag2aaa",
+    "wcag21a",
+    "wcag21aa",
+    "wcag21aaa",
+  ],
   all: [],
 };
 

--- a/web/tests/e2e/utils/accessibility.ts
+++ b/web/tests/e2e/utils/accessibility.ts
@@ -1,0 +1,148 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { Page } from "@playwright/test";
+import type { AxeResults, Result as AxeViolation } from "axe-core";
+
+/**
+ * WCAG tag sets used to scope axe-core analysis.
+ *
+ * "wcag-aa" targets WCAG 2.1 Level AA — the standard compliance bar for most
+ * products. "wcag-aaa" adds Level AAA rules for stricter audits. "all" runs
+ * every rule axe-core ships, including best-practice checks that aren't part
+ * of any WCAG success criterion.
+ */
+export type WcagLevel = "wcag-aa" | "wcag-aaa" | "all";
+
+const WCAG_TAGS: Record<WcagLevel, string[]> = {
+  "wcag-aa": ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+  "wcag-aaa": ["wcag2a", "wcag2aa", "wcag2aaa", "wcag21a", "wcag21aa"],
+  all: [],
+};
+
+/**
+ * Rules that have been fixed and MUST NOT regress. Violations of these rules
+ * will fail the test. All other rules are reported as warnings only.
+ *
+ * Workflow: fix all instances of a rule across the app, then move the rule ID
+ * here so CI prevents regressions. This is the ratchet — it only tightens.
+ */
+export const STRICT_RULES: string[] = [
+  // Add rule IDs here as they are fixed, e.g.:
+  // "button-name",
+  // "image-alt",
+];
+
+export interface A11yScanOptions {
+  /** CSS selectors to include in the scan. Defaults to the full page. */
+  include?: string[];
+  /** CSS selectors to exclude from the scan. */
+  exclude?: string[];
+  /** Rule IDs to disable for this scan. */
+  disableRules?: string[];
+  /** WCAG conformance level. Defaults to "wcag-aa". */
+  level?: WcagLevel;
+}
+
+/**
+ * Run an axe-core accessibility scan against the current page state and return
+ * the raw results. Use this when you need programmatic access to violations
+ * (e.g. to generate reports or filter results). For simple pass/fail
+ * assertions, prefer {@link expectAccessible} via the fixture.
+ */
+export async function scanAccessibility(
+  page: Page,
+  options: A11yScanOptions = {}
+): Promise<AxeResults> {
+  const { include, exclude, disableRules, level = "wcag-aa" } = options;
+
+  let builder = new AxeBuilder({ page });
+
+  const tags = WCAG_TAGS[level];
+  if (tags.length > 0) {
+    builder = builder.withTags(tags);
+  }
+
+  if (include) {
+    for (const selector of include) {
+      builder = builder.include(selector);
+    }
+  }
+  if (exclude) {
+    for (const selector of exclude) {
+      builder = builder.exclude(selector);
+    }
+  }
+  if (disableRules) {
+    builder = builder.disableRules(disableRules);
+  }
+
+  return builder.analyze();
+}
+
+/**
+ * Split violations into strict (must fail) and warnings (report only).
+ */
+export function partitionViolations(violations: AxeViolation[]): {
+  strict: AxeViolation[];
+  warnings: AxeViolation[];
+} {
+  const strictSet = new Set(STRICT_RULES);
+  const strict: AxeViolation[] = [];
+  const warnings: AxeViolation[] = [];
+
+  for (const v of violations) {
+    if (strictSet.has(v.id)) {
+      strict.push(v);
+    } else {
+      warnings.push(v);
+    }
+  }
+
+  return { strict, warnings };
+}
+
+/**
+ * Format a single axe violation into a human-readable string.
+ */
+function formatViolation(v: AxeViolation): string {
+  const nodes = v.nodes
+    .slice(0, 5)
+    .map((n) => `    ${n.target.join(" > ")}`)
+    .join("\n");
+
+  const truncated =
+    v.nodes.length > 5 ? `\n    ... and ${v.nodes.length - 5} more` : "";
+
+  return [
+    `  [${v.impact?.toUpperCase()}] ${v.id}: ${v.help} (${
+      v.nodes.length
+    } nodes)`,
+    `  ${v.helpUrl}`,
+    nodes + truncated,
+  ].join("\n");
+}
+
+/**
+ * Format violations for assertion failure messages.
+ */
+export function formatViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return "No accessibility violations found.";
+
+  const header = `${violations.length} accessibility violation(s):\n`;
+  return header + violations.map(formatViolation).join("\n\n");
+}
+
+/**
+ * Format violations as a compact warning summary for test annotations.
+ */
+export function formatWarnings(violations: AxeViolation[]): string {
+  if (violations.length === 0) return "";
+
+  return violations
+    .map(
+      (v) =>
+        `[${v.impact?.toUpperCase()}] ${v.id}: ${v.help} (${
+          v.nodes.length
+        } nodes)`
+    )
+    .join("\n");
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,11 +25,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@tests/*": ["./tests/*"],
-      "@public/*": ["./public/*"],
-      "@opal/*": ["./lib/opal/src/*"],
-      "@opal/types/*": ["./lib/opal/src/types/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ],
+      "@public/*": [
+        "./public/*"
+      ],
+      "@opal/*": [
+        "./lib/opal/src/*"
+      ],
+      "@opal/types/*": [
+        "./lib/opal/src/types/*"
+      ]
     }
   },
   "include": [
@@ -35,5 +49,8 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "lib/opal"]
+  "exclude": [
+    "node_modules",
+    "lib/opal"
+  ]
 }

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -25,21 +21,11 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@tests/*": [
-        "./tests/*"
-      ],
-      "@public/*": [
-        "./public/*"
-      ],
-      "@opal/*": [
-        "./lib/opal/src/*"
-      ],
-      "@opal/types/*": [
-        "./lib/opal/src/types/*"
-      ]
+      "@/*": ["./src/*"],
+      "@tests/*": ["./tests/*"],
+      "@public/*": ["./public/*"],
+      "@opal/*": ["./lib/opal/src/*"],
+      "@opal/types/*": ["./lib/opal/src/types/*"]
     }
   },
   "include": [
@@ -49,8 +35,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "lib/opal"
-  ]
+  "exclude": ["node_modules", "lib/opal"]
 }


### PR DESCRIPTION
## Description

## Add axe-core accessibility testing infrastructure for automated a11y regression detection

### Summary
- Adds `@axe-core/playwright` and a Playwright fixture/utility layer that scans every page against WCAG 2.1 AA rules
- Auto-discovers all admin and settings pages from the sidebar/nav — new pages are covered automatically
- Uses a **ratchet model**: violations are warnings (non-blocking) until a rule is fixed app-wide, then it becomes strict (CI-blocking). This lets us merge immediately without breaking anyone's workflow.

### Why this matters

Our frontend is increasingly AI-generated. Coding agents (Claude Code, Copilot, Cursor, etc.) produce functional UI quickly but routinely introduce accessibility regressions — missing `aria-label` on icon-only buttons, low-contrast text, invalid ARIA roles, nested interactive elements. These are invisible in screenshots and easy to miss in manual review.

Today we catch these through Playwright MCP + screenshot QA + human QA, which is slow, subjective, and doesn't scale. axe-core gives us **structured, machine-readable results** that tell an agent exactly what's wrong and where: rule ID, affected DOM selector, severity, and a fix URL. An agent can read `[CRITICAL] button-name: Buttons must have discernible text → .h-[var(--opal-line-height-md)]` and fix it in one shot — no screenshot interpretation needed.

### How we'll use this

1. **This PR**: Merge the infrastructure. All current violations are warnings. Nothing blocks.
2. **Fix-by-rule PRs**: Each axe rule (`button-name`, `link-name`, `color-contrast`, etc.) is a focused PR that touches one pattern across many components. AI agent teams can pick these off the prioritized list in the README.
3. **Ratchet after each fix**: Add the fixed rule ID to `STRICT_RULES`. CI blocks regressions from that point forward.
4. **Steady state**: Coding agents run against a strict a11y baseline. New violations from AI-generated code get caught in CI before merge — no human screenshot review needed for the class of issues axe covers (contrast, labels, ARIA, focus management, landmark structure).

### What's included

| File | Purpose |
|---|---|
| `tests/e2e/utils/accessibility.ts` | Core scanning utility, `STRICT_RULES` ratchet, WCAG level config |
| `tests/e2e/fixtures/accessibility.ts` | Playwright fixture — `expectAccessible()` (warn/fail) and `a11yScan()` (raw results) |
| `tests/e2e/accessibility/public_pages.spec.ts` | Login, signup |
| `tests/e2e/accessibility/app_pages.spec.ts` | Chat welcome, search |
| `tests/e2e/accessibility/admin_pages.spec.ts` | All admin pages (auto-discovered) |
| `tests/e2e/accessibility/settings_pages.spec.ts` | All settings tabs (auto-discovered) |
| `tests/e2e/accessibility/README.md` | Structure, philosophy, ratchet workflow, prioritized fix backlog |

### Test plan
- [ ] CI Playwright suite passes (all a11y tests pass in warning mode)
- [ ] Verify a11y annotations appear in Playwright HTML report
- [ ] Confirm adding a rule to `STRICT_RULES` causes a test failure when violations exist

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add automated accessibility testing with `@axe-core/playwright` across public, app, settings, and admin pages. Uses a ratchet that warns by default and fails CI for rules promoted to strict to prevent regressions.

- **New Features**
  - Playwright fixture with `expectAccessible()` (warn/fail via `STRICT_RULES`) and `a11yScan()`; supports include/exclude, rule disables, and WCAG level options (WCAG 2.1 AA default).
  - Tests cover login/signup, `/app`, `/search`, all settings tabs and all admin pages via auto-discovered links; excludes the admin date range selector from scans.
  - README with local run commands and CI behavior; warnings surface as Playwright report annotations.

- **Dependencies**
  - Added `@axe-core/playwright` (dev).
  - Bumped `axe-core` to 4.11.3 in the lockfile.

<sup>Written for commit 6d304e35a37d4ebe05b40aa8a8f1e1dd53630510. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



