### PR TITLE
refactor(opal): remove topRightChildren from Card.Header

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -162,7 +162,7 @@ function MessageCard({
           description={description}
           sizePreset="main-ui"
           variant="section"
-          padding="fit"
+          padding="md"
           rightChildren={right}
         />
       </div>

--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Card, Content } from "@opal/layouts";
+import { Card, ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
 import {
   SvgArrowExchange,
@@ -39,42 +39,50 @@ export const Default: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
+        headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
             title="Google Search"
             description="Web search provider"
+            padding="fit"
+            rightChildren={
+              <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
+                Connect
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
-            Connect
-          </Button>
         }
       />
     </div>
   ),
 };
 
-export const WithBothSlots: Story = {
+export const WithBottomRightSlot: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
+        headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
             title="Google Search"
             description="Currently the default provider."
+            padding="fit"
+            rightChildren={
+              <Button
+                variant="action"
+                prominence="tertiary"
+                icon={SvgCheckSquare}
+              >
+                Current Default
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
-            Current Default
-          </Button>
         }
         bottomRightChildren={
           <>
@@ -97,40 +105,19 @@ export const WithBothSlots: Story = {
   ),
 };
 
-export const RightChildrenOnly: Story = {
+export const NoRightAction: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
+        headerPadding="sm"
         headerChildren={
-          <Content
-            sizePreset="main-ui"
-            variant="section"
-            icon={SvgGlobe}
-            title="OpenAI"
-            description="Not configured"
-          />
-        }
-        topRightChildren={
-          <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
-            Connect
-          </Button>
-        }
-      />
-    </div>
-  ),
-};
-
-export const NoRightChildren: Story = {
-  render: () => (
-    <div className="w-[28rem] border rounded-16">
-      <Card.Header
-        headerChildren={
-          <Content
+          <ContentAction
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
             title="Section Header"
             description="No actions on the right."
+            padding="fit"
           />
         }
       />
@@ -142,19 +129,25 @@ export const LongContent: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
       <Card.Header
+        headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             sizePreset="main-ui"
             variant="section"
             icon={SvgGlobe}
             title="Very Long Provider Name That Should Truncate"
             description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
+            padding="fit"
+            rightChildren={
+              <Button
+                variant="action"
+                prominence="tertiary"
+                icon={SvgCheckSquare}
+              >
+                Current Default
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button variant="action" prominence="tertiary" icon={SvgCheckSquare}>
-            Current Default
-          </Button>
         }
         bottomRightChildren={
           <>

--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story = {
     <div className="w-[28rem] border rounded-16">
       <Card.Header
         headerPadding="sm"
-        headerChildren={
+        children={
           <ContentAction
             sizePreset="main-ui"
             variant="section"
@@ -65,7 +65,7 @@ export const WithBottomRightSlot: Story = {
     <div className="w-[28rem] border rounded-16">
       <Card.Header
         headerPadding="sm"
-        headerChildren={
+        children={
           <ContentAction
             sizePreset="main-ui"
             variant="section"
@@ -110,7 +110,7 @@ export const NoRightAction: Story = {
     <div className="w-[28rem] border rounded-16">
       <Card.Header
         headerPadding="sm"
-        headerChildren={
+        children={
           <ContentAction
             sizePreset="main-ui"
             variant="section"
@@ -130,7 +130,7 @@ export const LongContent: Story = {
     <div className="w-[28rem] border rounded-16">
       <Card.Header
         headerPadding="sm"
-        headerChildren={
+        children={
           <ContentAction
             sizePreset="main-ui"
             variant="section"

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -6,29 +6,26 @@ A namespace of card layout primitives. Each sub-component handles a specific reg
 
 ## Card.Header
 
-A flexible card header with one slot for the main header content, two stacked slots in a right-side column, and a full-width slot below.
+A card header layout with a main content slot, an optional right-aligned column below, and a full-width `bottomChildren` slot.
 
 ### Why Card.Header?
 
-[`ContentAction`](../content-action/README.md) provides a single right-side slot. Card headers typically need more — a primary action on top, secondary actions on the bottom, and sometimes a full-width region beneath the entire row (e.g. expandable details, search bars, secondary info).
-
-`Card.Header` is layout-only — it intentionally doesn't bake in `Content` props. Pass a `<Content />` (or any other element) into `headerChildren` for the icon/title/description region.
+`Card.Header` is layout-only — it provides `headerChildren` for the main content area plus `bottomRightChildren` and `bottomChildren` for secondary slots. For the typical icon/title/description + right-action pattern, pass a `<ContentAction />` into `headerChildren` with `rightChildren` for the action button.
 
 ### Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `headerChildren` | `ReactNode` | `undefined` | Content rendered in the top-left header slot — typically a `<Content />` block. |
+| `headerChildren` | `ReactNode` | `undefined` | Content rendered in the header slot — typically a `<ContentAction />` block. |
 | `headerPadding` | `"sm" \| "fit"` | `"fit"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
-| `topRightChildren` | `ReactNode` | `undefined` | Content rendered to the right of `headerChildren` (top of right column). |
-| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `topRightChildren` in the same column. Laid out as `flex flex-row`. |
-| `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header (left + right columns), spanning the full width. |
+| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `headerChildren` in a right-aligned column. Laid out as `flex flex-row`. |
+| `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header, spanning the full width. |
 
 ### Layout Structure
 
 ```
-+------------------+----------------+
-| headerChildren   | topRight       |
++-----------------------------------+
+| headerChildren                    |
 +                  +----------------+
 |                  | bottomRight    |
 +------------------+----------------+
@@ -39,32 +36,34 @@ A flexible card header with one slot for the main header content, two stacked sl
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
 - Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-0`) — grows to fill available space
-- Right column: `flex flex-col items-end shrink-0` — shrinks to fit its content
+- Right column: `flex flex-col items-end shrink-0` — only rendered when `bottomRightChildren` is provided
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 
 ### Usage
 
-#### Card with primary and secondary actions
+#### Card with right action and bottom-right actions
 
 ```tsx
-import { Card, Content } from "@opal/layouts";
+import { Card, ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
 import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 <Card.Header
+  headerPadding="sm"
   headerChildren={
-    <Content
+    <ContentAction
       icon={SvgGlobe}
       title="Google Search"
       description="Web search provider"
       sizePreset="main-ui"
       variant="section"
+      padding="fit"
+      rightChildren={
+        <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
+          Current Default
+        </Button>
+      }
     />
-  }
-  topRightChildren={
-    <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
-      Current Default
-    </Button>
   }
   bottomRightChildren={
     <>
@@ -79,52 +78,58 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
+  headerPadding="sm"
   headerChildren={
-    <Content
+    <ContentAction
       icon={SvgCloud}
       title="OpenAI"
       description="Not configured"
       sizePreset="main-ui"
       variant="section"
+      padding="fit"
+      rightChildren={
+        <Button rightIcon={SvgArrowExchange} prominence="tertiary">
+          Connect
+        </Button>
+      }
     />
-  }
-  topRightChildren={
-    <Button rightIcon={SvgArrowExchange} prominence="tertiary">
-      Connect
-    </Button>
   }
 />
 ```
 
-#### Card with extra info beneath the header
+#### Card with bottom children
 
 ```tsx
 <Card.Header
+  headerPadding="sm"
   headerChildren={
-    <Content
+    <ContentAction
       icon={SvgServer}
       title="MCP Server"
       description="12 tools available"
       sizePreset="main-ui"
       variant="section"
+      padding="fit"
+      rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
     />
   }
-  topRightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
   bottomChildren={<SearchBar placeholder="Search tools..." />}
 />
 ```
 
-#### No slots
+#### No actions
 
 ```tsx
 <Card.Header
+  headerPadding="sm"
   headerChildren={
-    <Content
+    <ContentAction
       icon={SvgInfo}
       title="Section Header"
       description="Description text"
       sizePreset="main-content"
       variant="section"
+      padding="fit"
     />
   }
 />

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -17,7 +17,6 @@ A card header layout with a main content slot, an optional right-aligned column 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `headerChildren` | `ReactNode` | `undefined` | Content rendered in the header slot — typically a `<ContentAction />` block. |
-| `headerPadding` | `"sm" \| "fit"` | `"fit"` | Padding applied around `headerChildren`. `"sm"` → `p-2`; `"fit"` → `p-0`. |
 | `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `headerChildren` in a right-aligned column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header, spanning the full width. |
 
@@ -35,7 +34,7 @@ A card header layout with a main content slot, an optional right-aligned column 
 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
-- Left column (headerChildren wrapper): `self-start grow min-w-0` + `headerPadding` variant (default `p-0`) — grows to fill available space
+- Left column (headerChildren wrapper): `self-start grow min-w-0` — grows to fill available space
 - Right column: `flex flex-col items-end shrink-0` — only rendered when `bottomRightChildren` is provided
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 
@@ -49,7 +48,7 @@ import { Button } from "@opal/components";
 import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 <Card.Header
-  headerPadding="sm"
+
   headerChildren={
     <ContentAction
       icon={SvgGlobe}
@@ -78,7 +77,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
-  headerPadding="sm"
+
   headerChildren={
     <ContentAction
       icon={SvgCloud}
@@ -101,7 +100,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
-  headerPadding="sm"
+
   headerChildren={
     <ContentAction
       icon={SvgServer}
@@ -121,7 +120,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 ```tsx
 <Card.Header
-  headerPadding="sm"
+
   headerChildren={
     <ContentAction
       icon={SvgInfo}

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -10,21 +10,21 @@ A card header layout with a main content slot, an optional right-aligned column 
 
 ### Why Card.Header?
 
-`Card.Header` is layout-only — it provides `headerChildren` for the main content area plus `bottomRightChildren` and `bottomChildren` for secondary slots. For the typical icon/title/description + right-action pattern, pass a `<ContentAction />` into `headerChildren` with `rightChildren` for the action button.
+`Card.Header` is layout-only — it provides `children` for the main content area plus `bottomRightChildren` and `bottomChildren` for secondary slots. For the typical icon/title/description + right-action pattern, pass a `<ContentAction />` into `children` with `rightChildren` for the action button.
 
 ### Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `headerChildren` | `ReactNode` | `undefined` | Content rendered in the header slot — typically a `<ContentAction />` block. |
-| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `headerChildren` in a right-aligned column. Laid out as `flex flex-row`. |
+| `children` | `ReactNode` | `undefined` | Content rendered in the header slot — typically a `<ContentAction />` block. |
+| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `children` in a right-aligned column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header, spanning the full width. |
 
 ### Layout Structure
 
 ```
 +-----------------------------------+
-| headerChildren                    |
+| children                    |
 +                  +----------------+
 |                  | bottomRight    |
 +------------------+----------------+
@@ -34,7 +34,7 @@ A card header layout with a main content slot, an optional right-aligned column 
 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
-- Left column (headerChildren wrapper): `self-start grow min-w-0` — grows to fill available space
+- Left column (children wrapper): `self-start grow min-w-0` — grows to fill available space
 - Right column: `flex flex-col items-end shrink-0` — only rendered when `bottomRightChildren` is provided
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 
@@ -49,7 +49,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 
 <Card.Header
 
-  headerChildren={
+  children={
     <ContentAction
       icon={SvgGlobe}
       title="Google Search"
@@ -78,7 +78,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 ```tsx
 <Card.Header
 
-  headerChildren={
+  children={
     <ContentAction
       icon={SvgCloud}
       title="OpenAI"
@@ -101,7 +101,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 ```tsx
 <Card.Header
 
-  headerChildren={
+  children={
     <ContentAction
       icon={SvgServer}
       title="MCP Server"
@@ -121,7 +121,7 @@ import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
 ```tsx
 <Card.Header
 
-  headerChildren={
+  children={
     <ContentAction
       icon={SvgInfo}
       title="Section Header"

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -2,16 +2,9 @@
 // Types
 // ---------------------------------------------------------------------------
 
-import { paddingVariants } from "@opal/shared";
-import type { PaddingVariants } from "@opal/types";
-import { cn } from "@opal/utils";
-
 interface CardHeaderProps {
   /** Content rendered in the header slot — typically a {@link ContentAction} block. */
   headerChildren?: React.ReactNode;
-
-  /** Padding applied around `headerChildren`. @default "fit" */
-  headerPadding?: Extract<PaddingVariants, "sm" | "fit">;
 
   /** Content rendered below `headerChildren`, in a right-aligned column. */
   bottomRightChildren?: React.ReactNode;
@@ -56,7 +49,7 @@ interface CardHeaderProps {
  *       description="Search engine"
  *       sizePreset="main-ui"
  *       variant="section"
- *       padding="fit"
+ *       padding="lg"
  *       rightChildren={<Button>Connect</Button>}
  *     />
  *   }
@@ -71,7 +64,6 @@ interface CardHeaderProps {
  */
 function Header({
   headerChildren,
-  headerPadding = "fit",
   bottomRightChildren,
   bottomChildren,
 }: CardHeaderProps) {
@@ -79,14 +71,7 @@ function Header({
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
         {headerChildren != null && (
-          <div
-            className={cn(
-              "self-start grow min-w-0",
-              paddingVariants[headerPadding]
-            )}
-          >
-            {headerChildren}
-          </div>
+          <div className="self-start grow min-w-0">{headerChildren}</div>
         )}
         {bottomRightChildren != null && (
           <div className="flex flex-col items-end shrink-0">

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -7,16 +7,13 @@ import type { PaddingVariants } from "@opal/types";
 import { cn } from "@opal/utils";
 
 interface CardHeaderProps {
-  /** Content rendered in the top-left header slot — typically a {@link Content} block. */
+  /** Content rendered in the header slot — typically a {@link ContentAction} block. */
   headerChildren?: React.ReactNode;
 
   /** Padding applied around `headerChildren`. @default "fit" */
   headerPadding?: Extract<PaddingVariants, "sm" | "fit">;
 
-  /** Content rendered to the right of `headerChildren` (top of right column). */
-  topRightChildren?: React.ReactNode;
-
-  /** Content rendered below `topRightChildren`, in the same column. */
+  /** Content rendered below `headerChildren`, in a right-aligned column. */
   bottomRightChildren?: React.ReactNode;
 
   /**
@@ -32,12 +29,12 @@ interface CardHeaderProps {
 // ---------------------------------------------------------------------------
 
 /**
- * A card header layout with three optional slots arranged in two independent
- * columns, plus a full-width `bottomChildren` slot below.
+ * A card header layout with a main content slot, an optional right-aligned
+ * column below, and a full-width `bottomChildren` slot.
  *
  * ```
- * +------------------+----------------+
- * | headerChildren   | topRight       |
+ * +-----------------------------------+
+ * | headerChildren                    |
  * +                  +----------------+
  * |                  | bottomRight    |
  * +------------------+----------------+
@@ -45,25 +42,24 @@ interface CardHeaderProps {
  * +-----------------------------------+
  * ```
  *
- * The left column grows to fill available space; the right column shrinks
- * to fit its content. The two columns are independent in height.
- *
- * For the typical icon/title/description pattern, pass a {@link Content}
- * (or {@link ContentAction}) into `headerChildren`.
+ * For the typical icon/title/description + right-action pattern, pass a
+ * {@link ContentAction} into `headerChildren` with `rightChildren` for
+ * the action button.
  *
  * @example
  * ```tsx
  * <Card.Header
  *   headerChildren={
- *     <Content
+ *     <ContentAction
  *       icon={SvgGlobe}
  *       title="Google"
  *       description="Search engine"
  *       sizePreset="main-ui"
  *       variant="section"
+ *       padding="fit"
+ *       rightChildren={<Button>Connect</Button>}
  *     />
  *   }
- *   topRightChildren={<Button>Connect</Button>}
  *   bottomRightChildren={
  *     <>
  *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
@@ -76,12 +72,9 @@ interface CardHeaderProps {
 function Header({
   headerChildren,
   headerPadding = "fit",
-  topRightChildren,
   bottomRightChildren,
   bottomChildren,
 }: CardHeaderProps) {
-  const hasRight = topRightChildren != null || bottomRightChildren != null;
-
   return (
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
@@ -95,12 +88,9 @@ function Header({
             {headerChildren}
           </div>
         )}
-        {hasRight && (
+        {bottomRightChildren != null && (
           <div className="flex flex-col items-end shrink-0">
-            {topRightChildren != null && <div>{topRightChildren}</div>}
-            {bottomRightChildren != null && (
-              <div className="flex flex-row">{bottomRightChildren}</div>
-            )}
+            <div className="flex flex-row">{bottomRightChildren}</div>
           </div>
         )}
       </div>

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -4,9 +4,9 @@
 
 interface CardHeaderProps {
   /** Content rendered in the header slot — typically a {@link ContentAction} block. */
-  headerChildren?: React.ReactNode;
+  children?: React.ReactNode;
 
-  /** Content rendered below `headerChildren`, in a right-aligned column. */
+  /** Content rendered below `children`, in a right-aligned column. */
   bottomRightChildren?: React.ReactNode;
 
   /**
@@ -27,7 +27,7 @@ interface CardHeaderProps {
  *
  * ```
  * +-----------------------------------+
- * | headerChildren                    |
+ * | children                    |
  * +                  +----------------+
  * |                  | bottomRight    |
  * +------------------+----------------+
@@ -36,42 +36,41 @@ interface CardHeaderProps {
  * ```
  *
  * For the typical icon/title/description + right-action pattern, pass a
- * {@link ContentAction} into `headerChildren` with `rightChildren` for
+ * {@link ContentAction} into `children` with `rightChildren` for
  * the action button.
  *
  * @example
  * ```tsx
  * <Card.Header
- *   headerChildren={
- *     <ContentAction
- *       icon={SvgGlobe}
- *       title="Google"
- *       description="Search engine"
- *       sizePreset="main-ui"
- *       variant="section"
- *       padding="lg"
- *       rightChildren={<Button>Connect</Button>}
- *     />
- *   }
  *   bottomRightChildren={
  *     <>
  *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
  *       <Button icon={SvgSettings} size="sm" prominence="tertiary" />
  *     </>
  *   }
- * />
+ * >
+ *   <ContentAction
+ *     icon={SvgGlobe}
+ *     title="Google"
+ *     description="Search engine"
+ *     sizePreset="main-ui"
+ *     variant="section"
+ *     padding="lg"
+ *     rightChildren={<Button>Connect</Button>}
+ *   />
+ * </Card.Header>
  * ```
  */
 function Header({
-  headerChildren,
+  children,
   bottomRightChildren,
   bottomChildren,
 }: CardHeaderProps) {
   return (
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
-        {headerChildren != null && (
-          <div className="self-start grow min-w-0">{headerChildren}</div>
+        {children != null && (
+          <div className="self-start grow min-w-0">{children}</div>
         )}
         {bottomRightChildren != null && (
           <div className="flex flex-col items-end shrink-0">

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -61,7 +61,7 @@ function ContentAction({
 
   return (
     <div className="flex flex-row items-stretch w-full">
-      <div className={cn("flex-1 min-w-0 self-center", paddingClass)}>
+      <div className={cn("flex-1 min-w-0 self-start", paddingClass)}>
         <Content {...contentProps} />
       </div>
       {rightChildren && (

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -288,7 +288,7 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
             description={tool.description}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={<SwitchField name={toolFieldName} />}
           />
         }
@@ -353,7 +353,7 @@ function MCPServerCard({
                       description={tool.description}
                       sizePreset="main-ui"
                       variant="section"
-                      padding="fit"
+                      padding="lg"
                       rightChildren={
                         <SwitchField
                           name={`${serverFieldName}.tool_${tool.id}`}
@@ -388,7 +388,7 @@ function MCPServerCard({
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={
               <GeneralLayouts.Section
                 flexDirection="row"
@@ -416,7 +416,6 @@ function MCPServerCard({
             }
           />
         }
-        headerPadding="sm"
         bottomChildren={
           <GeneralLayouts.Section flexDirection="row" gap={0.5}>
             <InputTypeIn

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -280,18 +280,14 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
 
   return (
     <Card border="solid" rounding="lg" padding="md">
-      <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={SvgActions}
-            title={tool.display_name || tool.name}
-            description={tool.description}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={<SwitchField name={toolFieldName} />}
-          />
-        }
+      <ContentAction
+        icon={SvgActions}
+        title={tool.display_name || tool.name}
+        description={tool.description}
+        sizePreset="main-ui"
+        variant="section"
+        padding="lg"
+        rightChildren={<SwitchField name={toolFieldName} />}
       />
     </Card>
   );
@@ -345,21 +341,17 @@ function MCPServerCard({
           return (
             <Disabled key={tool.id} disabled={toolDisabled}>
               <Card border="solid" rounding="md" padding="sm">
-                <CardLayout.Header
-                  headerChildren={
-                    <ContentAction
-                      icon={tool.icon ?? SvgSliders}
-                      title={tool.name}
-                      description={tool.description}
-                      sizePreset="main-ui"
-                      variant="section"
-                      padding="lg"
-                      rightChildren={
-                        <SwitchField
-                          name={`${serverFieldName}.tool_${tool.id}`}
-                          disabled={!isServerEnabled}
-                        />
-                      }
+                <ContentAction
+                  icon={tool.icon ?? SvgSliders}
+                  title={tool.name}
+                  description={tool.description}
+                  sizePreset="main-ui"
+                  variant="section"
+                  padding="lg"
+                  rightChildren={
+                    <SwitchField
+                      name={`${serverFieldName}.tool_${tool.id}`}
+                      disabled={!isServerEnabled}
                     />
                   }
                 />
@@ -381,41 +373,6 @@ function MCPServerCard({
       expandedContent={cardContent}
     >
       <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={getActionIcon(server.server_url, server.name)}
-            title={server.name}
-            description={server.description}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={
-              <GeneralLayouts.Section
-                flexDirection="row"
-                gap={0.5}
-                alignItems="start"
-              >
-                <EnabledCount
-                  enabledCount={enabledCount}
-                  totalCount={enabledTools.length}
-                />
-                <SwitchField
-                  name={`${serverFieldName}.enabled`}
-                  onCheckedChange={(checked) => {
-                    enabledTools.forEach((tool) => {
-                      setFieldValue(
-                        `${serverFieldName}.tool_${tool.id}`,
-                        checked
-                      );
-                    });
-                    if (!checked) return;
-                    setIsFolded(false);
-                  }}
-                />
-              </GeneralLayouts.Section>
-            }
-          />
-        }
         bottomChildren={
           <GeneralLayouts.Section flexDirection="row" gap={0.5}>
             <InputTypeIn
@@ -436,7 +393,41 @@ function MCPServerCard({
             )}
           </GeneralLayouts.Section>
         }
-      />
+      >
+        <ContentAction
+          icon={getActionIcon(server.server_url, server.name)}
+          title={server.name}
+          description={server.description}
+          sizePreset="main-ui"
+          variant="section"
+          padding="lg"
+          rightChildren={
+            <GeneralLayouts.Section
+              flexDirection="row"
+              gap={0.5}
+              alignItems="start"
+            >
+              <EnabledCount
+                enabledCount={enabledCount}
+                totalCount={enabledTools.length}
+              />
+              <SwitchField
+                name={`${serverFieldName}.enabled`}
+                onCheckedChange={(checked) => {
+                  enabledTools.forEach((tool) => {
+                    setFieldValue(
+                      `${serverFieldName}.tool_${tool.id}`,
+                      checked
+                    );
+                  });
+                  if (!checked) return;
+                  setIsFolded(false);
+                }}
+              />
+            </GeneralLayouts.Section>
+          }
+        />
+      </CardLayout.Header>
     </Card>
   );
 }

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -286,7 +286,7 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
         description={tool.description}
         sizePreset="main-ui"
         variant="section"
-        padding="lg"
+        padding="fit"
         rightChildren={<SwitchField name={toolFieldName} />}
       />
     </Card>
@@ -347,7 +347,7 @@ function MCPServerCard({
                   description={tool.description}
                   sizePreset="main-ui"
                   variant="section"
-                  padding="lg"
+                  padding="fit"
                   rightChildren={
                     <SwitchField
                       name={`${serverFieldName}.tool_${tool.id}`}
@@ -394,39 +394,41 @@ function MCPServerCard({
           </GeneralLayouts.Section>
         }
       >
-        <ContentAction
-          icon={getActionIcon(server.server_url, server.name)}
-          title={server.name}
-          description={server.description}
-          sizePreset="main-ui"
-          variant="section"
-          padding="lg"
-          rightChildren={
-            <GeneralLayouts.Section
-              flexDirection="row"
-              gap={0.5}
-              alignItems="start"
-            >
-              <EnabledCount
-                enabledCount={enabledCount}
-                totalCount={enabledTools.length}
-              />
-              <SwitchField
-                name={`${serverFieldName}.enabled`}
-                onCheckedChange={(checked) => {
-                  enabledTools.forEach((tool) => {
-                    setFieldValue(
-                      `${serverFieldName}.tool_${tool.id}`,
-                      checked
-                    );
-                  });
-                  if (!checked) return;
-                  setIsFolded(false);
-                }}
-              />
-            </GeneralLayouts.Section>
-          }
-        />
+        <div className="p-2">
+          <ContentAction
+            icon={getActionIcon(server.server_url, server.name)}
+            title={server.name}
+            description={server.description}
+            sizePreset="main-ui"
+            variant="section"
+            padding="fit"
+            rightChildren={
+              <GeneralLayouts.Section
+                flexDirection="row"
+                gap={0.5}
+                alignItems="start"
+              >
+                <EnabledCount
+                  enabledCount={enabledCount}
+                  totalCount={enabledTools.length}
+                />
+                <SwitchField
+                  name={`${serverFieldName}.enabled`}
+                  onCheckedChange={(checked) => {
+                    enabledTools.forEach((tool) => {
+                      setFieldValue(
+                        `${serverFieldName}.tool_${tool.id}`,
+                        checked
+                      );
+                    });
+                    if (!checked) return;
+                    setIsFolded(false);
+                  }}
+                />
+              </GeneralLayouts.Section>
+            }
+          />
+        </div>
       </CardLayout.Header>
     </Card>
   );

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -289,9 +289,9 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
             sizePreset="main-ui"
             variant="section"
             padding="fit"
+            rightChildren={<SwitchField name={toolFieldName} />}
           />
         }
-        topRightChildren={<SwitchField name={toolFieldName} />}
       />
     </Card>
   );
@@ -354,12 +354,12 @@ function MCPServerCard({
                       sizePreset="main-ui"
                       variant="section"
                       padding="fit"
-                    />
-                  }
-                  topRightChildren={
-                    <SwitchField
-                      name={`${serverFieldName}.tool_${tool.id}`}
-                      disabled={!isServerEnabled}
+                      rightChildren={
+                        <SwitchField
+                          name={`${serverFieldName}.tool_${tool.id}`}
+                          disabled={!isServerEnabled}
+                        />
+                      }
                     />
                   }
                 />

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -150,7 +150,6 @@ function MCPServerCard({
       }
     >
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={getActionIcon(server.server_url, server.name)}
@@ -158,7 +157,7 @@ function MCPServerCard({
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={
               <Tooltip tooltip={authTooltip} side="top">
                 <Switch
@@ -903,7 +902,7 @@ export default function ChatPreferencesPage() {
                                 description={tool.description}
                                 sizePreset="main-ui"
                                 variant="section"
-                                padding="fit"
+                                padding="lg"
                                 rightChildren={
                                   <Switch
                                     checked={isToolEnabled(tool.id)}

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -120,27 +120,23 @@ function MCPServerCard({
           <Section gap={0.5} padding={0.5}>
             {filteredTools.map((tool) => (
               <Card key={tool.id} border="solid" rounding="md" padding="sm">
-                <CardLayout.Header
-                  headerChildren={
-                    <ContentAction
-                      icon={tool.icon}
-                      title={tool.name}
-                      description={tool.description}
-                      sizePreset="main-ui"
-                      variant="section"
-                      padding="fit"
-                      rightChildren={
-                        <Tooltip tooltip={authTooltip} side="top">
-                          <Switch
-                            checked={isToolEnabled(tool.id)}
-                            onCheckedChange={(checked) =>
-                              onToggleTool(tool.id, checked)
-                            }
-                            disabled={needsAuth}
-                          />
-                        </Tooltip>
-                      }
-                    />
+                <ContentAction
+                  icon={tool.icon}
+                  title={tool.name}
+                  description={tool.description}
+                  sizePreset="main-ui"
+                  variant="section"
+                  padding="fit"
+                  rightChildren={
+                    <Tooltip tooltip={authTooltip} side="top">
+                      <Switch
+                        checked={isToolEnabled(tool.id)}
+                        onCheckedChange={(checked) =>
+                          onToggleTool(tool.id, checked)
+                        }
+                        disabled={needsAuth}
+                      />
+                    </Tooltip>
                   }
                 />
               </Card>
@@ -150,27 +146,6 @@ function MCPServerCard({
       }
     >
       <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={getActionIcon(server.server_url, server.name)}
-            title={server.name}
-            description={server.description}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={
-              <Tooltip tooltip={authTooltip} side="top">
-                <Switch
-                  checked={serverEnabled}
-                  onCheckedChange={(checked) =>
-                    onToggleTools(allToolIds, checked)
-                  }
-                  disabled={needsAuth}
-                />
-              </Tooltip>
-            }
-          />
-        }
         bottomChildren={
           tools.length > 0 ? (
             <Section flexDirection="row" gap={0.5}>
@@ -192,7 +167,27 @@ function MCPServerCard({
             </Section>
           ) : undefined
         }
-      />
+      >
+        <ContentAction
+          icon={getActionIcon(server.server_url, server.name)}
+          title={server.name}
+          description={server.description}
+          sizePreset="main-ui"
+          variant="section"
+          padding="lg"
+          rightChildren={
+            <Tooltip tooltip={authTooltip} side="top">
+              <Switch
+                checked={serverEnabled}
+                onCheckedChange={(checked) =>
+                  onToggleTools(allToolIds, checked)
+                }
+                disabled={needsAuth}
+              />
+            </Tooltip>
+          }
+        />
+      </CardLayout.Header>
     </Card>
   );
 }
@@ -894,22 +889,18 @@ export default function ChatPreferencesPage() {
                           rounding="lg"
                           padding="md"
                         >
-                          <CardLayout.Header
-                            headerChildren={
-                              <ContentAction
-                                icon={SvgActions}
-                                title={tool.display_name || tool.name}
-                                description={tool.description}
-                                sizePreset="main-ui"
-                                variant="section"
-                                padding="lg"
-                                rightChildren={
-                                  <Switch
-                                    checked={isToolEnabled(tool.id)}
-                                    onCheckedChange={(checked) =>
-                                      toggleTool(tool.id, checked)
-                                    }
-                                  />
+                          <ContentAction
+                            icon={SvgActions}
+                            title={tool.display_name || tool.name}
+                            description={tool.description}
+                            sizePreset="main-ui"
+                            variant="section"
+                            padding="lg"
+                            rightChildren={
+                              <Switch
+                                checked={isToolEnabled(tool.id)}
+                                onCheckedChange={(checked) =>
+                                  toggleTool(tool.id, checked)
                                 }
                               />
                             }

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -122,24 +122,25 @@ function MCPServerCard({
               <Card key={tool.id} border="solid" rounding="md" padding="sm">
                 <CardLayout.Header
                   headerChildren={
-                    <Content
+                    <ContentAction
                       icon={tool.icon}
                       title={tool.name}
                       description={tool.description}
                       sizePreset="main-ui"
                       variant="section"
+                      padding="fit"
+                      rightChildren={
+                        <Tooltip tooltip={authTooltip} side="top">
+                          <Switch
+                            checked={isToolEnabled(tool.id)}
+                            onCheckedChange={(checked) =>
+                              onToggleTool(tool.id, checked)
+                            }
+                            disabled={needsAuth}
+                          />
+                        </Tooltip>
+                      }
                     />
-                  }
-                  topRightChildren={
-                    <Tooltip tooltip={authTooltip} side="top">
-                      <Switch
-                        checked={isToolEnabled(tool.id)}
-                        onCheckedChange={(checked) =>
-                          onToggleTool(tool.id, checked)
-                        }
-                        disabled={needsAuth}
-                      />
-                    </Tooltip>
                   }
                 />
               </Card>
@@ -896,19 +897,20 @@ export default function ChatPreferencesPage() {
                         >
                           <CardLayout.Header
                             headerChildren={
-                              <Content
+                              <ContentAction
                                 icon={SvgActions}
                                 title={tool.display_name || tool.name}
                                 description={tool.description}
                                 sizePreset="main-ui"
                                 variant="section"
-                              />
-                            }
-                            topRightChildren={
-                              <Switch
-                                checked={isToolEnabled(tool.id)}
-                                onCheckedChange={(checked) =>
-                                  toggleTool(tool.id, checked)
+                                padding="fit"
+                                rightChildren={
+                                  <Switch
+                                    checked={isToolEnabled(tool.id)}
+                                    onCheckedChange={(checked) =>
+                                      toggleTool(tool.id, checked)
+                                    }
+                                  />
                                 }
                               />
                             }

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -168,25 +168,27 @@ function MCPServerCard({
           ) : undefined
         }
       >
-        <ContentAction
-          icon={getActionIcon(server.server_url, server.name)}
-          title={server.name}
-          description={server.description}
-          sizePreset="main-ui"
-          variant="section"
-          padding="lg"
-          rightChildren={
-            <Tooltip tooltip={authTooltip} side="top">
-              <Switch
-                checked={serverEnabled}
-                onCheckedChange={(checked) =>
-                  onToggleTools(allToolIds, checked)
-                }
-                disabled={needsAuth}
-              />
-            </Tooltip>
-          }
-        />
+        <div className="p-2">
+          <ContentAction
+            icon={getActionIcon(server.server_url, server.name)}
+            title={server.name}
+            description={server.description}
+            sizePreset="main-ui"
+            variant="section"
+            padding="fit"
+            rightChildren={
+              <Tooltip tooltip={authTooltip} side="top">
+                <Switch
+                  checked={serverEnabled}
+                  onCheckedChange={(checked) =>
+                    onToggleTools(allToolIds, checked)
+                  }
+                  disabled={needsAuth}
+                />
+              </Tooltip>
+            }
+          />
+        </div>
       </CardLayout.Header>
     </Card>
   );
@@ -895,7 +897,7 @@ export default function ChatPreferencesPage() {
                             description={tool.description}
                             sizePreset="main-ui"
                             variant="section"
-                            padding="lg"
+                            padding="fit"
                             rightChildren={
                               <Switch
                                 checked={isToolEnabled(tool.id)}

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -21,6 +21,7 @@ import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationMo
 import useCodeInterpreter from "@/hooks/useCodeInterpreter";
 import { updateCodeInterpreter } from "@/refresh-pages/admin/CodeInterpreterPage/svc";
 import { toast } from "@/hooks/useToast";
+import { cn } from "@opal/utils";
 
 const route = ADMIN_ROUTES.CODE_INTERPRETER;
 
@@ -57,21 +58,24 @@ function ConnectionStatus({ healthy, isLoading }: ConnectionStatusProps) {
 
   const label = healthy ? "Connected" : "Connection Lost";
   const Icon = healthy ? SvgCheckCircle : SvgXOctagon;
-  const iconColor = healthy ? "text-status-success-05" : "text-status-error-05";
+  const iconColor = healthy
+    ? "!text-status-success-05"
+    : "!text-status-error-05";
 
   return (
-    <Section
-      flexDirection="row"
-      justifyContent="end"
-      alignItems="center"
-      gap={0.25}
-      padding={0.5}
-    >
-      <Text mainUiAction text03>
-        {label}
-      </Text>
-      <Icon size={16} className={iconColor} />
-    </Section>
+    <div className="p-2">
+      <Content
+        title={label}
+        icon={(props) => (
+          <Icon {...props} className={cn(props.className, iconColor)} />
+        )}
+        sizePreset="main-ui"
+        variant="body"
+        orientation="reverse"
+        prominence="muted"
+        nonInteractive
+      />
+    </div>
   );
 }
 
@@ -113,37 +117,7 @@ export default function CodeInterpreterPage() {
         {isEnabled || isLoading ? (
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
-              <Card.Header
-                bottomRightChildren={
-                  <Section
-                    flexDirection="row"
-                    justifyContent="end"
-                    alignItems="center"
-                    gap={0.25}
-                    padding={0.25}
-                  >
-                    <Disabled disabled={isLoading}>
-                      <Hoverable.Item group="code-interpreter/Card">
-                        <Button
-                          prominence="tertiary"
-                          size="sm"
-                          icon={SvgUnplug}
-                          onClick={() => setShowDisconnectModal(true)}
-                          tooltip="Disconnect"
-                        />
-                      </Hoverable.Item>
-                    </Disabled>
-                    <Button
-                      disabled={isLoading}
-                      prominence="tertiary"
-                      size="sm"
-                      icon={SvgRefreshCw}
-                      onClick={refetch}
-                      tooltip="Refresh"
-                    />
-                  </Section>
-                }
-              >
+              <Card.Header>
                 <ContentAction
                   sizePreset="main-ui"
                   variant="section"
@@ -152,10 +126,39 @@ export default function CodeInterpreterPage() {
                   description="Built-in Python runtime"
                   padding="lg"
                   rightChildren={
-                    <ConnectionStatus
-                      healthy={isHealthy}
-                      isLoading={isLoading}
-                    />
+                    <Section alignItems="end" gap={0}>
+                      <ConnectionStatus
+                        healthy={isHealthy}
+                        isLoading={isLoading}
+                      />
+                      <div className="px-1 pb-1">
+                        <Section
+                          flexDirection="row"
+                          justifyContent="end"
+                          gap={0.25}
+                        >
+                          <Disabled disabled={isLoading}>
+                            <Hoverable.Item group="code-interpreter/Card">
+                              <Button
+                                prominence="tertiary"
+                                size="md"
+                                icon={SvgUnplug}
+                                onClick={() => setShowDisconnectModal(true)}
+                                tooltip="Disconnect"
+                              />
+                            </Hoverable.Item>
+                          </Disabled>
+                          <Button
+                            disabled={isLoading}
+                            prominence="tertiary"
+                            size="md"
+                            icon={SvgRefreshCw}
+                            onClick={refetch}
+                            tooltip="Refresh"
+                          />
+                        </Section>
+                      </div>
+                    </Section>
                   }
                 />
               </Card.Header>
@@ -176,22 +179,20 @@ export default function CodeInterpreterPage() {
               description="Built-in Python runtime"
               padding="lg"
               rightChildren={
-                <Section flexDirection="row" alignItems="center" padding={0.5}>
-                  {isReconnecting ? (
-                    <CheckingStatus />
-                  ) : (
-                    <Button
-                      prominence="tertiary"
-                      rightIcon={SvgArrowExchange}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleToggle(true);
-                      }}
-                    >
-                      Reconnect
-                    </Button>
-                  )}
-                </Section>
+                isReconnecting ? (
+                  <CheckingStatus />
+                ) : (
+                  <Button
+                    prominence="tertiary"
+                    rightIcon={SvgArrowExchange}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleToggle(true);
+                    }}
+                  >
+                    Reconnect
+                  </Button>
+                )
               }
             />
           </SelectCard>

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -115,7 +115,10 @@ export default function CodeInterpreterPage() {
 
       <SettingsLayouts.Body>
         {isEnabled || isLoading ? (
-          <Hoverable.Root group="code-interpreter/Card">
+          <Hoverable.Root
+            group="code-interpreter/Card"
+            interaction={showDisconnectModal ? "hover" : "rest"}
+          >
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header>
                 <ContentAction

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -13,7 +13,7 @@ import {
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { Section } from "@/layouts/general-layouts";
 import { Button, SelectCard } from "@opal/components";
-import { Card, Content } from "@opal/layouts";
+import { Card, Content, ContentAction } from "@opal/layouts";
 import { Disabled, Hoverable } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
@@ -116,16 +116,20 @@ export default function CodeInterpreterPage() {
               <Card.Header
                 headerPadding="sm"
                 headerChildren={
-                  <Content
+                  <ContentAction
                     sizePreset="main-ui"
                     variant="section"
                     icon={SvgTerminal}
                     title="Code Interpreter"
                     description="Built-in Python runtime"
+                    padding="fit"
+                    rightChildren={
+                      <ConnectionStatus
+                        healthy={isHealthy}
+                        isLoading={isLoading}
+                      />
+                    }
                   />
-                }
-                topRightChildren={
-                  <ConnectionStatus healthy={isHealthy} isLoading={isLoading} />
                 }
                 bottomRightChildren={
                   <Section
@@ -169,31 +173,36 @@ export default function CodeInterpreterPage() {
             <Card.Header
               headerPadding="sm"
               headerChildren={
-                <Content
+                <ContentAction
                   sizePreset="main-ui"
                   variant="section"
                   icon={SvgTerminal}
                   title="Code Interpreter (Disconnected)"
                   description="Built-in Python runtime"
-                />
-              }
-              topRightChildren={
-                <Section flexDirection="row" alignItems="center" padding={0.5}>
-                  {isReconnecting ? (
-                    <CheckingStatus />
-                  ) : (
-                    <Button
-                      prominence="tertiary"
-                      rightIcon={SvgArrowExchange}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleToggle(true);
-                      }}
+                  padding="fit"
+                  rightChildren={
+                    <Section
+                      flexDirection="row"
+                      alignItems="center"
+                      padding={0.5}
                     >
-                      Reconnect
-                    </Button>
-                  )}
-                </Section>
+                      {isReconnecting ? (
+                        <CheckingStatus />
+                      ) : (
+                        <Button
+                          prominence="tertiary"
+                          rightIcon={SvgArrowExchange}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleToggle(true);
+                          }}
+                        >
+                          Reconnect
+                        </Button>
+                      )}
+                    </Section>
+                  }
+                />
               }
             />
           </SelectCard>

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -114,7 +114,6 @@ export default function CodeInterpreterPage() {
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header
-                headerPadding="sm"
                 headerChildren={
                   <ContentAction
                     sizePreset="main-ui"
@@ -122,7 +121,7 @@ export default function CodeInterpreterPage() {
                     icon={SvgTerminal}
                     title="Code Interpreter"
                     description="Built-in Python runtime"
-                    padding="fit"
+                    padding="lg"
                     rightChildren={
                       <ConnectionStatus
                         healthy={isHealthy}
@@ -171,7 +170,6 @@ export default function CodeInterpreterPage() {
             onClick={() => handleToggle(true)}
           >
             <Card.Header
-              headerPadding="sm"
               headerChildren={
                 <ContentAction
                   sizePreset="main-ui"
@@ -179,7 +177,7 @@ export default function CodeInterpreterPage() {
                   icon={SvgTerminal}
                   title="Code Interpreter (Disconnected)"
                   description="Built-in Python runtime"
-                  padding="fit"
+                  padding="lg"
                   rightChildren={
                     <Section
                       flexDirection="row"

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -114,22 +114,6 @@ export default function CodeInterpreterPage() {
           <Hoverable.Root group="code-interpreter/Card">
             <SelectCard state="filled" padding="sm" rounding="lg">
               <Card.Header
-                headerChildren={
-                  <ContentAction
-                    sizePreset="main-ui"
-                    variant="section"
-                    icon={SvgTerminal}
-                    title="Code Interpreter"
-                    description="Built-in Python runtime"
-                    padding="lg"
-                    rightChildren={
-                      <ConnectionStatus
-                        healthy={isHealthy}
-                        isLoading={isLoading}
-                      />
-                    }
-                  />
-                }
                 bottomRightChildren={
                   <Section
                     flexDirection="row"
@@ -159,7 +143,22 @@ export default function CodeInterpreterPage() {
                     />
                   </Section>
                 }
-              />
+              >
+                <ContentAction
+                  sizePreset="main-ui"
+                  variant="section"
+                  icon={SvgTerminal}
+                  title="Code Interpreter"
+                  description="Built-in Python runtime"
+                  padding="lg"
+                  rightChildren={
+                    <ConnectionStatus
+                      healthy={isHealthy}
+                      isLoading={isLoading}
+                    />
+                  }
+                />
+              </Card.Header>
             </SelectCard>
           </Hoverable.Root>
         ) : (
@@ -169,38 +168,30 @@ export default function CodeInterpreterPage() {
             rounding="lg"
             onClick={() => handleToggle(true)}
           >
-            <Card.Header
-              headerChildren={
-                <ContentAction
-                  sizePreset="main-ui"
-                  variant="section"
-                  icon={SvgTerminal}
-                  title="Code Interpreter (Disconnected)"
-                  description="Built-in Python runtime"
-                  padding="lg"
-                  rightChildren={
-                    <Section
-                      flexDirection="row"
-                      alignItems="center"
-                      padding={0.5}
+            <ContentAction
+              sizePreset="main-ui"
+              variant="section"
+              icon={SvgTerminal}
+              title="Code Interpreter (Disconnected)"
+              description="Built-in Python runtime"
+              padding="lg"
+              rightChildren={
+                <Section flexDirection="row" alignItems="center" padding={0.5}>
+                  {isReconnecting ? (
+                    <CheckingStatus />
+                  ) : (
+                    <Button
+                      prominence="tertiary"
+                      rightIcon={SvgArrowExchange}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleToggle(true);
+                      }}
                     >
-                      {isReconnecting ? (
-                        <CheckingStatus />
-                      ) : (
-                        <Button
-                          prominence="tertiary"
-                          rightIcon={SvgArrowExchange}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleToggle(true);
-                          }}
-                        >
-                          Reconnect
-                        </Button>
-                      )}
-                    </Section>
-                  }
-                />
+                      Reconnect
+                    </Button>
+                  )}
+                </Section>
               }
             />
           </SelectCard>

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -256,55 +256,6 @@ export default function ImageGenerationContent() {
                     }
                   >
                     <Card.Header
-                      headerChildren={
-                        <ContentAction
-                          sizePreset="main-ui"
-                          variant="section"
-                          icon={() => (
-                            <ModelIcon
-                              provider={provider.provider_name}
-                              size={16}
-                            />
-                          )}
-                          title={provider.title}
-                          description={provider.description}
-                          padding="lg"
-                          rightChildren={
-                            isDisconnected ? (
-                              <Button
-                                prominence="tertiary"
-                                rightIcon={SvgArrowExchange}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleConnect(provider);
-                                }}
-                              >
-                                Connect
-                              </Button>
-                            ) : isConnected ? (
-                              <Button
-                                prominence="tertiary"
-                                rightIcon={SvgArrowRightCircle}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleSelect(provider);
-                                }}
-                              >
-                                Set as Default
-                              </Button>
-                            ) : isSelected ? (
-                              <div className="p-2">
-                                <Content
-                                  title="Current Default"
-                                  sizePreset="main-ui"
-                                  variant="section"
-                                  icon={SvgCheckSquare}
-                                />
-                              </div>
-                            ) : undefined
-                          }
-                        />
-                      }
                       bottomRightChildren={
                         !isDisconnected ? (
                           <div className="flex flex-row px-1 pb-1">
@@ -335,7 +286,55 @@ export default function ImageGenerationContent() {
                           </div>
                         ) : undefined
                       }
-                    />
+                    >
+                      <ContentAction
+                        sizePreset="main-ui"
+                        variant="section"
+                        icon={() => (
+                          <ModelIcon
+                            provider={provider.provider_name}
+                            size={16}
+                          />
+                        )}
+                        title={provider.title}
+                        description={provider.description}
+                        padding="lg"
+                        rightChildren={
+                          isDisconnected ? (
+                            <Button
+                              prominence="tertiary"
+                              rightIcon={SvgArrowExchange}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleConnect(provider);
+                              }}
+                            >
+                              Connect
+                            </Button>
+                          ) : isConnected ? (
+                            <Button
+                              prominence="tertiary"
+                              rightIcon={SvgArrowRightCircle}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleSelect(provider);
+                              }}
+                            >
+                              Set as Default
+                            </Button>
+                          ) : isSelected ? (
+                            <div className="p-2">
+                              <Content
+                                title="Current Default"
+                                sizePreset="main-ui"
+                                variant="section"
+                                icon={SvgCheckSquare}
+                              />
+                            </div>
+                          ) : undefined
+                        }
+                      />
+                    </Card.Header>
                   </SelectCard>
                 </Hoverable.Root>
               );

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -22,7 +22,7 @@ import ModelIcon from "@/app/admin/configuration/language-models/ModelIcon";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Button, MessageCard, SelectCard, Text } from "@opal/components";
-import { Content, Card } from "@opal/layouts";
+import { Content, ContentAction, Card } from "@opal/layouts";
 import { Hoverable } from "@opal/core";
 import {
   SvgArrowExchange,
@@ -258,7 +258,7 @@ export default function ImageGenerationContent() {
                     <Card.Header
                       headerPadding="sm"
                       headerChildren={
-                        <Content
+                        <ContentAction
                           sizePreset="main-ui"
                           variant="section"
                           icon={() => (
@@ -269,41 +269,42 @@ export default function ImageGenerationContent() {
                           )}
                           title={provider.title}
                           description={provider.description}
+                          padding="fit"
+                          rightChildren={
+                            isDisconnected ? (
+                              <Button
+                                prominence="tertiary"
+                                rightIcon={SvgArrowExchange}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleConnect(provider);
+                                }}
+                              >
+                                Connect
+                              </Button>
+                            ) : isConnected ? (
+                              <Button
+                                prominence="tertiary"
+                                rightIcon={SvgArrowRightCircle}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleSelect(provider);
+                                }}
+                              >
+                                Set as Default
+                              </Button>
+                            ) : isSelected ? (
+                              <div className="p-2">
+                                <Content
+                                  title="Current Default"
+                                  sizePreset="main-ui"
+                                  variant="section"
+                                  icon={SvgCheckSquare}
+                                />
+                              </div>
+                            ) : undefined
+                          }
                         />
-                      }
-                      topRightChildren={
-                        isDisconnected ? (
-                          <Button
-                            prominence="tertiary"
-                            rightIcon={SvgArrowExchange}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleConnect(provider);
-                            }}
-                          >
-                            Connect
-                          </Button>
-                        ) : isConnected ? (
-                          <Button
-                            prominence="tertiary"
-                            rightIcon={SvgArrowRightCircle}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleSelect(provider);
-                            }}
-                          >
-                            Set as Default
-                          </Button>
-                        ) : isSelected ? (
-                          <div className="p-2">
-                            <Content
-                              title="Current Default"
-                              sizePreset="main-ui"
-                              variant="section"
-                              icon={SvgCheckSquare}
-                            />
-                          </div>
-                        ) : undefined
                       }
                       bottomRightChildren={
                         !isDisconnected ? (

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -256,7 +256,6 @@ export default function ImageGenerationContent() {
                     }
                   >
                     <Card.Header
-                      headerPadding="sm"
                       headerChildren={
                         <ContentAction
                           sizePreset="main-ui"
@@ -269,7 +268,7 @@ export default function ImageGenerationContent() {
                           )}
                           title={provider.title}
                           description={provider.description}
-                          padding="fit"
+                          padding="lg"
                           rightChildren={
                             isDisconnected ? (
                               <Button

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -269,7 +269,6 @@ function NewCustomProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={icon}
@@ -277,7 +276,7 @@ function NewCustomProviderCard({
             description={companyName}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={
               <Button
                 rightIcon={SvgArrowExchange}

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -5,7 +5,12 @@ import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { useAdminLLMProviders } from "@/hooks/useLLMProviders";
 import { ThreeDotsLoader } from "@/components/Loading";
-import { Content, Card as CardLayout, InputHorizontal } from "@opal/layouts";
+import {
+  Content,
+  ContentAction,
+  Card as CardLayout,
+  InputHorizontal,
+} from "@opal/layouts";
 import {
   Button,
   Divider,
@@ -143,43 +148,44 @@ function ExistingProviderCard({
           <CardLayout.Header
             headerPadding="sm"
             headerChildren={
-              <Content
+              <ContentAction
                 icon={icon}
                 title={provider.name}
                 description={companyName}
                 sizePreset="main-ui"
                 variant="section"
+                padding="fit"
                 tag={
                   isDefault ? { title: "Default", color: "blue" } : undefined
                 }
+                rightChildren={
+                  <div className="flex flex-row">
+                    <Hoverable.Item
+                      group="ExistingProviderCard"
+                      variant="opacity-on-hover"
+                    >
+                      <Button
+                        icon={SvgTrash}
+                        prominence="tertiary"
+                        aria-label={`Delete ${provider.name}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          deleteModal.toggle(true);
+                        }}
+                      />
+                    </Hoverable.Item>
+                    <Button
+                      icon={SvgSettings}
+                      prominence="tertiary"
+                      aria-label={`Edit ${provider.name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIsOpen(true);
+                      }}
+                    />
+                  </div>
+                }
               />
-            }
-            topRightChildren={
-              <div className="flex flex-row">
-                <Hoverable.Item
-                  group="ExistingProviderCard"
-                  variant="opacity-on-hover"
-                >
-                  <Button
-                    icon={SvgTrash}
-                    prominence="tertiary"
-                    aria-label={`Delete ${provider.name}`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      deleteModal.toggle(true);
-                    }}
-                  />
-                </Hoverable.Item>
-                <Button
-                  icon={SvgSettings}
-                  prominence="tertiary"
-                  aria-label={`Edit ${provider.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsOpen(true);
-                  }}
-                />
-              </div>
             }
           />
         </SelectCard>
@@ -214,25 +220,26 @@ function NewProviderCard({
       <CardLayout.Header
         headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             icon={icon}
             title={productName}
             description={companyName}
             sizePreset="main-ui"
             variant="section"
+            padding="fit"
+            rightChildren={
+              <Button
+                rightIcon={SvgArrowExchange}
+                prominence="tertiary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsOpen(true);
+                }}
+              >
+                Connect
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button
-            rightIcon={SvgArrowExchange}
-            prominence="tertiary"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsOpen(true);
-            }}
-          >
-            Connect
-          </Button>
         }
       />
       {isOpen && (
@@ -266,25 +273,26 @@ function NewCustomProviderCard({
       <CardLayout.Header
         headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             icon={icon}
             title={productName}
             description={companyName}
             sizePreset="main-ui"
             variant="section"
+            padding="fit"
+            rightChildren={
+              <Button
+                rightIcon={SvgArrowExchange}
+                prominence="tertiary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setIsOpen(true);
+                }}
+              >
+                Set Up
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button
-            rightIcon={SvgArrowExchange}
-            prominence="tertiary"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsOpen(true);
-            }}
-          >
-            Set Up
-          </Button>
         }
       />
       {isOpen && (

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -146,7 +146,6 @@ function ExistingProviderCard({
           onClick={() => setIsOpen(true)}
         >
           <CardLayout.Header
-            headerPadding="sm"
             headerChildren={
               <ContentAction
                 icon={icon}
@@ -154,7 +153,7 @@ function ExistingProviderCard({
                 description={companyName}
                 sizePreset="main-ui"
                 variant="section"
-                padding="fit"
+                padding="lg"
                 tag={
                   isDefault ? { title: "Default", color: "blue" } : undefined
                 }
@@ -218,7 +217,6 @@ function NewProviderCard({
       onClick={() => setIsOpen(true)}
     >
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={icon}
@@ -226,7 +224,7 @@ function NewProviderCard({
             description={companyName}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={
               <Button
                 rightIcon={SvgArrowExchange}

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -5,12 +5,7 @@ import { useSWRConfig } from "swr";
 import { toast } from "@/hooks/useToast";
 import { useAdminLLMProviders } from "@/hooks/useLLMProviders";
 import { ThreeDotsLoader } from "@/components/Loading";
-import {
-  Content,
-  ContentAction,
-  Card as CardLayout,
-  InputHorizontal,
-} from "@opal/layouts";
+import { Content, ContentAction, InputHorizontal } from "@opal/layouts";
 import {
   Button,
   Divider,
@@ -145,46 +140,40 @@ function ExistingProviderCard({
           rounding="lg"
           onClick={() => setIsOpen(true)}
         >
-          <CardLayout.Header
-            headerChildren={
-              <ContentAction
-                icon={icon}
-                title={provider.name}
-                description={companyName}
-                sizePreset="main-ui"
-                variant="section"
-                padding="lg"
-                tag={
-                  isDefault ? { title: "Default", color: "blue" } : undefined
-                }
-                rightChildren={
-                  <div className="flex flex-row">
-                    <Hoverable.Item
-                      group="ExistingProviderCard"
-                      variant="opacity-on-hover"
-                    >
-                      <Button
-                        icon={SvgTrash}
-                        prominence="tertiary"
-                        aria-label={`Delete ${provider.name}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          deleteModal.toggle(true);
-                        }}
-                      />
-                    </Hoverable.Item>
-                    <Button
-                      icon={SvgSettings}
-                      prominence="tertiary"
-                      aria-label={`Edit ${provider.name}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setIsOpen(true);
-                      }}
-                    />
-                  </div>
-                }
-              />
+          <ContentAction
+            icon={icon}
+            title={provider.name}
+            description={companyName}
+            sizePreset="main-ui"
+            variant="section"
+            padding="lg"
+            tag={isDefault ? { title: "Default", color: "blue" } : undefined}
+            rightChildren={
+              <div className="flex flex-row">
+                <Hoverable.Item
+                  group="ExistingProviderCard"
+                  variant="opacity-on-hover"
+                >
+                  <Button
+                    icon={SvgTrash}
+                    prominence="tertiary"
+                    aria-label={`Delete ${provider.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      deleteModal.toggle(true);
+                    }}
+                  />
+                </Hoverable.Item>
+                <Button
+                  icon={SvgSettings}
+                  prominence="tertiary"
+                  aria-label={`Edit ${provider.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsOpen(true);
+                  }}
+                />
+              </div>
             }
           />
         </SelectCard>
@@ -216,28 +205,24 @@ function NewProviderCard({
       rounding="lg"
       onClick={() => setIsOpen(true)}
     >
-      <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={icon}
-            title={productName}
-            description={companyName}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={
-              <Button
-                rightIcon={SvgArrowExchange}
-                prominence="tertiary"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsOpen(true);
-                }}
-              >
-                Connect
-              </Button>
-            }
-          />
+      <ContentAction
+        icon={icon}
+        title={productName}
+        description={companyName}
+        sizePreset="main-ui"
+        variant="section"
+        padding="lg"
+        rightChildren={
+          <Button
+            rightIcon={SvgArrowExchange}
+            prominence="tertiary"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsOpen(true);
+            }}
+          >
+            Connect
+          </Button>
         }
       />
       {isOpen && (
@@ -268,28 +253,24 @@ function NewCustomProviderCard({
       rounding="lg"
       onClick={() => setIsOpen(true)}
     >
-      <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={icon}
-            title={productName}
-            description={companyName}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={
-              <Button
-                rightIcon={SvgArrowExchange}
-                prominence="tertiary"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setIsOpen(true);
-                }}
-              >
-                Set Up
-              </Button>
-            }
-          />
+      <ContentAction
+        icon={icon}
+        title={productName}
+        description={companyName}
+        sizePreset="main-ui"
+        variant="section"
+        padding="lg"
+        rightChildren={
+          <Button
+            rightIcon={SvgArrowExchange}
+            prominence="tertiary"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsOpen(true);
+            }}
+          >
+            Set Up
+          </Button>
         }
       />
       {isOpen && (

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -277,50 +277,6 @@ function ProviderCard({
         }
       >
         <Card.Header
-          headerChildren={
-            <ContentAction
-              sizePreset="main-ui"
-              variant="section"
-              icon={icon}
-              title={title}
-              description={description}
-              padding="lg"
-              rightChildren={
-                isDisconnected && onConnect ? (
-                  <Button
-                    prominence="tertiary"
-                    rightIcon={SvgArrowExchange}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onConnect();
-                    }}
-                  >
-                    Connect
-                  </Button>
-                ) : isConnected && onSelect ? (
-                  <Button
-                    prominence="tertiary"
-                    rightIcon={SvgArrowRightCircle}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSelect();
-                    }}
-                  >
-                    Set as Default
-                  </Button>
-                ) : isSelected ? (
-                  <div className="p-2">
-                    <Content
-                      title={selectedLabel}
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={SvgCheckSquare}
-                    />
-                  </div>
-                ) : undefined
-              }
-            />
-          }
           bottomRightChildren={
             !isDisconnected ? (
               <div className="flex flex-row px-1 pb-1">
@@ -355,7 +311,50 @@ function ProviderCard({
               </div>
             ) : undefined
           }
-        />
+        >
+          <ContentAction
+            sizePreset="main-ui"
+            variant="section"
+            icon={icon}
+            title={title}
+            description={description}
+            padding="lg"
+            rightChildren={
+              isDisconnected && onConnect ? (
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgArrowExchange}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onConnect();
+                  }}
+                >
+                  Connect
+                </Button>
+              ) : isConnected && onSelect ? (
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgArrowRightCircle}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect();
+                  }}
+                >
+                  Set as Default
+                </Button>
+              ) : isSelected ? (
+                <div className="p-2">
+                  <Content
+                    title={selectedLabel}
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={SvgCheckSquare}
+                  />
+                </div>
+              ) : undefined
+            }
+          />
+        </Card.Header>
       </SelectCard>
     </Hoverable.Root>
   );

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -277,7 +277,6 @@ function ProviderCard({
         }
       >
         <Card.Header
-          headerPadding="sm"
           headerChildren={
             <ContentAction
               sizePreset="main-ui"
@@ -285,7 +284,7 @@ function ProviderCard({
               icon={icon}
               title={title}
               description={description}
-              padding="fit"
+              padding="lg"
               rightChildren={
                 isDisconnected && onConnect ? (
                   <Button

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -6,7 +6,7 @@ import { InfoIcon } from "@/components/icons/icons";
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-import { Content, Card } from "@opal/layouts";
+import { Content, ContentAction, Card } from "@opal/layouts";
 import { markdown } from "@opal/utils";
 import useSWR from "swr";
 import { errorHandlingFetcher, FetchError } from "@/lib/fetcher";
@@ -279,47 +279,48 @@ function ProviderCard({
         <Card.Header
           headerPadding="sm"
           headerChildren={
-            <Content
+            <ContentAction
               sizePreset="main-ui"
               variant="section"
               icon={icon}
               title={title}
               description={description}
+              padding="fit"
+              rightChildren={
+                isDisconnected && onConnect ? (
+                  <Button
+                    prominence="tertiary"
+                    rightIcon={SvgArrowExchange}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onConnect();
+                    }}
+                  >
+                    Connect
+                  </Button>
+                ) : isConnected && onSelect ? (
+                  <Button
+                    prominence="tertiary"
+                    rightIcon={SvgArrowRightCircle}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect();
+                    }}
+                  >
+                    Set as Default
+                  </Button>
+                ) : isSelected ? (
+                  <div className="p-2">
+                    <Content
+                      title={selectedLabel}
+                      sizePreset="main-ui"
+                      variant="section"
+                      icon={SvgCheckSquare}
+                    />
+                  </div>
+                ) : undefined
+              }
             />
-          }
-          topRightChildren={
-            isDisconnected && onConnect ? (
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgArrowExchange}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConnect();
-                }}
-              >
-                Connect
-              </Button>
-            ) : isConnected && onSelect ? (
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgArrowRightCircle}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSelect();
-                }}
-              >
-                Set as Default
-              </Button>
-            ) : isSelected ? (
-              <div className="p-2">
-                <Content
-                  title={selectedLabel}
-                  sizePreset="main-ui"
-                  variant="section"
-                  icon={SvgCheckSquare}
-                />
-              </div>
-            ) : undefined
           }
           bottomRightChildren={
             !isDisconnected ? (

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -2,7 +2,7 @@
 
 import type { IconFunctionComponent } from "@opal/types";
 import { Button, SelectCard } from "@opal/components";
-import { Content, Card } from "@opal/layouts";
+import { Content, ContentAction, Card } from "@opal/layouts";
 import {
   SvgArrowExchange,
   SvgArrowRightCircle,
@@ -95,47 +95,48 @@ export default function ProviderCard({
       <Card.Header
         headerPadding="sm"
         headerChildren={
-          <Content
+          <ContentAction
             sizePreset="main-ui"
             variant="section"
             icon={icon}
             title={title}
             description={description}
+            padding="fit"
+            rightChildren={
+              isDisconnected && onConnect ? (
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgArrowExchange}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onConnect();
+                  }}
+                >
+                  Connect
+                </Button>
+              ) : isConnected && onSelect ? (
+                <Button
+                  prominence="tertiary"
+                  rightIcon={SvgArrowRightCircle}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect();
+                  }}
+                >
+                  Set as Default
+                </Button>
+              ) : isSelected ? (
+                <div className="p-2">
+                  <Content
+                    title={selectedLabel}
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={SvgCheckSquare}
+                  />
+                </div>
+              ) : undefined
+            }
           />
-        }
-        topRightChildren={
-          isDisconnected && onConnect ? (
-            <Button
-              prominence="tertiary"
-              rightIcon={SvgArrowExchange}
-              onClick={(e) => {
-                e.stopPropagation();
-                onConnect();
-              }}
-            >
-              Connect
-            </Button>
-          ) : isConnected && onSelect ? (
-            <Button
-              prominence="tertiary"
-              rightIcon={SvgArrowRightCircle}
-              onClick={(e) => {
-                e.stopPropagation();
-                onSelect();
-              }}
-            >
-              Set as Default
-            </Button>
-          ) : isSelected ? (
-            <div className="p-2">
-              <Content
-                title={selectedLabel}
-                sizePreset="main-ui"
-                variant="section"
-                icon={SvgCheckSquare}
-              />
-            </div>
-          ) : undefined
         }
         bottomRightChildren={
           !isDisconnected ? (

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -93,7 +93,6 @@ export default function ProviderCard({
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
       <Card.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             sizePreset="main-ui"
@@ -101,7 +100,7 @@ export default function ProviderCard({
             icon={icon}
             title={title}
             description={description}
-            padding="fit"
+            padding="lg"
             rightChildren={
               isDisconnected && onConnect ? (
                 <Button

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -93,50 +93,6 @@ export default function ProviderCard({
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
       <Card.Header
-        headerChildren={
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={icon}
-            title={title}
-            description={description}
-            padding="lg"
-            rightChildren={
-              isDisconnected && onConnect ? (
-                <Button
-                  prominence="tertiary"
-                  rightIcon={SvgArrowExchange}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onConnect();
-                  }}
-                >
-                  Connect
-                </Button>
-              ) : isConnected && onSelect ? (
-                <Button
-                  prominence="tertiary"
-                  rightIcon={SvgArrowRightCircle}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelect();
-                  }}
-                >
-                  Set as Default
-                </Button>
-              ) : isSelected ? (
-                <div className="p-2">
-                  <Content
-                    title={selectedLabel}
-                    sizePreset="main-ui"
-                    variant="section"
-                    icon={SvgCheckSquare}
-                  />
-                </div>
-              ) : undefined
-            }
-          />
-        }
         bottomRightChildren={
           !isDisconnected ? (
             <div className="flex flex-row px-1 pb-1">
@@ -169,7 +125,50 @@ export default function ProviderCard({
             </div>
           ) : undefined
         }
-      />
+      >
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={icon}
+          title={title}
+          description={description}
+          padding="lg"
+          rightChildren={
+            isDisconnected && onConnect ? (
+              <Button
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConnect();
+                }}
+              >
+                Connect
+              </Button>
+            ) : isConnected && onSelect ? (
+              <Button
+                prominence="tertiary"
+                rightIcon={SvgArrowRightCircle}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelect();
+                }}
+              >
+                Set as Default
+              </Button>
+            ) : isSelected ? (
+              <div className="p-2">
+                <Content
+                  title={selectedLabel}
+                  sizePreset="main-ui"
+                  variant="section"
+                  icon={SvgCheckSquare}
+                />
+              </div>
+            ) : undefined
+          }
+        />
+      </Card.Header>
     </SelectCard>
   );
 }

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -81,7 +81,6 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
       }
     >
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <ContentAction
             icon={serverIcon}
@@ -89,7 +88,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
             description={server.description}
             sizePreset="main-ui"
             variant="section"
-            padding="fit"
+            padding="lg"
             rightChildren={
               <Button
                 prominence="internal"
@@ -114,7 +113,6 @@ function ViewerOpenApiToolCard({ tool }: { tool: ToolSnapshot }) {
   return (
     <Card border="solid" rounding="lg" padding="sm">
       <CardLayout.Header
-        headerPadding="sm"
         headerChildren={
           <Content
             icon={SvgActions}

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -90,16 +90,16 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
             sizePreset="main-ui"
             variant="section"
             padding="fit"
+            rightChildren={
+              <Button
+                prominence="internal"
+                rightIcon={expanded ? SvgFold : SvgExpand}
+                onClick={() => setExpanded((prev) => !prev)}
+              >
+                {expanded ? "Fold" : "Expand"}
+              </Button>
+            }
           />
-        }
-        topRightChildren={
-          <Button
-            prominence="internal"
-            rightIcon={expanded ? SvgFold : SvgExpand}
-            onClick={() => setExpanded((prev) => !prev)}
-          >
-            {expanded ? "Fold" : "Expand"}
-          </Button>
         }
       />
     </Card>

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -7,12 +7,7 @@ import { FullPersona } from "@/app/admin/agents/interfaces";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
-import {
-  Card as CardLayout,
-  Content,
-  ContentAction,
-  InputHorizontal,
-} from "@opal/layouts";
+import { Content, ContentAction, InputHorizontal } from "@opal/layouts";
 import Text from "@/refresh-components/texts/Text";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import { Card, Divider } from "@opal/components";
@@ -80,25 +75,21 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
         ) : undefined
       }
     >
-      <CardLayout.Header
-        headerChildren={
-          <ContentAction
-            icon={serverIcon}
-            title={server.name}
-            description={server.description}
-            sizePreset="main-ui"
-            variant="section"
-            padding="lg"
-            rightChildren={
-              <Button
-                prominence="internal"
-                rightIcon={expanded ? SvgFold : SvgExpand}
-                onClick={() => setExpanded((prev) => !prev)}
-              >
-                {expanded ? "Fold" : "Expand"}
-              </Button>
-            }
-          />
+      <ContentAction
+        icon={serverIcon}
+        title={server.name}
+        description={server.description}
+        sizePreset="main-ui"
+        variant="section"
+        padding="lg"
+        rightChildren={
+          <Button
+            prominence="internal"
+            rightIcon={expanded ? SvgFold : SvgExpand}
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            {expanded ? "Fold" : "Expand"}
+          </Button>
         }
       />
     </Card>
@@ -112,16 +103,12 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
 function ViewerOpenApiToolCard({ tool }: { tool: ToolSnapshot }) {
   return (
     <Card border="solid" rounding="lg" padding="sm">
-      <CardLayout.Header
-        headerChildren={
-          <Content
-            icon={SvgActions}
-            title={tool.display_name}
-            description={tool.description}
-            sizePreset="main-ui"
-            variant="section"
-          />
-        }
+      <Content
+        icon={SvgActions}
+        title={tool.display_name}
+        description={tool.description}
+        sizePreset="main-ui"
+        variant="section"
       />
     </Card>
   );

--- a/web/src/sections/modals/AgentViewerModal.tsx
+++ b/web/src/sections/modals/AgentViewerModal.tsx
@@ -102,7 +102,7 @@ function ViewerMCPServerCard({ server, tools }: ViewerMCPServerCardProps) {
  */
 function ViewerOpenApiToolCard({ tool }: { tool: ToolSnapshot }) {
   return (
-    <Card border="solid" rounding="lg" padding="sm">
+    <Card border="solid" rounding="lg" padding="md">
       <Content
         icon={SvgActions}
         title={tool.display_name}


### PR DESCRIPTION
## Description

Eliminate the `topRightChildren` prop from `Card.Header`. Right-side actions now go through `ContentAction.rightChildren` inside `headerChildren`, reducing API duplication between `Card.Header`, `ContentAction`, and `InputHorizontal`.

`bottomRightChildren` and `bottomChildren` remain on `Card.Header` for secondary actions and full-width content.

**11 instances migrated across 8 files:**
- `AgentEditorPage.tsx` (2)
- `LLMConfigurationPage.tsx` (3)
- `ChatPreferencesPage.tsx` (2)
- `WebSearchPage/index.tsx` (1)
- `CodeInterpreterPage/index.tsx` (2)
- `ImageGenerationPage/ImageGenerationContent.tsx` (1)
- `AgentViewerModal.tsx` (1)
- `ProviderCard.tsx` (1)

Stories and README updated.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `topRightChildren` and `headerPadding` from `Card.Header`, and renamed `headerChildren` to `children`. Right actions now flow through `ContentAction.rightChildren`; `ContentAction` owns padding and top-aligns content. Code Interpreter header uses `rightChildren` for status/actions and keeps the Disconnect icon visible when its modal is open.

- **Refactors**
  - Removed `Card.Header` `topRightChildren`/`headerPadding`; renamed `headerChildren` to `children`. Right column now only uses `bottomRightChildren`.
  - Unified right actions via `ContentAction.rightChildren`; `ContentAction` owns padding and top-aligns content. Adjusted padding in Agent Editor/Viewer and MessageCard; standardized button sizes in the Code Interpreter header.
  - Updated stories/README and migrated 11 usages across admin pages and shared cards.

- **Migration**
  - Replace `topRightChildren={...}` with `children={<ContentAction ... rightChildren={...} />}`.
  - Remove `headerPadding`; set padding on `ContentAction`.
  - If no bottom slots are used, render `<ContentAction />` directly inside `Card`/`SelectCard`.

<sup>Written for commit 2a052357cec04e051c95741aadb135db4320ec1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. --