### PR TITLE
refactor(platform): env `DANSWER_RUNNING_IN_DOCKER`->`ONYX_RUNNING_IN_DOCKER`

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ founders@onyx.app for more information. Please visit https://github.com/onyx-dot
 ARG ENABLE_CRAFT=false
 
 # DO_NOT_TRACK is used to disable telemetry for Unstructured
-ENV DANSWER_RUNNING_IN_DOCKER="true" \
+ENV ONYX_RUNNING_IN_DOCKER="true" \
     DO_NOT_TRACK="true" \
     PLAYWRIGHT_BROWSERS_PATH="/app/.cache/ms-playwright"
 

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -1,7 +1,7 @@
 # Base stage with dependencies
 FROM python:3.11-slim-bookworm@sha256:9c6f90801e6b68e772b7c0ca74260cbf7af9f320acec894e26fccdaccfbe3b47 AS base
 
-ENV DANSWER_RUNNING_IN_DOCKER="true" \
+ENV ONYX_RUNNING_IN_DOCKER="true" \
     HF_HOME=/app/.cache/huggingface
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
@@ -47,6 +47,7 @@ WORKDIR /app
 
 # Utils used by model server
 COPY ./onyx/utils/logger.py /app/onyx/utils/logger.py
+COPY ./onyx/utils/platform.py /app/onyx/utils/platform.py
 COPY ./onyx/utils/middleware.py /app/onyx/utils/middleware.py
 COPY ./onyx/utils/tenant.py /app/onyx/utils/tenant.py
 

--- a/backend/onyx/background/celery/memory_monitoring.py
+++ b/backend/onyx/background/celery/memory_monitoring.py
@@ -5,8 +5,8 @@ from logging.handlers import RotatingFileHandler
 
 import psutil
 
-from onyx.utils.logger import is_running_in_container
 from onyx.utils.logger import setup_logger
+from onyx.utils.platform import is_running_in_container
 
 # Regular application logger
 logger = setup_logger()

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -42,7 +42,7 @@ from onyx.db.models import UserGroup
 from onyx.db.search_settings import get_active_search_settings_list
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
-from onyx.utils.logger import is_running_in_container
+from onyx.utils.platform import is_running_in_container
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
 from shared_configs.configs import MULTI_TENANT

--- a/backend/onyx/utils/logger.py
+++ b/backend/onyx/utils/logger.py
@@ -5,6 +5,7 @@ from collections.abc import MutableMapping
 from logging.handlers import RotatingFileHandler
 from typing import Any
 
+from onyx.utils.platform import is_running_in_container
 from onyx.utils.tenant import get_tenant_id_short_string
 from shared_configs.configs import DEV_LOGGING_ENABLED
 from shared_configs.configs import LOG_FILE_NAME
@@ -167,13 +168,6 @@ def get_standard_formatter() -> ColoredFormatter:
         "%(asctime)s %(filename)30s %(lineno)4s: %(message)s",
         datefmt="%m/%d/%Y %I:%M:%S %p",
     )
-
-
-DANSWER_DOCKER_ENV_STR = "DANSWER_RUNNING_IN_DOCKER"
-
-
-def is_running_in_container() -> bool:
-    return os.getenv(DANSWER_DOCKER_ENV_STR) == "true"
 
 
 def setup_logger(

--- a/backend/onyx/utils/platform.py
+++ b/backend/onyx/utils/platform.py
@@ -1,0 +1,30 @@
+import os
+import warnings
+
+_ONYX_DOCKER_ENV_STR = "ONYX_RUNNING_IN_DOCKER"
+_DANSWER_DOCKER_ENV_STR = "DANSWER_RUNNING_IN_DOCKER"
+
+
+def _resolve_container_flag() -> bool:
+    onyx_val = os.getenv(_ONYX_DOCKER_ENV_STR)
+    if onyx_val is not None:
+        return onyx_val.lower() == "true"
+
+    danswer_val = os.getenv(_DANSWER_DOCKER_ENV_STR)
+    if danswer_val is not None:
+        warnings.warn(
+            f"{_DANSWER_DOCKER_ENV_STR} is deprecated and will be ignored in a "
+            f"future release. Use {_ONYX_DOCKER_ENV_STR} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return danswer_val.lower() == "true"
+
+    return False
+
+
+_IS_RUNNING_IN_CONTAINER: bool = _resolve_container_flag()
+
+
+def is_running_in_container() -> bool:
+    return _IS_RUNNING_IN_CONTAINER


### PR DESCRIPTION
## Description

I was going to use this in https://github.com/onyx-dot-app/onyx/pull/10045, but I might abandon that change, but we can still get this refactor/env rename in at least.

## How Has This Been Tested?



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the container detection env var to `ONYX_RUNNING_IN_DOCKER` and centralized detection in `onyx.utils.platform`, keeping compatibility with `DANSWER_RUNNING_IN_DOCKER` via a deprecation warning. Ensures consistent behavior across the app and the model server.

- **Refactors**
  - Added `onyx.utils.platform.is_running_in_container()` that prefers `ONYX_RUNNING_IN_DOCKER`, falls back to `DANSWER_RUNNING_IN_DOCKER` with a warning, and caches the result.
  - Updated Dockerfiles to set `ONYX_RUNNING_IN_DOCKER="true"` and include `onyx.utils.platform` in the model server image.
  - Removed the helper from `onyx.utils.logger`; logger and monitoring modules now use `onyx.utils.platform`.

- **Migration**
  - Set `ONYX_RUNNING_IN_DOCKER=true` in all deployments and stop using `DANSWER_RUNNING_IN_DOCKER`. The old var still works for now but will be ignored in a future release.

<sup>Written for commit d5c6e97a4bb33f619a94b4de7547bd8d6600afc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



