### PR TITLE
feat(search): Pull associated files for internal search docs

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 from collections.abc import Callable
 from typing import cast
@@ -19,7 +18,7 @@ from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import TMP_DRALPHA_PERSONA_NAME
 from onyx.context.search.models import SearchDoc
-from onyx.context.search.utils import sandbox_filename_for_document_title
+from onyx.context.search.utils import resolve_sandbox_filenames
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_or_create_root_message
@@ -866,19 +865,6 @@ def create_tool_call_failure_messages(
     return messages
 
 
-def _dedupe_filename(name: str, taken: set[str]) -> str:
-    """Append `_2`, `_3`, ... before the extension on filename collision."""
-    if name not in taken:
-        return name
-    base, ext = os.path.splitext(name)
-    counter = 2
-    while True:
-        candidate = f"{base}_{counter}{ext}"
-        if candidate not in taken:
-            return candidate
-        counter += 1
-
-
 def build_python_chat_files_from_search_docs(
     search_docs: list[SearchDoc],
 ) -> list[ChatFile]:
@@ -891,24 +877,15 @@ def build_python_chat_files_from_search_docs(
 
     file_store = get_default_file_store()
 
-    # Dedupe by file_id while preserving order (first hit wins).
-    seen_file_ids: set[str] = set()
-    ordered_candidates: list[tuple[str, str]] = []  # (file_id, doc_title)
-    for doc in search_docs:
-        if not doc.file_id:
-            continue
-        if doc.file_id in seen_file_ids:
-            continue
-        seen_file_ids.add(doc.file_id)
-        ordered_candidates.append((doc.file_id, doc.semantic_identifier))
-
-    if not ordered_candidates:
+    candidates: list[tuple[str, str]] = [
+        (doc.file_id, doc.semantic_identifier) for doc in search_docs if doc.file_id
+    ]
+    filename_by_file_id = resolve_sandbox_filenames(candidates)
+    if not filename_by_file_id:
         return []
 
     chat_files: list[ChatFile] = []
-    taken_names: set[str] = set()
-
-    for file_id, doc_title in ordered_candidates:
+    for file_id, filename in filename_by_file_id.items():
         try:
             record = file_store.read_file_record(file_id)
         except Exception as e:
@@ -931,14 +908,6 @@ def build_python_chat_files_from_search_docs(
                 f"Failed to read bytes for file_id={file_id!r}: {e}; skipping."
             )
             continue
-
-        # Derive filename from the document title + resolve collisions
-        # against files already added in THIS search. Uses the same helper
-        # the LLM-facing JSON uses, so the filename the LLM sees matches
-        # the filename that actually lands in the sandbox.
-        sandbox_name = sandbox_filename_for_document_title(doc_title)
-        filename = _dedupe_filename(sandbox_name, taken_names)
-        taken_names.add(filename)
 
         chat_files.append(ChatFile(filename=filename, content=content))
 

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -18,7 +18,7 @@ from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import TMP_DRALPHA_PERSONA_NAME
 from onyx.context.search.models import SearchDoc
-from onyx.context.search.utils import resolve_sandbox_filenames
+from onyx.context.search.utils import sandbox_filename_for_document
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_or_create_root_message
@@ -877,38 +877,37 @@ def build_python_chat_files_from_search_docs(
 
     file_store = get_default_file_store()
 
-    candidates: list[tuple[str, str]] = [
-        (doc.file_id, doc.semantic_identifier) for doc in search_docs if doc.file_id
-    ]
-    filename_by_file_id = resolve_sandbox_filenames(candidates)
-    if not filename_by_file_id:
-        return []
-
     chat_files: list[ChatFile] = []
-    for file_id, filename in filename_by_file_id.items():
+    seen_file_ids: set[str] = set()
+    for doc in search_docs:
+        if not doc.file_id or doc.file_id in seen_file_ids:
+            continue
+        seen_file_ids.add(doc.file_id)
+
         try:
-            record = file_store.read_file_record(file_id)
+            record = file_store.read_file_record(doc.file_id)
         except Exception as e:
             logger.warning(
-                f"file_id={file_id!r} not found in file store ({e}); skipping."
+                f"file_id={doc.file_id!r} not found in file store ({e}); skipping."
             )
             continue
 
         if record.file_origin != FileOrigin.CONNECTOR:
             logger.warning(
-                f"file_id={file_id!r} has origin={record.file_origin!r}, "
+                f"file_id={doc.file_id!r} has origin={record.file_origin!r}, "
                 "not eligible for code-interpreter staging; skipping."
             )
             continue
 
         try:
-            content = file_store.read_file(file_id, mode="b").read()
+            content = file_store.read_file(doc.file_id, mode="b").read()
         except Exception as e:
             logger.warning(
-                f"Failed to read bytes for file_id={file_id!r}: {e}; skipping."
+                f"Failed to read bytes for file_id={doc.file_id!r}: {e}; skipping."
             )
             continue
 
+        filename = sandbox_filename_for_document(doc.semantic_identifier, doc.file_id)
         chat_files.append(ChatFile(filename=filename, content=content))
 
     return chat_files

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from collections.abc import Callable
 from typing import cast
@@ -14,8 +15,11 @@ from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import FileToolMetadata
 from onyx.chat.models import ToolCallSimple
 from onyx.configs.constants import DEFAULT_PERSONA_ID
+from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import TMP_DRALPHA_PERSONA_NAME
+from onyx.context.search.models import SearchDoc
+from onyx.context.search.utils import sandbox_filename_for_document_title
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_or_create_root_message
@@ -42,6 +46,7 @@ from onyx.prompts.chat_prompts import TOOL_CALL_RESPONSE_CROSS_MESSAGE
 from onyx.prompts.tool_prompts import TOOL_CALL_FAILURE_PROMPT
 from onyx.server.query_and_chat.models import ChatSessionCreationRequest
 from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.tools.models import ChatFile
 from onyx.tools.models import ToolCallKickoff
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
@@ -859,3 +864,82 @@ def create_tool_call_failure_messages(
         messages.append(failure_response_msg)
 
     return messages
+
+
+def _dedupe_filename(name: str, taken: set[str]) -> str:
+    """Append `_2`, `_3`, ... before the extension on filename collision."""
+    if name not in taken:
+        return name
+    base, ext = os.path.splitext(name)
+    counter = 2
+    while True:
+        candidate = f"{base}_{counter}{ext}"
+        if candidate not in taken:
+            return candidate
+        counter += 1
+
+
+def build_python_chat_files_from_search_docs(
+    search_docs: list[SearchDoc],
+) -> list[ChatFile]:
+    """Turn each eligible search hit into a ready-to-upload `ChatFile`.
+    The associated file needs to have been uploaded to the file store
+    by a Connector.
+    """
+    if not search_docs:
+        return []
+
+    file_store = get_default_file_store()
+
+    # Dedupe by file_id while preserving order (first hit wins).
+    seen_file_ids: set[str] = set()
+    ordered_candidates: list[tuple[str, str]] = []  # (file_id, doc_title)
+    for doc in search_docs:
+        if not doc.file_id:
+            continue
+        if doc.file_id in seen_file_ids:
+            continue
+        seen_file_ids.add(doc.file_id)
+        ordered_candidates.append((doc.file_id, doc.semantic_identifier))
+
+    if not ordered_candidates:
+        return []
+
+    chat_files: list[ChatFile] = []
+    taken_names: set[str] = set()
+
+    for file_id, doc_title in ordered_candidates:
+        try:
+            record = file_store.read_file_record(file_id)
+        except Exception as e:
+            logger.warning(
+                f"file_id={file_id!r} not found in file store ({e}); skipping."
+            )
+            continue
+
+        if record.file_origin != FileOrigin.CONNECTOR:
+            logger.warning(
+                f"file_id={file_id!r} has origin={record.file_origin!r}, "
+                "not eligible for code-interpreter staging; skipping."
+            )
+            continue
+
+        try:
+            content = file_store.read_file(file_id, mode="b").read()
+        except Exception as e:
+            logger.warning(
+                f"Failed to read bytes for file_id={file_id!r}: {e}; skipping."
+            )
+            continue
+
+        # Derive filename from the document title + resolve collisions
+        # against files already added in THIS search. Uses the same helper
+        # the LLM-facing JSON uses, so the filename the LLM sees matches
+        # the filename that actually lands in the sandbox.
+        sandbox_name = sandbox_filename_for_document_title(doc_title)
+        filename = _dedupe_filename(sandbox_name, taken_names)
+        taken_names.add(filename)
+
+        chat_files.append(ChatFile(filename=filename, content=content))
+
+    return chat_files

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Literal
 
 from onyx.chat.chat_state import ChatStateContainer
+from onyx.chat.chat_utils import build_python_chat_files_from_search_docs
 from onyx.chat.chat_utils import create_tool_call_failure_messages
 from onyx.chat.citation_processor import CitationMapping
 from onyx.chat.citation_processor import CitationMode
@@ -656,6 +657,11 @@ def run_llm_loop(
 
         initialize_litellm()
 
+        # Normalize chat_files to a mutable list so we can extend it mid-loop
+        # when a search hit carries an attached file the Python tool should
+        # see.
+        chat_files = list(chat_files or [])
+
         # Track when the loop starts for calculating time-to-answer
         loop_start_time = time.monotonic()
 
@@ -996,6 +1002,21 @@ def run_llm_loop(
                     # only do this if the web search tool yielded results
                     if search_docs and tool_call.tool_name == WebSearchTool.NAME:
                         just_ran_web_search = True
+
+                    # Stage any raw source files attached to these hits into
+                    # the session's chat_files so the next Python tool call
+                    # sees them already uploaded under their display names.
+                    if search_docs:
+                        staged = build_python_chat_files_from_search_docs(
+                            search_docs=search_docs,
+                        )
+                        if staged:
+                            existing_filenames = {cf.filename for cf in chat_files}
+                            chat_files.extend(
+                                cf
+                                for cf in staged
+                                if cf.filename not in existing_filenames
+                            )
 
                 # Extract generated_images if this is an image generation tool response
                 generated_images = None

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -164,6 +164,10 @@ class InferenceChunk(BaseChunk):
 
     is_federated: bool = False
 
+    # `Document.file_id` for the doc this chunk belongs to. Populated post-
+    # retrieval via a Postgres lookup
+    file_id: str | None = None
+
     @property
     def unique_id(self) -> str:
         return f"{self.document_id}__{self.chunk_id}"
@@ -263,6 +267,10 @@ class SearchDoc(BaseModel):
     secondary_owners: list[str] | None = None
     is_internet: bool = False
 
+    # Mirrors `InferenceChunk.file_id`. Only present once sections have been
+    # run through `populate_file_ids_on_sections`.
+    file_id: str | None = None
+
     @classmethod
     def from_chunks_or_sections(
         cls,
@@ -295,6 +303,7 @@ class SearchDoc(BaseModel):
                 primary_owners=chunk.primary_owners,
                 secondary_owners=chunk.secondary_owners,
                 is_internet=False,
+                file_id=chunk.file_id,
             )
             for item in items
         ]

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -38,6 +38,8 @@ TSection = TypeVar(
     SavedSearchDocWithContent,
 )
 
+_UNSAFE_CHARS_RE = re.compile(r"[\x00-\x1f/\\:\*\?\"<>\|]+")
+
 
 def inference_section_from_chunks(
     center_chunk: InferenceChunk,
@@ -109,10 +111,9 @@ def convert_inference_sections_to_search_docs(
 def sandbox_filename_for_document_title(title: str) -> str:
     """Sanitize a document title into a sandbox-safe filename; extensions on
     the title are preserved verbatim, extensionless titles get no suffix."""
-    unsafe_chars = re.compile(r"[\x00-\x1f/\\:\*\?\"<>\|]+")
     max_length = 200
 
-    name = unsafe_chars.sub("_", title).strip().strip(".")
+    name = _UNSAFE_CHARS_RE.sub("_", title).strip().strip(".")
     if not name:
         name = "document"
     return name[:max_length]

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -134,19 +134,14 @@ def _dedupe_filename(name: str, taken: set[str]) -> str:
 
 def resolve_sandbox_filenames(
     items: list[tuple[str, str]],
-    *,
-    existing_filenames: set[str] | None = None,
-    already_resolved_file_ids: set[str] | None = None,
 ) -> dict[str, str]:
     """Deterministic `file_id -> sandbox_filename` map. First occurrence of a
     file_id wins; later distinct file_ids with colliding titles get `_2`, `_3`
-    suffixes. Callers that need identical mappings (LLM-facing JSON and
-    sandbox staging) must drive this from the same ordered input."""
-    taken: set[str] = set(existing_filenames) if existing_filenames else set()
-    resolved_seed = already_resolved_file_ids or set()
+    suffixes."""
+    taken: set[str] = set()
     result: dict[str, str] = {}
     for file_id, title in items:
-        if not file_id or file_id in result or file_id in resolved_seed:
+        if not file_id or file_id in result:
             continue
         name = _dedupe_filename(sandbox_filename_for_document_title(title), taken)
         taken.add(name)

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import TypeVar
 
@@ -117,6 +118,40 @@ def sandbox_filename_for_document_title(title: str) -> str:
     if not name:
         name = "document"
     return name[:max_length]
+
+
+def _dedupe_filename(name: str, taken: set[str]) -> str:
+    if name not in taken:
+        return name
+    base, ext = os.path.splitext(name)
+    counter = 2
+    while True:
+        candidate = f"{base}_{counter}{ext}"
+        if candidate not in taken:
+            return candidate
+        counter += 1
+
+
+def resolve_sandbox_filenames(
+    items: list[tuple[str, str]],
+    *,
+    existing_filenames: set[str] | None = None,
+    already_resolved_file_ids: set[str] | None = None,
+) -> dict[str, str]:
+    """Deterministic `file_id -> sandbox_filename` map. First occurrence of a
+    file_id wins; later distinct file_ids with colliding titles get `_2`, `_3`
+    suffixes. Callers that need identical mappings (LLM-facing JSON and
+    sandbox staging) must drive this from the same ordered input."""
+    taken: set[str] = set(existing_filenames) if existing_filenames else set()
+    resolved_seed = already_resolved_file_ids or set()
+    result: dict[str, str] = {}
+    for file_id, title in items:
+        if not file_id or file_id in result or file_id in resolved_seed:
+            continue
+        name = _dedupe_filename(sandbox_filename_for_document_title(title), taken)
+        taken.add(name)
+        result[file_id] = name
+    return result
 
 
 def populate_file_ids_on_sections(

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -109,44 +109,18 @@ def convert_inference_sections_to_search_docs(
     return search_docs
 
 
-def sandbox_filename_for_document_title(title: str) -> str:
-    """Sanitize a document title into a sandbox-safe filename; extensions on
-    the title are preserved verbatim, extensionless titles get no suffix."""
+def sandbox_filename_for_document(title: str, file_id: str) -> str:
+    """Sanitize a document title and append its file_id to produce a globally
+    unique sandbox filename. Extensions on the title are preserved verbatim."""
     max_length = 200
 
-    name = _UNSAFE_CHARS_RE.sub("_", title).strip().strip(".")
-    if not name:
-        name = "document"
-    return name[:max_length]
-
-
-def _dedupe_filename(name: str, taken: set[str]) -> str:
-    if name not in taken:
-        return name
-    base, ext = os.path.splitext(name)
-    counter = 2
-    while True:
-        candidate = f"{base}_{counter}{ext}"
-        if candidate not in taken:
-            return candidate
-        counter += 1
-
-
-def resolve_sandbox_filenames(
-    items: list[tuple[str, str]],
-) -> dict[str, str]:
-    """Deterministic `file_id -> sandbox_filename` map. First occurrence of a
-    file_id wins; later distinct file_ids with colliding titles get `_2`, `_3`
-    suffixes."""
-    taken: set[str] = set()
-    result: dict[str, str] = {}
-    for file_id, title in items:
-        if not file_id or file_id in result:
-            continue
-        name = _dedupe_filename(sandbox_filename_for_document_title(title), taken)
-        taken.add(name)
-        result[file_id] = name
-    return result
+    sanitized = _UNSAFE_CHARS_RE.sub("_", title).strip().strip(".")
+    base, ext = os.path.splitext(sanitized)
+    if not base:
+        base = "document"
+    suffix = f"_{file_id}{ext}"
+    max_base_len = max(1, max_length - len(suffix))
+    return f"{base[:max_base_len]}{suffix}"
 
 
 def populate_file_ids_on_sections(

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -40,6 +40,7 @@ TSection = TypeVar(
 )
 
 _UNSAFE_CHARS_RE = re.compile(r"[\x00-\x1f/\\:\*\?\"<>\|]+")
+_SANDBOX_FILENAME_MAX_LENGTH = 200
 
 
 def inference_section_from_chunks(
@@ -112,14 +113,12 @@ def convert_inference_sections_to_search_docs(
 def sandbox_filename_for_document(title: str, file_id: str) -> str:
     """Sanitize a document title and append its file_id to produce a globally
     unique sandbox filename. Extensions on the title are preserved verbatim."""
-    max_length = 200
-
     sanitized = _UNSAFE_CHARS_RE.sub("_", title).strip().strip(".")
     base, ext = os.path.splitext(sanitized)
     if not base:
         base = "document"
     suffix = f"_{file_id}{ext}"
-    max_base_len = max(1, max_length - len(suffix))
+    max_base_len = max(1, _SANDBOX_FILENAME_MAX_LENGTH - len(suffix))
     return f"{base[:max_base_len]}{suffix}"
 
 

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -1,3 +1,4 @@
+import re
 from typing import TypeVar
 
 from sqlalchemy.orm import Session
@@ -7,6 +8,7 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import SavedSearchDoc
 from onyx.context.search.models import SavedSearchDocWithContent
 from onyx.context.search.models import SearchDoc
+from onyx.db.document import get_document_id_to_file_id_map
 from onyx.db.search_settings import get_current_search_settings
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.utils.logger import setup_logger
@@ -102,3 +104,39 @@ def convert_inference_sections_to_search_docs(
     for search_doc in search_docs:
         search_doc.is_internet = is_internet
     return search_docs
+
+
+def sandbox_filename_for_document_title(title: str) -> str:
+    """Sanitize a document title into a sandbox-safe filename; extensions on
+    the title are preserved verbatim, extensionless titles get no suffix."""
+    unsafe_chars = re.compile(r"[\x00-\x1f/\\:\*\?\"<>\|]+")
+    max_length = 200
+
+    name = unsafe_chars.sub("_", title).strip().strip(".")
+    if not name:
+        name = "document"
+    return name[:max_length]
+
+
+def populate_file_ids_on_sections(
+    sections: list[InferenceSection],
+    db_session: Session,
+) -> None:
+    """Stamp `Document.file_id` onto every chunk in-place."""
+    if not sections:
+        return
+
+    document_ids = list({section.center_chunk.document_id for section in sections})
+    file_id_map = get_document_id_to_file_id_map(
+        db_session=db_session, document_ids=document_ids
+    )
+    if not file_id_map:
+        return
+
+    for section in sections:
+        # Set on every chunk so the section's chunks stay consistent with
+        # center_chunk regardless of which one downstream code looks at.
+        for chunk in (section.center_chunk, *section.chunks):
+            file_id = file_id_map.get(chunk.document_id)
+            if file_id is not None:
+                chunk.file_id = file_id

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -948,12 +948,7 @@ def get_document_id_to_file_id_map(
     db_session: Session,
     document_ids: list[str],
 ) -> dict[str, str]:
-    """Return a `{document_id: file_id}` map for docs that have a file_id.
-
-    Intended for post-retrieval enrichment of search results: one round-trip
-    to look up attached files for a batch of hits. Docs without a file_id are
-    omitted from the map — callers can treat a missing key as "no file".
-    """
+    """Return a `{document_id: file_id}` map for docs that have a file_id."""
     if not document_ids:
         return {}
     rows = (

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -944,6 +944,27 @@ def get_file_ids_for_document_ids(
     return [row.file_id for row in rows if row.file_id is not None]
 
 
+def get_document_id_to_file_id_map(
+    db_session: Session,
+    document_ids: list[str],
+) -> dict[str, str]:
+    """Return a `{document_id: file_id}` map for docs that have a file_id.
+
+    Intended for post-retrieval enrichment of search results: one round-trip
+    to look up attached files for a batch of hits. Docs without a file_id are
+    omitted from the map — callers can treat a missing key as "no file".
+    """
+    if not document_ids:
+        return {}
+    rows = (
+        db_session.query(DbDocument.id, DbDocument.file_id)
+        .filter(DbDocument.id.in_(document_ids))
+        .filter(DbDocument.file_id.isnot(None))
+        .all()
+    )
+    return {doc_id: file_id for doc_id, file_id in rows}
+
+
 def delete_documents_complete__no_commit(
     db_session: Session, document_ids: list[str]
 ) -> None:

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -59,6 +59,7 @@ from onyx.context.search.preprocessing.access_filters import (
     build_access_filters_for_user,
 )
 from onyx.context.search.utils import convert_inference_sections_to_search_docs
+from onyx.context.search.utils import populate_file_ids_on_sections
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -813,6 +814,11 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 ),
                 llm_facing_response="",
             )
+
+        # Enrich chunks with `Document.file_id` (Postgres-only metadata not
+        # stored in Vespa).
+        with get_session_with_current_tenant() as enrichment_session:
+            populate_file_ids_on_sections(top_sections, enrichment_session)
 
         # Convert InferenceSections to SearchDocs for emission
         search_docs = convert_inference_sections_to_search_docs(

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -4,11 +4,10 @@ from onyx.context.search.models import InferenceSection
 from onyx.context.search.utils import sandbox_filename_for_document
 
 
-CODE_INTERPRETER_GUIDANCE = (
+FILE_ASSOCIATED_GUIDANCE = (
     "Only a short excerpt from this document is shown below. The complete "
     'file is available in the sandbox as "{filename}" — prefer the Python '
-    "code interpreter to read, parse, or analyze it (use the file reader "
-    "tool if you only need plain text).\n\n"
+    "code interpreter to read, parse, or analyze it\n\n"
     "Excerpt: {content}"
 )
 
@@ -91,7 +90,7 @@ def convert_inference_sections_to_llm_string(
             )
             result["file_name"] = filename
 
-            result["content"] = CODE_INTERPRETER_GUIDANCE.format(
+            result["content"] = FILE_ASSOCIATED_GUIDANCE.format(
                 filename=filename, content=chunk.content
             )
         else:

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -1,6 +1,16 @@
 import json
 
 from onyx.context.search.models import InferenceSection
+from onyx.context.search.utils import sandbox_filename_for_document_title
+
+
+CODE_INTERPRETER_GUIDANCE = (
+    "Only a short excerpt from this document is shown below. The complete "
+    'file is available in the sandbox as "{filename}" — prefer the Python '
+    "code interpreter to read, parse, or analyze it (use the file reader "
+    "tool if you only need plain text).\n\n"
+    "Excerpt: {content}"
+)
 
 
 def convert_inference_sections_to_llm_string(
@@ -75,9 +85,17 @@ def convert_inference_sections_to_llm_string(
                 result["url"] = link
         if include_document_id:
             result["document_identifier"] = chunk.document_id
+        if chunk.file_id is not None:
+            filename = sandbox_filename_for_document_title(chunk.semantic_identifier)
+            result["code_interpreter_file"] = filename
+
+            result["content"] = CODE_INTERPRETER_GUIDANCE.format(
+                filename=filename, content=chunk.content
+            )
+        else:
+            result["content"] = section.combined_content
         if chunk.metadata:
             result["metadata"] = json.dumps(chunk.metadata, ensure_ascii=False)
-        result["content"] = section.combined_content
         results.append(result)
 
     return (

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -89,7 +89,7 @@ def convert_inference_sections_to_llm_string(
             filename = sandbox_filename_for_document(
                 chunk.semantic_identifier, chunk.file_id
             )
-            result["code_interpreter_file"] = filename
+            result["file_name"] = filename
 
             result["content"] = CODE_INTERPRETER_GUIDANCE.format(
                 filename=filename, content=chunk.content

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -1,7 +1,7 @@
 import json
 
 from onyx.context.search.models import InferenceSection
-from onyx.context.search.utils import sandbox_filename_for_document_title
+from onyx.context.search.utils import resolve_sandbox_filenames
 
 
 CODE_INTERPRETER_GUIDANCE = (
@@ -41,6 +41,14 @@ def convert_inference_sections_to_llm_string(
             document_id_to_citation_id[document_id] = current_citation_id
             citation_mapping[current_citation_id] = document_id
             current_citation_id += 1
+
+    sandbox_filename_by_file_id = resolve_sandbox_filenames(
+        [
+            (section.center_chunk.file_id, section.center_chunk.semantic_identifier)
+            for section in top_sections
+            if section.center_chunk.file_id is not None
+        ]
+    )
 
     # Second pass: build results with citation_ids assigned per document
     results = []
@@ -86,7 +94,7 @@ def convert_inference_sections_to_llm_string(
         if include_document_id:
             result["document_identifier"] = chunk.document_id
         if chunk.file_id is not None:
-            filename = sandbox_filename_for_document_title(chunk.semantic_identifier)
+            filename = sandbox_filename_by_file_id[chunk.file_id]
             result["code_interpreter_file"] = filename
 
             result["content"] = CODE_INTERPRETER_GUIDANCE.format(

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -1,7 +1,7 @@
 import json
 
 from onyx.context.search.models import InferenceSection
-from onyx.context.search.utils import resolve_sandbox_filenames
+from onyx.context.search.utils import sandbox_filename_for_document
 
 
 CODE_INTERPRETER_GUIDANCE = (
@@ -41,14 +41,6 @@ def convert_inference_sections_to_llm_string(
             document_id_to_citation_id[document_id] = current_citation_id
             citation_mapping[current_citation_id] = document_id
             current_citation_id += 1
-
-    sandbox_filename_by_file_id = resolve_sandbox_filenames(
-        [
-            (section.center_chunk.file_id, section.center_chunk.semantic_identifier)
-            for section in top_sections
-            if section.center_chunk.file_id is not None
-        ]
-    )
 
     # Second pass: build results with citation_ids assigned per document
     results = []
@@ -94,7 +86,9 @@ def convert_inference_sections_to_llm_string(
         if include_document_id:
             result["document_identifier"] = chunk.document_id
         if chunk.file_id is not None:
-            filename = sandbox_filename_by_file_id[chunk.file_id]
+            filename = sandbox_filename_for_document(
+                chunk.semantic_identifier, chunk.file_id
+            )
             result["code_interpreter_file"] = filename
 
             result["content"] = CODE_INTERPRETER_GUIDANCE.format(

--- a/backend/tests/external_dependency_unit/chat/test_build_python_chat_files.py
+++ b/backend/tests/external_dependency_unit/chat/test_build_python_chat_files.py
@@ -122,7 +122,7 @@ class TestBuildPythonChatFiles:
         chat_files = build_python_chat_files_from_search_docs(docs)
 
         assert len(chat_files) == 1
-        assert chat_files[0].filename == "greetings.csv"
+        assert chat_files[0].filename == f"greetings_{file_id}.csv"
         assert chat_files[0].content == b"hello,world\n1,2\n"
 
     def test_disallowed_origin_is_rejected(
@@ -168,7 +168,7 @@ class TestBuildPythonChatFiles:
 
         chat_files = build_python_chat_files_from_search_docs(docs)
 
-        assert [cf.filename for cf in chat_files] == ["ok.csv"]
+        assert [cf.filename for cf in chat_files] == [f"ok_{good_id}.csv"]
 
     def test_duplicate_file_ids_deduped_first_hit_wins(
         self,
@@ -190,15 +190,15 @@ class TestBuildPythonChatFiles:
         chat_files = build_python_chat_files_from_search_docs(docs)
 
         assert len(chat_files) == 1
-        assert chat_files[0].filename == "first.csv"
+        assert chat_files[0].filename == f"first_{file_id}.csv"
 
-    def test_filename_collisions_resolved_with_numeric_suffix(
+    def test_distinct_file_ids_with_same_title_get_distinct_names(
         self,
         file_cleanup: list[str],
     ) -> None:
-        """Two distinct file_ids with IDENTICAL sanitized titles must each
-        get a unique sandbox filename — else the second upload overwrites
-        the first in the workspace."""
+        """Two distinct file_ids with IDENTICAL titles must each get a unique
+        sandbox filename — file_id is embedded in the filename so collisions
+        are impossible by construction."""
         file_a = _write_file(b"first")
         file_b = _write_file(b"second")
         file_c = _write_file(b"third")
@@ -213,11 +213,10 @@ class TestBuildPythonChatFiles:
         chat_files = build_python_chat_files_from_search_docs(docs)
 
         assert [cf.filename for cf in chat_files] == [
-            "Report.pdf",
-            "Report_2.pdf",
-            "Report_3.pdf",
+            f"Report_{file_a}.pdf",
+            f"Report_{file_b}.pdf",
+            f"Report_{file_c}.pdf",
         ]
-        # Bytes are intact (no cross-contamination from the rename).
         assert chat_files[0].content == b"first"
         assert chat_files[1].content == b"second"
         assert chat_files[2].content == b"third"
@@ -226,8 +225,6 @@ class TestBuildPythonChatFiles:
         self,
         file_cleanup: list[str],
     ) -> None:
-        """Unsafe chars in the title get replaced — same sanitizer the LLM
-        JSON path uses, so the LLM-visible filename == sandbox filename."""
         file_id = _write_file(b"payload")
         file_cleanup.append(file_id)
 
@@ -236,15 +233,13 @@ class TestBuildPythonChatFiles:
         chat_files = build_python_chat_files_from_search_docs(docs)
 
         assert len(chat_files) == 1
-        assert chat_files[0].filename == "Q1_Q2 Report"
+        assert chat_files[0].filename == f"Q1_Q2 Report_{file_id}"
 
     def test_original_order_preserved(
         self,
         file_cleanup: list[str],
     ) -> None:
-        """Output order follows the input SearchDoc order, not DB order or
-        any implicit sort — the first search hit's file appears first in
-        the ChatFile list."""
+        """Output order follows the input SearchDoc order."""
         ids = [_write_file(f"body-{i}".encode()) for i in range(3)]
         file_cleanup.extend(ids)
 
@@ -256,4 +251,8 @@ class TestBuildPythonChatFiles:
 
         chat_files = build_python_chat_files_from_search_docs(docs)
 
-        assert [cf.filename for cf in chat_files] == ["a.csv", "b.csv", "c.csv"]
+        assert [cf.filename for cf in chat_files] == [
+            f"a_{ids[0]}.csv",
+            f"b_{ids[1]}.csv",
+            f"c_{ids[2]}.csv",
+        ]

--- a/backend/tests/external_dependency_unit/chat/test_build_python_chat_files.py
+++ b/backend/tests/external_dependency_unit/chat/test_build_python_chat_files.py
@@ -1,0 +1,259 @@
+"""External-dependency tests for `build_python_chat_files_from_search_docs`.
+
+This is the staging step that turns connector-file-bearing search hits into
+`ChatFile`s for the Python code interpreter. Uses real Postgres + real file
+store because the function reads bytes + file_records from the store, and
+mocking those would obscure the origin-allowlist + metadata plumbing that
+are the whole point.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat.chat_utils import build_python_chat_files_from_search_docs
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
+from onyx.context.search.models import SearchDoc
+from onyx.file_store.file_store import get_default_file_store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_search_doc(
+    *,
+    file_id: str | None,
+    semantic_identifier: str,
+    document_id: str | None = None,
+) -> SearchDoc:
+    return SearchDoc(
+        document_id=document_id or f"doc-{uuid4().hex[:8]}",
+        chunk_ind=0,
+        semantic_identifier=semantic_identifier,
+        link=None,
+        blurb="",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        boost=1,
+        hidden=False,
+        metadata={},
+        score=0.5,
+        match_highlights=[],
+        file_id=file_id,
+    )
+
+
+def _write_file(
+    content: bytes,
+    *,
+    origin: FileOrigin = FileOrigin.CONNECTOR,
+) -> str:
+    return get_default_file_store().save_file(
+        content=BytesIO(content),
+        display_name=None,
+        file_origin=origin,
+        file_type="text/csv",
+        file_metadata={"test": True},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def file_cleanup(
+    db_session: Session,  # noqa: ARG001 — keeps tenant context alive for file_store
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[list[str], None, None]:
+    """Track file_ids written by the test so teardown reaps them."""
+    created: list[str] = []
+    try:
+        yield created
+    finally:
+        store = get_default_file_store()
+        for fid in created:
+            try:
+                store.delete_file(fid, error_on_missing=False)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPythonChatFiles:
+    def test_empty_input_returns_empty(
+        self,
+        file_cleanup: list[str],  # noqa: ARG002 — keeps tenant + store fixtures alive
+    ) -> None:
+        assert build_python_chat_files_from_search_docs([]) == []
+
+    def test_docs_without_file_id_return_empty(
+        self,
+        file_cleanup: list[str],  # noqa: ARG002
+    ) -> None:
+        docs = [
+            _make_search_doc(file_id=None, semantic_identifier="no-file.pdf"),
+            _make_search_doc(file_id=None, semantic_identifier="also-none"),
+        ]
+        assert build_python_chat_files_from_search_docs(docs) == []
+
+    def test_connector_origin_file_is_staged(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        file_id = _write_file(b"hello,world\n1,2\n")
+        file_cleanup.append(file_id)
+
+        docs = [
+            _make_search_doc(file_id=file_id, semantic_identifier="greetings.csv"),
+        ]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert len(chat_files) == 1
+        assert chat_files[0].filename == "greetings.csv"
+        assert chat_files[0].content == b"hello,world\n1,2\n"
+
+    def test_disallowed_origin_is_rejected(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        """Only `CONNECTOR`-origin files are eligible via this path —
+        `CHAT_UPLOAD` and others use different pipelines and must not leak
+        through even if a SearchDoc happens to reference their file_id."""
+        file_id = _write_file(b"from chat", origin=FileOrigin.CHAT_UPLOAD)
+        file_cleanup.append(file_id)
+
+        docs = [_make_search_doc(file_id=file_id, semantic_identifier="usr-upload.txt")]
+
+        assert build_python_chat_files_from_search_docs(docs) == []
+
+    def test_unknown_file_id_is_silently_dropped(
+        self,
+        file_cleanup: list[str],  # noqa: ARG002
+    ) -> None:
+        """Bad/stale file_id → log warning, skip it, continue the batch."""
+        docs = [
+            _make_search_doc(
+                file_id="does-not-exist", semantic_identifier="missing.csv"
+            )
+        ]
+        assert build_python_chat_files_from_search_docs(docs) == []
+
+    def test_mixed_good_and_bad_entries_return_only_good(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        good_id = _write_file(b"ok")
+        blocked_id = _write_file(b"nope", origin=FileOrigin.CHAT_UPLOAD)
+        file_cleanup.extend([good_id, blocked_id])
+
+        docs = [
+            _make_search_doc(file_id=good_id, semantic_identifier="ok.csv"),
+            _make_search_doc(file_id=blocked_id, semantic_identifier="blocked.csv"),
+            _make_search_doc(file_id="ghost", semantic_identifier="ghost.csv"),
+            _make_search_doc(file_id=None, semantic_identifier="no-id.csv"),
+        ]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert [cf.filename for cf in chat_files] == ["ok.csv"]
+
+    def test_duplicate_file_ids_deduped_first_hit_wins(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        """Repeated hits for the same doc only ship one ChatFile, and the
+        filename comes from the FIRST hit's semantic_identifier."""
+        file_id = _write_file(b"single copy")
+        file_cleanup.append(file_id)
+
+        docs = [
+            _make_search_doc(file_id=file_id, semantic_identifier="first.csv"),
+            _make_search_doc(
+                file_id=file_id, semantic_identifier="second-name-ignored.csv"
+            ),
+            _make_search_doc(file_id=file_id, semantic_identifier="third-ignored.csv"),
+        ]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert len(chat_files) == 1
+        assert chat_files[0].filename == "first.csv"
+
+    def test_filename_collisions_resolved_with_numeric_suffix(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        """Two distinct file_ids with IDENTICAL sanitized titles must each
+        get a unique sandbox filename — else the second upload overwrites
+        the first in the workspace."""
+        file_a = _write_file(b"first")
+        file_b = _write_file(b"second")
+        file_c = _write_file(b"third")
+        file_cleanup.extend([file_a, file_b, file_c])
+
+        docs = [
+            _make_search_doc(file_id=file_a, semantic_identifier="Report.pdf"),
+            _make_search_doc(file_id=file_b, semantic_identifier="Report.pdf"),
+            _make_search_doc(file_id=file_c, semantic_identifier="Report.pdf"),
+        ]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert [cf.filename for cf in chat_files] == [
+            "Report.pdf",
+            "Report_2.pdf",
+            "Report_3.pdf",
+        ]
+        # Bytes are intact (no cross-contamination from the rename).
+        assert chat_files[0].content == b"first"
+        assert chat_files[1].content == b"second"
+        assert chat_files[2].content == b"third"
+
+    def test_title_sanitization_applied_to_filename(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        """Unsafe chars in the title get replaced — same sanitizer the LLM
+        JSON path uses, so the LLM-visible filename == sandbox filename."""
+        file_id = _write_file(b"payload")
+        file_cleanup.append(file_id)
+
+        docs = [_make_search_doc(file_id=file_id, semantic_identifier="Q1/Q2 Report")]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert len(chat_files) == 1
+        assert chat_files[0].filename == "Q1_Q2 Report"
+
+    def test_original_order_preserved(
+        self,
+        file_cleanup: list[str],
+    ) -> None:
+        """Output order follows the input SearchDoc order, not DB order or
+        any implicit sort — the first search hit's file appears first in
+        the ChatFile list."""
+        ids = [_write_file(f"body-{i}".encode()) for i in range(3)]
+        file_cleanup.extend(ids)
+
+        docs = [
+            _make_search_doc(file_id=ids[0], semantic_identifier="a.csv"),
+            _make_search_doc(file_id=ids[1], semantic_identifier="b.csv"),
+            _make_search_doc(file_id=ids[2], semantic_identifier="c.csv"),
+        ]
+
+        chat_files = build_python_chat_files_from_search_docs(docs)
+
+        assert [cf.filename for cf in chat_files] == ["a.csv", "b.csv", "c.csv"]

--- a/backend/tests/external_dependency_unit/db/test_document_file_id_lookup.py
+++ b/backend/tests/external_dependency_unit/db/test_document_file_id_lookup.py
@@ -1,0 +1,262 @@
+"""External dependency tests for the `Document.file_id` enrichment pipeline.
+
+Two tightly-coupled surfaces live in this file:
+
+  1. `get_document_id_to_file_id_map` — the batched DB lookup that joins
+     chunk-level `document_id`s to their `Document.file_id` rows.
+  2. `populate_file_ids_on_sections` — the post-retrieval enrichment step
+     that calls (1) and stamps `file_id` onto every `InferenceChunk` in a
+     batch of sections.
+
+Uses real Postgres — mocking the ORM would defeat the point of the batched
+query (1) and would hide the section-mutation behavior of (2).
+"""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import InferenceChunk
+from onyx.context.search.models import InferenceSection
+from onyx.context.search.utils import populate_file_ids_on_sections
+from onyx.db.document import get_document_id_to_file_id_map
+from onyx.db.models import Document as DBDocument
+from onyx.kg.models import KGStage
+
+
+@pytest.fixture
+def doc_cleanup(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[list[str], None, None]:
+    """Tracks doc_ids seeded by the test so teardown can reap them.
+
+    These tests seed Document rows directly (no cc_pair wiring) because the
+    lookup under test only touches `Document.id` / `Document.file_id`.
+    """
+    created: list[str] = []
+    try:
+        yield created
+    finally:
+        if created:
+            db_session.query(DBDocument).filter(DBDocument.id.in_(created)).delete(
+                synchronize_session="fetch"
+            )
+            db_session.commit()
+
+
+def _seed_doc(
+    db_session: Session,
+    tracker: list[str],
+    doc_id: str,
+    file_id: str | None,
+) -> DBDocument:
+    doc = DBDocument(
+        id=doc_id,
+        semantic_id=f"semantic-{doc_id}",
+        kg_stage=KGStage.NOT_STARTED,
+        file_id=file_id,
+    )
+    db_session.add(doc)
+    db_session.commit()
+    tracker.append(doc_id)
+    return doc
+
+
+class TestGetDocumentIdToFileIdMap:
+    def test_returns_mapping_only_for_docs_with_file_id(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        with_file = f"doc-{uuid4().hex[:8]}"
+        without_file = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, with_file, file_id="file-abc")
+        _seed_doc(db_session, doc_cleanup, without_file, file_id=None)
+
+        result = get_document_id_to_file_id_map(
+            db_session=db_session,
+            document_ids=[with_file, without_file],
+        )
+
+        # Only the doc with a file_id appears; missing keys mean "no file".
+        assert result == {with_file: "file-abc"}
+
+    def test_empty_input_returns_empty_map(self, db_session: Session) -> None:
+        assert get_document_id_to_file_id_map(db_session, []) == {}
+
+    def test_unknown_document_ids_are_silently_ignored(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        known = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, known, file_id="file-xyz")
+
+        result = get_document_id_to_file_id_map(
+            db_session=db_session,
+            document_ids=[known, "doc-does-not-exist"],
+        )
+
+        assert result == {known: "file-xyz"}
+
+    def test_multiple_docs_all_with_file_ids(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        doc_a = f"doc-{uuid4().hex[:8]}"
+        doc_b = f"doc-{uuid4().hex[:8]}"
+        doc_c = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, doc_a, file_id="file-a")
+        _seed_doc(db_session, doc_cleanup, doc_b, file_id="file-b")
+        _seed_doc(db_session, doc_cleanup, doc_c, file_id="file-c")
+
+        result = get_document_id_to_file_id_map(
+            db_session=db_session,
+            document_ids=[doc_a, doc_b, doc_c],
+        )
+
+        assert result == {doc_a: "file-a", doc_b: "file-b", doc_c: "file-c"}
+
+
+# ---------------------------------------------------------------------------
+# `populate_file_ids_on_sections` — helpers for InferenceChunk fabrication
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(document_id: str, chunk_id: int = 0) -> InferenceChunk:
+    return InferenceChunk(
+        document_id=document_id,
+        chunk_id=chunk_id,
+        content=f"content-{document_id}-{chunk_id}",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"sem-{document_id}",
+        title=document_id,
+        boost=1,
+        score=0.5,
+        hidden=False,
+        metadata={},
+        match_highlights=[],
+        doc_summary="",
+        chunk_context="",
+        updated_at=None,
+        image_file_id=None,
+        source_links={},
+        section_continuation=False,
+        blurb="",
+        file_id=None,
+    )
+
+
+def _make_section(
+    center: InferenceChunk,
+    *adjacent: InferenceChunk,
+) -> InferenceSection:
+    return InferenceSection(
+        center_chunk=center,
+        chunks=[center, *adjacent],
+        combined_content=" ".join(c.content for c in (center, *adjacent)),
+    )
+
+
+class TestPopulateFileIdsOnSections:
+    def test_stamps_file_id_on_matching_chunk(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        doc_id = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, doc_id, file_id="file-abc")
+
+        section = _make_section(_make_chunk(doc_id))
+        populate_file_ids_on_sections([section], db_session)
+
+        assert section.center_chunk.file_id == "file-abc"
+
+    def test_stamps_file_id_on_all_chunks_in_section(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        """Adjacent chunks for the same doc all share the same file_id so
+        downstream code doesn't care which chunk it inspects."""
+        doc_id = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, doc_id, file_id="file-shared")
+
+        center = _make_chunk(doc_id, chunk_id=5)
+        above = _make_chunk(doc_id, chunk_id=4)
+        below = _make_chunk(doc_id, chunk_id=6)
+        section = _make_section(center, above, below)
+
+        populate_file_ids_on_sections([section], db_session)
+
+        assert all(c.file_id == "file-shared" for c in section.chunks)
+
+    def test_doc_without_file_id_leaves_chunk_unchanged(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        doc_id = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, doc_id, file_id=None)
+
+        section = _make_section(_make_chunk(doc_id))
+        populate_file_ids_on_sections([section], db_session)
+
+        assert section.center_chunk.file_id is None
+
+    def test_unknown_document_leaves_chunk_unchanged(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """Federated hits (Slack, internet) have no `Document` row in
+        Postgres — they should cleanly stay `file_id=None`."""
+        section = _make_section(_make_chunk("nonexistent-doc-id"))
+        populate_file_ids_on_sections([section], db_session)
+
+        assert section.center_chunk.file_id is None
+
+    def test_mixed_batch_only_matches_get_stamped(
+        self,
+        db_session: Session,
+        doc_cleanup: list[str],
+    ) -> None:
+        with_file = f"doc-{uuid4().hex[:8]}"
+        without_file = f"doc-{uuid4().hex[:8]}"
+        _seed_doc(db_session, doc_cleanup, with_file, file_id="file-mixed")
+        _seed_doc(db_session, doc_cleanup, without_file, file_id=None)
+
+        section_a = _make_section(_make_chunk(with_file))
+        section_b = _make_section(_make_chunk(without_file))
+        section_c = _make_section(_make_chunk("nonexistent-id"))
+
+        populate_file_ids_on_sections([section_a, section_b, section_c], db_session)
+
+        assert section_a.center_chunk.file_id == "file-mixed"
+        assert section_b.center_chunk.file_id is None
+        assert section_c.center_chunk.file_id is None
+
+    def test_empty_input_is_noop(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        # Shouldn't raise, shouldn't query the DB meaningfully.
+        populate_file_ids_on_sections([], db_session)
+
+    def test_all_chunks_unknown_shortcircuits_cleanly(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """When no Document rows exist for any chunk, the early-return
+        path skips the per-section mutation loop — just assert nothing
+        explodes and chunks stay None."""
+        sections = [_make_section(_make_chunk(f"ghost-{i}")) for i in range(3)]
+        populate_file_ids_on_sections(sections, db_session)
+        assert all(s.center_chunk.file_id is None for s in sections)

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -1,17 +1,4 @@
-"""Unit tests for the search-result → LLM surface.
-
-Two concerns, one test file — they're the same pipeline end-to-end:
-
-  1. `sandbox_filename_for_document_title` turns a Document title into the
-     sandbox-safe filename used both in the LLM JSON and in the actual
-     `ChatFile` staged to the Python sandbox. It's load-bearing that both
-     paths produce identical names, so we pin the helper here.
-
-  2. `convert_inference_sections_to_llm_string` wraps file-bearing hits
-     with `CODE_INTERPRETER_GUIDANCE` and emits `code_interpreter_file` =
-     the same sanitized filename, so the LLM knows which filename to
-     reference in Python code.
-"""
+"""Unit tests for the search-result → LLM surface."""
 
 import json
 
@@ -20,122 +7,116 @@ import pytest
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
-from onyx.context.search.utils import sandbox_filename_for_document_title
+from onyx.context.search.utils import sandbox_filename_for_document
 from onyx.tools.tool_implementations.utils import CODE_INTERPRETER_GUIDANCE
 from onyx.tools.tool_implementations.utils import (
     convert_inference_sections_to_llm_string,
 )
 
 
-# =============================================================================
-# sandbox_filename_for_document_title
-# =============================================================================
+FID = "550e8400-e29b-41d4-a716-446655440000"
 
 
 class TestSafeTitlePassthrough:
-    def test_plain_name_with_extension_is_preserved(self) -> None:
-        assert sandbox_filename_for_document_title("Q3 Sales.pdf") == "Q3 Sales.pdf"
-
-    def test_extensionless_title_is_preserved_as_is(self) -> None:
-        """No extension gets synthesized — the helper only sanitizes."""
-        assert sandbox_filename_for_document_title("Quarterly Plan") == "Quarterly Plan"
-
-    def test_spaces_and_underscores_are_preserved(self) -> None:
+    def test_plain_name_with_extension(self) -> None:
         assert (
-            sandbox_filename_for_document_title("my_report v2.csv")
-            == "my_report v2.csv"
+            sandbox_filename_for_document("Q3 Sales.pdf", FID) == f"Q3 Sales_{FID}.pdf"
+        )
+
+    def test_extensionless_title(self) -> None:
+        assert (
+            sandbox_filename_for_document("Quarterly Plan", FID)
+            == f"Quarterly Plan_{FID}"
+        )
+
+    def test_spaces_and_underscores_preserved(self) -> None:
+        assert (
+            sandbox_filename_for_document("my_report v2.csv", FID)
+            == f"my_report v2_{FID}.csv"
         )
 
 
 class TestUnsafeCharacterReplacement:
     def test_forward_slash_becomes_underscore(self) -> None:
-        assert sandbox_filename_for_document_title("Q1/Q2 Report") == "Q1_Q2 Report"
+        assert (
+            sandbox_filename_for_document("Q1/Q2 Report", FID) == f"Q1_Q2 Report_{FID}"
+        )
 
     def test_backslash_becomes_underscore(self) -> None:
-        assert sandbox_filename_for_document_title("path\\to\\file") == "path_to_file"
+        assert (
+            sandbox_filename_for_document("path\\to\\file", FID)
+            == f"path_to_file_{FID}"
+        )
 
     def test_colon_becomes_underscore(self) -> None:
-        assert sandbox_filename_for_document_title("Re: meeting") == "Re_ meeting"
+        assert sandbox_filename_for_document("Re: meeting", FID) == f"Re_ meeting_{FID}"
 
     def test_wildcards_and_pipes_replaced(self) -> None:
-        assert sandbox_filename_for_document_title("file*?|<>") == "file_"
+        assert sandbox_filename_for_document("file*?|<>", FID) == f"file__{FID}"
 
     def test_quotes_and_angle_brackets_replaced(self) -> None:
         assert (
-            sandbox_filename_for_document_title('"quoted" <html>') == "_quoted_ _html_"
+            sandbox_filename_for_document('"quoted" <html>', FID)
+            == f"_quoted_ _html__{FID}"
         )
 
     def test_null_byte_replaced(self) -> None:
-        assert sandbox_filename_for_document_title("ok\x00bad") == "ok_bad"
+        assert sandbox_filename_for_document("ok\x00bad", FID) == f"ok_bad_{FID}"
 
     def test_control_chars_replaced(self) -> None:
-        assert sandbox_filename_for_document_title("line\x01\x02\x1fok") == "line_ok"
+        assert (
+            sandbox_filename_for_document("line\x01\x02\x1fok", FID) == f"line_ok_{FID}"
+        )
 
-    def test_consecutive_unsafe_chars_collapse_to_single_underscore(self) -> None:
-        """The regex uses `+`, so runs of unsafe chars produce exactly one `_`."""
-        assert sandbox_filename_for_document_title("a///b\\\\c") == "a_b_c"
+    def test_consecutive_unsafe_chars_collapse(self) -> None:
+        assert sandbox_filename_for_document("a///b\\\\c", FID) == f"a_b_c_{FID}"
 
     def test_path_traversal_is_neutralized(self) -> None:
-        """`../` attacks lose the slash, so the result is just a filename."""
-        result = sandbox_filename_for_document_title("../etc/passwd")
+        result = sandbox_filename_for_document("../etc/passwd", FID)
         assert "/" not in result
-        assert result == "_etc_passwd"
+        assert result == f"_etc_passwd_{FID}"
 
 
 class TestTrimmingAndFallbacks:
     def test_leading_and_trailing_whitespace_stripped(self) -> None:
-        assert sandbox_filename_for_document_title("   report.csv   ") == "report.csv"
+        assert (
+            sandbox_filename_for_document("   report.csv   ", FID)
+            == f"report_{FID}.csv"
+        )
 
     def test_leading_and_trailing_dots_stripped(self) -> None:
-        assert sandbox_filename_for_document_title("...hidden...") == "hidden"
+        assert sandbox_filename_for_document("...hidden...", FID) == f"hidden_{FID}"
 
-    def test_empty_input_returns_document_fallback(self) -> None:
-        assert sandbox_filename_for_document_title("") == "document"
+    def test_empty_input_falls_back_to_document(self) -> None:
+        assert sandbox_filename_for_document("", FID) == f"document_{FID}"
 
-    def test_spaces_only_returns_document_fallback(self) -> None:
-        """Plain spaces aren't matched by the unsafe-char regex, so the
-        subsequent `.strip()` empties the string → fallback."""
-        assert sandbox_filename_for_document_title("     ") == "document"
+    def test_spaces_only_falls_back_to_document(self) -> None:
+        assert sandbox_filename_for_document("     ", FID) == f"document_{FID}"
 
-    def test_only_unsafe_chars_does_not_fall_back_to_document(self) -> None:
-        """Unsafe chars get replaced with underscores BEFORE the empty-check,
-        so a title that's all unsafe chars becomes `_`, not `document`.
-        Same story for whitespace mixed with control chars (tabs are
-        `\\x09` and get replaced, not stripped). Pinned here because the
-        interaction is subtle."""
-        assert sandbox_filename_for_document_title("////") == "_"
-        assert sandbox_filename_for_document_title("   \t  ") == "_"
+    def test_only_unsafe_chars_does_not_fall_back(self) -> None:
+        assert sandbox_filename_for_document("////", FID) == f"__{FID}"
+        assert sandbox_filename_for_document("   \t  ", FID) == f"__{FID}"
 
-    def test_only_dots_returns_document_fallback(self) -> None:
-        """Leading/trailing dot stripping eats the whole string, which
-        triggers the empty-name fallback."""
-        assert sandbox_filename_for_document_title("....") == "document"
+    def test_only_dots_falls_back_to_document(self) -> None:
+        assert sandbox_filename_for_document("....", FID) == f"document_{FID}"
 
 
 class TestLengthCap:
-    def test_long_name_truncated_to_max_length(self) -> None:
-        long_title = "x" * 500
-        result = sandbox_filename_for_document_title(long_title)
+    def test_long_base_truncated_but_file_id_and_ext_preserved(self) -> None:
+        fid = "abc"
+        result = sandbox_filename_for_document("x" * 500 + ".pdf", fid)
         assert len(result) == 200
-        assert result == "x" * 200
+        assert result.endswith(f"_{fid}.pdf")
 
-    def test_just_under_cap_is_unchanged(self) -> None:
-        title = "y" * 200
-        assert sandbox_filename_for_document_title(title) == title
-
-    def test_truncation_ignores_extension(self) -> None:
-        """The cap is a raw char count — extensions aren't protected, so a
-        very long title followed by `.pdf` still gets chopped. Deliberate
-        tradeoff (simplicity over preserving extensions on pathological
-        inputs)."""
-        result = sandbox_filename_for_document_title("x" * 300 + ".pdf")
+    def test_extension_survives_pathological_input(self) -> None:
+        fid = "abc"
+        result = sandbox_filename_for_document("x" * 300 + ".pdf", fid)
         assert len(result) == 200
-        assert not result.endswith(".pdf")
+        assert result.endswith(".pdf")
 
-
-# =============================================================================
-# convert_inference_sections_to_llm_string
-# =============================================================================
+    def test_file_id_never_truncated(self) -> None:
+        result = sandbox_filename_for_document("x" * 500, FID)
+        assert result.endswith(f"_{FID}")
 
 
 def _make_chunk(
@@ -182,7 +163,7 @@ def _make_section(
 
 
 class TestCodeInterpreterFilenameInLLMJson:
-    def test_filename_derived_from_title_when_file_id_present(self) -> None:
+    def test_filename_embeds_file_id_when_present(self) -> None:
         chunk = _make_chunk(
             "doc-a",
             semantic_identifier="Q3 Sales Report.pdf",
@@ -193,10 +174,9 @@ class TestCodeInterpreterFilenameInLLMJson:
         llm_string, _ = convert_inference_sections_to_llm_string([section])
         payload = json.loads(llm_string)
 
-        # Sandbox filename = sanitized title; same helper the staging
-        # pipeline uses, so the LLM-visible name matches the filesystem.
-        assert payload["results"][0]["code_interpreter_file"] == "Q3 Sales Report.pdf"
-        # Internal-only — must not leak into the LLM JSON.
+        assert payload["results"][0]["code_interpreter_file"] == (
+            "Q3 Sales Report_file-abc123.pdf"
+        )
         assert "file_id" not in payload["results"][0]
 
     def test_omitted_when_no_file_id(self) -> None:
@@ -208,25 +188,17 @@ class TestCodeInterpreterFilenameInLLMJson:
 
         assert "code_interpreter_file" not in payload["results"][0]
 
-    def test_title_with_unsafe_chars_is_sanitized(self) -> None:
-        chunk = _make_chunk(
-            "doc-c",
-            semantic_identifier="Report: Q1/Q2 Analysis",
-            file_id="file-xyz",
-        )
-        section = _make_section(chunk)
+    def test_same_title_distinct_file_ids_produce_distinct_names(self) -> None:
+        a = _make_chunk("doc-a", semantic_identifier="Report.pdf", file_id="fid-A")
+        b = _make_chunk("doc-b", semantic_identifier="Report.pdf", file_id="fid-B")
 
-        llm_string, _ = convert_inference_sections_to_llm_string([section])
-        payload = json.loads(llm_string)
-
-        assert payload["results"][0]["code_interpreter_file"] == (
-            "Report_ Q1_Q2 Analysis"
+        llm_string, _ = convert_inference_sections_to_llm_string(
+            [_make_section(a), _make_section(b)]
         )
+        names = [r["code_interpreter_file"] for r in json.loads(llm_string)["results"]]
+        assert names == ["Report_fid-A.pdf", "Report_fid-B.pdf"]
 
     def test_filename_matches_shared_helper(self) -> None:
-        """The serializer must route through the same helper the staging
-        pipeline uses — otherwise the LLM-visible name and the actual
-        sandbox filename can drift apart."""
         title = "Weird/Name*With:Stuff"
         chunk = _make_chunk("doc-d", semantic_identifier=title, file_id="file-match")
         section = _make_section(chunk)
@@ -236,11 +208,9 @@ class TestCodeInterpreterFilenameInLLMJson:
 
         assert payload["results"][0][
             "code_interpreter_file"
-        ] == sandbox_filename_for_document_title(title)
+        ] == sandbox_filename_for_document(title, "file-match")
 
     def test_citation_mapping_unchanged_by_file_presence(self) -> None:
-        """Adding code-interpreter guidance is purely additive — citation
-        numbering still keys off document_id."""
         chunk = _make_chunk(
             "doc-e",
             semantic_identifier="Anything.csv",
@@ -256,8 +226,6 @@ class TestCodeInterpreterFilenameInLLMJson:
 
 
 class TestContentFieldWrappingForFileBearingHits:
-    """The `content` value differs for file-bearing hits vs. ordinary hits."""
-
     def test_file_hit_wraps_content_with_guidance(self) -> None:
         chunk = _make_chunk(
             "doc-f",
@@ -273,18 +241,14 @@ class TestContentFieldWrappingForFileBearingHits:
         payload = json.loads(llm_string)
         content = payload["results"][0]["content"]
 
-        # Content is the guidance template wrapped around the center chunk.
-        # Expanded section content is NOT included (code interpreter is
-        # the better path for the full file).
         expected = CODE_INTERPRETER_GUIDANCE.format(
-            filename="data.csv", content="just the center chunk"
+            filename="data_file-wrap.csv", content="just the center chunk"
         )
         assert content == expected
-        # Concrete properties we care about for LLM steering:
-        assert "data.csv" in content
+        assert "data_file-wrap.csv" in content
         assert "just the center chunk" in content
         assert "code interpreter" in content.lower()
-        assert "PLUS adjacent" not in content  # combined_content suppressed
+        assert "PLUS adjacent" not in content
 
     def test_non_file_hit_uses_combined_content_unchanged(self) -> None:
         chunk = _make_chunk(
@@ -302,9 +266,6 @@ class TestContentFieldWrappingForFileBearingHits:
         assert payload["results"][0]["content"] == "full combined section text here"
 
     def test_guidance_mentions_filename_and_interpreter(self) -> None:
-        """Load-bearing phrasing: the LLM should be able to read the
-        content field and know (1) this is an excerpt, (2) what the real
-        filename is, (3) which tool gets it the full file."""
         chunk = _make_chunk(
             "doc-h",
             semantic_identifier="report.pdf",
@@ -318,9 +279,7 @@ class TestContentFieldWrappingForFileBearingHits:
         content = payload["results"][0]["content"]
 
         assert "excerpt" in content.lower()
-        assert "report.pdf" in content
-        # Whichever exact wording CODE_INTERPRETER_GUIDANCE uses, the
-        # Python code interpreter recommendation must be there.
+        assert "report_file-phrasing.pdf" in content
         assert "python code interpreter" in content.lower()
 
     def test_mixed_batch_only_file_hits_get_guidance(self) -> None:
@@ -339,9 +298,8 @@ class TestContentFieldWrappingForFileBearingHits:
         llm_string, _ = convert_inference_sections_to_llm_string(sections)
         results = json.loads(llm_string)["results"]
 
-        assert "sheet.xlsx" in results[0]["content"]
+        assert "sheet_file-mixed.xlsx" in results[0]["content"]
         assert "code interpreter" in results[0]["content"].lower()
-        # Plain hit carries its combined_content as-is, no guidance text.
         assert results[1]["content"] == "plain combined"
         assert "code_interpreter_file" not in results[1]
 

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -79,7 +79,7 @@ class TestUnsafeCharacterReplacement:
         """`../` attacks lose the slash, so the result is just a filename."""
         result = sandbox_filename_for_document_title("../etc/passwd")
         assert "/" not in result
-        assert result == ".._etc_passwd"
+        assert result == "_etc_passwd"
 
 
 class TestTrimmingAndFallbacks:

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -174,9 +174,7 @@ class TestCodeInterpreterFilenameInLLMJson:
         llm_string, _ = convert_inference_sections_to_llm_string([section])
         payload = json.loads(llm_string)
 
-        assert payload["results"][0]["code_interpreter_file"] == (
-            "Q3 Sales Report_file-abc123.pdf"
-        )
+        assert payload["results"][0]["file_name"] == ("Q3 Sales Report_file-abc123.pdf")
         assert "file_id" not in payload["results"][0]
 
     def test_omitted_when_no_file_id(self) -> None:
@@ -186,7 +184,7 @@ class TestCodeInterpreterFilenameInLLMJson:
         llm_string, _ = convert_inference_sections_to_llm_string([section])
         payload = json.loads(llm_string)
 
-        assert "code_interpreter_file" not in payload["results"][0]
+        assert "file_name" not in payload["results"][0]
 
     def test_same_title_distinct_file_ids_produce_distinct_names(self) -> None:
         a = _make_chunk("doc-a", semantic_identifier="Report.pdf", file_id="fid-A")
@@ -195,7 +193,7 @@ class TestCodeInterpreterFilenameInLLMJson:
         llm_string, _ = convert_inference_sections_to_llm_string(
             [_make_section(a), _make_section(b)]
         )
-        names = [r["code_interpreter_file"] for r in json.loads(llm_string)["results"]]
+        names = [r["file_name"] for r in json.loads(llm_string)["results"]]
         assert names == ["Report_fid-A.pdf", "Report_fid-B.pdf"]
 
     def test_filename_matches_shared_helper(self) -> None:
@@ -206,9 +204,9 @@ class TestCodeInterpreterFilenameInLLMJson:
         llm_string, _ = convert_inference_sections_to_llm_string([section])
         payload = json.loads(llm_string)
 
-        assert payload["results"][0][
-            "code_interpreter_file"
-        ] == sandbox_filename_for_document(title, "file-match")
+        assert payload["results"][0]["file_name"] == sandbox_filename_for_document(
+            title, "file-match"
+        )
 
     def test_citation_mapping_unchanged_by_file_presence(self) -> None:
         chunk = _make_chunk(
@@ -301,7 +299,7 @@ class TestContentFieldWrappingForFileBearingHits:
         assert "sheet_file-mixed.xlsx" in results[0]["content"]
         assert "code interpreter" in results[0]["content"].lower()
         assert results[1]["content"] == "plain combined"
-        assert "code_interpreter_file" not in results[1]
+        assert "file_name" not in results[1]
 
 
 if __name__ == "__main__":

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -8,10 +8,10 @@ from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.utils import sandbox_filename_for_document
-from onyx.tools.tool_implementations.utils import CODE_INTERPRETER_GUIDANCE
 from onyx.tools.tool_implementations.utils import (
     convert_inference_sections_to_llm_string,
 )
+from onyx.tools.tool_implementations.utils import FILE_ASSOCIATED_GUIDANCE
 
 
 FID = "550e8400-e29b-41d4-a716-446655440000"
@@ -239,7 +239,7 @@ class TestContentFieldWrappingForFileBearingHits:
         payload = json.loads(llm_string)
         content = payload["results"][0]["content"]
 
-        expected = CODE_INTERPRETER_GUIDANCE.format(
+        expected = FILE_ASSOCIATED_GUIDANCE.format(
             filename="data_file-wrap.csv", content="just the center chunk"
         )
         assert content == expected

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -1,0 +1,350 @@
+"""Unit tests for the search-result → LLM surface.
+
+Two concerns, one test file — they're the same pipeline end-to-end:
+
+  1. `sandbox_filename_for_document_title` turns a Document title into the
+     sandbox-safe filename used both in the LLM JSON and in the actual
+     `ChatFile` staged to the Python sandbox. It's load-bearing that both
+     paths produce identical names, so we pin the helper here.
+
+  2. `convert_inference_sections_to_llm_string` wraps file-bearing hits
+     with `CODE_INTERPRETER_GUIDANCE` and emits `code_interpreter_file` =
+     the same sanitized filename, so the LLM knows which filename to
+     reference in Python code.
+"""
+
+import json
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import InferenceChunk
+from onyx.context.search.models import InferenceSection
+from onyx.context.search.utils import sandbox_filename_for_document_title
+from onyx.tools.tool_implementations.utils import CODE_INTERPRETER_GUIDANCE
+from onyx.tools.tool_implementations.utils import (
+    convert_inference_sections_to_llm_string,
+)
+
+
+# =============================================================================
+# sandbox_filename_for_document_title
+# =============================================================================
+
+
+class TestSafeTitlePassthrough:
+    def test_plain_name_with_extension_is_preserved(self) -> None:
+        assert sandbox_filename_for_document_title("Q3 Sales.pdf") == "Q3 Sales.pdf"
+
+    def test_extensionless_title_is_preserved_as_is(self) -> None:
+        """No extension gets synthesized — the helper only sanitizes."""
+        assert sandbox_filename_for_document_title("Quarterly Plan") == "Quarterly Plan"
+
+    def test_spaces_and_underscores_are_preserved(self) -> None:
+        assert (
+            sandbox_filename_for_document_title("my_report v2.csv")
+            == "my_report v2.csv"
+        )
+
+
+class TestUnsafeCharacterReplacement:
+    def test_forward_slash_becomes_underscore(self) -> None:
+        assert sandbox_filename_for_document_title("Q1/Q2 Report") == "Q1_Q2 Report"
+
+    def test_backslash_becomes_underscore(self) -> None:
+        assert sandbox_filename_for_document_title("path\\to\\file") == "path_to_file"
+
+    def test_colon_becomes_underscore(self) -> None:
+        assert sandbox_filename_for_document_title("Re: meeting") == "Re_ meeting"
+
+    def test_wildcards_and_pipes_replaced(self) -> None:
+        assert sandbox_filename_for_document_title("file*?|<>") == "file_"
+
+    def test_quotes_and_angle_brackets_replaced(self) -> None:
+        assert (
+            sandbox_filename_for_document_title('"quoted" <html>') == "_quoted_ _html_"
+        )
+
+    def test_null_byte_replaced(self) -> None:
+        assert sandbox_filename_for_document_title("ok\x00bad") == "ok_bad"
+
+    def test_control_chars_replaced(self) -> None:
+        assert sandbox_filename_for_document_title("line\x01\x02\x1fok") == "line_ok"
+
+    def test_consecutive_unsafe_chars_collapse_to_single_underscore(self) -> None:
+        """The regex uses `+`, so runs of unsafe chars produce exactly one `_`."""
+        assert sandbox_filename_for_document_title("a///b\\\\c") == "a_b_c"
+
+    def test_path_traversal_is_neutralized(self) -> None:
+        """`../` attacks lose the slash, so the result is just a filename."""
+        result = sandbox_filename_for_document_title("../etc/passwd")
+        assert "/" not in result
+        assert result == ".._etc_passwd"
+
+
+class TestTrimmingAndFallbacks:
+    def test_leading_and_trailing_whitespace_stripped(self) -> None:
+        assert sandbox_filename_for_document_title("   report.csv   ") == "report.csv"
+
+    def test_leading_and_trailing_dots_stripped(self) -> None:
+        assert sandbox_filename_for_document_title("...hidden...") == "hidden"
+
+    def test_empty_input_returns_document_fallback(self) -> None:
+        assert sandbox_filename_for_document_title("") == "document"
+
+    def test_spaces_only_returns_document_fallback(self) -> None:
+        """Plain spaces aren't matched by the unsafe-char regex, so the
+        subsequent `.strip()` empties the string → fallback."""
+        assert sandbox_filename_for_document_title("     ") == "document"
+
+    def test_only_unsafe_chars_does_not_fall_back_to_document(self) -> None:
+        """Unsafe chars get replaced with underscores BEFORE the empty-check,
+        so a title that's all unsafe chars becomes `_`, not `document`.
+        Same story for whitespace mixed with control chars (tabs are
+        `\\x09` and get replaced, not stripped). Pinned here because the
+        interaction is subtle."""
+        assert sandbox_filename_for_document_title("////") == "_"
+        assert sandbox_filename_for_document_title("   \t  ") == "_"
+
+    def test_only_dots_returns_document_fallback(self) -> None:
+        """Leading/trailing dot stripping eats the whole string, which
+        triggers the empty-name fallback."""
+        assert sandbox_filename_for_document_title("....") == "document"
+
+
+class TestLengthCap:
+    def test_long_name_truncated_to_max_length(self) -> None:
+        long_title = "x" * 500
+        result = sandbox_filename_for_document_title(long_title)
+        assert len(result) == 200
+        assert result == "x" * 200
+
+    def test_just_under_cap_is_unchanged(self) -> None:
+        title = "y" * 200
+        assert sandbox_filename_for_document_title(title) == title
+
+    def test_truncation_ignores_extension(self) -> None:
+        """The cap is a raw char count — extensions aren't protected, so a
+        very long title followed by `.pdf` still gets chopped. Deliberate
+        tradeoff (simplicity over preserving extensions on pathological
+        inputs)."""
+        result = sandbox_filename_for_document_title("x" * 300 + ".pdf")
+        assert len(result) == 200
+        assert not result.endswith(".pdf")
+
+
+# =============================================================================
+# convert_inference_sections_to_llm_string
+# =============================================================================
+
+
+def _make_chunk(
+    document_id: str,
+    semantic_identifier: str | None = None,
+    chunk_id: int = 0,
+    file_id: str | None = None,
+    content: str | None = None,
+) -> InferenceChunk:
+    return InferenceChunk(
+        document_id=document_id,
+        chunk_id=chunk_id,
+        content=content if content is not None else f"content-{document_id}",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=semantic_identifier or f"sem-{document_id}",
+        title=document_id,
+        boost=1,
+        score=0.5,
+        hidden=False,
+        metadata={},
+        match_highlights=[],
+        doc_summary="",
+        chunk_context="",
+        updated_at=None,
+        image_file_id=None,
+        source_links={},
+        section_continuation=False,
+        blurb=f"blurb-{document_id}",
+        file_id=file_id,
+    )
+
+
+def _make_section(
+    chunk: InferenceChunk,
+    combined_content: str | None = None,
+) -> InferenceSection:
+    return InferenceSection(
+        center_chunk=chunk,
+        chunks=[chunk],
+        combined_content=(
+            combined_content if combined_content is not None else chunk.content
+        ),
+    )
+
+
+class TestCodeInterpreterFilenameInLLMJson:
+    def test_filename_derived_from_title_when_file_id_present(self) -> None:
+        chunk = _make_chunk(
+            "doc-a",
+            semantic_identifier="Q3 Sales Report.pdf",
+            file_id="file-abc123",
+        )
+        section = _make_section(chunk)
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+
+        # Sandbox filename = sanitized title; same helper the staging
+        # pipeline uses, so the LLM-visible name matches the filesystem.
+        assert payload["results"][0]["code_interpreter_file"] == "Q3 Sales Report.pdf"
+        # Internal-only — must not leak into the LLM JSON.
+        assert "file_id" not in payload["results"][0]
+
+    def test_omitted_when_no_file_id(self) -> None:
+        chunk = _make_chunk("doc-b", file_id=None)
+        section = _make_section(chunk)
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+
+        assert "code_interpreter_file" not in payload["results"][0]
+
+    def test_title_with_unsafe_chars_is_sanitized(self) -> None:
+        chunk = _make_chunk(
+            "doc-c",
+            semantic_identifier="Report: Q1/Q2 Analysis",
+            file_id="file-xyz",
+        )
+        section = _make_section(chunk)
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+
+        assert payload["results"][0]["code_interpreter_file"] == (
+            "Report_ Q1_Q2 Analysis"
+        )
+
+    def test_filename_matches_shared_helper(self) -> None:
+        """The serializer must route through the same helper the staging
+        pipeline uses — otherwise the LLM-visible name and the actual
+        sandbox filename can drift apart."""
+        title = "Weird/Name*With:Stuff"
+        chunk = _make_chunk("doc-d", semantic_identifier=title, file_id="file-match")
+        section = _make_section(chunk)
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+
+        assert payload["results"][0][
+            "code_interpreter_file"
+        ] == sandbox_filename_for_document_title(title)
+
+    def test_citation_mapping_unchanged_by_file_presence(self) -> None:
+        """Adding code-interpreter guidance is purely additive — citation
+        numbering still keys off document_id."""
+        chunk = _make_chunk(
+            "doc-e",
+            semantic_identifier="Anything.csv",
+            file_id="file-citation",
+        )
+        section = _make_section(chunk)
+
+        _, citation_mapping = convert_inference_sections_to_llm_string(
+            [section], citation_start=42
+        )
+
+        assert citation_mapping == {42: "doc-e"}
+
+
+class TestContentFieldWrappingForFileBearingHits:
+    """The `content` value differs for file-bearing hits vs. ordinary hits."""
+
+    def test_file_hit_wraps_content_with_guidance(self) -> None:
+        chunk = _make_chunk(
+            "doc-f",
+            semantic_identifier="data.csv",
+            file_id="file-wrap",
+            content="just the center chunk",
+        )
+        section = _make_section(
+            chunk, combined_content="center chunk\nPLUS adjacent\nAND MORE"
+        )
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+        content = payload["results"][0]["content"]
+
+        # Content is the guidance template wrapped around the center chunk.
+        # Expanded section content is NOT included (code interpreter is
+        # the better path for the full file).
+        expected = CODE_INTERPRETER_GUIDANCE.format(
+            filename="data.csv", content="just the center chunk"
+        )
+        assert content == expected
+        # Concrete properties we care about for LLM steering:
+        assert "data.csv" in content
+        assert "just the center chunk" in content
+        assert "code interpreter" in content.lower()
+        assert "PLUS adjacent" not in content  # combined_content suppressed
+
+    def test_non_file_hit_uses_combined_content_unchanged(self) -> None:
+        chunk = _make_chunk(
+            "doc-g",
+            content="only this chunk",
+            file_id=None,
+        )
+        section = _make_section(
+            chunk, combined_content="full combined section text here"
+        )
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+
+        assert payload["results"][0]["content"] == "full combined section text here"
+
+    def test_guidance_mentions_filename_and_interpreter(self) -> None:
+        """Load-bearing phrasing: the LLM should be able to read the
+        content field and know (1) this is an excerpt, (2) what the real
+        filename is, (3) which tool gets it the full file."""
+        chunk = _make_chunk(
+            "doc-h",
+            semantic_identifier="report.pdf",
+            file_id="file-phrasing",
+            content="excerpt body",
+        )
+        section = _make_section(chunk)
+
+        llm_string, _ = convert_inference_sections_to_llm_string([section])
+        payload = json.loads(llm_string)
+        content = payload["results"][0]["content"]
+
+        assert "excerpt" in content.lower()
+        assert "report.pdf" in content
+        # Whichever exact wording CODE_INTERPRETER_GUIDANCE uses, the
+        # Python code interpreter recommendation must be there.
+        assert "python code interpreter" in content.lower()
+
+    def test_mixed_batch_only_file_hits_get_guidance(self) -> None:
+        file_chunk = _make_chunk(
+            "doc-i",
+            semantic_identifier="sheet.xlsx",
+            file_id="file-mixed",
+            content="body",
+        )
+        plain_chunk = _make_chunk("doc-j", content="plain", file_id=None)
+        sections = [
+            _make_section(file_chunk, combined_content="file combined"),
+            _make_section(plain_chunk, combined_content="plain combined"),
+        ]
+
+        llm_string, _ = convert_inference_sections_to_llm_string(sections)
+        results = json.loads(llm_string)["results"]
+
+        assert "sheet.xlsx" in results[0]["content"]
+        assert "code interpreter" in results[0]["content"].lower()
+        # Plain hit carries its combined_content as-is, no guidance text.
+        assert results[1]["content"] == "plain combined"
+        assert "code_interpreter_file" not in results[1]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])


### PR DESCRIPTION
## Description
For documents that we receive from internal search, if they have a file id associated with them, we assume that the file should be used instead of injecting the content in.

This PR handles that lifecycle of taking the document, giving the llm guidance and upserting the documents to code interpreter.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stages connector-uploaded files tied to internal search results into the Python sandbox and exposes stable filenames to the model. Adds a Postgres-backed `file_id` enrichment so only eligible files are staged and referenced.

- **New Features**
  - Added `get_document_id_to_file_id_map` and `populate_file_ids_on_sections` to stamp `file_id` onto chunks and surface it on `SearchDoc`; invoked by the search tool after retrieval.
  - Introduced `sandbox_filename_for_document` for safe, deterministic filenames that embed the `file_id` and cap length.
  - Added `build_python_chat_files_from_search_docs` and integrated it in `run_llm_loop` to stage only `CONNECTOR` files; preserves input order, dedupes by `file_id`, skips missing/disallowed files, and avoids filename collisions in `chat_files`.
  - Updated LLM JSON in `convert_inference_sections_to_llm_string` to set `file_name` and wrap `content` with concise interpreter guidance based on the center-chunk excerpt; non-file hits unchanged.

<sup>Written for commit b437d2759e907fae74b2197fd02fd29eea12e049. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



