### PR TITLE
fix(files): Add img generated files to user accessible (#10434) to release v3.2

### DIFF
--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -422,6 +422,9 @@ jobs:
               -e ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=false \
               -e REDIS_HOST=cache \
               -e API_SERVER_HOST=api_server \
+              -e S3_ENDPOINT_URL=http://minio:9000 \
+              -e S3_AWS_ACCESS_KEY_ID=minioadmin \
+              -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
               -e OPENAI_API_KEY=${OPENAI_API_KEY} \
               -e EXA_API_KEY=${EXA_API_KEY} \
               -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -15,6 +15,7 @@ from onyx.db.models import ChatSessionSharedStatus
 from onyx.db.models import FileRecord
 from onyx.db.models import Persona
 from onyx.db.models import Project__UserFile
+from onyx.db.models import ToolCall
 from onyx.db.models import UserFile
 
 
@@ -137,6 +138,9 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
     - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
       session the user owns or a session publicly shared via
       `ChatSessionSharedStatus.PUBLIC`.
+    - The `file_id` appears in a `ToolCall.generated_images` entry on a chat
+      session the user owns or a publicly shared session (image-generation
+      outputs are persisted there, not on `ChatMessage.files`).
     """
     owns_user_file = db_session.query(
         select(UserFile.id)
@@ -178,7 +182,22 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
         )
         .limit(1)
     )
-    return db_session.execute(chat_file_stmt).first() is not None
+    if db_session.execute(chat_file_stmt).first() is not None:
+        return True
+
+    generated_image_stmt = (
+        select(ToolCall.id)
+        .join(ChatSession, ToolCall.chat_session_id == ChatSession.id)
+        .where(ToolCall.generated_images.op("@>")([{"file_id": file_id}]))
+        .where(
+            or_(
+                ChatSession.user_id == user_id,
+                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
+            )
+        )
+        .limit(1)
+    )
+    return db_session.execute(generated_image_stmt).first() is not None
 
 
 def get_file_ids_by_user_file_ids(

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -2,14 +2,25 @@
 This file tests user file permissions in different scenarios:
 1. Public assistant with user files - files should be accessible to all users
 2. Direct file access - user files should NOT be accessible by users who don't own them
+3. Image-generation tool outputs - files persisted on `ToolCall.generated_images`
+   must be downloadable by the chat session owner (and by anyone if the session
+   is publicly shared), but not by other users on private sessions.
 """
 
 import io
 from typing import NamedTuple
+from uuid import UUID
+from uuid import uuid4
 
 import pytest
 import requests
 
+from onyx.configs.constants import FileOrigin
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import ChatSessionSharedStatus
+from onyx.db.models import ChatSession
+from onyx.db.models import ToolCall
+from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import FileDescriptor
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.managers.chat import ChatSessionManager
@@ -17,6 +28,7 @@ from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestChatSession
 from tests.integration.common_utils.test_models import DATestPersona
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -149,3 +161,140 @@ def test_cannot_download_other_users_file_via_chat_file_endpoint(
             f"when fetching file_id={file_id}"
         )
         assert user2_response.content != owner_response.content
+
+
+# -----------------------------------------------------------------------------
+# Image-generation tool output access checks
+#
+# Image-generation results are persisted on `ToolCall.generated_images` (JSONB),
+# *not* on `ChatMessage.files`. The hardening commit `a7a5b66d6` added an
+# authorization gate to `GET /chat/file/{file_id}` that did not know about that
+# column, so previously-rendered images started returning 404 on chat reload.
+# These tests pin the post-fix behavior end-to-end.
+# -----------------------------------------------------------------------------
+
+
+_IMAGE_GEN_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"image-gen-test-bytes"
+
+
+class ImageGenSetup(NamedTuple):
+    owner: DATestUser
+    intruder: DATestUser
+    chat_session: DATestChatSession
+    file_id: str
+
+
+def _seed_image_gen_tool_call(chat_session_id: UUID) -> str:
+    """Persist a fake image to the file store and link it via a ToolCall row,
+    mirroring what `ImageGenerationTool` produces at runtime."""
+    file_store = get_default_file_store()
+    file_id = file_store.save_file(
+        content=io.BytesIO(_IMAGE_GEN_PNG_BYTES),
+        display_name="GeneratedImage",
+        file_origin=FileOrigin.CHAT_IMAGE_GEN,
+        file_type="image/png",
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        tool_call = ToolCall(
+            chat_session_id=chat_session_id,
+            parent_chat_message_id=None,
+            parent_tool_call_id=None,
+            turn_number=0,
+            tab_index=0,
+            tool_id=0,
+            tool_call_id=uuid4().hex,
+            tool_call_arguments={},
+            tool_call_response="",
+            tool_call_tokens=0,
+            generated_images=[
+                {
+                    "file_id": file_id,
+                    "url": f"/api/chat/file/{file_id}",
+                    "revised_prompt": "a cat",
+                    "shape": "square",
+                }
+            ],
+        )
+        db_session.add(tool_call)
+        db_session.commit()
+
+    return file_id
+
+
+@pytest.fixture
+def image_gen_setup(reset: None) -> ImageGenSetup:  # noqa: ARG001
+    """Owner with a chat session that has an image-generation tool output."""
+    owner: DATestUser = UserManager.create(name="img_gen_owner")
+    intruder: DATestUser = UserManager.create(name="img_gen_intruder")
+    LLMProviderManager.create(user_performing_action=owner)
+
+    chat_session = ChatSessionManager.create(
+        user_performing_action=owner,
+        description="image gen permission test",
+    )
+    file_id = _seed_image_gen_tool_call(UUID(str(chat_session.id)))
+    return ImageGenSetup(
+        owner=owner,
+        intruder=intruder,
+        chat_session=chat_session,
+        file_id=file_id,
+    )
+
+
+def test_owner_can_download_image_gen_file(
+    image_gen_setup: ImageGenSetup,
+) -> None:
+    """The chat session owner must be able to fetch an image-gen file_id stored
+    on `ToolCall.generated_images`. Pre-fix, this returned 404 — that 404 is
+    the exact regression these tests pin."""
+    response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{image_gen_setup.file_id}",
+        headers=image_gen_setup.owner.headers,
+    )
+    assert response.status_code == 200, (
+        f"Owner should receive image-gen file, got {response.status_code}: "
+        f"{response.text}"
+    )
+    assert response.content == _IMAGE_GEN_PNG_BYTES
+
+
+def test_non_owner_cannot_download_image_gen_file_in_private_session(
+    image_gen_setup: ImageGenSetup,
+) -> None:
+    """A non-owner must not be able to read an image-gen file in a PRIVATE
+    session — the new branch should not over-grant access."""
+    response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{image_gen_setup.file_id}",
+        headers=image_gen_setup.intruder.headers,
+    )
+    assert response.status_code in (403, 404), (
+        f"Non-owner should be denied on a private session, got "
+        f"{response.status_code}: {response.text}"
+    )
+    assert response.content != _IMAGE_GEN_PNG_BYTES
+
+
+def test_non_owner_can_download_image_gen_file_in_public_session(
+    image_gen_setup: ImageGenSetup,
+) -> None:
+    """When the chat session is publicly shared, any authenticated user must
+    be able to fetch its image-gen outputs — mirrors the existing
+    `ChatMessage.files` public-share branch."""
+    with get_session_with_current_tenant() as db_session:
+        chat_session = db_session.get(
+            ChatSession, UUID(str(image_gen_setup.chat_session.id))
+        )
+        assert chat_session is not None
+        chat_session.shared_status = ChatSessionSharedStatus.PUBLIC
+        db_session.commit()
+
+    response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{image_gen_setup.file_id}",
+        headers=image_gen_setup.intruder.headers,
+    )
+    assert response.status_code == 200, (
+        f"Non-owner should be able to read image-gen file on public session, "
+        f"got {response.status_code}: {response.text}"
+    )
+    assert response.content == _IMAGE_GEN_PNG_BYTES


### PR DESCRIPTION
Cherry-pick of commit 688b7a5f4535b5bb3fc83058fd254dac073eab8c to release/v3.2 branch.

Original PR: #10434

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat file access to include image-generation outputs stored in `ToolCall.generated_images`, so owners (and public sessions) can download generated images instead of getting 404s.

- **Bug Fixes**
  - Extend `user_can_access_chat_file` to allow access when `file_id` is in `ToolCall.generated_images` for the session owner or when the session is public.
  - Add integration tests covering owner access, denial for non-owners on private sessions, and access for public sessions.
  - Configure integration tests to use MinIO by setting `S3_ENDPOINT_URL`, `S3_AWS_ACCESS_KEY_ID`, and `S3_AWS_SECRET_ACCESS_KEY` in CI.

<sup>Written for commit 19386ea1699de4be034135fdf1610f4a206d92b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

