### PR TITLE
fix: preserve DCR fields on server update

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -113,16 +113,25 @@ def _resolve_oauth_credentials(
     frontend flags a field as changed, take the request value as-is, but
     defensively reject masked placeholders so a buggy client can't write
     a mask to the database.
+
+    When there is no stored client yet (`existing_client is None`), an
+    unchanged flag means the user did not edit since load — still use the
+    request body (`_connect_oauth` runs after upsert with the same payload).
+    Treating unchanged plus no storage as None would rebuild empty OAuth config.
     """
     resolved_id = request_client_id
     if not request_client_id_changed:
-        resolved_id = existing_client.client_id if existing_client else None
+        resolved_id = (
+            existing_client.client_id if existing_client else request_client_id
+        )
     elif resolved_id:
         reject_masked_credentials({"oauth_client_id": resolved_id})
 
     resolved_secret = request_client_secret
     if not request_client_secret_changed:
-        resolved_secret = existing_client.client_secret if existing_client else None
+        resolved_secret = (
+            existing_client.client_secret if existing_client else request_client_secret
+        )
     elif resolved_secret:
         reject_masked_credentials({"oauth_client_secret": resolved_secret})
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -205,6 +205,15 @@ def _build_oauth_admin_config_data_for_update(
     merged.client_secret = client_secret
     merged.redirect_uris = [AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")]
     merged.scope = REQUESTED_SCOPE  # TODO(evan): allow specifying scopes?
+    # Heal stale records that were seeded before `_upsert_mcp_server` always
+    # set `token_endpoint_auth_method`. The SDK silently omits the client
+    # secret on token exchange when this is None, which manifests as
+    # `invalid_client` from the IdP. Preserve any explicitly-negotiated
+    # method (e.g. DCR's `client_secret_basic`).
+    if merged.token_endpoint_auth_method is None:
+        merged.token_endpoint_auth_method = (
+            "client_secret_post" if client_secret else "none"
+        )
 
     config_data = MCPConnectionData(headers={})
     config_data[MCPOAuthKeys.CLIENT_INFO.value] = merged.model_dump(mode="json")
@@ -1647,20 +1656,13 @@ def _upsert_mcp_server(
             # Create initial admin config. If client credentials were provided,
             # seed client_info so the OAuth provider can skip dynamic
             # registration; otherwise, the provider will attempt it.
-            cfg: MCPConnectionData = MCPConnectionData(headers={})
-            if request.oauth_client_id:
-                client_info = OAuthClientInformationFull(
-                    client_id=request.oauth_client_id,
-                    client_secret=request.oauth_client_secret,
-                    redirect_uris=[AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")],
-                    grant_types=["authorization_code", "refresh_token"],
-                    response_types=["code"],
-                    scope=REQUESTED_SCOPE,  # TODO: allow specifying scopes?
-                    # default token_endpoint_auth_method is client_secret_post
-                )
-                cfg[MCPOAuthKeys.CLIENT_INFO.value] = client_info.model_dump(
-                    mode="json"
-                )
+            # NOTE: must go through the shared helper so
+            # `token_endpoint_auth_method` matches what `_connect_oauth`'s
+            # update path expects to preserve later.
+            cfg: MCPConnectionData = _build_oauth_admin_config_data(
+                client_id=request.oauth_client_id,
+                client_secret=request.oauth_client_secret,
+            )
 
             admin_config = create_connection_config(
                 config_data=cfg,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -158,6 +158,50 @@ def _build_oauth_admin_config_data(
     return config_data
 
 
+def _build_oauth_admin_config_data_for_update(
+    *,
+    client_id: str | None,
+    client_secret: str | None,
+    existing_client: OAuthClientInformationFull,
+) -> MCPConnectionData:
+    """Construct the admin connection config payload for an OAuth client
+    that already has a stored `client_info`, preserving provider-managed
+    fields (DCR registration token, expiry timestamps, negotiated auth
+    method, etc.) wherever possible.
+
+    When `client_id` matches the stored client_id, the merged payload
+    starts from `existing_client` and only overwrites the admin-managed
+    fields (`client_secret`, `redirect_uris`, `scope`). When `client_id`
+    differs, the admin is pointing at a brand-new OAuth registration so
+    the old DCR metadata is stale; we fall back to the template path.
+    """
+    if not client_id:
+        # No id means we have nothing to seed client_info with; matches
+        # the template-path behavior of returning an empty config so the
+        # OAuth provider can attempt DCR.
+        return _build_oauth_admin_config_data(
+            client_id=client_id, client_secret=client_secret
+        )
+
+    if existing_client.client_id != client_id:
+        logger.info(
+            "OAuth client_id changed for existing MCP server; discarding "
+            "stored DCR registration metadata and starting fresh."
+        )
+        return _build_oauth_admin_config_data(
+            client_id=client_id, client_secret=client_secret
+        )
+
+    merged = existing_client.model_copy(deep=True)
+    merged.client_secret = client_secret
+    merged.redirect_uris = [AnyUrl(f"{WEB_DOMAIN}/mcp/oauth/callback")]
+    merged.scope = REQUESTED_SCOPE  # TODO(evan): allow specifying scopes?
+
+    config_data = MCPConnectionData(headers={})
+    config_data[MCPOAuthKeys.CLIENT_INFO.value] = merged.model_dump(mode="json")
+    return config_data
+
+
 router = APIRouter(prefix="/mcp")
 admin_router = APIRouter(prefix="/admin/mcp")
 STATE_TTL_SECONDS = 60 * 5  # 5 minutes
@@ -478,9 +522,21 @@ async def _connect_oauth(
         existing_client=existing_client,
     )
 
-    config_data = _build_oauth_admin_config_data(
-        client_id=request.oauth_client_id,
-        client_secret=request.oauth_client_secret,
+    # When we already have a stored `client_info`, merge into it so we
+    # preserve any provider-managed fields (DCR registration token,
+    # `client_secret_expires_at`, negotiated `token_endpoint_auth_method`,
+    # etc.) that the hardcoded template would otherwise drop.
+    config_data = (
+        _build_oauth_admin_config_data_for_update(
+            client_id=request.oauth_client_id,
+            client_secret=request.oauth_client_secret,
+            existing_client=existing_client,
+        )
+        if existing_client is not None
+        else _build_oauth_admin_config_data(
+            client_id=request.oauth_client_id,
+            client_secret=request.oauth_client_secret,
+        )
     )
 
     if mcp_server.admin_connection_config_id is None:

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
@@ -361,6 +361,31 @@ class TestBuildOAuthAdminConfigDataForUpdate:
         assert client_info_dict["client_secret"] == "newly-typed-secret"
         assert client_info_dict["token_endpoint_auth_method"] == "none"
 
+    def test_stale_none_auth_method_is_healed_from_secret_presence(self) -> None:
+        # Before the helper enforced `token_endpoint_auth_method`, records
+        # could be persisted with it as None. The SDK silently omits the
+        # client secret on token exchange in that case, which manifests as
+        # `invalid_client` from the IdP. The merge path heals these records
+        # by deriving the method from the resolved client_secret.
+        existing = OAuthClientInformationFull(
+            client_id="legacy-id",
+            client_secret="legacy-secret",
+            redirect_uris=[AnyUrl("https://example.com/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method=None,
+        )
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="legacy-id",
+            client_secret="legacy-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["token_endpoint_auth_method"] == "client_secret_post"
+
     def test_redirect_uris_and_scope_are_refreshed_from_defaults(self) -> None:
         # The admin-managed fields (redirect_uris, scope) should always be
         # rewritten from our deployment config, not preserved from the

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
@@ -7,14 +7,21 @@ credential field as unchanged, the backend reuses the stored value instead of
 overwriting it with whatever (likely masked) string the form replayed.
 """
 
+from typing import Literal
+
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull
 from pydantic import AnyUrl
 
 from onyx.server.features.mcp.api import _build_oauth_admin_config_data
+from onyx.server.features.mcp.api import _build_oauth_admin_config_data_for_update
 from onyx.server.features.mcp.api import _resolve_oauth_credentials
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.utils.encryption import mask_string
+
+TokenEndpointAuthMethod = Literal[
+    "none", "client_secret_post", "client_secret_basic", "private_key_jwt"
+]
 
 
 def _make_existing_client(
@@ -29,6 +36,37 @@ def _make_existing_client(
         grant_types=["authorization_code", "refresh_token"],
         response_types=["code"],
         token_endpoint_auth_method=("client_secret_post" if client_secret else "none"),
+    )
+
+
+def _make_dcr_registered_client(
+    *,
+    client_id: str = "dcr-client-id",
+    client_secret: str | None = "dcr-client-secret",
+    token_endpoint_auth_method: TokenEndpointAuthMethod = "client_secret_basic",
+) -> OAuthClientInformationFull:
+    """Build a client_info that looks like a real DCR response — with the
+    provider-managed fields the merge helper is responsible for preserving.
+
+    NOTE: the MCP SDK's `OAuthClientInformationFull` only models a subset of
+    the DCR response (RFC 7591). RFC 7592 fields like `registration_access_token`
+    and `registration_client_uri` are not on the model and are silently
+    dropped at validate time. The merge helper can therefore only preserve
+    fields that the SDK actually models — primarily `client_id_issued_at`,
+    `client_secret_expires_at`, the negotiated `token_endpoint_auth_method`,
+    and metadata like `client_name`.
+    """
+    return OAuthClientInformationFull(
+        client_id=client_id,
+        client_secret=client_secret,
+        client_id_issued_at=1_700_000_000,
+        client_secret_expires_at=1_900_000_000,
+        client_name="DCR Registered Client",
+        redirect_uris=[AnyUrl("https://idp.example.com/legacy-callback")],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+        token_endpoint_auth_method=token_endpoint_auth_method,
+        scope="openid profile",
     )
 
 
@@ -205,3 +243,147 @@ class TestBuildOAuthAdminConfigData:
         assert client_info_dict["client_id"] == "confidential-id"
         assert client_info_dict["client_secret"] == "confidential-secret"
         assert client_info_dict["token_endpoint_auth_method"] == "client_secret_post"
+
+
+class TestBuildOAuthAdminConfigDataForUpdate:
+    """Tests for the merge variant that preserves provider-managed fields
+    (`client_id_issued_at`, `client_secret_expires_at`,
+    `token_endpoint_auth_method`, etc.) when re-saving OAuth config.
+
+    See `plans/mcp-oauth-resubmit-preserve-client-info.md`.
+    """
+
+    def test_only_client_secret_changed_preserves_dcr_metadata(self) -> None:
+        existing = _make_dcr_registered_client(
+            client_id="dcr-id",
+            client_secret="old-secret",
+            token_endpoint_auth_method="client_secret_basic",
+        )
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="dcr-id",
+            client_secret="new-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        # admin-managed fields reflect the update
+        assert client_info_dict["client_id"] == "dcr-id"
+        assert client_info_dict["client_secret"] == "new-secret"
+        # provider-managed fields are preserved
+        assert client_info_dict["client_id_issued_at"] == 1_700_000_000
+        assert client_info_dict["client_secret_expires_at"] == 1_900_000_000
+        assert client_info_dict["token_endpoint_auth_method"] == "client_secret_basic"
+        assert client_info_dict["client_name"] == "DCR Registered Client"
+
+    def test_client_id_changed_discards_dcr_metadata(self) -> None:
+        existing = _make_dcr_registered_client(
+            client_id="old-dcr-id",
+            client_secret="old-secret",
+            token_endpoint_auth_method="client_secret_basic",
+        )
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="brand-new-id",
+            client_secret="brand-new-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["client_id"] == "brand-new-id"
+        assert client_info_dict["client_secret"] == "brand-new-secret"
+        # DCR metadata tied to the OLD client_id is stale; we should start
+        # fresh from the template.
+        assert client_info_dict.get("client_id_issued_at") is None
+        assert client_info_dict.get("client_secret_expires_at") is None
+        assert client_info_dict.get("client_name") is None
+        # Template path negotiates auth method based on secret presence.
+        assert client_info_dict["token_endpoint_auth_method"] == "client_secret_post"
+
+    def test_existing_without_dcr_metadata_resubmit_succeeds(self) -> None:
+        # Manually-entered confidential client with no provider-managed
+        # fields to preserve: the merge path should still cleanly update
+        # the secret without erroring out.
+        existing = _make_existing_client(
+            client_id="manual-id",
+            client_secret="old-secret",
+        )
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="manual-id",
+            client_secret="new-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["client_id"] == "manual-id"
+        assert client_info_dict["client_secret"] == "new-secret"
+        assert client_info_dict["token_endpoint_auth_method"] == "client_secret_post"
+        assert client_info_dict.get("client_id_issued_at") is None
+
+    def test_no_client_id_returns_empty_config(self) -> None:
+        # A resubmit that clears the client_id (e.g., admin wants to fall
+        # back to DCR) collapses to the template's empty-config behavior
+        # rather than carrying the merged dict forward with a None id.
+        existing = _make_dcr_registered_client(client_id="dcr-id")
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id=None,
+            client_secret=None,
+            existing_client=existing,
+        )
+
+        assert config_data == {"headers": {}}
+        assert MCPOAuthKeys.CLIENT_INFO.value not in config_data
+
+    def test_public_to_confidential_keeps_negotiated_auth_method(self) -> None:
+        # Existing registration was negotiated as a public client
+        # (token_endpoint_auth_method="none"). Admin types a brand-new
+        # secret without changing the client_id. The provider-negotiated
+        # auth method is preserved verbatim — admin must explicitly
+        # re-register the client with the IdP to switch flows.
+        existing = _make_dcr_registered_client(
+            client_id="public-id",
+            client_secret=None,
+            token_endpoint_auth_method="none",
+        )
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="public-id",
+            client_secret="newly-typed-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        assert client_info_dict["client_id"] == "public-id"
+        assert client_info_dict["client_secret"] == "newly-typed-secret"
+        assert client_info_dict["token_endpoint_auth_method"] == "none"
+
+    def test_redirect_uris_and_scope_are_refreshed_from_defaults(self) -> None:
+        # The admin-managed fields (redirect_uris, scope) should always be
+        # rewritten from our deployment config, not preserved from the
+        # stored value — otherwise we'd be stuck with whatever a
+        # mis-deployed callback URL was originally registered as.
+        existing = _make_dcr_registered_client(client_id="dcr-id")
+
+        config_data = _build_oauth_admin_config_data_for_update(
+            client_id="dcr-id",
+            client_secret="new-secret",
+            existing_client=existing,
+        )
+
+        client_info_dict = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        assert client_info_dict is not None
+        # redirect_uris was overwritten from our WEB_DOMAIN-derived default
+        assert client_info_dict["redirect_uris"] != [
+            "https://idp.example.com/legacy-callback"
+        ]
+        assert any(
+            "/mcp/oauth/callback" in str(u) for u in client_info_dict["redirect_uris"]
+        )
+        # scope is reset to REQUESTED_SCOPE (currently None)
+        assert client_info_dict.get("scope") is None

--- a/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_oauth_credentials_resolver.py
@@ -178,11 +178,9 @@ class TestResolveOAuthCredentials:
             )
 
     def test_no_existing_client_passes_request_values_through(self) -> None:
-        # Create flow: nothing is stored yet; both flags are False (the default)
-        # but there's nothing to fall back to. The resolver should resolve to
-        # None for both fields, leaving the caller to handle the create path
-        # explicitly (which `_upsert_mcp_server` does by only invoking the
-        # resolver when an `existing_client` is present).
+        # Nothing stored yet but the form replayed defaults (both *_changed False).
+        # `_connect_oauth` always runs the resolver; we must keep the submitted
+        # credentials so OAuth config is not rebuilt empty after upsert.
         resolved_id, resolved_secret = _resolve_oauth_credentials(
             request_client_id="user-typed-id",
             request_client_id_changed=False,
@@ -191,8 +189,8 @@ class TestResolveOAuthCredentials:
             existing_client=None,
         )
 
-        assert resolved_id is None
-        assert resolved_secret is None
+        assert resolved_id == "user-typed-id"
+        assert resolved_secret == "user-typed-secret"
 
     def test_no_existing_client_with_changed_flags_uses_request_values(self) -> None:
         resolved_id, resolved_secret = _resolve_oauth_credentials(


### PR DESCRIPTION
## Description

When an admin resaved OAuth credentials for an existing MCP server (e.g., rotated the client_secret), the backend rebuilt client_info from a hardcoded template and silently dropped every field the OAuth provider had previously negotiated: token_endpoint_auth_method, client_id_issued_at, client_secret_expires_at, client_name, etc. The next OAuth handshake could then fail (e.g., providers that registered the client as client_secret_basic would reject our subsequent client_secret_post exchange).

This PR adds a merge variant of the config builder that preserves provider-managed fields when the client_id is unchanged, and falls back to the template path when the client_id differs (a brand-new registration → old metadata is stale).

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OAuth DCR client metadata when re-saving MCP server credentials and keeps submitted credentials on first save, preventing empty configs and failed handshakes. Also heals stale `token_endpoint_auth_method` values to avoid invalid_client errors.

- **Bug Fixes**
  - Added a merge builder that starts from stored `client_info`, preserves provider-managed fields, refreshes `redirect_uris`/`scope` when `client_id` is unchanged, and heals missing `token_endpoint_auth_method` based on secret presence.
  - Updated the server update path to use the merge builder when an existing client is present; create/upsert now uses the shared template builder to keep defaults consistent.
  - Fixed the credentials resolver to pass through submitted `client_id`/`client_secret` when no stored client exists, even if flags are “unchanged”; still rejects masked placeholders.
  - Expanded tests to cover first-save pass-through, unchanged vs. changed `client_id`, public→confidential cases, redirect URI/scope refresh, DCR metadata preservation, and healing of `token_endpoint_auth_method=None`.

<sup>Written for commit 331df58630b67508a0e4209ae7063cc7ad37ff81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

