### PR TITLE
fix(llm): Fields unexpectedly None in llm model object

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -669,10 +669,12 @@ def get_bedrock_token_limit(model_id: str) -> int:
         for key in [f"bedrock/{model_id}", model_id]:
             if key in model_map:
                 model_info = model_map[key]
-                if "max_input_tokens" in model_info:
-                    return model_info["max_input_tokens"]
-                if "max_tokens" in model_info:
-                    return model_info["max_tokens"]
+                max_input_tokens = model_info.get("max_input_tokens")
+                if max_input_tokens is not None:
+                    return max_input_tokens
+                max_tokens = model_info.get("max_tokens")
+                if max_tokens is not None:
+                    return max_tokens
     except Exception:
         pass  # Fall through to mapping
 

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -563,8 +563,6 @@ def get_llm_max_output_tokens(
         )
         return default_output_tokens
 
-    # LiteLLM may include the keys with a literal `None` value, so check the
-    # value rather than just key presence and fall through to the next option.
     max_output_tokens = model_obj.get("max_output_tokens")
     if max_output_tokens is not None:
         return max_output_tokens

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -531,11 +531,13 @@ def llm_max_input_tokens(
         )
         return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 
-    if "max_input_tokens" in model_obj:
-        return model_obj["max_input_tokens"]
+    max_input_tokens = model_obj.get("max_input_tokens")
+    if max_input_tokens is not None:
+        return max_input_tokens
 
-    if "max_tokens" in model_obj:
-        return model_obj["max_tokens"]
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return max_tokens
 
     logger.warning(
         f"No max tokens found for '{model_name}'. Falling back to {GEN_AI_MODEL_FALLBACK_MAX_TOKENS} tokens."
@@ -561,12 +563,16 @@ def get_llm_max_output_tokens(
         )
         return default_output_tokens
 
-    if "max_output_tokens" in model_obj:
-        return model_obj["max_output_tokens"]
+    # LiteLLM may include the keys with a literal `None` value, so check the
+    # value rather than just key presence and fall through to the next option.
+    max_output_tokens = model_obj.get("max_output_tokens")
+    if max_output_tokens is not None:
+        return max_output_tokens
 
     # Fallback to a fraction of max_tokens if max_output_tokens is not specified
-    if "max_tokens" in model_obj:
-        return int(model_obj["max_tokens"] * 0.1)
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return int(max_tokens * 0.1)
 
     logger.warning(
         f"No max output tokens found for '{model_name}'. Falling back to {default_output_tokens} output tokens."

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -21,10 +21,9 @@ def explicit_tool_calling_supported(model_provider: str, model_name: str) -> boo
         model_name=model_name,
     )
 
-    model_supports = (
-        model_obj.get("supports_function_calling", False) if model_obj else False
-    )
-    return model_supports
+    if not model_obj:
+        return False
+    return bool(model_obj.get("supports_function_calling"))
 
 
 def compute_tool_tokens(tool: Tool, llm_tokenizer: BaseTokenizer) -> int:


### PR DESCRIPTION
## Description
We get a model object from litellm internals. There are functions that return defined types and we assume those types to be correct. However, since the litellm internals sometimes are set to None, this results in us returning None instead of the type we expect. This leads to more upstream issues.

## How Has This Been Tested?
None :(

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cases where `litellm` model objects include None-valued fields that leaked into token limit calculations and tool support checks. We now ignore None values and use safe fallbacks to prevent errors.

- **Bug Fixes**
  - Read `max_input_tokens`, `max_tokens`, and `max_output_tokens` via `.get(...)` and only use them when not None; fallback to defaults or 10% of `max_tokens`.
  - Apply the same None-aware checks in Bedrock token limit lookup for both `bedrock/{model_id}` and `{model_id}` keys.
  - In tool utils, return False when the model is missing and coerce `supports_function_calling` to `bool`.

<sup>Written for commit 549684768b9978b1b73283b50954f8b89c0d30a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

