### PR TITLE
feat: Admin page cleanup

### DIFF
--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -47,6 +47,9 @@ interface MessageCardBaseProps {
    */
   bottomChildren?: React.ReactNode;
 
+  /** Vertically center the icon/title and right-side actions. @default false */
+  centered?: boolean;
+
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -126,6 +129,7 @@ function MessageCard({
   description,
   padding = "sm",
   headerPadding = "fit",
+  centered,
   bottomChildren,
   rightChildren,
   onClose,
@@ -163,6 +167,7 @@ function MessageCard({
           sizePreset="main-ui"
           variant="section"
           padding="md"
+          centered={centered}
           rightChildren={right}
         />
       </div>

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -47,9 +47,6 @@ interface MessageCardBaseProps {
    */
   bottomChildren?: React.ReactNode;
 
-  /** Vertically center the icon/title and right-side actions. @default false */
-  center?: boolean;
-
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -129,7 +126,6 @@ function MessageCard({
   description,
   padding = "sm",
   headerPadding = "fit",
-  center,
   bottomChildren,
   rightChildren,
   onClose,
@@ -167,7 +163,6 @@ function MessageCard({
           sizePreset="main-ui"
           variant="section"
           padding="md"
-          center={center}
           rightChildren={right}
         />
       </div>

--- a/web/lib/opal/src/components/cards/message-card/components.tsx
+++ b/web/lib/opal/src/components/cards/message-card/components.tsx
@@ -48,7 +48,7 @@ interface MessageCardBaseProps {
   bottomChildren?: React.ReactNode;
 
   /** Vertically center the icon/title and right-side actions. @default false */
-  centered?: boolean;
+  center?: boolean;
 
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
@@ -129,7 +129,7 @@ function MessageCard({
   description,
   padding = "sm",
   headerPadding = "fit",
-  centered,
+  center,
   bottomChildren,
   rightChildren,
   onClose,
@@ -167,7 +167,7 @@ function MessageCard({
           sizePreset="main-ui"
           variant="section"
           padding="md"
-          centered={centered}
+          center={center}
           rightChildren={right}
         />
       </div>

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -30,7 +30,7 @@ type ContentActionProps = ContentProps & {
    *
    * @default false
    */
-  centered?: boolean;
+  center?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -65,13 +65,13 @@ type ContentActionProps = ContentProps & {
 function ContentAction({
   rightChildren,
   padding = "lg",
-  centered = false,
+  center = false,
   ...contentProps
 }: ContentActionProps) {
   const { padding: paddingClass } = containerSizeVariants[padding];
 
   return (
-    <div className="opal-content-action" data-centered={centered || undefined}>
+    <div className="opal-content-action" data-centered={center || undefined}>
       <div className={cn("opal-content-action-content", paddingClass)}>
         <Content {...contentProps} />
       </div>

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -1,3 +1,4 @@
+import "@opal/layouts/content-action/styles.css";
 import { Content, type ContentProps } from "@opal/layouts/content/components";
 import {
   containerSizeVariants,
@@ -70,30 +71,12 @@ function ContentAction({
   const { padding: paddingClass } = containerSizeVariants[padding];
 
   return (
-    <div
-      className={cn(
-        "flex flex-row w-full",
-        centered ? "items-center" : "items-stretch"
-      )}
-    >
-      <div
-        className={cn(
-          "flex-1 min-w-0",
-          centered ? "self-center" : "self-start",
-          paddingClass
-        )}
-      >
+    <div className="opal-content-action" data-centered={centered || undefined}>
+      <div className={cn("opal-content-action-content", paddingClass)}>
         <Content {...contentProps} />
       </div>
       {rightChildren && (
-        <div
-          className={cn(
-            "flex shrink-0",
-            centered ? "items-center" : "items-stretch"
-          )}
-        >
-          {rightChildren}
-        </div>
+        <div className="opal-content-action-right">{rightChildren}</div>
       )}
     </div>
   );

--- a/web/lib/opal/src/layouts/content-action/components.tsx
+++ b/web/lib/opal/src/layouts/content-action/components.tsx
@@ -21,6 +21,15 @@ type ContentActionProps = ContentProps & {
    * @see {@link ContainerSizeVariants} for the full list of presets.
    */
   padding?: ContainerSizeVariants;
+
+  /**
+   * When true, vertically centers the Content and rightChildren.
+   * When false (default), Content is top-aligned and rightChildren
+   * stretches to full height.
+   *
+   * @default false
+   */
+  centered?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -55,17 +64,36 @@ type ContentActionProps = ContentProps & {
 function ContentAction({
   rightChildren,
   padding = "lg",
+  centered = false,
   ...contentProps
 }: ContentActionProps) {
   const { padding: paddingClass } = containerSizeVariants[padding];
 
   return (
-    <div className="flex flex-row items-stretch w-full">
-      <div className={cn("flex-1 min-w-0 self-start", paddingClass)}>
+    <div
+      className={cn(
+        "flex flex-row w-full",
+        centered ? "items-center" : "items-stretch"
+      )}
+    >
+      <div
+        className={cn(
+          "flex-1 min-w-0",
+          centered ? "self-center" : "self-start",
+          paddingClass
+        )}
+      >
         <Content {...contentProps} />
       </div>
       {rightChildren && (
-        <div className="flex items-stretch shrink-0">{rightChildren}</div>
+        <div
+          className={cn(
+            "flex shrink-0",
+            centered ? "items-center" : "items-stretch"
+          )}
+        >
+          {rightChildren}
+        </div>
       )}
     </div>
   );

--- a/web/lib/opal/src/layouts/content-action/styles.css
+++ b/web/lib/opal/src/layouts/content-action/styles.css
@@ -1,0 +1,23 @@
+.opal-content-action {
+  @apply flex flex-row w-full gap-4 items-stretch;
+}
+
+.opal-content-action[data-centered="true"] {
+  @apply items-center;
+}
+
+.opal-content-action-content {
+  @apply flex-1 min-w-0 self-start;
+}
+
+.opal-content-action[data-centered="true"] .opal-content-action-content {
+  @apply self-center;
+}
+
+.opal-content-action-right {
+  @apply flex shrink-0 items-stretch;
+}
+
+.opal-content-action[data-centered="true"] .opal-content-action-right {
+  @apply items-center;
+}

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -61,8 +61,6 @@ interface InputLayoutProps {
   /** Ref forwarded to the inner content `Section`. */
   ref?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
-  /** Optional icon rendered beside the title. */
-  icon?: IconFunctionComponent;
   title: string | RichStr;
   /** Tag rendered inline beside the title (passed through to Content). */
   tag?: TagProps;
@@ -84,7 +82,6 @@ function Vertical({
   ref,
   children,
   subDescription,
-  icon,
   title,
   tag,
   description,
@@ -96,7 +93,6 @@ function Vertical({
   const content = (
     <Section ref={ref} gap={0.25} alignItems="start">
       <Content
-        icon={icon}
         title={title}
         description={description}
         suffix={suffix}
@@ -129,6 +125,8 @@ function Vertical({
 export interface HorizontalProps extends InputLayoutProps {
   /** Align input to the center (middle) of the label/description. */
   center?: boolean;
+  /** Optional icon rendered beside the title. */
+  icon?: IconFunctionComponent;
 }
 
 function Horizontal({

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -8,7 +8,7 @@ import { SvgXOctagon, SvgAlertCircle } from "@opal/icons";
 import { useContext } from "react";
 import { useField, FormikContext } from "formik";
 import { Section } from "@/layouts/general-layouts";
-import { Content } from "@opal/layouts";
+import { Content, ContentAction } from "@opal/layouts";
 
 // ---------------------------------------------------------------------------
 // Label
@@ -139,24 +139,18 @@ function Horizontal({
 
   const content = (
     <Section ref={ref} gap={0.25} alignItems="start">
-      <Section
-        flexDirection="row"
-        justifyContent="between"
-        alignItems={center ? "center" : "start"}
-      >
-        <div className="flex flex-col flex-1 min-w-0 self-stretch">
-          <Content
-            title={title}
-            description={description}
-            suffix={suffix}
-            tag={tag}
-            sizePreset="main-ui"
-            variant="section"
-            width="full"
-          />
-        </div>
-        <div className="flex flex-col items-end">{children}</div>
-      </Section>
+      <ContentAction
+        title={title}
+        description={description}
+        suffix={suffix}
+        tag={tag}
+        sizePreset="main-ui"
+        variant="section"
+        width="full"
+        padding="fit"
+        centered={center}
+        rightChildren={children}
+      />
       {fieldName && <FormikInputError name={fieldName} />}
     </Section>
   );

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import "@opal/layouts/inputs/styles.css";
-import type { RichStr, WithoutStyles } from "@opal/types";
+import type {
+  IconFunctionComponent,
+  RichStr,
+  WithoutStyles,
+} from "@opal/types";
 import type { TagProps } from "@opal/components/tag/components";
 import { Text, Divider } from "@opal/components";
 import { SvgXOctagon, SvgAlertCircle } from "@opal/icons";
@@ -57,6 +61,8 @@ interface InputLayoutProps {
   /** Ref forwarded to the inner content `Section`. */
   ref?: React.Ref<HTMLDivElement>;
   children?: React.ReactNode;
+  /** Optional icon rendered beside the title. */
+  icon?: IconFunctionComponent;
   title: string | RichStr;
   /** Tag rendered inline beside the title (passed through to Content). */
   tag?: TagProps;
@@ -78,6 +84,7 @@ function Vertical({
   ref,
   children,
   subDescription,
+  icon,
   title,
   tag,
   description,
@@ -89,6 +96,7 @@ function Vertical({
   const content = (
     <Section ref={ref} gap={0.25} alignItems="start">
       <Content
+        icon={icon}
         title={title}
         description={description}
         suffix={suffix}
@@ -129,6 +137,7 @@ function Horizontal({
   ref,
   children,
   center,
+  icon,
   title,
   tag,
   description,
@@ -140,6 +149,7 @@ function Horizontal({
   const content = (
     <Section ref={ref} gap={0.25} alignItems="start">
       <ContentAction
+        icon={icon}
         title={title}
         description={description}
         suffix={suffix}
@@ -148,7 +158,7 @@ function Horizontal({
         variant="section"
         width="full"
         padding="fit"
-        centered={center}
+        center={center}
         rightChildren={children}
       />
       {fieldName && <FormikInputError name={fieldName} />}

--- a/web/src/app/admin/actions/mcp/page.tsx
+++ b/web/src/app/admin/actions/mcp/page.tsx
@@ -13,7 +13,7 @@ export default function Main() {
         icon={route.icon}
         title={route.title}
         description="Connect MCP (Model Context Protocol) servers to add custom actions and tools for your agents."
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <MCPPageContent />

--- a/web/src/app/admin/actions/open-api/page.tsx
+++ b/web/src/app/admin/actions/open-api/page.tsx
@@ -13,7 +13,7 @@ export default function Main() {
         icon={route.icon}
         title={route.title}
         description="Connect OpenAPI servers to add custom actions and tools for your agents."
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <OpenApiPageContent />

--- a/web/src/app/admin/add-connector/page.tsx
+++ b/web/src/app/admin/add-connector/page.tsx
@@ -251,7 +251,7 @@ export default function Page() {
         rightChildren={
           <Button href="/admin/indexing/status">See Connectors</Button>
         }
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <InputTypeIn

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -463,7 +463,7 @@ export default function BillingPage() {
         title={viewConfig.title}
         backButton={viewConfig.showBackButton}
         onBack={handleBack}
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <div className="flex flex-col items-center gap-6">

--- a/web/src/app/admin/bots/SlackBotCreationForm.tsx
+++ b/web/src/app/admin/bots/SlackBotCreationForm.tsx
@@ -22,7 +22,7 @@ export function NewSlackBotForm() {
       <SettingsLayouts.Header
         icon={SvgSlack}
         title="New Slack Bot"
-        separator
+        divider
         backButton
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/[id]/page.tsx
@@ -59,7 +59,7 @@ function EditSlackChannelConfigContent({ id }: { id: string }) {
       <SettingsLayouts.Header
         icon={SvgSlack}
         title={title}
-        separator
+        divider
         backButton
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/bots/[bot-id]/channels/new/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/channels/new/page.tsx
@@ -109,7 +109,7 @@ export default function Page(props: { params: Promise<{ "bot-id": string }> }) {
       <SettingsLayouts.Header
         icon={SvgSlack}
         title="Configure OnyxBot for Slack Channel"
-        separator
+        divider
         backButton
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/bots/[bot-id]/page.tsx
+++ b/web/src/app/admin/bots/[bot-id]/page.tsx
@@ -82,7 +82,7 @@ export default function Page({
         icon={SvgSlack}
         title="Edit Slack Bot"
         backButton
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <SlackBotEditContent botId={unwrappedParams["bot-id"]} />

--- a/web/src/app/admin/bots/page.tsx
+++ b/web/src/app/admin/bots/page.tsx
@@ -79,7 +79,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <InstantSSRAutoRefresh />
         <Main />

--- a/web/src/app/admin/configuration/document-processing/page.tsx
+++ b/web/src/app/admin/configuration/document-processing/page.tsx
@@ -153,7 +153,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/configuration/search/page.tsx
+++ b/web/src/app/admin/configuration/search/page.tsx
@@ -150,7 +150,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header title={route.title} icon={route.icon} separator />
+      <SettingsLayouts.Header title={route.title} icon={route.icon} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/debug/page.tsx
+++ b/web/src/app/admin/debug/page.tsx
@@ -122,7 +122,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/document-index-migration/page.tsx
+++ b/web/src/app/admin/document-index-migration/page.tsx
@@ -229,7 +229,7 @@ export default function Page() {
         icon={route.icon}
         title={route.title}
         description="Monitor the migration from Vespa to OpenSearch and control the active retrieval source."
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <MigrationStatusSection />

--- a/web/src/app/admin/documents/explorer/DocumentExplorerPage.tsx
+++ b/web/src/app/admin/documents/explorer/DocumentExplorerPage.tsx
@@ -21,7 +21,7 @@ export default function DocumentExplorerPage({
 }: DocumentExplorerPageProps) {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
 
       <SettingsLayouts.Body>
         <Explorer

--- a/web/src/app/admin/documents/feedback/page.tsx
+++ b/web/src/app/admin/documents/feedback/page.tsx
@@ -65,7 +65,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
+++ b/web/src/app/admin/documents/sets/[documentSetId]/page.tsx
@@ -101,7 +101,7 @@ export default function Page(props: {
       <SettingsLayouts.Header
         icon={route.icon}
         title="Edit Document Set"
-        separator
+        divider
         backButton
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/documents/sets/new/page.tsx
+++ b/web/src/app/admin/documents/sets/new/page.tsx
@@ -65,7 +65,7 @@ export default function Page() {
       <SettingsLayouts.Header
         icon={route.icon}
         title="New Document Set"
-        separator
+        divider
         backButton
       />
       <SettingsLayouts.Body>

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -415,7 +415,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/admin/indexing/status/page.tsx
+++ b/web/src/app/admin/indexing/status/page.tsx
@@ -224,7 +224,7 @@ export default function Status() {
         rightChildren={
           <Button href="/admin/add-connector">Add Connector</Button>
         }
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <Main />

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -130,7 +130,7 @@ export default function Page() {
         icon={SvgUserSync}
         title="SCIM"
         description="Sync users and groups via System for Cross-domain Identity Management (SCIM) protocol."
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <ScimContent />

--- a/web/src/app/admin/token-rate-limits/page.tsx
+++ b/web/src/app/admin/token-rate-limits/page.tsx
@@ -212,7 +212,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header title={route.title} icon={route.icon} separator />
+      <SettingsLayouts.Header title={route.title} icon={route.icon} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/app/message/copyingUtils.tsx
+++ b/web/src/app/app/message/copyingUtils.tsx
@@ -46,9 +46,9 @@ export function convertMarkdownTablesToTsv(content: string): string {
     // Check if line is a markdown table row (starts and ends with |)
     const trimmed = line.trim();
     if (trimmed.startsWith("|") && trimmed.endsWith("|")) {
-      // Check if it's a separator row (contains only |, -, :, and spaces)
+      // Check if it's a divider row (contains only |, -, :, and spaces)
       if (/^\|[\s\-:|\s]+\|$/.test(trimmed)) {
-        // Skip separator rows
+        // Skip divider rows
         continue;
       }
       // Convert table row: split by |, trim cells, join with tabs

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -25,7 +25,7 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <AppLayouts.Root>
       <SettingsLayouts.Root width="lg">
-        <SettingsLayouts.Header icon={SvgSliders} title="Settings" separator />
+        <SettingsLayouts.Header icon={SvgSliders} title="Settings" divider />
 
         <SettingsLayouts.Body>
           <Section

--- a/web/src/app/ee/admin/billing/page.tsx
+++ b/web/src/app/ee/admin/billing/page.tsx
@@ -22,7 +22,7 @@ export default function page() {
       <SettingsLayouts.Header
         icon={SvgCreditCard}
         title="Billing Information"
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <BillingInformationPage />

--- a/web/src/app/ee/admin/performance/custom-analytics/page.tsx
+++ b/web/src/app/ee/admin/performance/custom-analytics/page.tsx
@@ -40,7 +40,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/app/ee/admin/performance/query-history/page.tsx
+++ b/web/src/app/ee/admin/performance/query-history/page.tsx
@@ -9,7 +9,7 @@ const route = ADMIN_ROUTES.QUERY_HISTORY;
 export default function QueryHistoryPage() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
 
       <SettingsLayouts.Body>
         <QueryHistoryTable />

--- a/web/src/app/ee/admin/performance/usage/page.tsx
+++ b/web/src/app/ee/admin/performance/usage/page.tsx
@@ -20,7 +20,7 @@ export default function AnalyticsPage() {
 
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <AdminDateRangeSelector
           value={timeRange}

--- a/web/src/app/ee/admin/standard-answer/[id]/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
         icon={route.icon}
         title="Edit Standard Answer"
         backButton
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <Main id={params.id} />

--- a/web/src/app/ee/admin/standard-answer/new/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/new/page.tsx
@@ -29,7 +29,7 @@ async function Page() {
         icon={route.icon}
         title="New Standard Answer"
         backButton
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <StandardAnswerCreationForm

--- a/web/src/app/ee/admin/standard-answer/page.tsx
+++ b/web/src/app/ee/admin/standard-answer/page.tsx
@@ -423,7 +423,7 @@ function Main() {
 export default function Page() {
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
       <SettingsLayouts.Body>
         <Main />
       </SettingsLayouts.Body>

--- a/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
@@ -578,7 +578,7 @@ export default function HooksPage() {
           icon={route.icon}
           title={route.title}
           description="Extend Onyx pipelines by registering external API endpoints as callbacks at predefined hook points."
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           {isLoading ? (

--- a/web/src/layouts/settings-layouts.tsx
+++ b/web/src/layouts/settings-layouts.tsx
@@ -113,7 +113,7 @@ function SettingsRoot({ width = "md", ...props }: SettingsRootProps) {
  * - Optional right-aligned action buttons via rightChildren
  * - Optional children content below title/description
  * - Optional back button
- * - Optional bottom separator
+ * - Optional bottom divider
  * - Automatic scroll shadow effect
  *
  * @example
@@ -141,12 +141,12 @@ function SettingsRoot({ width = "md", ...props }: SettingsRootProps) {
  *   }
  * />
  *
- * // With search/filter below and bottom separator
+ * // With search/filter below and bottom divider
  * <SettingsLayouts.Header
  *   icon={SvgDatabase}
  *   title="Data Sources"
  *   description="Manage your connected data sources"
- *   separator
+ *   divider
  * >
  *   <InputTypeIn placeholder="Search data sources..." />
  * </SettingsLayouts.Header>
@@ -175,7 +175,7 @@ export interface SettingsHeaderProps {
   rightChildren?: React.ReactNode;
   backButton?: boolean;
   onBack?: () => void;
-  separator?: boolean;
+  divider?: boolean;
 }
 function SettingsHeader({
   icon: Icon,
@@ -185,7 +185,7 @@ function SettingsHeader({
   rightChildren,
   backButton,
   onBack,
-  separator,
+  divider,
 }: SettingsHeaderProps) {
   const [showShadow, setShowShadow] = useState(false);
   const headerRef = useRef<HTMLDivElement>(null);
@@ -249,7 +249,7 @@ function SettingsHeader({
         {children}
       </div>
 
-      {separator ? (
+      {divider ? (
         <>
           <Spacer vertical rem={1.5} />
           <Divider paddingParallel="md" paddingPerpendicular="fit" />

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -71,7 +71,6 @@ function ToastContainer() {
               title={text}
               description={buildDescription(t)}
               padding="xs"
-              center
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
             />
           </div>

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -71,6 +71,7 @@ function ToastContainer() {
               title={text}
               description={buildDescription(t)}
               padding="xs"
+              centered
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
             />
           </div>

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -71,7 +71,7 @@ function ToastContainer() {
               title={text}
               description={buildDescription(t)}
               padding="xs"
-              centered
+              center
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
             />
           </div>

--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -172,10 +172,10 @@ function SeparatorHelper() {
 /**
  * Popover Menu Component
  *
- * Converts a list of React nodes into a vertical menu with automatic separator handling.
+ * Converts a list of React nodes into a vertical menu with automatic divider handling.
  *
  * @remarks
- * - Treats `null` values as separator lines
+ * - Treats `null` values as divider lines
  * - Filters out `undefined` and `false` values
  * - Removes separators at the beginning and end of the list
  *
@@ -237,7 +237,7 @@ export function PopoverMenu({
             {child === undefined ? (
               <></>
             ) : child === null ? (
-              // Render `null`s as separator lines
+              // Render `null`s as divider lines
               <SeparatorHelper />
             ) : (
               child

--- a/web/src/refresh-components/Separator.tsx
+++ b/web/src/refresh-components/Separator.tsx
@@ -21,10 +21,10 @@ export interface SeparatorProps
  *
  * @example
  * ```tsx
- * // Horizontal separator (default)
+ * // Horizontal divider (default)
  * <Separator />
  *
- * // Vertical separator
+ * // Vertical divider
  * <Separator orientation="vertical" />
  *
  * // With custom className

--- a/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/InputComboBox.test.tsx
@@ -239,7 +239,7 @@ describe("InputComboBox", () => {
       expect(screen.getByText("No options found")).toBeInTheDocument();
     });
 
-    test("shows separator between matched and unmatched options when enabled", async () => {
+    test("shows divider between matched and unmatched options when enabled", async () => {
       const user = setupUser();
       render(
         <InputComboBox

--- a/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
+++ b/web/src/refresh-components/inputs/InputComboBox/components/OptionsList.tsx
@@ -30,7 +30,7 @@ interface OptionsListProps {
 
 /**
  * Renders the list of options with matched/unmatched sections
- * Includes separator between sections when filtering
+ * Includes divider between sections when filtering
  */
 export const OptionsList: React.FC<OptionsListProps> = ({
   matchedOptions,

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -1282,7 +1282,7 @@ export default function AgentEditorPage({
                         </div>
                       }
                       backButton
-                      separator
+                      divider
                     />
 
                     {/* Agent Form Content */}
@@ -1479,7 +1479,7 @@ export default function AgentEditorPage({
 
                             {/* Tools */}
                             <>
-                              {/* render the separator if there is at least one mcp-server or open-api-tool */}
+                              {/* render the divider if there is at least one mcp-server or open-api-tool */}
                               {(mcpServers.length > 0 ||
                                 openApiTools.length > 0) && (
                                 <Divider

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -279,16 +279,15 @@ function OpenApiToolCard({ tool }: OpenApiToolCardProps) {
   const toolFieldName = `openapi_tool_${tool.id}`;
 
   return (
-    <Card border="solid" rounding="lg" padding="md">
-      <ContentAction
+    <Card border="solid" rounding="lg">
+      <InputHorizontal
         icon={SvgActions}
         title={tool.display_name || tool.name}
         description={tool.description}
-        sizePreset="main-ui"
-        variant="section"
-        padding="fit"
-        rightChildren={<SwitchField name={toolFieldName} />}
-      />
+        withLabel={toolFieldName}
+      >
+        <SwitchField name={toolFieldName} />
+      </InputHorizontal>
     </Card>
   );
 }

--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -487,7 +487,7 @@ export default function AgentsNavigationPage() {
                       const isSelected = selectedCreatorIds.has(creator.id);
                       const isCurrentUser = user && creator.id === user.id;
 
-                      // Check if we need to add a separator after this item
+                      // Check if we need to add a divider after this item
                       const nextCreator = filteredCreators[index + 1];
                       const nextIsCurrentUser =
                         user && nextCreator && nextCreator.id === user.id;
@@ -523,7 +523,7 @@ export default function AgentsNavigationPage() {
                         </LineItem>
                       );
 
-                      // Return the line item, and optionally a separator
+                      // Return the line item, and optionally a divider
                       return needsSeparator ? [lineItem, null] : [lineItem];
                     }),
                   ]}
@@ -565,7 +565,7 @@ export default function AgentsNavigationPage() {
                         const systemIcon = SYSTEM_TOOL_ICONS[action.name];
                         const isSystemTool = !!systemIcon;
 
-                        // Check if we need to add a separator after this item
+                        // Check if we need to add a divider after this item
                         const nextAction = filteredActions[index + 1];
                         const nextIsSystemTool =
                           nextAction && nextAction.type === "tool"

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -119,26 +119,23 @@ function MCPServerCard({
         hasContent ? (
           <Section gap={0.5} padding={0.5}>
             {filteredTools.map((tool) => (
-              <Card key={tool.id} border="solid" rounding="md" padding="sm">
-                <ContentAction
+              <Card key={tool.id} border="solid" rounding="md">
+                <InputHorizontal
                   icon={tool.icon}
                   title={tool.name}
                   description={tool.description}
-                  sizePreset="main-ui"
-                  variant="section"
-                  padding="fit"
-                  rightChildren={
-                    <Tooltip tooltip={authTooltip} side="top">
-                      <Switch
-                        checked={isToolEnabled(tool.id)}
-                        onCheckedChange={(checked) =>
-                          onToggleTool(tool.id, checked)
-                        }
-                        disabled={needsAuth}
-                      />
-                    </Tooltip>
-                  }
-                />
+                  withLabel
+                >
+                  <Tooltip tooltip={authTooltip} side="top">
+                    <Switch
+                      checked={isToolEnabled(tool.id)}
+                      onCheckedChange={(checked) =>
+                        onToggleTool(tool.id, checked)
+                      }
+                      disabled={needsAuth}
+                    />
+                  </Tooltip>
+                </InputHorizontal>
               </Card>
             ))}
           </Section>
@@ -885,28 +882,20 @@ export default function ChatPreferencesPage() {
                         />
                       ))}
                       {openApiTools.map((tool) => (
-                        <Card
-                          key={tool.id}
-                          border="solid"
-                          rounding="lg"
-                          padding="md"
-                        >
-                          <ContentAction
+                        <Card key={tool.id} border="solid" rounding="lg">
+                          <InputHorizontal
                             icon={SvgActions}
                             title={tool.display_name || tool.name}
                             description={tool.description}
-                            sizePreset="main-ui"
-                            variant="section"
-                            padding="fit"
-                            rightChildren={
-                              <Switch
-                                checked={isToolEnabled(tool.id)}
-                                onCheckedChange={(checked) =>
-                                  toggleTool(tool.id, checked)
-                                }
-                              />
-                            }
-                          />
+                            withLabel
+                          >
+                            <Switch
+                              checked={isToolEnabled(tool.id)}
+                              onCheckedChange={(checked) =>
+                                toggleTool(tool.id, checked)
+                              }
+                            />
+                          </InputHorizontal>
                         </Card>
                       ))}
                     </Section>
@@ -928,6 +917,7 @@ export default function ChatPreferencesPage() {
                     title="Keep Chat History"
                     description="Specify how long Onyx should retain chats in your organization."
                     withLabel
+                    center
                   >
                     <InputSelect
                       value={

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -546,7 +546,7 @@ export default function ChatPreferencesPage() {
           icon={route.icon}
           title={route.title}
           description="Organization-wide chat settings and defaults. Users can override some of these in their personal settings."
-          separator
+          divider
         />
 
         <SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
+++ b/web/src/refresh-pages/admin/CodeInterpreterPage/index.tsx
@@ -110,7 +110,7 @@ export default function CodeInterpreterPage() {
         icon={route.icon}
         title={route.title}
         description="Safe and sandboxed Python runtime available to your LLM. See docs for more details."
-        separator
+        divider
       />
 
       <SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/CreateGroupPage.tsx
@@ -87,7 +87,7 @@ function CreateGroupPage() {
       <SettingsLayouts.Header
         icon={SvgUsers}
         title="Create Group"
-        separator
+        divider
         rightChildren={headerActions}
       />
 

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -272,7 +272,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         <SettingsLayouts.Header
           icon={SvgUsers}
           title="Group Not Found"
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <IllustrationContent
@@ -313,7 +313,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         <SettingsLayouts.Header
           icon={SvgUsers}
           title="Edit Group"
-          separator
+          divider
           rightChildren={headerActions}
         />
 

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -29,7 +29,7 @@ function GroupsPage() {
   return (
     <SettingsLayouts.Root>
       <div data-testid="groups-page-heading">
-        <SettingsLayouts.Header icon={SvgUsers} title="Groups" separator>
+        <SettingsLayouts.Header icon={SvgUsers} title="Groups" divider>
           <MessageCard
             variant="info"
             title="Upcoming changes to permissions"

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -22,7 +22,7 @@ import ModelIcon from "@/app/admin/configuration/language-models/ModelIcon";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Button, MessageCard, SelectCard, Text } from "@opal/components";
-import { Content, ContentAction, Card } from "@opal/layouts";
+import { Content, ContentAction } from "@opal/layouts";
 import { Hoverable } from "@opal/core";
 import {
   SvgArrowExchange,
@@ -255,86 +255,89 @@ export default function ImageGenerationContent() {
                           : undefined
                     }
                   >
-                    <Card.Header
-                      bottomRightChildren={
-                        !isDisconnected ? (
-                          <div className="flex flex-row px-1 pb-1">
-                            <Hoverable.Item group="image-gen/ProviderCard">
+                    <ContentAction
+                      sizePreset="main-ui"
+                      variant="section"
+                      icon={() => (
+                        <ModelIcon
+                          provider={provider.provider_name}
+                          size={16}
+                        />
+                      )}
+                      title={provider.title}
+                      description={provider.description}
+                      padding="lg"
+                      rightChildren={
+                        isDisconnected ? (
+                          <Button
+                            prominence="tertiary"
+                            rightIcon={SvgArrowExchange}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleConnect(provider);
+                            }}
+                          >
+                            Connect
+                          </Button>
+                        ) : (
+                          <Section alignItems="end" gap={0}>
+                            {isConnected ? (
                               <Button
-                                icon={SvgUnplug}
-                                tooltip="Disconnect"
-                                aria-label={`Disconnect ${provider.title}`}
                                 prominence="tertiary"
+                                rightIcon={SvgArrowRightCircle}
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  setDisconnectProvider(provider);
+                                  handleSelect(provider);
                                 }}
-                                size="md"
-                              />
-                            </Hoverable.Item>
-                            <Button
-                              icon={SvgSettings}
-                              tooltip="Edit"
-                              aria-label={`Edit ${provider.title}`}
-                              prominence="tertiary"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleEdit(provider);
-                              }}
-                              size="md"
-                            />
-                          </div>
-                        ) : undefined
-                      }
-                    >
-                      <ContentAction
-                        sizePreset="main-ui"
-                        variant="section"
-                        icon={() => (
-                          <ModelIcon
-                            provider={provider.provider_name}
-                            size={16}
-                          />
-                        )}
-                        title={provider.title}
-                        description={provider.description}
-                        padding="lg"
-                        rightChildren={
-                          isDisconnected ? (
-                            <Button
-                              prominence="tertiary"
-                              rightIcon={SvgArrowExchange}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleConnect(provider);
-                              }}
-                            >
-                              Connect
-                            </Button>
-                          ) : isConnected ? (
-                            <Button
-                              prominence="tertiary"
-                              rightIcon={SvgArrowRightCircle}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleSelect(provider);
-                              }}
-                            >
-                              Set as Default
-                            </Button>
-                          ) : isSelected ? (
-                            <div className="p-2">
-                              <Content
-                                title="Current Default"
-                                sizePreset="main-ui"
-                                variant="section"
-                                icon={SvgCheckSquare}
-                              />
+                              >
+                                Set as Default
+                              </Button>
+                            ) : isSelected ? (
+                              <div className="p-2">
+                                <Content
+                                  title="Current Default"
+                                  sizePreset="main-ui"
+                                  variant="section"
+                                  icon={SvgCheckSquare}
+                                />
+                              </div>
+                            ) : undefined}
+                            <div className="px-1 pb-1">
+                              <Section
+                                flexDirection="row"
+                                justifyContent="end"
+                                gap={0.25}
+                              >
+                                <Hoverable.Item group="image-gen/ProviderCard">
+                                  <Button
+                                    icon={SvgUnplug}
+                                    tooltip="Disconnect"
+                                    aria-label={`Disconnect ${provider.title}`}
+                                    prominence="tertiary"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setDisconnectProvider(provider);
+                                    }}
+                                    size="md"
+                                  />
+                                </Hoverable.Item>
+                                <Button
+                                  icon={SvgSettings}
+                                  tooltip="Edit"
+                                  aria-label={`Edit ${provider.title}`}
+                                  prominence="tertiary"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleEdit(provider);
+                                  }}
+                                  size="md"
+                                />
+                              </Section>
                             </div>
-                          ) : undefined
-                        }
-                      />
-                    </Card.Header>
+                          </Section>
+                        )
+                      }
+                    />
                   </SelectCard>
                 </Hoverable.Root>
               );

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -235,9 +235,8 @@ export default function ImageGenerationContent() {
                   status={status}
                   aria-label={`image-gen-provider-${provider.image_provider_id}`}
                   onConnect={() => handleConnect(provider)}
-                  onSelectChange={(selected) =>
-                    selected ? handleSelect(provider) : handleDeselect(provider)
-                  }
+                  onSelect={() => handleSelect(provider)}
+                  onDeselect={() => handleDeselect(provider)}
                   onEdit={() => handleEdit(provider)}
                   onDisconnect={() => setDisconnectProvider(provider)}
                   disconnectModalOpen={

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -239,6 +239,10 @@ export default function ImageGenerationContent() {
                   onDeselect={() => handleDeselect(provider)}
                   onEdit={() => handleEdit(provider)}
                   onDisconnect={() => setDisconnectProvider(provider)}
+                  disconnectModalOpen={
+                    disconnectProvider?.image_provider_id ===
+                    provider.image_provider_id
+                  }
                 />
               );
             })}

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -235,8 +235,9 @@ export default function ImageGenerationContent() {
                   status={status}
                   aria-label={`image-gen-provider-${provider.image_provider_id}`}
                   onConnect={() => handleConnect(provider)}
-                  onSelect={() => handleSelect(provider)}
-                  onDeselect={() => handleDeselect(provider)}
+                  onSelectChange={(selected) =>
+                    selected ? handleSelect(provider) : handleDeselect(provider)
+                  }
                   onEdit={() => handleEdit(provider)}
                   onDisconnect={() => setDisconnectProvider(provider)}
                   disconnectModalOpen={

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -21,27 +21,14 @@ import {
 import ModelIcon from "@/app/admin/configuration/language-models/ModelIcon";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-import { Button, MessageCard, SelectCard, Text } from "@opal/components";
-import { Content, ContentAction } from "@opal/layouts";
-import { Hoverable } from "@opal/core";
-import {
-  SvgArrowExchange,
-  SvgArrowRightCircle,
-  SvgCheckSquare,
-  SvgSettings,
-  SvgSlash,
-  SvgUnplug,
-} from "@opal/icons";
+import { Button, MessageCard, Text } from "@opal/components";
+import { Content } from "@opal/layouts";
+import { SvgSlash, SvgUnplug } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import { getImageGenForm } from "@/refresh-pages/admin/ImageGenerationPage/forms";
+import ProviderCard from "@/sections/admin/ProviderCard";
 
 const NO_DEFAULT_VALUE = "__none__";
-
-const STATUS_TO_STATE = {
-  disconnected: "empty",
-  connected: "filled",
-  selected: "selected",
-} as const;
 
 export default function ImageGenerationContent() {
   const {
@@ -238,108 +225,21 @@ export default function ImageGenerationContent() {
               const isSelected = status === "selected";
 
               return (
-                <Hoverable.Root
+                <ProviderCard
                   key={provider.image_provider_id}
-                  group="image-gen/ProviderCard"
-                >
-                  <SelectCard
-                    state={STATUS_TO_STATE[status]}
-                    padding="sm"
-                    rounding="lg"
-                    aria-label={`image-gen-provider-${provider.image_provider_id}`}
-                    onClick={
-                      isDisconnected
-                        ? () => handleConnect(provider)
-                        : isSelected
-                          ? () => handleDeselect(provider)
-                          : undefined
-                    }
-                  >
-                    <ContentAction
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={() => (
-                        <ModelIcon
-                          provider={provider.provider_name}
-                          size={16}
-                        />
-                      )}
-                      title={provider.title}
-                      description={provider.description}
-                      padding="lg"
-                      rightChildren={
-                        isDisconnected ? (
-                          <Button
-                            prominence="tertiary"
-                            rightIcon={SvgArrowExchange}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleConnect(provider);
-                            }}
-                          >
-                            Connect
-                          </Button>
-                        ) : (
-                          <Section alignItems="end" gap={0}>
-                            {isConnected ? (
-                              <Button
-                                prominence="tertiary"
-                                rightIcon={SvgArrowRightCircle}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleSelect(provider);
-                                }}
-                              >
-                                Set as Default
-                              </Button>
-                            ) : isSelected ? (
-                              <div className="p-2">
-                                <Content
-                                  title="Current Default"
-                                  sizePreset="main-ui"
-                                  variant="section"
-                                  icon={SvgCheckSquare}
-                                />
-                              </div>
-                            ) : undefined}
-                            <div className="px-1 pb-1">
-                              <Section
-                                flexDirection="row"
-                                justifyContent="end"
-                                gap={0.25}
-                              >
-                                <Hoverable.Item group="image-gen/ProviderCard">
-                                  <Button
-                                    icon={SvgUnplug}
-                                    tooltip="Disconnect"
-                                    aria-label={`Disconnect ${provider.title}`}
-                                    prominence="tertiary"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setDisconnectProvider(provider);
-                                    }}
-                                    size="md"
-                                  />
-                                </Hoverable.Item>
-                                <Button
-                                  icon={SvgSettings}
-                                  tooltip="Edit"
-                                  aria-label={`Edit ${provider.title}`}
-                                  prominence="tertiary"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleEdit(provider);
-                                  }}
-                                  size="md"
-                                />
-                              </Section>
-                            </div>
-                          </Section>
-                        )
-                      }
-                    />
-                  </SelectCard>
-                </Hoverable.Root>
+                  icon={() => (
+                    <ModelIcon provider={provider.provider_name} size={16} />
+                  )}
+                  title={provider.title}
+                  description={provider.description}
+                  status={status}
+                  aria-label={`image-gen-provider-${provider.image_provider_id}`}
+                  onConnect={() => handleConnect(provider)}
+                  onSelect={() => handleSelect(provider)}
+                  onDeselect={() => handleDeselect(provider)}
+                  onEdit={() => handleEdit(provider)}
+                  onDisconnect={() => setDisconnectProvider(provider)}
+                />
               );
             })}
           </div>

--- a/web/src/refresh-pages/admin/ImageGenerationPage/index.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/index.tsx
@@ -13,7 +13,7 @@ export default function ImageGenerationPage() {
         icon={route.icon}
         title={route.title}
         description="Settings for in-chat image generation."
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <ImageGenerationContent />

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -335,7 +335,7 @@ export default function LLMConfigurationPage() {
 
   return (
     <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} separator />
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
 
       <SettingsLayouts.Body>
         {hasProviders ? (

--- a/web/src/refresh-pages/admin/ServiceAccountsPage/index.tsx
+++ b/web/src/refresh-pages/admin/ServiceAccountsPage/index.tsx
@@ -251,7 +251,7 @@ export default function ServiceAccountsPage() {
           title={route.title}
           icon={route.icon}
           description="Use service accounts to programmatically access Onyx API."
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <IllustrationContent
@@ -271,7 +271,7 @@ export default function ServiceAccountsPage() {
           title={route.title}
           icon={route.icon}
           description="Use service accounts to programmatically access Onyx API."
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <SimpleLoader />
@@ -288,7 +288,7 @@ export default function ServiceAccountsPage() {
         title={route.title}
         icon={route.icon}
         description="Use service accounts to programmatically access Onyx API."
-        separator
+        divider
       />
 
       <SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -495,11 +495,13 @@ export default function VoiceConfigurationPage() {
         description={model.subtitle}
         status={status}
         onConnect={() => handleConnect(model.providerType, mode, model.id)}
-        onSelect={() => {
-          if (provider?.id) handleSetDefault(provider.id, mode, model.id);
-        }}
-        onDeselect={() => {
-          if (provider?.id) handleDeactivate(provider.id, mode);
+        onSelectChange={(selected) => {
+          if (!provider?.id) return;
+          if (selected) {
+            handleSetDefault(provider.id, mode, model.id);
+          } else {
+            handleDeactivate(provider.id, mode);
+          }
         }}
         onEdit={() => {
           if (provider) handleEdit(provider, mode, model.id);

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -514,6 +514,7 @@ export default function VoiceConfigurationPage() {
                 })
             : undefined
         }
+        disconnectModalOpen={disconnectTarget?.providerId === provider?.id}
       />
     );
   };

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -531,7 +531,7 @@ export default function VoiceConfigurationPage() {
           icon={route.icon}
           title={route.title}
           description={pageDescription}
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <Callout type="danger" title="Failed to load voice settings">
@@ -554,7 +554,7 @@ export default function VoiceConfigurationPage() {
           icon={route.icon}
           title={route.title}
           description={pageDescription}
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <ThreeDotsLoader />
@@ -569,7 +569,7 @@ export default function VoiceConfigurationPage() {
         icon={route.icon}
         title={route.title}
         description={pageDescription}
-        separator
+        divider
       />
       <SettingsLayouts.Body>
         <div className="flex flex-col gap-6">

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -531,6 +531,7 @@ export default function VoiceConfigurationPage() {
           icon={route.icon}
           title={route.title}
           description={pageDescription}
+          separator
         />
         <SettingsLayouts.Body>
           <Callout type="danger" title="Failed to load voice settings">
@@ -553,6 +554,7 @@ export default function VoiceConfigurationPage() {
           icon={route.icon}
           title={route.title}
           description={pageDescription}
+          separator
         />
         <SettingsLayouts.Body>
           <ThreeDotsLoader />
@@ -567,6 +569,7 @@ export default function VoiceConfigurationPage() {
         icon={route.icon}
         title={route.title}
         description={pageDescription}
+        separator
       />
       <SettingsLayouts.Body>
         <div className="flex flex-col gap-6">

--- a/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/VoiceConfigurationPage.tsx
@@ -495,13 +495,11 @@ export default function VoiceConfigurationPage() {
         description={model.subtitle}
         status={status}
         onConnect={() => handleConnect(model.providerType, mode, model.id)}
-        onSelectChange={(selected) => {
-          if (!provider?.id) return;
-          if (selected) {
-            handleSetDefault(provider.id, mode, model.id);
-          } else {
-            handleDeactivate(provider.id, mode);
-          }
+        onSelect={() => {
+          if (provider?.id) handleSetDefault(provider.id, mode, model.id);
+        }}
+        onDeselect={() => {
+          if (provider?.id) handleDeactivate(provider.id, mode);
         }}
         onEdit={() => {
           if (provider) handleEdit(provider, mode, model.id);

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState, useReducer } from "react";
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-import { Content, ContentAction, Card } from "@opal/layouts";
+import { Content, ContentAction } from "@opal/layouts";
 import { markdown } from "@opal/utils";
 import useSWR from "swr";
 import { errorHandlingFetcher, FetchError } from "@/lib/fetcher";
@@ -275,85 +275,84 @@ function ProviderCard({
               : undefined
         }
       >
-        <Card.Header
-          bottomRightChildren={
-            !isDisconnected ? (
-              <div className="flex flex-row px-1 pb-1">
-                {onDisconnect && (
-                  <Hoverable.Item group="web-search/ProviderCard">
-                    <Button
-                      icon={SvgUnplug}
-                      tooltip="Disconnect"
-                      aria-label={`Disconnect ${title}`}
-                      prominence="tertiary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDisconnect();
-                      }}
-                      size="md"
-                    />
-                  </Hoverable.Item>
-                )}
-                {onEdit && (
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={icon}
+          title={title}
+          description={description}
+          padding="lg"
+          rightChildren={
+            isDisconnected && onConnect ? (
+              <Button
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConnect();
+                }}
+              >
+                Connect
+              </Button>
+            ) : (
+              <Section alignItems="end" gap={0}>
+                {isConnected && onSelect ? (
                   <Button
-                    icon={SvgSettings}
-                    tooltip="Edit"
-                    aria-label={`Edit ${title}`}
                     prominence="tertiary"
+                    rightIcon={SvgArrowRightCircle}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onEdit();
+                      onSelect();
                     }}
-                    size="md"
-                  />
-                )}
-              </div>
-            ) : undefined
-          }
-        >
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={icon}
-            title={title}
-            description={description}
-            padding="lg"
-            rightChildren={
-              isDisconnected && onConnect ? (
-                <Button
-                  prominence="tertiary"
-                  rightIcon={SvgArrowExchange}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onConnect();
-                  }}
-                >
-                  Connect
-                </Button>
-              ) : isConnected && onSelect ? (
-                <Button
-                  prominence="tertiary"
-                  rightIcon={SvgArrowRightCircle}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelect();
-                  }}
-                >
-                  Set as Default
-                </Button>
-              ) : isSelected ? (
-                <div className="p-2">
-                  <Content
-                    title={selectedLabel}
-                    sizePreset="main-ui"
-                    variant="section"
-                    icon={SvgCheckSquare}
-                  />
+                  >
+                    Set as Default
+                  </Button>
+                ) : isSelected ? (
+                  <div className="p-2">
+                    <Content
+                      title={selectedLabel}
+                      sizePreset="main-ui"
+                      variant="section"
+                      icon={SvgCheckSquare}
+                    />
+                  </div>
+                ) : undefined}
+                <div className="px-1 pb-1">
+                  <Section flexDirection="row" justifyContent="end" gap={0.25}>
+                    {onDisconnect && (
+                      <Hoverable.Item group="web-search/ProviderCard">
+                        <Button
+                          icon={SvgUnplug}
+                          tooltip="Disconnect"
+                          aria-label={`Disconnect ${title}`}
+                          prominence="tertiary"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDisconnect();
+                          }}
+                          size="md"
+                        />
+                      </Hoverable.Item>
+                    )}
+                    {onEdit && (
+                      <Button
+                        icon={SvgSettings}
+                        tooltip="Edit"
+                        aria-label={`Edit ${title}`}
+                        prominence="tertiary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEdit();
+                        }}
+                        size="md"
+                      />
+                    )}
+                  </Section>
                 </div>
-              ) : undefined
-            }
-          />
-        </Card.Header>
+              </Section>
+            )
+          }
+        />
       </SelectCard>
     </Hoverable.Root>
   );

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -941,6 +941,10 @@ export default function WebSearchPage() {
                               })
                           : undefined
                       }
+                      disconnectModalOpen={
+                        disconnectTarget?.id === providerId &&
+                        disconnectTarget?.category === "search"
+                      }
                     />
                   );
                 }
@@ -1054,6 +1058,10 @@ export default function WebSearchPage() {
                               providerType: provider.provider_type,
                             })
                         : undefined
+                    }
+                    disconnectModalOpen={
+                      disconnectTarget?.id === providerId &&
+                      disconnectTarget?.category === "content"
                     }
                   />
                 );

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -669,7 +669,7 @@ export default function WebSearchPage() {
           icon={route.icon}
           title={route.title}
           description="Search settings for external search across the internet."
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <Callout type="danger" title="Failed to load web search settings">
@@ -692,7 +692,7 @@ export default function WebSearchPage() {
           icon={route.icon}
           title={route.title}
           description="Search settings for external search across the internet."
-          separator
+          divider
         />
         <SettingsLayouts.Body>
           <ThreeDotsLoader />
@@ -978,7 +978,7 @@ export default function WebSearchPage() {
           icon={route.icon}
           title={route.title}
           description="Search settings for external search across the internet."
-          separator
+          divider
         />
 
         <SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -906,17 +906,14 @@ export default function WebSearchPage() {
                             }
                           : undefined
                       }
-                      onSelect={
+                      onSelectChange={
                         providerId
-                          ? () => {
-                              void handleActivateSearchProvider(providerId);
-                            }
-                          : undefined
-                      }
-                      onDeselect={
-                        providerId
-                          ? () => {
-                              void handleDeactivateSearchProvider(providerId);
+                          ? (selected) => {
+                              if (selected) {
+                                void handleActivateSearchProvider(providerId);
+                              } else {
+                                void handleDeactivateSearchProvider(providerId);
+                              }
                             }
                           : undefined
                       }
@@ -1025,19 +1022,20 @@ export default function WebSearchPage() {
                       openContentModal(provider.provider_type, provider);
                       setContentActivationError(null);
                     }}
-                    onSelect={
+                    onSelectChange={
                       canActivate
-                        ? () => {
-                            void handleActivateContentProvider(provider);
+                        ? (selected) => {
+                            if (selected) {
+                              void handleActivateContentProvider(provider);
+                            } else {
+                              void handleDeactivateContentProvider(
+                                providerId,
+                                provider.provider_type
+                              );
+                            }
                           }
                         : undefined
                     }
-                    onDeselect={() => {
-                      void handleDeactivateContentProvider(
-                        providerId,
-                        provider.provider_type
-                      );
-                    }}
                     onEdit={
                       provider.provider_type !== "onyx_web_crawler" &&
                       isConfigured

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import { useEffect, useMemo, useState, useReducer } from "react";
-import { InfoIcon } from "@/components/icons/icons";
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
@@ -25,7 +24,7 @@ import {
   SvgUnplug,
 } from "@opal/icons";
 import { SvgOnyxLogo } from "@opal/logos";
-import { Button, SelectCard } from "@opal/components";
+import { Button, MessageCard, SelectCard } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { WebProviderSetupModal } from "@/refresh-pages/admin/WebSearchPage/WebProviderSetupModal";
@@ -999,31 +998,14 @@ export default function WebSearchPage() {
             )}
 
             {!hasActiveSearchProvider && (
-              <div
-                className="flex items-start rounded-16 border p-1"
-                style={{
-                  backgroundColor: "var(--status-info-00)",
-                  borderColor: "var(--status-info-02)",
-                }}
-              >
-                <div className="flex items-start gap-1 p-2">
-                  <div
-                    className="flex size-5 items-center justify-center rounded-full p-0.5"
-                    style={{
-                      backgroundColor: "var(--status-info-01)",
-                    }}
-                  >
-                    <div style={{ color: "var(--status-text-info-05)" }}>
-                      <InfoIcon size={16} />
-                    </div>
-                  </div>
-                  <Text as="p" className="flex-1 px-0.5" mainUiBody text04>
-                    {hasConfiguredSearchProvider
-                      ? "Select a search engine to enable web search."
-                      : "Connect a search engine to set up web search."}
-                  </Text>
-                </div>
-              </div>
+              <MessageCard
+                variant="info"
+                title={
+                  hasConfiguredSearchProvider
+                    ? "Select a search engine to enable web search."
+                    : "Connect a search engine to set up web search."
+                }
+              />
             )}
 
             <div className="flex flex-col gap-2">

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -906,15 +906,15 @@ export default function WebSearchPage() {
                             }
                           : undefined
                       }
-                      onSelectChange={
+                      onSelect={
                         providerId
-                          ? (selected) => {
-                              if (selected) {
-                                void handleActivateSearchProvider(providerId);
-                              } else {
-                                void handleDeactivateSearchProvider(providerId);
-                              }
-                            }
+                          ? () => void handleActivateSearchProvider(providerId)
+                          : undefined
+                      }
+                      onDeselect={
+                        providerId
+                          ? () =>
+                              void handleDeactivateSearchProvider(providerId)
                           : undefined
                       }
                       onEdit={
@@ -1022,19 +1022,16 @@ export default function WebSearchPage() {
                       openContentModal(provider.provider_type, provider);
                       setContentActivationError(null);
                     }}
-                    onSelectChange={
+                    onSelect={
                       canActivate
-                        ? (selected) => {
-                            if (selected) {
-                              void handleActivateContentProvider(provider);
-                            } else {
-                              void handleDeactivateContentProvider(
-                                providerId,
-                                provider.provider_type
-                              );
-                            }
-                          }
+                        ? () => void handleActivateContentProvider(provider)
                         : undefined
+                    }
+                    onDeselect={() =>
+                      void handleDeactivateContentProvider(
+                        providerId,
+                        provider.provider_type
+                      )
                     }
                     onEdit={
                       provider.provider_type !== "onyx_web_crawler" &&

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -5,7 +5,8 @@ import { useEffect, useMemo, useState, useReducer } from "react";
 import Text from "@/refresh-components/texts/Text";
 import { Section } from "@/layouts/general-layouts";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
-import { Content, ContentAction } from "@opal/layouts";
+import { Content } from "@opal/layouts";
+import ProviderCard from "@/sections/admin/ProviderCard";
 import { markdown } from "@opal/utils";
 import useSWR from "swr";
 import { errorHandlingFetcher, FetchError } from "@/lib/fetcher";
@@ -14,18 +15,9 @@ import { ThreeDotsLoader } from "@/components/Loading";
 import { Callout } from "@/components/ui/callout";
 import { cn } from "@/lib/utils";
 import { toast } from "@/hooks/useToast";
-import {
-  SvgArrowExchange,
-  SvgArrowRightCircle,
-  SvgCheckSquare,
-  SvgGlobe,
-  SvgSettings,
-  SvgSlash,
-  SvgUnplug,
-} from "@opal/icons";
+import { SvgGlobe, SvgSlash, SvgUnplug } from "@opal/icons";
 import { SvgOnyxLogo } from "@opal/logos";
-import { Button, MessageCard, SelectCard } from "@opal/components";
-import { Hoverable } from "@opal/core";
+import { Button, MessageCard } from "@opal/components";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { WebProviderSetupModal } from "@/refresh-pages/admin/WebSearchPage/WebProviderSetupModal";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
@@ -217,144 +209,6 @@ function WebSearchDisconnectModal({
         </>
       )}
     </ConfirmationModalLayout>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ProviderCard — uses SelectCard for stateful interactive provider cards
-// ---------------------------------------------------------------------------
-
-type ProviderStatus = "disconnected" | "connected" | "selected";
-
-interface ProviderCardProps {
-  icon: React.FunctionComponent<{ size?: number; className?: string }>;
-  title: string;
-  description: string;
-  status: ProviderStatus;
-  onConnect?: () => void;
-  onSelect?: () => void;
-  onDeselect?: () => void;
-  onEdit?: () => void;
-  onDisconnect?: () => void;
-  selectedLabel?: string;
-}
-
-const STATUS_TO_STATE = {
-  disconnected: "empty",
-  connected: "filled",
-  selected: "selected",
-} as const;
-
-function ProviderCard({
-  icon,
-  title,
-  description,
-  status,
-  onConnect,
-  onSelect,
-  onDeselect,
-  onEdit,
-  onDisconnect,
-  selectedLabel = "Current Default",
-}: ProviderCardProps) {
-  const isDisconnected = status === "disconnected";
-  const isConnected = status === "connected";
-  const isSelected = status === "selected";
-
-  return (
-    <Hoverable.Root group="web-search/ProviderCard">
-      <SelectCard
-        state={STATUS_TO_STATE[status]}
-        padding="sm"
-        rounding="lg"
-        onClick={
-          isDisconnected && onConnect
-            ? onConnect
-            : isSelected && onDeselect
-              ? onDeselect
-              : undefined
-        }
-      >
-        <ContentAction
-          sizePreset="main-ui"
-          variant="section"
-          icon={icon}
-          title={title}
-          description={description}
-          padding="lg"
-          rightChildren={
-            isDisconnected && onConnect ? (
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgArrowExchange}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConnect();
-                }}
-              >
-                Connect
-              </Button>
-            ) : (
-              <Section alignItems="end" gap={0}>
-                {isConnected && onSelect ? (
-                  <Button
-                    prominence="tertiary"
-                    rightIcon={SvgArrowRightCircle}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onSelect();
-                    }}
-                  >
-                    Set as Default
-                  </Button>
-                ) : isSelected ? (
-                  <div className="p-2">
-                    <Content
-                      title={selectedLabel}
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={SvgCheckSquare}
-                    />
-                  </div>
-                ) : undefined}
-                <div className="px-1 pb-1">
-                  <Section flexDirection="row" justifyContent="end" gap={0.25}>
-                    {onDisconnect && (
-                      <Hoverable.Item group="web-search/ProviderCard">
-                        <Button
-                          icon={SvgUnplug}
-                          tooltip="Disconnect"
-                          aria-label={`Disconnect ${title}`}
-                          prominence="tertiary"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDisconnect();
-                          }}
-                          size="md"
-                        />
-                      </Hoverable.Item>
-                    )}
-                    {onEdit && (
-                      <Button
-                        icon={SvgSettings}
-                        tooltip="Edit"
-                        aria-label={`Edit ${title}`}
-                        prominence="tertiary"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onEdit();
-                        }}
-                        size="md"
-                      />
-                    )}
-                  </Section>
-                </div>
-              </Section>
-            )
-          }
-        />
-      </SelectCard>
-    </Hoverable.Root>
   );
 }
 

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -60,6 +60,8 @@ interface ProviderCardProps {
   onDeselect?: () => void;
   onEdit?: () => void;
   onDisconnect?: () => void;
+  /** When true, keeps the disconnect button visible (as if hovered). */
+  disconnectModalOpen?: boolean;
   selectedLabel?: string;
   "aria-label"?: string;
 }
@@ -80,6 +82,7 @@ export default function ProviderCard({
   onDeselect,
   onEdit,
   onDisconnect,
+  disconnectModalOpen,
   selectedLabel = "Current Default",
   "aria-label": ariaLabel,
 }: ProviderCardProps) {
@@ -88,7 +91,10 @@ export default function ProviderCard({
   const isSelected = status === "selected";
 
   return (
-    <Hoverable.Root group="ProviderCard">
+    <Hoverable.Root
+      group="ProviderCard"
+      interaction={disconnectModalOpen ? "hover" : "rest"}
+    >
       <SelectCard
         state={STATUS_TO_STATE[status]}
         padding="sm"
@@ -144,41 +150,47 @@ export default function ProviderCard({
                     />
                   </div>
                 ) : undefined}
-                <div className="px-1 pb-1">
-                  <Section flexDirection="row" justifyContent="end" gap={0.25}>
-                    {onDisconnect && (
-                      <Hoverable.Item
-                        group="ProviderCard"
-                        variant="opacity-on-hover"
-                      >
+                {(onDisconnect || onEdit) && (
+                  <div className="px-1 pb-1">
+                    <Section
+                      flexDirection="row"
+                      justifyContent="end"
+                      gap={0.25}
+                    >
+                      {onDisconnect && (
+                        <Hoverable.Item
+                          group="ProviderCard"
+                          variant="opacity-on-hover"
+                        >
+                          <Button
+                            icon={SvgUnplug}
+                            tooltip="Disconnect"
+                            aria-label={`Disconnect ${title}`}
+                            prominence="tertiary"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDisconnect();
+                            }}
+                            size="md"
+                          />
+                        </Hoverable.Item>
+                      )}
+                      {onEdit && (
                         <Button
-                          icon={SvgUnplug}
-                          tooltip="Disconnect"
-                          aria-label={`Disconnect ${title}`}
+                          icon={SvgSettings}
+                          tooltip="Edit"
+                          aria-label={`Edit ${title}`}
                           prominence="tertiary"
                           onClick={(e) => {
                             e.stopPropagation();
-                            onDisconnect();
+                            onEdit();
                           }}
                           size="md"
                         />
-                      </Hoverable.Item>
-                    )}
-                    {onEdit && (
-                      <Button
-                        icon={SvgSettings}
-                        tooltip="Edit"
-                        aria-label={`Edit ${title}`}
-                        prominence="tertiary"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onEdit();
-                        }}
-                        size="md"
-                      />
-                    )}
-                  </Section>
-                </div>
+                      )}
+                    </Section>
+                  </div>
+                )}
               </Section>
             )
           }

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -4,6 +4,7 @@ import type { IconFunctionComponent } from "@opal/types";
 import { Button, SelectCard } from "@opal/components";
 import { Content, ContentAction } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
+import { Hoverable } from "@opal/core";
 import {
   SvgArrowExchange,
   SvgArrowRightCircle,
@@ -16,7 +17,7 @@ import {
  * ProviderCard — a stateful card for selecting / connecting / disconnecting
  * an external service provider (LLM, search engine, voice model, etc.).
  *
- * Built on opal `SelectCard` + `Card.Header`. Maps a three-state
+ * Built on opal `SelectCard` + `ContentAction`. Maps a three-state
  * status model to the `SelectCard` state system:
  *
  * | Status         | SelectCard state | Right action           |
@@ -25,8 +26,8 @@ import {
  * | `connected`    | `filled`         | "Set as Default" button|
  * | `selected`     | `selected`       | "Current Default" label|
  *
- * Bottom-right actions (Disconnect, Edit) are always visible when the
- * provider is connected or selected.
+ * Disconnect and Edit buttons are shown on hover when the provider
+ * is connected or selected.
  *
  * Used on admin configuration pages: Web Search, Image Generation,
  * Voice, and LLM Configuration.
@@ -40,6 +41,7 @@ import {
  *   status="connected"
  *   onConnect={() => openModal()}
  *   onSelect={() => setDefault(id)}
+ *   onDeselect={() => removeDefault(id)}
  *   onEdit={() => openEditModal()}
  *   onDisconnect={() => confirmDisconnect(id)}
  * />
@@ -86,90 +88,103 @@ export default function ProviderCard({
   const isSelected = status === "selected";
 
   return (
-    <SelectCard
-      state={STATUS_TO_STATE[status]}
-      padding="sm"
-      rounding="lg"
-      aria-label={ariaLabel}
-      onClick={isDisconnected && onConnect ? onConnect : undefined}
-    >
-      <ContentAction
-        sizePreset="main-ui"
-        variant="section"
-        icon={icon}
-        title={title}
-        description={description}
-        padding="lg"
-        rightChildren={
-          isDisconnected && onConnect ? (
-            <Button
-              prominence="tertiary"
-              rightIcon={SvgArrowExchange}
-              onClick={(e) => {
-                e.stopPropagation();
-                onConnect();
-              }}
-            >
-              Connect
-            </Button>
-          ) : (
-            <Section alignItems="end" gap={0}>
-              {isConnected && onSelect ? (
-                <Button
-                  prominence="tertiary"
-                  rightIcon={SvgArrowRightCircle}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelect();
-                  }}
-                >
-                  Set as Default
-                </Button>
-              ) : isSelected ? (
-                <div className="p-2">
-                  <Content
-                    title={selectedLabel}
-                    sizePreset="main-ui"
-                    variant="section"
-                    icon={SvgCheckSquare}
-                  />
-                </div>
-              ) : undefined}
-              <div className="px-1 pb-1">
-                <Section flexDirection="row" justifyContent="end" gap={0.25}>
-                  {onDisconnect && (
-                    <Button
-                      icon={SvgUnplug}
-                      tooltip="Disconnect"
-                      aria-label={`Disconnect ${title}`}
-                      prominence="tertiary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDisconnect();
-                      }}
-                      size="md"
-                    />
-                  )}
-                  {onEdit && (
-                    <Button
-                      icon={SvgSettings}
-                      tooltip="Edit"
-                      aria-label={`Edit ${title}`}
-                      prominence="tertiary"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onEdit();
-                      }}
-                      size="md"
-                    />
-                  )}
-                </Section>
-              </div>
-            </Section>
-          )
+    <Hoverable.Root group="ProviderCard">
+      <SelectCard
+        state={STATUS_TO_STATE[status]}
+        padding="sm"
+        rounding="lg"
+        aria-label={ariaLabel}
+        onClick={
+          isDisconnected && onConnect
+            ? onConnect
+            : isSelected && onDeselect
+              ? onDeselect
+              : undefined
         }
-      />
-    </SelectCard>
+      >
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={icon}
+          title={title}
+          description={description}
+          padding="lg"
+          rightChildren={
+            isDisconnected && onConnect ? (
+              <Button
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConnect();
+                }}
+              >
+                Connect
+              </Button>
+            ) : (
+              <Section alignItems="end" gap={0}>
+                {isConnected && onSelect ? (
+                  <Button
+                    prominence="tertiary"
+                    rightIcon={SvgArrowRightCircle}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelect();
+                    }}
+                  >
+                    Set as Default
+                  </Button>
+                ) : isSelected ? (
+                  <div className="p-2">
+                    <Content
+                      title={selectedLabel}
+                      sizePreset="main-ui"
+                      variant="section"
+                      icon={SvgCheckSquare}
+                    />
+                  </div>
+                ) : undefined}
+                <div className="px-1 pb-1">
+                  <Section flexDirection="row" justifyContent="end" gap={0.25}>
+                    {onDisconnect && (
+                      <Hoverable.Item
+                        group="ProviderCard"
+                        variant="opacity-on-hover"
+                      >
+                        <Button
+                          icon={SvgUnplug}
+                          tooltip="Disconnect"
+                          aria-label={`Disconnect ${title}`}
+                          prominence="tertiary"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDisconnect();
+                          }}
+                          size="md"
+                        />
+                      </Hoverable.Item>
+                    )}
+                    {onEdit && (
+                      <Button
+                        icon={SvgSettings}
+                        tooltip="Edit"
+                        aria-label={`Edit ${title}`}
+                        prominence="tertiary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onEdit();
+                        }}
+                        size="md"
+                      />
+                    )}
+                  </Section>
+                </div>
+              </Section>
+            )
+          }
+        />
+      </SelectCard>
+    </Hoverable.Root>
   );
 }
 

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -101,9 +101,11 @@ export default function ProviderCard({
         onClick={
           isDisconnected && onConnect
             ? onConnect
-            : isSelected && onSelectChange
-              ? () => onSelectChange(false)
-              : undefined
+            : isConnected && onSelectChange
+              ? () => onSelectChange(true)
+              : isSelected && onSelectChange
+                ? () => onSelectChange(false)
+                : undefined
         }
       >
         <ContentAction

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -2,7 +2,8 @@
 
 import type { IconFunctionComponent } from "@opal/types";
 import { Button, SelectCard } from "@opal/components";
-import { Content, ContentAction, Card } from "@opal/layouts";
+import { Content, ContentAction } from "@opal/layouts";
+import { Section } from "@/layouts/general-layouts";
 import {
   SvgArrowExchange,
   SvgArrowRightCircle,
@@ -92,83 +93,82 @@ export default function ProviderCard({
       aria-label={ariaLabel}
       onClick={isDisconnected && onConnect ? onConnect : undefined}
     >
-      <Card.Header
-        bottomRightChildren={
-          !isDisconnected ? (
-            <div className="flex flex-row px-1 pb-1">
-              {onDisconnect && (
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={icon}
+        title={title}
+        description={description}
+        padding="lg"
+        rightChildren={
+          isDisconnected && onConnect ? (
+            <Button
+              prominence="tertiary"
+              rightIcon={SvgArrowExchange}
+              onClick={(e) => {
+                e.stopPropagation();
+                onConnect();
+              }}
+            >
+              Connect
+            </Button>
+          ) : (
+            <Section alignItems="end" gap={0}>
+              {isConnected && onSelect ? (
                 <Button
-                  icon={SvgUnplug}
-                  tooltip="Disconnect"
-                  aria-label={`Disconnect ${title}`}
                   prominence="tertiary"
+                  rightIcon={SvgArrowRightCircle}
                   onClick={(e) => {
                     e.stopPropagation();
-                    onDisconnect();
+                    onSelect();
                   }}
-                  size="md"
-                />
-              )}
-              {onEdit && (
-                <Button
-                  icon={SvgSettings}
-                  tooltip="Edit"
-                  aria-label={`Edit ${title}`}
-                  prominence="tertiary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onEdit();
-                  }}
-                  size="md"
-                />
-              )}
-            </div>
-          ) : undefined
-        }
-      >
-        <ContentAction
-          sizePreset="main-ui"
-          variant="section"
-          icon={icon}
-          title={title}
-          description={description}
-          padding="lg"
-          rightChildren={
-            isDisconnected && onConnect ? (
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgArrowExchange}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConnect();
-                }}
-              >
-                Connect
-              </Button>
-            ) : isConnected && onSelect ? (
-              <Button
-                prominence="tertiary"
-                rightIcon={SvgArrowRightCircle}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSelect();
-                }}
-              >
-                Set as Default
-              </Button>
-            ) : isSelected ? (
-              <div className="p-2">
-                <Content
-                  title={selectedLabel}
-                  sizePreset="main-ui"
-                  variant="section"
-                  icon={SvgCheckSquare}
-                />
+                >
+                  Set as Default
+                </Button>
+              ) : isSelected ? (
+                <div className="p-2">
+                  <Content
+                    title={selectedLabel}
+                    sizePreset="main-ui"
+                    variant="section"
+                    icon={SvgCheckSquare}
+                  />
+                </div>
+              ) : undefined}
+              <div className="px-1 pb-1">
+                <Section flexDirection="row" justifyContent="end" gap={0.25}>
+                  {onDisconnect && (
+                    <Button
+                      icon={SvgUnplug}
+                      tooltip="Disconnect"
+                      aria-label={`Disconnect ${title}`}
+                      prominence="tertiary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDisconnect();
+                      }}
+                      size="md"
+                    />
+                  )}
+                  {onEdit && (
+                    <Button
+                      icon={SvgSettings}
+                      tooltip="Edit"
+                      aria-label={`Edit ${title}`}
+                      prominence="tertiary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onEdit();
+                      }}
+                      size="md"
+                    />
+                  )}
+                </Section>
               </div>
-            ) : undefined
-          }
-        />
-      </Card.Header>
+            </Section>
+          )
+        }
+      />
     </SelectCard>
   );
 }

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -128,7 +128,7 @@ export default function ProviderCard({
                 Connect
               </Button>
             ) : (
-              <Section alignItems="end" gap={0}>
+              <Section alignItems="end" justifyContent="start" gap={0}>
                 {isConnected && onSelect ? (
                   <Button
                     prominence="tertiary"

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -40,7 +40,8 @@ import {
  *   description="Exa.ai"
  *   status="connected"
  *   onConnect={() => openModal()}
- *   onSelectChange={(selected) => selected ? setDefault(id) : removeDefault(id)}
+ *   onSelect={() => setDefault(id)}
+ *   onDeselect={() => removeDefault(id)}
  *   onEdit={() => openEditModal()}
  *   onDisconnect={() => confirmDisconnect(id)}
  * />
@@ -55,8 +56,8 @@ interface ProviderCardProps {
   description: string;
   status: ProviderStatus;
   onConnect?: () => void;
-  /** Called with `true` when selecting (set as default), `false` when deselecting. */
-  onSelectChange?: (selected: boolean) => void;
+  onSelect?: () => void;
+  onDeselect?: () => void;
   onEdit?: () => void;
   onDisconnect?: () => void;
   /** When true, keeps the disconnect button visible (as if hovered). */
@@ -77,7 +78,8 @@ export default function ProviderCard({
   description,
   status,
   onConnect,
-  onSelectChange,
+  onSelect,
+  onDeselect,
   onEdit,
   onDisconnect,
   disconnectModalOpen,
@@ -101,10 +103,10 @@ export default function ProviderCard({
         onClick={
           isDisconnected && onConnect
             ? onConnect
-            : isConnected && onSelectChange
-              ? () => onSelectChange(true)
-              : isSelected && onSelectChange
-                ? () => onSelectChange(false)
+            : isConnected && onSelect
+              ? onSelect
+              : isSelected && onDeselect
+                ? onDeselect
                 : undefined
         }
       >
@@ -129,13 +131,13 @@ export default function ProviderCard({
               </Button>
             ) : (
               <Section alignItems="end" justifyContent="start" gap={0}>
-                {isConnected && onSelectChange ? (
+                {isConnected && onSelect ? (
                   <Button
                     prominence="tertiary"
                     rightIcon={SvgArrowRightCircle}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onSelectChange(true);
+                      onSelect();
                     }}
                   >
                     Set as Default

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -40,8 +40,7 @@ import {
  *   description="Exa.ai"
  *   status="connected"
  *   onConnect={() => openModal()}
- *   onSelect={() => setDefault(id)}
- *   onDeselect={() => removeDefault(id)}
+ *   onSelectChange={(selected) => selected ? setDefault(id) : removeDefault(id)}
  *   onEdit={() => openEditModal()}
  *   onDisconnect={() => confirmDisconnect(id)}
  * />
@@ -56,8 +55,8 @@ interface ProviderCardProps {
   description: string;
   status: ProviderStatus;
   onConnect?: () => void;
-  onSelect?: () => void;
-  onDeselect?: () => void;
+  /** Called with `true` when selecting (set as default), `false` when deselecting. */
+  onSelectChange?: (selected: boolean) => void;
   onEdit?: () => void;
   onDisconnect?: () => void;
   /** When true, keeps the disconnect button visible (as if hovered). */
@@ -78,8 +77,7 @@ export default function ProviderCard({
   description,
   status,
   onConnect,
-  onSelect,
-  onDeselect,
+  onSelectChange,
   onEdit,
   onDisconnect,
   disconnectModalOpen,
@@ -103,8 +101,8 @@ export default function ProviderCard({
         onClick={
           isDisconnected && onConnect
             ? onConnect
-            : isSelected && onDeselect
-              ? onDeselect
+            : isSelected && onSelectChange
+              ? () => onSelectChange(false)
               : undefined
         }
       >
@@ -129,13 +127,13 @@ export default function ProviderCard({
               </Button>
             ) : (
               <Section alignItems="end" justifyContent="start" gap={0}>
-                {isConnected && onSelect ? (
+                {isConnected && onSelectChange ? (
                   <Button
                     prominence="tertiary"
                     rightIcon={SvgArrowRightCircle}
                     onClick={(e) => {
                       e.stopPropagation();
-                      onSelect();
+                      onSelectChange(true);
                     }}
                   >
                     Set as Default

--- a/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
+++ b/web/src/sections/sidebar/ChatSearchCommandMenu.tsx
@@ -354,7 +354,7 @@ export default function ChatSearchCommandMenu({
                 </CommandMenu.Action>
               )}
 
-            {/* No more results separator - shown when no results for the active filter */}
+            {/* No more results divider - shown when no results for the active filter */}
             {((activeFilter === "chats" && displayedChats.length === 0) ||
               (activeFilter === "projects" && displayedProjects.length === 0) ||
               (activeFilter === "all" &&


### PR DESCRIPTION
## Description

- Add `centered` prop to `ContentAction` — when true, vertically centers Content and rightChildren (`items-center`). Default false preserves existing top-aligned behavior.
- Pass `centered` through `MessageCard` to its internal `ContentAction`.
- Update `ToastProvider` to use `centered` for vertically centered close buttons on toasts.
- Refactor `InputHorizontal` to compose on `ContentAction` internally, eliminating duplicate flex-row layout logic. The existing `center` prop maps directly to `centered`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `center` prop to `ContentAction` and composes it into `InputHorizontal` for consistent alignment. Unifies `ProviderCard` with hover actions, adds `disconnectModalOpen`, migrates Web Search, Image Generation, and Voice to the shared card, and uses separate `onSelect`/`onDeselect` callbacks.

- **New Features**
  - `ContentAction` supports `center` (default `false`); used in toast close buttons.
  - `InputHorizontal` adds `icon` on `HorizontalProps`.
  - `ProviderCard` adds `disconnectModalOpen`; connected cards are clickable to set or clear default via `onSelect`/`onDeselect`.

- **Refactors**
  - `InputHorizontal` now composes `ContentAction`; styles extracted to `@opal/layouts/content-action/styles.css`.
  - Unified `ProviderCard` with `Hoverable`; actions moved into `ContentAction.rightChildren` (Disconnect on hover, Edit always visible). Web Search, Image Generation, and Voice now use the shared `ProviderCard`; OpenAPI/MCP tool cards use `InputHorizontal` (`withLabel` for larger switch targets). Replaced the manual info banner with `MessageCard` on Web Search.
  - Removed `center` from `MessageCard`. Renamed `SettingsLayouts.Header` prop `separator` to `divider` and updated all call sites.

<sup>Written for commit 893ffdfde56ec729fe5bee58b72999c2a16939e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->