### PR TITLE
fix(mcp): normalize empty parameters schema for Azure OpenAI

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -36,6 +36,18 @@ DENYLISTED_MCP_HEADERS = {
 #     server_name: str
 
 
+def _normalize_parameters_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
+    # Azure OpenAI rejects object schemas that omit `properties` with
+    # "object schema missing properties". MCP servers (e.g. AWS Knowledge MCP's
+    # aws___list_regions) may legally return `{"type": "object"}` with no
+    # properties for zero-arg tools, so seed `properties: {}` ourselves.
+    if not schema:
+        return {"type": "object", "properties": {}}
+    if schema.get("type", "object") == "object" and "properties" not in schema:
+        return {**schema, "type": "object", "properties": {}}
+    return schema
+
+
 class MCPTool(Tool[None]):
     """Tool implementation for MCP (Model Context Protocol) servers"""
 
@@ -97,7 +109,7 @@ class MCPTool(Tool[None]):
             "function": {
                 "name": self._name,
                 "description": self._description,
-                "parameters": self._tool_definition,
+                "parameters": _normalize_parameters_schema(self._tool_definition),
             },
         }
 

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -1,0 +1,127 @@
+"""Tests for MCPTool.tool_definition() schema normalization.
+
+MCP servers may legally return `inputSchema` values that omit `properties`
+(e.g. `{"type": "object"}` for zero-arg tools like AWS Knowledge MCP's
+`aws___list_regions`). Azure OpenAI rejects such schemas with
+"object schema missing properties", which breaks every chat request for
+the persona as soon as one offending tool is registered.
+
+These tests pin the contract that MCPTool.tool_definition() always returns
+a JSON-Schema-valid `parameters` dict with a `properties` key.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.tools.tool_implementations.mcp.mcp_tool import (
+    _normalize_parameters_schema,
+)
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+class TestNormalizeParametersSchema:
+    def test_empty_dict_gets_object_shell(self) -> None:
+        assert _normalize_parameters_schema({}) == {
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_none_gets_object_shell(self) -> None:
+        assert _normalize_parameters_schema(None) == {
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_object_without_properties_gets_seeded(self) -> None:
+        # This is the AWS Knowledge MCP case: aws___list_regions returns
+        # `{"type": "object"}` for a zero-arg tool.
+        assert _normalize_parameters_schema({"type": "object"}) == {
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_object_with_properties_is_passed_through(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {"region": {"type": "string"}},
+            "required": ["region"],
+        }
+        assert _normalize_parameters_schema(schema) == schema
+
+    def test_schema_without_type_treated_as_object(self) -> None:
+        # Some MCP servers omit `type` entirely; JSON Schema defaults to
+        # accepting anything, but OpenAI's validator expects an object.
+        assert _normalize_parameters_schema({"description": "no args"}) == {
+            "description": "no args",
+            "type": "object",
+            "properties": {},
+        }
+
+    def test_non_object_schema_is_left_alone(self) -> None:
+        # A non-object root schema (rare but valid JSON Schema) shouldn't
+        # have `properties` forced onto it.
+        schema = {"type": "string"}
+        assert _normalize_parameters_schema(schema) == schema
+
+    def test_existing_empty_properties_preserved(self) -> None:
+        schema = {"type": "object", "properties": {}}
+        assert _normalize_parameters_schema(schema) == schema
+
+
+def _make_tool(input_schema: dict) -> MCPTool:
+    mcp_server = MagicMock()
+    mcp_server.name = "aws-knowledge"
+    return MCPTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        mcp_server=mcp_server,
+        tool_name="aws___list_regions",
+        tool_description="List AWS regions",
+        tool_definition=input_schema,
+    )
+
+
+class TestMCPToolDefinition:
+    def test_zero_arg_mcp_tool_emits_valid_openai_schema(self) -> None:
+        # Regression: the AWS Knowledge MCP server returned
+        # `{"type": "object"}` for aws___list_regions, which Azure OpenAI
+        # rejected. The parameters field must always include `properties`.
+        tool = _make_tool({"type": "object"})
+
+        params = tool.tool_definition()["function"]["parameters"]
+
+        assert params == {"type": "object", "properties": {}}
+
+    def test_empty_input_schema_emits_valid_openai_schema(self) -> None:
+        tool = _make_tool({})
+
+        params = tool.tool_definition()["function"]["parameters"]
+
+        assert params == {"type": "object", "properties": {}}
+
+    def test_populated_schema_is_preserved(self) -> None:
+        input_schema = {
+            "type": "object",
+            "properties": {"region": {"type": "string"}},
+            "required": ["region"],
+        }
+        tool = _make_tool(input_schema)
+
+        params = tool.tool_definition()["function"]["parameters"]
+
+        assert params == input_schema
+
+    def test_normalization_does_not_mutate_stored_schema(self) -> None:
+        # Azure-only normalization shouldn't corrupt the schema we kept for
+        # display / future re-serialization.
+        stored = {"type": "object"}
+        tool = _make_tool(stored)
+
+        tool.tool_definition()
+
+        assert stored == {"type": "object"}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])


### PR DESCRIPTION
## Description

MCP servers may legally return `inputSchema` values that omit `properties` (e.g. `{"type": "object"}` for zero-arg tools like AWS Knowledge MCP's `aws___list_regions`). Azure OpenAI rejects such schemas with `"object schema missing properties"`, which blocks every chat request for the persona since the full tool list is sent on each LLM call. Claude/Bedrock is more lenient, so this only manifests on GPT‑x via Azure.

`MCPTool.tool_definition()` now normalizes the parameters dict to always include `properties: {}`, mirroring the shape Onyx already produces for OpenAPI custom tools (`openapi_parsing.py:68`). Normalization happens at read-time, so no migration is needed for already-stored schemas. The original `_tool_definition` is spread-copied, not mutated.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/tools/test_mcp_tool_schema.py` (11 cases) covering the helper in isolation and end-to-end through `MCPTool.tool_definition()`, including the specific `aws___list_regions` regression and a mutation-safety check.
- `pytest tests/unit/onyx/tools/` — 274 passed.
- `ty check` on the changed files — clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize MCP tool parameter schemas to always include an empty `properties` object for zero‑arg tools, fixing Azure OpenAI’s “object schema missing properties” error and unblocking GPT‑x chats. Does not mutate stored schemas and matches our OpenAPI tool shape.

- **Bug Fixes**
  - Normalize parameters in `MCPTool.tool_definition()` using `_normalize_parameters_schema`, seeding `{"type": "object", "properties": {}}` when missing.
  - Keep the original schema unchanged; normalization happens at read time.
  - Add unit tests for the helper and end-to-end, including the `aws___list_regions` regression.

<sup>Written for commit f79be9c89ff7d875c2ba5029e607a2fef27effb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

