### PR TITLE
feat(query-history): add admin toggle for query history type

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -65,8 +65,9 @@ def export_query_history_task(
                 end=end,
             )
 
+            query_history_type = load_settings().query_history_type
             for snapshot in snapshot_generator:
-                if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
+                if query_history_type == QueryHistoryType.ANONYMIZED:
                     snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
                 writer.writerows(

--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -10,7 +10,6 @@ from ee.onyx.server.query_history.api import ONYX_ANONYMIZED_EMAIL
 from ee.onyx.server.query_history.models import QuestionAnswerPairSnapshot
 from onyx.background.task_utils import construct_query_history_report_name
 from onyx.configs.app_configs import JOB_TIMEOUT
-from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
 from onyx.configs.constants import OnyxCeleryTask
@@ -20,6 +19,7 @@ from onyx.db.tasks import delete_task_with_id
 from onyx.db.tasks import mark_task_as_finished_with_id
 from onyx.db.tasks import mark_task_as_started_with_id
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -66,7 +66,7 @@ def export_query_history_task(
             )
 
             for snapshot in snapshot_generator:
-                if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+                if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
                     snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
                 writer.writerows(

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -45,6 +45,8 @@ from onyx.db.models import ChatSession
 from onyx.db.models import User
 from onyx.db.tasks import get_task_with_id
 from onyx.db.tasks import register_task
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.query_and_chat.models import ChatSessionDetails
@@ -63,9 +65,9 @@ def ensure_query_history_is_enabled(
 ) -> None:
     query_history_type = load_settings().query_history_type
     if query_history_type in disallowed:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN,
-            detail="Query history has been disabled by the administrator.",
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Query history has been disabled by the administrator.",
         )
 
 

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -25,7 +25,6 @@ from onyx.auth.users import get_display_email
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.task_utils import construct_query_history_report_name
 from onyx.chat.chat_utils import create_chat_history_chain
-from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
 from onyx.configs.constants import MessageType
@@ -50,6 +49,7 @@ from onyx.file_store.file_store import get_default_file_store
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.query_and_chat.models import ChatSessionDetails
 from onyx.server.query_and_chat.models import ChatSessionsResponse
+from onyx.server.settings.store import load_settings
 from onyx.utils.threadpool_concurrency import parallel_yield
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -61,7 +61,8 @@ ONYX_ANONYMIZED_EMAIL = "anonymous@anonymous.invalid"
 def ensure_query_history_is_enabled(
     disallowed: list[QueryHistoryType],
 ) -> None:
-    if ONYX_QUERY_HISTORY_TYPE in disallowed:
+    query_history_type = load_settings().query_history_type
+    if query_history_type in disallowed:
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,
             detail="Query history has been disabled by the administrator.",
@@ -222,7 +223,7 @@ def get_chat_session_history(
 
     for chat_session in page_of_chat_sessions:
         minimal_chat_session = ChatSessionMinimal.from_chat_session(chat_session)
-        if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+        if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
             minimal_chat_session.user_email = ONYX_ANONYMIZED_EMAIL
         minimal_chat_sessions.append(minimal_chat_session)
 
@@ -262,7 +263,7 @@ def get_chat_session_admin(
             f"Could not create snapshot for chat session with id '{chat_session_id}'",
         )
 
-    if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+    if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
         snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
     return snapshot

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -62,13 +62,14 @@ ONYX_ANONYMIZED_EMAIL = "anonymous@anonymous.invalid"
 
 def ensure_query_history_is_enabled(
     disallowed: list[QueryHistoryType],
-) -> None:
-    query_history_type = load_settings().query_history_type
+) -> QueryHistoryType:
+    query_history_type = load_settings().query_history_type or QueryHistoryType.NORMAL
     if query_history_type in disallowed:
         raise OnyxError(
             OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
             "Query history has been disabled by the administrator.",
         )
+    return query_history_type
 
 
 def yield_snapshot_from_chat_session(
@@ -203,7 +204,9 @@ def get_chat_session_history(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedReturn[ChatSessionMinimal]:
-    ensure_query_history_is_enabled(disallowed=[QueryHistoryType.DISABLED])
+    query_history_type = ensure_query_history_is_enabled(
+        disallowed=[QueryHistoryType.DISABLED]
+    )
 
     page_of_chat_sessions = get_page_of_chat_sessions(
         page_num=page_num,
@@ -225,7 +228,7 @@ def get_chat_session_history(
 
     for chat_session in page_of_chat_sessions:
         minimal_chat_session = ChatSessionMinimal.from_chat_session(chat_session)
-        if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
+        if query_history_type == QueryHistoryType.ANONYMIZED:
             minimal_chat_session.user_email = ONYX_ANONYMIZED_EMAIL
         minimal_chat_sessions.append(minimal_chat_session)
 
@@ -241,7 +244,9 @@ def get_chat_session_admin(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ChatSessionSnapshot:
-    ensure_query_history_is_enabled(disallowed=[QueryHistoryType.DISABLED])
+    query_history_type = ensure_query_history_is_enabled(
+        disallowed=[QueryHistoryType.DISABLED]
+    )
 
     try:
         chat_session = get_chat_session_by_id(
@@ -265,7 +270,7 @@ def get_chat_session_admin(
             f"Could not create snapshot for chat session with id '{chat_session_id}'",
         )
 
-    if load_settings().query_history_type == QueryHistoryType.ANONYMIZED:
+    if query_history_type == QueryHistoryType.ANONYMIZED:
         snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
     return snapshot

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -52,7 +52,8 @@ def load_settings() -> Settings:
         anonymous_user_enabled = False
 
     settings.anonymous_user_enabled = anonymous_user_enabled
-    settings.query_history_type = ONYX_QUERY_HISTORY_TYPE
+    if settings.query_history_type is None:
+        settings.query_history_type = ONYX_QUERY_HISTORY_TYPE
 
     if DISABLE_USER_KNOWLEDGE:
         settings.user_knowledge_enabled = False

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -913,37 +913,79 @@ export default function ChatPreferencesPage() {
             <SimpleCollapsible.Content>
               <Section gap={1}>
                 <Card border="solid" rounding="lg">
-                  <InputHorizontal
-                    title="Keep Chat History"
-                    description="Specify how long Onyx should retain chats in your organization."
-                    withLabel
-                    center
-                  >
-                    <InputSelect
-                      value={
-                        s.maximum_chat_retention_days?.toString() ?? "forever"
-                      }
-                      onValueChange={(value) => {
-                        void saveSettings({
-                          maximum_chat_retention_days:
-                            value === "forever" ? null : parseInt(value, 10),
-                        });
-                      }}
+                  <Section>
+                    <InputHorizontal
+                      title="Keep Chat History"
+                      description="Specify how long Onyx should retain chats in your organization."
+                      withLabel
                     >
-                      <InputSelect.Trigger />
-                      <InputSelect.Content>
-                        <InputSelect.Item value="forever">
-                          Forever
-                        </InputSelect.Item>
-                        <InputSelect.Item value="7">7 days</InputSelect.Item>
-                        <InputSelect.Item value="30">30 days</InputSelect.Item>
-                        <InputSelect.Item value="90">90 days</InputSelect.Item>
-                        <InputSelect.Item value="365">
-                          365 days
-                        </InputSelect.Item>
-                      </InputSelect.Content>
-                    </InputSelect>
-                  </InputHorizontal>
+                      <InputSelect
+                        value={
+                          s.maximum_chat_retention_days?.toString() ?? "forever"
+                        }
+                        onValueChange={(value) => {
+                          void saveSettings({
+                            maximum_chat_retention_days:
+                              value === "forever" ? null : parseInt(value, 10),
+                          });
+                        }}
+                      >
+                        <InputSelect.Trigger />
+                        <InputSelect.Content>
+                          <InputSelect.Item value="forever">
+                            Forever
+                          </InputSelect.Item>
+                          <InputSelect.Item value="7">7 days</InputSelect.Item>
+                          <InputSelect.Item value="30">
+                            30 days
+                          </InputSelect.Item>
+                          <InputSelect.Item value="90">
+                            90 days
+                          </InputSelect.Item>
+                          <InputSelect.Item value="365">
+                            365 days
+                          </InputSelect.Item>
+                        </InputSelect.Content>
+                      </InputSelect>
+                    </InputHorizontal>
+
+                    <InputHorizontal
+                      title="Query History Visibility"
+                      description="Control how your organization's full chat history appears in the Admin Panel."
+                      withLabel
+                    >
+                      <InputSelect
+                        value={s.query_history_type ?? QueryHistoryType.NORMAL}
+                        onValueChange={(value) => {
+                          void saveSettings({
+                            query_history_type: value as QueryHistoryType,
+                          });
+                        }}
+                      >
+                        <InputSelect.Trigger />
+                        <InputSelect.Content>
+                          <InputSelect.Item
+                            value={QueryHistoryType.NORMAL}
+                            description="All queries are visible to admins and linked to individual users."
+                          >
+                            Show with User Info
+                          </InputSelect.Item>
+                          <InputSelect.Item
+                            value={QueryHistoryType.ANONYMIZED}
+                            description="Queries are visible to admins with user identity removed"
+                          >
+                            Anonymized
+                          </InputSelect.Item>
+                          <InputSelect.Item
+                            value={QueryHistoryType.DISABLED}
+                            description="Query history reporting is disabled."
+                          >
+                            Hidden
+                          </InputSelect.Item>
+                        </InputSelect.Content>
+                      </InputSelect>
+                    </InputHorizontal>
+                  </Section>
                 </Card>
 
                 <Card border="solid" rounding="lg">
@@ -1031,45 +1073,6 @@ export default function ChatPreferencesPage() {
                       />
                     </InputHorizontal>
                   </Section>
-                </Card>
-
-                <Card border="solid" rounding="lg">
-                  <InputHorizontal
-                    title="Query History"
-                    description="Control whether admin query history reports include user emails, anonymized emails, or are fully disabled."
-                    withLabel
-                  >
-                    <InputSelect
-                      value={s.query_history_type ?? QueryHistoryType.NORMAL}
-                      onValueChange={(value) => {
-                        void saveSettings({
-                          query_history_type: value as QueryHistoryType,
-                        });
-                      }}
-                    >
-                      <InputSelect.Trigger />
-                      <InputSelect.Content>
-                        <InputSelect.Item
-                          value={QueryHistoryType.NORMAL}
-                          description="Query history with real user emails"
-                        >
-                          Normal
-                        </InputSelect.Item>
-                        <InputSelect.Item
-                          value={QueryHistoryType.ANONYMIZED}
-                          description="Query history with anonymized user emails"
-                        >
-                          Anonymized
-                        </InputSelect.Item>
-                        <InputSelect.Item
-                          value={QueryHistoryType.DISABLED}
-                          description="No query history collected"
-                        >
-                          Disabled
-                        </InputSelect.Item>
-                      </InputSelect.Content>
-                    </InputSelect>
-                  </InputHorizontal>
                 </Card>
               </Section>
             </SimpleCollapsible.Content>

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -38,7 +38,7 @@ import {
 import useCCPairs from "@/hooks/useCCPairs";
 import { getSourceMetadata } from "@/lib/sources";
 import { EmptyMessageCard } from "@opal/components";
-import { Settings } from "@/interfaces/settings";
+import { QueryHistoryType, Settings } from "@/interfaces/settings";
 import { toast } from "@/hooks/useToast";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import {
@@ -1031,6 +1031,45 @@ export default function ChatPreferencesPage() {
                       />
                     </InputHorizontal>
                   </Section>
+                </Card>
+
+                <Card border="solid" rounding="lg">
+                  <InputHorizontal
+                    title="Query History"
+                    description="Control whether admin query history reports include user emails, anonymized emails, or are fully disabled."
+                    withLabel
+                  >
+                    <InputSelect
+                      value={s.query_history_type ?? QueryHistoryType.NORMAL}
+                      onValueChange={(value) => {
+                        void saveSettings({
+                          query_history_type: value as QueryHistoryType,
+                        });
+                      }}
+                    >
+                      <InputSelect.Trigger />
+                      <InputSelect.Content>
+                        <InputSelect.Item
+                          value={QueryHistoryType.NORMAL}
+                          description="Query history with real user emails"
+                        >
+                          Normal
+                        </InputSelect.Item>
+                        <InputSelect.Item
+                          value={QueryHistoryType.ANONYMIZED}
+                          description="Query history with anonymized user emails"
+                        >
+                          Anonymized
+                        </InputSelect.Item>
+                        <InputSelect.Item
+                          value={QueryHistoryType.DISABLED}
+                          description="No query history collected"
+                        >
+                          Disabled
+                        </InputSelect.Item>
+                      </InputSelect.Content>
+                    </InputSelect>
+                  </InputHorizontal>
                 </Card>
               </Section>
             </SimpleCollapsible.Content>

--- a/web/tests/e2e/admin/query_history_toggle.spec.ts
+++ b/web/tests/e2e/admin/query_history_toggle.spec.ts
@@ -1,0 +1,145 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "@tests/e2e/fixtures/eeFeatures";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+async function expandAdvancedOptions(page: Page): Promise<void> {
+  await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
+    timeout: 10000,
+  });
+
+  const header = page.getByText("Advanced Options", { exact: true });
+  await expect(header).toBeVisible({ timeout: 10000 });
+
+  const queryHistoryTrigger = page
+    .locator("label")
+    .filter({ hasText: "Query History" })
+    .first();
+
+  const alreadyVisible = await queryHistoryTrigger
+    .isVisible()
+    .catch(() => false);
+  if (alreadyVisible) return;
+
+  await header.scrollIntoViewIfNeeded();
+  await header.click();
+
+  await expect(queryHistoryTrigger).toBeVisible({ timeout: 5000 });
+}
+
+async function getQueryHistoryValue(page: Page): Promise<string> {
+  await expandAdvancedOptions(page);
+
+  const trigger = page
+    .locator("label")
+    .filter({ hasText: "Query History" })
+    .locator('[role="combobox"]');
+
+  const text = (await trigger.textContent()) ?? "";
+  for (const label of ["Normal", "Anonymized", "Disabled"]) {
+    if (text.includes(label)) return label;
+  }
+  return text;
+}
+
+async function setQueryHistoryType(
+  page: Page,
+  value: "Normal" | "Anonymized" | "Disabled"
+): Promise<void> {
+  await page.goto("/admin/configuration/chat-preferences");
+  await page.waitForLoadState("networkidle");
+  await expandAdvancedOptions(page);
+
+  const currentValue = await getQueryHistoryValue(page);
+  if (currentValue === value) return;
+
+  const trigger = page
+    .locator("label")
+    .filter({ hasText: "Query History" })
+    .locator('[role="combobox"]');
+
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.click();
+
+  const option = page.locator('[role="option"]').filter({ hasText: value });
+  await expect(option).toBeVisible({ timeout: 3000 });
+  await option.click();
+
+  await expect(page.getByText("Settings updated")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("Query History Toggle @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test.afterEach(async ({ page }) => {
+    await setQueryHistoryType(page, "Normal");
+  });
+
+  test("dropdown shows current value and persists after reload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/configuration/chat-preferences");
+    await page.waitForLoadState("networkidle");
+
+    const currentValue = await getQueryHistoryValue(page);
+    expect(["Normal", "Anonymized", "Disabled"]).toContain(currentValue);
+
+    await setQueryHistoryType(page, "Anonymized");
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const newValue = await getQueryHistoryValue(page);
+    expect(newValue).toBe("Anonymized");
+  });
+
+  test("setting to Disabled hides query history sidebar link", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Query History page requires enterprise license");
+
+    await setQueryHistoryType(page, "Normal");
+
+    await page.goto("/admin/performance/usage");
+    await page.waitForLoadState("networkidle");
+
+    const sidebar = page.locator('[class*="group/SidebarWrapper"]');
+    const queryHistoryLink = sidebar.locator(
+      'a[href="/admin/performance/query-history"]'
+    );
+    await expect(queryHistoryLink).toBeVisible({ timeout: 5000 });
+
+    await setQueryHistoryType(page, "Disabled");
+
+    await page.goto("/admin/performance/usage");
+    await page.waitForLoadState("networkidle");
+
+    const sidebarAfter = page.locator('[class*="group/SidebarWrapper"]');
+    const queryHistoryLinkAfter = sidebarAfter.locator(
+      'a[href="/admin/performance/query-history"]'
+    );
+    await expect(queryHistoryLinkAfter).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test("can cycle through all three options", async ({ page }) => {
+    await setQueryHistoryType(page, "Normal");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Normal");
+
+    await setQueryHistoryType(page, "Anonymized");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Anonymized");
+
+    await setQueryHistoryType(page, "Disabled");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Disabled");
+  });
+});

--- a/web/tests/e2e/admin/query_history_toggle.spec.ts
+++ b/web/tests/e2e/admin/query_history_toggle.spec.ts
@@ -12,7 +12,7 @@ async function expandAdvancedOptions(page: Page): Promise<void> {
 
   const queryHistoryTrigger = page
     .locator("label")
-    .filter({ hasText: "Query History" })
+    .filter({ hasText: "Query History Visibility" })
     .first();
 
   const alreadyVisible = await queryHistoryTrigger
@@ -31,11 +31,11 @@ async function getQueryHistoryValue(page: Page): Promise<string> {
 
   const trigger = page
     .locator("label")
-    .filter({ hasText: "Query History" })
+    .filter({ hasText: "Query History Visibility" })
     .locator('[role="combobox"]');
 
   const text = (await trigger.textContent()) ?? "";
-  for (const label of ["Normal", "Anonymized", "Disabled"]) {
+  for (const label of ["Show with User Info", "Anonymized", "Hidden"]) {
     if (text.includes(label)) return label;
   }
   return text;
@@ -43,7 +43,7 @@ async function getQueryHistoryValue(page: Page): Promise<string> {
 
 async function setQueryHistoryType(
   page: Page,
-  value: "Normal" | "Anonymized" | "Disabled"
+  value: "Show with User Info" | "Anonymized" | "Hidden"
 ): Promise<void> {
   await page.goto("/admin/configuration/chat-preferences");
   await page.waitForLoadState("networkidle");
@@ -54,7 +54,7 @@ async function setQueryHistoryType(
 
   const trigger = page
     .locator("label")
-    .filter({ hasText: "Query History" })
+    .filter({ hasText: "Query History Visibility" })
     .locator('[role="combobox"]');
 
   await trigger.scrollIntoViewIfNeeded();
@@ -76,7 +76,7 @@ test.describe("Query History Toggle @exclusive", () => {
   });
 
   test.afterEach(async ({ page }) => {
-    await setQueryHistoryType(page, "Normal");
+    await setQueryHistoryType(page, "Show with User Info");
   });
 
   test("dropdown shows current value and persists after reload", async ({
@@ -86,7 +86,9 @@ test.describe("Query History Toggle @exclusive", () => {
     await page.waitForLoadState("networkidle");
 
     const currentValue = await getQueryHistoryValue(page);
-    expect(["Normal", "Anonymized", "Disabled"]).toContain(currentValue);
+    expect(["Show with User Info", "Anonymized", "Hidden"]).toContain(
+      currentValue
+    );
 
     await setQueryHistoryType(page, "Anonymized");
 
@@ -97,13 +99,13 @@ test.describe("Query History Toggle @exclusive", () => {
     expect(newValue).toBe("Anonymized");
   });
 
-  test("setting to Disabled hides query history sidebar link", async ({
+  test("setting to Hidden hides query history sidebar link", async ({
     page,
     eeEnabled,
   }) => {
     test.skip(!eeEnabled, "Query History page requires enterprise license");
 
-    await setQueryHistoryType(page, "Normal");
+    await setQueryHistoryType(page, "Show with User Info");
 
     await page.goto("/admin/performance/usage");
     await page.waitForLoadState("networkidle");
@@ -114,7 +116,7 @@ test.describe("Query History Toggle @exclusive", () => {
     );
     await expect(queryHistoryLink).toBeVisible({ timeout: 5000 });
 
-    await setQueryHistoryType(page, "Disabled");
+    await setQueryHistoryType(page, "Hidden");
 
     await page.goto("/admin/performance/usage");
     await page.waitForLoadState("networkidle");
@@ -127,19 +129,19 @@ test.describe("Query History Toggle @exclusive", () => {
   });
 
   test("can cycle through all three options", async ({ page }) => {
-    await setQueryHistoryType(page, "Normal");
+    await setQueryHistoryType(page, "Show with User Info");
     await page.reload();
     await page.waitForLoadState("networkidle");
-    expect(await getQueryHistoryValue(page)).toBe("Normal");
+    expect(await getQueryHistoryValue(page)).toBe("Show with User Info");
 
     await setQueryHistoryType(page, "Anonymized");
     await page.reload();
     await page.waitForLoadState("networkidle");
     expect(await getQueryHistoryValue(page)).toBe("Anonymized");
 
-    await setQueryHistoryType(page, "Disabled");
+    await setQueryHistoryType(page, "Hidden");
     await page.reload();
     await page.waitForLoadState("networkidle");
-    expect(await getQueryHistoryValue(page)).toBe("Disabled");
+    expect(await getQueryHistoryValue(page)).toBe("Hidden");
   });
 });


### PR DESCRIPTION
## Description
  - Add a dropdown in admin Chat Preferences to control query history type (Normal / Anonymized / Disabled) at runtime, replacing
  the previous environment-variable-only configuration
  - Refactor backend to read query_history_type from persisted settings instead of the static ONYX_QUERY_HISTORY_TYPE env var,
  making the setting take effect immediately without restarts
  - Replace HTTPException with OnyxError in the query history permission check

## How Has This Been Tested?
- Playwright E2E tests added covering value persistence, sidebar visibility when disabled, and cycling through all three options
<img width="924" height="680" alt="Screenshot 2026-04-22 at 11 57 09 AM" src="https://github.com/user-attachments/assets/94862504-0aa4-4b68-b014-dec6754c468c" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an admin dropdown to control query history visibility (Show with User Info, Anonymized, Hidden) at runtime. The setting is persisted and applies immediately across the app and exports, replacing `ONYX_QUERY_HISTORY_TYPE`.

- New Features
  - Added Query History Visibility select in Admin → Chat Preferences.
  - Hides the Query History sidebar link when set to Hidden.
  - Anonymizes emails in admin views/exports when set to Anonymized.
  - E2E tests cover persistence, sidebar visibility, cycling all options, and labels.

- Refactors
  - Backend reads `query_history_type` from persisted settings via `load_settings()` (API and Celery export).
  - `ensure_query_history_is_enabled` returns the current type and raises `OnyxError(INSUFFICIENT_PERMISSIONS)` when disabled; callers use the returned type to handle anonymization.
  - Settings store defaults `query_history_type` to the env var only if not already set.

<sup>Written for commit c14e9f01317439e530688c140f8a59e8b6a63d2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



