### PR TITLE
feat(auth): add health-check bypass header for login captcha

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1165,6 +1165,11 @@ RECAPTCHA_HOSTNAME_ALLOWLIST = frozenset(
 )
 RECAPTCHA_SCORE_THRESHOLD = float(os.environ.get("RECAPTCHA_SCORE_THRESHOLD", "0.5"))
 
+# Shared secret for automated health-check clients (e.g. BetterStack Playwright)
+# to bypass login captcha. Empty value = bypass disabled (fail-closed). Sent by
+# the client as the `X-Healthcheck-Token` header and compared constant-time.
+HEALTH_CHECK_BYPASS_TOKEN = os.environ.get("HEALTH_CHECK_BYPASS_TOKEN", "")
+
 # Opt-in per-IP rate limit on /auth/register.
 SIGNUP_RATE_LIMIT_ENABLED = (
     os.environ.get("SIGNUP_RATE_LIMIT_ENABLED", "").lower() == "true"

--- a/backend/onyx/server/auth/captcha_api.py
+++ b/backend/onyx/server/auth/captcha_api.py
@@ -141,6 +141,18 @@ def _health_check_bypass_ok(request: Request) -> bool:
     return hmac.compare_digest(expected, provided)
 
 
+def _client_ip_for_log(request: Request) -> str:
+    """Return the external client IP for log attribution. Prefers the first
+    hop in ``X-Forwarded-For`` (set by nginx-ingress) so logs identify the
+    real source rather than the in-cluster proxy address.
+    """
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    first_hop = forwarded.split(",")[0].strip() if forwarded else ""
+    if first_hop:
+        return first_hop
+    return request.client.host if request.client else "unknown"
+
+
 class LoginCaptchaMiddleware(BaseHTTPMiddleware):
     """Reject ``/auth/login`` requests without a valid captcha token.
 
@@ -164,7 +176,7 @@ class LoginCaptchaMiddleware(BaseHTTPMiddleware):
         ):
             if _health_check_bypass_ok(request):
                 logger.info(
-                    f"Login captcha bypassed via health-check token client={request.client.host if request.client else 'unknown'}"
+                    f"Login captcha bypassed via health-check token client={_client_ip_for_log(request)}"
                 )
             else:
                 token = request.headers.get(LOGIN_CAPTCHA_HEADER, "")

--- a/backend/onyx/server/auth/captcha_api.py
+++ b/backend/onyx/server/auth/captcha_api.py
@@ -12,6 +12,8 @@ Three entry points are gated:
    ``UserManager.create`` via the body's ``captcha_token`` field.
 """
 
+import hmac
+
 from fastapi import APIRouter
 from fastapi import Request
 from fastapi import Response
@@ -27,6 +29,7 @@ from onyx.auth.captcha import issue_captcha_cookie_value
 from onyx.auth.captcha import validate_captcha_cookie_value
 from onyx.auth.captcha import verify_captcha_token
 from onyx.configs.app_configs import CAPTCHA_COOKIE_TTL_SECONDS
+from onyx.configs.app_configs import HEALTH_CHECK_BYPASS_TOKEN
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import onyx_error_to_json_response
@@ -121,6 +124,21 @@ class CaptchaCookieMiddleware(BaseHTTPMiddleware):
 
 GUARDED_LOGIN_PATHS = frozenset({"/auth/login"})
 LOGIN_CAPTCHA_HEADER = "X-Captcha-Token"
+HEALTH_CHECK_BYPASS_HEADER = "X-Healthcheck-Token"
+
+
+def _health_check_bypass_ok(request: Request) -> bool:
+    """Constant-time compare of the request's health-check header against the
+    server-side shared secret. Empty env var = bypass disabled (fail-closed)
+    so an accidentally-unset secret never matches a blank client header.
+    """
+    expected = HEALTH_CHECK_BYPASS_TOKEN
+    if not expected:
+        return False
+    provided = request.headers.get(HEALTH_CHECK_BYPASS_HEADER, "")
+    if not provided:
+        return False
+    return hmac.compare_digest(expected, provided)
 
 
 class LoginCaptchaMiddleware(BaseHTTPMiddleware):
@@ -129,6 +147,11 @@ class LoginCaptchaMiddleware(BaseHTTPMiddleware):
     Enforced before the fastapi-users handler runs, so credential-stuffing
     attempts cost the attacker a fresh captcha token per try. No-op when
     ``is_captcha_enabled()`` is false.
+
+    Automated health-check clients that present a valid
+    ``X-Healthcheck-Token`` header skip the captcha step — the token is a
+    backend-only shared secret, so possession alone does not grant auth
+    (credentials are still required by the login handler).
     """
 
     async def dispatch(
@@ -139,12 +162,17 @@ class LoginCaptchaMiddleware(BaseHTTPMiddleware):
             and request.url.path in GUARDED_LOGIN_PATHS
             and is_captcha_enabled()
         ):
-            token = request.headers.get(LOGIN_CAPTCHA_HEADER, "")
-            try:
-                await verify_captcha_token(token, CaptchaAction.LOGIN)
-            except CaptchaVerificationError as exc:
-                return onyx_error_to_json_response(
-                    OnyxError(OnyxErrorCode.UNAUTHORIZED, str(exc))
+            if _health_check_bypass_ok(request):
+                logger.info(
+                    f"Login captcha bypassed via health-check token client={request.client.host if request.client else 'unknown'}"
                 )
+            else:
+                token = request.headers.get(LOGIN_CAPTCHA_HEADER, "")
+                try:
+                    await verify_captcha_token(token, CaptchaAction.LOGIN)
+                except CaptchaVerificationError as exc:
+                    return onyx_error_to_json_response(
+                        OnyxError(OnyxErrorCode.UNAUTHORIZED, str(exc))
+                    )
 
         return await call_next(request)

--- a/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
+++ b/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
@@ -173,7 +173,11 @@ def test_health_check_bypass_wrong_secret_falls_through_to_captcha() -> None:
 
 
 def test_health_check_bypass_disabled_when_env_empty_is_fail_closed() -> None:
-    """Empty HEALTH_CHECK_BYPASS_TOKEN env var must never match any header value."""
+    """Empty HEALTH_CHECK_BYPASS_TOKEN env var must never match any header value,
+    regardless of whether the client header is empty or non-empty. Exercises
+    both ``if not expected`` (server side) and ``if not provided`` (client side)
+    early-return guards.
+    """
     app = build_app()
     client = TestClient(app)
     with (
@@ -189,12 +193,23 @@ def test_health_check_bypass_disabled_when_env_empty_is_fail_closed() -> None:
             ),
         ) as verify_mock,
     ):
-        res = client.post(
+        # Empty client header: hits `if not provided` guard.
+        res_empty = client.post(
             "/auth/login",
             headers={"X-Healthcheck-Token": ""},
         )
-    assert res.status_code == 403
-    verify_mock.assert_awaited_once_with("", CaptchaAction.LOGIN)
+        # Non-empty client header: exercises the `if not expected` guard
+        # specifically — confirms an unset server secret never accidentally
+        # matches an arbitrary client-supplied token.
+        res_nonempty = client.post(
+            "/auth/login",
+            headers={"X-Healthcheck-Token": "attacker-guess-12345"},
+        )
+    assert res_empty.status_code == 403
+    assert res_nonempty.status_code == 403
+    assert verify_mock.await_count == 2
+    assert verify_mock.await_args_list[0].args == ("", CaptchaAction.LOGIN)
+    assert verify_mock.await_args_list[1].args == ("", CaptchaAction.LOGIN)
 
 
 def test_health_check_bypass_uses_constant_time_compare() -> None:

--- a/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
+++ b/backend/tests/unit/onyx/server/auth/test_login_captcha_middleware.py
@@ -115,3 +115,114 @@ def test_does_not_gate_other_endpoints() -> None:
     assert register_res.status_code == 200
     assert get_login_res.status_code == 200
     verify_mock.assert_not_awaited()
+
+
+def test_health_check_bypass_allows_request() -> None:
+    """Valid X-Healthcheck-Token header skips captcha verification entirely."""
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "HEALTH_CHECK_BYPASS_TOKEN",
+            "super-secret-bypass-token",
+        ),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(),
+        ) as verify_mock,
+    ):
+        res = client.post(
+            "/auth/login",
+            headers={"X-Healthcheck-Token": "super-secret-bypass-token"},
+        )
+    assert res.status_code == 200
+    assert res.json() == {"status": "logged-in"}
+    verify_mock.assert_not_awaited()
+
+
+def test_health_check_bypass_wrong_secret_falls_through_to_captcha() -> None:
+    """Wrong secret in X-Healthcheck-Token must NOT bypass — normal captcha path runs."""
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "HEALTH_CHECK_BYPASS_TOKEN",
+            "super-secret-bypass-token",
+        ),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(
+                side_effect=CaptchaVerificationError(
+                    "Captcha verification failed: Captcha token is required"
+                )
+            ),
+        ) as verify_mock,
+    ):
+        res = client.post(
+            "/auth/login",
+            headers={"X-Healthcheck-Token": "wrong-guess"},
+        )
+    assert res.status_code == 403
+    verify_mock.assert_awaited_once_with("", CaptchaAction.LOGIN)
+
+
+def test_health_check_bypass_disabled_when_env_empty_is_fail_closed() -> None:
+    """Empty HEALTH_CHECK_BYPASS_TOKEN env var must never match any header value."""
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_api_module, "HEALTH_CHECK_BYPASS_TOKEN", ""),
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(
+                side_effect=CaptchaVerificationError(
+                    "Captcha verification failed: Captcha token is required"
+                )
+            ),
+        ) as verify_mock,
+    ):
+        res = client.post(
+            "/auth/login",
+            headers={"X-Healthcheck-Token": ""},
+        )
+    assert res.status_code == 403
+    verify_mock.assert_awaited_once_with("", CaptchaAction.LOGIN)
+
+
+def test_health_check_bypass_uses_constant_time_compare() -> None:
+    """Assert hmac.compare_digest is the comparison primitive (no `==` timing oracle)."""
+    app = build_app()
+    client = TestClient(app)
+    with (
+        patch.object(captcha_api_module, "is_captcha_enabled", return_value=True),
+        patch.object(
+            captcha_api_module,
+            "HEALTH_CHECK_BYPASS_TOKEN",
+            "super-secret-bypass-token",
+        ),
+        patch.object(
+            captcha_api_module.hmac,
+            "compare_digest",
+            wraps=captcha_api_module.hmac.compare_digest,
+        ) as compare_spy,
+        patch.object(
+            captcha_api_module,
+            "verify_captcha_token",
+            new=AsyncMock(),
+        ),
+    ):
+        client.post(
+            "/auth/login",
+            headers={"X-Healthcheck-Token": "super-secret-bypass-token"},
+        )
+    compare_spy.assert_called_once_with(
+        "super-secret-bypass-token", "super-secret-bypass-token"
+    )


### PR DESCRIPTION
## Description

Let automated health-check clients (BetterStack Playwright monitor) bypass the login captcha by presenting an `X-Healthcheck-Token` header matching a new `HEALTH_CHECK_BYPASS_TOKEN` env var.

**Why:** reCAPTCHA Enterprise hard-rejects Playwright traffic with reason `UNEXPECTED_ENVIRONMENT` (in the server-side `_HARD_REJECT_REASONS` set), so the monitor cannot score its way past the gate. A shared-secret backend-to-backend bypass is the simplest escape hatch.

**Security properties:**
- Fails closed when the env var is empty — blank secret never matches a blank client header.
- Constant-time compare via `hmac.compare_digest`.
- Secret lives in the k8s Secret (not ConfigMap) and is only known to BetterStack + the api-server pod.
- Bypass only skips the bot-deterrent layer — the login handler still requires valid credentials, so leaking the token does not grant auth.
- Info log on every bypass so Datadog can alert on anomalous volume (indicator of leak / unexpected use).

**Scope:** login gate only. Signup and OAuth flows untouched.

Companion change in `cloud-deployment-yamls` provisions `HEALTH_CHECK_BYPASS_TOKEN` as a k8s secret. Bypass stays disabled in every environment until the secret is set (fail-closed default).

## How Has This Been Tested?

<!-- fill in -->

## Additional Options

- [x] Override Linear Check
- [ ] This PR is ready to cherry-pick to a release branch