### PR TITLE
feat(chat): chat preference to disable smooth streaming

### DIFF
--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -28,7 +28,7 @@ import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
 import { cn, transformLinkUri } from "@/lib/utils";
-import { NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING } from "@/lib/constants";
+import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
 
 /** Maps a visible-char count to a markdown index (skips formatting chars,
  *  extends to word boundary). Used by the voice-sync reveal path only. */
@@ -97,6 +97,8 @@ export const MessageTextRenderer: MessageRenderer<
   stopReason,
   children,
 }) => {
+  const { enabled: smoothStreamingEnabled } = useSmoothStreaming();
+
   const lastStableSyncedContentRef = useRef("");
   const lastVisibleContentRef = useRef("");
 
@@ -249,7 +251,7 @@ export const MessageTextRenderer: MessageRenderer<
     animate &&
     !shouldUseAutoPlaybackSync &&
     stopReason !== StopReason.USER_CANCELLED &&
-    !NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING;
+    smoothStreamingEnabled;
 
   const isStreamFinished = isFinalAnswerComplete(packets);
 

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -28,6 +28,7 @@ import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
 import { cn, transformLinkUri } from "@/lib/utils";
+import { NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING } from "@/lib/constants";
 
 /** Maps a visible-char count to a markdown index (skips formatting chars,
  *  extends to word boundary). Used by the voice-sync reveal path only. */
@@ -247,7 +248,8 @@ export const MessageTextRenderer: MessageRenderer<
   const isStreamingAnimationEnabled =
     animate &&
     !shouldUseAutoPlaybackSync &&
-    stopReason !== StopReason.USER_CANCELLED;
+    stopReason !== StopReason.USER_CANCELLED &&
+    !NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING;
 
   const isStreamFinished = isFinalAnswerComplete(packets);
 

--- a/web/src/hooks/useSmoothStreaming.ts
+++ b/web/src/hooks/useSmoothStreaming.ts
@@ -1,0 +1,42 @@
+import Cookies from "js-cookie";
+import { useCallback, useEffect, useState } from "react";
+
+import { SMOOTH_STREAMING_COOKIE_NAME } from "@/lib/constants";
+
+const CHANGE_EVENT = "smoothStreaming:change";
+const DEFAULT_ENABLED = true;
+const COOKIE_EXPIRES_DAYS = 365;
+
+function readCookie(): boolean {
+  const value = Cookies.get(SMOOTH_STREAMING_COOKIE_NAME);
+  if (value === undefined) return DEFAULT_ENABLED;
+  return value !== "false";
+}
+
+interface UseSmoothStreamingResult {
+  enabled: boolean;
+  setEnabled: (next: boolean) => void;
+}
+
+export function useSmoothStreaming(): UseSmoothStreamingResult {
+  const [enabled, setEnabledState] = useState<boolean>(() =>
+    typeof window === "undefined" ? DEFAULT_ENABLED : readCookie()
+  );
+
+  useEffect(() => {
+    setEnabledState(readCookie());
+    const handler = () => setEnabledState(readCookie());
+    window.addEventListener(CHANGE_EVENT, handler);
+    return () => window.removeEventListener(CHANGE_EVENT, handler);
+  }, []);
+
+  const setEnabled = useCallback((next: boolean) => {
+    Cookies.set(SMOOTH_STREAMING_COOKIE_NAME, String(next), {
+      expires: COOKIE_EXPIRES_DAYS,
+    });
+    setEnabledState(next);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }, []);
+
+  return { enabled, setEnabled };
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -81,6 +81,11 @@ export const NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED =
 export const NEXT_PUBLIC_TEST_ENV =
   process.env.NEXT_PUBLIC_TEST_ENV?.toLowerCase() === "true";
 
+// When true, disables the per-character typewriter reveal and renders
+// streamed chat content as chunks arrive.
+export const NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING =
+  process.env.NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING?.toLowerCase() === "true";
+
 export const NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK =
   process.env.NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK?.toLowerCase() ===
   "true";

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -81,10 +81,9 @@ export const NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED =
 export const NEXT_PUBLIC_TEST_ENV =
   process.env.NEXT_PUBLIC_TEST_ENV?.toLowerCase() === "true";
 
-// When true, disables the per-character typewriter reveal and renders
-// streamed chat content as chunks arrive.
-export const NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING =
-  process.env.NEXT_PUBLIC_DISABLE_SMOOTH_STREAMING?.toLowerCase() === "true";
+// Cookie controlling the per-character typewriter reveal in chat.
+// "false" disables smooth streaming — chunks render as they arrive.
+export const SMOOTH_STREAMING_COOKIE_NAME = "smoothStreamingEnabled";
 
 export const NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK =
   process.env.NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK?.toLowerCase() ===

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -67,6 +67,7 @@ import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidE
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { Tooltip } from "@opal/components";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
+import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
 
 interface PAT {
   id: number;
@@ -763,6 +764,10 @@ function ChatPreferencesSettings() {
   const settings = useSettingsContext();
   const { isSearchModeAvailable: searchUiEnabled } = settings;
   const llmManager = useLlmManager();
+  const {
+    enabled: smoothStreamingEnabled,
+    setEnabled: setSmoothStreamingEnabled,
+  } = useSmoothStreaming();
 
   const {
     personalizationValues,
@@ -857,6 +862,17 @@ function ChatPreferencesSettings() {
               onCheckedChange={(checked) => {
                 updateUserAutoScroll(checked);
               }}
+            />
+          </InputHorizontal>
+
+          <InputHorizontal
+            title="Smooth Streaming"
+            description="Animate streamed responses character-by-character. Disable to render chunks as they arrive."
+            withLabel
+          >
+            <Switch
+              checked={smoothStreamingEnabled}
+              onCheckedChange={setSmoothStreamingEnabled}
             />
           </InputHorizontal>
 


### PR DESCRIPTION
## Description

Adds a Chat Preferences toggle that controls the per-character typewriter reveal in streamed chat responses. When disabled, chunks render as they arrive from the backend.

- Persisted in a long-lived (365d) cookie `smoothStreamingEnabled` — no backend changes
- New `useSmoothStreaming` hook reads the cookie and broadcasts a custom event so every open renderer resyncs instantly when the toggle flips
- Toggle lives in **Settings → Chat Preferences → Chats**, next to Chat Auto-scroll
- `MessageTextRenderer` AND-gates the hook value into `isStreamingAnimationEnabled`; when off, `useTypewriter` snaps to the full target (existing code path, no hook changes)
- Voice-sync reveal path untouched

## How Has This Been Tested?


https://github.com/user-attachments/assets/7ef341ac-7e63-476d-9bd1-cbe18ff476e6



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check