### PR TITLE
chore(tests): LLM provider tests for openai and ollama

### DIFF
--- a/.github/workflows/nightly-external-dependency-unit-tests.yml
+++ b/.github/workflows/nightly-external-dependency-unit-tests.yml
@@ -1,0 +1,74 @@
+name: Nightly External Dependency Unit Tests
+concurrency:
+  group: Nightly-External-Dependency-Unit-Tests-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    # Runs daily at 10:30 UTC (2:30 AM PST / 3:30 AM PDT) — same slot as
+    # nightly-llm-provider-chat.yml.
+    - cron: "30 10 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly-external-dependency-unit-tests:
+    # Runs every test under backend/tests/external_dependency_unit marked
+    # with `@pytest.mark.nightly` — i.e. tests that are too slow, expensive,
+    # or flaky to run on every PR but should still be exercised daily.
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - ${{ format('run-id={0}-nightly-external-dependency-unit-tests', github.run_id) }}
+    timeout-minutes: 30
+    environment: ci-protected
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC-based AWS credential exchange
+    steps:
+      - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Setup Python and Install Dependencies
+        uses: ./.github/actions/setup-python-and-install-dependencies
+        with:
+          requirements: |
+            backend/requirements/default.txt
+            backend/requirements/dev.txt
+            backend/requirements/ee.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Run nightly external dependency unit tests
+        env:
+          PYTHONPATH: ./backend
+        run: |
+          uv run pytest -m nightly \
+            backend/tests/external_dependency_unit
+
+  notify-slack-on-failure:
+    needs: [nightly-external-dependency-unit-tests]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-slim
+    environment: ci-protected
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Send Slack notification
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          failed-jobs: nightly-external-dependency-unit-tests
+          title: "🚨 Nightly External Dependency Unit Tests failed!"
+          ref-name: ${{ github.ref_name }}

--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -161,6 +161,7 @@ jobs:
             -o junit_family=xunit2 \
             -xv \
             --ff \
+            -m "not nightly" \
             backend/tests/external_dependency_unit/${TEST_DIR}
 
       - name: Collect Docker logs on failure

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -6,6 +6,7 @@ asyncio_default_fixture_loop_scope = function
 markers =
     slow: marks tests as slow
     alembic: marks tests for alembic migration testing
+    nightly: marks tests that should only run on the nightly schedule (skipped on PRs)
 filterwarnings =
     ignore::DeprecationWarning
     ignore::cryptography.utils.CryptographyDeprecationWarning

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -15,6 +15,13 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.full_setup import ensure_full_deployment_setup
 
+# Opt into the shared @pytest.mark.secrets / test_secrets infrastructure.
+from tests.utils.pytest_secrets import (
+    pytest_collection_modifyitems as pytest_collection_modifyitems,
+)
+from tests.utils.pytest_secrets import pytest_configure as pytest_configure
+from tests.utils.pytest_secrets import test_secrets as test_secrets
+
 
 @pytest.fixture(scope="function")
 def db_session() -> Generator[Session, None, None]:

--- a/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
+++ b/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
@@ -1,0 +1,96 @@
+"""Live behavior test for Ollama streaming through LiteLLM.
+
+`_patch_ollama_chunk_parser` (in `monkey_patches.py`) ensures reasoning
+tokens are routed to `Delta.reasoning_content` and visible answer tokens
+land on `Delta.content`, for both native `thinking` field chunks and
+legacy `<think>...</think>`-tagged content chunks. Unit tests in
+`backend/tests/unit/onyx/llm/test_litellm_monkey_patches.py` cover the
+state machine against crafted chunk dicts; this test exercises the same
+path against Ollama Cloud's live wire format so we catch upstream
+protocol drift.
+"""
+
+import pytest
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+# gpt-oss:120b-cloud emits native `thinking` tokens and is included in the
+# nightly Ollama Cloud matrix, so the credential already has access.
+_THINKING_MODEL = "gpt-oss:120b-cloud"
+
+
+@pytest.mark.secrets(TestSecret.OLLAMA_API_KEY)
+def test_streaming_separates_reasoning_content_from_visible_content(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """A thinking-capable Ollama model must stream its chain-of-thought on
+    `Delta.reasoning_content` and its final answer on `Delta.content`, and
+    every thinking chunk must surface (not just the first two). A single
+    chunk may legitimately carry both fields — Ollama emits transition
+    chunks with both `thinking` and `content` populated, and the patch
+    routes them to their respective Delta fields rather than dropping
+    either.
+
+    Without `_patch_ollama_chunk_parser`, LiteLLM's Ollama transformer
+    silently drops reasoning_content from the third chunk onwards
+    (transformation.py:504-510 only branches for the first two thinking
+    chunks). This test guards against regression in either the patch or
+    upstream Ollama chunk shape.
+    """
+    llm = LitellmLLM(
+        api_key=test_secrets[TestSecret.OLLAMA_API_KEY],
+        model_provider=LlmProviderNames.OLLAMA_CHAT,
+        model_name=_THINKING_MODEL,
+        api_base="https://ollama.com",
+        max_input_tokens=8192,
+        timeout=120,
+    )
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Think briefly about what 12 * 7 is, then respond with just "
+                "the number."
+            ),
+        )
+    ]
+
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    for chunk in llm.stream(prompt=prompt):
+        delta = chunk.choice.delta
+        rc = delta.reasoning_content
+        content = delta.content
+        if rc:
+            reasoning_parts.append(rc)
+        if content:
+            content_parts.append(content)
+
+    full_reasoning = "".join(reasoning_parts)
+    full_content = "".join(content_parts)
+
+    assert full_content.strip(), (
+        f"Model produced reasoning but no visible answer tokens. "
+        f"reasoning={full_reasoning!r}"
+    )
+    # Upstream LiteLLM only emits reasoning on the first two thinking chunks
+    # then silently drops the rest. A thinking model on a non-trivial prompt
+    # should always stream more than two reasoning chunks, so anything <= 2
+    # means the patch is missing or upstream regressed.
+    assert len(reasoning_parts) > 2, (
+        f"Expected more than 2 reasoning chunks (upstream bug drops chunks "
+        f"3+), got {len(reasoning_parts)}. reasoning_parts={reasoning_parts!r}"
+    )
+    assert (
+        "<think>" not in full_content and "</think>" not in full_content
+    ), f"Raw <think> tags leaked into visible content: {full_content!r}"
+    assert (
+        "<think>" not in full_reasoning and "</think>" not in full_reasoning
+    ), f"Raw <think> tags leaked into reasoning_content: {full_reasoning!r}"

--- a/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
@@ -1,0 +1,222 @@
+"""Live behavior tests for the OpenAI Responses API path through LiteLLM.
+
+`LitellmLLM` routes true OpenAI models through LiteLLM's Responses API
+bridge (model name prefixed with `openai/responses/`). These tests exercise
+behavior of that bridge that cannot be reached with mocks:
+
+- Parallel tool calls land in distinct streaming slots with intact arguments.
+- Streaming errors surface as the appropriate exception type rather than
+  being masked by an internal `TypeError`.
+- Reasoning summary sections are separated by a blank line in the streamed
+  `reasoning_content` (covered by `_patch_responses_reasoning_summary_newlines`
+  in `monkey_patches.py`).
+"""
+
+import json
+
+import pytest
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.litellm_singleton import litellm
+from onyx.llm.models import ChatCompletionMessage
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+
+def _build_openai_llm(model: str, api_key: str) -> LitellmLLM:
+    return LitellmLLM(
+        api_key=api_key,
+        model_provider=LlmProviderNames.OPENAI,
+        model_name=model,
+        max_input_tokens=128_000,
+        timeout=60,
+    )
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_parallel_tool_calls_land_in_distinct_slots(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Concurrent tool calls in a single streaming response must arrive on
+    distinct `index` values with intact, parseable arguments.
+
+    Pre-litellm-1.83.0 the responses bridge hardcoded `index=0` for every
+    tool call, causing argument deltas from the second call to overwrite the
+    first; it also set `finish_reason="tool_calls"` on the first
+    `output_item.done`, terminating the stream before the second call
+    arrived. Onyx's responses-streaming patch was removed once upstream
+    fixed both. This test is the regression guard against either failure
+    re-emerging.
+    """
+    llm = _build_openai_llm("gpt-4o-mini", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "get_population",
+                "description": "Get the population of a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        },
+    ]
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "For Paris, France: call get_weather AND get_population. "
+                "Issue both tool calls in a single response."
+            ),
+        )
+    ]
+
+    accumulated: dict[int, dict[str, str]] = {}
+    for chunk in llm.stream(prompt=prompt, tools=tools):
+        for tc in chunk.choice.delta.tool_calls:
+            slot = accumulated.setdefault(
+                tc.index, {"id": "", "name": "", "arguments": ""}
+            )
+            if tc.id:
+                slot["id"] = tc.id
+            if tc.function:
+                if tc.function.name:
+                    slot["name"] = tc.function.name
+                if tc.function.arguments:
+                    slot["arguments"] += tc.function.arguments
+
+    indices = sorted(accumulated.keys())
+    assert indices == list(
+        range(len(indices))
+    ), f"Tool call indices should be 0..N-1, got {indices}"
+
+    names = {slot["name"] for slot in accumulated.values()}
+    assert names == {
+        "get_weather",
+        "get_population",
+    }, f"Expected both tool names to land in distinct slots, got {names}"
+
+    for slot in accumulated.values():
+        assert slot["id"], f"Tool call slot missing id: {slot}"
+        try:
+            parsed = json.loads(slot["arguments"])
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"Tool call arguments not valid JSON for {slot['name']!r}: "
+                f"{slot['arguments']!r} ({e})"
+            )
+        assert "city" in parsed, f"Expected 'city' in arguments, got {parsed}"
+
+
+def test_responses_call_with_invalid_key_raises_authentication_error() -> None:
+    """An invalid API key must surface as `AuthenticationError`.
+
+    Specifically, passing `metadata=None` together with a bad key must NOT
+    surface as `TypeError: argument of type 'NoneType' is not iterable`.
+    Pre-1.83.0 LiteLLM's `@client` wrapper did `kwargs.get("metadata", {})`
+    which returned `None` when the key existed with value `None`, masking
+    the real auth failure. Upstream now uses `kwargs.get("metadata") or {}`.
+    Onyx's `_patch_responses_metadata_none` was removed once that fix
+    landed; this test guards against regression.
+    """
+    with pytest.raises(Exception) as exc_info:
+        litellm.responses(
+            model="openai/gpt-5.4-nano",
+            input="hi",
+            api_key="sk-onyx-contract-test-deliberately-invalid",
+            metadata=None,
+            max_output_tokens=8,
+        )
+
+    err = exc_info.value
+    err_str = str(err)
+    assert (
+        "NoneType" not in err_str
+    ), f"metadata=None TypeError leaked into the surfaced exception: {err_str!r}"
+    assert (
+        isinstance(err, litellm.exceptions.AuthenticationError)
+        or "auth" in err_str.lower()
+        or "401" in err_str
+    ), (
+        f"Expected AuthenticationError-shaped exception, got "
+        f"{type(err).__name__}: {err_str!r}"
+    )
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_responses_call_tolerates_explicit_metadata_none(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Passing `metadata=None` on the happy path must not raise.
+
+    Sister test to `test_responses_call_with_invalid_key_raises_authentication_error`:
+    confirms `metadata=None` is tolerated for *successful* calls, not just
+    error paths.
+    """
+    response = litellm.responses(
+        model="openai/gpt-5.4-nano",
+        input="Reply with exactly the word: ok",
+        api_key=test_secrets[TestSecret.OPENAI_API_KEY],
+        metadata=None,
+        max_output_tokens=16,
+    )
+    assert response is not None
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_reasoning_summary_sections_are_separated_by_blank_line(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Streamed `reasoning_content` must contain a `\\n\\n` separator
+    between distinct summary sections.
+
+    LiteLLM passes through `response.reasoning_summary_text.delta` events
+    as-is, with no separator when `summary_index` changes. Without the
+    separator, multiple sections render as a single concatenated wall of
+    text. `_patch_responses_reasoning_summary_newlines` (in
+    `monkey_patches.py`) inserts the blank line. This test guards that the
+    patch is still firing for current LiteLLM and OpenAI behavior.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Plan a 3-day trip to Tokyo for someone with a peanut allergy on a $2000 budget. "
+                "First plan the itinerary, then verify each restaurant choice is safe, then check "
+                "the budget math."
+            ),
+        )
+    ]
+
+    reasoning_parts: list[str] = []
+    for chunk in llm.stream(prompt=prompt):
+        rc = chunk.choice.delta.reasoning_content
+        if rc:
+            reasoning_parts.append(rc)
+
+    full_reasoning = "".join(reasoning_parts)
+
+    assert (
+        "\n\n" in full_reasoning
+    ), f"Expected double-newline separator between summary sections: {full_reasoning!r}"

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -26,6 +26,7 @@ class TestSecret(StrEnum):
     AZURE_API_URL = "AZURE_API_URL"
     LITELLM_API_KEY = "LITELLM_API_KEY"
     LITELLM_API_URL = "LITELLM_API_URL"
+    OLLAMA_API_KEY = "OLLAMA_API_KEY"
 
     @classmethod
     def aws_prefix(cls) -> str:


### PR DESCRIPTION
## Description

Some external dependency integration tests in preparation for the LiteLLM upgrade.

These tests are a little costly and a bit finicky since they're making real requests to LLMs and depend on in the output in some cases, so I implemented a nightly job to run them. Their presubmit counterparts aren't `required`, but I think nightly is sufficient coverage and the potential noise for developers is probably not worth.

## How Has This Been Tested?

```
uv run --active pytest \
  backend/tests/external_dependency_unit/llm/test_openai_responses_api.py \
  backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
```

I can't test the `.github/workflows/nightly-external-dependency-unit-tests.yml` until it's merged into `main`, but I confirmed these tests would pass on presubmit and I can follow up with fixes as needed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live integration tests for `litellm` OpenAI Responses streaming and Ollama thinking models, plus a nightly workflow to run external-dependency tests. Validates reasoning/content separation and guards against known `litellm` regressions.

- **New Features**
  - OpenAI Responses: parallel tool calls stream to separate indices with valid JSON args; invalid keys raise `AuthenticationError` (no `NoneType` from `metadata=None`); accepts `metadata=None`; reasoning summaries include blank-line separators in `reasoning_content`.
  - Ollama: streams thinking to `reasoning_content` and answers to `content`; preserves transition chunks with both fields; no `<think>` tag leaks; streams >2 reasoning chunks; supports native `thinking` and legacy `<think>` tags.

- **Dependencies**
  - CI: add nightly workflow for `@pytest.mark.nightly` tests with Slack alerts; PR workflow skips nightlies (`-m "not nightly"`); enable OIDC and assume AWS via `aws-actions/configure-aws-credentials` in `us-east-2`.
  - Tests: opt into shared `@pytest.mark.secrets` infra; add `OLLAMA_API_KEY` to `TestSecret`.

<sup>Written for commit 56295cb3d5722bc5d4d2289635406dbb3574559c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



