### PR TITLE
fix(GoogleDriveConnector): Handle RefreshError for removed Workspace users

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -865,10 +865,19 @@ class GoogleDriveConnector(
             raise
         except RefreshError as e:
             logger.warning(
-                f"User '{user_email}' could not refresh their token. Error: {e}"
+                f"User '{user_email}' token refresh failed, re-fetching user list "
+                f"to check if they were removed. Error: {e}"
             )
-            # mark this user as done so we don't try to retrieve anything for them
-            # again
+            fresh_emails = self._get_all_user_emails()
+            if user_email not in fresh_emails:
+                # User was removed from the workspace — update checkpoint and skip silently
+                logger.warning(
+                    f"User '{user_email}' confirmed removed from workspace, skipping."
+                )
+                checkpoint.user_emails = fresh_emails
+                curr_stage.stage = DriveRetrievalStage.DONE
+                return
+            # User still exists — this is a real token problem, surface as a failure
             yield RetrievedDriveFile(
                 completion_stage=DriveRetrievalStage.DONE,
                 drive_file={},

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -868,13 +868,20 @@ class GoogleDriveConnector(
                 f"User '{user_email}' token refresh failed, re-fetching user list "
                 f"to check if they were removed. Error: {e}"
             )
-            fresh_emails = self._get_all_user_emails()
+            try:
+                fresh_emails = self._get_all_user_emails()
+                checkpoint.user_emails = fresh_emails
+            except Exception as fetch_err:
+                logger.warning(
+                    f"Could not re-fetch user list to verify '{user_email}' removal "
+                    f"(error: {fetch_err}); surfacing original RefreshError as failure."
+                )
+                fresh_emails = [user_email]  # treat as if user still exists
             if user_email not in fresh_emails:
-                # User was removed from the workspace — update checkpoint and skip silently
+                # User was removed from the workspace — skip silently
                 logger.warning(
                     f"User '{user_email}' confirmed removed from workspace, skipping."
                 )
-                checkpoint.user_emails = fresh_emails
                 curr_stage.stage = DriveRetrievalStage.DONE
                 return
             # User still exists — this is a real token problem, surface as a failure

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -10,11 +10,14 @@ Verifies that:
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from google.auth.exceptions import RefreshError
+
 from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.models import DriveRetrievalStage
 from onyx.connectors.google_drive.models import GoogleDriveCheckpoint
+from onyx.connectors.google_drive.models import StageCompletion
 from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import SlimDocument
@@ -424,3 +427,109 @@ class TestOrphanedPathBackfill:
             )
 
         mock_api.assert_not_called()
+
+
+def _make_checkpoint_with_user(user_email: str) -> GoogleDriveCheckpoint:
+    completion_map: ThreadSafeDict[str, StageCompletion] = ThreadSafeDict(
+        {
+            user_email: StageCompletion(
+                stage=DriveRetrievalStage.START,
+                completed_until=0,
+            )
+        }
+    )
+    return GoogleDriveCheckpoint(
+        retrieved_folder_and_drive_ids=set(),
+        completion_stage=DriveRetrievalStage.MY_DRIVE_FILES,
+        completion_map=completion_map,
+        all_retrieved_file_ids=set(),
+        has_more=False,
+        user_emails=[user_email],
+    )
+
+
+class TestImpersonateUserRefreshError:
+    def test_refresh_error_user_removed_skips_silently(self) -> None:
+        """When RefreshError occurs and the user is absent from the re-fetched
+        user list, the connector should skip them silently (no error yielded),
+        mark them DONE in completion_map, and update checkpoint.user_emails."""
+        user_email = "wilbur.suero@savvywealth.com"
+        connector = _make_connector()
+        checkpoint = _make_checkpoint_with_user(user_email)
+
+        refresh_error = RefreshError("invalid_grant: Invalid email or User ID")
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_root_folder_id",
+                side_effect=refresh_error,
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.retry_builder",
+                return_value=lambda f: f,
+            ),
+            patch.object(
+                connector,
+                "_get_all_user_emails",
+                return_value=["admin@example.com"],  # user absent
+            ),
+        ):
+            results = list(
+                connector._impersonate_user_for_retrieval(
+                    user_email=user_email,
+                    field_type=DriveFileFieldType.SLIM,
+                    checkpoint=checkpoint,
+                    get_new_drive_id=lambda _: None,
+                    sorted_filtered_folder_ids=[],
+                )
+            )
+
+        assert results == []
+        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
+        assert user_email not in (checkpoint.user_emails or [])
+
+    def test_refresh_error_user_still_exists_yields_error(self) -> None:
+        """When RefreshError occurs but the user is still present in the
+        re-fetched user list, the error should be yielded as a real failure."""
+        user_email = "wilbur.suero@savvywealth.com"
+        connector = _make_connector()
+        checkpoint = _make_checkpoint_with_user(user_email)
+
+        refresh_error = RefreshError("token_refresh_failed")
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_root_folder_id",
+                side_effect=refresh_error,
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.retry_builder",
+                return_value=lambda f: f,
+            ),
+            patch.object(
+                connector,
+                "_get_all_user_emails",
+                return_value=[user_email, "admin@example.com"],  # user still present
+            ),
+        ):
+            results = list(
+                connector._impersonate_user_for_retrieval(
+                    user_email=user_email,
+                    field_type=DriveFileFieldType.SLIM,
+                    checkpoint=checkpoint,
+                    get_new_drive_id=lambda _: None,
+                    sorted_filtered_folder_ids=[],
+                )
+            )
+
+        assert len(results) == 1
+        assert results[0].error is refresh_error
+        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -533,3 +533,51 @@ class TestImpersonateUserRefreshError:
         assert len(results) == 1
         assert results[0].error is refresh_error
         assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
+        assert checkpoint.user_emails == [user_email, "admin@example.com"]
+
+    def test_refresh_error_refetch_fails_yields_error_and_preserves_checkpoint(
+        self,
+    ) -> None:
+        """When the re-fetch of user emails itself fails, the original RefreshError
+        should be surfaced as a failure and checkpoint.user_emails must not be
+        overwritten with a partial/incorrect list."""
+        user_email = "wilbur.suero@savvywealth.com"
+        connector = _make_connector()
+        checkpoint = _make_checkpoint_with_user(user_email)
+        original_user_emails = list(checkpoint.user_emails or [])
+
+        refresh_error = RefreshError("invalid_grant: Invalid email or User ID")
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_root_folder_id",
+                side_effect=refresh_error,
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.retry_builder",
+                return_value=lambda f: f,
+            ),
+            patch.object(
+                connector,
+                "_get_all_user_emails",
+                side_effect=Exception("Admin SDK unavailable"),
+            ),
+        ):
+            results = list(
+                connector._impersonate_user_for_retrieval(
+                    user_email=user_email,
+                    field_type=DriveFileFieldType.SLIM,
+                    checkpoint=checkpoint,
+                    get_new_drive_id=lambda _: None,
+                    sorted_filtered_folder_ids=[],
+                )
+            )
+
+        assert len(results) == 1
+        assert results[0].error is refresh_error
+        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
+        assert checkpoint.user_emails == original_user_emails


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
When a user is deleted or suspended from Google Workspace mid-run, impersonating them raises a RefreshError (invalid_grant) which was incorrectly counted as a ConnectorFailure. Combined with other failures, this could trip the failure threshold and abort the connector run — with the RefreshError being re-raised as the last recorded failure.

Fix: On RefreshError, re-fetch the user list from the Admin SDK. If the user is gone, update checkpoint.user_emails, mark them DONE in completion_map, and skip silently. If they still exist, surface the error as a real failure.

https://linear.app/onyx-app/issue/ENG-4071/handle-refresherror-for-removed-workspace-users
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Two unit tests added covering both branches
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false connector failures when a Google Workspace user is deleted or suspended mid-run by correctly handling `RefreshError` and skipping removed users. Addresses Linear ENG-4071 and avoids tripping failure thresholds.

- **Bug Fixes**
  - On `RefreshError`, re-fetch the user list via the Admin SDK.
  - If the user was removed, update `checkpoint.user_emails`, mark stage `DONE`, and skip silently.
  - If the user still exists, surface the token issue as a real failure and update `checkpoint.user_emails`.
  - If the re-fetch fails, surface the original `RefreshError` and keep `checkpoint.user_emails` unchanged.

<sup>Written for commit f6f72a97c1dd75991a427448f4d66c6067d51a9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



