### PR TITLE
chore(playwright): chat file upload tests

### DIFF
--- a/.secretsignore
+++ b/.secretsignore
@@ -1,1 +1,5 @@
 .devcontainer/github_known_hosts
+
+[secrets]
+# This is from a PNG image used in tests.
+EAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYI

--- a/.secretsignore
+++ b/.secretsignore
@@ -1,5 +1,5 @@
 .devcontainer/github_known_hosts
 
 [secrets]
-# This is from a PNG image used in tests.
-EAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYI
+# This is from a 50x50 checkered PNG image used in tests.
+iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJUuHylcFApyWhTVc1rkkOzczwZLCwsrN9YuXXH+1lLxMLCwtpz5XV5fwsLC0uX1+WxsLCwdHldHgsLC+uxLK9hJFqMAN43AAAAAElFTkSuQmCC

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "types:check": "tsgo --noEmit --project tsconfig.types.json",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "playwright": "playwright test",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/web/tests/e2e/chat/ChatPage.ts
+++ b/web/tests/e2e/chat/ChatPage.ts
@@ -1,0 +1,78 @@
+/**
+ * Page Object Model for the main chat page (/app).
+ *
+ * Encapsulates locators and interactions shared across chat specs so that
+ * individual tests remain declarative.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
+
+export class ChatPage {
+  readonly page: Page;
+
+  // Layout containers
+  readonly container: Locator;
+  readonly scrollContainer: Locator;
+
+  // Input
+  readonly chatInputTextarea: Locator;
+  readonly sendButton: Locator;
+
+  // Message collections
+  readonly humanMessages: Locator;
+  readonly aiMessages: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.container = page.locator("[data-main-container]");
+    this.scrollContainer = page.getByTestId("chat-scroll-container");
+    this.chatInputTextarea = page.locator("#onyx-chat-input-textarea");
+    this.sendButton = page.locator("#onyx-chat-input-send-button");
+    this.humanMessages = page.locator("#onyx-human-message");
+    this.aiMessages = page.getByTestId("onyx-ai-message");
+  }
+
+  humanMessage(index = 0): Locator {
+    return this.humanMessages.nth(index);
+  }
+
+  aiMessage(index = 0): Locator {
+    return this.aiMessages.nth(index);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto("/app");
+    await this.page.waitForLoadState("networkidle");
+    await this.chatInputTextarea.waitFor({ state: "visible", timeout: 15000 });
+  }
+
+  async scrollTo(position: "top" | "bottom"): Promise<void> {
+    await this.scrollContainer.evaluate(async (el, pos) => {
+      el.scrollTo({ top: pos === "top" ? 0 : el.scrollHeight });
+      await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    }, position);
+  }
+
+  async screenshotContainer(name: string): Promise<void> {
+    await expect(this.container).toBeVisible();
+    await this.scrollTo("bottom");
+    await expectElementScreenshot(this.container, { name });
+  }
+
+  /**
+   * Captures two screenshots of the chat container for long-content tests:
+   * one scrolled to the top and one scrolled to the bottom. Ensures
+   * consistent scroll positions regardless of whether the page was just
+   * navigated to (top) or just finished streaming (bottom).
+   */
+  async screenshotContainerTopAndBottom(name: string): Promise<void> {
+    await expect(this.container).toBeVisible();
+
+    await this.scrollTo("top");
+    await expectElementScreenshot(this.container, { name: `${name}-top` });
+
+    await this.scrollTo("bottom");
+    await expectElementScreenshot(this.container, { name: `${name}-bottom` });
+  }
+}

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -2,6 +2,12 @@ import { expect, Page, test } from "@playwright/test";
 import { ChatPage } from "@tests/e2e/chat/ChatPage";
 import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { sendMessage } from "@tests/e2e/utils/chatActions";
+import {
+  buildMockImageGenStream,
+  buildMockStream,
+  mockChatEndpoint,
+  resetTurnCounter,
+} from "@tests/e2e/utils/chatMock";
 import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
 const SHORT_AI_RESPONSE = "I've reviewed the file you uploaded.";
@@ -22,116 +28,6 @@ const PYTHON_CODE = `def greet(name: str) -> str:
 if __name__ == "__main__":
     print(greet("Onyx"))
 `;
-
-let turnCounter = 0;
-
-function buildMockStream(content: string): string {
-  turnCounter += 1;
-  const userMessageId = turnCounter * 100 + 1;
-  const agentMessageId = turnCounter * 100 + 2;
-
-  const packets = [
-    {
-      user_message_id: userMessageId,
-      reserved_assistant_message_id: agentMessageId,
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: {
-        type: "message_start",
-        id: `mock-${agentMessageId}`,
-        content,
-        final_documents: null,
-      },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "stop", stop_reason: "finished" },
-    },
-    {
-      message_id: agentMessageId,
-      citations: {},
-      files: [],
-    },
-  ];
-
-  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
-}
-
-interface ImageGenStreamOptions {
-  fileId: string;
-  revisedPrompt: string;
-  message: string;
-}
-
-function buildMockImageGenStream({
-  fileId,
-  revisedPrompt,
-  message,
-}: ImageGenStreamOptions): string {
-  turnCounter += 1;
-  const userMessageId = turnCounter * 100 + 1;
-  const agentMessageId = turnCounter * 100 + 2;
-
-  const packets = [
-    {
-      user_message_id: userMessageId,
-      reserved_assistant_message_id: agentMessageId,
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "image_generation_start" },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: {
-        type: "image_generation_final",
-        images: [
-          {
-            file_id: fileId,
-            url: `/api/chat/file/${fileId}`,
-            revised_prompt: revisedPrompt,
-            shape: "square",
-          },
-        ],
-      },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "section_end" },
-    },
-    {
-      placement: { turn_index: 1, tab_index: 0 },
-      obj: {
-        type: "message_start",
-        id: `mock-${agentMessageId}`,
-        content: message,
-        final_documents: null,
-      },
-    },
-    {
-      placement: { turn_index: 1, tab_index: 0 },
-      obj: { type: "stop", stop_reason: "finished" },
-    },
-    {
-      message_id: agentMessageId,
-      citations: {},
-      files: [{ id: fileId, type: "image" }],
-    },
-  ];
-
-  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
-}
-
-async function mockChatEndpoint(page: Page, body: string): Promise<void> {
-  await page.route("**/api/chat/send-chat-message", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/plain",
-      body,
-    });
-  });
-}
 
 interface UploadFile {
   name: string;
@@ -181,7 +77,7 @@ test.describe("Chat File Uploads", () => {
   let chat: ChatPage;
 
   test.beforeEach(async ({ page }, testInfo) => {
-    turnCounter = 0;
+    resetTurnCounter();
     chat = new ChatPage(page);
     await page.context().clearCookies();
     await loginAsWorkerUser(page, testInfo.workerIndex);
@@ -361,7 +257,7 @@ test.describe("Chat File Uploads", () => {
           .filter({ hasText: /python/i })
           .first()
       ).toBeVisible();
-      await expect(modal.getByText("greet")).toBeVisible();
+      await expect(modal.getByText("greet", { exact: true })).toBeVisible();
       await expect(modal.locator("a[download]")).toBeVisible();
 
       await expectElementScreenshot(modal, {

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -1,0 +1,372 @@
+import { expect, Page, test } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import { sendMessage } from "@tests/e2e/utils/chatActions";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
+
+const SHORT_AI_RESPONSE = "I've reviewed the file you uploaded.";
+const IMAGE_GEN_AI_MESSAGE = "Here is the image I generated for you.";
+
+// Smallest known-valid 1x1 PNG — used both as a user-uploaded image and as
+// the mocked response for LLM-generated image fetches. The bytes pass PIL
+// validation (which the upload endpoint runs to reject malformed images).
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64"
+);
+
+const PYTHON_CODE = `def greet(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+if __name__ == "__main__":
+    print(greet("Onyx"))
+`;
+
+let turnCounter = 0;
+
+function buildMockStream(content: string): string {
+  turnCounter += 1;
+  const userMessageId = turnCounter * 100 + 1;
+  const agentMessageId = turnCounter * 100 + 2;
+
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content,
+        final_documents: null,
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: {},
+      files: [],
+    },
+  ];
+
+  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
+}
+
+interface ImageGenStreamOptions {
+  fileId: string;
+  revisedPrompt: string;
+  message: string;
+}
+
+function buildMockImageGenStream({
+  fileId,
+  revisedPrompt,
+  message,
+}: ImageGenStreamOptions): string {
+  turnCounter += 1;
+  const userMessageId = turnCounter * 100 + 1;
+  const agentMessageId = turnCounter * 100 + 2;
+
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "image_generation_start" },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "image_generation_final",
+        images: [
+          {
+            file_id: fileId,
+            url: `/api/chat/file/${fileId}`,
+            revised_prompt: revisedPrompt,
+            shape: "square",
+          },
+        ],
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "section_end" },
+    },
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content: message,
+        final_documents: null,
+      },
+    },
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: {},
+      files: [{ id: fileId, type: "image" }],
+    },
+  ];
+
+  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
+}
+
+async function mockChatEndpoint(page: Page, body: string): Promise<void> {
+  await page.route("**/api/chat/send-chat-message", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body,
+    });
+  });
+}
+
+interface UploadFile {
+  name: string;
+  mimeType: string;
+  buffer: Buffer;
+}
+
+/**
+ * Uploads one or more files via the hidden chat-input file picker and
+ * waits for the upload request to return plus the file card(s) to render.
+ *
+ * `ImageFileCard` renders only a thumbnail `<img alt={filename}>` with no
+ * visible text, so images are located by `img[alt=...]`; non-image cards
+ * render the filename as visible text.
+ */
+async function uploadFilesToChat(
+  page: Page,
+  files: UploadFile[]
+): Promise<void> {
+  const fileInput = page.locator('input[type="file"]').first();
+  const chooserPromise = page.waitForEvent("filechooser");
+  await fileInput.dispatchEvent("click");
+  const chooser = await chooserPromise;
+
+  const uploadResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/user/projects/file/upload") &&
+      response.request().method() === "POST"
+  );
+
+  await chooser.setFiles(files);
+
+  const uploadResponse = await uploadResponsePromise;
+  expect(uploadResponse.ok()).toBeTruthy();
+
+  await page.waitForLoadState("networkidle");
+  const inputWrapper = page.locator("#onyx-chat-input");
+  for (const file of files) {
+    const card = file.mimeType.startsWith("image/")
+      ? inputWrapper.locator(`img[alt="${file.name}"]`)
+      : inputWrapper.getByText(file.name);
+    await expect(card.first()).toBeVisible({ timeout: 10000 });
+  }
+}
+
+test.describe("Chat File Uploads", () => {
+  let chat: ChatPage;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    turnCounter = 0;
+    chat = new ChatPage(page);
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+  });
+
+  test.describe("User-Uploaded Files", () => {
+    test("uploaded text file renders in user message", async ({ page }) => {
+      await chat.goto();
+      await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
+
+      const fileName = "notes-rendering.txt";
+      await uploadFilesToChat(page, [
+        {
+          name: fileName,
+          mimeType: "text/plain",
+          buffer: Buffer.from(
+            "Some notes about the upcoming Q3 roadmap.",
+            "utf-8"
+          ),
+        },
+      ]);
+
+      await sendMessage(page, "Summarize this file");
+
+      const userMessage = page.locator("#onyx-human-message").first();
+      const fileDisplay = userMessage.locator("#onyx-file");
+      await expect(fileDisplay).toBeVisible();
+      await expect(fileDisplay.getByText(fileName)).toBeVisible();
+
+      await chat.screenshotContainer("chat-uploaded-text-file");
+    });
+
+    test("uploaded image renders in user message", async ({ page }) => {
+      await chat.goto();
+      await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
+
+      const fileName = "diagram-rendering.png";
+      await uploadFilesToChat(page, [
+        {
+          name: fileName,
+          mimeType: "image/png",
+          buffer: TINY_PNG,
+        },
+      ]);
+
+      await sendMessage(page, "What's in this image?");
+
+      const userMessage = page.locator("#onyx-human-message").first();
+      const imageDisplay = userMessage.locator("#onyx-image");
+      await expect(imageDisplay).toBeVisible();
+      await expect(imageDisplay.locator("img").first()).toBeVisible();
+
+      await chat.screenshotContainer("chat-uploaded-image");
+    });
+
+    test("multiple uploaded files render together", async ({ page }) => {
+      await chat.goto();
+      await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
+
+      const textName = "notes-multi.txt";
+      const imageName = "diagram-multi.png";
+      await uploadFilesToChat(page, [
+        {
+          name: textName,
+          mimeType: "text/plain",
+          buffer: Buffer.from("Multi-file upload notes.", "utf-8"),
+        },
+        {
+          name: imageName,
+          mimeType: "image/png",
+          buffer: TINY_PNG,
+        },
+      ]);
+
+      await sendMessage(page, "Look at both of these");
+
+      const userMessage = page.locator("#onyx-human-message").first();
+      await expect(
+        userMessage.locator("#onyx-file").getByText(textName)
+      ).toBeVisible();
+      await expect(
+        userMessage.locator("#onyx-image").locator("img").first()
+      ).toBeVisible();
+
+      await chat.screenshotContainer("chat-uploaded-multiple-files");
+    });
+  });
+
+  test.describe("LLM-Generated Images", () => {
+    test("AI response with generated image renders correctly", async ({
+      page,
+    }) => {
+      await chat.goto();
+
+      const fileId = "00000000-0000-0000-0000-00000000aaaa";
+
+      await page.route(`**/api/chat/file/${fileId}`, async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "image/png",
+          body: TINY_PNG,
+        });
+      });
+
+      await mockChatEndpoint(
+        page,
+        buildMockImageGenStream({
+          fileId,
+          revisedPrompt: "A friendly cartoon onyx stone with a smile",
+          message: IMAGE_GEN_AI_MESSAGE,
+        })
+      );
+
+      await sendMessage(
+        page,
+        "Generate an image of a friendly cartoon onyx stone"
+      );
+
+      const aiMessage = page.getByTestId("onyx-ai-message").first();
+      const generatedImage = aiMessage.locator('img[alt="Chat Message Image"]');
+      await expect(generatedImage).toBeVisible({ timeout: 10000 });
+      await expect(generatedImage).toHaveAttribute(
+        "src",
+        new RegExp(`/api/chat/file/${fileId}`)
+      );
+      await expect(aiMessage).toContainText(IMAGE_GEN_AI_MESSAGE);
+
+      await chat.screenshotContainer("chat-llm-generated-image");
+    });
+  });
+
+  test.describe("Code Preview Modal", () => {
+    test("clicking expand on uploaded code file opens preview modal", async ({
+      page,
+    }) => {
+      await chat.goto();
+      await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
+
+      // Serve our controlled Python source for any chat file fetch so the
+      // modal renders deterministically regardless of the backend-assigned
+      // storage file_id.
+      await page.route("**/api/chat/file/**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "text/x-python",
+          body: PYTHON_CODE,
+        });
+      });
+
+      const fileName = "greet.py";
+      await uploadFilesToChat(page, [
+        {
+          name: fileName,
+          mimeType: "text/x-python",
+          buffer: Buffer.from(PYTHON_CODE, "utf-8"),
+        },
+      ]);
+
+      await sendMessage(page, "Review this script");
+
+      const userMessage = page.locator("#onyx-human-message").first();
+      const fileDisplay = userMessage.locator("#onyx-file");
+      await expect(fileDisplay).toBeVisible();
+
+      const expandButton = fileDisplay.locator(
+        'button[aria-label="Expand document"]'
+      );
+      await expect(expandButton).toBeVisible();
+      await expandButton.click();
+
+      const modal = page.getByRole("dialog");
+      await expect(modal).toBeVisible({ timeout: 5000 });
+      await expect(modal.getByText(fileName)).toBeVisible();
+      await expect(
+        modal
+          .locator("div")
+          .filter({ hasText: /python/i })
+          .first()
+      ).toBeVisible();
+      await expect(modal.getByText("greet")).toBeVisible();
+      await expect(modal.locator("a[download]")).toBeVisible();
+
+      await expectElementScreenshot(modal, {
+        name: "chat-code-preview-modal",
+      });
+    });
+  });
+});

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -13,11 +13,12 @@ import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 const SHORT_AI_RESPONSE = "I've reviewed the file you uploaded.";
 const IMAGE_GEN_AI_MESSAGE = "Here is the image I generated for you.";
 
-// Smallest known-valid 1x1 PNG — used both as a user-uploaded image and as
-// the mocked response for LLM-generated image fetches. The bytes pass PIL
-// validation (which the upload endpoint runs to reject malformed images).
-const TINY_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+// 50x50 black/white checkered PNG — clearly a test artifact, used both as a
+// user-uploaded image and as the mocked response for LLM-generated image
+// fetches. The bytes pass PIL validation (which the upload endpoint runs to
+// reject malformed images).
+const CHECKERED_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJUuHylcFApyWhTVc1rkkOzczwZLCwsrN9YuXXH+1lLxMLCwtpz5XV5fwsLC0uX1+WxsLCwdHldHgsLC+uxLK9hJFqMAN43AAAAAElFTkSuQmCC",
   "base64"
 );
 
@@ -119,7 +120,7 @@ test.describe("Chat File Uploads", () => {
         {
           name: fileName,
           mimeType: "image/png",
-          buffer: TINY_PNG,
+          buffer: CHECKERED_PNG,
         },
       ]);
 
@@ -148,7 +149,7 @@ test.describe("Chat File Uploads", () => {
         {
           name: imageName,
           mimeType: "image/png",
-          buffer: TINY_PNG,
+          buffer: CHECKERED_PNG,
         },
       ]);
 
@@ -178,7 +179,7 @@ test.describe("Chat File Uploads", () => {
         await route.fulfill({
           status: 200,
           contentType: "image/png",
-          body: TINY_PNG,
+          body: CHECKERED_PNG,
         });
       });
 

--- a/web/tests/e2e/chat/chat_message_rendering.spec.ts
+++ b/web/tests/e2e/chat/chat_message_rendering.spec.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
 import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { sendMessage } from "@tests/e2e/utils/chatActions";
 import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
@@ -240,12 +241,6 @@ function buildMockSearchStream(options: SearchMockOptions): string {
   return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
 }
 
-async function openChat(page: Page): Promise<void> {
-  await page.goto("/app");
-  await page.waitForLoadState("networkidle");
-  await page.waitForSelector("#onyx-chat-input-textarea", { timeout: 15000 });
-}
-
 async function mockChatEndpoint(
   page: Page,
   responseContent: string
@@ -277,51 +272,13 @@ async function mockChatEndpointSequence(
   });
 }
 
-async function scrollChatTo(
-  page: Page,
-  position: "top" | "bottom"
-): Promise<void> {
-  const scrollContainer = page.getByTestId("chat-scroll-container");
-  await scrollContainer.evaluate(async (el, pos) => {
-    el.scrollTo({ top: pos === "top" ? 0 : el.scrollHeight });
-    await new Promise<void>((r) => requestAnimationFrame(() => r()));
-  }, position);
-}
-
-async function screenshotChatContainer(
-  page: Page,
-  name: string
-): Promise<void> {
-  const container = page.locator("[data-main-container]");
-  await expect(container).toBeVisible();
-  await scrollChatTo(page, "bottom");
-  await expectElementScreenshot(container, { name });
-}
-
-/**
- * Captures two screenshots of the chat container for long-content tests:
- * one scrolled to the top and one scrolled to the bottom. Both are captured
- * for the current theme, ensuring consistent scroll positions regardless of
- * whether the page was just navigated to (top) or just finished streaming (bottom).
- */
-async function screenshotChatContainerTopAndBottom(
-  page: Page,
-  name: string
-): Promise<void> {
-  const container = page.locator("[data-main-container]");
-  await expect(container).toBeVisible();
-
-  await scrollChatTo(page, "top");
-  await expectElementScreenshot(container, { name: `${name}-top` });
-
-  await scrollChatTo(page, "bottom");
-  await expectElementScreenshot(container, { name: `${name}-bottom` });
-}
-
 for (const theme of THEMES) {
   test.describe(`Chat Message Rendering (${theme} mode)`, () => {
+    let chat: ChatPage;
+
     test.beforeEach(async ({ page }, testInfo) => {
       turnCounter = 0;
+      chat = new ChatPage(page);
       await page.context().clearCookies();
       await setThemeBeforeNavigation(page, theme);
       await loginAsWorkerUser(page, testInfo.workerIndex);
@@ -331,7 +288,7 @@ for (const theme of THEMES) {
       test("short user message with short AI response renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, SHORT_AI_RESPONSE);
 
         await sendMessage(page, SHORT_USER_MESSAGE);
@@ -342,8 +299,7 @@ for (const theme of THEMES) {
         const aiMessage = page.getByTestId("onyx-ai-message").first();
         await expect(aiMessage).toContainText("open-source AI-powered");
 
-        await screenshotChatContainer(
-          page,
+        await chat.screenshotContainer(
           `chat-short-message-short-response-${theme}`
         );
       });
@@ -351,7 +307,7 @@ for (const theme of THEMES) {
 
     test.describe("Long Messages", () => {
       test("long user message renders without truncation", async ({ page }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, SHORT_AI_RESPONSE);
 
         await sendMessage(page, LONG_USER_MESSAGE);
@@ -362,8 +318,7 @@ for (const theme of THEMES) {
         await expect(userMessage).toContainText("real-time or near-real-time");
         await expect(userMessage).toContainText("architecture of the AI chat");
 
-        await screenshotChatContainer(
-          page,
+        await chat.screenshotContainer(
           `chat-long-user-message-short-response-${theme}`
         );
       });
@@ -371,7 +326,7 @@ for (const theme of THEMES) {
       test("long AI response with markdown renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, LONG_AI_RESPONSE);
 
         await sendMessage(page, SHORT_USER_MESSAGE);
@@ -382,8 +337,7 @@ for (const theme of THEMES) {
         await expect(aiMessage).toContainText("Indexing Latency");
         await expect(aiMessage).toContainText("AI Chat Architecture");
 
-        await screenshotChatContainerTopAndBottom(
-          page,
+        await chat.screenshotContainerTopAndBottom(
           `chat-short-message-long-response-${theme}`
         );
       });
@@ -391,7 +345,7 @@ for (const theme of THEMES) {
       test("user message with very long words wraps without overflowing", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, SHORT_AI_RESPONSE);
 
         await sendMessage(page, LONG_WORD_USER_MESSAGE);
@@ -399,10 +353,7 @@ for (const theme of THEMES) {
         const userMessage = page.locator("#onyx-human-message").first();
         await expect(userMessage).toContainText("__________");
 
-        await screenshotChatContainer(
-          page,
-          `chat-long-word-user-message-${theme}`
-        );
+        await chat.screenshotContainer(`chat-long-word-user-message-${theme}`);
 
         // Assert the message bubble does not overflow horizontally.
         const overflows = await userMessage.evaluate((el) => {
@@ -421,7 +372,7 @@ for (const theme of THEMES) {
       test("long user message with long AI response renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, LONG_AI_RESPONSE);
 
         await sendMessage(page, LONG_USER_MESSAGE);
@@ -432,8 +383,7 @@ for (const theme of THEMES) {
         const aiMessage = page.getByTestId("onyx-ai-message").first();
         await expect(aiMessage).toContainText("Retrieval-Augmented Generation");
 
-        await screenshotChatContainerTopAndBottom(
-          page,
+        await chat.screenshotContainerTopAndBottom(
           `chat-long-message-long-response-${theme}`
         );
       });
@@ -443,7 +393,7 @@ for (const theme of THEMES) {
       test("AI response with tables and code blocks renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, MARKDOWN_AI_RESPONSE);
 
         await sendMessage(page, "Give me an overview of Onyx features");
@@ -453,26 +403,20 @@ for (const theme of THEMES) {
         await expect(aiMessage).toContainText("OnyxClient");
         await expect(aiMessage).toContainText("Privacy");
 
-        await screenshotChatContainer(
-          page,
-          `chat-markdown-code-response-${theme}`
-        );
+        await chat.screenshotContainer(`chat-markdown-code-response-${theme}`);
       });
 
       test("AI response with LaTeX math renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, LATEX_AI_RESPONSE);
 
         await sendMessage(page, "Show me inline and block math");
 
         const aiMessage = page.getByTestId("onyx-ai-message").first();
 
-        await screenshotChatContainer(
-          page,
-          `chat-latex-math-response-${theme}`
-        );
+        await chat.screenshotContainer(`chat-latex-math-response-${theme}`);
 
         await expect(aiMessage).toContainText("Inline math should render");
         await expect(aiMessage).toContainText(
@@ -490,7 +434,7 @@ for (const theme of THEMES) {
       test("multi-turn conversation renders all messages correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
 
         const responses = [
           SHORT_AI_RESPONSE,
@@ -518,8 +462,7 @@ for (const theme of THEMES) {
         const userMessages = page.locator("#onyx-human-message");
         await expect(userMessages).toHaveCount(3);
 
-        await screenshotChatContainerTopAndBottom(
-          page,
+        await chat.screenshotContainerTopAndBottom(
           `chat-multi-turn-conversation-${theme}`
         );
       });
@@ -527,7 +470,7 @@ for (const theme of THEMES) {
       test("multi-turn with mixed message lengths renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
 
         const responses = [LONG_AI_RESPONSE, SHORT_AI_RESPONSE];
 
@@ -543,8 +486,7 @@ for (const theme of THEMES) {
           timeout: 30000,
         });
 
-        await screenshotChatContainerTopAndBottom(
-          page,
+        await chat.screenshotContainerTopAndBottom(
           `chat-multi-turn-mixed-lengths-${theme}`
         );
       });
@@ -645,7 +587,7 @@ Key advantages include:
       test("web search response with citations renders correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
 
         await page.route("**/api/chat/send-chat-message", async (route) => {
           await route.fulfill({
@@ -672,8 +614,7 @@ Key advantages include:
         await expect(aiMessage).toContainText("Docker Compose");
         await expect(aiMessage).toContainText("MIT licensed");
 
-        await screenshotChatContainer(
-          page,
+        await chat.screenshotContainer(
           `chat-web-search-with-citations-${theme}`
         );
 
@@ -714,7 +655,7 @@ The Q3 2025 priorities focus on three main areas [[D1]](https://company.atlassia
 
 The platform architecture document provides additional context on how these improvements fit into the overall system design [[D2]](https://drive.google.com/file/d/abc123). The microservices architecture allows each component to be scaled independently.`;
 
-        await openChat(page);
+        await chat.goto();
 
         await page.route("**/api/chat/send-chat-message", async (route) => {
           await route.fulfill({
@@ -740,8 +681,7 @@ The platform architecture document provides additional context on how these impr
         await expect(aiMessage).toContainText("New integrations");
         await expect(aiMessage).toContainText("Performance");
 
-        await screenshotChatContainer(
-          page,
+        await chat.screenshotContainer(
           `chat-internal-search-with-citations-${theme}`
         );
 
@@ -769,7 +709,7 @@ Set \`max_results\` to limit the number of returned documents.`;
       test("h1 through h4 headings with inline code render correctly", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, HEADINGS_RESPONSE);
 
         await sendMessage(page, "Show me all heading levels");
@@ -794,10 +734,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         await expect(aiMessage.locator("h3")).toHaveCount(1);
         await expect(aiMessage.locator("h4")).toHaveCount(1);
 
-        await screenshotChatContainer(
-          page,
-          `chat-heading-levels-h1-h4-${theme}`
-        );
+        await chat.screenshotContainer(`chat-heading-levels-h1-h4-${theme}`);
       });
     });
 
@@ -805,7 +742,7 @@ Set \`max_results\` to limit the number of returned documents.`;
       test("hovering over user message shows action buttons", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, SHORT_AI_RESPONSE);
 
         await sendMessage(page, SHORT_USER_MESSAGE);
@@ -816,8 +753,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         const editButton = userMessage.getByTestId("HumanMessage/edit-button");
         await expect(editButton).toBeVisible({ timeout: 5000 });
 
-        await screenshotChatContainer(
-          page,
+        await chat.screenshotContainer(
           `chat-user-message-hover-state-${theme}`
         );
       });
@@ -825,7 +761,7 @@ Set \`max_results\` to limit the number of returned documents.`;
       test("AI message toolbar is visible after response completes", async ({
         page,
       }) => {
-        await openChat(page);
+        await chat.goto();
         await mockChatEndpoint(page, SHORT_AI_RESPONSE);
 
         await sendMessage(page, SHORT_USER_MESSAGE);
@@ -842,10 +778,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         await expect(likeButton).toBeVisible();
         await expect(dislikeButton).toBeVisible();
 
-        await screenshotChatContainer(
-          page,
-          `chat-ai-message-with-toolbar-${theme}`
-        );
+        await chat.screenshotContainer(`chat-ai-message-with-toolbar-${theme}`);
       });
     });
   });

--- a/web/tests/e2e/chat/chat_message_rendering.spec.ts
+++ b/web/tests/e2e/chat/chat_message_rendering.spec.ts
@@ -2,6 +2,14 @@ import { expect, Page, test } from "@playwright/test";
 import { ChatPage } from "@tests/e2e/chat/ChatPage";
 import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { sendMessage } from "@tests/e2e/utils/chatActions";
+import {
+  buildMockSearchStream,
+  buildMockStream,
+  mockChatEndpoint,
+  mockChatEndpointSequence,
+  type MockDocument,
+  resetTurnCounter,
+} from "@tests/e2e/utils/chatMock";
 import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
 import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
@@ -113,171 +121,12 @@ And this LaTeX source should remain a code block:
 \\int_0^1 x^2 \\, dx = \\frac{1}{3}
 \`\`\``;
 
-interface MockDocument {
-  document_id: string;
-  semantic_identifier: string;
-  link: string;
-  source_type: string;
-  blurb: string;
-  is_internet: boolean;
-}
-
-interface SearchMockOptions {
-  content: string;
-  queries: string[];
-  documents: MockDocument[];
-  /** Maps citation number -> document_id */
-  citations: Record<number, string>;
-  isInternetSearch?: boolean;
-}
-
-let turnCounter = 0;
-
-function buildMockStream(content: string): string {
-  turnCounter += 1;
-  const userMessageId = turnCounter * 100 + 1;
-  const agentMessageId = turnCounter * 100 + 2;
-
-  const packets = [
-    {
-      user_message_id: userMessageId,
-      reserved_assistant_message_id: agentMessageId,
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: {
-        type: "message_start",
-        id: `mock-${agentMessageId}`,
-        content,
-        final_documents: null,
-      },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "stop", stop_reason: "finished" },
-    },
-    {
-      message_id: agentMessageId,
-      citations: {},
-      files: [],
-    },
-  ];
-
-  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
-}
-
-function buildMockSearchStream(options: SearchMockOptions): string {
-  turnCounter += 1;
-  const userMessageId = turnCounter * 100 + 1;
-  const agentMessageId = turnCounter * 100 + 2;
-
-  const fullDocs = options.documents.map((doc) => ({
-    ...doc,
-    boost: 0,
-    hidden: false,
-    score: 0.95,
-    chunk_ind: 0,
-    match_highlights: [],
-    metadata: {},
-    updated_at: null,
-  }));
-
-  // Turn 0: search tool
-  // Turn 1: answer + citations
-  const packets: Record<string, unknown>[] = [
-    {
-      user_message_id: userMessageId,
-      reserved_assistant_message_id: agentMessageId,
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: {
-        type: "search_tool_start",
-        ...(options.isInternetSearch !== undefined && {
-          is_internet_search: options.isInternetSearch,
-        }),
-      },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "search_tool_queries_delta", queries: options.queries },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "search_tool_documents_delta", documents: fullDocs },
-    },
-    {
-      placement: { turn_index: 0, tab_index: 0 },
-      obj: { type: "section_end" },
-    },
-    {
-      placement: { turn_index: 1, tab_index: 0 },
-      obj: {
-        type: "message_start",
-        id: `mock-${agentMessageId}`,
-        content: options.content,
-        final_documents: fullDocs,
-      },
-    },
-    ...Object.entries(options.citations).map(([num, docId]) => ({
-      placement: { turn_index: 1, tab_index: 0 },
-      obj: {
-        type: "citation_info",
-        citation_number: Number(num),
-        document_id: docId,
-      },
-    })),
-    {
-      placement: { turn_index: 1, tab_index: 0 },
-      obj: { type: "stop", stop_reason: "finished" },
-    },
-    {
-      message_id: agentMessageId,
-      citations: options.citations,
-      files: [],
-    },
-  ];
-
-  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
-}
-
-async function mockChatEndpoint(
-  page: Page,
-  responseContent: string
-): Promise<void> {
-  await page.route("**/api/chat/send-chat-message", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "text/plain",
-      body: buildMockStream(responseContent),
-    });
-  });
-}
-
-async function mockChatEndpointSequence(
-  page: Page,
-  responses: string[]
-): Promise<void> {
-  let callIndex = 0;
-  await page.route("**/api/chat/send-chat-message", async (route) => {
-    const content =
-      responses[Math.min(callIndex, responses.length - 1)] ??
-      responses[responses.length - 1]!;
-    callIndex += 1;
-    await route.fulfill({
-      status: 200,
-      contentType: "text/plain",
-      body: buildMockStream(content),
-    });
-  });
-}
-
 for (const theme of THEMES) {
   test.describe(`Chat Message Rendering (${theme} mode)`, () => {
     let chat: ChatPage;
 
     test.beforeEach(async ({ page }, testInfo) => {
-      turnCounter = 0;
+      resetTurnCounter();
       chat = new ChatPage(page);
       await page.context().clearCookies();
       await setThemeBeforeNavigation(page, theme);
@@ -289,7 +138,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, SHORT_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
 
         await sendMessage(page, SHORT_USER_MESSAGE);
 
@@ -308,7 +157,7 @@ for (const theme of THEMES) {
     test.describe("Long Messages", () => {
       test("long user message renders without truncation", async ({ page }) => {
         await chat.goto();
-        await mockChatEndpoint(page, SHORT_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
 
         await sendMessage(page, LONG_USER_MESSAGE);
 
@@ -327,7 +176,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, LONG_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(LONG_AI_RESPONSE));
 
         await sendMessage(page, SHORT_USER_MESSAGE);
 
@@ -346,7 +195,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, SHORT_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
 
         await sendMessage(page, LONG_WORD_USER_MESSAGE);
 
@@ -373,7 +222,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, LONG_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(LONG_AI_RESPONSE));
 
         await sendMessage(page, LONG_USER_MESSAGE);
 
@@ -394,7 +243,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, MARKDOWN_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(MARKDOWN_AI_RESPONSE));
 
         await sendMessage(page, "Give me an overview of Onyx features");
 
@@ -410,7 +259,7 @@ for (const theme of THEMES) {
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, LATEX_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(LATEX_AI_RESPONSE));
 
         await sendMessage(page, "Show me inline and block math");
 
@@ -710,7 +559,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, HEADINGS_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(HEADINGS_RESPONSE));
 
         await sendMessage(page, "Show me all heading levels");
 
@@ -743,7 +592,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, SHORT_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
 
         await sendMessage(page, SHORT_USER_MESSAGE);
 
@@ -762,7 +611,7 @@ Set \`max_results\` to limit the number of returned documents.`;
         page,
       }) => {
         await chat.goto();
-        await mockChatEndpoint(page, SHORT_AI_RESPONSE);
+        await mockChatEndpoint(page, buildMockStream(SHORT_AI_RESPONSE));
 
         await sendMessage(page, SHORT_USER_MESSAGE);
 

--- a/web/tests/e2e/chat/llm_runtime_selection.spec.ts
+++ b/web/tests/e2e/chat/llm_runtime_selection.spec.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
 import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import {
   selectModelFromInputPopover,
@@ -18,12 +19,6 @@ type SendChatMessagePayload = {
 
 function uniqueName(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-async function openChat(page: Page): Promise<void> {
-  await page.goto("/app");
-  await page.waitForLoadState("networkidle");
-  await page.waitForSelector("#onyx-chat-input-textarea", { timeout: 15000 });
 }
 
 async function loginWithCleanCookies(
@@ -215,7 +210,7 @@ test.describe("LLM Runtime Selection", () => {
     ]);
 
     await loginWithCleanCookies(page, testInfo.workerIndex);
-    await openChat(page);
+    await new ChatPage(page).goto();
 
     let turn = 0;
     await page.route("**/api/chat/send-chat-message", async (route) => {
@@ -262,7 +257,7 @@ test.describe("LLM Runtime Selection", () => {
   test("regenerate with alternate model preserves version history semantics", async ({
     page,
   }) => {
-    await openChat(page);
+    await new ChatPage(page).goto();
 
     let turn = 0;
     await page.route("**/api/chat/send-chat-message", async (route) => {
@@ -403,7 +398,7 @@ test.describe("LLM Runtime Selection", () => {
       });
     });
 
-    await openChat(page);
+    await new ChatPage(page).goto();
 
     await page.getByTestId("model-selector").locator("button").last().click();
     await page.waitForSelector('[role="dialog"]', { state: "visible" });
@@ -508,7 +503,7 @@ test.describe("LLM Runtime Selection", () => {
     providersToCleanup.push(restrictedProviderId);
 
     await loginWithCleanCookies(page, testInfo.workerIndex);
-    await openChat(page);
+    await new ChatPage(page).goto();
 
     await page.getByTestId("model-selector").locator("button").last().click();
     await page.waitForSelector('[role="dialog"]', { state: "visible" });

--- a/web/tests/e2e/utils/chatMock.ts
+++ b/web/tests/e2e/utils/chatMock.ts
@@ -1,0 +1,257 @@
+/**
+ * Shared helpers for mocking the chat streaming endpoint in Playwright specs.
+ *
+ * The helpers fall into two layers:
+ *   1. `buildMock*Stream` — construct NDJSON response bodies matching the
+ *      shape produced by `/api/chat/send-chat-message`.
+ *   2. `mockChatEndpoint` / `mockChatEndpointSequence` — register
+ *      `page.route` handlers that fulfill the endpoint with a provided body.
+ *
+ * Specs that share a module instance (same worker process) share the
+ * `turnCounter` used to generate unique message IDs. Call
+ * `resetTurnCounter()` in `beforeEach` so IDs start fresh per test.
+ */
+
+import type { Page } from "@playwright/test";
+
+let turnCounter = 0;
+
+export function resetTurnCounter(): void {
+  turnCounter = 0;
+}
+
+function nextMessageIds(): { userMessageId: number; agentMessageId: number } {
+  turnCounter += 1;
+  return {
+    userMessageId: turnCounter * 100 + 1,
+    agentMessageId: turnCounter * 100 + 2,
+  };
+}
+
+function serializePackets(packets: unknown[]): string {
+  return `${packets.map((p) => JSON.stringify(p)).join("\n")}\n`;
+}
+
+export function buildMockStream(content: string): string {
+  const { userMessageId, agentMessageId } = nextMessageIds();
+
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content,
+        final_documents: null,
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: {},
+      files: [],
+    },
+  ];
+
+  return serializePackets(packets);
+}
+
+export interface ImageGenStreamOptions {
+  fileId: string;
+  revisedPrompt: string;
+  message: string;
+}
+
+export function buildMockImageGenStream({
+  fileId,
+  revisedPrompt,
+  message,
+}: ImageGenStreamOptions): string {
+  const { userMessageId, agentMessageId } = nextMessageIds();
+
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "image_generation_start" },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "image_generation_final",
+        images: [
+          {
+            file_id: fileId,
+            url: `/api/chat/file/${fileId}`,
+            revised_prompt: revisedPrompt,
+            shape: "square",
+          },
+        ],
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "section_end" },
+    },
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content: message,
+        final_documents: null,
+      },
+    },
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: {},
+      files: [{ id: fileId, type: "image" }],
+    },
+  ];
+
+  return serializePackets(packets);
+}
+
+export interface MockDocument {
+  document_id: string;
+  semantic_identifier: string;
+  link: string;
+  source_type: string;
+  blurb: string;
+  is_internet: boolean;
+}
+
+export interface SearchMockOptions {
+  content: string;
+  queries: string[];
+  documents: MockDocument[];
+  /** Maps citation number -> document_id */
+  citations: Record<number, string>;
+  isInternetSearch?: boolean;
+}
+
+export function buildMockSearchStream(options: SearchMockOptions): string {
+  const { userMessageId, agentMessageId } = nextMessageIds();
+
+  const fullDocs = options.documents.map((doc) => ({
+    ...doc,
+    boost: 0,
+    hidden: false,
+    score: 0.95,
+    chunk_ind: 0,
+    match_highlights: [],
+    metadata: {},
+    updated_at: null,
+  }));
+
+  // Turn 0: search tool
+  // Turn 1: answer + citations
+  const packets: Record<string, unknown>[] = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "search_tool_start",
+        ...(options.isInternetSearch !== undefined && {
+          is_internet_search: options.isInternetSearch,
+        }),
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "search_tool_queries_delta", queries: options.queries },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "search_tool_documents_delta", documents: fullDocs },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "section_end" },
+    },
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content: options.content,
+        final_documents: fullDocs,
+      },
+    },
+    ...Object.entries(options.citations).map(([num, docId]) => ({
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: {
+        type: "citation_info",
+        citation_number: Number(num),
+        document_id: docId,
+      },
+    })),
+    {
+      placement: { turn_index: 1, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: options.citations,
+      files: [],
+    },
+  ];
+
+  return serializePackets(packets);
+}
+
+/**
+ * Registers a route that fulfills every call to the chat streaming endpoint
+ * with the provided pre-built NDJSON body.
+ */
+export async function mockChatEndpoint(
+  page: Page,
+  body: string
+): Promise<void> {
+  await page.route("**/api/chat/send-chat-message", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body,
+    });
+  });
+}
+
+/**
+ * Registers a route that returns a different `buildMockStream(content)` body
+ * for each successive call. Calls beyond the list length reuse the last entry.
+ */
+export async function mockChatEndpointSequence(
+  page: Page,
+  contents: string[]
+): Promise<void> {
+  let callIndex = 0;
+  await page.route("**/api/chat/send-chat-message", async (route) => {
+    const content =
+      contents[Math.min(callIndex, contents.length - 1)] ??
+      contents[contents.length - 1]!;
+    callIndex += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/plain",
+      body: buildMockStream(content),
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds some e2e tests for file upload related workflows around the Chat UI.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright e2e coverage for chat file uploads, LLM‑generated images, and the code preview modal. Adds a shared `ChatPage` and `utils/chatMock.ts` to simplify specs and reduce duplication.

- **New Features**
  - User uploads: verifies text and image rendering (including multiple files); asserts file cards and thumbnails.
  - Model-generated images: mocks image‑generation stream and file fetch; uses a 50x50 checkered PNG test fixture; validates image URL and assistant message.
  - Code preview modal: opens from an uploaded code file; checks filename, language detection, content, and download link with a snapshot.

- **Refactors**
  - Added `ChatPage` (`web/tests/e2e/chat/ChatPage.ts`) with shared locators and `goto`/scroll/screenshot helpers; updated chat specs (including `llm_runtime_selection.spec.ts`) to use it; added `playwright` npm script.
  - Extracted chat mock helpers to `web/tests/e2e/utils/chatMock.ts` (`buildMockStream`, `buildMockImageGenStream`, `buildMockSearchStream`, `mockChatEndpoint*`); `mockChatEndpoint` now accepts a pre‑built body and call sites wrap with `buildMockStream`.
  - Fixed a strict-mode text matcher in the code preview modal test; updated `.secretsignore` to ignore the 50x50 checkered PNG fixture’s base64 chunk.

<sup>Written for commit 7de6346566821f6c5232b88f71c37006d14c4cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

