### PR TITLE
chore(devtools): `ods dev tunnel`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   openssh-client \
   python3-venv \
   ripgrep \
+  socat \
   sudo \
   ca-certificates \
   iptables \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:9aedd9b6e127c7e23c57eb05bbe14f466dec3093d26bfdb82c3299b275211419",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:e663b2bfed88cfc9fd7c86cae25885816692a1e19d9e88110a97ff8d4f700a25",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/tools/ods/cmd/dev.go
+++ b/tools/ods/cmd/dev.go
@@ -20,7 +20,8 @@ Commands:
   exec      Run a command inside the devcontainer
   restart   Remove and recreate the devcontainer
   rebuild   Pull the latest image and recreate
-  stop      Stop the running devcontainer`,
+  stop      Stop the running devcontainer
+  tunnel    Tunnel a devcontainer port to the host`,
 	}
 
 	cmd.AddCommand(newDevUpCommand())
@@ -29,6 +30,7 @@ Commands:
 	cmd.AddCommand(newDevRestartCommand())
 	cmd.AddCommand(newDevRebuildCommand())
 	cmd.AddCommand(newDevStopCommand())
+	cmd.AddCommand(newDevTunnelCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/dev_tunnel.go
+++ b/tools/ods/cmd/dev_tunnel.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+)
+
+const (
+	tunnelNetwork = "onyx_default"
+	tunnelImage   = "alpine/socat"
+)
+
+func newDevTunnelCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tunnel <port|host:container>",
+		Short: "Tunnel a devcontainer port to the host",
+		Long: `Forward a TCP port from the running devcontainer to the host.
+
+Launches a short-lived socat sidecar on the devcontainer's docker network that
+publishes the chosen host port and proxies connections into the devcontainer.
+Runs in the foreground — Ctrl-C tears the tunnel down.
+
+Examples:
+  ods dev tunnel 8080        # host 8080 -> devcontainer 8080
+  ods dev tunnel 9000:8080   # host 9000 -> devcontainer 8080`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			hostPort, containerPort, err := parseTunnelPorts(args[0])
+			if err != nil {
+				log.Fatalf("Invalid port spec %q: %v", args[0], err)
+			}
+			runDevTunnel(hostPort, containerPort)
+		},
+	}
+
+	return cmd
+}
+
+func parseTunnelPorts(spec string) (int, int, error) {
+	parts := strings.Split(spec, ":")
+	switch len(parts) {
+	case 1:
+		p, err := parsePort(parts[0])
+		if err != nil {
+			return 0, 0, err
+		}
+		return p, p, nil
+	case 2:
+		host, err := parsePort(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("host port: %w", err)
+		}
+		container, err := parsePort(parts[1])
+		if err != nil {
+			return 0, 0, fmt.Errorf("container port: %w", err)
+		}
+		return host, container, nil
+	default:
+		return 0, 0, fmt.Errorf("expected <port> or <host>:<container>")
+	}
+}
+
+func parsePort(s string) (int, error) {
+	p, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("not a number: %q", s)
+	}
+	if p < 1 || p > 65535 {
+		return 0, fmt.Errorf("out of range: %d", p)
+	}
+	return p, nil
+}
+
+func runDevTunnel(hostPort, containerPort int) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+
+	out, err := exec.Command(
+		"docker", "ps", "-q",
+		"--filter", "label=devcontainer.local_folder="+root,
+	).Output()
+	if err != nil {
+		log.Fatalf("Failed to find devcontainer: %v", err)
+	}
+	containerID := strings.TrimSpace(string(out))
+	if containerID == "" {
+		log.Fatal("No running devcontainer found — run `ods dev up` first")
+	}
+
+	log.Infof("Tunneling host :%d -> devcontainer :%d (Ctrl-C to stop)", hostPort, containerPort)
+
+	socatArgs := []string{
+		"run", "--rm", "-i",
+		"--network", tunnelNetwork,
+		"-p", fmt.Sprintf("%d:%d", hostPort, containerPort),
+		tunnelImage,
+		fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", containerPort),
+		fmt.Sprintf("TCP:%s:%d", containerID, containerPort),
+	}
+
+	log.Debugf("Running: docker %v", socatArgs)
+
+	c := exec.Command("docker", socatArgs...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	if err := c.Run(); err != nil {
+		log.Fatalf("docker run failed: %v", err)
+	}
+}

--- a/tools/ods/cmd/dev_tunnel.go
+++ b/tools/ods/cmd/dev_tunnel.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	tunnelNetwork = "onyx_default"
-	tunnelImage   = "alpine/socat"
+	tunnelImage   = "alpine/socat:1.8.0.3@sha256:76d1e4fc91bdd9d08f2a72a3fde1776798fd00cc00d3bded940dc154cd7ab6fd"
 )
 
 func newDevTunnelCommand() *cobra.Command {

--- a/tools/ods/cmd/dev_tunnel.go
+++ b/tools/ods/cmd/dev_tunnel.go
@@ -13,19 +13,17 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
-const (
-	tunnelNetwork = "onyx_default"
-	tunnelImage   = "alpine/socat:1.8.0.3@sha256:76d1e4fc91bdd9d08f2a72a3fde1776798fd00cc00d3bded940dc154cd7ab6fd"
-)
-
 func newDevTunnelCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tunnel <port|host:container>",
 		Short: "Tunnel a devcontainer port to the host",
 		Long: `Forward a TCP port from the running devcontainer to the host.
 
-Launches a short-lived socat sidecar on the devcontainer's docker network that
-publishes the chosen host port and proxies connections into the devcontainer.
+Runs socat on the host and forwards each accepted connection into the
+devcontainer via ` + "`docker exec socat`" + `, which connects to
+127.0.0.1:<container-port> inside the container.  Routing via loopback
+sidesteps the devcontainer's default-deny inbound firewall.
+
 Runs in the foreground — Ctrl-C tears the tunnel down.
 
 Examples:
@@ -100,21 +98,17 @@ func runDevTunnel(hostPort, containerPort int) {
 	log.Infof("Tunneling host :%d -> devcontainer :%d (Ctrl-C to stop)", hostPort, containerPort)
 
 	socatArgs := []string{
-		"run", "--rm", "-i",
-		"--network", tunnelNetwork,
-		"-p", fmt.Sprintf("%d:%d", hostPort, containerPort),
-		tunnelImage,
-		fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", containerPort),
-		fmt.Sprintf("TCP:%s:%d", containerID, containerPort),
+		fmt.Sprintf("TCP-LISTEN:%d,fork,reuseaddr", hostPort),
+		fmt.Sprintf("SYSTEM:docker exec -i %s socat - TCP\\:127.0.0.1\\:%d", containerID, containerPort),
 	}
 
-	log.Debugf("Running: docker %v", socatArgs)
+	log.Debugf("Running: socat %v", socatArgs)
 
-	c := exec.Command("docker", socatArgs...)
+	c := exec.Command("socat", socatArgs...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
 	if err := c.Run(); err != nil {
-		log.Fatalf("docker run failed: %v", err)
+		log.Fatalf("socat failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Description

> Launches a short-lived socat sidecar on the devcontainer's docker network that
publishes the chosen host port and proxies connections into the devcontainer.

## How Has This Been Tested?

Ran it locally

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods dev tunnel` to forward a devcontainer TCP port to your host. Runs in the foreground; Ctrl-C stops it.

- **New Features**
  - New command: `ods dev tunnel <port|host:container>` (e.g., `8080` or `9000:8080`).
  - Uses host `socat` + `docker exec` to proxy to `127.0.0.1:<container-port>`; auto-detects the devcontainer via `devcontainer.local_folder=<git root>`.

- **Dependencies**
  - Adds `socat` to the devcontainer and updates the `onyx-devcontainer` image digest.

<sup>Written for commit 0a5d8693a73c2ff91f4d94c32b38f258ecab7297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

