### PR TITLE
feat(auth): add LOW_CONFIDENCE_SCORE + SUSPECTED_CARDING to hard-reject set

### DIFF
--- a/backend/onyx/auth/captcha.py
+++ b/backend/onyx/auth/captcha.py
@@ -41,9 +41,17 @@ logger = setup_logger()
 CAPTCHA_COOKIE_NAME = "onyx_captcha_verified"
 
 # Enterprise Assessment reason enums defined by Google — not a
-# per-deployment tuning knob.
+# per-deployment tuning knob. Any of these reasons on a token means the
+# risk signal is strong enough to reject outright regardless of the
+# numeric score.
 _HARD_REJECT_REASONS: frozenset[str] = frozenset(
-    {"AUTOMATION", "UNEXPECTED_ENVIRONMENT", "TOO_MUCH_TRAFFIC"}
+    {
+        "AUTOMATION",
+        "UNEXPECTED_ENVIRONMENT",
+        "TOO_MUCH_TRAFFIC",
+        "LOW_CONFIDENCE_SCORE",
+        "SUSPECTED_CARDING",
+    }
 )
 
 # Matches Google's own ~2 minute token validity window.

--- a/backend/tests/unit/onyx/auth/test_captcha_enterprise.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_enterprise.py
@@ -181,6 +181,28 @@ async def test_unexpected_environment_reason_rejects() -> None:
 
 
 @pytest.mark.asyncio
+async def test_low_confidence_score_reason_rejects() -> None:
+    client = _fake_client(_assessment(score=0.9, reasons=["LOW_CONFIDENCE_SCORE"]))
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="LOW_CONFIDENCE_SCORE"):
+            await verify_captcha_token("tok", CaptchaAction.SIGNUP)
+
+
+@pytest.mark.asyncio
+async def test_suspected_carding_reason_rejects() -> None:
+    client = _fake_client(_assessment(score=0.9, reasons=["SUSPECTED_CARDING"]))
+    with (
+        patch.object(captcha_module, "is_captcha_enabled", return_value=True),
+        patch.object(captcha_module.httpx, "AsyncClient", return_value=client),
+    ):
+        with pytest.raises(CaptchaVerificationError, match="SUSPECTED_CARDING"):
+            await verify_captcha_token("tok", CaptchaAction.SIGNUP)
+
+
+@pytest.mark.asyncio
 async def test_score_below_floor_rejects() -> None:
     client = _fake_client(_assessment(score=0.1))
     with (
@@ -193,9 +215,15 @@ async def test_score_below_floor_rejects() -> None:
 
 @pytest.mark.asyncio
 async def test_soft_reason_alone_does_not_reject() -> None:
-    """LOW_CONFIDENCE_SCORE is not in the hard-reject set; if the score is
-    above floor and nothing else fails, the request passes."""
-    client = _fake_client(_assessment(score=0.9, reasons=["LOW_CONFIDENCE_SCORE"]))
+    """Reasons outside the hard-reject set (e.g. SUSPECTED_CHARGEBACK,
+    UNEXPECTED_USAGE_PATTERNS) do not by themselves reject — if the score is
+    above floor and nothing else fails, the request passes.
+    """
+    client = _fake_client(
+        _assessment(
+            score=0.9, reasons=["SUSPECTED_CHARGEBACK", "UNEXPECTED_USAGE_PATTERNS"]
+        )
+    )
     with (
         patch.object(captcha_module, "is_captcha_enabled", return_value=True),
         patch.object(captcha_module.httpx, "AsyncClient", return_value=client),


### PR DESCRIPTION
## Description

Expand the captcha rejection ladder to hard-reject assessments flagged with `LOW_CONFIDENCE_SCORE` or `SUSPECTED_CARDING` regardless of numeric score.

**Motivation.** 7-day audit of our reCAPTCHA Enterprise distribution showed 315 signups/week landing in the 0.8–0.89 borderline score band — the well-documented zone for residential-proxy + stealth-browser automation. Raising the score threshold helps (handled in cloud-deployment-yamls#262) but the reason-based layer is complementary: Google's classifier emits strong behavioral/network signals that may accompany scores still above the floor.

**Reasons added.** Both are standard `ClassificationReason` enum values from the reCAPTCHA Enterprise Assessment API:
- `LOW_CONFIDENCE_SCORE` — model flagged the score as unreliable
- `SUSPECTED_CARDING` — pattern matches known card-testing / automated credential abuse

**Kept out of hard-reject.** `UNEXPECTED_USAGE_PATTERNS` and `SUSPECTED_CHARGEBACK` — these are softer signals that can fire on legit power users, so they fall through to score-threshold evaluation.

**Behavior change scope.**
- No new env vars, no config, no migration.
- Applies uniformly to signup, login, oauth — same as the existing `AUTOMATION` / `UNEXPECTED_ENVIRONMENT` / `TOO_MUCH_TRAFFIC` reasons.
- Failure message surfaces the specific reason string (`"Captcha verification failed: LOW_CONFIDENCE_SCORE"`) for Datadog filterability.

**Rollback.** Revert this commit. Single file change.

## How Has This Been Tested?

<!-- fill in -->

## Additional Options

- [x] Override Linear Check
- [x] This PR is ready to cherry-pick to a release branch