### PR TITLE
fix(indexing): Reap files after doc processing

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -95,6 +95,7 @@ from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.document_index.factory import get_all_document_indices
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
 from onyx.file_store.document_batch_storage import get_document_batch_storage
+from onyx.file_store.staging import cleanup_staged_files_for_attempt
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.adapters.document_indexing_adapter import (
     DocumentIndexingBatchAdapter,
@@ -618,6 +619,23 @@ def check_indexing_completion(
         storage.cleanup_all_batches()
     except Exception:
         logger.exception("Failed to clean up document batches - continuing")
+
+    # Reap any STAGING files this attempt staged but never promoted.
+    # Safe to run here: indexing_completed guarantees every docprocessing
+    # batch has finished, so anything still STAGING for this attempt is a
+    # genuine drop (connector emitted no Document, or the Document was
+    # filtered as stale by `index_doc_batch_prepare`).
+    try:
+        with get_session_with_current_tenant() as cleanup_session:
+            cleanup_staged_files_for_attempt(
+                index_attempt_id=index_attempt_id,
+                db_session=cleanup_session,
+            )
+    except Exception:
+        logger.exception(
+            "Failed to run attempt-end staging cleanup; orphans will be "
+            "caught by the next attempt's start-of-run sweep."
+        )
 
     logger.info(f"Database coordination completed for attempt {index_attempt_id}")
 

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -59,7 +59,6 @@ from onyx.db.models import IndexAttempt
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
 from onyx.file_store.document_batch_storage import get_document_batch_storage
 from onyx.file_store.staging import build_raw_file_callback
-from onyx.file_store.staging import cleanup_staged_files_for_attempt
 from onyx.file_store.staging import RawFileCallback
 from onyx.file_store.staging import reap_prior_attempt_staged_files
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
@@ -299,31 +298,15 @@ def run_docfetching_entrypoint(
             db_session=reap_session,
         )
 
-    try:
-        connector_document_extraction(
-            app,
-            index_attempt_id,
-            attempt.connector_credential_pair_id,
-            attempt.search_settings_id,
-            tenant_id,
-            callback,
-            raw_file_callback=raw_file_callback,
-        )
-    finally:
-        # Reap any STAGING files this attempt created but never promoted.
-        # Runs on both the success path (docs filtered / ingestion-hook
-        # rejected) and the exception path.
-        try:
-            with get_session_with_current_tenant() as cleanup_session:
-                cleanup_staged_files_for_attempt(
-                    index_attempt_id=index_attempt_id,
-                    db_session=cleanup_session,
-                )
-        except Exception:
-            logger.exception(
-                "Failed to run attempt-end staging cleanup; orphans will be "
-                "caught by the next attempt's start-of-run sweep."
-            )
+    connector_document_extraction(
+        app,
+        index_attempt_id,
+        attempt.connector_credential_pair_id,
+        attempt.search_settings_id,
+        tenant_id,
+        callback,
+        raw_file_callback=raw_file_callback,
+    )
 
     logger.info(
         f"Docfetching finished{tenant_str}: "

--- a/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
+++ b/backend/tests/external_dependency_unit/celery/test_docprocessing_priority.py
@@ -218,77 +218,106 @@ class TestDocprocessingPriorityInDocumentExtraction:
             db_session, cc_pair, search_settings, from_beginning=False
         )
 
-        # Setup mocks
-        mock_batch_storage = MagicMock()
-        mock_get_batch_storage.return_value = mock_batch_storage
+        try:
+            # Setup mocks
+            mock_batch_storage = MagicMock()
+            mock_get_batch_storage.return_value = mock_batch_storage
 
-        mock_memory_tracer = MagicMock()
-        mock_memory_tracer_class.return_value = mock_memory_tracer
+            mock_memory_tracer = MagicMock()
+            mock_memory_tracer_class.return_value = mock_memory_tracer
 
-        # Mock Redis-related functions (not the focus of this test)
-        # Configure mock Redis client to return None for common operations
-        # as a safety net in case any patches don't work as expected
-        mock_redis_client = MagicMock()
-        mock_redis_client.get.return_value = None
-        mock_redis_client.hget.return_value = None
-        mock_redis_client.hset.return_value = None
-        mock_redis_client.exists.return_value = 0
-        mock_redis_client.expire.return_value = True
-        mock_get_redis_client.return_value = mock_redis_client
+            # Mock Redis-related functions (not the focus of this test)
+            # Configure mock Redis client to return None for common operations
+            # as a safety net in case any patches don't work as expected
+            mock_redis_client = MagicMock()
+            mock_redis_client.get.return_value = None
+            mock_redis_client.hget.return_value = None
+            mock_redis_client.hset.return_value = None
+            mock_redis_client.exists.return_value = 0
+            mock_redis_client.expire.return_value = True
+            mock_get_redis_client.return_value = mock_redis_client
 
-        # Mock hierarchy/cache functions
-        mock_ensure_source_node_exists.return_value = 1  # Return a valid node ID
-        mock_get_source_node_id_from_cache.return_value = (
-            1  # Return a valid source node ID
-        )
-        mock_get_node_id_from_raw_id.return_value = (None, False)  # (node_id, found)
-        # cache_hierarchy_nodes_batch doesn't need a return value (returns None)
+            # Mock hierarchy/cache functions
+            mock_ensure_source_node_exists.return_value = 1  # Return a valid node ID
+            mock_get_source_node_id_from_cache.return_value = (
+                1  # Return a valid source node ID
+            )
+            mock_get_node_id_from_raw_id.return_value = (
+                None,
+                False,
+            )  # (node_id, found)
+            # cache_hierarchy_nodes_batch doesn't need a return value (returns None)
 
-        # Create checkpoint mocks - initial checkpoint has_more=True, final has_more=False
-        mock_initial_checkpoint = MagicMock(has_more=True)
-        mock_final_checkpoint = MagicMock(has_more=False)
+            # Create checkpoint mocks - initial checkpoint has_more=True, final has_more=False
+            mock_initial_checkpoint = MagicMock(has_more=True)
+            mock_final_checkpoint = MagicMock(has_more=False)
 
-        # get_latest_valid_checkpoint returns (checkpoint, resuming_from_checkpoint)
-        mock_get_latest_valid_checkpoint.return_value = (mock_initial_checkpoint, False)
+            # get_latest_valid_checkpoint returns (checkpoint, resuming_from_checkpoint)
+            mock_get_latest_valid_checkpoint.return_value = (
+                mock_initial_checkpoint,
+                False,
+            )
 
-        # Create a mock connector runner that yields one document batch
-        mock_connector = MagicMock()
-        mock_connector_runner = MagicMock()
-        mock_connector_runner.connector = mock_connector
-        # The connector runner yields (document_batch, hierarchy_nodes, failure, next_checkpoint)
-        # We provide one batch of documents to trigger a send_task call
-        mock_doc = MagicMock()
-        mock_doc.to_short_descriptor.return_value = "test_doc"
-        mock_doc.sections = []
-        # Set to None to avoid Redis operations trying to resolve hierarchy
-        mock_doc.parent_hierarchy_raw_node_id = None
-        mock_doc.parent_hierarchy_node_id = None
-        mock_connector_runner.run.return_value = iter(
-            [([mock_doc], None, None, mock_final_checkpoint)]
-        )
-        mock_get_connector_runner.return_value = mock_connector_runner
+            # Create a mock connector runner that yields one document batch
+            mock_connector = MagicMock()
+            mock_connector_runner = MagicMock()
+            mock_connector_runner.connector = mock_connector
+            # The connector runner yields (document_batch, hierarchy_nodes, failure, next_checkpoint)
+            # We provide one batch of documents to trigger a send_task call
+            mock_doc = MagicMock()
+            mock_doc.to_short_descriptor.return_value = "test_doc"
+            mock_doc.sections = []
+            # Set to None to avoid Redis operations trying to resolve hierarchy
+            mock_doc.parent_hierarchy_raw_node_id = None
+            mock_doc.parent_hierarchy_node_id = None
+            mock_connector_runner.run.return_value = iter(
+                [([mock_doc], None, None, mock_final_checkpoint)]
+            )
+            mock_get_connector_runner.return_value = mock_connector_runner
 
-        mock_get_recent_completed_attempts.return_value = iter([])
-        mock_get_last_successful_attempt_poll_range_end.return_value = 0
+            mock_get_recent_completed_attempts.return_value = iter([])
+            mock_get_last_successful_attempt_poll_range_end.return_value = 0
 
-        # Mock celery app to capture task submission
-        mock_celery_app = MagicMock()
-        mock_celery_app.send_task.return_value = MagicMock()
+            # Mock celery app to capture task submission
+            mock_celery_app = MagicMock()
+            mock_celery_app.send_task.return_value = MagicMock()
 
-        # Call the function
-        connector_document_extraction(
-            app=mock_celery_app,
-            index_attempt_id=index_attempt.id,
-            cc_pair_id=cc_pair.id,
-            search_settings_id=search_settings.id,
-            tenant_id=TEST_TENANT_ID,
-            callback=None,
-        )
+            # Call the function
+            connector_document_extraction(
+                app=mock_celery_app,
+                index_attempt_id=index_attempt.id,
+                cc_pair_id=cc_pair.id,
+                search_settings_id=search_settings.id,
+                tenant_id=TEST_TENANT_ID,
+                callback=None,
+            )
 
-        # Verify send_task was called with the expected priority for docprocessing
-        assert mock_celery_app.send_task.called, "send_task should have been called"
-        call_kwargs = mock_celery_app.send_task.call_args
-        actual_priority = call_kwargs.kwargs["priority"]
-        assert (
-            actual_priority == expected_priority
-        ), f"Expected priority {expected_priority} for has_successful_index={has_successful_index}, but got {actual_priority}"
+            # Verify send_task was called with the expected priority for docprocessing
+            assert mock_celery_app.send_task.called, "send_task should have been called"
+            call_kwargs = mock_celery_app.send_task.call_args
+            actual_priority = call_kwargs.kwargs["priority"]
+            assert (
+                actual_priority == expected_priority
+            ), f"Expected priority {expected_priority} for has_successful_index={has_successful_index}, but got {actual_priority}"
+        finally:
+            # Drop rows in FK-safe order so the test doesn't pollute a shared
+            # database. Important: the seeded SearchSettings carries
+            # `status=PRESENT`, so if it lingers the production "current
+            # embedding model" lookup can pick it up and corrupt later real
+            # indexing attempts.
+            db_session.query(IndexAttempt).filter(
+                IndexAttempt.id == index_attempt.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(SearchSettings).filter(
+                SearchSettings.id == search_settings.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(ConnectorCredentialPair).filter(
+                ConnectorCredentialPair.id == cc_pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(Credential).filter(Credential.id == credential.id).delete(
+                synchronize_session="fetch"
+            )
+            db_session.query(Connector).filter(Connector.id == connector.id).delete(
+                synchronize_session="fetch"
+            )
+            db_session.commit()

--- a/backend/tests/external_dependency_unit/indexing/test_docfetching_orphan_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_docfetching_orphan_cleanup.py
@@ -1,13 +1,22 @@
 """End-to-end test for docfetching orphan-file cleanup.
 
-Simulates the full scenario the docfetching cleanup hooks are designed to
-handle:
+Two cleanup seams are covered:
 
-    run 1: a mock connector stages a raw file via raw_file_callback, then
-           crashes hard BEFORE the attempt's `finally` can fire (OOM kill
-           or pod eviction leave that block unrunnable).
-    run 2: the same cc_pair's next attempt starts up, and the start-of-run
-           sweep detects the orphan from run 1 and reaps it.
+    Start-of-run sweep (`reap_prior_attempt_staged_files`):
+        run 1: a mock connector stages a raw file via raw_file_callback,
+               then crashes — docfetching re-raises without reaping,
+               because promotion happens in a separate docprocessing pod
+               and the files may still be in-flight.
+        run 2: the same cc_pair's next attempt starts up, and the
+               start-of-run sweep detects the orphan from run 1 and
+               reaps it.
+
+    Attempt-end cleanup (`cleanup_staged_files_for_attempt`):
+        Exercised directly. Called from `check_indexing_completion` in
+        docprocessing once every batch has been processed — at that point
+        any file still INDEXING_STAGING for the attempt is a real drop
+        (connector emitted no Document, or the Document was filtered as
+        stale by `index_doc_batch_prepare`).
 
 Runs against real Postgres + real file store because the sweep's query
 depends on JSONB metadata filtering and the file_store client is what
@@ -240,16 +249,17 @@ def test_run_one_crashes_after_staging_then_run_two_cleans_up(
     )
 
 
-def test_run_one_exception_path_finally_cleans_up(
+def test_attempt_end_cleanup_wipes_staged_files(
     db_session: Session,
     tenant_and_cc_pair_ids: tuple[str, int],
     file_cleanup: list[str],
 ) -> None:
-    """Softer failure mode: connector raises but the attempt's own
-    `try/finally` gets to run. The finally's cleanup wipes the file.
+    """Attempt-end cleanup path: connector stages and raises, then the
+    attempt-completion hook (in production, `check_indexing_completion`)
+    invokes `cleanup_staged_files_for_attempt` and wipes the orphan.
 
     Distinguishes the attempt-end cleanup from the attempt-start sweep —
-    here we never get to run 2, because the finally handles it.
+    here we never get to run 2, because the completion hook handles it.
     """
     tenant_id, cc_pair_id = tenant_and_cc_pair_ids
 
@@ -266,23 +276,17 @@ def test_run_one_exception_path_finally_cleans_up(
     )
     connector.set_raw_file_callback(callback)
 
-    try:
-        try:
-            for _ in connector.load_from_state():
-                pass
-        finally:
-            cleanup_staged_files_for_attempt(
-                index_attempt_id=attempt_id, db_session=db_session
-            )
-    except RuntimeError:
-        # Expected — the connector's crash propagates through the finally.
-        pass
+    with pytest.raises(RuntimeError, match="simulated connector crash"):
+        for _ in connector.load_from_state():
+            pass
 
     assert connector.staged_file_id is not None
     file_cleanup.append(connector.staged_file_id)
 
-    # The finally wiped the staged file even though the original exception
-    # still propagated up (modeling `run_docfetching_entrypoint`'s shape).
+    # Simulate the completion-path cleanup (what `check_indexing_completion`
+    # calls once every docprocessing batch has finished).
+    cleanup_staged_files_for_attempt(index_attempt_id=attempt_id, db_session=db_session)
+
     assert (
         get_filerecord_by_file_id_optional(
             file_id=connector.staged_file_id, db_session=db_session
@@ -384,9 +388,9 @@ def test_real_factory_path_with_injected_mock_connector(
 ) -> None:
     """Full factory-path exercise: the real `instantiate_connector` resolves
     our mock via `_connector_cache`, wires the `raw_file_callback` via
-    `set_raw_file_callback`, and returns a ready-to-run connector. We then
-    drive it inside the same `try/finally` shape `run_docfetching_entrypoint`
-    uses, and verify the cleanup hook wipes the staged file.
+    `set_raw_file_callback`, and returns a ready-to-run connector. We drive
+    it, let it crash, and then invoke the attempt-end cleanup directly
+    (standing in for `check_indexing_completion`'s completion-path call).
 
     What this proves over the direct-construction tests:
     - Injection into the production factory works — a mock connector can be
@@ -394,7 +398,7 @@ def test_real_factory_path_with_injected_mock_connector(
     - `set_raw_file_callback` is called by the factory at the right point
       (after `load_credentials`), so the staging metadata flows through.
     - The complete path — factory → connector.run → callback → file_store →
-      exception → finally → cleanup — matches what the entrypoint wires up.
+      exception → cleanup — reaps the orphan.
 
     This uses the real factory module but stays below the `run_docfetching_entrypoint`
     seam (no IndexAttempt / SearchSettings / Celery app / DocumentBatchStorage
@@ -450,21 +454,16 @@ def test_real_factory_path_with_injected_mock_connector(
     connector.doc_id = f"doc-{uuid4().hex[:8]}"
     connector.raise_after_first = True
 
-    # Drive the connector inside the same try/finally shape the entrypoint
-    # uses. Exception propagates; cleanup runs regardless.
-    try:
-        try:
-            for _ in connector.load_from_state():
-                pass
-        finally:
-            cleanup_staged_files_for_attempt(
-                index_attempt_id=attempt_id, db_session=db_session
-            )
-    except RuntimeError:
-        pass
+    # Drive the connector, let it crash, then run the completion-path
+    # cleanup directly.
+    with pytest.raises(RuntimeError, match="simulated connector crash"):
+        for _ in connector.load_from_state():
+            pass
 
     assert connector.staged_file_id is not None
     file_cleanup.append(connector.staged_file_id)
+
+    cleanup_staged_files_for_attempt(index_attempt_id=attempt_id, db_session=db_session)
 
     # Attempt-end cleanup wiped the staged file, even though the connector
     # raised after the callback fired.
@@ -480,7 +479,7 @@ def test_real_factory_path_with_injected_mock_connector(
     db_session.commit()
 
 
-def test_run_docfetching_entrypoint_cleans_up_on_connector_crash(
+def test_run_docfetching_entrypoint_leaves_crash_orphans_for_next_sweep(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     initialize_file_store: None,  # noqa: ARG001
@@ -496,15 +495,15 @@ def test_run_docfetching_entrypoint_cleans_up_on_connector_crash(
       batch completes so this is never actually exercised.
 
     Everything else is production code: `transition_attempt_to_in_progress`,
-    the real factory, the real ConnectorRunner, the real file_store,
-    `connector_document_extraction`'s DocumentBatchStorage setup, and
-    crucially `run_docfetching_entrypoint`'s own `try/finally` block — the
-    code under test.
+    the real factory, the real ConnectorRunner, the real file_store, and
+    `connector_document_extraction`'s DocumentBatchStorage setup.
 
     The mock stages a file via the real raw_file_callback, then raises.
-    We expect the exception to propagate out of the entrypoint (per its
-    "Don't swallow exceptions here" contract), and for the staged file
-    to be gone afterward because the `finally` ran the cleanup.
+    The entrypoint deliberately does NOT reap on crash — attempt-end
+    cleanup lives in docprocessing's `check_indexing_completion`, not
+    here, because docprocessing runs in a separate pod and may still be
+    promoting files. Instead, the orphan survives and is picked up by
+    the next attempt's start-of-run sweep.
     """
     # Subclass of the mock connector so we can (a) preset the crash config
     # at construction time — the factory calls `connector_class(**{})`, so
@@ -581,14 +580,33 @@ def test_run_docfetching_entrypoint_cleans_up_on_connector_crash(
             "raw_file_callback wiring likely broken."
         )
 
-        # `run_docfetching_entrypoint`'s own `finally` ran
-        # `cleanup_staged_files_for_attempt` — the staged file should be gone.
+        # Entrypoint no longer reaps on crash — the file must still exist.
+        # Any cleanup now happens via the completion path in docprocessing
+        # or the next attempt's start-of-run sweep.
+        record = get_filerecord_by_file_id_optional(
+            file_id=staged_file_id, db_session=db_session
+        )
+        assert record is not None, (
+            "Staged file was unexpectedly reaped by the entrypoint; "
+            "attempt-end cleanup should live in check_indexing_completion."
+        )
+        assert record.file_origin == FileOrigin.INDEXING_STAGING
+
+        # Now simulate the next attempt starting up — the start-of-run
+        # sweep should reap the orphan from the crashed attempt.
+        reaped = reap_prior_attempt_staged_files(
+            current_attempt_id=attempt_id + 1,
+            cc_pair_id=cc_pair.id,
+            tenant_id=TEST_TENANT_ID,
+            db_session=db_session,
+        )
+        assert reaped == 1
         assert (
             get_filerecord_by_file_id_optional(
                 file_id=staged_file_id, db_session=db_session
             )
             is None
-        ), "Staged file should have been reaped by the entrypoint's finally block"
+        )
 
     finally:
         # Clean up seeded rows in FK-safe order: attempt → settings → cc_pair.


### PR DESCRIPTION
## Description
There is a bug where we reap files after doc fetching. Files are reaped if they are not promoted. Files are promoted in the docprocessing pipeline. This leads to all files getting reaped. 

This moves the file reaping to after all the batches have been processed, from where we then reap any remaining staging files.

## How Has This Been Tested?
Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix staged file cleanup to run after docprocessing completes, preventing premature reaping of files that haven’t been promoted yet. This removes entrypoint-level reaping and ensures orphans are cleaned at attempt end or on the next attempt’s start-of-run sweep.

- **Bug Fixes**
  - Moved staged-file cleanup to docprocessing: call `cleanup_staged_files_for_attempt` from `check_indexing_completion` after all batches finish.
  - Removed `finally`-based reaping in `run_docfetching_entrypoint`; crashes now leave staged files for the next attempt’s `reap_prior_attempt_staged_files` sweep.
  - Updated tests to reflect new timing, cover both cleanup seams, and add FK-safe teardown to avoid DB pollution.

<sup>Written for commit 1e4e2e9fc6234dc15966f3ca22c6c16ae700257d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

