### PR TITLE
feat(tracing): auto-wrap every LLM subclass with braintrust generation_span

### DIFF
--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -1,7 +1,7 @@
 import abc
 from collections.abc import Iterator
+from typing import Any
 
-from braintrust import traced
 from pydantic import BaseModel
 
 from onyx.llm.model_response import ModelResponse
@@ -9,6 +9,8 @@ from onyx.llm.model_response import ModelResponseStream
 from onyx.llm.models import LanguageModelInput
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.tracing_wrap import wrap_invoke
+from onyx.llm.tracing_wrap import wrap_stream
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -34,12 +36,31 @@ class LLMConfig(BaseModel):
 
 
 class LLM(abc.ABC):
+    """Abstract base for every LLM backend used by Onyx.
+
+    Concrete subclasses have their ``invoke`` and ``stream`` methods
+    auto-wrapped (via ``__init_subclass__`` below) with a fallback braintrust
+    ``generation_span``. This guarantees that every LLM call — from any call
+    site, including future subclasses — is captured in braintrust without
+    per-callsite instrumentation. Callers that explicitly wrap their calls
+    with ``llm_generation_span`` are unaffected: the fallback detects the
+    outer span and no-ops.
+    """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        invoke_fn = cls.__dict__.get("invoke")
+        if invoke_fn is not None:
+            setattr(cls, "invoke", wrap_invoke(invoke_fn))
+        stream_fn = cls.__dict__.get("stream")
+        if stream_fn is not None:
+            setattr(cls, "stream", wrap_stream(stream_fn))
+
     @property
     @abc.abstractmethod
     def config(self) -> LLMConfig:
         raise NotImplementedError
 
-    @traced(name="invoke llm", type="llm")
     def invoke(
         self,
         prompt: LanguageModelInput,

--- a/backend/onyx/llm/interfaces.py
+++ b/backend/onyx/llm/interfaces.py
@@ -1,4 +1,5 @@
 import abc
+from collections.abc import Callable
 from collections.abc import Iterator
 from typing import Any
 
@@ -49,12 +50,25 @@ class LLM(abc.ABC):
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        invoke_fn = cls.__dict__.get("invoke")
-        if invoke_fn is not None:
-            setattr(cls, "invoke", wrap_invoke(invoke_fn))
-        stream_fn = cls.__dict__.get("stream")
-        if stream_fn is not None:
-            setattr(cls, "stream", wrap_stream(stream_fn))
+        cls._wrap_method_if_defined("invoke", wrap_invoke)
+        cls._wrap_method_if_defined("stream", wrap_stream)
+
+    @classmethod
+    def _wrap_method_if_defined(
+        cls,
+        name: str,
+        wrapper_fn: Callable[[Callable[..., Any]], Callable[..., Any]],
+    ) -> None:
+        """Replace ``cls.<name>`` with ``wrapper_fn(cls.<name>)`` iff the method
+        is defined directly on this subclass.
+
+        Inherited methods are skipped — they've already been wrapped on the
+        parent class, so re-wrapping would nest two fallback spans around
+        the same call.
+        """
+        fn = cls.__dict__.get(name)
+        if fn is not None:
+            setattr(cls, name, wrapper_fn(fn))
 
     @property
     @abc.abstractmethod

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -50,11 +50,6 @@ from onyx.llm.well_known_providers.constants import (
     VERTEX_CREDENTIALS_FILE_KWARG_ENV_VAR_FORMAT,
 )
 from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
-from onyx.tracing.framework.create import get_current_span
-from onyx.tracing.framework.span_data import GenerationSpanData
-from onyx.tracing.llm_utils import llm_generation_span
-from onyx.tracing.llm_utils import record_llm_response
-from onyx.tracing.llm_utils import record_llm_span_output
 from onyx.utils.encryption import mask_string
 from onyx.utils.logger import setup_logger
 
@@ -247,30 +242,6 @@ def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
         adaptive_model in normalized_model_name
         for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
     )
-
-
-def _outer_generation_span_active() -> bool:
-    """Return True if we're already inside a `generation_span` created by an outer caller.
-
-    Used as a guard so the fallback tracing around `invoke`/`stream` doesn't double-count
-    LLM cost for code paths that already wrap their calls with `llm_generation_span`.
-    """
-    current = get_current_span()
-    return current is not None and isinstance(current.span_data, GenerationSpanData)
-
-
-@contextmanager
-def _fallback_generation_span(llm: LLM, flow: str) -> Iterator[Any]:
-    """Open an `llm_generation_span` only if no outer caller has already wrapped the call.
-
-    Yields the created span (to be used for recording output/usage) or ``None`` when an
-    outer wrapper is active — callers must guard recording logic with `if span is not None`.
-    """
-    if _outer_generation_span_active():
-        yield None
-        return
-    with llm_generation_span(llm, flow=flow) as span:
-        yield span
 
 
 class LitellmLLM(LLM):
@@ -782,39 +753,35 @@ class LitellmLLM(LLM):
             from litellm import stream_chunk_builder
             from litellm import CustomStreamWrapper as LiteLLMCustomStreamWrapper
 
-            with _fallback_generation_span(self, flow="llm_invoke_fallback") as span:
-                stream_response = cast(
-                    LiteLLMCustomStreamWrapper,
-                    self._completion(
-                        prompt=prompt,
-                        tools=tools,
-                        tool_choice=tool_choice,
-                        stream=True,
-                        structured_response_format=structured_response_format,
-                        timeout_override=timeout_override,
-                        max_tokens=max_tokens,
-                        parallel_tool_calls=True,
-                        reasoning_effort=reasoning_effort,
-                        user_identity=user_identity,
-                        client=client,
-                    ),
-                )
-                chunks = list(stream_response)
-                response = cast(
-                    LiteLLMModelResponse,
-                    stream_chunk_builder(chunks),
-                )
+            stream_response = cast(
+                LiteLLMCustomStreamWrapper,
+                self._completion(
+                    prompt=prompt,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    stream=True,
+                    structured_response_format=structured_response_format,
+                    timeout_override=timeout_override,
+                    max_tokens=max_tokens,
+                    parallel_tool_calls=True,
+                    reasoning_effort=reasoning_effort,
+                    user_identity=user_identity,
+                    client=client,
+                ),
+            )
+            chunks = list(stream_response)
+            response = cast(
+                LiteLLMModelResponse,
+                stream_chunk_builder(chunks),
+            )
 
-                model_response = from_litellm_model_response(response)
+            model_response = from_litellm_model_response(response)
 
-                # Track LLM cost for Onyx-managed API keys
-                if model_response.usage:
-                    self._track_llm_cost(model_response.usage)
+            # Track LLM cost for Onyx-managed API keys
+            if model_response.usage:
+                self._track_llm_cost(model_response.usage)
 
-                if span is not None:
-                    record_llm_response(span, model_response)
-
-                return model_response
+            return model_response
         finally:
             if client is not None:
                 client.close()
@@ -869,54 +836,31 @@ class LitellmLLM(LLM):
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
         try:
-            with _fallback_generation_span(self, flow="llm_stream_fallback") as span:
-                response = cast(
-                    LiteLLMCustomStreamWrapper,
-                    self._completion(
-                        prompt=prompt,
-                        tools=tools,
-                        tool_choice=tool_choice,
-                        stream=True,
-                        structured_response_format=structured_response_format,
-                        timeout_override=timeout_override,
-                        max_tokens=max_tokens,
-                        parallel_tool_calls=True,
-                        reasoning_effort=reasoning_effort,
-                        user_identity=user_identity,
-                        client=client,
-                    ),
-                )
+            response = cast(
+                LiteLLMCustomStreamWrapper,
+                self._completion(
+                    prompt=prompt,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    stream=True,
+                    structured_response_format=structured_response_format,
+                    timeout_override=timeout_override,
+                    max_tokens=max_tokens,
+                    parallel_tool_calls=True,
+                    reasoning_effort=reasoning_effort,
+                    user_identity=user_identity,
+                    client=client,
+                ),
+            )
 
-                accumulated_content: list[str] = []
-                final_usage: Usage | None = None
-                for chunk in response:
-                    model_response = from_litellm_model_response_stream(chunk)
+            for chunk in response:
+                model_response = from_litellm_model_response_stream(chunk)
 
-                    # Track LLM cost when usage info is available (typically in the last chunk)
-                    if model_response.usage:
-                        self._track_llm_cost(model_response.usage)
-                        final_usage = model_response.usage
+                # Track LLM cost when usage info is available (typically in the last chunk)
+                if model_response.usage:
+                    self._track_llm_cost(model_response.usage)
 
-                    if span is not None and model_response.choice.delta.content:
-                        accumulated_content.append(model_response.choice.delta.content)
-
-                    yield model_response
-
-                # Only reached if the stream is fully consumed without error.
-                # If the consumer abandons the generator or an exception
-                # propagates out, we skip the final record and the span will
-                # exit via the context-manager __exit__ without output set.
-                # We intentionally do NOT record per-chunk delta tool_calls —
-                # they arrive as partial fragments (arguments streamed char
-                # by char keyed on `index`) and would need stream_chunk_builder
-                # to reassemble before being safe to log.
-                if span is not None:
-                    record_llm_span_output(
-                        span,
-                        output="".join(accumulated_content) or None,
-                        usage=final_usage,
-                        tool_calls=None,
-                    )
+                yield model_response
         finally:
             if client is not None:
                 client.close()

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -259,6 +259,20 @@ def _outer_generation_span_active() -> bool:
     return current is not None and isinstance(current.span_data, GenerationSpanData)
 
 
+@contextmanager
+def _fallback_generation_span(llm: LLM, flow: str) -> Iterator[Any]:
+    """Open an `llm_generation_span` only if no outer caller has already wrapped the call.
+
+    Yields the created span (to be used for recording output/usage) or ``None`` when an
+    outer wrapper is active — callers must guard recording logic with `if span is not None`.
+    """
+    if _outer_generation_span_active():
+        yield None
+        return
+    with llm_generation_span(llm, flow=flow) as span:
+        yield span
+
+
 class LitellmLLM(LLM):
     """Uses Litellm library to allow easy configuration to use a multitude of LLMs
     See https://python.langchain.com/docs/integrations/chat/litellm"""
@@ -759,14 +773,6 @@ class LitellmLLM(LLM):
         if is_true_openai_model(self.config.model_provider, self.config.model_name):
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
-        # Fallback generation_span wrap. Skipped when an outer caller already
-        # wrapped this invocation so braintrust doesn't double-count cost.
-        span_ctx = (
-            nullcontext()
-            if _outer_generation_span_active()
-            else llm_generation_span(self, flow="llm_invoke_fallback")
-        )
-
         try:
             # When custom_config is set, env vars are temporarily injected
             # under a global lock. Using stream=True here means the lock is
@@ -776,7 +782,7 @@ class LitellmLLM(LLM):
             from litellm import stream_chunk_builder
             from litellm import CustomStreamWrapper as LiteLLMCustomStreamWrapper
 
-            with span_ctx as span:
+            with _fallback_generation_span(self, flow="llm_invoke_fallback") as span:
                 stream_response = cast(
                     LiteLLMCustomStreamWrapper,
                     self._completion(
@@ -862,16 +868,8 @@ class LitellmLLM(LLM):
         if is_true_openai_model(self.config.model_provider, self.config.model_name):
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
-        # Fallback generation_span wrap. Skipped when an outer caller already
-        # wrapped this invocation so braintrust doesn't double-count cost.
-        span_ctx = (
-            nullcontext()
-            if _outer_generation_span_active()
-            else llm_generation_span(self, flow="llm_stream_fallback")
-        )
-
         try:
-            with span_ctx as span:
+            with _fallback_generation_span(self, flow="llm_stream_fallback") as span:
                 response = cast(
                     LiteLLMCustomStreamWrapper,
                     self._completion(
@@ -890,8 +888,7 @@ class LitellmLLM(LLM):
                 )
 
                 accumulated_content: list[str] = []
-                final_usage: Any = None
-                accumulated_tool_calls: list[Any] = []
+                final_usage: Usage | None = None
                 for chunk in response:
                     model_response = from_litellm_model_response_stream(chunk)
 
@@ -900,24 +897,25 @@ class LitellmLLM(LLM):
                         self._track_llm_cost(model_response.usage)
                         final_usage = model_response.usage
 
-                    if span is not None:
-                        if model_response.choice.delta.content:
-                            accumulated_content.append(
-                                model_response.choice.delta.content
-                            )
-                        if model_response.choice.delta.tool_calls:
-                            accumulated_tool_calls.extend(
-                                model_response.choice.delta.tool_calls
-                            )
+                    if span is not None and model_response.choice.delta.content:
+                        accumulated_content.append(model_response.choice.delta.content)
 
                     yield model_response
 
+                # Only reached if the stream is fully consumed without error.
+                # If the consumer abandons the generator or an exception
+                # propagates out, we skip the final record and the span will
+                # exit via the context-manager __exit__ without output set.
+                # We intentionally do NOT record per-chunk delta tool_calls —
+                # they arrive as partial fragments (arguments streamed char
+                # by char keyed on `index`) and would need stream_chunk_builder
+                # to reassemble before being safe to log.
                 if span is not None:
                     record_llm_span_output(
                         span,
                         output="".join(accumulated_content) or None,
                         usage=final_usage,
-                        tool_calls=accumulated_tool_calls or None,
+                        tool_calls=None,
                     )
         finally:
             if client is not None:

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -50,6 +50,11 @@ from onyx.llm.well_known_providers.constants import (
     VERTEX_CREDENTIALS_FILE_KWARG_ENV_VAR_FORMAT,
 )
 from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
+from onyx.tracing.framework.create import get_current_span
+from onyx.tracing.framework.span_data import GenerationSpanData
+from onyx.tracing.llm_utils import llm_generation_span
+from onyx.tracing.llm_utils import record_llm_response
+from onyx.tracing.llm_utils import record_llm_span_output
 from onyx.utils.encryption import mask_string
 from onyx.utils.logger import setup_logger
 
@@ -242,6 +247,16 @@ def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
         adaptive_model in normalized_model_name
         for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
     )
+
+
+def _outer_generation_span_active() -> bool:
+    """Return True if we're already inside a `generation_span` created by an outer caller.
+
+    Used as a guard so the fallback tracing around `invoke`/`stream` doesn't double-count
+    LLM cost for code paths that already wrap their calls with `llm_generation_span`.
+    """
+    current = get_current_span()
+    return current is not None and isinstance(current.span_data, GenerationSpanData)
 
 
 class LitellmLLM(LLM):
@@ -744,6 +759,14 @@ class LitellmLLM(LLM):
         if is_true_openai_model(self.config.model_provider, self.config.model_name):
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
+        # Fallback generation_span wrap. Skipped when an outer caller already
+        # wrapped this invocation so braintrust doesn't double-count cost.
+        span_ctx = (
+            nullcontext()
+            if _outer_generation_span_active()
+            else llm_generation_span(self, flow="llm_invoke_fallback")
+        )
+
         try:
             # When custom_config is set, env vars are temporarily injected
             # under a global lock. Using stream=True here means the lock is
@@ -753,35 +776,39 @@ class LitellmLLM(LLM):
             from litellm import stream_chunk_builder
             from litellm import CustomStreamWrapper as LiteLLMCustomStreamWrapper
 
-            stream_response = cast(
-                LiteLLMCustomStreamWrapper,
-                self._completion(
-                    prompt=prompt,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    stream=True,
-                    structured_response_format=structured_response_format,
-                    timeout_override=timeout_override,
-                    max_tokens=max_tokens,
-                    parallel_tool_calls=True,
-                    reasoning_effort=reasoning_effort,
-                    user_identity=user_identity,
-                    client=client,
-                ),
-            )
-            chunks = list(stream_response)
-            response = cast(
-                LiteLLMModelResponse,
-                stream_chunk_builder(chunks),
-            )
+            with span_ctx as span:
+                stream_response = cast(
+                    LiteLLMCustomStreamWrapper,
+                    self._completion(
+                        prompt=prompt,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        stream=True,
+                        structured_response_format=structured_response_format,
+                        timeout_override=timeout_override,
+                        max_tokens=max_tokens,
+                        parallel_tool_calls=True,
+                        reasoning_effort=reasoning_effort,
+                        user_identity=user_identity,
+                        client=client,
+                    ),
+                )
+                chunks = list(stream_response)
+                response = cast(
+                    LiteLLMModelResponse,
+                    stream_chunk_builder(chunks),
+                )
 
-            model_response = from_litellm_model_response(response)
+                model_response = from_litellm_model_response(response)
 
-            # Track LLM cost for Onyx-managed API keys
-            if model_response.usage:
-                self._track_llm_cost(model_response.usage)
+                # Track LLM cost for Onyx-managed API keys
+                if model_response.usage:
+                    self._track_llm_cost(model_response.usage)
 
-            return model_response
+                if span is not None:
+                    record_llm_response(span, model_response)
+
+                return model_response
         finally:
             if client is not None:
                 client.close()
@@ -835,32 +862,63 @@ class LitellmLLM(LLM):
         if is_true_openai_model(self.config.model_provider, self.config.model_name):
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
+        # Fallback generation_span wrap. Skipped when an outer caller already
+        # wrapped this invocation so braintrust doesn't double-count cost.
+        span_ctx = (
+            nullcontext()
+            if _outer_generation_span_active()
+            else llm_generation_span(self, flow="llm_stream_fallback")
+        )
+
         try:
-            response = cast(
-                LiteLLMCustomStreamWrapper,
-                self._completion(
-                    prompt=prompt,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    stream=True,
-                    structured_response_format=structured_response_format,
-                    timeout_override=timeout_override,
-                    max_tokens=max_tokens,
-                    parallel_tool_calls=True,
-                    reasoning_effort=reasoning_effort,
-                    user_identity=user_identity,
-                    client=client,
-                ),
-            )
+            with span_ctx as span:
+                response = cast(
+                    LiteLLMCustomStreamWrapper,
+                    self._completion(
+                        prompt=prompt,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        stream=True,
+                        structured_response_format=structured_response_format,
+                        timeout_override=timeout_override,
+                        max_tokens=max_tokens,
+                        parallel_tool_calls=True,
+                        reasoning_effort=reasoning_effort,
+                        user_identity=user_identity,
+                        client=client,
+                    ),
+                )
 
-            for chunk in response:
-                model_response = from_litellm_model_response_stream(chunk)
+                accumulated_content: list[str] = []
+                final_usage: Any = None
+                accumulated_tool_calls: list[Any] = []
+                for chunk in response:
+                    model_response = from_litellm_model_response_stream(chunk)
 
-                # Track LLM cost when usage info is available (typically in the last chunk)
-                if model_response.usage:
-                    self._track_llm_cost(model_response.usage)
+                    # Track LLM cost when usage info is available (typically in the last chunk)
+                    if model_response.usage:
+                        self._track_llm_cost(model_response.usage)
+                        final_usage = model_response.usage
 
-                yield model_response
+                    if span is not None:
+                        if model_response.choice.delta.content:
+                            accumulated_content.append(
+                                model_response.choice.delta.content
+                            )
+                        if model_response.choice.delta.tool_calls:
+                            accumulated_tool_calls.extend(
+                                model_response.choice.delta.tool_calls
+                            )
+
+                    yield model_response
+
+                if span is not None:
+                    record_llm_span_output(
+                        span,
+                        output="".join(accumulated_content) or None,
+                        usage=final_usage,
+                        tool_calls=accumulated_tool_calls or None,
+                    )
         finally:
             if client is not None:
                 client.close()

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -35,12 +35,16 @@ def _outer_generation_span_active() -> bool:
     The fallback wrap becomes a no-op in that case so we don't double-count
     cost or produce nested duplicate spans in Braintrust.
 
-    ``ended_at is None`` guard: ``SpanImpl.__exit__`` intentionally skips
-    ``Scope.reset_current_span`` when the exit was triggered by
-    ``GeneratorExit`` (i.e. a streaming consumer abandoned the generator
-    early). That leaves a finished ``GenerationSpanData`` in the contextvar.
-    Without this guard, every subsequent LLM call in the same asyncio task
-    would see a stale "outer span" and silently skip fallback tracing.
+    Uses both ``started_at is not None`` and ``ended_at is None`` to reject
+    two edge cases:
+
+    - ``SpanImpl.__exit__`` intentionally skips ``Scope.reset_current_span``
+      when the exit was triggered by ``GeneratorExit`` (streaming consumer
+      abandoned the generator early). That leaves a finished span in the
+      contextvar; the ``ended_at`` check filters it out.
+    - ``NoOpSpan`` (returned when tracing is disabled or no trace is active)
+      always has ``started_at = None``. The ``started_at`` check prevents a
+      stale ``NoOpSpan`` from suppressing fallback tracing.
     """
     from onyx.tracing.framework.create import get_current_span
     from onyx.tracing.framework.span_data import GenerationSpanData
@@ -49,6 +53,7 @@ def _outer_generation_span_active() -> bool:
     return (
         current is not None
         and isinstance(current.span_data, GenerationSpanData)
+        and current.started_at is not None
         and current.ended_at is None
     )
 
@@ -85,7 +90,17 @@ def wrap_invoke(
         with llm_generation_span(
             self, flow="llm_invoke_fallback", input_messages=prompt
         ) as span:
-            response = invoke_fn(self, *args, **kwargs)
+            try:
+                response = invoke_fn(self, *args, **kwargs)
+            except Exception as exc:
+                if span is not None:
+                    span.set_error(
+                        {
+                            "message": f"{type(exc).__name__}: {exc}",
+                            "data": None,
+                        }
+                    )
+                raise
             if span is not None and response is not None:
                 record_llm_response(span, response)
             return response
@@ -127,12 +142,22 @@ def wrap_stream(
             accumulated_content: list[str] = []
             final_usage: Usage | None = None
 
-            for chunk in stream_fn(self, *args, **kwargs):
-                if chunk.usage:
-                    final_usage = chunk.usage
-                if span is not None and chunk.choice.delta.content:
-                    accumulated_content.append(chunk.choice.delta.content)
-                yield chunk
+            try:
+                for chunk in stream_fn(self, *args, **kwargs):
+                    if chunk.usage:
+                        final_usage = chunk.usage
+                    if span is not None and chunk.choice.delta.content:
+                        accumulated_content.append(chunk.choice.delta.content)
+                    yield chunk
+            except Exception as exc:
+                if span is not None:
+                    span.set_error(
+                        {
+                            "message": f"{type(exc).__name__}: {exc}",
+                            "data": None,
+                        }
+                    )
+                raise
 
             # Only reached on clean stream completion. If the consumer abandons
             # the generator or an exception propagates, the context manager

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -15,6 +15,7 @@ avoid an import cycle between `onyx.llm.interfaces` and
 from __future__ import annotations
 
 import functools
+import inspect
 from collections.abc import Callable
 from collections.abc import Iterator
 from typing import Any
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
 
 
 _ALREADY_WRAPPED_ATTR = "_onyx_tracing_wrapped"
+_PROMPT_PARAM_NAME = "prompt"
 
 
 def _outer_generation_span_active() -> bool:
@@ -58,17 +60,45 @@ def _outer_generation_span_active() -> bool:
     )
 
 
-def _extract_prompt(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any | None:
-    """Return the ``prompt`` argument passed to ``invoke``/``stream``, if any.
+def _validate_prompt_param(fn: Callable[..., Any]) -> inspect.Signature:
+    """Return the signature of ``fn`` after asserting it exposes ``prompt``.
 
-    ``LLM.invoke`` and ``LLM.stream`` take ``prompt`` as the first positional
-    parameter. Fallback to ``kwargs['prompt']`` when callers pass it by keyword.
-    Returns ``None`` if the argument cannot be located — the fallback span will
-    simply omit input messages rather than fail the request.
+    Runs once at wrap time so a subclass whose ``invoke`` / ``stream``
+    signature drifts away from the abstract base surfaces a clear error
+    during class creation rather than silently producing blank-input spans
+    at runtime. The returned :class:`inspect.Signature` is reused by
+    :func:`_extract_prompt` to bind arguments per call.
     """
-    if args:
-        return args[0]
-    return kwargs.get("prompt")
+    sig = inspect.signature(fn)
+    if _PROMPT_PARAM_NAME not in sig.parameters:
+        name = getattr(fn, "__qualname__", repr(fn))
+        raise TypeError(
+            f"Cannot auto-trace {name}: missing required "
+            f"'{_PROMPT_PARAM_NAME}' parameter. LLM.invoke / LLM.stream "
+            f"subclass overrides must keep the 'prompt' parameter name."
+        )
+    return sig
+
+
+def _extract_prompt(
+    sig: inspect.Signature,
+    self_: "LLM",
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any | None:
+    """Bind ``args`` / ``kwargs`` against ``sig`` and return the ``prompt`` value.
+
+    Uses ``Signature.bind`` so extraction is robust to any mix of positional
+    / keyword argument passing and immune to future parameter reordering.
+    Returns ``None`` if the arguments don't match the signature — the
+    fallback span will simply omit input messages rather than fail the
+    request.
+    """
+    try:
+        bound = sig.bind(self_, *args, **kwargs)
+    except TypeError:
+        return None
+    return bound.arguments.get(_PROMPT_PARAM_NAME)
 
 
 def wrap_invoke(
@@ -78,6 +108,8 @@ def wrap_invoke(
     if getattr(invoke_fn, _ALREADY_WRAPPED_ATTR, False):
         return invoke_fn
 
+    sig = _validate_prompt_param(invoke_fn)
+
     @functools.wraps(invoke_fn)
     def wrapper(self: "LLM", *args: Any, **kwargs: Any) -> "ModelResponse":
         if _outer_generation_span_active():
@@ -86,7 +118,7 @@ def wrap_invoke(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_response
 
-        prompt = _extract_prompt(args, kwargs)
+        prompt = _extract_prompt(sig, self, args, kwargs)
         with llm_generation_span(
             self, flow="llm_invoke_fallback", input_messages=prompt
         ) as span:
@@ -123,6 +155,8 @@ def wrap_stream(
     if getattr(stream_fn, _ALREADY_WRAPPED_ATTR, False):
         return stream_fn
 
+    sig = _validate_prompt_param(stream_fn)
+
     @functools.wraps(stream_fn)
     def wrapper(
         self: "LLM", *args: Any, **kwargs: Any
@@ -135,7 +169,7 @@ def wrap_stream(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_span_output
 
-        prompt = _extract_prompt(args, kwargs)
+        prompt = _extract_prompt(sig, self, args, kwargs)
         with llm_generation_span(
             self, flow="llm_stream_fallback", input_messages=prompt
         ) as span:

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -1,0 +1,119 @@
+"""Auto-tracing wrapper applied to every concrete `LLM` subclass.
+
+Every concrete subclass of `onyx.llm.interfaces.LLM` has its `invoke` and
+`stream` methods auto-wrapped via `LLM.__init_subclass__` so that every LLM
+call lands in Braintrust without per-callsite instrumentation. The wrap is a
+no-op when an outer `generation_span` is already active — callers that
+explicitly wrap their calls (via `llm_generation_span`) continue to work and
+are not double-counted.
+
+Imports from `onyx.tracing.*` are performed lazily inside the wrappers to
+avoid an import cycle between `onyx.llm.interfaces` and
+`onyx.tracing.llm_utils` (which itself imports `LLM`).
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from collections.abc import Iterator
+from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from onyx.llm.interfaces import LLM
+    from onyx.llm.model_response import ModelResponse
+    from onyx.llm.model_response import ModelResponseStream
+
+
+_ALREADY_WRAPPED_ATTR = "_onyx_tracing_wrapped"
+
+
+def _outer_generation_span_active() -> bool:
+    """Return True when an outer caller has already opened a generation_span.
+
+    The fallback wrap becomes a no-op in that case so we don't double-count
+    cost or produce nested duplicate spans in Braintrust.
+    """
+    from onyx.tracing.framework.create import get_current_span
+    from onyx.tracing.framework.span_data import GenerationSpanData
+
+    current = get_current_span()
+    return current is not None and isinstance(current.span_data, GenerationSpanData)
+
+
+def wrap_invoke(
+    invoke_fn: Callable[..., "ModelResponse"],
+) -> Callable[..., "ModelResponse"]:
+    """Wrap a concrete ``LLM.invoke`` implementation with a fallback generation_span."""
+    if getattr(invoke_fn, _ALREADY_WRAPPED_ATTR, False):
+        return invoke_fn
+
+    @functools.wraps(invoke_fn)
+    def wrapper(self: "LLM", *args: Any, **kwargs: Any) -> "ModelResponse":
+        if _outer_generation_span_active():
+            return invoke_fn(self, *args, **kwargs)
+
+        from onyx.tracing.llm_utils import llm_generation_span
+        from onyx.tracing.llm_utils import record_llm_response
+
+        with llm_generation_span(self, flow="llm_invoke_fallback") as span:
+            response = invoke_fn(self, *args, **kwargs)
+            if span is not None and response is not None:
+                record_llm_response(span, response)
+            return response
+
+    setattr(wrapper, _ALREADY_WRAPPED_ATTR, True)
+    return wrapper
+
+
+def wrap_stream(
+    stream_fn: Callable[..., Iterator["ModelResponseStream"]],
+) -> Callable[..., Iterator["ModelResponseStream"]]:
+    """Wrap a concrete ``LLM.stream`` implementation with a fallback generation_span.
+
+    Accumulates content + final usage across yielded chunks and records them on
+    the span when the stream is fully consumed. Tool-call deltas are
+    intentionally NOT accumulated — streaming deltas are partial fragments
+    keyed on ``index`` that need ``litellm.stream_chunk_builder``-style
+    reassembly before being safe to log.
+    """
+    if getattr(stream_fn, _ALREADY_WRAPPED_ATTR, False):
+        return stream_fn
+
+    @functools.wraps(stream_fn)
+    def wrapper(
+        self: "LLM", *args: Any, **kwargs: Any
+    ) -> Iterator["ModelResponseStream"]:
+        if _outer_generation_span_active():
+            yield from stream_fn(self, *args, **kwargs)
+            return
+
+        from onyx.llm.model_response import Usage
+        from onyx.tracing.llm_utils import llm_generation_span
+        from onyx.tracing.llm_utils import record_llm_span_output
+
+        with llm_generation_span(self, flow="llm_stream_fallback") as span:
+            accumulated_content: list[str] = []
+            final_usage: Usage | None = None
+
+            for chunk in stream_fn(self, *args, **kwargs):
+                if chunk.usage:
+                    final_usage = chunk.usage
+                if span is not None and chunk.choice.delta.content:
+                    accumulated_content.append(chunk.choice.delta.content)
+                yield chunk
+
+            # Only reached on clean stream completion. If the consumer abandons
+            # the generator or an exception propagates, the context manager
+            # exits via __exit__ without output set.
+            if span is not None:
+                record_llm_span_output(
+                    span,
+                    output="".join(accumulated_content) or None,
+                    usage=final_usage,
+                    tool_calls=None,
+                )
+
+    setattr(wrapper, _ALREADY_WRAPPED_ATTR, True)
+    return wrapper

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -61,21 +61,37 @@ def _outer_generation_span_active() -> bool:
 
 
 def _validate_prompt_param(fn: Callable[..., Any]) -> inspect.Signature:
-    """Return the signature of ``fn`` after asserting it exposes ``prompt``.
+    """Return the signature of ``fn``, asserting it can accept a ``prompt``.
 
     Runs once at wrap time so a subclass whose ``invoke`` / ``stream``
-    signature drifts away from the abstract base surfaces a clear error
-    during class creation rather than silently producing blank-input spans
-    at runtime. The returned :class:`inspect.Signature` is reused by
-    :func:`_extract_prompt` to bind arguments per call.
+    signature can't possibly carry a ``prompt`` surfaces a clear error at
+    class creation rather than silently producing blank-input spans at
+    runtime.
+
+    An override is considered valid if it has any of:
+    - a named ``prompt`` parameter (the expected shape), or
+    - a ``**kwargs`` (VAR_KEYWORD) parameter that could carry it, or
+    - an ``*args`` (VAR_POSITIONAL) parameter that could carry it.
+
+    Test doubles commonly use ``*args, **kwargs`` catch-alls to ignore the
+    full signature — those are accepted here. Only overrides that *can't*
+    receive a prompt at all (e.g. a fixed unrelated parameter list) are
+    rejected.
     """
     sig = inspect.signature(fn)
-    if _PROMPT_PARAM_NAME not in sig.parameters:
+    params = sig.parameters.values()
+    has_prompt = _PROMPT_PARAM_NAME in sig.parameters
+    accepts_var_keyword = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params)
+    accepts_var_positional = any(
+        p.kind is inspect.Parameter.VAR_POSITIONAL for p in params
+    )
+    if not (has_prompt or accepts_var_keyword or accepts_var_positional):
         name = getattr(fn, "__qualname__", repr(fn))
         raise TypeError(
-            f"Cannot auto-trace {name}: missing required "
-            f"'{_PROMPT_PARAM_NAME}' parameter. LLM.invoke / LLM.stream "
-            f"subclass overrides must keep the 'prompt' parameter name."
+            f"Cannot auto-trace {name}: signature cannot accept a "
+            f"'{_PROMPT_PARAM_NAME}' argument. LLM.invoke / LLM.stream "
+            f"subclass overrides must either keep the 'prompt' parameter "
+            f"name or accept *args / **kwargs."
         )
     return sig
 

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -34,12 +34,36 @@ def _outer_generation_span_active() -> bool:
 
     The fallback wrap becomes a no-op in that case so we don't double-count
     cost or produce nested duplicate spans in Braintrust.
+
+    ``ended_at is None`` guard: ``SpanImpl.__exit__`` intentionally skips
+    ``Scope.reset_current_span`` when the exit was triggered by
+    ``GeneratorExit`` (i.e. a streaming consumer abandoned the generator
+    early). That leaves a finished ``GenerationSpanData`` in the contextvar.
+    Without this guard, every subsequent LLM call in the same asyncio task
+    would see a stale "outer span" and silently skip fallback tracing.
     """
     from onyx.tracing.framework.create import get_current_span
     from onyx.tracing.framework.span_data import GenerationSpanData
 
     current = get_current_span()
-    return current is not None and isinstance(current.span_data, GenerationSpanData)
+    return (
+        current is not None
+        and isinstance(current.span_data, GenerationSpanData)
+        and current.ended_at is None
+    )
+
+
+def _extract_prompt(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any | None:
+    """Return the ``prompt`` argument passed to ``invoke``/``stream``, if any.
+
+    ``LLM.invoke`` and ``LLM.stream`` take ``prompt`` as the first positional
+    parameter. Fallback to ``kwargs['prompt']`` when callers pass it by keyword.
+    Returns ``None`` if the argument cannot be located — the fallback span will
+    simply omit input messages rather than fail the request.
+    """
+    if args:
+        return args[0]
+    return kwargs.get("prompt")
 
 
 def wrap_invoke(
@@ -57,7 +81,10 @@ def wrap_invoke(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_response
 
-        with llm_generation_span(self, flow="llm_invoke_fallback") as span:
+        prompt = _extract_prompt(args, kwargs)
+        with llm_generation_span(
+            self, flow="llm_invoke_fallback", input_messages=prompt
+        ) as span:
             response = invoke_fn(self, *args, **kwargs)
             if span is not None and response is not None:
                 record_llm_response(span, response)
@@ -93,7 +120,10 @@ def wrap_stream(
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_span_output
 
-        with llm_generation_span(self, flow="llm_stream_fallback") as span:
+        prompt = _extract_prompt(args, kwargs)
+        with llm_generation_span(
+            self, flow="llm_stream_fallback", input_messages=prompt
+        ) as span:
             accumulated_content: list[str] = []
             final_usage: Usage | None = None
 

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -222,11 +222,26 @@ def test_extract_prompt_returns_none_on_signature_mismatch() -> None:
 
 
 def test_validate_prompt_param_rejects_signature_without_prompt() -> None:
+    # Fixed parameter list with no ``prompt``, no ``*args``, no ``**kwargs``
+    # — the override cannot receive a prompt at all, so validation fails.
     def bad_override(self: object, foo: str) -> None:  # noqa: ARG001
         return None
 
-    with pytest.raises(TypeError, match="missing required 'prompt' parameter"):
+    with pytest.raises(TypeError, match="signature cannot accept a 'prompt' argument"):
         _validate_prompt_param(bad_override)
+
+
+def test_validate_prompt_param_accepts_catch_all_signature() -> None:
+    """Test doubles commonly override with ``*args, **kwargs`` catch-all.
+    Those signatures can accept a prompt via the variable-keyword parameter,
+    so validation must not reject them."""
+
+    def catch_all(self: object, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        return None
+
+    # Should not raise.
+    sig = _validate_prompt_param(catch_all)
+    assert sig is not None
 
 
 def test_wrap_invoke_raises_on_signature_without_prompt() -> None:
@@ -236,7 +251,7 @@ def test_wrap_invoke_raises_on_signature_without_prompt() -> None:
     def bad_invoke(self: object, foo: str) -> ModelResponse:  # noqa: ARG001
         raise AssertionError("bad_invoke should never run")
 
-    with pytest.raises(TypeError, match="missing required 'prompt' parameter"):
+    with pytest.raises(TypeError, match="signature cannot accept a 'prompt' argument"):
         wrap_invoke(cast(Callable[..., ModelResponse], bad_invoke))
 
 

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -1,0 +1,231 @@
+# ruff: noqa: ARG002
+"""Unit tests for `onyx.llm.tracing_wrap`.
+
+Cover:
+- `LLM.__init_subclass__` auto-wraps `invoke` and `stream` on concrete subclasses
+- Wrapper is idempotent (double-application is a no-op)
+- Outer-span guard (``_outer_generation_span_active``) skips fallback when
+  an outer ``generation_span`` is active
+- Stale-span guard: a finished ``GenerationSpanData`` in the contextvar does
+  not suppress fallback tracing (regression guard for the ``GeneratorExit``
+  corner case)
+- `_extract_prompt` helper reads positional and keyword arguments
+
+The `_FakeLLM` test double's `invoke` / `stream` signatures intentionally
+mirror the `LLM` abstract interface, which means many parameters are
+declared but unused — hence the `ARG002` suppression at the file level.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from onyx.llm.interfaces import LLM
+from onyx.llm.interfaces import LLMConfig
+from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_response import Choice
+from onyx.llm.model_response import Delta
+from onyx.llm.model_response import Message
+from onyx.llm.model_response import ModelResponse
+from onyx.llm.model_response import ModelResponseStream
+from onyx.llm.model_response import StreamingChoice
+from onyx.llm.models import LanguageModelInput
+from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.models import UserMessage
+from onyx.llm.tracing_wrap import _ALREADY_WRAPPED_ATTR
+from onyx.llm.tracing_wrap import _extract_prompt
+from onyx.llm.tracing_wrap import _outer_generation_span_active
+from onyx.llm.tracing_wrap import wrap_invoke
+from onyx.llm.tracing_wrap import wrap_stream
+from onyx.tracing.framework.create import generation_span
+from onyx.tracing.framework.create import trace
+
+_TEST_MODEL_RESPONSE = ModelResponse(
+    id="test-id",
+    created="2026-04-22T00:00:00Z",
+    choice=Choice(message=Message(content="hi")),
+)
+
+
+class _FakeLLM(LLM):
+    """Minimal concrete subclass used to exercise `__init_subclass__`."""
+
+    def __init__(self) -> None:
+        self._invoke_calls = 0
+        self._stream_calls = 0
+        self._last_prompt: Any = None
+
+    @property
+    def config(self) -> LLMConfig:
+        return LLMConfig(
+            model_provider="test",
+            model_name="test-model",
+            temperature=0.0,
+            max_input_tokens=1000,
+        )
+
+    def invoke(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> ModelResponse:
+        self._invoke_calls += 1
+        self._last_prompt = prompt
+        return _TEST_MODEL_RESPONSE
+
+    def stream(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> Iterator[ModelResponseStream]:
+        self._stream_calls += 1
+        self._last_prompt = prompt
+        for chunk_text in ("hello", " ", "world"):
+            yield ModelResponseStream(
+                id="stream-id",
+                created="2026-04-22T00:00:00Z",
+                choice=StreamingChoice(delta=Delta(content=chunk_text)),
+            )
+
+
+class _NoOverrideLLM(_FakeLLM):
+    """Subclass that does not override ``invoke`` / ``stream`` — the inherited
+    (already-wrapped) methods must not be wrapped a second time."""
+
+
+def test_init_subclass_auto_wraps_invoke_and_stream() -> None:
+    assert getattr(_FakeLLM.invoke, _ALREADY_WRAPPED_ATTR, False) is True
+    assert getattr(_FakeLLM.stream, _ALREADY_WRAPPED_ATTR, False) is True
+
+
+def test_inherited_methods_are_not_rewrapped() -> None:
+    # _NoOverrideLLM inherits from _FakeLLM without redefining invoke/stream,
+    # so __init_subclass__ should not wrap them again.
+    assert _NoOverrideLLM.invoke is _FakeLLM.invoke
+    assert _NoOverrideLLM.stream is _FakeLLM.stream
+
+
+def test_wrap_invoke_is_idempotent() -> None:
+    # Calling wrap_invoke on an already-wrapped function returns the same
+    # function instance rather than wrapping it again.
+    wrapped_once = _FakeLLM.invoke
+    wrapped_twice = wrap_invoke(wrapped_once)
+    assert wrapped_twice is wrapped_once
+
+
+def test_wrap_stream_is_idempotent() -> None:
+    wrapped_once = _FakeLLM.stream
+    wrapped_twice = wrap_stream(wrapped_once)
+    assert wrapped_twice is wrapped_once
+
+
+def test_invoke_returns_inner_response() -> None:
+    llm = _FakeLLM()
+    prompt = UserMessage(content="hello")
+    result = llm.invoke(prompt)
+    assert result is _TEST_MODEL_RESPONSE
+    assert llm._invoke_calls == 1
+    assert llm._last_prompt is prompt
+
+
+def test_stream_yields_all_chunks() -> None:
+    llm = _FakeLLM()
+    prompt = UserMessage(content="hello")
+    chunks = list(llm.stream(prompt))
+    assert len(chunks) == 3
+    assert llm._stream_calls == 1
+    assert llm._last_prompt is prompt
+
+
+def test_outer_guard_false_when_no_span_active() -> None:
+    assert _outer_generation_span_active() is False
+
+
+def test_outer_guard_true_inside_generation_span() -> None:
+    # An active trace is required for `generation_span` to return a real
+    # SpanImpl rather than a NoOpSpan (see provider.py).
+    with trace("test_outer_guard_true"):
+        with generation_span(model="test", model_config={"model_provider": "test"}):
+            assert _outer_generation_span_active() is True
+    # Span exited cleanly — contextvar reset, guard flips back to False.
+    assert _outer_generation_span_active() is False
+
+
+def test_outer_guard_false_for_finished_span_leaked_into_contextvar() -> None:
+    """Regression guard for the ``GeneratorExit`` corner case.
+
+    ``SpanImpl.__exit__`` intentionally skips ``Scope.reset_current_span``
+    when the exit was triggered by ``GeneratorExit`` (abandoned streaming
+    generator). That leaves a finished span object in the contextvar.
+    The outer-span guard must ignore it so subsequent LLM calls in the same
+    asyncio task still receive fallback tracing.
+    """
+    with trace("test_stale_span_guard"):
+        span = generation_span(model="test", model_config={"model_provider": "test"})
+        # Simulate the GeneratorExit exit path: start the span so it lives
+        # in the contextvar, then call __exit__ with GeneratorExit, which
+        # sets ended_at but does NOT reset the contextvar.
+        span.start(mark_as_current=True)
+        span.__exit__(GeneratorExit, GeneratorExit(), None)
+        try:
+            assert span.ended_at is not None  # span is finished
+            assert _outer_generation_span_active() is False
+        finally:
+            # Clean up the leaked contextvar so later code in this test
+            # isn't polluted.
+            span.finish(reset_current=True)
+
+
+def test_extract_prompt_reads_positional_arg() -> None:
+    assert _extract_prompt(("hi",), {}) == "hi"
+
+
+def test_extract_prompt_reads_keyword_arg() -> None:
+    assert _extract_prompt((), {"prompt": "hi"}) == "hi"
+
+
+def test_extract_prompt_returns_none_when_missing() -> None:
+    assert _extract_prompt((), {}) is None
+
+
+def test_invoke_does_not_nest_inside_outer_generation_span() -> None:
+    """When an outer caller has already opened a ``generation_span``, the
+    fallback wrap must skip creating a new span (so cost is not
+    double-counted). We can't observe span creation directly here, but we can
+    verify the guard sees the outer span and that the inner call still
+    executes and returns the response."""
+    llm = _FakeLLM()
+    prompt = UserMessage(content="hello")
+    with trace("test_no_nesting"):
+        with generation_span(model="test", model_config={"model_provider": "test"}):
+            assert _outer_generation_span_active() is True
+            result = llm.invoke(prompt)
+    assert result is _TEST_MODEL_RESPONSE
+    assert llm._invoke_calls == 1
+
+
+@pytest.mark.parametrize("prompt_kind", ["positional", "keyword"])
+def test_invoke_records_prompt_via_both_call_styles(prompt_kind: str) -> None:
+    llm = _FakeLLM()
+    prompt = UserMessage(content=f"p-{prompt_kind}")
+    if prompt_kind == "positional":
+        llm.invoke(prompt)
+    else:
+        llm.invoke(prompt=prompt)
+    assert llm._last_prompt is prompt

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -229,3 +229,72 @@ def test_invoke_records_prompt_via_both_call_styles(prompt_kind: str) -> None:
     else:
         llm.invoke(prompt=prompt)
     assert llm._last_prompt is prompt
+
+
+class _ExplodingLLM(LLM):
+    """Test double whose `invoke` / `stream` always raise."""
+
+    @property
+    def config(self) -> LLMConfig:
+        return LLMConfig(
+            model_provider="test",
+            model_name="test-model",
+            temperature=0.0,
+            max_input_tokens=1000,
+        )
+
+    def invoke(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> ModelResponse:
+        raise RuntimeError("invoke-boom")
+
+    def stream(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> Iterator[ModelResponseStream]:
+        raise RuntimeError("stream-boom")
+        yield  # pragma: no cover — unreachable, keeps this a generator
+
+
+def test_invoke_propagates_exception_from_inner_call() -> None:
+    llm = _ExplodingLLM()
+    with pytest.raises(RuntimeError, match="invoke-boom"):
+        llm.invoke(UserMessage(content="hi"))
+
+
+def test_stream_propagates_exception_from_inner_call() -> None:
+    llm = _ExplodingLLM()
+    with pytest.raises(RuntimeError, match="stream-boom"):
+        list(llm.stream(UserMessage(content="hi")))
+
+
+def test_outer_guard_false_for_noop_span_in_contextvar() -> None:
+    """A ``NoOpSpan`` (returned when no trace is active) always has
+    ``started_at = None`` and ``ended_at = None``. Without the ``started_at``
+    guard, a stale ``NoOpSpan`` left in the contextvar (e.g. after an
+    abandoned generator) would cause ``_outer_generation_span_active`` to
+    return ``True`` and silently suppress fallback tracing. Verify the guard
+    filters it out."""
+    # Generating a span outside any `trace()` context returns a NoOpSpan.
+    noop_span = generation_span(model="test", model_config={"model_provider": "test"})
+    noop_span.start(mark_as_current=True)
+    try:
+        assert noop_span.started_at is None
+        assert _outer_generation_span_active() is False
+    finally:
+        noop_span.finish(reset_current=True)

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -18,8 +18,10 @@ declared but unused — hence the `ARG002` suppression at the file level.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Iterator
 from typing import Any
+from typing import cast
 
 import pytest
 
@@ -39,6 +41,7 @@ from onyx.llm.models import UserMessage
 from onyx.llm.tracing_wrap import _ALREADY_WRAPPED_ATTR
 from onyx.llm.tracing_wrap import _extract_prompt
 from onyx.llm.tracing_wrap import _outer_generation_span_active
+from onyx.llm.tracing_wrap import _validate_prompt_param
 from onyx.llm.tracing_wrap import wrap_invoke
 from onyx.llm.tracing_wrap import wrap_stream
 from onyx.tracing.framework.create import generation_span
@@ -192,16 +195,49 @@ def test_outer_guard_false_for_finished_span_leaked_into_contextvar() -> None:
             span.finish(reset_current=True)
 
 
+# `functools.wraps` sets __wrapped__ on the auto-wrapped methods so the
+# underlying (undecorated) function is reachable for signature introspection.
+# mypy doesn't know about this attribute on the Callable type, so we access
+# it via getattr below.
+
+
 def test_extract_prompt_reads_positional_arg() -> None:
-    assert _extract_prompt(("hi",), {}) == "hi"
+    llm = _FakeLLM()
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    assert _extract_prompt(sig, llm, ("hi",), {}) == "hi"
 
 
 def test_extract_prompt_reads_keyword_arg() -> None:
-    assert _extract_prompt((), {"prompt": "hi"}) == "hi"
+    llm = _FakeLLM()
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    assert _extract_prompt(sig, llm, (), {"prompt": "hi"}) == "hi"
 
 
-def test_extract_prompt_returns_none_when_missing() -> None:
-    assert _extract_prompt((), {}) is None
+def test_extract_prompt_returns_none_on_signature_mismatch() -> None:
+    """Unknown keyword arguments don't match the signature → bind fails →
+    extraction returns None rather than raising."""
+    llm = _FakeLLM()
+    sig = _validate_prompt_param(getattr(_FakeLLM.invoke, "__wrapped__"))
+    assert _extract_prompt(sig, llm, (), {"not_a_real_param": "hi"}) is None
+
+
+def test_validate_prompt_param_rejects_signature_without_prompt() -> None:
+    def bad_override(self: object, foo: str) -> None:  # noqa: ARG001
+        return None
+
+    with pytest.raises(TypeError, match="missing required 'prompt' parameter"):
+        _validate_prompt_param(bad_override)
+
+
+def test_wrap_invoke_raises_on_signature_without_prompt() -> None:
+    """Wrap-time validation surfaces a clear error at class-creation time so
+    subclass signature drift doesn't silently produce blank-input spans."""
+
+    def bad_invoke(self: object, foo: str) -> ModelResponse:  # noqa: ARG001
+        raise AssertionError("bad_invoke should never run")
+
+    with pytest.raises(TypeError, match="missing required 'prompt' parameter"):
+        wrap_invoke(cast(Callable[..., ModelResponse], bad_invoke))
 
 
 def test_invoke_does_not_nest_inside_outer_generation_span() -> None:


### PR DESCRIPTION
## Description

Auto-wrap `invoke` and `stream` on every concrete subclass of the abstract `LLM` base (`backend/onyx/llm/interfaces.py`) with a fallback braintrust `generation_span`. Applied at class-creation time via `LLM.__init_subclass__`, so every LLM call — from any call site, including future `LLM` subclasses — is captured in Braintrust without per-callsite or per-subclass instrumentation.

### Why

Onyx's existing Braintrust tracing is opt-in via per-callsite `llm_generation_span` wraps. Paths that don't wrap explicitly bypass Braintrust entirely, producing incomplete observability and no way to attribute LLM usage across the codebase. A previously-existing `@traced` decorator on the abstract `LLM.invoke` never actually ran, because subclass overrides bypass base-class decorators. This PR replaces that dead decorator with a working class-level wrap.

### How

- **New module** `backend/onyx/llm/tracing_wrap.py`: `wrap_invoke`, `wrap_stream`, `_outer_generation_span_active`, and `_extract_prompt` helpers. Tracing imports are lazy inside the wrappers to break a circular import with `onyx.tracing.llm_utils` (which imports `LLM`).
- **`LLM.__init_subclass__`** in `interfaces.py`: inspects `cls.__dict__` for `invoke`/`stream`. If either is defined on this specific subclass (not inherited), it's replaced with the wrapped version via `setattr`. Inherited wraps are not re-wrapped, preventing double-wrap.
- **Idempotent wrappers**: each sets a `_onyx_tracing_wrapped` attribute so accidental double-application is a no-op.
- **Outer-span guard** (`_outer_generation_span_active`): when a caller has already opened a `generation_span` via `llm_generation_span`, the wrap short-circuits so Braintrust never double-counts. Includes an `ended_at is None` check — `SpanImpl.__exit__` intentionally skips `Scope.reset_current_span` on `GeneratorExit`, so a stale finished span can otherwise linger in the contextvar and suppress subsequent fallback tracing.
- **Prompt forwarding**: `wrap_invoke` and `wrap_stream` pull the `prompt` argument from `args[0]` / `kwargs['prompt']` and pass it as `input_messages` to `llm_generation_span`, so the fallback span records the prompt alongside cost/usage.
- **Stream wrapper** accumulates yielded content + final usage and records on clean stream completion. Tool-call deltas are intentionally NOT accumulated — streaming deltas are partial fragments keyed on `index` that need `litellm.stream_chunk_builder`-style reassembly before being safe to log. Can be added as a follow-up.
- **Removed** dead `@traced(name="invoke llm", type="llm")` on the abstract `LLM.invoke`.

### Coverage

| Call-site pattern | Before | After |
|---|---|---|
| Explicit `llm_generation_span` wrap | traced | unchanged (guard short-circuits fallback) |
| `llm.invoke` / `llm.stream` called directly without explicit wrap | not traced | traced via fallback |
| Future `LLM` subclasses that override `invoke` / `stream` | would require manual instrumentation | automatically wrapped at class creation |

### Fallback-span tagging

Spans created by the fallback are tagged `flow=llm_invoke_fallback` or `flow=llm_stream_fallback`, so Braintrust queries can distinguish explicit callsite wraps from the catch-all.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check