### PR TITLE
Remove search-time image processing

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -60,9 +60,7 @@ from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.configs.constants import MilestoneRecordType
-from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.context.search.models import BaseFilters
-from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import SearchDoc
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_chat_session_by_id
@@ -76,17 +74,12 @@ from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.projects import get_user_files_from_project
-from onyx.db.search_settings import get_active_search_settings
 from onyx.db.tools import get_tools
 from onyx.deep_research.dr_loop import run_deep_research_llm_loop
-from onyx.document_index.factory import get_default_document_index
-from onyx.document_index.interfaces import DocumentIndex
-from onyx.document_index.interfaces import VespaChunkRequest
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import log_onyx_error
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.extract_file_text import extract_file_text
-from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile
 from onyx.file_store.utils import load_in_memory_chat_files
@@ -129,7 +122,6 @@ from onyx.tools.tool_constructor import SearchToolConfig
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
 from onyx.utils.timing import log_function_time
-from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -252,51 +244,8 @@ def _empty_extracted_context_files() -> ExtractedContextFiles:
     )
 
 
-def _fetch_cached_image_captions(
-    user_file: UserFile | None,
-    document_index: DocumentIndex | None,
-) -> list[str]:
-    """Read image-caption chunks for a user file from the document index.
-
-    During indexing, embedded images are summarized via a vision LLM and
-    those summaries are stored as chunks whose `image_file_id` is set. Reading
-    them back at chat time avoids re-running vision-LLM calls per turn.
-    Returns an empty list if the index has no chunks yet (e.g. indexing is
-    still in flight) or on any fetch failure.
-    """
-    if user_file is None or document_index is None:
-        return []
-    try:
-        chunks = document_index.id_based_retrieval(
-            chunk_requests=[VespaChunkRequest(document_id=str(user_file.id))],
-            filters=IndexFilters(
-                access_control_list=None,
-                tenant_id=get_current_tenant_id() if MULTI_TENANT else None,
-            ),
-        )
-    except Exception:
-        logger.warning(
-            f"Failed to fetch cached captions for user_file {user_file.id}",
-            exc_info=True,
-        )
-        return []
-
-    # An image can be spread across multiple chunks; combine by image_file_id
-    # so a single caption appears once in the context.
-    combined: dict[str, list[str]] = {}
-    for chunk in chunks:
-        if chunk.image_file_id and chunk.content:
-            combined.setdefault(chunk.image_file_id, []).append(chunk.content)
-    return [
-        f"[Image — {image_file_id}]\n" + "\n".join(contents)
-        for image_file_id, contents in combined.items()
-    ]
-
-
 def _extract_text_from_in_memory_file(
     f: InMemoryChatFile,
-    user_file: UserFile | None = None,
-    document_index: DocumentIndex | None = None,
 ) -> str | None:
     """Extract text content from an InMemoryChatFile.
 
@@ -304,54 +253,19 @@ def _extract_text_from_in_memory_file(
     ingestion — decode directly.
     DOC / CSV / other text types: the content is the original file bytes —
     use extract_file_text which handles encoding detection and format parsing.
-    When image extraction is enabled and the file has embedded images, cached
-    captions are pulled from the document index and appended to the text.
-    The index fetch is skipped for files with no embedded images. We do not
-    re-summarize images inline here — this path is hot and the indexing
-    pipeline writes chunks atomically, so a missed caption means the file
-    is mid-indexing and will be picked up on the next turn.
+    Search-time image processing has been removed; embedded-image summaries are
+    only generated during indexing.
     """
     try:
         if f.file_type == ChatFileType.PLAIN_TEXT:
             return f.content.decode("utf-8", errors="ignore").replace("\x00", "")
 
-        filename = f.filename or ""
-        if not get_image_extraction_and_analysis_enabled():
-            return extract_file_text(
-                file=io.BytesIO(f.content),
-                file_name=filename,
-                break_on_unprocessable=False,
-            )
-
-        extraction = extract_text_and_images(
+        text_content = extract_file_text(
             file=io.BytesIO(f.content),
-            file_name=filename,
+            file_name=f.filename or "",
+            break_on_unprocessable=False,
         )
-        text = extraction.text_content
-        has_text = bool(text.strip())
-        has_images = bool(extraction.embedded_images)
-
-        if not has_text and not has_images:
-            # extract_text_and_images has no is_text_file() fallback for
-            # unknown extensions (.py/.rs/.md without a dedicated handler).
-            # Defer to the legacy path so those files remain readable.
-            return extract_file_text(
-                file=io.BytesIO(f.content),
-                file_name=filename,
-                break_on_unprocessable=False,
-            )
-
-        if not has_images:
-            return text if has_text else None
-
-        cached_captions = _fetch_cached_image_captions(user_file, document_index)
-
-        parts: list[str] = []
-        if has_text:
-            parts.append(text)
-        parts.extend(cached_captions)
-
-        return "\n\n".join(parts).strip() or None
+        return text_content or None
     except Exception:
         logger.warning(f"Failed to extract text from file {f.file_id}", exc_info=True)
         return None
@@ -433,23 +347,6 @@ def extract_context_files(
         db_session=db_session,
     )
 
-    # The document index is used at chat time to read cached image captions
-    # (produced during indexing) so vision-LLM calls don't re-run per turn.
-    document_index: DocumentIndex | None = None
-    if not DISABLE_VECTOR_DB and get_image_extraction_and_analysis_enabled():
-        try:
-            active_search_settings = get_active_search_settings(db_session)
-            document_index = get_default_document_index(
-                search_settings=active_search_settings.primary,
-                secondary_search_settings=None,
-                db_session=db_session,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to construct document index for caption lookup",
-                exc_info=True,
-            )
-
     file_texts: list[str] = []
     image_files: list[ChatLoadedFile] = []
     file_metadata: list[ContextFileMetadata] = []
@@ -470,9 +367,7 @@ def extract_context_files(
                 continue
             tool_metadata.append(_build_tool_metadata(uf))
         elif f.file_type.is_text_file():
-            text_content = _extract_text_from_in_memory_file(
-                f, user_file=uf, document_index=document_index
-            )
+            text_content = _extract_text_from_in_memory_file(f)
             if not text_content:
                 continue
             if not uf:

--- a/backend/onyx/configs/llm_configs.py
+++ b/backend/onyx/configs/llm_configs.py
@@ -21,18 +21,6 @@ def get_image_extraction_and_analysis_enabled() -> bool:
     return False
 
 
-def get_search_time_image_analysis_enabled() -> bool:
-    """Get search time image analysis enabled setting from workspace settings or fallback to False"""
-    try:
-        settings = load_settings()
-        if settings.search_time_image_analysis_enabled is not None:
-            return settings.search_time_image_analysis_enabled
-    except Exception:
-        pass
-
-    return False
-
-
 def get_image_analysis_max_size_mb() -> int:
     """Get image analysis max size MB setting from workspace settings or fallback to environment variable"""
     try:

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -82,7 +82,6 @@ class Settings(BaseModel):
 
     # Image processing settings
     image_extraction_and_analysis_enabled: bool | None = True
-    search_time_image_analysis_enabled: bool | None = False
     image_analysis_max_size_mb: int | None = 20
 
     # User Knowledge settings

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -248,7 +248,6 @@ class DATestSettings(BaseModel):
     product_gating: DATestGatingType = DATestGatingType.NONE
     anonymous_user_enabled: bool | None = None
     image_extraction_and_analysis_enabled: bool | None = True
-    search_time_image_analysis_enabled: bool | None = False
 
 
 @dataclass

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -44,7 +44,6 @@ def test_image_indexing(
 
     SettingsManager.update_settings(
         DATestSettings(
-            search_time_image_analysis_enabled=True,
             image_extraction_and_analysis_enabled=True,
         ),
         user_performing_action=admin_user,
@@ -140,7 +139,6 @@ def test_docx_image_indexing(
 
     SettingsManager.update_settings(
         DATestSettings(
-            search_time_image_analysis_enabled=True,
             image_extraction_and_analysis_enabled=True,
         ),
         user_performing_action=admin_user,

--- a/backend/tests/unit/onyx/chat/test_context_files.py
+++ b/backend/tests/unit/onyx/chat/test_context_files.py
@@ -300,6 +300,39 @@ class TestExtractContextFiles:
         assert result.file_texts == []
         assert result.total_token_count == 50
 
+    @patch("onyx.chat.process_message.extract_file_text")
+    @patch("onyx.chat.process_message.load_in_memory_chat_files")
+    def test_doc_files_use_text_only_extraction(
+        self,
+        mock_load: MagicMock,
+        mock_extract_file_text: MagicMock,
+    ) -> None:
+        file_id = str(uuid4())
+        uf = _make_user_file(token_count=100, file_id=file_id, name="report.docx")
+        uf.file_type = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        mock_load.return_value = [
+            InMemoryChatFile(
+                file_id=file_id,
+                content=b"doc bytes",
+                file_type=ChatFileType.DOC,
+                filename="report.docx",
+            )
+        ]
+        mock_extract_file_text.return_value = "document body"
+
+        result = extract_context_files(
+            user_files=[uf],
+            llm_max_context_window=10000,
+            reserved_token_count=0,
+            db_session=MagicMock(),
+        )
+
+        assert result.file_texts == ["document body"]
+        assert result.total_token_count == 100
+        mock_extract_file_text.assert_called_once()
+
     @patch("onyx.chat.process_message.load_in_memory_chat_files")
     def test_tool_metadata_file_id_matches_chat_history_file_id(
         self, mock_load: MagicMock

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -32,7 +32,6 @@ export interface Settings {
 
   // Image processing settings
   image_extraction_and_analysis_enabled?: boolean;
-  search_time_image_analysis_enabled?: boolean;
   image_analysis_max_size_mb?: number | null;
 
   // User Knowledge settings


### PR DESCRIPTION
## Summary
- remove chat-time image caption hydration from context file loading
- keep image analysis limited to indexing time
- remove the stale search-time image processing setting from backend and frontend settings surfaces
- update related tests and settings fixtures

## Testing
- `source ../../../.venv/bin/activate && pytest -xv backend/tests/unit/onyx/chat/test_context_files.py`
- repo-wide grep confirms no remaining references to `search_time_image_analysis_enabled`, `get_search_time_image_analysis_enabled`, or `_fetch_cached_image_captions`

## Notes
- I did not run the image indexing integration tests.
- local pre-commit TypeScript hook is currently broken in this environment because it tries to resolve a missing `tsgo` npm package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed search-time image processing per Linear ENG-4037 and kept image analysis only at indexing time. This simplifies chat-time context loading and removes the `search_time_image_analysis_enabled` setting across backend and web.

- **Refactors**
  - Removed document-index caption lookup at chat time and related flags.
  - Switched doc extraction to use only `extract_file_text`; no image caption hydration.
  - Deleted `search_time_image_analysis_enabled` from settings models and `web/src/interfaces/settings.ts`.
  - Updated unit/integration tests and fixtures.

<sup>Written for commit 20122a50e9b3a31d2a664fb1de1331a1ee08747c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

