### PR TITLE
feat(connector): File connector attaches file_id

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -892,7 +892,10 @@ def build_python_chat_files_from_search_docs(
             )
             continue
 
-        if record.file_origin != FileOrigin.CONNECTOR:
+        if record.file_origin not in (
+            FileOrigin.CONNECTOR,
+            FileOrigin.CONNECTOR_FILE_UPLOAD,
+        ):
             logger.warning(
                 f"file_id={doc.file_id!r} has origin={record.file_origin!r}, "
                 "not eligible for code-interpreter staging; skipping."

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -374,6 +374,7 @@ class FileOrigin(str, Enum):
     CHAT_UPLOAD = "chat_upload"
     CHAT_IMAGE_GEN = "chat_image_gen"
     CONNECTOR = "connector"
+    CONNECTOR_FILE_UPLOAD = "connector_file_upload"
     CONNECTOR_METADATA = "connector_metadata"
     GENERATED_REPORT = "generated_report"
     INDEXING_CHECKPOINT = "indexing_checkpoint"

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -13,9 +13,6 @@ from onyx.configs.constants import FileOrigin
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     process_onyx_metadata,
 )
-from onyx.connectors.cross_connector_utils.tabular_section_utils import (
-    extract_and_stage_tabular_file,
-)
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
 from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     tabular_file_to_sections,
@@ -32,7 +29,6 @@ from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.file_store import get_default_file_store
-from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
 
 
@@ -89,7 +85,6 @@ def _process_file(
     metadata: dict[str, Any] | None,
     pdf_pass: str | None,
     file_type: str | None,
-    raw_file_callback: RawFileCallback | None = None,
 ) -> list[Document]:
     """
     Process a file and return a list of Documents.
@@ -191,7 +186,6 @@ def _process_file(
 
     # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
-    staged_file_id: str | None = None
     if is_tabular_file(file_name):
         # Produce TabularSections
         lowered_name = file_name.lower()
@@ -203,24 +197,13 @@ def _process_file(
                 extraction_result.text_content.encode("utf-8", errors="replace")
             )
         try:
-            if raw_file_callback is not None:
-                result = extract_and_stage_tabular_file(
+            sections.extend(
+                tabular_file_to_sections(
                     file=tabular_source,
                     file_name=file_name,
-                    content_type=file_type or "application/octet-stream",
-                    raw_file_callback=raw_file_callback,
                     link=link or "",
                 )
-                sections.extend(result.sections)
-                staged_file_id = result.staged_file_id
-            else:
-                sections.extend(
-                    tabular_file_to_sections(
-                        file=tabular_source,
-                        file_name=file_name,
-                        link=link or "",
-                    )
-                )
+            )
         except Exception as e:
             logger.error(f"Failed to process tabular file {file_name}: {e}")
             return []
@@ -267,7 +250,7 @@ def _process_file(
             primary_owners=primary_owners,
             secondary_owners=secondary_owners,
             metadata=custom_tags,
-            file_id=staged_file_id,
+            file_id=file_id,
         )
     ]
 
@@ -351,7 +334,6 @@ class LocalFileConnector(LoadConnector):
                 metadata=metadata,
                 pdf_pass=self.pdf_pass,
                 file_type=file_record.file_type,
-                raw_file_callback=self.raw_file_callback,
             )
             documents.extend(new_docs)
 

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -186,9 +186,9 @@ def _process_file(
 
     # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
+    # Only set the file id if it is a tabular document
     doc_file_id = None
     if is_tabular_file(file_name):
-        # Only set the file id if it is a tabular document
         doc_file_id = file_id
 
         # Produce TabularSections

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -13,6 +13,9 @@ from onyx.configs.constants import FileOrigin
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     process_onyx_metadata,
 )
+from onyx.connectors.cross_connector_utils.tabular_section_utils import (
+    extract_and_stage_tabular_file,
+)
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
 from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     tabular_file_to_sections,
@@ -29,6 +32,7 @@ from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
 
 
@@ -85,6 +89,7 @@ def _process_file(
     metadata: dict[str, Any] | None,
     pdf_pass: str | None,
     file_type: str | None,
+    raw_file_callback: RawFileCallback | None = None,
 ) -> list[Document]:
     """
     Process a file and return a list of Documents.
@@ -186,6 +191,7 @@ def _process_file(
 
     # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
+    staged_file_id: str | None = None
     if is_tabular_file(file_name):
         # Produce TabularSections
         lowered_name = file_name.lower()
@@ -197,13 +203,24 @@ def _process_file(
                 extraction_result.text_content.encode("utf-8", errors="replace")
             )
         try:
-            sections.extend(
-                tabular_file_to_sections(
+            if raw_file_callback is not None:
+                result = extract_and_stage_tabular_file(
                     file=tabular_source,
                     file_name=file_name,
+                    content_type=file_type or "application/octet-stream",
+                    raw_file_callback=raw_file_callback,
                     link=link or "",
                 )
-            )
+                sections.extend(result.sections)
+                staged_file_id = result.staged_file_id
+            else:
+                sections.extend(
+                    tabular_file_to_sections(
+                        file=tabular_source,
+                        file_name=file_name,
+                        link=link or "",
+                    )
+                )
         except Exception as e:
             logger.error(f"Failed to process tabular file {file_name}: {e}")
             return []
@@ -250,6 +267,7 @@ def _process_file(
             primary_owners=primary_owners,
             secondary_owners=secondary_owners,
             metadata=custom_tags,
+            file_id=staged_file_id,
         )
     ]
 
@@ -333,6 +351,7 @@ class LocalFileConnector(LoadConnector):
                 metadata=metadata,
                 pdf_pass=self.pdf_pass,
                 file_type=file_record.file_type,
+                raw_file_callback=self.raw_file_callback,
             )
             documents.extend(new_docs)
 

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -186,7 +186,11 @@ def _process_file(
 
     # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
+    doc_file_id = None
     if is_tabular_file(file_name):
+        # Only set the file id if it is a tabular document
+        doc_file_id = file_id
+
         # Produce TabularSections
         lowered_name = file_name.lower()
         if lowered_name.endswith(tuple(OnyxFileExtensions.SPREADSHEET_EXTENSIONS)):
@@ -238,9 +242,6 @@ def _process_file(
             logger.warning(
                 f"Failed to process embedded image {idx} in {file_name}: {e}"
             )
-
-    # Only set the file id if it is a tabular document
-    doc_file_id = file_id if is_tabular_file(file_name) else None
 
     return [
         Document(

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -239,6 +239,9 @@ def _process_file(
                 f"Failed to process embedded image {idx} in {file_name}: {e}"
             )
 
+    # Only set the file id if it is a tabular document
+    doc_file_id = file_id if is_tabular_file(file_name) else None
+
     return [
         Document(
             id=doc_id,
@@ -250,7 +253,7 @@ def _process_file(
             primary_owners=primary_owners,
             secondary_owners=secondary_owners,
             metadata=custom_tags,
-            file_id=file_id,
+            file_id=doc_file_id,
         )
     ]
 

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -642,7 +642,7 @@ def upload_files_api(
     unzip: bool = True,
     _: User = Depends(current_curator_or_admin_user),
 ) -> FileUploadResponse:
-    return upload_files(files, FileOrigin.OTHER, unzip=unzip)
+    return upload_files(files, FileOrigin.CONNECTOR_FILE_UPLOAD, unzip=unzip)
 
 
 @router.get("/admin/connector/{connector_id}/files", tags=PUBLIC_API_TAGS)

--- a/backend/tests/daily/connectors/file/test_file_connector.py
+++ b/backend/tests/daily/connectors/file/test_file_connector.py
@@ -160,3 +160,124 @@ def test_two_text_files_with_zip_metadata(
         == "dave@onyx.app"
     )
     assert doc2.doc_updated_at == datetime(2023, 3, 3, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@patch("onyx.connectors.file.connector.get_default_file_store")
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key", return_value=None
+)
+def test_tabular_file_sets_file_id_on_document(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_get_filestore: MagicMock,  # noqa: ARG001
+    mock_file_store: MagicMock,
+) -> None:
+    """Tabular files (CSV / XLSX) carry the original uploaded file_id on
+    the Document so the code-interpreter staging path can fetch the raw
+    bytes for pandas/analysis (see `build_python_chat_files_from_search_docs`).
+    """
+    csv_content = io.BytesIO(b"name,value\nAlice,1\nBob,2\n")
+    file_id = str(uuid4())
+    mock_file_store.read_file_record.return_value = MagicMock(
+        file_id=file_id,
+        display_name="data.csv",
+        file_type="text/csv",
+    )
+    mock_file_store.read_file.return_value = csv_content
+
+    with patch(
+        "onyx.connectors.file.connector.get_default_file_store",
+        return_value=mock_file_store,
+    ):
+        connector = LocalFileConnector(
+            file_locations=[file_id], file_names=["data.csv"], zip_metadata={}
+        )
+        batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    docs = batches[0]
+    assert len(docs) == 1
+    doc = docs[0]
+    assert not isinstance(doc, HierarchyNode)
+    assert doc.file_id == file_id
+
+
+@patch("onyx.connectors.file.connector.get_default_file_store")
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key", return_value=None
+)
+def test_non_tabular_file_leaves_file_id_none(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_get_filestore: MagicMock,  # noqa: ARG001
+    mock_file_store: MagicMock,
+) -> None:
+    """Non-tabular files don't carry file_id — the extracted text already
+    fully represents the Document, so the code-interpreter staging path
+    has no reason to hand the LLM the raw blob.
+    """
+    txt_content = io.BytesIO(b"Some plain text content for the LLM.")
+    file_id = str(uuid4())
+    mock_file_store.read_file_record.return_value = MagicMock(
+        file_id=file_id,
+        display_name="notes.txt",
+        file_type="text/plain",
+    )
+    mock_file_store.read_file.return_value = txt_content
+
+    with patch(
+        "onyx.connectors.file.connector.get_default_file_store",
+        return_value=mock_file_store,
+    ):
+        connector = LocalFileConnector(
+            file_locations=[file_id], file_names=["notes.txt"], zip_metadata={}
+        )
+        batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    docs = batches[0]
+    assert len(docs) == 1
+    doc = docs[0]
+    assert not isinstance(doc, HierarchyNode)
+    assert doc.file_id is None
+
+
+@patch("onyx.connectors.file.connector.get_default_file_store")
+@patch(
+    "onyx.file_processing.extract_file_text.get_unstructured_api_key", return_value=None
+)
+def test_mixed_batch_only_tabular_gets_file_id(
+    mock_get_unstructured_api_key: MagicMock,  # noqa: ARG001
+    mock_get_filestore: MagicMock,  # noqa: ARG001
+    mock_file_store: MagicMock,
+) -> None:
+    """When a batch mixes tabular and non-tabular files, file_id is set
+    per-document — only the CSV doc carries its file_id; the .txt doc
+    stays None. Confirms the check happens per-file, not once per batch.
+    """
+    csv_id = str(uuid4())
+    txt_id = str(uuid4())
+    csv_content = io.BytesIO(b"col,val\nfoo,1\nbar,2\n")
+    txt_content = io.BytesIO(b"Just some notes.")
+
+    mock_file_store.read_file_record.side_effect = [
+        MagicMock(file_id=csv_id, display_name="data.csv", file_type="text/csv"),
+        MagicMock(file_id=txt_id, display_name="notes.txt", file_type="text/plain"),
+    ]
+    mock_file_store.read_file.side_effect = [csv_content, txt_content]
+
+    with patch(
+        "onyx.connectors.file.connector.get_default_file_store",
+        return_value=mock_file_store,
+    ):
+        connector = LocalFileConnector(
+            file_locations=[csv_id, txt_id],
+            file_names=["data.csv", "notes.txt"],
+            zip_metadata={},
+        )
+        batches = list(connector.load_from_state())
+
+    assert len(batches) == 1
+    csv_doc, txt_doc = batches[0]
+    assert not isinstance(csv_doc, HierarchyNode)
+    assert not isinstance(txt_doc, HierarchyNode)
+    assert csv_doc.file_id == csv_id
+    assert txt_doc.file_id is None


### PR DESCRIPTION
## Description
This updates the file connector to attach the file_id of a document to the document IF it is a tabular file. This means that during the inference pipeline for smarter CSV/Excel handling, the document can be directly referenced.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach `file_id` to tabular documents from the file connector and add `CONNECTOR_FILE_UPLOAD` origin so code‑interpreter can stage connector uploads for CSV/Excel analysis. Chat utils now accept both connector origins; tests cover tabular vs non‑tabular and mixed batches.

- **New Features**
  - File connector sets `Document.file_id` for tabular files only.
  - `/admin/connector/{connector_id}/upload` now uses `FileOrigin.CONNECTOR_FILE_UPLOAD`.
  - Code interpreter accepts `CONNECTOR` and `CONNECTOR_FILE_UPLOAD`.

<sup>Written for commit c5993028fa6b2a63edcaef0d73b5abdd45ceaf7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





