### PR TITLE
feat(connector): Blob + Sharepoint connector attach file_id for tabular sections

### DIFF
--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -466,9 +466,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
                 # Handle tabular files (xlsx, csv, tsv) — produce one
                 # TabularSection per sheet (or per file for csv/tsv)
-                # instead of a flat TextSection. When a raw_file_callback
-                # is wired, also stage the raw bytes so the code-interpreter
-                # staging path can pull them for pandas/analysis.
+                # instead of a flat TextSection.
                 if is_tabular_file(file_name):
                     try:
                         downloaded_file = self._download_object(key)

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 import time
 from collections.abc import Mapping
@@ -25,6 +26,9 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FileOrigin
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     process_onyx_metadata,
+)
+from onyx.connectors.cross_connector_utils.tabular_section_utils import (
+    extract_and_stage_tabular_file,
 )
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
 from onyx.connectors.cross_connector_utils.tabular_section_utils import (
@@ -462,17 +466,32 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
                 # Handle tabular files (xlsx, csv, tsv) — produce one
                 # TabularSection per sheet (or per file for csv/tsv)
-                # instead of a flat TextSection.
+                # instead of a flat TextSection. When a raw_file_callback
+                # is wired, also stage the raw bytes so the code-interpreter
+                # staging path can pull them for pandas/analysis.
                 if is_tabular_file(file_name):
                     try:
                         downloaded_file = self._download_object(key)
                         if downloaded_file is None:
                             continue
-                        tabular_sections = tabular_file_to_sections(
-                            BytesIO(downloaded_file),
-                            file_name=file_name,
-                            link=link,
-                        )
+                        staged_file_id: str | None = None
+                        if self.raw_file_callback is not None:
+                            content_type, _ = mimetypes.guess_type(file_name)
+                            result = extract_and_stage_tabular_file(
+                                file=BytesIO(downloaded_file),
+                                file_name=file_name,
+                                content_type=content_type or "application/octet-stream",
+                                raw_file_callback=self.raw_file_callback,
+                                link=link,
+                            )
+                            tabular_sections = result.sections
+                            staged_file_id = result.staged_file_id
+                        else:
+                            tabular_sections = tabular_file_to_sections(
+                                BytesIO(downloaded_file),
+                                file_name=file_name,
+                                link=link,
+                            )
                         batch.append(
                             Document(
                                 id=f"{self.bucket_type}:{self.bucket_name}:{key}",
@@ -485,6 +504,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                                 semantic_identifier=file_name,
                                 doc_updated_at=last_modified,
                                 metadata={},
+                                file_id=staged_file_id,
                             )
                         )
                         if len(batch) == self.batch_size:

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -472,6 +472,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                         downloaded_file = self._download_object(key)
                         if downloaded_file is None:
                             continue
+                        tabular_sections: list[TabularSection] = []
                         staged_file_id: str | None = None
                         if self.raw_file_callback is not None:
                             content_type, _ = mimetypes.guess_type(file_name)

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -41,6 +41,9 @@ from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.app_configs import SHAREPOINT_CONNECTOR_SIZE_THRESHOLD
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FileOrigin
+from onyx.connectors.cross_connector_utils.tabular_section_utils import (
+    extract_and_stage_tabular_file,
+)
 from onyx.connectors.cross_connector_utils.tabular_section_utils import is_tabular_file
 from onyx.connectors.cross_connector_utils.tabular_section_utils import (
     tabular_file_to_sections,
@@ -73,6 +76,7 @@ from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_processing.image_utils import store_image_and_create_section
+from onyx.file_store.staging import RawFileCallback
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import SSRFException
@@ -529,6 +533,7 @@ def _convert_driveitem_to_document_with_permissions(
     parent_hierarchy_raw_node_id: str | None = None,
     access_token: str | None = None,
     treat_sharing_link_as_public: bool = False,
+    raw_file_callback: RawFileCallback | None = None,
 ) -> Document | ConnectorFailure | None:
 
     if not driveitem.name or not driveitem.id:
@@ -598,6 +603,9 @@ def _convert_driveitem_to_document_with_permissions(
             )
 
     sections: list[TextSection | ImageSection | TabularSection] = []
+    # Only tabular files carry a `file_id` on the Document — the code-
+    # interpreter staging path needs the original bytes for pandas/analysis.
+    staged_file_id: str | None = None
     file_ext = get_file_ext(driveitem.name)
 
     if not content_bytes:
@@ -615,13 +623,24 @@ def _convert_driveitem_to_document_with_permissions(
         sections.append(image_section)
     elif is_tabular_file(driveitem.name):
         try:
-            sections.extend(
-                tabular_file_to_sections(
+            if raw_file_callback is not None:
+                result = extract_and_stage_tabular_file(
                     file=io.BytesIO(content_bytes),
                     file_name=driveitem.name,
+                    content_type=mime_type or "application/octet-stream",
+                    raw_file_callback=raw_file_callback,
                     link=driveitem.web_url or "",
                 )
-            )
+                sections.extend(result.sections)
+                staged_file_id = result.staged_file_id
+            else:
+                sections.extend(
+                    tabular_file_to_sections(
+                        file=io.BytesIO(content_bytes),
+                        file_name=driveitem.name,
+                        link=driveitem.web_url or "",
+                    )
+                )
         except Exception as e:
             logger.warning(
                 f"Failed to extract tabular sections for '{driveitem.name}': {e}"
@@ -698,6 +717,7 @@ def _convert_driveitem_to_document_with_permissions(
         ],
         metadata={"drive": drive_name},
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        file_id=staged_file_id,
     )
     return doc
 
@@ -2482,6 +2502,7 @@ class SharepointConnector(
                         graph_api_base=self.graph_api_base,
                         access_token=access_token,
                         treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        raw_file_callback=self.raw_file_callback,
                     )
 
                     if isinstance(doc_or_failure, Document):

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -603,8 +603,7 @@ def _convert_driveitem_to_document_with_permissions(
             )
 
     sections: list[TextSection | ImageSection | TabularSection] = []
-    # Only tabular files carry a `file_id` on the Document — the code-
-    # interpreter staging path needs the original bytes for pandas/analysis.
+    # Only tabular files carry a `file_id` on the Document
     staged_file_id: str | None = None
     file_ext = get_file_ext(driveitem.name)
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_delta_checkpointing.py
@@ -146,6 +146,7 @@ def _mock_convert(monkeypatch: pytest.MonkeyPatch) -> None:
         parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
         access_token: str | None = None,  # noqa: ARG001
         treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+        raw_file_callback: Any = None,  # noqa: ARG001
     ) -> Document:
         return _make_document(driveitem)
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -212,6 +212,7 @@ def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -
         parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
         access_token: str | None = None,  # noqa: ARG001
         treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+        raw_file_callback: Any = None,  # noqa: ARG001
     ) -> Document:
         captured_drive_names.append(drive_name)
         return Document(


### PR DESCRIPTION
## Description
Hooks up the file callback to the blbob and sharepoint connector

## How Has This Been Tested?
Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hooked Blob and SharePoint connectors into tabular file staging so raw tabular files are saved and linked to documents. When a `raw_file_callback` is provided, tabular files are staged and the returned `file_id` is stored on the `Document`.

- **New Features**
  - Stage tabular files via `extract_and_stage_tabular_file` when `raw_file_callback` is set; otherwise use `tabular_file_to_sections`.
  - Set `Document.file_id` to the staged `file_id` for tabular files only.
  - Blob: detect `content_type` with `mimetypes.guess_type(file_name)`; default to `application/octet-stream`.
  - SharePoint: pass `raw_file_callback` to `_convert_driveitem_to_document_with_permissions` and `_load_from_checkpoint`; use `mime_type` or default to `application/octet-stream`.

<sup>Written for commit cfeeafbd720d631f5f71e306b139038ee2456b55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



