### PR TITLE
feat(tracing): reassemble streaming tool-call deltas on fallback span

### DIFF
--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -7,9 +7,10 @@ no-op when an outer `generation_span` is already active — callers that
 explicitly wrap their calls (via `llm_generation_span`) continue to work and
 are not double-counted.
 
-Imports from `onyx.tracing.*` are performed lazily inside the wrappers to
-avoid an import cycle between `onyx.llm.interfaces` and
-`onyx.tracing.llm_utils` (which itself imports `LLM`).
+Imports from `onyx.tracing.llm_utils` stay lazy (inside the wrappers) because
+it imports `onyx.llm.interfaces`, which imports this module — loading it at
+module level would deadlock the import graph. Everything else is imported
+at the top of the file.
 """
 
 from __future__ import annotations
@@ -21,9 +22,14 @@ from collections.abc import Iterator
 from typing import Any
 from typing import TYPE_CHECKING
 
+from onyx.llm.model_response import ChatCompletionDeltaToolCall
+from onyx.llm.model_response import FunctionCall as DeltaFunctionCall
+from onyx.llm.model_response import Usage
+from onyx.tracing.framework.create import get_current_span
+from onyx.tracing.framework.span_data import GenerationSpanData
+
 if TYPE_CHECKING:
     from onyx.llm.interfaces import LLM
-    from onyx.llm.model_response import ChatCompletionDeltaToolCall
     from onyx.llm.model_response import ModelResponse
     from onyx.llm.model_response import ModelResponseStream
     from onyx.llm.models import ToolCall
@@ -50,9 +56,6 @@ def _outer_generation_span_active() -> bool:
       always has ``started_at = None``. The ``started_at`` check prevents a
       stale ``NoOpSpan`` from suppressing fallback tracing.
     """
-    from onyx.tracing.framework.create import get_current_span
-    from onyx.tracing.framework.span_data import GenerationSpanData
-
     current = get_current_span()
     return (
         current is not None
@@ -184,7 +187,6 @@ def wrap_stream(
             yield from stream_fn(self, *args, **kwargs)
             return
 
-        from onyx.llm.model_response import Usage
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_span_output
 
@@ -249,9 +251,6 @@ def _merge_tool_call_delta(
     keyed by ``index`` that can be converted to fully-formed ``ToolCall``
     objects via :func:`_finalize_tool_calls`.
     """
-    from onyx.llm.model_response import ChatCompletionDeltaToolCall
-    from onyx.llm.model_response import FunctionCall as DeltaFunctionCall
-
     existing = buffer.get(delta.index)
     if existing is None:
         # Copy into a fresh pydantic model so later mutations don't leak back

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -23,8 +23,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from onyx.llm.interfaces import LLM
+    from onyx.llm.model_response import ChatCompletionDeltaToolCall
     from onyx.llm.model_response import ModelResponse
     from onyx.llm.model_response import ModelResponseStream
+    from onyx.llm.models import ToolCall
 
 
 _ALREADY_WRAPPED_ATTR = "_onyx_tracing_wrapped"
@@ -162,11 +164,12 @@ def wrap_stream(
 ) -> Callable[..., Iterator["ModelResponseStream"]]:
     """Wrap a concrete ``LLM.stream`` implementation with a fallback generation_span.
 
-    Accumulates content + final usage across yielded chunks and records them on
-    the span when the stream is fully consumed. Tool-call deltas are
-    intentionally NOT accumulated — streaming deltas are partial fragments
-    keyed on ``index`` that need ``litellm.stream_chunk_builder``-style
-    reassembly before being safe to log.
+    Accumulates content, final usage, and tool-call deltas across yielded
+    chunks and records them on the span when the stream is fully consumed.
+    Tool-call deltas arrive as partial fragments keyed on ``index`` — this
+    wrap reassembles them via ``_merge_tool_call_delta`` before logging so
+    Braintrust shows one complete tool-call entry per invocation rather than
+    fragmented duplicates.
     """
     if getattr(stream_fn, _ALREADY_WRAPPED_ATTR, False):
         return stream_fn
@@ -191,6 +194,7 @@ def wrap_stream(
         ) as span:
             accumulated_content: list[str] = []
             final_usage: Usage | None = None
+            tool_call_buffer: dict[int, ChatCompletionDeltaToolCall] = {}
 
             try:
                 for chunk in stream_fn(self, *args, **kwargs):
@@ -198,6 +202,9 @@ def wrap_stream(
                         final_usage = chunk.usage
                     if span is not None and chunk.choice.delta.content:
                         accumulated_content.append(chunk.choice.delta.content)
+                    if span is not None and chunk.choice.delta.tool_calls:
+                        for delta_tc in chunk.choice.delta.tool_calls:
+                            _merge_tool_call_delta(tool_call_buffer, delta_tc)
                     yield chunk
             except Exception as exc:
                 if span is not None:
@@ -217,8 +224,99 @@ def wrap_stream(
                     span,
                     output="".join(accumulated_content) or None,
                     usage=final_usage,
-                    tool_calls=None,
+                    tool_calls=_finalize_tool_calls(tool_call_buffer),
                 )
 
     setattr(wrapper, _ALREADY_WRAPPED_ATTR, True)
     return wrapper
+
+
+def _merge_tool_call_delta(
+    buffer: dict[int, "ChatCompletionDeltaToolCall"],
+    delta: "ChatCompletionDeltaToolCall",
+) -> None:
+    """Merge a single streaming tool-call delta into the per-``index`` buffer.
+
+    Streaming tool calls from LiteLLM arrive as partial fragments:
+    - Early chunks for a given ``index`` usually carry ``id`` and
+      ``function.name`` (and possibly the first slice of ``function.arguments``).
+    - Subsequent chunks for the same ``index`` carry additional
+      ``function.arguments`` fragments with ``id`` / ``name`` set to ``None``.
+
+    This helper merges them in place: it preserves the first seen ``id`` and
+    ``function.name`` and concatenates ``function.arguments`` fragments. The
+    result is a dict of complete ``ChatCompletionDeltaToolCall`` objects
+    keyed by ``index`` that can be converted to fully-formed ``ToolCall``
+    objects via :func:`_finalize_tool_calls`.
+    """
+    from onyx.llm.model_response import ChatCompletionDeltaToolCall
+    from onyx.llm.model_response import FunctionCall as DeltaFunctionCall
+
+    existing = buffer.get(delta.index)
+    if existing is None:
+        # Copy into a fresh pydantic model so later mutations don't leak back
+        # into the caller's chunk object.
+        delta_fn = delta.function
+        buffer[delta.index] = ChatCompletionDeltaToolCall(
+            id=delta.id,
+            index=delta.index,
+            type=delta.type,
+            function=(
+                DeltaFunctionCall(
+                    name=delta_fn.name if delta_fn else None,
+                    arguments=delta_fn.arguments if delta_fn else None,
+                )
+                if delta_fn is not None
+                else None
+            ),
+        )
+        return
+
+    if delta.id and not existing.id:
+        existing.id = delta.id
+    if delta.function is not None:
+        if existing.function is None:
+            existing.function = DeltaFunctionCall(
+                name=delta.function.name,
+                arguments=delta.function.arguments,
+            )
+        else:
+            if delta.function.name and not existing.function.name:
+                existing.function.name = delta.function.name
+            if delta.function.arguments:
+                existing.function.arguments = (
+                    existing.function.arguments or ""
+                ) + delta.function.arguments
+
+
+def _finalize_tool_calls(
+    buffer: dict[int, "ChatCompletionDeltaToolCall"],
+) -> list["ToolCall"] | None:
+    """Convert a reassembled delta buffer into a list of complete ``ToolCall``.
+
+    Entries missing a required field (``id`` or ``function.name``) are skipped
+    — these would indicate a truncated / malformed stream, and it's safer to
+    log nothing for that index than to fabricate a partial record.
+    """
+    if not buffer:
+        return None
+
+    from onyx.llm.models import FunctionCall as ModelFunctionCall
+    from onyx.llm.models import ToolCall
+
+    finalized: list[ToolCall] = []
+    for idx in sorted(buffer.keys()):
+        delta = buffer[idx]
+        if delta.id is None or delta.function is None or delta.function.name is None:
+            continue
+        finalized.append(
+            ToolCall(
+                id=delta.id,
+                type="function",
+                function=ModelFunctionCall(
+                    name=delta.function.name,
+                    arguments=delta.function.arguments or "",
+                ),
+            )
+        )
+    return finalized or None

--- a/backend/tests/unit/onyx/llm/test_tracing_wrap.py
+++ b/backend/tests/unit/onyx/llm/test_tracing_wrap.py
@@ -28,8 +28,10 @@ import pytest
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMConfig
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_response import ChatCompletionDeltaToolCall
 from onyx.llm.model_response import Choice
 from onyx.llm.model_response import Delta
+from onyx.llm.model_response import FunctionCall as DeltaFunctionCall
 from onyx.llm.model_response import Message
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.model_response import ModelResponseStream
@@ -40,6 +42,8 @@ from onyx.llm.models import ToolChoiceOptions
 from onyx.llm.models import UserMessage
 from onyx.llm.tracing_wrap import _ALREADY_WRAPPED_ATTR
 from onyx.llm.tracing_wrap import _extract_prompt
+from onyx.llm.tracing_wrap import _finalize_tool_calls
+from onyx.llm.tracing_wrap import _merge_tool_call_delta
 from onyx.llm.tracing_wrap import _outer_generation_span_active
 from onyx.llm.tracing_wrap import _validate_prompt_param
 from onyx.llm.tracing_wrap import wrap_invoke
@@ -349,3 +353,156 @@ def test_outer_guard_false_for_noop_span_in_contextvar() -> None:
         assert _outer_generation_span_active() is False
     finally:
         noop_span.finish(reset_current=True)
+
+
+# ---------------------------------------------------------------------------
+# Tool-call delta reassembly
+# ---------------------------------------------------------------------------
+
+
+def _delta(
+    index: int,
+    *,
+    id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+) -> ChatCompletionDeltaToolCall:
+    fn = (
+        DeltaFunctionCall(name=name, arguments=arguments)
+        if (name is not None or arguments is not None)
+        else None
+    )
+    return ChatCompletionDeltaToolCall(id=id, index=index, type="function", function=fn)
+
+
+def test_merge_tool_call_delta_single_call_across_chunks() -> None:
+    buf: dict[int, ChatCompletionDeltaToolCall] = {}
+    # Chunk 1: id + name + arg fragment 1
+    _merge_tool_call_delta(
+        buf, _delta(0, id="call_1", name="search", arguments='{"q":"')
+    )
+    # Chunk 2: arg fragment 2
+    _merge_tool_call_delta(buf, _delta(0, arguments="hello"))
+    # Chunk 3: arg fragment 3
+    _merge_tool_call_delta(buf, _delta(0, arguments='"}'))
+
+    finalized = _finalize_tool_calls(buf)
+    assert finalized is not None
+    assert len(finalized) == 1
+    tc = finalized[0]
+    assert tc.id == "call_1"
+    assert tc.function.name == "search"
+    assert tc.function.arguments == '{"q":"hello"}'
+
+
+def test_merge_tool_call_delta_multiple_calls_by_index() -> None:
+    buf: dict[int, ChatCompletionDeltaToolCall] = {}
+    # Interleaved deltas across two tool calls (indices 0 and 1)
+    _merge_tool_call_delta(buf, _delta(0, id="call_a", name="fn_a", arguments='{"x":'))
+    _merge_tool_call_delta(buf, _delta(1, id="call_b", name="fn_b", arguments='{"y":'))
+    _merge_tool_call_delta(buf, _delta(0, arguments="1}"))
+    _merge_tool_call_delta(buf, _delta(1, arguments="2}"))
+
+    finalized = _finalize_tool_calls(buf)
+    assert finalized is not None
+    assert len(finalized) == 2
+    # Sorted by index
+    assert finalized[0].id == "call_a"
+    assert finalized[0].function.name == "fn_a"
+    assert finalized[0].function.arguments == '{"x":1}'
+    assert finalized[1].id == "call_b"
+    assert finalized[1].function.name == "fn_b"
+    assert finalized[1].function.arguments == '{"y":2}'
+
+
+def test_merge_tool_call_delta_does_not_overwrite_first_id_or_name() -> None:
+    buf: dict[int, ChatCompletionDeltaToolCall] = {}
+    _merge_tool_call_delta(
+        buf, _delta(0, id="call_real", name="real_fn", arguments="{}")
+    )
+    # A later delta that (incorrectly) supplies a different id/name must not
+    # clobber the first-seen values.
+    _merge_tool_call_delta(
+        buf, _delta(0, id="call_ignored", name="ignored_fn", arguments="")
+    )
+    finalized = _finalize_tool_calls(buf)
+    assert finalized is not None
+    assert finalized[0].id == "call_real"
+    assert finalized[0].function.name == "real_fn"
+
+
+def test_finalize_tool_calls_skips_entries_missing_required_fields() -> None:
+    buf: dict[int, ChatCompletionDeltaToolCall] = {}
+    # Complete entry
+    _merge_tool_call_delta(buf, _delta(0, id="call_ok", name="fn_ok", arguments="{}"))
+    # Incomplete entry — never got an id or name
+    _merge_tool_call_delta(buf, _delta(1, arguments='{"partial":true}'))
+    finalized = _finalize_tool_calls(buf)
+    assert finalized is not None
+    assert len(finalized) == 1
+    assert finalized[0].id == "call_ok"
+
+
+def test_finalize_tool_calls_returns_none_for_empty_buffer() -> None:
+    assert _finalize_tool_calls({}) is None
+
+
+class _ToolStreamLLM(LLM):
+    """Test double that streams one tool call split across three chunks."""
+
+    @property
+    def config(self) -> LLMConfig:
+        return LLMConfig(
+            model_provider="test",
+            model_name="test-model",
+            temperature=0.0,
+            max_input_tokens=1000,
+        )
+
+    def invoke(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> ModelResponse:
+        return _TEST_MODEL_RESPONSE
+
+    def stream(
+        self,
+        prompt: LanguageModelInput,
+        tools: list[dict] | None = None,
+        tool_choice: ToolChoiceOptions | None = None,
+        structured_response_format: dict | None = None,
+        timeout_override: int | None = None,
+        max_tokens: int | None = None,
+        reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
+        user_identity: LLMUserIdentity | None = None,
+    ) -> Iterator[ModelResponseStream]:
+        frames = [
+            _delta(0, id="call_1", name="search", arguments='{"q":"'),
+            _delta(0, arguments="hi"),
+            _delta(0, arguments='"}'),
+        ]
+        for delta_tc in frames:
+            yield ModelResponseStream(
+                id="stream-id",
+                created="2026-04-22T00:00:00Z",
+                choice=StreamingChoice(delta=Delta(tool_calls=[delta_tc])),
+            )
+
+
+def test_stream_forwards_every_chunk_unchanged_when_tool_calls_present() -> None:
+    """Regression guard: the wrap must not alter the yielded chunks even
+    while it accumulates tool-call deltas internally."""
+    llm = _ToolStreamLLM()
+    chunks = list(llm.stream(UserMessage(content="hi")))
+    assert len(chunks) == 3
+    # The deltas yielded downstream still look like partial fragments.
+    assert chunks[0].choice.delta.tool_calls[0].id == "call_1"
+    assert chunks[1].choice.delta.tool_calls[0].id is None  # fragment
+    assert chunks[2].choice.delta.tool_calls[0].id is None  # fragment


### PR DESCRIPTION
## Description

Follow-up to #10478. Adds tool-call-delta reassembly to the streaming fallback wrap in `onyx/llm/tracing_wrap.py` so Braintrust captures complete tool invocations on streamed calls.

**Stacked on `nikg/trace-all-llm-invocations`** — merge that PR first.

### The problem

LiteLLM streaming delivers tool calls as partial fragments per chunk, keyed on ``index``. Typical pattern:

```
chunk 1: tool_calls=[{id:"call_123", index:0, function:{name:"search", arguments:"{\"qu"}}]
chunk 2: tool_calls=[{id:None,       index:0, function:{name:None,     arguments:"ery\":"}}]
chunk 3: tool_calls=[{id:None,       index:0, function:{name:None,     arguments:" \"hi\"}"}}]
```

The original stream wrap in #10478 intentionally passed ``tool_calls=None`` to ``record_llm_span_output`` because blindly extending a list with every delta would produce `N` malformed partial entries per tool call — each with a different subset of `id` / `name` / `arguments`. `record_llm_span_output` then calls `.model_dump()` on each, writing fragmented duplicate records.

### The fix

Two new helpers in `tracing_wrap.py`:

- **`_merge_tool_call_delta(buffer, delta)`** — merges a single streaming delta into a per-`index` buffer. Preserves the first-seen `id` and `function.name`, concatenates `function.arguments` fragments.
- **`_finalize_tool_calls(buffer)`** — converts the reassembled buffer into a list of complete `onyx.llm.models.ToolCall` objects, sorted by `index`. Entries missing required fields (`id` or `function.name`) are skipped rather than fabricated.

The stream wrap now runs these during the chunk loop and passes the finalized list to `record_llm_span_output`. Braintrust displays one complete tool-call entry per invocation, matching the metadata level of the non-streaming `invoke` path (which already gets full reassembly via `litellm.stream_chunk_builder` before `record_llm_response` runs).

### Tests

Six new test cases in `backend/tests/unit/onyx/llm/test_tracing_wrap.py`:

- `test_merge_tool_call_delta_single_call_across_chunks`
- `test_merge_tool_call_delta_multiple_calls_by_index` — verifies per-`index` keying with interleaved deltas
- `test_merge_tool_call_delta_does_not_overwrite_first_id_or_name`
- `test_finalize_tool_calls_skips_entries_missing_required_fields`
- `test_finalize_tool_calls_returns_none_for_empty_buffer`
- `test_stream_forwards_every_chunk_unchanged_when_tool_calls_present` — regression guard: downstream consumers still receive the raw delta fragments; reassembly is internal to the span

All 24 tests pass (18 from the base PR + 6 new).

## How Has This Been Tested?

a bunch of local testing
https://www.braintrust.dev/app/Onyx%202/p/Nik%20Local/logs?r=trace_20aefa5118da4c83bcac554b15c8dd61&s=caa1a8b3-be68-42bf-a8bd-0443c3e68fb0

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check