### PR TITLE
feat(gitlab): expose include_code_files option in connector UI

### DIFF
--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -320,6 +320,15 @@ export const connectorConfigs: Record<
         description: "Index issues from repositories",
         default: true,
       },
+      {
+        type: "checkbox",
+        query: "Include source code files?",
+        label: "Include Code Files",
+        name: "include_code_files",
+        description:
+          "Index source code files from the repository. Warning: this can be slow for large repositories.",
+        default: false,
+      },
     ],
   },
   bitbucket: {
@@ -1928,6 +1937,7 @@ export interface GitlabConfig {
   project_name: string;
   include_mrs: boolean;
   include_issues: boolean;
+  include_code_files: boolean;
 }
 
 export interface BitbucketConfig {


### PR DESCRIPTION
Add a checkbox in the GitLab connector advanced settings to let users enable source code file indexing via the UI instead of requiring the GITLAB_CONNECTOR_INCLUDE_CODE_FILES environment variable.

https://claude.ai/code/session_01FqgKWe6zMrSLJcg7AUVk55

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Include Code Files" checkbox to the GitLab connector’s advanced settings so users can enable source code indexing from the UI instead of the `GITLAB_CONNECTOR_INCLUDE_CODE_FILES` env var.

- **New Features**
  - Added "Include Code Files" checkbox (default off) with a warning about large repos.
  - Extended `GitlabConfig` with `include_code_files: boolean`.

<sup>Written for commit 3932de0d50b11bab3d5aa2394fd123249b467eb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

