### PR TITLE
fix(ConfluenceConnector): preserve /Date macro text and fix Cyrillic encoding

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -1072,6 +1072,9 @@ def extract_text_from_confluence_html(
 
     _remove_macro_stylings(soup=soup)
 
+    for date_span in soup.findAll("span", {"class": "date-lozenger-container"}):
+        date_span.replaceWith(date_span.get_text())
+
     for user in soup.findAll("ri:user"):
         user_id = (
             user.attrs["ri:account-id"]

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -93,10 +93,24 @@ def is_text_file(file: IO[bytes]) -> bool:
 
 
 def detect_encoding(file: IO[bytes]) -> str:
+    """Detect the character encoding of a binary file.
+
+    Tries UTF-8 first — if the bytes decode cleanly, they are definitively UTF-8
+    (UTF-8 is self-validating). Falls back to chardet only when UTF-8 fails, since
+    chardet can misidentify valid UTF-8 text (e.g. Cyrillic) as a legacy encoding
+    like windows-1251, producing mojibake. Defaults to utf-8 if chardet gives up.
+
+    Resets the file cursor to 0 after sampling so callers can still read the full file.
+    """
     raw_data = file.read(50000)
     file.seek(0)
-    encoding = chardet.detect(raw_data)["encoding"] or "utf-8"
-    return encoding
+    try:
+        raw_data.decode("utf-8")
+        return "utf-8"
+    except UnicodeDecodeError:
+        # utf-8 failed — bytes are genuinely non-UTF-8, let chardet guess
+        encoding = chardet.detect(raw_data)["encoding"] or "utf-8"
+        return encoding
 
 
 def is_macos_resource_fork_file(file_name: str) -> bool:

--- a/backend/tests/unit/onyx/connectors/confluence/test_extract_text.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_extract_text.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+from onyx.connectors.confluence.onyx_confluence import extract_text_from_confluence_html
+
+
+def _make_confluence_object(html: str) -> dict:
+    return {"body": {"storage": {"value": html}}}
+
+
+def _make_mock_client() -> mock.Mock:
+    client = mock.Mock()
+    client.paginated_cql_retrieval.return_value = iter([])
+    return client
+
+
+def test_date_lozenge_text_is_preserved() -> None:
+    """Text inside a /Date macro span must appear in the extracted output."""
+    html = (
+        "<p>Meeting on "
+        '<span class="date-lozenger-container">April 22, 2026</span>'
+        " at noon.</p>"
+    )
+    result = extract_text_from_confluence_html(
+        confluence_client=_make_mock_client(),
+        confluence_object=_make_confluence_object(html),
+        fetched_titles=set(),
+    )
+    assert "April 22, 2026" in result
+
+
+def test_page_without_date_lozenge_unaffected() -> None:
+    """Pages with no date lozenge spans are processed normally."""
+    html = "<p>No dates here.</p>"
+    result = extract_text_from_confluence_html(
+        confluence_client=_make_mock_client(),
+        confluence_object=_make_confluence_object(html),
+        fetched_titles=set(),
+    )
+    assert "No dates here." in result

--- a/backend/tests/unit/onyx/file_processing/test_detect_encoding.py
+++ b/backend/tests/unit/onyx/file_processing/test_detect_encoding.py
@@ -1,0 +1,29 @@
+from io import BytesIO
+from unittest import mock
+
+from onyx.file_processing.extract_file_text import detect_encoding
+
+
+def test_utf8_cyrillic_returns_utf8_without_chardet() -> None:
+    """Valid UTF-8 Cyrillic text must be identified as utf-8 without calling chardet."""
+    cyrillic = "Привет мир".encode("utf-8")
+    with mock.patch("onyx.file_processing.extract_file_text.chardet.detect") as m:
+        result = detect_encoding(BytesIO(cyrillic))
+    assert result == "utf-8"
+    m.assert_not_called()
+
+
+def test_legacy_encoded_bytes_falls_back_to_chardet() -> None:
+    """Bytes that are not valid UTF-8 must fall back to chardet detection."""
+    windows1251 = "Привет мир".encode("windows-1251")
+    result = detect_encoding(BytesIO(windows1251))
+    # chardet should identify this as a Cyrillic legacy encoding, not utf-8
+    assert result.lower() != "utf-8"
+
+
+def test_file_seek_reset_after_call() -> None:
+    """detect_encoding must reset the file cursor to 0 so callers can re-read."""
+    data = b"hello world"
+    f = BytesIO(data)
+    detect_encoding(f)
+    assert f.tell() == 0


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
This PR fixed two issue in confluence connector

1. /Date macro text dropped from index
Confluence's /Date macro wraps dates in <span class="date-lozenger-container">. BeautifulSoup's format_document_soup was stripping these spans, silently dropping the date text from indexed content. Fixed by replacing each such span with its plain text before formatting.

Issue #4862 — Confluence connector missing dates added with /Date macro

2. Cyrillic / multi-byte attachment text corrupted (mojibake)
detect_encoding was passing all files through chardet first. chardet sometimes misidentifies valid UTF-8 (Cyrillic, CJK, accented Latin) as a legacy encoding (e.g. windows-1251), causing garbled text in the index. Fixed by attempting UTF-8 decode first — falling back to chardet only on UnicodeDecodeError. Since UTF-8 is self-validating, this is unambiguous. Affects all connectors using detect_encoding (Confluence, Jira, File Upload).

Issue #6401 — [Bug] Incorrect encoding detection causes Mojibake (corrupted Cyrillic text) in File Connectors (Confluence, Jira, File Upload)


https://linear.app/onyx-app/issue/ENG-4072/improve-confluence-connector


## How Has This Been Tested?
Added unit tests
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Confluence /Date macro text and fixes corrupted Cyrillic/multi‑byte attachment text by preferring UTF‑8 in `detect_encoding`. Improves indexing for Confluence and any connector using `detect_encoding` (Linear ENG‑4072).

- **Bug Fixes**
  - Keep /Date macro text by replacing `span.date-lozenger-container` with its plain text before formatting.
  - Decode as UTF‑8 first; fall back to `chardet` only on UnicodeDecodeError, and reset the file cursor to 0 after sampling to prevent mojibake in attachments/uploads.

<sup>Written for commit 027ba4dbab7c161cc386737f54be4c77549b52ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



