### PR TITLE
feat: add forced arguments support for MCP tools

### DIFF
--- a/backend/alembic/versions/1f4163774e3d_add_forced_args_to_tool.py
+++ b/backend/alembic/versions/1f4163774e3d_add_forced_args_to_tool.py
@@ -1,6 +1,6 @@
 """Add forced_args to tool
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: 1f4163774e3d
 Revises: d129f37b3d87
 Create Date: 2026-04-21 20:00:00.000000
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "1f4163774e3d"
 down_revision = "d129f37b3d87"
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_forced_args_to_tool.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_forced_args_to_tool.py
@@ -1,0 +1,28 @@
+"""Add forced_args to tool
+
+Revision ID: a1b2c3d4e5f6
+Revises: d129f37b3d87
+Create Date: 2026-04-21 20:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "d129f37b3d87"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tool",
+        sa.Column("forced_args", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tool", "forced_args")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3341,6 +3341,12 @@ class Tool(Base):
         Integer, ForeignKey("oauth_config.id", ondelete="SET NULL"), nullable=True
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # Forced arguments that are always injected/overridden when this tool is called.
+    # These take precedence over LLM-provided arguments. Useful for MCP tools where
+    # specific argument values must be guaranteed (e.g., theme_id, org_id).
+    forced_args: Mapped[dict[str, Any] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
 
     user: Mapped[User | None] = relationship("User", back_populates="custom_tools")
     oauth_config: Mapped["OAuthConfig | None"] = relationship(

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -143,6 +143,7 @@ def update_tool(
     db_session: Session,
     passthrough_auth: bool | None,
     oauth_config_id: int | None | UnsetType = UNSET,
+    forced_args: dict[str, Any] | None | UnsetType = UNSET,
 ) -> Tool:
     tool = get_tool_by_id(tool_id, db_session)
     if tool is None:
@@ -162,6 +163,8 @@ def update_tool(
         ]
     if passthrough_auth is not None:
         tool.passthrough_auth = passthrough_auth
+    if not isinstance(forced_args, UnsetType):
+        tool.forced_args = forced_args
     old_oauth_config_id = tool.oauth_config_id
     if not isinstance(oauth_config_id, UnsetType):
         tool.oauth_config_id = oauth_config_id

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -160,20 +160,20 @@ def update_tool_forced_args(
 
     Forced arguments are always injected into tool calls, overriding any
     values the LLM provides. Set to null to clear forced arguments.
+
+    Unlike custom tool updates, this endpoint works on ANY tool type
+    (MCP, custom, built-in) since forced_args is a generic capability.
+    Only admins can set forced args — enforced by current_curator_or_admin_user
+    on the admin_router.
     """
-    _get_editable_custom_tool(tool_id, db_session, user)
-    updated_tool = update_tool(
-        tool_id=tool_id,
-        name=None,
-        description=None,
-        openapi_schema=None,
-        custom_headers=None,
-        user_id=None,
-        db_session=db_session,
-        passthrough_auth=None,
-        forced_args=request.forced_args,
-    )
-    return ToolSnapshot.from_model(updated_tool)
+    try:
+        tool = get_tool_by_id(tool_id, db_session)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    tool.forced_args = request.forced_args
+    db_session.commit()
+    return ToolSnapshot.from_model(tool)
 
 
 class ToolStatusUpdateRequest(BaseModel):

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -154,21 +154,26 @@ def update_tool_forced_args(
     tool_id: int,
     request: ToolForcedArgsUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
+    user: User = Depends(current_curator_or_admin_user),
 ) -> ToolSnapshot:
     """Set forced arguments for a tool (especially useful for MCP tools).
 
     Forced arguments are always injected into tool calls, overriding any
     values the LLM provides. Set to null to clear forced arguments.
     """
-    try:
-        tool = get_tool_by_id(tool_id, db_session)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-    tool.forced_args = request.forced_args
-    db_session.commit()
-    return ToolSnapshot.from_model(tool)
+    _get_editable_custom_tool(tool_id, db_session, user)
+    updated_tool = update_tool(
+        tool_id=tool_id,
+        name=None,
+        description=None,
+        openapi_schema=None,
+        custom_headers=None,
+        user_id=None,
+        db_session=db_session,
+        passthrough_auth=None,
+        forced_args=request.forced_args,
+    )
+    return ToolSnapshot.from_model(updated_tool)
 
 
 class ToolStatusUpdateRequest(BaseModel):

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -145,6 +145,32 @@ def delete_custom_tool(
     db_session.commit()
 
 
+class ToolForcedArgsUpdateRequest(BaseModel):
+    forced_args: dict[str, Any] | None = None
+
+
+@admin_router.patch("/{tool_id}/forced-args")
+def update_tool_forced_args(
+    tool_id: int,
+    request: ToolForcedArgsUpdateRequest,
+    db_session: Session = Depends(get_session),
+    user: User = Depends(current_curator_or_admin_user),  # noqa: ARG001
+) -> ToolSnapshot:
+    """Set forced arguments for a tool (especially useful for MCP tools).
+
+    Forced arguments are always injected into tool calls, overriding any
+    values the LLM provides. Set to null to clear forced arguments.
+    """
+    try:
+        tool = get_tool_by_id(tool_id, db_session)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    tool.forced_args = request.forced_args
+    db_session.commit()
+    return ToolSnapshot.from_model(tool)
+
+
 class ToolStatusUpdateRequest(BaseModel):
     tool_ids: list[int]
     enabled: bool

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -20,6 +20,7 @@ class ToolSnapshot(BaseModel):
     oauth_config_id: int | None = None
     oauth_config_name: str | None = None
     enabled: bool = True
+    forced_args: dict[str, Any] | None = None
 
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG
     chat_selectable: bool = True
@@ -45,6 +46,7 @@ class ToolSnapshot(BaseModel):
             oauth_config_id=tool.oauth_config_id,
             oauth_config_name=tool.oauth_config.name if tool.oauth_config else None,
             enabled=tool.enabled,
+            forced_args=tool.forced_args,
             # Populate visibility settings from config or use defaults
             chat_selectable=config.chat_selectable if config else True,
             agent_creation_selectable=(

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -446,6 +446,7 @@ def _construct_tools_impl(
                     user_id=str(user.id),
                     user_oauth_token=mcp_user_oauth_token,
                     additional_headers=additional_mcp_headers,
+                    forced_args=saved_tool.forced_args,
                 )
                 mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -52,6 +52,7 @@ class MCPTool(Tool[None]):
         user_id: str = "",
         user_oauth_token: str | None = None,
         additional_headers: dict[str, str] | None = None,
+        forced_args: dict[str, Any] | None = None,
     ) -> None:
         super().__init__(emitter=emitter)
 
@@ -62,6 +63,7 @@ class MCPTool(Tool[None]):
         self._user_id = user_id
         self._user_oauth_token = user_oauth_token
         self._additional_headers = additional_headers or {}
+        self._forced_args = forced_args or {}
 
         self._name = tool_name
         self._tool_definition = tool_definition
@@ -231,10 +233,15 @@ class MCPTool(Tool[None]):
                         None,
                     )
 
+            # Merge forced arguments over LLM-provided values.
+            # Forced args always take precedence, ensuring admin-configured
+            # values (e.g., theme_id, org_id) cannot be overridden by the LLM.
+            effective_kwargs = {**llm_kwargs, **self._forced_args}
+
             tool_result = call_mcp_tool(
                 self.mcp_server.server_url,
                 self._name,
-                llm_kwargs,
+                effective_kwargs,
                 connection_headers=headers,
                 transport=self.mcp_server.transport or MCPTransport.STREAMABLE_HTTP,
                 auth=auth,

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -240,8 +240,8 @@ class MCPTool(Tool[None]):
 
             if self._forced_args:
                 logger.info(
-                    f"MCP tool '{self._name}': applied forced_args {self._forced_args}, "
-                    f"effective kwargs: {effective_kwargs}"
+                    f"MCP tool '{self._name}': applied forced args "
+                    f"({len(self._forced_args)} keys)"
                 )
 
             tool_result = call_mcp_tool(

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -238,6 +238,12 @@ class MCPTool(Tool[None]):
             # values (e.g., theme_id, org_id) cannot be overridden by the LLM.
             effective_kwargs = {**llm_kwargs, **self._forced_args}
 
+            if self._forced_args:
+                logger.info(
+                    f"MCP tool '{self._name}': applied forced_args {self._forced_args}, "
+                    f"effective kwargs: {effective_kwargs}"
+                )
+
             tool_result = call_mcp_tool(
                 self.mcp_server.server_url,
                 self._name,

--- a/web/src/hooks/useServerTools.ts
+++ b/web/src/hooks/useServerTools.ts
@@ -98,6 +98,7 @@ export default function useServerTools(
         description: tool.description,
         isAvailable: true,
         isEnabled: tool.enabled,
+        forcedArgs: tool.forced_args,
       }))
     : [];
 

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -60,6 +60,7 @@ export interface MCPTool {
   icon?: React.FunctionComponent<IconProps>;
   isAvailable: boolean;
   isEnabled: boolean;
+  forcedArgs: Record<string, any> | null;
 }
 
 export interface MethodSpec {
@@ -102,6 +103,9 @@ export interface ToolSnapshot {
 
   // Whether the tool is enabled
   enabled: boolean;
+
+  // Forced arguments that override LLM-provided values
+  forced_args: Record<string, any> | null;
 
   // Visibility settings from backend TOOL_VISIBILITY_CONFIG
   chat_selectable: boolean;

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -23,6 +23,29 @@ export interface ToolStatusUpdateResponse {
 }
 
 /**
+ * Update forced arguments for a tool
+ */
+export async function updateToolForcedArgs(
+  toolId: number,
+  forcedArgs: Record<string, any> | null
+): Promise<ToolSnapshot> {
+  const response = await fetch(`/api/admin/tool/${toolId}/forced-args`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ forced_args: forcedArgs }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || "Failed to update forced arguments");
+  }
+
+  return await response.json();
+}
+
+/**
  * Delete an MCP server
  */
 export async function deleteMCPServer(serverId: number): Promise<void> {

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -549,6 +549,7 @@ export default function AgentEditorPage({
         description: tool.description,
         isAvailable: true,
         isEnabled: tool.enabled,
+        forcedArgs: tool.forced_args,
       }));
 
     return { server, tools: serverTools, isLoading: false };

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -28,6 +28,7 @@ import Text from "@/refresh-components/texts/Text";
 import { timeAgo } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
+import ForcedArgsModal from "@/sections/actions/modals/ForcedArgsModal";
 
 export interface MCPActionCardProps {
   // Server identification
@@ -105,6 +106,7 @@ export default function MCPActionCard({
   const [searchQuery, setSearchQuery] = useState("");
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
+  const [forcedArgsToolId, setForcedArgsToolId] = useState<number | null>(null);
   const deleteModal = useCreateModal();
 
   // Update expanded state when initialExpanded changes
@@ -314,14 +316,33 @@ export default function MCPActionCard({
               icon={tool.icon}
               isAvailable={tool.isAvailable}
               isEnabled={tool.isEnabled}
+              hasForcedArgs={
+                tool.forcedArgs !== null &&
+                tool.forcedArgs !== undefined &&
+                Object.keys(tool.forcedArgs).length > 0
+              }
               onToggle={(enabled) =>
                 onToolToggle?.(serverId, tool.id, enabled, mutate)
               }
+              onConfigure={() => setForcedArgsToolId(parseInt(tool.id))}
               variant="mcp"
             />
           ))}
         </ToolsList>
       </ActionCard>
+
+      {forcedArgsToolId !== null && (() => {
+        const tool = tools.find((t) => t.id === forcedArgsToolId.toString());
+        return tool ? (
+          <ForcedArgsModal
+            toolId={forcedArgsToolId}
+            toolName={tool.name}
+            forcedArgs={tool.forcedArgs}
+            onClose={() => setForcedArgsToolId(null)}
+            onSaved={() => mutate()}
+          />
+        ) : null;
+      })()}
 
       {deleteModal.isOpen && (
         <Modal

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -12,7 +12,9 @@ import {
   SvgArrowRightDot,
   SvgCornerRightUpDot,
   SvgMinusCircle,
+  SvgSettings,
 } from "@opal/icons";
+import { Button } from "@opal/components";
 
 type ToolItemVariant = "mcp" | "openapi";
 
@@ -71,8 +73,12 @@ export interface ToolItemProps {
   variant?: ToolItemVariant;
   openApiMetadata?: OpenApiMetadata;
 
+  // Forced args indicator
+  hasForcedArgs?: boolean;
+
   // Handlers
   onToggle?: (enabled: boolean) => void;
+  onConfigure?: () => void;
 
   // Optional styling
   className?: string;
@@ -84,9 +90,11 @@ const ToolItem: React.FC<ToolItemProps> = ({
   icon: Icon,
   isAvailable = true,
   isEnabled = true,
+  hasForcedArgs = false,
   variant = "mcp",
   openApiMetadata,
   onToggle,
+  onConfigure,
   className,
 }) => {
   const isMcpVariant = variant === "mcp";
@@ -219,6 +227,20 @@ const ToolItem: React.FC<ToolItemProps> = ({
                 </div>
               </div>
             </div>
+          )}
+
+          {/* Configure Button */}
+          {onConfigure && (
+            <Button
+              icon={SvgSettings}
+              prominence="tertiary"
+              onClick={onConfigure}
+              tooltip="Configure forced arguments"
+              aria-label={`Configure ${name}`}
+              className={cn(
+                hasForcedArgs && "text-status-info-05"
+              )}
+            />
           )}
 
           {/* Switch */}

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -231,16 +231,15 @@ const ToolItem: React.FC<ToolItemProps> = ({
 
           {/* Configure Button */}
           {onConfigure && (
-            <Button
-              icon={SvgSettings}
-              prominence="tertiary"
-              onClick={onConfigure}
-              tooltip="Configure forced arguments"
-              aria-label={`Configure ${name}`}
-              className={cn(
-                hasForcedArgs && "text-status-info-05"
-              )}
-            />
+            <div className={cn(hasForcedArgs && "text-status-info-05")}>
+              <Button
+                icon={SvgSettings}
+                prominence="tertiary"
+                onClick={onConfigure}
+                tooltip="Configure forced arguments"
+                aria-label={`Configure ${name}`}
+              />
+            </div>
           )}
 
           {/* Switch */}

--- a/web/src/sections/actions/modals/ForcedArgsModal.tsx
+++ b/web/src/sections/actions/modals/ForcedArgsModal.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React, { useState, useCallback } from "react";
+import Modal from "@/refresh-components/Modal";
+import { Button } from "@opal/components";
+import Text from "@/refresh-components/texts/Text";
+import KeyValueInput, {
+  type KeyValue,
+} from "@/refresh-components/inputs/InputKeyValue";
+import { SvgSettings } from "@opal/icons";
+import { updateToolForcedArgs } from "@/lib/tools/mcpService";
+
+interface ForcedArgsModalProps {
+  toolId: number;
+  toolName: string;
+  forcedArgs: Record<string, any> | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function toKeyValueItems(args: Record<string, any> | null): KeyValue[] {
+  if (!args || Object.keys(args).length === 0) return [];
+  return Object.entries(args).map(([key, value]) => ({
+    key,
+    value: String(value),
+  }));
+}
+
+function toForcedArgs(items: KeyValue[]): Record<string, any> | null {
+  const filtered = items.filter((item) => item.key.trim() !== "");
+  if (filtered.length === 0) return null;
+  return Object.fromEntries(filtered.map((item) => [item.key, item.value]));
+}
+
+export default function ForcedArgsModal({
+  toolId,
+  toolName,
+  forcedArgs,
+  onClose,
+  onSaved,
+}: ForcedArgsModalProps) {
+  const [items, setItems] = useState<KeyValue[]>(toKeyValueItems(forcedArgs));
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSave = useCallback(async () => {
+    if (validationError) return;
+
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateToolForcedArgs(toolId, toForcedArgs(items));
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [toolId, items, validationError, onSaved, onClose]);
+
+  return (
+    <Modal open onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <Modal.Content width="md">
+        <Modal.Header
+          icon={SvgSettings}
+          title="Forced Arguments"
+          description={toolName}
+          onClose={onClose}
+        />
+        <Modal.Body>
+          <div className="flex flex-col gap-3">
+            <Text as="p" text03 secondaryBody>
+              Forced arguments are always injected into this tool&apos;s calls,
+              overriding any values the AI provides. Useful for ensuring specific
+              values like theme IDs or organization IDs.
+            </Text>
+
+            <KeyValueInput
+              keyTitle="Argument"
+              valueTitle="Value"
+              keyPlaceholder="e.g. theme_id"
+              valuePlaceholder="e.g. abc-123"
+              items={items}
+              onChange={setItems}
+              mode="line"
+              layout="key-wide"
+              onValidationError={setValidationError}
+              addButtonLabel="Add Argument"
+            />
+
+            {error && (
+              <Text as="p" className="text-status-error-05">
+                {error}
+              </Text>
+            )}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button prominence="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || !!validationError}
+          >
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/sections/actions/modals/ForcedArgsModal.tsx
+++ b/web/src/sections/actions/modals/ForcedArgsModal.tsx
@@ -22,14 +22,27 @@ function toKeyValueItems(args: Record<string, any> | null): KeyValue[] {
   if (!args || Object.keys(args).length === 0) return [];
   return Object.entries(args).map(([key, value]) => ({
     key,
-    value: String(value),
+    value: typeof value === "string" ? value : JSON.stringify(value),
   }));
+}
+
+function parseValue(value: string): any {
+  // Preserve original JSON types: booleans, numbers, null, objects, arrays
+  try {
+    const parsed = JSON.parse(value);
+    return parsed;
+  } catch {
+    // Not valid JSON — treat as plain string
+    return value;
+  }
 }
 
 function toForcedArgs(items: KeyValue[]): Record<string, any> | null {
   const filtered = items.filter((item) => item.key.trim() !== "");
   if (filtered.length === 0) return null;
-  return Object.fromEntries(filtered.map((item) => [item.key, item.value]));
+  return Object.fromEntries(
+    filtered.map((item) => [item.key, parseValue(item.value)])
+  );
 }
 
 export default function ForcedArgsModal({


### PR DESCRIPTION
## Summary

Adds `forced_args` support for MCP tools, allowing admins to guarantee specific argument values that the LLM cannot override.

Closes #10502

- New `forced_args` JSONB column on `tool` table
- `MCPTool.run()` merges forced args over LLM-provided kwargs
- `PATCH /api/admin/tool/{tool_id}/forced-args` endpoint (admin-only)
- Frontend settings button per MCP tool for key-value configuration
- Backward compatible — nullable field, existing tools unaffected

## Motivation

MCP tools pass LLM arguments directly to the server with no filtering. Admins cannot guarantee values like `theme_id`, `org_id`, or `channel_id` — the LLM frequently omits them despite system prompt instructions. This feature fills the gap that built-in tools already have via `override_kwargs`.

## Test plan

- [ ] Verify migration runs cleanly (`alembic upgrade head`)
- [ ] Set forced_args on an MCP tool via API and verify they override LLM args
- [ ] Verify MCP tools without forced_args still work normally
- [ ] Verify the frontend settings button opens modal and saves correctly
- [ ] Verify JSON types are preserved (booleans, numbers, not coerced to strings)
- [ ] Verify sensitive args are not logged in plaintext