### PR TITLE
fix(files): allow connector file previews through /chat/file

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -226,6 +226,15 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
       session the user owns or a session publicly shared via
       `ChatSessionSharedStatus.PUBLIC`.
+    - The `file_id` is a `FileRecord` with origin `CHAT_IMAGE_GEN`.
+      TODO: A CHAT_IMAGE_GEN file is uploaded to the file store before
+      the linking tool-call DB row is written, so the FE can request it
+      even though there's nothing to ACL-check against. We currently
+      hack around this by treating these files as public; tightening it
+      requires a larger refactor of the streaming/tool-call write order.
+      Ordered before the connector-file branch so image previews
+      short-circuit on an indexed primary-key lookup instead of falling
+      through to the JSONB fallback.
     - The `file_id` is referenced by a `Document` (via `Document.file_id`)
       whose ACL grants access to this user. `Document.file_id` is only
       populated by connector ingestion, so this covers any connector-ingested
@@ -238,11 +247,6 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
       `connector_specific_config['file_locations']` lists this `file_id`.
       Lets users preview cited files from indexed connectors through
       `PreviewModal`.
-    - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
-      tool call database entry is added. This the file is there and the FE can
-      request it despite us not having the linking tool call. We currently
-      hackily get around this by making these files public, but this will need
-      to change with a larger refactor.
     """
     owns_user_file = db_session.query(
         select(UserFile.id)
@@ -287,12 +291,12 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     if db_session.execute(chat_file_stmt).first() is not None:
         return True
 
-    if _user_can_access_connector_file(file_id, user, db_session):
-        return True
-
-    # TODO: Chat image generated images are currently public
-    # We will want to make this private but it requires a larger
-    # refactor.
+    # TODO: Chat image generated images are currently public; tighten
+    # this once the tool-call linkage is populated before the file lands
+    # in the store. Ordered above the connector-file branch so image-gen
+    # previews short-circuit on an indexed `FileRecord.file_id` primary-
+    # key lookup rather than falling through to the JSONB fallback in
+    # `_documents_from_file_connector_config`.
     is_chat_image_gen = db_session.query(
         select(FileRecord.file_id)
         .where(
@@ -301,7 +305,10 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
         )
         .exists()
     ).scalar()
-    return bool(is_chat_image_gen)
+    if is_chat_image_gen:
+        return True
+
+    return _user_can_access_connector_file(file_id, user, db_session)
 
 
 def _user_can_access_connector_file(
@@ -356,32 +363,32 @@ def _documents_from_file_connector_config(
     so one sample per connector is enough for the downstream ACL check.
     Almost always a single connector, since file_ids are UUIDs.
 
-    TODO(perf): the `@>` containment check on a JSONB array cannot use a
-    regular btree index — at best we'd need a GIN index on
-    `connector.connector_specific_config`, and even then each File-connector
-    upload adds one entry to the array so lookups are O(files per connector)
-    per hit. The structurally correct fix is a dedicated join table, e.g.:
+    TODO(delete-me): this whole function is a temporary patch for a data-
+    layer inconsistency — the File connector only stamps `Document.file_id`
+    for tabular inputs (see `backend/onyx/connectors/file/connector.py:190`),
+    leaving non-tabular uploads with `Document.file_id=NULL` even though
+    the bytes exist in the file store. The `@>` containment check on a
+    JSONB array also can't use a btree index, so every miss on the fast
+    path runs a scan of `connector.connector_specific_config`.
 
-        class ConnectorFile(Base):
-            file_id: Mapped[str] = mapped_column(primary_key=True)
-            connector_id: Mapped[int] = mapped_column(
-                ForeignKey("connector.id", ondelete="CASCADE"),
-                primary_key=True,
-            )
+    The proper fix decouples `Document.file_id` (linkage) from the
+    code-interpreter staging signal that currently rides on it:
 
-    populated alongside `Connector.connector_specific_config['file_locations']`
-    by the File-connector upload/update/delete paths in
-    `onyx/server/documents/connector.py`. With that in place this function
-    becomes a single indexed `SELECT ... FROM connector_file` and the
-    per-connector fan-out loop below collapses into one JOIN.
-
-    TODO(model): a cleaner long-term fix is dropping
-    `Connector.connector_specific_config['file_locations']` entirely in favor
-    of the join table — the JSONB array is the only reason `Document.file_id`
-    vs. `FileRecord` vs. `connector_specific_config` are three different
-    sources of truth for "which cc_pair owns this file". Unifying them would
-    let the access check go through a single `(file_id) → cc_pair → ACL`
-    lookup instead of the two-step probe in `_user_can_access_connector_file`.
+      1. In `build_python_chat_files_from_search_docs`
+         (`onyx/chat/chat_utils.py:882`), add an
+         `is_tabular_file(record.display_name)` guard so stamping
+         `Document.file_id` on non-tabular files doesn't cause every
+         cited PDF/TXT/DOCX to be auto-staged into the Python sandbox.
+      2. In the File connector (`onyx/connectors/file/connector.py:190`),
+         drop the `is_tabular_file` gate so `Document.file_id` is stamped
+         unconditionally. New uploads then take the fast path by design.
+      3. Alembic backfill: for every existing non-tabular connector file,
+         join `connector.connector_specific_config->'file_locations'` →
+         `document_by_connector_credential_pair` → `document` and set
+         `document.file_id`. One-time cost at deploy.
+      4. Delete this helper and the fallback branch in
+         `_user_can_access_connector_file`. The access check collapses to
+         a single indexed `SELECT document.id WHERE file_id = :file_id`.
     """
     connector_ids: list[int] = list(
         db_session.execute(
@@ -397,10 +404,9 @@ def _documents_from_file_connector_config(
     if not connector_ids:
         return []
 
-    # TODO(perf): this loop fires one query per matching connector. In
-    # practice `connector_ids` has length 1, but if it ever didn't, this
-    # could fold into a single `DISTINCT ON (connector_id)` query. Not
-    # urgent while the outer JSONB scan dominates the cost.
+    # In practice `connector_ids` has length 1 (file_ids are UUIDs), so
+    # the per-connector fan-out here is a non-issue; not worth folding
+    # into a `DISTINCT ON` when the whole helper is slated for deletion.
     document_ids: list[str] = []
     for connector_id in connector_ids:
         doc_id = db_session.execute(

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable
 from typing import cast
 
+from sqlalchemy import cast as sa_cast
 from sqlalchemy import or_
 from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 
 from onyx.access.models import DocumentAccess
@@ -15,7 +17,9 @@ from onyx.db.document import get_access_info_for_documents
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import ChatSessionSharedStatus
+from onyx.db.models import Connector
 from onyx.db.models import Document
+from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import FileRecord
 from onyx.db.models import Persona
 from onyx.db.models import User
@@ -207,6 +211,15 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     """Return True if `user` is allowed to read the raw `file_id` served by
     `GET /chat/file/{file_id}`. Access is granted when any of:
 
+    TODO(auth-perf): this function fans out 4–5 queries per request because
+    `/chat/file/{file_id}` is overloaded with unrelated asset classes (user
+    files, persona avatars, chat attachments, tool outputs, connector files).
+    The proper fix is to split this into per-asset-class endpoints
+    (`/user-files/{id}`, `/assistants/{id}/avatar`, `/messages/{id}/files/{n}`,
+    etc.) where the URL itself carries the access-control context and a single
+    indexed lookup suffices. The connector-file branch in particular does a
+    JSONB scan on every call — see `_documents_from_file_connector_config`.
+
     - The `file_id` is the storage id of a `UserFile` owned by the user.
     - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
       are visible to any authenticated user.
@@ -218,8 +231,13 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
       populated by connector ingestion, so this covers any connector-ingested
       file regardless of its `FileOrigin` stamp (which has varied over time:
       `OTHER` pre-#10484, `CONNECTOR_FILE_UPLOAD` post-#10484, and
-      `CONNECTOR` for pipeline-promoted files). Lets users preview cited
-      files from indexed connectors through `PreviewModal`.
+      `CONNECTOR` for pipeline-promoted files). For non-tabular File
+      connector uploads `Document.file_id` is left NULL
+      (`backend/onyx/connectors/file/connector.py:190`), so we also fall
+      back to the cc_pair ACL of any `Connector` whose
+      `connector_specific_config['file_locations']` lists this `file_id`.
+      Lets users preview cited files from indexed connectors through
+      `PreviewModal`.
     - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
       tool call database entry is added. This the file is there and the FE can
       request it despite us not having the linking tool call. We currently
@@ -289,28 +307,107 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
 def _user_can_access_connector_file(
     file_id: str, user: User, db_session: Session
 ) -> bool:
-    """Grant access when `file_id` is referenced by at least one `Document`
-    (via `Document.file_id`) whose ACL overlaps the user's ACL. Mirrors the
-    access-control layer applied during retrieval so preview access stays
-    consistent with search result access.
+    """Grant access when `file_id` is reachable from a `Document` whose ACL
+    overlaps the user's ACL. Mirrors the access-control layer applied during
+    retrieval so preview access stays consistent with search result access.
 
-    Gated on `Document.file_id` rather than `FileRecord.file_origin` because
-    (a) only connector ingestion writes `Document.file_id`, so its presence
-    is itself the signal that the file is connector-ingested, and (b) the
-    origin has varied historically (`OTHER` pre-#10484,
-    `CONNECTOR_FILE_UPLOAD` post-#10484, and `CONNECTOR` for pipeline-
-    promoted files) — any origin filter would either miss legacy files or
-    need to be widened to a grab-bag."""
-    document_ids = (
+    Two lookup paths:
+
+    1. `Document.file_id == file_id` — the fast path. Covers tabular File
+       connector uploads, Blob/SharePoint attachments, and any other
+       connector that stamps `Document.file_id` during ingestion.
+    2. `Connector.connector_specific_config['file_locations']` contains
+       `file_id` — the fallback. The File connector only sets
+       `Document.file_id` for tabular inputs
+       (`backend/onyx/connectors/file/connector.py:190`), so non-tabular
+       uploads (txt/pdf/docx/etc.) have no direct `Document.file_id` link.
+       In that case the `Connector` config still points at the file_id, and
+       every `Document` indexed through its cc_pair shares the same ACL —
+       so checking any one representative document answers the question.
+
+    The `FileRecord.file_origin` is intentionally not consulted: it has
+    varied historically (`OTHER` pre-#10484, `CONNECTOR_FILE_UPLOAD` post-
+    #10484, and `CONNECTOR` for pipeline-promoted files) and any origin
+    filter would either miss legacy files or grow into a grab-bag."""
+    document_ids: list[str] = list(
         db_session.execute(select(Document.id).where(Document.file_id == file_id))
         .scalars()
         .all()
     )
     if not document_ids:
+        document_ids = _documents_from_file_connector_config(file_id, db_session)
+    if not document_ids:
         return False
 
     user_acl = get_acl_for_user(user, db_session)
-    doc_access = get_access_for_documents(list(document_ids), db_session)
+    doc_access = get_access_for_documents(document_ids, db_session)
     return any(
         not user_acl.isdisjoint(access.to_acl()) for access in doc_access.values()
     )
+
+
+def _documents_from_file_connector_config(
+    file_id: str, db_session: Session
+) -> list[str]:
+    """Return one representative document per `Connector` whose
+    `connector_specific_config['file_locations']` lists `file_id`.
+
+    Documents ingested through a single cc_pair share that cc_pair's ACL,
+    so one sample per connector is enough for the downstream ACL check.
+    Almost always a single connector, since file_ids are UUIDs.
+
+    TODO(perf): the `@>` containment check on a JSONB array cannot use a
+    regular btree index — at best we'd need a GIN index on
+    `connector.connector_specific_config`, and even then each File-connector
+    upload adds one entry to the array so lookups are O(files per connector)
+    per hit. The structurally correct fix is a dedicated join table, e.g.:
+
+        class ConnectorFile(Base):
+            file_id: Mapped[str] = mapped_column(primary_key=True)
+            connector_id: Mapped[int] = mapped_column(
+                ForeignKey("connector.id", ondelete="CASCADE"),
+                primary_key=True,
+            )
+
+    populated alongside `Connector.connector_specific_config['file_locations']`
+    by the File-connector upload/update/delete paths in
+    `onyx/server/documents/connector.py`. With that in place this function
+    becomes a single indexed `SELECT ... FROM connector_file` and the
+    per-connector fan-out loop below collapses into one JOIN.
+
+    TODO(model): a cleaner long-term fix is dropping
+    `Connector.connector_specific_config['file_locations']` entirely in favor
+    of the join table — the JSONB array is the only reason `Document.file_id`
+    vs. `FileRecord` vs. `connector_specific_config` are three different
+    sources of truth for "which cc_pair owns this file". Unifying them would
+    let the access check go through a single `(file_id) → cc_pair → ACL`
+    lookup instead of the two-step probe in `_user_can_access_connector_file`.
+    """
+    connector_ids: list[int] = list(
+        db_session.execute(
+            select(Connector.id).where(
+                Connector.connector_specific_config["file_locations"].op("@>")(
+                    sa_cast([file_id], postgresql.JSONB)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not connector_ids:
+        return []
+
+    # TODO(perf): this loop fires one query per matching connector. In
+    # practice `connector_ids` has length 1, but if it ever didn't, this
+    # could fold into a single `DISTINCT ON (connector_id)` query. Not
+    # urgent while the outer JSONB scan dominates the cost.
+    document_ids: list[str] = []
+    for connector_id in connector_ids:
+        doc_id = db_session.execute(
+            select(DocumentByConnectorCredentialPair.id)
+            .where(DocumentByConnectorCredentialPair.connector_id == connector_id)
+            .limit(1)
+        ).scalar()
+        if doc_id is not None:
+            document_ids.append(doc_id)
+    return document_ids

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -1,14 +1,23 @@
 from collections.abc import Callable
 from typing import cast
 
+from sqlalchemy import or_
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.access.models import DocumentAccess
 from onyx.access.utils import prefix_user_email
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import PUBLIC_DOC_PAT
 from onyx.db.document import get_access_info_for_document
 from onyx.db.document import get_access_info_for_documents
+from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
+from onyx.db.models import ChatSessionSharedStatus
+from onyx.db.models import Document
+from onyx.db.models import FileRecord
+from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.user_file import fetch_user_files_with_access_relationships
@@ -192,3 +201,118 @@ def collect_user_file_access(user_file: UserFile) -> tuple[set[str], bool]:
         for shared_user in persona.users:
             emails.add(shared_user.email)
     return emails, is_public
+
+
+def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> bool:
+    """Return True if `user` is allowed to read the raw `file_id` served by
+    `GET /chat/file/{file_id}`. Access is granted when any of:
+
+    - The `file_id` is the storage id of a `UserFile` owned by the user.
+    - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
+      are visible to any authenticated user.
+    - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
+      session the user owns or a session publicly shared via
+      `ChatSessionSharedStatus.PUBLIC`.
+    - The `file_id` is the storage id of a connector-ingested document
+      (`FileOrigin.CONNECTOR`) whose associated `Document` grants access to
+      this user via the standard ACL. This allows users to preview cited
+      files returned from indexed connector sources (e.g. the `File`
+      connector) through `PreviewModal`.
+    - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
+      tool call database entry is added. This the file is there and the FE can
+      request it despite us not having the linking tool call. We currently
+      hackily get around this by making these files public, but this will need
+      to change with a larger refactor.
+    """
+    owns_user_file = db_session.query(
+        select(UserFile.id)
+        .where(UserFile.file_id == file_id, UserFile.user_id == user.id)
+        .exists()
+    ).scalar()
+    if owns_user_file:
+        return True
+
+    # TODO: move persona avatars to a dedicated endpoint (e.g.
+    # /assistants/{id}/avatar) so this branch can be removed. /chat/file is
+    # currently overloaded with multiple asset classes (user files, chat
+    # attachments, tool outputs, avatars), forcing this access-check fan-out.
+    #
+    # Restrict the avatar path to CHAT_UPLOAD-origin files so an attacker
+    # cannot bind another user's USER_FILE (or any other origin) to their
+    # own persona and read it through this check.
+    is_persona_avatar = db_session.query(
+        select(Persona.id)
+        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
+        .where(
+            Persona.uploaded_image_id == file_id,
+            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
+        )
+        .exists()
+    ).scalar()
+    if is_persona_avatar:
+        return True
+
+    chat_file_stmt = (
+        select(ChatMessage.id)
+        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
+        .where(ChatMessage.files.op("@>")([{"id": file_id}]))
+        .where(
+            or_(
+                ChatSession.user_id == user.id,
+                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
+            )
+        )
+        .limit(1)
+    )
+    if db_session.execute(chat_file_stmt).first() is not None:
+        return True
+
+    if _user_can_access_connector_file(file_id, user, db_session):
+        return True
+
+    # TODO: Chat image generated images are currently public
+    # We will want to make this private but it requires a larger
+    # refactor.
+    is_chat_image_gen = db_session.query(
+        select(FileRecord.file_id)
+        .where(
+            FileRecord.file_id == file_id,
+            FileRecord.file_origin == FileOrigin.CHAT_IMAGE_GEN,
+        )
+        .exists()
+    ).scalar()
+    return bool(is_chat_image_gen)
+
+
+def _user_can_access_connector_file(
+    file_id: str, user: User, db_session: Session
+) -> bool:
+    """Grant access when `file_id` corresponds to a connector-ingested file
+    (`FileOrigin.CONNECTOR`) and the user's ACL overlaps the ACL of at least
+    one `Document` that references that `file_id`. Mirrors the access-control
+    layer applied during retrieval so preview access stays consistent with
+    search result access."""
+    is_connector_file = db_session.query(
+        select(FileRecord.file_id)
+        .where(
+            FileRecord.file_id == file_id,
+            FileRecord.file_origin == FileOrigin.CONNECTOR,
+        )
+        .exists()
+    ).scalar()
+    if not is_connector_file:
+        return False
+
+    document_ids = (
+        db_session.execute(select(Document.id).where(Document.file_id == file_id))
+        .scalars()
+        .all()
+    )
+    if not document_ids:
+        return False
+
+    user_acl = get_acl_for_user(user, db_session)
+    doc_access = get_access_for_documents(list(document_ids), db_session)
+    return any(
+        not user_acl.isdisjoint(access.to_acl()) for access in doc_access.values()
+    )

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -213,12 +213,13 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
       session the user owns or a session publicly shared via
       `ChatSessionSharedStatus.PUBLIC`.
-    - The `file_id` is the storage id of a connector-ingested document
-      (`FileOrigin.CONNECTOR` or `FileOrigin.CONNECTOR_FILE_UPLOAD`) whose
-      associated `Document` grants access to this user via the standard
-      ACL. This allows users to preview cited files returned from indexed
-      connector sources (e.g. the `File` connector, or admin-uploaded
-      files via the connector upload API) through `PreviewModal`.
+    - The `file_id` is referenced by a `Document` (via `Document.file_id`)
+      whose ACL grants access to this user. `Document.file_id` is only
+      populated by connector ingestion, so this covers any connector-ingested
+      file regardless of its `FileOrigin` stamp (which has varied over time:
+      `OTHER` pre-#10484, `CONNECTOR_FILE_UPLOAD` post-#10484, and
+      `CONNECTOR` for pipeline-promoted files). Lets users preview cited
+      files from indexed connectors through `PreviewModal`.
     - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
       tool call database entry is added. This the file is there and the FE can
       request it despite us not having the linking tool call. We currently
@@ -288,24 +289,18 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
 def _user_can_access_connector_file(
     file_id: str, user: User, db_session: Session
 ) -> bool:
-    """Grant access when `file_id` corresponds to a connector-ingested file
-    (`FileOrigin.CONNECTOR` or `FileOrigin.CONNECTOR_FILE_UPLOAD`) and the
-    user's ACL overlaps the ACL of at least one `Document` that references
-    that `file_id`. Mirrors the access-control layer applied during retrieval
-    so preview access stays consistent with search result access."""
-    is_connector_file = db_session.query(
-        select(FileRecord.file_id)
-        .where(
-            FileRecord.file_id == file_id,
-            FileRecord.file_origin.in_(
-                [FileOrigin.CONNECTOR, FileOrigin.CONNECTOR_FILE_UPLOAD]
-            ),
-        )
-        .exists()
-    ).scalar()
-    if not is_connector_file:
-        return False
+    """Grant access when `file_id` is referenced by at least one `Document`
+    (via `Document.file_id`) whose ACL overlaps the user's ACL. Mirrors the
+    access-control layer applied during retrieval so preview access stays
+    consistent with search result access.
 
+    Gated on `Document.file_id` rather than `FileRecord.file_origin` because
+    (a) only connector ingestion writes `Document.file_id`, so its presence
+    is itself the signal that the file is connector-ingested, and (b) the
+    origin has varied historically (`OTHER` pre-#10484,
+    `CONNECTOR_FILE_UPLOAD` post-#10484, and `CONNECTOR` for pipeline-
+    promoted files) — any origin filter would either miss legacy files or
+    need to be widened to a grab-bag."""
     document_ids = (
         db_session.execute(select(Document.id).where(Document.file_id == file_id))
         .scalars()

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -214,10 +214,11 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
       session the user owns or a session publicly shared via
       `ChatSessionSharedStatus.PUBLIC`.
     - The `file_id` is the storage id of a connector-ingested document
-      (`FileOrigin.CONNECTOR`) whose associated `Document` grants access to
-      this user via the standard ACL. This allows users to preview cited
-      files returned from indexed connector sources (e.g. the `File`
-      connector) through `PreviewModal`.
+      (`FileOrigin.CONNECTOR` or `FileOrigin.CONNECTOR_FILE_UPLOAD`) whose
+      associated `Document` grants access to this user via the standard
+      ACL. This allows users to preview cited files returned from indexed
+      connector sources (e.g. the `File` connector, or admin-uploaded
+      files via the connector upload API) through `PreviewModal`.
     - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
       tool call database entry is added. This the file is there and the FE can
       request it despite us not having the linking tool call. We currently
@@ -288,15 +289,17 @@ def _user_can_access_connector_file(
     file_id: str, user: User, db_session: Session
 ) -> bool:
     """Grant access when `file_id` corresponds to a connector-ingested file
-    (`FileOrigin.CONNECTOR`) and the user's ACL overlaps the ACL of at least
-    one `Document` that references that `file_id`. Mirrors the access-control
-    layer applied during retrieval so preview access stays consistent with
-    search result access."""
+    (`FileOrigin.CONNECTOR` or `FileOrigin.CONNECTOR_FILE_UPLOAD`) and the
+    user's ACL overlaps the ACL of at least one `Document` that references
+    that `file_id`. Mirrors the access-control layer applied during retrieval
+    so preview access stays consistent with search result access."""
     is_connector_file = db_session.query(
         select(FileRecord.file_id)
         .where(
             FileRecord.file_id == file_id,
-            FileRecord.file_origin == FileOrigin.CONNECTOR,
+            FileRecord.file_origin.in_(
+                [FileOrigin.CONNECTOR, FileOrigin.CONNECTOR_FILE_UPLOAD]
+            ),
         )
         .exists()
     ).scalar()

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -208,45 +208,22 @@ def collect_user_file_access(user_file: UserFile) -> tuple[set[str], bool]:
 
 
 def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> bool:
-    """Return True if `user` is allowed to read the raw `file_id` served by
-    `GET /chat/file/{file_id}`. Access is granted when any of:
+    """Return True if `user` can read `file_id` via `GET /chat/file/{file_id}`.
 
-    TODO(auth-perf): this function fans out 4–5 queries per request because
-    `/chat/file/{file_id}` is overloaded with unrelated asset classes (user
-    files, persona avatars, chat attachments, tool outputs, connector files).
-    The proper fix is to split this into per-asset-class endpoints
-    (`/user-files/{id}`, `/assistants/{id}/avatar`, `/messages/{id}/files/{n}`,
-    etc.) where the URL itself carries the access-control context and a single
-    indexed lookup suffices. The connector-file branch in particular does a
-    JSONB scan on every call — see `_documents_from_file_connector_config`.
+    The endpoint is overloaded across several asset classes, so we check
+    each in turn (cheapest first, so common paths short-circuit before the
+    JSONB scan in `_documents_from_file_connector_config`):
 
-    - The `file_id` is the storage id of a `UserFile` owned by the user.
-    - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
-      are visible to any authenticated user.
-    - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
-      session the user owns or a session publicly shared via
+    - `UserFile` owned by the user.
+    - `Persona.uploaded_image_id` (avatars are public to authenticated users).
+    - `ChatMessage.files` of a session the user owns or that is shared as
       `ChatSessionSharedStatus.PUBLIC`.
-    - The `file_id` is a `FileRecord` with origin `CHAT_IMAGE_GEN`.
-      TODO: A CHAT_IMAGE_GEN file is uploaded to the file store before
-      the linking tool-call DB row is written, so the FE can request it
-      even though there's nothing to ACL-check against. We currently
-      hack around this by treating these files as public; tightening it
-      requires a larger refactor of the streaming/tool-call write order.
-      Ordered before the connector-file branch so image previews
-      short-circuit on an indexed primary-key lookup instead of falling
-      through to the JSONB fallback.
-    - The `file_id` is referenced by a `Document` (via `Document.file_id`)
-      whose ACL grants access to this user. `Document.file_id` is only
-      populated by connector ingestion, so this covers any connector-ingested
-      file regardless of its `FileOrigin` stamp (which has varied over time:
-      `OTHER` pre-#10484, `CONNECTOR_FILE_UPLOAD` post-#10484, and
-      `CONNECTOR` for pipeline-promoted files). For non-tabular File
-      connector uploads `Document.file_id` is left NULL
-      (`backend/onyx/connectors/file/connector.py:190`), so we also fall
-      back to the cc_pair ACL of any `Connector` whose
-      `connector_specific_config['file_locations']` lists this `file_id`.
-      Lets users preview cited files from indexed connectors through
-      `PreviewModal`.
+    - `FileRecord` with origin `CHAT_IMAGE_GEN` (see inline TODO).
+    - `Document` whose ACL grants access (covers connector-ingested files).
+
+    TODO(auth-perf): split `/chat/file` into per-asset-class endpoints so the
+    URL carries the access context and one indexed lookup suffices, instead
+    of fanning out 4–5 queries across unrelated classes on every request.
     """
     owns_user_file = db_session.query(
         select(UserFile.id)
@@ -256,14 +233,10 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     if owns_user_file:
         return True
 
-    # TODO: move persona avatars to a dedicated endpoint (e.g.
-    # /assistants/{id}/avatar) so this branch can be removed. /chat/file is
-    # currently overloaded with multiple asset classes (user files, chat
-    # attachments, tool outputs, avatars), forcing this access-check fan-out.
-    #
-    # Restrict the avatar path to CHAT_UPLOAD-origin files so an attacker
-    # cannot bind another user's USER_FILE (or any other origin) to their
-    # own persona and read it through this check.
+    # TODO: move persona avatars to a dedicated endpoint so this branch
+    # can go away. Restrict to CHAT_UPLOAD-origin for now so an attacker
+    # cannot bind another user's USER_FILE to their persona and read it
+    # through this check.
     is_persona_avatar = db_session.query(
         select(Persona.id)
         .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
@@ -291,12 +264,10 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     if db_session.execute(chat_file_stmt).first() is not None:
         return True
 
-    # TODO: Chat image generated images are currently public; tighten
-    # this once the tool-call linkage is populated before the file lands
-    # in the store. Ordered above the connector-file branch so image-gen
-    # previews short-circuit on an indexed `FileRecord.file_id` primary-
-    # key lookup rather than falling through to the JSONB fallback in
-    # `_documents_from_file_connector_config`.
+    # TODO: CHAT_IMAGE_GEN files are public because the bytes land in the
+    # store before the linking tool-call row is written; tightening this
+    # requires reordering the streaming/tool-call writes. Kept above the
+    # connector branch so previews hit a PK lookup, not the JSONB scan.
     is_chat_image_gen = db_session.query(
         select(FileRecord.file_id)
         .where(
@@ -314,28 +285,21 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
 def _user_can_access_connector_file(
     file_id: str, user: User, db_session: Session
 ) -> bool:
-    """Grant access when `file_id` is reachable from a `Document` whose ACL
-    overlaps the user's ACL. Mirrors the access-control layer applied during
-    retrieval so preview access stays consistent with search result access.
+    """Mirror retrieval-time ACL: grant access if any `Document` referencing
+    `file_id` has an ACL the user satisfies.
 
     Two lookup paths:
+    1. `Document.file_id == file_id` — fast path; set by most connectors
+       and by tabular File-connector uploads.
+    2. `Connector.connector_specific_config['file_locations']` — fallback
+       for non-tabular File-connector uploads (which leave
+       `Document.file_id=NULL`). Documents under one cc_pair share its
+       ACL, so any one representative document answers the question.
 
-    1. `Document.file_id == file_id` — the fast path. Covers tabular File
-       connector uploads, Blob/SharePoint attachments, and any other
-       connector that stamps `Document.file_id` during ingestion.
-    2. `Connector.connector_specific_config['file_locations']` contains
-       `file_id` — the fallback. The File connector only sets
-       `Document.file_id` for tabular inputs
-       (`backend/onyx/connectors/file/connector.py:190`), so non-tabular
-       uploads (txt/pdf/docx/etc.) have no direct `Document.file_id` link.
-       In that case the `Connector` config still points at the file_id, and
-       every `Document` indexed through its cc_pair shares the same ACL —
-       so checking any one representative document answers the question.
-
-    The `FileRecord.file_origin` is intentionally not consulted: it has
-    varied historically (`OTHER` pre-#10484, `CONNECTOR_FILE_UPLOAD` post-
-    #10484, and `CONNECTOR` for pipeline-promoted files) and any origin
-    filter would either miss legacy files or grow into a grab-bag."""
+    `FileRecord.file_origin` is deliberately not consulted: the stamp has
+    varied across releases and any origin filter would either miss legacy
+    files or sprawl.
+    """
     document_ids: list[str] = list(
         db_session.execute(select(Document.id).where(Document.file_id == file_id))
         .scalars()
@@ -357,38 +321,16 @@ def _documents_from_file_connector_config(
     file_id: str, db_session: Session
 ) -> list[str]:
     """Return one representative document per `Connector` whose
-    `connector_specific_config['file_locations']` lists `file_id`.
+    `connector_specific_config['file_locations']` lists `file_id`. Documents
+    under a single cc_pair share its ACL, so one sample per connector is
+    enough for the downstream ACL check.
 
-    Documents ingested through a single cc_pair share that cc_pair's ACL,
-    so one sample per connector is enough for the downstream ACL check.
-    Almost always a single connector, since file_ids are UUIDs.
-
-    TODO(delete-me): this whole function is a temporary patch for a data-
-    layer inconsistency — the File connector only stamps `Document.file_id`
-    for tabular inputs (see `backend/onyx/connectors/file/connector.py:190`),
-    leaving non-tabular uploads with `Document.file_id=NULL` even though
-    the bytes exist in the file store. The `@>` containment check on a
-    JSONB array also can't use a btree index, so every miss on the fast
-    path runs a scan of `connector.connector_specific_config`.
-
-    The proper fix decouples `Document.file_id` (linkage) from the
-    code-interpreter staging signal that currently rides on it:
-
-      1. In `build_python_chat_files_from_search_docs`
-         (`onyx/chat/chat_utils.py:882`), add an
-         `is_tabular_file(record.display_name)` guard so stamping
-         `Document.file_id` on non-tabular files doesn't cause every
-         cited PDF/TXT/DOCX to be auto-staged into the Python sandbox.
-      2. In the File connector (`onyx/connectors/file/connector.py:190`),
-         drop the `is_tabular_file` gate so `Document.file_id` is stamped
-         unconditionally. New uploads then take the fast path by design.
-      3. Alembic backfill: for every existing non-tabular connector file,
-         join `connector.connector_specific_config->'file_locations'` →
-         `document_by_connector_credential_pair` → `document` and set
-         `document.file_id`. One-time cost at deploy.
-      4. Delete this helper and the fallback branch in
-         `_user_can_access_connector_file`. The access check collapses to
-         a single indexed `SELECT document.id WHERE file_id = :file_id`.
+    TODO(delete-me): exists only because the File connector leaves
+    `Document.file_id=NULL` for non-tabular uploads (see comment in
+    `onyx/connectors/file/connector.py`). The `@>` lookup also can't use
+    a btree index, so every fast-path miss does a JSONB scan. Once the
+    connector stamps `Document.file_id` unconditionally and a backfill
+    runs, this helper and its caller branch can go away.
     """
     connector_ids: list[int] = list(
         db_session.execute(
@@ -404,9 +346,8 @@ def _documents_from_file_connector_config(
     if not connector_ids:
         return []
 
-    # In practice `connector_ids` has length 1 (file_ids are UUIDs), so
-    # the per-connector fan-out here is a non-issue; not worth folding
-    # into a `DISTINCT ON` when the whole helper is slated for deletion.
+    # `connector_ids` is virtually always length 1 (file_ids are UUIDs),
+    # so the per-connector fan-out here is a non-issue.
     document_ids: list[str] = []
     for connector_id in connector_ids:
         doc_id = db_session.execute(

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -320,10 +320,13 @@ def _user_can_access_connector_file(
 def _documents_from_file_connector_config(
     file_id: str, db_session: Session
 ) -> list[str]:
-    """Return one representative document per `Connector` whose
-    `connector_specific_config['file_locations']` lists `file_id`. Documents
-    under a single cc_pair share its ACL, so one sample per connector is
-    enough for the downstream ACL check.
+    """Return one representative document per cc_pair (connector +
+    credential) whose `Connector.connector_specific_config['file_locations']`
+    lists `file_id`. Sampling per cc_pair (not per connector) is required
+    because ACLs are scoped to the cc_pair: the same connector paired with
+    different credentials can have different ACLs, and a user with access
+    via one credential must not be denied because we sampled a doc from
+    another.
 
     TODO(delete-me): exists only because the File connector leaves
     `Document.file_id=NULL` for non-tabular uploads (see comment in
@@ -332,27 +335,33 @@ def _documents_from_file_connector_config(
     connector stamps `Document.file_id` unconditionally and a backfill
     runs, this helper and its caller branch can go away.
     """
-    connector_ids: list[int] = list(
-        db_session.execute(
-            select(Connector.id).where(
-                Connector.connector_specific_config["file_locations"].op("@>")(
-                    sa_cast([file_id], postgresql.JSONB)
-                )
+    cc_pair_keys = db_session.execute(
+        select(
+            DocumentByConnectorCredentialPair.connector_id,
+            DocumentByConnectorCredentialPair.credential_id,
+        )
+        .join(
+            Connector,
+            Connector.id == DocumentByConnectorCredentialPair.connector_id,
+        )
+        .where(
+            Connector.connector_specific_config["file_locations"].op("@>")(
+                sa_cast([file_id], postgresql.JSONB)
             )
         )
-        .scalars()
-        .all()
-    )
-    if not connector_ids:
+        .distinct()
+    ).all()
+    if not cc_pair_keys:
         return []
 
-    # `connector_ids` is virtually always length 1 (file_ids are UUIDs),
-    # so the per-connector fan-out here is a non-issue.
     document_ids: list[str] = []
-    for connector_id in connector_ids:
+    for connector_id, credential_id in cc_pair_keys:
         doc_id = db_session.execute(
             select(DocumentByConnectorCredentialPair.id)
-            .where(DocumentByConnectorCredentialPair.connector_id == connector_id)
+            .where(
+                DocumentByConnectorCredentialPair.connector_id == connector_id,
+                DocumentByConnectorCredentialPair.credential_id == credential_id,
+            )
             .limit(1)
         ).scalar()
         if doc_id is not None:

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -185,7 +185,17 @@ def _process_file(
 
     # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
-    # Only set the file id if it is a tabular document
+    # Only set the file id if it is a tabular document. Non-tabular files
+    # thus have `Document.file_id=NULL`, which forces
+    # `onyx.access.access._user_can_access_connector_file` to fall back to
+    # a JSONB scan of `Connector.connector_specific_config['file_locations']`
+    # on every `/chat/file/{file_id}` access for a cited non-tabular doc.
+    # TODO: populate `Document.file_id` unconditionally here and move the
+    # "is this a tabular file?" check into
+    # `onyx.chat.chat_utils.build_python_chat_files_from_search_docs`
+    # (keyed off `FileRecord.display_name`), so we don't stage every PDF/
+    # TXT into the code-interpreter sandbox just because it now has a
+    # file_id. That would let us drop the fallback lookup path entirely.
     doc_file_id = None
     if is_tabular_file(file_name):
         doc_file_id = file_id

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -183,6 +183,7 @@ def _process_file(
         title = onyx_metadata.title or onyx_metadata.file_display_name or title
         link = onyx_metadata.link or link
 
+    # Build sections: first the text as a single Section
     sections: list[TextSection | ImageSection | TabularSection] = []
     # `Document.file_id` doubles as the "stage these bytes into the
     # code-interpreter sandbox" signal read by

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -183,19 +183,35 @@ def _process_file(
         title = onyx_metadata.title or onyx_metadata.file_display_name or title
         link = onyx_metadata.link or link
 
-    # Build sections: first the text as a single Section
+    # Build sections: first the text as a single Section.
     sections: list[TextSection | ImageSection | TabularSection] = []
-    # Only set the file id if it is a tabular document. Non-tabular files
-    # thus have `Document.file_id=NULL`, which forces
-    # `onyx.access.access._user_can_access_connector_file` to fall back to
-    # a JSONB scan of `Connector.connector_specific_config['file_locations']`
-    # on every `/chat/file/{file_id}` access for a cited non-tabular doc.
-    # TODO: populate `Document.file_id` unconditionally here and move the
-    # "is this a tabular file?" check into
+    # `Document.file_id` is currently doing double duty: the linkage back
+    # to the raw bytes AND the "these bytes are pandas-ready, stage them
+    # into the code-interpreter sandbox" signal consumed by
     # `onyx.chat.chat_utils.build_python_chat_files_from_search_docs`
-    # (keyed off `FileRecord.display_name`), so we don't stage every PDF/
-    # TXT into the code-interpreter sandbox just because it now has a
-    # file_id. That would let us drop the fallback lookup path entirely.
+    # (`chat/chat_utils.py:882`). That code auto-uploads any CONNECTOR /
+    # CONNECTOR_FILE_UPLOAD file_id with no tabular check, so stamping
+    # every connector file here would bloat every Python tool call with
+    # cited PDFs/TXTs/DOCXs.
+    #
+    # The narrow side effect: non-tabular uploads land with
+    # `Document.file_id=NULL` even though the bytes exist in the file
+    # store, which forces `_user_can_access_connector_file` (in
+    # `onyx/access/access.py`) into a JSONB scan of
+    # `Connector.connector_specific_config['file_locations']` on every
+    # `/chat/file/{file_id}` request.
+    #
+    # TODO: decouple linkage from the staging signal, in this order:
+    #   1. Add `is_tabular_file(record.display_name)` in
+    #      `build_python_chat_files_from_search_docs` so only tabular
+    #      files continue to auto-stage.
+    #   2. Remove the `is_tabular_file` gate below so every upload gets
+    #      `Document.file_id` set.
+    #   3. Alembic backfill for existing non-tabular connector rows
+    #      (join `connector_specific_config->'file_locations'` →
+    #      `document_by_connector_credential_pair` → `document`).
+    #   4. Delete the JSONB fallback in
+    #      `onyx.access.access._documents_from_file_connector_config`.
     doc_file_id = None
     if is_tabular_file(file_name):
         doc_file_id = file_id

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -183,35 +183,18 @@ def _process_file(
         title = onyx_metadata.title or onyx_metadata.file_display_name or title
         link = onyx_metadata.link or link
 
-    # Build sections: first the text as a single Section.
     sections: list[TextSection | ImageSection | TabularSection] = []
-    # `Document.file_id` is currently doing double duty: the linkage back
-    # to the raw bytes AND the "these bytes are pandas-ready, stage them
-    # into the code-interpreter sandbox" signal consumed by
-    # `onyx.chat.chat_utils.build_python_chat_files_from_search_docs`
-    # (`chat/chat_utils.py:882`). That code auto-uploads any CONNECTOR /
-    # CONNECTOR_FILE_UPLOAD file_id with no tabular check, so stamping
-    # every connector file here would bloat every Python tool call with
-    # cited PDFs/TXTs/DOCXs.
-    #
-    # The narrow side effect: non-tabular uploads land with
-    # `Document.file_id=NULL` even though the bytes exist in the file
-    # store, which forces `_user_can_access_connector_file` (in
-    # `onyx/access/access.py`) into a JSONB scan of
-    # `Connector.connector_specific_config['file_locations']` on every
-    # `/chat/file/{file_id}` request.
-    #
-    # TODO: decouple linkage from the staging signal, in this order:
-    #   1. Add `is_tabular_file(record.display_name)` in
-    #      `build_python_chat_files_from_search_docs` so only tabular
-    #      files continue to auto-stage.
-    #   2. Remove the `is_tabular_file` gate below so every upload gets
-    #      `Document.file_id` set.
-    #   3. Alembic backfill for existing non-tabular connector rows
-    #      (join `connector_specific_config->'file_locations'` →
-    #      `document_by_connector_credential_pair` → `document`).
-    #   4. Delete the JSONB fallback in
-    #      `onyx.access.access._documents_from_file_connector_config`.
+    # `Document.file_id` doubles as the "stage these bytes into the
+    # code-interpreter sandbox" signal read by
+    # `build_python_chat_files_from_search_docs`, which has no tabular
+    # gate of its own — stamping every file would auto-stage every cited
+    # PDF/TXT/DOCX. Trade-off: non-tabular uploads keep
+    # `Document.file_id=NULL`, forcing `_user_can_access_connector_file`
+    # into a JSONB scan (see TODO there).
+    # TODO: stamp `Document.file_id` unconditionally here and add the
+    # tabular check to `build_python_chat_files_from_search_docs` (keyed
+    # off `FileRecord.display_name`). Combined with a backfill, that lets
+    # us drop the JSONB fallback entirely.
     doc_file_id = None
     if is_tabular_file(file_name):
         doc_file_id = file_id

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -12,9 +12,11 @@ from onyx.configs.constants import FileOrigin
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import ChatSessionSharedStatus
+from onyx.db.models import Document
 from onyx.db.models import FileRecord
 from onyx.db.models import Persona
 from onyx.db.models import Project__UserFile
+from onyx.db.models import User
 from onyx.db.models import UserFile
 
 
@@ -127,8 +129,8 @@ def get_file_id_by_user_file_id(
     return None
 
 
-def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) -> bool:
-    """Return True if `user_id` is allowed to read the raw `file_id` served by
+def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> bool:
+    """Return True if `user` is allowed to read the raw `file_id` served by
     `GET /chat/file/{file_id}`. Access is granted when any of:
 
     - The `file_id` is the storage id of a `UserFile` owned by the user.
@@ -137,6 +139,11 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
     - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
       session the user owns or a session publicly shared via
       `ChatSessionSharedStatus.PUBLIC`.
+    - The `file_id` is the storage id of a connector-ingested document
+      (`FileOrigin.CONNECTOR`) whose associated `Document` grants access to
+      this user via the standard ACL. This allows users to preview cited
+      files returned from indexed connector sources (e.g. the `File`
+      connector) through `PreviewModal`.
     - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
       tool call database entry is added. This the file is there and the FE can
       request it despite us not having the linking tool call. We currently
@@ -145,7 +152,7 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
     """
     owns_user_file = db_session.query(
         select(UserFile.id)
-        .where(UserFile.file_id == file_id, UserFile.user_id == user_id)
+        .where(UserFile.file_id == file_id, UserFile.user_id == user.id)
         .exists()
     ).scalar()
     if owns_user_file:
@@ -177,13 +184,16 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
         .where(ChatMessage.files.op("@>")([{"id": file_id}]))
         .where(
             or_(
-                ChatSession.user_id == user_id,
+                ChatSession.user_id == user.id,
                 ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
             )
         )
         .limit(1)
     )
     if db_session.execute(chat_file_stmt).first() is not None:
+        return True
+
+    if _user_can_access_connector_file(file_id, user, db_session):
         return True
 
     # TODO: Chat image generated images are currently public
@@ -198,6 +208,46 @@ def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) 
         .exists()
     ).scalar()
     return bool(is_chat_image_gen)
+
+
+def _user_can_access_connector_file(
+    file_id: str, user: User, db_session: Session
+) -> bool:
+    """Grant access when `file_id` corresponds to a connector-ingested file
+    (`FileOrigin.CONNECTOR`) and the user's ACL overlaps the ACL of at least
+    one `Document` that references that `file_id`. Mirrors the access-control
+    layer applied during retrieval so preview access stays consistent with
+    search result access."""
+    # Imported here to avoid a circular import between `onyx.access.access`
+    # (which imports from this module for user-file ACL helpers) and this
+    # module.
+    from onyx.access.access import get_access_for_documents
+    from onyx.access.access import get_acl_for_user
+
+    is_connector_file = db_session.query(
+        select(FileRecord.file_id)
+        .where(
+            FileRecord.file_id == file_id,
+            FileRecord.file_origin == FileOrigin.CONNECTOR,
+        )
+        .exists()
+    ).scalar()
+    if not is_connector_file:
+        return False
+
+    document_ids = (
+        db_session.execute(select(Document.id).where(Document.file_id == file_id))
+        .scalars()
+        .all()
+    )
+    if not document_ids:
+        return False
+
+    user_acl = get_acl_for_user(user, db_session)
+    doc_access = get_access_for_documents(list(document_ids), db_session)
+    return any(
+        not user_acl.isdisjoint(access.to_acl()) for access in doc_access.values()
+    )
 
 
 def get_file_ids_by_user_file_ids(

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -2,21 +2,13 @@ import datetime
 from uuid import UUID
 
 from sqlalchemy import func
-from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import FileOrigin
-from onyx.db.models import ChatMessage
-from onyx.db.models import ChatSession
-from onyx.db.models import ChatSessionSharedStatus
-from onyx.db.models import Document
-from onyx.db.models import FileRecord
 from onyx.db.models import Persona
 from onyx.db.models import Project__UserFile
-from onyx.db.models import User
 from onyx.db.models import UserFile
 
 
@@ -127,127 +119,6 @@ def get_file_id_by_user_file_id(
     if user_file:
         return user_file.file_id
     return None
-
-
-def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> bool:
-    """Return True if `user` is allowed to read the raw `file_id` served by
-    `GET /chat/file/{file_id}`. Access is granted when any of:
-
-    - The `file_id` is the storage id of a `UserFile` owned by the user.
-    - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
-      are visible to any authenticated user.
-    - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
-      session the user owns or a session publicly shared via
-      `ChatSessionSharedStatus.PUBLIC`.
-    - The `file_id` is the storage id of a connector-ingested document
-      (`FileOrigin.CONNECTOR`) whose associated `Document` grants access to
-      this user via the standard ACL. This allows users to preview cited
-      files returned from indexed connector sources (e.g. the `File`
-      connector) through `PreviewModal`.
-    - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
-      tool call database entry is added. This the file is there and the FE can
-      request it despite us not having the linking tool call. We currently
-      hackily get around this by making these files public, but this will need
-      to change with a larger refactor.
-    """
-    owns_user_file = db_session.query(
-        select(UserFile.id)
-        .where(UserFile.file_id == file_id, UserFile.user_id == user.id)
-        .exists()
-    ).scalar()
-    if owns_user_file:
-        return True
-
-    # TODO: move persona avatars to a dedicated endpoint (e.g.
-    # /assistants/{id}/avatar) so this branch can be removed. /chat/file is
-    # currently overloaded with multiple asset classes (user files, chat
-    # attachments, tool outputs, avatars), forcing this access-check fan-out.
-    #
-    # Restrict the avatar path to CHAT_UPLOAD-origin files so an attacker
-    # cannot bind another user's USER_FILE (or any other origin) to their
-    # own persona and read it through this check.
-    is_persona_avatar = db_session.query(
-        select(Persona.id)
-        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
-        .where(
-            Persona.uploaded_image_id == file_id,
-            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
-        )
-        .exists()
-    ).scalar()
-    if is_persona_avatar:
-        return True
-
-    chat_file_stmt = (
-        select(ChatMessage.id)
-        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
-        .where(ChatMessage.files.op("@>")([{"id": file_id}]))
-        .where(
-            or_(
-                ChatSession.user_id == user.id,
-                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
-            )
-        )
-        .limit(1)
-    )
-    if db_session.execute(chat_file_stmt).first() is not None:
-        return True
-
-    if _user_can_access_connector_file(file_id, user, db_session):
-        return True
-
-    # TODO: Chat image generated images are currently public
-    # We will want to make this private but it requires a larger
-    # refactor.
-    is_chat_image_gen = db_session.query(
-        select(FileRecord.file_id)
-        .where(
-            FileRecord.file_id == file_id,
-            FileRecord.file_origin == FileOrigin.CHAT_IMAGE_GEN,
-        )
-        .exists()
-    ).scalar()
-    return bool(is_chat_image_gen)
-
-
-def _user_can_access_connector_file(
-    file_id: str, user: User, db_session: Session
-) -> bool:
-    """Grant access when `file_id` corresponds to a connector-ingested file
-    (`FileOrigin.CONNECTOR`) and the user's ACL overlaps the ACL of at least
-    one `Document` that references that `file_id`. Mirrors the access-control
-    layer applied during retrieval so preview access stays consistent with
-    search result access."""
-    # Imported here to avoid a circular import between `onyx.access.access`
-    # (which imports from this module for user-file ACL helpers) and this
-    # module.
-    from onyx.access.access import get_access_for_documents
-    from onyx.access.access import get_acl_for_user
-
-    is_connector_file = db_session.query(
-        select(FileRecord.file_id)
-        .where(
-            FileRecord.file_id == file_id,
-            FileRecord.file_origin == FileOrigin.CONNECTOR,
-        )
-        .exists()
-    ).scalar()
-    if not is_connector_file:
-        return False
-
-    document_ids = (
-        db_session.execute(select(Document.id).where(Document.file_id == file_id))
-        .scalars()
-        .all()
-    )
-    if not document_ids:
-        return False
-
-    user_acl = get_acl_for_user(user, db_session)
-    doc_access = get_access_for_documents(list(document_ids), db_session)
-    return any(
-        not user_acl.isdisjoint(access.to_acl()) for access in doc_access.values()
-    )
 
 
 def get_file_ids_by_user_file_ids(

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -875,7 +875,7 @@ def fetch_chat_file(
     file_id_from_user_file = get_file_id_by_user_file_id(file_id, user.id, db_session)
     if file_id_from_user_file:
         file_id = file_id_from_user_file
-    elif not user_can_access_chat_file(file_id, user.id, db_session):
+    elif not user_can_access_chat_file(file_id, user, db_session):
         # Return 404 (rather than 403) so callers cannot probe for file
         # existence across ownership boundaries.
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "File not found")

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -14,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.access.access import user_can_access_chat_file
 from onyx.auth.api_key import get_hashed_api_key_from_request
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.permissions import require_permission
@@ -63,7 +64,6 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.usage import increment_usage
 from onyx.db.usage import UsageType
 from onyx.db.user_file import get_file_id_by_user_file_id
-from onyx.db.user_file import user_can_access_chat_file
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -314,20 +314,10 @@ def test_non_owner_can_download_image_gen_file_in_public_session(
     assert response.content == _IMAGE_GEN_PNG_BYTES
 
 
-# -----------------------------------------------------------------------------
-# Connector-ingested file access checks
-#
-# Files ingested by connectors (e.g. the File connector) are saved to the file
-# store with `FileOrigin.CONNECTOR` and referenced from the corresponding
-# `Document.file_id`. The `PreviewModal` in the frontend downloads these via
-# `GET /chat/file/{file_id}` when no external `.link` is available.
-#
-# The chat-file hardening in PR #10380 omitted this branch, causing a
-# "Failed to load document." regression (tracked in issue #10472). These tests
-# pin the fix: connector files must be readable by any user whose ACL covers
-# at least one Document that references the file, and must stay gated for
-# users whose ACL does not.
-# -----------------------------------------------------------------------------
+# Connector-ingested files: PR #10380 hardened `/chat/file/{file_id}` but
+# missed the connector branch (issue #10472), breaking `PreviewModal` with
+# "Failed to load document.". These tests pin that access lines up with
+# the underlying `Document` ACL.
 
 
 _CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
@@ -338,10 +328,8 @@ def _seed_connector_file(
     document_id: str,
     file_origin: FileOrigin = FileOrigin.CONNECTOR,
 ) -> str:
-    """Save bytes to the file store under a connector-adjacent origin and
-    point the ingested `Document.file_id` at the returned storage id. The
-    cc_pair already links the document via the ingestion API, so the ACL
-    resolution path used by `user_can_access_chat_file` will find it."""
+    """Save bytes and link `Document.file_id` to the storage id, exercising
+    the fast path in `_user_can_access_connector_file`."""
     file_store = get_default_file_store()
     storage_id = file_store.save_file(
         content=io.BytesIO(_CONNECTOR_FILE_BYTES),
@@ -357,15 +345,11 @@ def _seed_connector_file(
     return storage_id
 
 
-# Connector-ingested files have carried several origin stamps over time:
-#   * `FileOrigin.CONNECTOR` — pipeline-promoted during indexing.
-#   * `FileOrigin.CONNECTOR_FILE_UPLOAD` — admin uploads via the connector
-#     upload API (added in #10484).
-#   * `FileOrigin.OTHER` — the pre-#10484 stamp for admin connector uploads.
-#     Files from that era still live in production file stores, so the
-#     preview path must stay backwards-compatible with them.
-# All that matters for access is that a `Document` references the `file_id`;
-# the `FileOrigin` stamp is not consulted by `_user_can_access_connector_file`.
+# Origins that connector-ingested files have carried in prod: pipeline-
+# promoted (`CONNECTOR`), modern admin upload (`CONNECTOR_FILE_UPLOAD`,
+# added in #10484), and legacy admin upload (`OTHER`, pre-#10484). The
+# access check ignores origin, but parametrizing here guards against a
+# regression that re-introduces an origin filter.
 _CONNECTOR_FILE_ORIGINS = [
     FileOrigin.CONNECTOR,
     FileOrigin.CONNECTOR_FILE_UPLOAD,
@@ -378,14 +362,9 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
     reset: None,  # noqa: ARG001
     file_origin: FileOrigin,
 ) -> None:
-    """Regression test for issue #10472.
-
-    Connector-ingested files have carried several `FileOrigin` stamps over
-    time (`CONNECTOR`, `CONNECTOR_FILE_UPLOAD`, or `OTHER` for pre-#10484
-    admin uploads). When the owning cc_pair is PUBLIC, any authenticated
-    user must be able to fetch the file via `GET /chat/file/{file_id}`
-    regardless of origin — previously this returned 404, breaking
-    `PreviewModal` with "Failed to load document."."""
+    """Regression test for #10472: PUBLIC connector file is fetchable by
+    any authenticated user via `/chat/file/{file_id}`, regardless of
+    `FileOrigin` stamp."""
     admin_user: DATestUser = UserManager.create(name="connector_admin")
     basic_user: DATestUser = UserManager.create(name="connector_basic")
 
@@ -422,10 +401,8 @@ def test_connector_file_denied_for_users_without_access(
     reset: None,  # noqa: ARG001
     file_origin: FileOrigin,
 ) -> None:
-    """Flip side of the regression fix: a connector file backed by a PRIVATE
-    cc_pair must NOT be readable by users who have no ACL overlap with the
-    cc_pair, even after the fix. Covers every `FileOrigin` stamp the
-    connector file path has used historically."""
+    """Flip side: a PRIVATE cc_pair connector file stays denied for users
+    with no ACL overlap, across every historical `FileOrigin` stamp."""
     admin_user: DATestUser = UserManager.create(name="priv_connector_admin")
     basic_user: DATestUser = UserManager.create(name="priv_connector_basic")
 
@@ -457,26 +434,12 @@ def test_connector_file_denied_for_users_without_access(
     assert basic_response.content != _CONNECTOR_FILE_BYTES
 
 
-# -----------------------------------------------------------------------------
-# Non-tabular File-connector upload access checks
-#
-# The File connector only stamps `Document.file_id` for tabular files
-# (`backend/onyx/connectors/file/connector.py:190`). Non-tabular uploads
-# (txt/pdf/docx/etc.) leave `Document.file_id=NULL`, so the `Document.file_id`
-# lookup path alone is not enough — users clicking a citation on a .txt file
-# would previously see "Failed to load document." even for publicly-indexed
-# connector files.
-#
-# The access check falls back to matching the file_id against
-# `Connector.connector_specific_config['file_locations']`, which the File
-# connector populates for every uploaded file regardless of extension. These
-# tests pin that fallback across both current (`CONNECTOR_FILE_UPLOAD`) and
-# legacy pre-#10484 (`OTHER`) origin stamps.
-# -----------------------------------------------------------------------------
-
-
-# `CONNECTOR` isn't included here because pipeline-promoted files already get
-# `Document.file_id` stamped, so they never hit the connector-config fallback.
+# Non-tabular File-connector uploads (txt/pdf/docx/...) leave
+# `Document.file_id=NULL` (see `connectors/file/connector.py`), so the fast
+# path misses and access falls back to matching against
+# `Connector.connector_specific_config['file_locations']`. These tests pin
+# that fallback. `CONNECTOR` is excluded because pipeline-promoted files
+# always get `Document.file_id` stamped and so never hit the fallback.
 _NON_TABULAR_FILE_ORIGINS = [
     FileOrigin.CONNECTOR_FILE_UPLOAD,
     FileOrigin.OTHER,
@@ -490,10 +453,8 @@ def _seed_non_tabular_file_connector_cc_pair(
     access_type: AccessType,
     groups: list[int] | None = None,
 ) -> DATestCCPair:
-    """Build a File-source cc_pair whose `connector_specific_config` points at
-    `file_id` WITHOUT linking any `Document.file_id` to it — mirroring what
-    happens in prod when a user uploads a non-tabular file through the File
-    connector UI."""
+    """Build a File-source cc_pair pointing at `file_id` without setting
+    `Document.file_id` — mirrors a non-tabular upload."""
     return CCPairManager.create_from_scratch(
         user_performing_action=admin_user,
         source=DocumentSource.FILE,
@@ -509,10 +470,9 @@ def _seed_non_tabular_file_connector_cc_pair(
 
 
 def _save_non_tabular_file_bytes(file_id: str, file_origin: FileOrigin) -> None:
-    """Write bytes into the file store under the *exact* `file_id` referenced
-    by `Connector.connector_specific_config['file_locations']`. We cannot reuse
-    `_seed_connector_file` because that helper also stamps `Document.file_id`,
-    which would bypass the fallback path we're trying to exercise."""
+    """Save bytes under the exact `file_id` listed in the cc_pair's
+    `file_locations`. Can't reuse `_seed_connector_file` because that
+    stamps `Document.file_id` and would bypass the fallback under test."""
     file_store = get_default_file_store()
     file_store.save_file(
         content=io.BytesIO(_CONNECTOR_FILE_BYTES),
@@ -528,11 +488,8 @@ def test_non_tabular_connector_file_is_accessible_via_chat_file_endpoint(
     reset: None,  # noqa: ARG001
     file_origin: FileOrigin,
 ) -> None:
-    """Non-tabular File connector uploads (txt/pdf/docx/etc.) have no
-    `Document.file_id` link, so the original fix for #10472 left them
-    unreachable via `/chat/file/{file_id}`. The fallback keyed off
-    `Connector.connector_specific_config['file_locations']` is what lets
-    `PreviewModal` render these files again."""
+    """PUBLIC non-tabular File-connector upload: the JSONB fallback in
+    `_user_can_access_connector_file` lets any user fetch it."""
     admin_user: DATestUser = UserManager.create(name="non_tabular_admin")
     basic_user: DATestUser = UserManager.create(name="non_tabular_basic")
     api_key = APIKeyManager.create(user_performing_action=admin_user)
@@ -544,8 +501,8 @@ def test_non_tabular_connector_file_is_accessible_via_chat_file_endpoint(
         access_type=AccessType.PUBLIC,
     )
 
-    # Ingest a document against this cc_pair but do NOT set its `file_id` —
-    # that's what makes this the "non-tabular" case.
+    # Document ingested against the cc_pair without `file_id` — the
+    # "non-tabular" case under test.
     DocumentManager.seed_doc_with_content(
         cc_pair=public_cc_pair,
         content="non-tabular body text",
@@ -571,9 +528,8 @@ def test_non_tabular_connector_file_denied_for_users_without_access(
     reset: None,  # noqa: ARG001
     file_origin: FileOrigin,
 ) -> None:
-    """Flip side of the fallback: a non-tabular File-connector upload owned by
-    a PRIVATE cc_pair must stay gated for users with no ACL overlap, even
-    though the connector-config fallback finds the file."""
+    """PRIVATE non-tabular File-connector upload: ACL still gates access
+    even though the JSONB fallback locates the file."""
     admin_user: DATestUser = UserManager.create(name="non_tabular_priv_admin")
     basic_user: DATestUser = UserManager.create(name="non_tabular_priv_basic")
     api_key = APIKeyManager.create(user_performing_action=admin_user)

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -314,12 +314,6 @@ def test_non_owner_can_download_image_gen_file_in_public_session(
     assert response.content == _IMAGE_GEN_PNG_BYTES
 
 
-# Connector-ingested files: PR #10380 hardened `/chat/file/{file_id}` but
-# missed the connector branch (issue #10472), breaking `PreviewModal` with
-# "Failed to load document.". These tests pin that access lines up with
-# the underlying `Document` ACL.
-
-
 _CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
 
 

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -334,16 +334,17 @@ _CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
 def _seed_connector_file(
     *,
     document_id: str,
+    file_origin: FileOrigin = FileOrigin.CONNECTOR,
 ) -> str:
-    """Save bytes to the file store as `FileOrigin.CONNECTOR` and point the
-    ingested `Document.file_id` at the returned storage id. The cc_pair
-    already links the document via the ingestion API, so the ACL resolution
-    path used by `user_can_access_chat_file` will find it."""
+    """Save bytes to the file store under a connector-adjacent origin and
+    point the ingested `Document.file_id` at the returned storage id. The
+    cc_pair already links the document via the ingestion API, so the ACL
+    resolution path used by `user_can_access_chat_file` will find it."""
     file_store = get_default_file_store()
     storage_id = file_store.save_file(
         content=io.BytesIO(_CONNECTOR_FILE_BYTES),
         display_name="connector_doc.txt",
-        file_origin=FileOrigin.CONNECTOR,
+        file_origin=file_origin,
         file_type="text/plain",
     )
     with get_session_with_current_tenant() as db_session:
@@ -354,14 +355,28 @@ def _seed_connector_file(
     return storage_id
 
 
+# Both `FileOrigin.CONNECTOR` (pipeline-promoted) and
+# `FileOrigin.CONNECTOR_FILE_UPLOAD` (admin-uploaded via the connector upload
+# API) flow through the same indexing path and land on `Document.file_id`.
+# `_user_can_access_connector_file` must treat them identically.
+_CONNECTOR_FILE_ORIGINS = [
+    FileOrigin.CONNECTOR,
+    FileOrigin.CONNECTOR_FILE_UPLOAD,
+]
+
+
+@pytest.mark.parametrize("file_origin", _CONNECTOR_FILE_ORIGINS)
 def test_connector_file_is_accessible_via_chat_file_endpoint(
     reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
 ) -> None:
     """Regression test for issue #10472.
 
     A file ingested by a connector (e.g. the File connector) is served from
-    the file store with `FileOrigin.CONNECTOR`. When its owning cc_pair is
-    PUBLIC, any authenticated user must be able to fetch it via
+    the file store with `FileOrigin.CONNECTOR`. Admin-uploaded connector
+    files are stored as `FileOrigin.CONNECTOR_FILE_UPLOAD` but flow through
+    the same indexing path. When the owning cc_pair is PUBLIC, any
+    authenticated user must be able to fetch it via
     `GET /chat/file/{file_id}` — previously this returned 404, breaking
     `PreviewModal` with "Failed to load document."."""
     admin_user: DATestUser = UserManager.create(name="connector_admin")
@@ -380,6 +395,7 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
     )
     storage_id = _seed_connector_file(
         document_id=document.id,
+        file_origin=file_origin,
     )
 
     for user in (admin_user, basic_user):
@@ -388,18 +404,21 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
             headers=user.headers,
         )
         assert response.status_code == 200, (
-            f"User {user.email} must be able to fetch a PUBLIC connector file, "
-            f"got {response.status_code}: {response.text}"
+            f"User {user.email} must be able to fetch a PUBLIC connector file "
+            f"(origin={file_origin}), got {response.status_code}: {response.text}"
         )
         assert response.content == _CONNECTOR_FILE_BYTES
 
 
+@pytest.mark.parametrize("file_origin", _CONNECTOR_FILE_ORIGINS)
 def test_connector_file_denied_for_users_without_access(
     reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
 ) -> None:
     """Flip side of the regression fix: a connector file backed by a PRIVATE
     cc_pair must NOT be readable by users who have no ACL overlap with the
-    cc_pair, even after the fix."""
+    cc_pair, even after the fix. Covers both `CONNECTOR` and
+    `CONNECTOR_FILE_UPLOAD` origins."""
     admin_user: DATestUser = UserManager.create(name="priv_connector_admin")
     basic_user: DATestUser = UserManager.create(name="priv_connector_basic")
 
@@ -416,6 +435,7 @@ def test_connector_file_denied_for_users_without_access(
     )
     storage_id = _seed_connector_file(
         document_id=document.id,
+        file_origin=file_origin,
     )
 
     basic_response = requests.get(
@@ -423,7 +443,8 @@ def test_connector_file_denied_for_users_without_access(
         headers=basic_user.headers,
     )
     assert basic_response.status_code in (403, 404), (
-        f"Non-member should be denied on PRIVATE connector file, got "
-        f"{basic_response.status_code}: {basic_response.text}"
+        f"Non-member should be denied on PRIVATE connector file "
+        f"(origin={file_origin}), got {basic_response.status_code}: "
+        f"{basic_response.text}"
     )
     assert basic_response.content != _CONNECTOR_FILE_BYTES

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -355,13 +355,19 @@ def _seed_connector_file(
     return storage_id
 
 
-# Both `FileOrigin.CONNECTOR` (pipeline-promoted) and
-# `FileOrigin.CONNECTOR_FILE_UPLOAD` (admin-uploaded via the connector upload
-# API) flow through the same indexing path and land on `Document.file_id`.
-# `_user_can_access_connector_file` must treat them identically.
+# Connector-ingested files have carried several origin stamps over time:
+#   * `FileOrigin.CONNECTOR` — pipeline-promoted during indexing.
+#   * `FileOrigin.CONNECTOR_FILE_UPLOAD` — admin uploads via the connector
+#     upload API (added in #10484).
+#   * `FileOrigin.OTHER` — the pre-#10484 stamp for admin connector uploads.
+#     Files from that era still live in production file stores, so the
+#     preview path must stay backwards-compatible with them.
+# All that matters for access is that a `Document` references the `file_id`;
+# the `FileOrigin` stamp is not consulted by `_user_can_access_connector_file`.
 _CONNECTOR_FILE_ORIGINS = [
     FileOrigin.CONNECTOR,
     FileOrigin.CONNECTOR_FILE_UPLOAD,
+    FileOrigin.OTHER,
 ]
 
 
@@ -372,12 +378,11 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
 ) -> None:
     """Regression test for issue #10472.
 
-    A file ingested by a connector (e.g. the File connector) is served from
-    the file store with `FileOrigin.CONNECTOR`. Admin-uploaded connector
-    files are stored as `FileOrigin.CONNECTOR_FILE_UPLOAD` but flow through
-    the same indexing path. When the owning cc_pair is PUBLIC, any
-    authenticated user must be able to fetch it via
-    `GET /chat/file/{file_id}` — previously this returned 404, breaking
+    Connector-ingested files have carried several `FileOrigin` stamps over
+    time (`CONNECTOR`, `CONNECTOR_FILE_UPLOAD`, or `OTHER` for pre-#10484
+    admin uploads). When the owning cc_pair is PUBLIC, any authenticated
+    user must be able to fetch the file via `GET /chat/file/{file_id}`
+    regardless of origin — previously this returned 404, breaking
     `PreviewModal` with "Failed to load document."."""
     admin_user: DATestUser = UserManager.create(name="connector_admin")
     basic_user: DATestUser = UserManager.create(name="connector_basic")
@@ -417,8 +422,8 @@ def test_connector_file_denied_for_users_without_access(
 ) -> None:
     """Flip side of the regression fix: a connector file backed by a PRIVATE
     cc_pair must NOT be readable by users who have no ACL overlap with the
-    cc_pair, even after the fix. Covers both `CONNECTOR` and
-    `CONNECTOR_FILE_UPLOAD` origins."""
+    cc_pair, even after the fix. Covers every `FileOrigin` stamp the
+    connector file path has used historically."""
     admin_user: DATestUser = UserManager.create(name="priv_connector_admin")
     basic_user: DATestUser = UserManager.create(name="priv_connector_basic")
 

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -333,14 +333,12 @@ _CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
 
 def _seed_connector_file(
     *,
-    cc_pair_id: int,
     document_id: str,
 ) -> str:
     """Save bytes to the file store as `FileOrigin.CONNECTOR` and point the
     ingested `Document.file_id` at the returned storage id. The cc_pair
     already links the document via the ingestion API, so the ACL resolution
     path used by `user_can_access_chat_file` will find it."""
-    _ = cc_pair_id  # cc_pair linkage is established by DocumentManager
     file_store = get_default_file_store()
     storage_id = file_store.save_file(
         content=io.BytesIO(_CONNECTOR_FILE_BYTES),
@@ -381,7 +379,6 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
         api_key=api_key,
     )
     storage_id = _seed_connector_file(
-        cc_pair_id=public_cc_pair.id,
         document_id=document.id,
     )
 
@@ -418,7 +415,6 @@ def test_connector_file_denied_for_users_without_access(
         api_key=api_key,
     )
     storage_id = _seed_connector_file(
-        cc_pair_id=private_cc_pair.id,
         document_id=document.id,
     )
 

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -19,6 +19,7 @@ import pytest
 import requests
 
 from onyx.configs.constants import FileOrigin
+from onyx.connectors.models import InputType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ChatSessionSharedStatus
@@ -37,6 +38,7 @@ from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestChatSession
 from tests.integration.common_utils.test_models import DATestPersona
 from tests.integration.common_utils.test_models import DATestUser
@@ -449,6 +451,152 @@ def test_connector_file_denied_for_users_without_access(
     )
     assert basic_response.status_code in (403, 404), (
         f"Non-member should be denied on PRIVATE connector file "
+        f"(origin={file_origin}), got {basic_response.status_code}: "
+        f"{basic_response.text}"
+    )
+    assert basic_response.content != _CONNECTOR_FILE_BYTES
+
+
+# -----------------------------------------------------------------------------
+# Non-tabular File-connector upload access checks
+#
+# The File connector only stamps `Document.file_id` for tabular files
+# (`backend/onyx/connectors/file/connector.py:190`). Non-tabular uploads
+# (txt/pdf/docx/etc.) leave `Document.file_id=NULL`, so the `Document.file_id`
+# lookup path alone is not enough — users clicking a citation on a .txt file
+# would previously see "Failed to load document." even for publicly-indexed
+# connector files.
+#
+# The access check falls back to matching the file_id against
+# `Connector.connector_specific_config['file_locations']`, which the File
+# connector populates for every uploaded file regardless of extension. These
+# tests pin that fallback across both current (`CONNECTOR_FILE_UPLOAD`) and
+# legacy pre-#10484 (`OTHER`) origin stamps.
+# -----------------------------------------------------------------------------
+
+
+# `CONNECTOR` isn't included here because pipeline-promoted files already get
+# `Document.file_id` stamped, so they never hit the connector-config fallback.
+_NON_TABULAR_FILE_ORIGINS = [
+    FileOrigin.CONNECTOR_FILE_UPLOAD,
+    FileOrigin.OTHER,
+]
+
+
+def _seed_non_tabular_file_connector_cc_pair(
+    *,
+    admin_user: DATestUser,
+    file_id: str,
+    access_type: AccessType,
+    groups: list[int] | None = None,
+) -> DATestCCPair:
+    """Build a File-source cc_pair whose `connector_specific_config` points at
+    `file_id` WITHOUT linking any `Document.file_id` to it — mirroring what
+    happens in prod when a user uploads a non-tabular file through the File
+    connector UI."""
+    return CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "file_locations": [file_id],
+            "file_names": ["non_tabular.txt"],
+            "zip_metadata_file_id": None,
+        },
+        access_type=access_type,
+        groups=groups,
+    )
+
+
+def _save_non_tabular_file_bytes(file_id: str, file_origin: FileOrigin) -> None:
+    """Write bytes into the file store under the *exact* `file_id` referenced
+    by `Connector.connector_specific_config['file_locations']`. We cannot reuse
+    `_seed_connector_file` because that helper also stamps `Document.file_id`,
+    which would bypass the fallback path we're trying to exercise."""
+    file_store = get_default_file_store()
+    file_store.save_file(
+        content=io.BytesIO(_CONNECTOR_FILE_BYTES),
+        display_name="non_tabular.txt",
+        file_origin=file_origin,
+        file_type="text/plain",
+        file_id=file_id,
+    )
+
+
+@pytest.mark.parametrize("file_origin", _NON_TABULAR_FILE_ORIGINS)
+def test_non_tabular_connector_file_is_accessible_via_chat_file_endpoint(
+    reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
+) -> None:
+    """Non-tabular File connector uploads (txt/pdf/docx/etc.) have no
+    `Document.file_id` link, so the original fix for #10472 left them
+    unreachable via `/chat/file/{file_id}`. The fallback keyed off
+    `Connector.connector_specific_config['file_locations']` is what lets
+    `PreviewModal` render these files again."""
+    admin_user: DATestUser = UserManager.create(name="non_tabular_admin")
+    basic_user: DATestUser = UserManager.create(name="non_tabular_basic")
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+
+    file_id = str(uuid4())
+    public_cc_pair = _seed_non_tabular_file_connector_cc_pair(
+        admin_user=admin_user,
+        file_id=file_id,
+        access_type=AccessType.PUBLIC,
+    )
+
+    # Ingest a document against this cc_pair but do NOT set its `file_id` —
+    # that's what makes this the "non-tabular" case.
+    DocumentManager.seed_doc_with_content(
+        cc_pair=public_cc_pair,
+        content="non-tabular body text",
+        api_key=api_key,
+    )
+    _save_non_tabular_file_bytes(file_id, file_origin)
+
+    for user in (admin_user, basic_user):
+        response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=user.headers,
+        )
+        assert response.status_code == 200, (
+            f"User {user.email} must access a PUBLIC File-connector non-tabular "
+            f"file (origin={file_origin}), got {response.status_code}: "
+            f"{response.text}"
+        )
+        assert response.content == _CONNECTOR_FILE_BYTES
+
+
+@pytest.mark.parametrize("file_origin", _NON_TABULAR_FILE_ORIGINS)
+def test_non_tabular_connector_file_denied_for_users_without_access(
+    reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
+) -> None:
+    """Flip side of the fallback: a non-tabular File-connector upload owned by
+    a PRIVATE cc_pair must stay gated for users with no ACL overlap, even
+    though the connector-config fallback finds the file."""
+    admin_user: DATestUser = UserManager.create(name="non_tabular_priv_admin")
+    basic_user: DATestUser = UserManager.create(name="non_tabular_priv_basic")
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+
+    file_id = str(uuid4())
+    private_cc_pair = _seed_non_tabular_file_connector_cc_pair(
+        admin_user=admin_user,
+        file_id=file_id,
+        access_type=AccessType.PRIVATE,
+    )
+    DocumentManager.seed_doc_with_content(
+        cc_pair=private_cc_pair,
+        content="non-tabular private content",
+        api_key=api_key,
+    )
+    _save_non_tabular_file_bytes(file_id, file_origin)
+
+    basic_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{file_id}",
+        headers=basic_user.headers,
+    )
+    assert basic_response.status_code in (403, 404), (
+        f"Non-member should be denied on PRIVATE non-tabular connector file "
         f"(origin={file_origin}), got {basic_response.status_code}: "
         f"{basic_response.text}"
     )

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -5,6 +5,9 @@ This file tests user file permissions in different scenarios:
 3. Image-generation tool outputs - files persisted on `ToolCall.generated_images`
    must be downloadable by the chat session owner (and by anyone if the session
    is publicly shared), but not by other users on private sessions.
+4. Connector-ingested files - files stored with `FileOrigin.CONNECTOR` must be
+   fetchable via `GET /chat/file/{file_id}` by any user whose ACL covers at
+   least one `Document` that references the file, and must be denied otherwise.
 """
 
 import io
@@ -17,13 +20,19 @@ import requests
 
 from onyx.configs.constants import FileOrigin
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
 from onyx.db.enums import ChatSessionSharedStatus
 from onyx.db.models import ChatSession
+from onyx.db.models import Document
 from onyx.db.models import ToolCall
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import FileDescriptor
+from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.api_key import APIKeyManager
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
+from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.persona import PersonaManager
@@ -301,3 +310,124 @@ def test_non_owner_can_download_image_gen_file_in_public_session(
         f"got {response.status_code}: {response.text}"
     )
     assert response.content == _IMAGE_GEN_PNG_BYTES
+
+
+# -----------------------------------------------------------------------------
+# Connector-ingested file access checks
+#
+# Files ingested by connectors (e.g. the File connector) are saved to the file
+# store with `FileOrigin.CONNECTOR` and referenced from the corresponding
+# `Document.file_id`. The `PreviewModal` in the frontend downloads these via
+# `GET /chat/file/{file_id}` when no external `.link` is available.
+#
+# The chat-file hardening in PR #10380 omitted this branch, causing a
+# "Failed to load document." regression (tracked in issue #10472). These tests
+# pin the fix: connector files must be readable by any user whose ACL covers
+# at least one Document that references the file, and must stay gated for
+# users whose ACL does not.
+# -----------------------------------------------------------------------------
+
+
+_CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
+
+
+def _seed_connector_file(
+    *,
+    cc_pair_id: int,
+    document_id: str,
+) -> str:
+    """Save bytes to the file store as `FileOrigin.CONNECTOR` and point the
+    ingested `Document.file_id` at the returned storage id. The cc_pair
+    already links the document via the ingestion API, so the ACL resolution
+    path used by `user_can_access_chat_file` will find it."""
+    _ = cc_pair_id  # cc_pair linkage is established by DocumentManager
+    file_store = get_default_file_store()
+    storage_id = file_store.save_file(
+        content=io.BytesIO(_CONNECTOR_FILE_BYTES),
+        display_name="connector_doc.txt",
+        file_origin=FileOrigin.CONNECTOR,
+        file_type="text/plain",
+    )
+    with get_session_with_current_tenant() as db_session:
+        document = db_session.get(Document, document_id)
+        assert document is not None, f"Seeded document {document_id} not found"
+        document.file_id = storage_id
+        db_session.commit()
+    return storage_id
+
+
+def test_connector_file_is_accessible_via_chat_file_endpoint(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Regression test for issue #10472.
+
+    A file ingested by a connector (e.g. the File connector) is served from
+    the file store with `FileOrigin.CONNECTOR`. When its owning cc_pair is
+    PUBLIC, any authenticated user must be able to fetch it via
+    `GET /chat/file/{file_id}` — previously this returned 404, breaking
+    `PreviewModal` with "Failed to load document."."""
+    admin_user: DATestUser = UserManager.create(name="connector_admin")
+    basic_user: DATestUser = UserManager.create(name="connector_basic")
+
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    public_cc_pair = CCPairManager.create_from_scratch(
+        access_type=AccessType.PUBLIC,
+        source=DocumentSource.INGESTION_API,
+        user_performing_action=admin_user,
+    )
+    document = DocumentManager.seed_doc_with_content(
+        cc_pair=public_cc_pair,
+        content="hello from connector",
+        api_key=api_key,
+    )
+    storage_id = _seed_connector_file(
+        cc_pair_id=public_cc_pair.id,
+        document_id=document.id,
+    )
+
+    for user in (admin_user, basic_user):
+        response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{storage_id}",
+            headers=user.headers,
+        )
+        assert response.status_code == 200, (
+            f"User {user.email} must be able to fetch a PUBLIC connector file, "
+            f"got {response.status_code}: {response.text}"
+        )
+        assert response.content == _CONNECTOR_FILE_BYTES
+
+
+def test_connector_file_denied_for_users_without_access(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Flip side of the regression fix: a connector file backed by a PRIVATE
+    cc_pair must NOT be readable by users who have no ACL overlap with the
+    cc_pair, even after the fix."""
+    admin_user: DATestUser = UserManager.create(name="priv_connector_admin")
+    basic_user: DATestUser = UserManager.create(name="priv_connector_basic")
+
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    private_cc_pair = CCPairManager.create_from_scratch(
+        access_type=AccessType.PRIVATE,
+        source=DocumentSource.INGESTION_API,
+        user_performing_action=admin_user,
+    )
+    document = DocumentManager.seed_doc_with_content(
+        cc_pair=private_cc_pair,
+        content="private connector content",
+        api_key=api_key,
+    )
+    storage_id = _seed_connector_file(
+        cc_pair_id=private_cc_pair.id,
+        document_id=document.id,
+    )
+
+    basic_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{storage_id}",
+        headers=basic_user.headers,
+    )
+    assert basic_response.status_code in (403, 404), (
+        f"Non-member should be denied on PRIVATE connector file, got "
+        f"{basic_response.status_code}: {basic_response.text}"
+    )
+    assert basic_response.content != _CONNECTOR_FILE_BYTES


### PR DESCRIPTION
## Summary

- PR #10380 hardened `GET /chat/file/{file_id}` but `user_can_access_chat_file` never whitelisted `FileOrigin.CONNECTOR`, so `PreviewModal` lookups for documents ingested by the File (and similar) connectors regressed to "Failed to load document." (404).
- This fix grants access when the requesting user's ACL overlaps the ACL of at least one `Document` that references the file, keeping preview access consistent with retrieval-side access control.
- `user_can_access_chat_file` now takes the `User` object (rather than just `user_id`) so the standard ACL helpers can be applied.

## Test plan

- [x] New integration test in `backend/tests/integration/tests/permissions/test_user_file_permissions.py`:
  - `test_connector_file_is_accessible_via_chat_file_endpoint` — admin + basic user can fetch a `FileOrigin.CONNECTOR` file backed by a PUBLIC cc_pair.
  - `test_connector_file_denied_for_users_without_access` — a non-member is still denied when the cc_pair is PRIVATE.
- [x] Manual: index a file via the File connector, run a query that cites it, and confirm the citation `PreviewModal` renders the document instead of the error message.

Closes #10472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore connector file previews via GET `/chat/file` by granting access when a user’s ACL overlaps any `Document` that references the file, with a fallback for non‑tabular File‑connector uploads listed in `Connector.connector_specific_config['file_locations']`. Fixes PreviewModal 404s and keeps previews consistent with retrieval (closes #10472).

- **Bug Fixes**
  - Grant access via `Document.file_id` ACL overlap, with fallback to `connector_specific_config['file_locations']` when `Document.file_id` is NULL; covers `FileOrigin.CONNECTOR`, `FileOrigin.CONNECTOR_FILE_UPLOAD`, and legacy `FileOrigin.OTHER`.
  - Update `user_can_access_chat_file` to accept a `User` and use standard ACL helpers; pass `user` from `fetch_chat_file`.
  - Add integration tests for PUBLIC allow and PRIVATE deny across connector origins, including non‑tabular File‑connector uploads.

- **Refactors**
  - Move `user_can_access_chat_file` to `onyx.access.access` and remove the DB-layer version; update `chat_backend` to import from `onyx.access.access`.

<sup>Written for commit 06ff6b58f0b71a7fc3ce95758ab582e9e160f8d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



