### PR TITLE
refactor: chat input bar to contentEditable for rich content

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10545,7 +10545,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10545,6 +10545,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -168,6 +168,7 @@ const InputBar = memo(
       const {
         ref: inputRef,
         message,
+        isEmpty,
         setContent,
         clearContent,
         handleInput: onInput,
@@ -351,6 +352,7 @@ const InputBar = memo(
                 aria-label={placeholder}
                 aria-multiline={true}
                 data-placeholder={placeholder}
+                data-empty={isEmpty ? "" : undefined}
               />
             </div>
 

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -229,7 +229,7 @@ const InputBar = memo(
           if (!text) return;
           insertTextAtCursor(text);
         },
-        [uploadFiles, insertTextAtCursor]
+        [disabled, uploadFiles, insertTextAtCursor]
       );
 
       const handleSubmit = useCallback(() => {
@@ -344,9 +344,10 @@ const InputBar = memo(
                   scrollbarColor: "var(--border-02) transparent",
                 }}
                 role="textbox"
-                aria-label={placeholder}
+                aria-label="Message input"
                 aria-multiline={true}
                 aria-disabled={disabled}
+                aria-placeholder={placeholder}
                 data-placeholder={placeholder}
                 data-empty={!message ? "" : undefined}
               />

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -3,11 +3,10 @@
 import {
   memo,
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useCallback,
-  useEffect,
   useRef,
-  useState,
   type ChangeEvent,
   type ClipboardEvent,
   type KeyboardEvent,
@@ -39,8 +38,7 @@ import {
   SvgOrganization,
   SvgAlertCircle,
 } from "@opal/icons";
-
-const MAX_INPUT_HEIGHT = 200;
+import { useContentEditable } from "@/hooks/useContentEditable";
 
 export interface InputBarHandle {
   reset: () => void;
@@ -166,9 +164,25 @@ const InputBar = memo(
     ) => {
       const router = useRouter();
       const demoDataEnabled = useDemoDataEnabled();
-      const [message, setMessage] = useState("");
+      const inputWrapperRef = useRef<HTMLDivElement>(null);
+      const {
+        ref: inputRef,
+        message,
+        setContent,
+        clearContent,
+        handleInput: onInput,
+        handleCompositionStart,
+        handleCompositionEnd,
+        insertTextAtCursor,
+        setCursorToEnd,
+      } = useContentEditable({
+        wrapperRef: inputWrapperRef,
+      });
 
-      const textAreaRef = useRef<HTMLTextAreaElement>(null);
+      useEffect(() => {
+        inputRef.current?.focus();
+      }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
       const containerRef = useRef<HTMLDivElement>(null);
       const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -180,44 +194,19 @@ const InputBar = memo(
         hasUploadingFiles,
       } = useUploadFilesContext();
 
-      // Expose reset, focus, and setMessage methods to parent via ref
       useImperativeHandle(ref, () => ({
         reset: () => {
-          setMessage("");
+          clearContent();
           clearFiles();
         },
         focus: () => {
-          textAreaRef.current?.focus();
+          inputRef.current?.focus();
+          setCursorToEnd();
         },
         setMessage: (msg: string) => {
-          setMessage(msg);
-          // Move cursor to end after setting message
-          setTimeout(() => {
-            const textarea = textAreaRef.current;
-            if (textarea) {
-              textarea.focus();
-              textarea.setSelectionRange(msg.length, msg.length);
-            }
-          }, 0);
+          setContent(msg);
         },
       }));
-
-      // Auto-resize textarea based on content
-      useEffect(() => {
-        const textarea = textAreaRef.current;
-        if (textarea) {
-          textarea.style.height = "0px";
-          textarea.style.height = `${Math.min(
-            textarea.scrollHeight,
-            MAX_INPUT_HEIGHT
-          )}px`;
-        }
-      }, [message]);
-
-      // Auto-focus on mount
-      useEffect(() => {
-        textAreaRef.current?.focus();
-      }, []);
 
       const handleFileSelect = useCallback(
         async (e: ChangeEvent<HTMLInputElement>) => {
@@ -235,18 +224,16 @@ const InputBar = memo(
           const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
           if (pastedFiles.length > 0) {
             event.preventDefault();
-            // Context handles session binding internally
             uploadFiles(pastedFiles);
+            return;
           }
-        },
-        [uploadFiles]
-      );
 
-      const handleInputChange = useCallback(
-        (event: ChangeEvent<HTMLTextAreaElement>) => {
-          setMessage(event.target.value);
+          event.preventDefault();
+          const text = event.clipboardData.getData("text/plain");
+          if (!text) return;
+          insertTextAtCursor(text);
         },
-        []
+        [uploadFiles, insertTextAtCursor]
       );
 
       const handleSubmit = useCallback(() => {
@@ -258,11 +245,9 @@ const InputBar = memo(
 
         if (hasMessage) {
           onSubmit(message.trim(), currentMessageFiles, demoDataEnabled);
-          setMessage("");
+          clearContent();
           clearFiles({ suppressRefetch: true });
         } else if (hasFiles) {
-          // User hit Enter with only files attached: remove files from input bar
-          // (File stays in session; no way to delete from session for now)
           clearFiles({ suppressRefetch: true });
         }
       }, [
@@ -275,10 +260,12 @@ const InputBar = memo(
         currentMessageFiles,
         clearFiles,
         demoDataEnabled,
+        clearContent,
       ]);
 
       const handleKeyDown = useCallback(
-        (event: KeyboardEvent<HTMLTextAreaElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
+          // Shift+Enter falls through to browser default: inserts <br>
           if (
             event.key === "Enter" &&
             !event.shiftKey &&
@@ -331,34 +318,41 @@ const InputBar = memo(
             )}
 
             {/* Input area */}
-            <textarea
-              onPaste={handlePaste}
-              onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
-              ref={textAreaRef}
-              className={cn(
-                "w-full",
-                "h-[44px]",
-                "outline-none",
-                "bg-transparent",
-                "resize-none",
-                "placeholder:text-text-03",
-                "whitespace-pre-wrap",
-                "break-word",
-                "overscroll-contain",
-                "overflow-y-auto",
-                "px-3",
-                "pb-2",
-                "pt-3"
-              )}
-              autoFocus
-              style={{ scrollbarWidth: "thin" }}
-              role="textarea"
-              aria-multiline
-              placeholder={placeholder}
-              value={message}
-              disabled={disabled}
-            />
+            <div ref={inputWrapperRef} className="flex-1 overflow-hidden">
+              <div
+                ref={inputRef}
+                contentEditable={!disabled}
+                suppressContentEditableWarning
+                onPaste={handlePaste}
+                onInput={onInput}
+                onCompositionStart={handleCompositionStart}
+                onCompositionEnd={handleCompositionEnd}
+                onKeyDown={handleKeyDown}
+                className={cn(
+                  "w-full",
+                  "h-full",
+                  "min-h-[44px]",
+                  "outline-none",
+                  "bg-transparent",
+                  "whitespace-pre-wrap",
+                  "break-words",
+                  "overscroll-contain",
+                  "overflow-y-auto",
+                  "px-3",
+                  "pb-2",
+                  "pt-3"
+                )}
+                tabIndex={0}
+                style={{
+                  scrollbarWidth: "thin",
+                  scrollbarColor: "var(--border-02) transparent",
+                }}
+                role="textbox"
+                aria-label={placeholder}
+                aria-multiline={true}
+                data-placeholder={placeholder}
+              />
+            </div>
 
             {/* Bottom controls */}
             <div className="flex justify-between items-center w-full p-1 min-h-[40px]">

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -3,7 +3,6 @@
 import {
   memo,
   forwardRef,
-  useEffect,
   useImperativeHandle,
   useCallback,
   useRef,
@@ -180,10 +179,6 @@ const InputBar = memo(
         wrapperRef: inputWrapperRef,
       });
 
-      useEffect(() => {
-        inputRef.current?.focus();
-      }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
       const containerRef = useRef<HTMLDivElement>(null);
       const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -222,6 +217,7 @@ const InputBar = memo(
 
       const handlePaste = useCallback(
         (event: ClipboardEvent) => {
+          if (disabled) return;
           const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
           if (pastedFiles.length > 0) {
             event.preventDefault();
@@ -351,6 +347,7 @@ const InputBar = memo(
                 role="textbox"
                 aria-label={placeholder}
                 aria-multiline={true}
+                aria-disabled={disabled}
                 data-placeholder={placeholder}
                 data-empty={isEmpty ? "" : undefined}
               />

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -167,9 +167,8 @@ const InputBar = memo(
       const {
         ref: inputRef,
         message,
-        isEmpty,
-        setContent,
-        clearContent,
+        setMessage,
+        clearMessage,
         handleInput: onInput,
         handleCompositionStart,
         handleCompositionEnd,
@@ -192,7 +191,7 @@ const InputBar = memo(
 
       useImperativeHandle(ref, () => ({
         reset: () => {
-          clearContent();
+          clearMessage();
           clearFiles();
         },
         focus: () => {
@@ -200,7 +199,7 @@ const InputBar = memo(
           setCursorToEnd();
         },
         setMessage: (msg: string) => {
-          setContent(msg);
+          setMessage(msg);
         },
       }));
 
@@ -242,7 +241,7 @@ const InputBar = memo(
 
         if (hasMessage) {
           onSubmit(message.trim(), currentMessageFiles, demoDataEnabled);
-          clearContent();
+          clearMessage();
           clearFiles({ suppressRefetch: true });
         } else if (hasFiles) {
           clearFiles({ suppressRefetch: true });
@@ -257,7 +256,7 @@ const InputBar = memo(
         currentMessageFiles,
         clearFiles,
         demoDataEnabled,
-        clearContent,
+        clearMessage,
       ]);
 
       const handleKeyDown = useCallback(
@@ -349,7 +348,7 @@ const InputBar = memo(
                 aria-multiline={true}
                 aria-disabled={disabled}
                 data-placeholder={placeholder}
-                data-empty={isEmpty ? "" : undefined}
+                data-empty={!message ? "" : undefined}
               />
             </div>
 

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -343,7 +343,7 @@ const InputBar = memo(
                   "pb-2",
                   "pt-3"
                 )}
-                tabIndex={0}
+                tabIndex={disabled ? -1 : 0}
                 style={{
                   scrollbarWidth: "thin",
                   scrollbarColor: "var(--border-02) transparent",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -483,3 +483,14 @@ textarea {
 .container {
   margin-bottom: 1rem;
 }
+
+/* contentEditable placeholder */
+[data-placeholder][data-empty] {
+  position: relative;
+}
+[data-placeholder][data-empty]::before {
+  content: attr(data-placeholder);
+  color: var(--text-03);
+  pointer-events: none;
+  position: absolute;
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -493,4 +493,7 @@ textarea {
   color: var(--text-03);
   pointer-events: none;
   position: absolute;
+  top: 0;
+  left: 0;
+  padding: inherit;
 }

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -110,6 +110,9 @@ export function useContentEditable({
 
   const handleCompositionStart = useCallback(() => {
     isComposingRef.current = true;
+    if (ref.current) {
+      ref.current.removeAttribute("data-empty");
+    }
   }, []);
 
   const handleCompositionEnd = useCallback(() => {

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  setCursorToEnd as setCursorToEndUtil,
+  insertTextAtCursor as insertTextAtCursorUtil,
+  getTextContent,
+} from "@/lib/contentEditable";
+
+export interface UseContentEditableOptions {
+  initialContent?: string;
+  wrapperRef: React.RefObject<HTMLDivElement | null>;
+  minHeight?: number;
+  maxHeight?: number;
+  onContentChange?: (text: string) => void;
+}
+
+export interface UseContentEditableReturn {
+  ref: React.RefObject<HTMLDivElement | null>;
+  message: string;
+  isEmpty: boolean;
+  setContent: (text: string) => void;
+  clearContent: () => void;
+  handleInput: (event: React.FormEvent<HTMLDivElement>) => void;
+  handleCompositionStart: () => void;
+  handleCompositionEnd: () => void;
+  insertTextAtCursor: (text: string) => void;
+  setCursorToEnd: () => void;
+  resize: () => void;
+}
+
+export function useContentEditable({
+  initialContent = "",
+  wrapperRef,
+  minHeight = 44,
+  maxHeight = 200,
+  onContentChange,
+}: UseContentEditableOptions): UseContentEditableReturn {
+  const ref = useRef<HTMLDivElement>(null);
+  const [message, setMessage] = useState(initialContent);
+  const isEmpty = useMemo(() => !message, [message]);
+  const isComposingRef = useRef(false);
+  const onContentChangeRef = useRef(onContentChange);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onContentChangeRef.current = onContentChange;
+  }, [onContentChange]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const resize = useCallback(() => {
+    const wrapper = wrapperRef.current;
+    const div = ref.current;
+    if (!wrapper || !div) return;
+
+    wrapper.style.height = `${minHeight}px`;
+    const clamped = Math.min(Math.max(div.scrollHeight, minHeight), maxHeight);
+    wrapper.style.height = `${clamped}px`;
+  }, [wrapperRef, minHeight, maxHeight]);
+
+  const updateEmpty = useCallback((el: HTMLElement, text: string) => {
+    if (text) {
+      el.removeAttribute("data-empty");
+    } else {
+      el.setAttribute("data-empty", "");
+    }
+  }, []);
+
+  const syncFromDOM = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // Clean up stale <br> that browsers leave in empty contentEditable divs.
+    // Only when not composing and when the only content is non-text nodes (e.g. <br>).
+    if (!isComposingRef.current && !el.textContent && el.innerHTML) {
+      el.innerHTML = "";
+    }
+
+    const text = getTextContent(el);
+    setMessage(text);
+    updateEmpty(el, text);
+    onContentChangeRef.current?.(text);
+  }, [updateEmpty]);
+
+  const handleInput = useCallback(
+    (_event: React.FormEvent<HTMLDivElement>) => {
+      if (isComposingRef.current) return;
+      syncFromDOM();
+      resize();
+    },
+    [syncFromDOM, resize]
+  );
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+    syncFromDOM();
+    resize();
+  }, [syncFromDOM, resize]);
+
+  const setContent = useCallback(
+    (text: string) => {
+      if (!ref.current) return;
+
+      ref.current.textContent = text;
+      setMessage(text);
+      updateEmpty(ref.current, text);
+      resize();
+      onContentChangeRef.current?.(text);
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        if (ref.current) {
+          setCursorToEndUtil(ref.current);
+        }
+      });
+    },
+    [resize, updateEmpty]
+  );
+
+  const clearContent = useCallback(() => {
+    if (!ref.current) return;
+
+    ref.current.innerHTML = "";
+    setMessage("");
+    updateEmpty(ref.current, "");
+    resize();
+    onContentChangeRef.current?.("");
+  }, [resize, updateEmpty]);
+
+  const insertTextAtCursor = useCallback(
+    (text: string) => {
+      if (!ref.current) return;
+      insertTextAtCursorUtil(ref.current, text);
+      syncFromDOM();
+      resize();
+    },
+    [syncFromDOM, resize]
+  );
+
+  const setCursorToEnd = useCallback(() => {
+    if (!ref.current) return;
+    setCursorToEndUtil(ref.current);
+  }, []);
+
+  return {
+    ref,
+    message,
+    isEmpty,
+    setContent,
+    clearContent,
+    handleInput,
+    handleCompositionStart,
+    handleCompositionEnd,
+    insertTextAtCursor,
+    setCursorToEnd,
+    resize,
+  };
+}

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   setCursorToEnd as setCursorToEndUtil,
   insertTextAtCursor as insertTextAtCursorUtil,
@@ -11,6 +11,7 @@ export interface UseContentEditableOptions {
   minHeight?: number;
   maxHeight?: number;
   onContentChange?: (text: string) => void;
+  disabled?: boolean;
 }
 
 export interface UseContentEditableReturn {
@@ -33,10 +34,11 @@ export function useContentEditable({
   minHeight = 44,
   maxHeight = 200,
   onContentChange,
+  disabled = false,
 }: UseContentEditableOptions): UseContentEditableReturn {
   const ref = useRef<HTMLDivElement>(null);
   const [message, setMessage] = useState(initialContent);
-  const isEmpty = useMemo(() => !message, [message]);
+  const isEmpty = !message;
   const isComposingRef = useRef(false);
   const onContentChangeRef = useRef(onContentChange);
   const rafRef = useRef<number | null>(null);
@@ -53,6 +55,11 @@ export function useContentEditable({
         parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
     }
   }, [wrapperRef]);
+
+  useEffect(() => {
+    if (disabled) return;
+    ref.current?.focus();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return () => {

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -17,10 +17,9 @@ export interface UseContentEditableOptions {
 export interface UseContentEditableReturn {
   ref: React.RefObject<HTMLDivElement | null>;
   message: string;
-  isEmpty: boolean;
-  setContent: (text: string) => void;
-  clearContent: () => void;
-  handleInput: (event: React.FormEvent<HTMLDivElement>) => void;
+  setMessage: (text: string) => void;
+  clearMessage: () => void;
+  handleInput: (event: React.SyntheticEvent<HTMLDivElement>) => string;
   handleCompositionStart: () => void;
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
@@ -37,8 +36,7 @@ export function useContentEditable({
   disabled = false,
 }: UseContentEditableOptions): UseContentEditableReturn {
   const ref = useRef<HTMLDivElement>(null);
-  const [message, setMessage] = useState(initialContent);
-  const isEmpty = !message;
+  const [message, setMessageState] = useState(initialContent);
   const isComposingRef = useRef(false);
   const onContentChangeRef = useRef(onContentChange);
   const rafRef = useRef<number | null>(null);
@@ -82,17 +80,9 @@ export function useContentEditable({
     wrapper.style.height = `${clamped}px`;
   }, [wrapperRef, minHeight, maxHeight]);
 
-  const updateEmpty = useCallback((el: HTMLElement, text: string) => {
-    if (text) {
-      el.removeAttribute("data-empty");
-    } else {
-      el.setAttribute("data-empty", "");
-    }
-  }, []);
-
-  const syncFromDOM = useCallback(() => {
+  const syncFromDOM = useCallback((): string => {
     const el = ref.current;
-    if (!el) return;
+    if (!el) return "";
 
     // Clean up stale <br> that browsers leave in empty contentEditable divs.
     // Only when not composing and when the only content is non-text nodes (e.g. <br>).
@@ -101,18 +91,19 @@ export function useContentEditable({
     }
 
     const text = getTextContent(el);
-    setMessage(text);
-    updateEmpty(el, text);
+    setMessageState(text);
     onContentChangeRef.current?.(text);
-  }, [updateEmpty]);
+    return text;
+  }, []);
 
   const handleInput = useCallback(
-    (_event: React.FormEvent<HTMLDivElement>) => {
-      if (isComposingRef.current) return;
-      syncFromDOM();
+    (_event: React.SyntheticEvent<HTMLDivElement>): string => {
+      if (isComposingRef.current) return message;
+      const text = syncFromDOM();
       resize();
+      return text;
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, message]
   );
 
   const handleCompositionStart = useCallback(() => {
@@ -128,13 +119,12 @@ export function useContentEditable({
     resize();
   }, [syncFromDOM, resize]);
 
-  const setContent = useCallback(
+  const setMessage = useCallback(
     (text: string) => {
       if (!ref.current) return;
 
       ref.current.textContent = text;
-      setMessage(text);
-      updateEmpty(ref.current, text);
+      setMessageState(text);
       resize();
       onContentChangeRef.current?.(text);
 
@@ -149,18 +139,17 @@ export function useContentEditable({
         }
       });
     },
-    [resize, updateEmpty]
+    [resize]
   );
 
-  const clearContent = useCallback(() => {
+  const clearMessage = useCallback(() => {
     if (!ref.current) return;
 
     ref.current.innerHTML = "";
-    setMessage("");
-    updateEmpty(ref.current, "");
+    setMessageState("");
     resize();
     onContentChangeRef.current?.("");
-  }, [resize, updateEmpty]);
+  }, [resize]);
 
   const insertTextAtCursor = useCallback(
     (text: string) => {
@@ -180,9 +169,8 @@ export function useContentEditable({
   return {
     ref,
     message,
-    isEmpty,
-    setContent,
-    clearContent,
+    setMessage,
+    clearMessage,
     handleInput,
     handleCompositionStart,
     handleCompositionEnd,

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -37,6 +37,7 @@ export function useContentEditable({
 }: UseContentEditableOptions): UseContentEditableReturn {
   const ref = useRef<HTMLDivElement>(null);
   const [message, setMessageState] = useState(initialContent);
+  const messageRef = useRef(initialContent);
   const isComposingRef = useRef(false);
   const onContentChangeRef = useRef(onContentChange);
   const rafRef = useRef<number | null>(null);
@@ -91,6 +92,7 @@ export function useContentEditable({
     }
 
     const text = getTextContent(el);
+    messageRef.current = text;
     setMessageState(text);
     onContentChangeRef.current?.(text);
     return text;
@@ -98,12 +100,12 @@ export function useContentEditable({
 
   const handleInput = useCallback(
     (_event: React.SyntheticEvent<HTMLDivElement>): string => {
-      if (isComposingRef.current) return message;
+      if (isComposingRef.current) return messageRef.current;
       const text = syncFromDOM();
       resize();
       return text;
     },
-    [syncFromDOM, resize, message]
+    [syncFromDOM, resize]
   );
 
   const handleCompositionStart = useCallback(() => {
@@ -119,14 +121,22 @@ export function useContentEditable({
     resize();
   }, [syncFromDOM, resize]);
 
+  const disabledRef = useRef(disabled);
+  useEffect(() => {
+    disabledRef.current = disabled;
+  }, [disabled]);
+
   const setMessage = useCallback(
     (text: string) => {
       if (!ref.current) return;
 
       ref.current.textContent = text;
+      messageRef.current = text;
       setMessageState(text);
       resize();
       onContentChangeRef.current?.(text);
+
+      if (disabledRef.current) return;
 
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
@@ -146,6 +156,7 @@ export function useContentEditable({
     if (!ref.current) return;
 
     ref.current.innerHTML = "";
+    messageRef.current = "";
     setMessageState("");
     resize();
     onContentChangeRef.current?.("");

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -137,6 +137,7 @@ export function useContentEditable({
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null;
         if (ref.current) {
+          ref.current.focus();
           setCursorToEndUtil(ref.current);
         }
       });

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -40,10 +40,19 @@ export function useContentEditable({
   const isComposingRef = useRef(false);
   const onContentChangeRef = useRef(onContentChange);
   const rafRef = useRef<number | null>(null);
+  const wrapperPaddingYRef = useRef(0);
 
   useEffect(() => {
     onContentChangeRef.current = onContentChange;
   }, [onContentChange]);
+
+  useEffect(() => {
+    if (wrapperRef.current) {
+      const cs = getComputedStyle(wrapperRef.current);
+      wrapperPaddingYRef.current =
+        parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+    }
+  }, [wrapperRef]);
 
   useEffect(() => {
     return () => {
@@ -59,7 +68,10 @@ export function useContentEditable({
     if (!wrapper || !div) return;
 
     wrapper.style.height = `${minHeight}px`;
-    const clamped = Math.min(Math.max(div.scrollHeight, minHeight), maxHeight);
+    const clamped = Math.min(
+      Math.max(div.scrollHeight + wrapperPaddingYRef.current, minHeight),
+      maxHeight
+    );
     wrapper.style.height = `${clamped}px`;
   }, [wrapperRef, minHeight, maxHeight]);
 

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -548,7 +548,7 @@ function Root({ children, enableBackground }: AppRootProps) {
       const activeEl = document.activeElement;
       const isFocused =
         activeEl instanceof HTMLElement &&
-        activeEl.id === "onyx-chat-input-textarea";
+        activeEl.id === "onyx-chat-input-textbox";
       const target = event.target;
       const isInteractive =
         target instanceof HTMLElement && !!target.closest(INTERACTIVE_SELECTOR);
@@ -562,7 +562,7 @@ function Root({ children, enableBackground }: AppRootProps) {
     inputWasFocused.current = false;
     const sel = window.getSelection();
     if (sel && !sel.isCollapsed) return;
-    const textarea = document.getElementById("onyx-chat-input-textarea");
+    const textarea = document.getElementById("onyx-chat-input-textbox");
     // Only restore focus if no other element has grabbed it since mousedown.
     if (textarea && document.activeElement !== textarea) {
       textarea.focus();

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -1,0 +1,71 @@
+/**
+ * Move cursor to end of a contentEditable element.
+ */
+export function setCursorToEnd(element: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+/**
+ * Insert a plain-text string at the current cursor position within a
+ * contentEditable element. If the element doesn't have focus or a valid
+ * selection, appends to the end. Returns the element's new text content.
+ */
+export function insertTextAtCursor(element: HTMLElement, text: string): string {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    element.appendChild(document.createTextNode(text));
+    setCursorToEnd(element);
+    element.normalize();
+    return getTextContent(element);
+  }
+
+  const range = selection.getRangeAt(0);
+
+  if (!element.contains(range.commonAncestorContainer)) {
+    element.appendChild(document.createTextNode(text));
+    setCursorToEnd(element);
+    element.normalize();
+    return getTextContent(element);
+  }
+
+  range.deleteContents();
+
+  const textNode = document.createTextNode(text);
+  range.insertNode(textNode);
+
+  range.setStartAfter(textNode);
+  range.setEndAfter(textNode);
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  element.normalize();
+  return getTextContent(element);
+}
+
+/**
+ * Read the plain-text content of a contentEditable element, converting
+ * <br> elements to newlines via DOM traversal (avoids innerText reflow).
+ */
+export function getTextContent(element: HTMLElement): string {
+  const parts: string[] = [];
+  const nodes = Array.from(element.childNodes);
+  for (const node of nodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      parts.push(node.textContent ?? "");
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const el = node as HTMLElement;
+      if (el.tagName === "BR") {
+        parts.push("\n");
+      } else {
+        parts.push(getTextContent(el));
+      }
+    }
+  }
+  return parts.join("");
+}

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -55,7 +55,8 @@ export function insertTextAtCursor(element: HTMLElement, text: string): string {
 export function getTextContent(element: HTMLElement): string {
   const parts: string[] = [];
   const nodes = Array.from(element.childNodes);
-  for (const node of nodes) {
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
     if (node.nodeType === Node.TEXT_NODE) {
       parts.push(node.textContent ?? "");
     } else if (node.nodeType === Node.ELEMENT_NODE) {
@@ -63,6 +64,11 @@ export function getTextContent(element: HTMLElement): string {
       if (el.tagName === "BR") {
         parts.push("\n");
       } else {
+        // Block elements (e.g. <div> from Chrome's Enter) get a leading newline
+        // unless they're the first child
+        if (i > 0) {
+          parts.push("\n");
+        }
         parts.push(getTextContent(el));
       }
     }

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -52,6 +52,19 @@ export function insertTextAtCursor(element: HTMLElement, text: string): string {
  * Read the plain-text content of a contentEditable element, converting
  * <br> elements to newlines via DOM traversal (avoids innerText reflow).
  */
+const BLOCK_TAGS = new Set([
+  "DIV",
+  "P",
+  "BLOCKQUOTE",
+  "LI",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+]);
+
 export function getTextContent(element: HTMLElement): string {
   const parts: string[] = [];
   const nodes = Array.from(element.childNodes);
@@ -64,9 +77,7 @@ export function getTextContent(element: HTMLElement): string {
       if (el.tagName === "BR") {
         parts.push("\n");
       } else {
-        // Block elements (e.g. <div> from Chrome's Enter) get a leading newline
-        // unless they're the first child
-        if (i > 0) {
+        if (i > 0 && BLOCK_TAGS.has(el.tagName)) {
           parts.push("\n");
         }
         parts.push(getTextContent(el));

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -147,6 +147,7 @@ const AppInputBar = React.memo(
     const {
       ref: inputRef,
       message,
+      isEmpty,
       setContent,
       clearContent,
       handleInput,
@@ -839,6 +840,7 @@ const AppInputBar = React.memo(
                                 ? "Search connected sources"
                                 : "How can I help you today?"
                       }
+                      data-empty={isEmpty ? "" : undefined}
                       onKeyDown={(event) => {
                         // Queue navigation mode
                         if (highlightedQueueIndex !== null) {

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -160,10 +160,6 @@ const AppInputBar = React.memo(
       wrapperRef: inputWrapperRef,
     });
 
-    useEffect(() => {
-      inputRef.current?.focus();
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
     const filesWrapperRef = useRef<HTMLDivElement>(null);
     const filesContentRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -350,6 +346,7 @@ const AppInputBar = React.memo(
     }, [showFiles, currentMessageFiles]);
 
     function handlePaste(event: React.ClipboardEvent) {
+      if (disabled) return;
       const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
       if (pastedFiles.length > 0) {
         event.preventDefault();
@@ -829,6 +826,7 @@ const AppInputBar = React.memo(
                         scrollbarColor: "var(--border-02) transparent",
                       }}
                       aria-multiline={true}
+                      aria-disabled={disabled}
                       data-placeholder={
                         queuedMessages.length > 0 && !message
                           ? "Press up to edit queued messages"

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -13,6 +13,7 @@ import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import { InputPrompt } from "@/app/app/interfaces";
 import { FilterManager, LlmManager, useFederatedConnectors } from "@/lib/hooks";
 import usePromptShortcuts from "@/hooks/usePromptShortcuts";
+import { useContentEditable } from "@/hooks/useContentEditable";
 import useFilter from "@/hooks/useFilter";
 import useCCPairs from "@/hooks/useCCPairs";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
@@ -65,9 +66,6 @@ import {
   useChatSessionStore,
 } from "@/app/app/stores/useChatSessionStore";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
-
-const MIN_INPUT_HEIGHT = 44;
-const MAX_INPUT_HEIGHT = 200;
 
 export interface AppInputBarHandle {
   reset: () => void;
@@ -125,8 +123,6 @@ const AppInputBar = React.memo(
     currentTabUrl,
     onToggleTabReading,
   }: AppInputBarProps) => {
-    // Internal message state - kept local to avoid parent re-renders on every keystroke
-    const [message, setMessage] = useState(initialMessage);
     const [isRecording, setIsRecording] = useState(false);
     const [recordingCycleCount, setRecordingCycleCount] = useState(0);
     const [isMuted, setIsMuted] = useState(false);
@@ -146,8 +142,26 @@ const AppInputBar = React.memo(
       number | null
     >(null);
     const isAutoSending = useRef(false);
-    const textAreaRef = useRef<HTMLTextAreaElement>(null);
-    const textAreaWrapperRef = useRef<HTMLDivElement>(null);
+    const inputWrapperRef = useRef<HTMLDivElement>(null);
+    const {
+      ref: inputRef,
+      message,
+      setContent,
+      clearContent,
+      handleInput,
+      handleCompositionStart,
+      handleCompositionEnd,
+      insertTextAtCursor,
+      setCursorToEnd,
+    } = useContentEditable({
+      initialContent: initialMessage,
+      wrapperRef: inputWrapperRef,
+    });
+
+    useEffect(() => {
+      inputRef.current?.focus();
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
     const filesWrapperRef = useRef<HTMLDivElement>(null);
     const filesContentRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -209,11 +223,12 @@ const AppInputBar = React.memo(
     React.useImperativeHandle(ref, () => ({
       reset: () => {
         if (!isAutoSending.current) {
-          setMessage("");
+          clearContent();
         }
       },
       focus: () => {
-        textAreaRef.current?.focus();
+        inputRef.current?.focus();
+        setCursorToEnd();
       },
     }));
 
@@ -222,9 +237,9 @@ const AppInputBar = React.memo(
     // imperative ref.reset() method, not by passing initialMessage="".
     useEffect(() => {
       if (initialMessage) {
-        setMessage(initialMessage);
+        setContent(initialMessage);
       }
-    }, [initialMessage]);
+    }, [initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
     const shouldShowRecordingWaveformBelow =
       isRecording &&
       !isVoicePlaybackActive &&
@@ -232,9 +247,9 @@ const AppInputBar = React.memo(
 
     useEffect(() => {
       if (isNewSession && !initialMessage) {
-        setMessage("");
+        clearContent();
       }
-    }, [isNewSession, initialMessage]);
+    }, [isNewSession, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
     const { forcedToolIds, setForcedToolIds } = useForcedTools();
     const { currentMessageFiles, setCurrentMessageFiles, currentProjectId } =
@@ -278,31 +293,6 @@ const AppInputBar = React.memo(
     );
 
     const combinedSettings = useContext(SettingsContext);
-
-    // TODO(@raunakab): Replace this useEffect with CSS `field-sizing: content` once
-    // Firefox ships it unflagged (currently behind `layout.css.field-sizing.enabled`).
-    // Auto-resize textarea based on content (chat mode only).
-    // Reset to min-height first so scrollHeight reflects actual content size,
-    // then clamp between min and max. This handles both growing and shrinking.
-    useEffect(() => {
-      const wrapper = textAreaWrapperRef.current;
-      const textarea = textAreaRef.current;
-      if (!wrapper || !textarea) return;
-
-      // Reset so scrollHeight reflects actual content size
-      wrapper.style.height = `${MIN_INPUT_HEIGHT}px`;
-
-      // scrollHeight doesn't include the wrapper's padding, so add it back
-      const wrapperStyle = getComputedStyle(wrapper);
-      const paddingTop = parseFloat(wrapperStyle.paddingTop);
-      const paddingBottom = parseFloat(wrapperStyle.paddingBottom);
-      const contentHeight = textarea.scrollHeight + paddingTop + paddingBottom;
-
-      wrapper.style.height = `${Math.min(
-        Math.max(contentHeight, MIN_INPUT_HEIGHT),
-        MAX_INPUT_HEIGHT
-      )}px`;
-    }, [message, isSearchMode]);
 
     const prevChatStateRef = useRef(chatState);
     const prevAwaitingRef = useRef(awaitingPreferredSelection);
@@ -362,7 +352,13 @@ const AppInputBar = React.memo(
       if (pastedFiles.length > 0) {
         event.preventDefault();
         handleFileUpload(pastedFiles);
+        return;
       }
+
+      event.preventDefault();
+      const text = event.clipboardData.getData("text/plain");
+      if (!text) return;
+      insertTextAtCursor(text);
     }
 
     const handleRemoveMessageFile = useCallback(
@@ -407,7 +403,7 @@ const AppInputBar = React.memo(
 
     function updateInputPrompt(prompt: InputPrompt) {
       hidePrompts();
-      setMessage(`${prompt.content}`);
+      setContent(prompt.content);
     }
 
     const { filtered: filteredPrompts, setQuery: setPromptFilterQuery } =
@@ -424,27 +420,19 @@ const AppInputBar = React.memo(
       setTabbingIconIndex(0);
     }, [filteredPrompts]);
 
-    const handlePromptInput = useCallback(
-      (text: string) => {
+    const handleContentEditableInput = useCallback(
+      (event: React.FormEvent<HTMLDivElement>) => {
+        handleInput(event);
+        const text = event.currentTarget.innerText ?? "";
         if (text.startsWith("/")) {
           setShowPrompts(true);
+          setPromptFilterQuery(text.slice(1));
         } else {
           hidePrompts();
+          setPromptFilterQuery("");
         }
       },
-      [hidePrompts]
-    );
-
-    const handleInputChange = useCallback(
-      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        const text = event.target.value;
-        setMessage(text);
-        handlePromptInput(text);
-
-        const promptFilterQuery = text.startsWith("/") ? text.slice(1) : "";
-        setPromptFilterQuery(promptFilterQuery);
-      },
-      [setMessage, handlePromptInput, setPromptFilterQuery]
+      [handleInput, hidePrompts, setPromptFilterQuery]
     );
 
     // Determine if we should hide processing state based on context limits
@@ -492,7 +480,7 @@ const AppInputBar = React.memo(
     ]);
 
     function handleKeyDownForPromptShortcuts(
-      e: React.KeyboardEvent<HTMLTextAreaElement>
+      e: React.KeyboardEvent<HTMLDivElement>
     ) {
       if (!user?.preferences?.shortcut_enabled || !showPrompts) return;
 
@@ -663,7 +651,7 @@ const AppInputBar = React.memo(
           {showMicButton &&
             (sttEnabled ? (
               <MicrophoneButton
-                onTranscription={(text) => setMessage(text)}
+                onTranscription={(text) => setContent(text)}
                 disabled={disabled || chatState === "streaming"}
                 autoSend={user?.preferences?.voice_auto_send ?? false}
                 autoListen={user?.preferences?.voice_auto_playback ?? false}
@@ -715,7 +703,7 @@ const AppInputBar = React.memo(
               if (!canSubmitNormally && message.trim()) {
                 if (queuedMessages.length < 5) {
                   enqueueCurrentMessage(message.trim());
-                  setMessage("");
+                  clearContent();
                 }
               } else if (chatState == "streaming") {
                 stopTTS({ manual: true });
@@ -816,26 +804,30 @@ const AppInputBar = React.memo(
               >
                 <Popover.Anchor asChild>
                   <div
-                    ref={textAreaWrapperRef}
-                    className="px-3 py-2 flex-1 flex h-[2.75rem]"
+                    ref={inputWrapperRef}
+                    className="px-3 py-2 flex-1 flex h-[2.75rem] overflow-hidden"
                   >
-                    <textarea
-                      id="onyx-chat-input-textarea"
-                      role="textarea"
-                      ref={textAreaRef}
+                    <div
+                      ref={inputRef}
+                      id="onyx-chat-input-textbox"
+                      role="textbox"
+                      aria-label="Message input"
+                      contentEditable={!disabled}
+                      suppressContentEditableWarning
                       onPaste={handlePaste}
                       onBlur={() => setHighlightedQueueIndex(null)}
                       onKeyDownCapture={handleKeyDownForPromptShortcuts}
-                      onChange={handleInputChange}
-                      className={cn(
-                        "p-[2px] w-full h-full outline-none bg-transparent resize-none placeholder:text-text-03 whitespace-pre-wrap break-words",
-                        "overflow-y-auto"
-                      )}
-                      autoFocus
-                      rows={1}
-                      style={{ scrollbarWidth: "thin" }}
+                      onInput={handleContentEditableInput}
+                      onCompositionStart={handleCompositionStart}
+                      onCompositionEnd={handleCompositionEnd}
+                      className="p-[2px] w-full h-full outline-none bg-transparent whitespace-pre-wrap break-words overflow-y-auto"
+                      tabIndex={0}
+                      style={{
+                        scrollbarWidth: "thin",
+                        scrollbarColor: "var(--border-02) transparent",
+                      }}
                       aria-multiline={true}
-                      placeholder={
+                      data-placeholder={
                         queuedMessages.length > 0 && !message
                           ? "Press up to edit queued messages"
                           : isRecording
@@ -846,7 +838,6 @@ const AppInputBar = React.memo(
                                 ? "Search connected sources"
                                 : "How can I help you today?"
                       }
-                      value={message}
                       onKeyDown={(event) => {
                         // Queue navigation mode
                         if (highlightedQueueIndex !== null) {
@@ -855,7 +846,7 @@ const AppInputBar = React.memo(
                             const text =
                               queuedMessages[highlightedQueueIndex]!.text;
                             removeCurrentQueuedMessage(highlightedQueueIndex);
-                            setMessage(text);
+                            setContent(text);
                             setHighlightedQueueIndex(null);
                             return;
                           }
@@ -914,7 +905,7 @@ const AppInputBar = React.memo(
                           return;
                         }
 
-                        // Enter to submit or queue
+                        // Enter to submit or queue (Shift+Enter falls through to browser default: inserts <br>)
                         if (
                           event.key === "Enter" &&
                           !showPrompts &&
@@ -942,12 +933,10 @@ const AppInputBar = React.memo(
                             queuedMessages.length < 5
                           ) {
                             enqueueCurrentMessage(message.trim());
-                            setMessage("");
+                            clearContent();
                           }
                         }
                       }}
-                      suppressContentEditableWarning={true}
-                      disabled={disabled}
                     />
                   </div>
                 </Popover.Anchor>
@@ -995,7 +984,7 @@ const AppInputBar = React.memo(
                   <Button
                     disabled={!message || isClassifying}
                     icon={SvgX}
-                    onClick={() => setMessage("")}
+                    onClick={() => clearContent()}
                     prominence="tertiary"
                   />
                   <Button

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -824,6 +824,7 @@ const AppInputBar = React.memo(
                       }}
                       aria-multiline={true}
                       aria-disabled={disabled}
+                      aria-placeholder="How can I help you today?"
                       data-placeholder={
                         queuedMessages.length > 0 && !message
                           ? "Press up to edit queued messages"

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -21,7 +21,6 @@ import { ChatState } from "@/app/app/interfaces";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
-import { getTextContent } from "@/lib/contentEditable";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
@@ -147,9 +146,8 @@ const AppInputBar = React.memo(
     const {
       ref: inputRef,
       message,
-      isEmpty,
-      setContent,
-      clearContent,
+      setMessage,
+      clearMessage,
       handleInput,
       handleCompositionStart,
       handleCompositionEnd,
@@ -221,7 +219,7 @@ const AppInputBar = React.memo(
     React.useImperativeHandle(ref, () => ({
       reset: () => {
         if (!isAutoSending.current) {
-          clearContent();
+          clearMessage();
         }
       },
       focus: () => {
@@ -235,7 +233,7 @@ const AppInputBar = React.memo(
     // imperative ref.reset() method, not by passing initialMessage="".
     useEffect(() => {
       if (initialMessage) {
-        setContent(initialMessage);
+        setMessage(initialMessage);
       }
     }, [initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
     const shouldShowRecordingWaveformBelow =
@@ -245,7 +243,7 @@ const AppInputBar = React.memo(
 
     useEffect(() => {
       if (isNewSession && !initialMessage) {
-        clearContent();
+        clearMessage();
       }
     }, [isNewSession, initialMessage]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -402,7 +400,7 @@ const AppInputBar = React.memo(
 
     function updateInputPrompt(prompt: InputPrompt) {
       hidePrompts();
-      setContent(prompt.content);
+      setMessage(prompt.content);
     }
 
     const { filtered: filteredPrompts, setQuery: setPromptFilterQuery } =
@@ -420,9 +418,8 @@ const AppInputBar = React.memo(
     }, [filteredPrompts]);
 
     const handleContentEditableInput = useCallback(
-      (event: React.FormEvent<HTMLDivElement>) => {
-        handleInput(event);
-        const text = getTextContent(event.currentTarget as HTMLElement);
+      (event: React.SyntheticEvent<HTMLDivElement>) => {
+        const text = handleInput(event);
         if (text.startsWith("/")) {
           setShowPrompts(true);
           setPromptFilterQuery(text.slice(1));
@@ -650,7 +647,7 @@ const AppInputBar = React.memo(
           {showMicButton &&
             (sttEnabled ? (
               <MicrophoneButton
-                onTranscription={(text) => setContent(text)}
+                onTranscription={(text) => setMessage(text)}
                 disabled={disabled || chatState === "streaming"}
                 autoSend={user?.preferences?.voice_auto_send ?? false}
                 autoListen={user?.preferences?.voice_auto_playback ?? false}
@@ -702,7 +699,7 @@ const AppInputBar = React.memo(
               if (!canSubmitNormally && message.trim()) {
                 if (queuedMessages.length < 5) {
                   enqueueCurrentMessage(message.trim());
-                  clearContent();
+                  clearMessage();
                 }
               } else if (chatState == "streaming") {
                 stopTTS({ manual: true });
@@ -838,7 +835,7 @@ const AppInputBar = React.memo(
                                 ? "Search connected sources"
                                 : "How can I help you today?"
                       }
-                      data-empty={isEmpty ? "" : undefined}
+                      data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
                         // Queue navigation mode
                         if (highlightedQueueIndex !== null) {
@@ -847,7 +844,7 @@ const AppInputBar = React.memo(
                             const text =
                               queuedMessages[highlightedQueueIndex]!.text;
                             removeCurrentQueuedMessage(highlightedQueueIndex);
-                            setContent(text);
+                            setMessage(text);
                             setHighlightedQueueIndex(null);
                             return;
                           }
@@ -934,7 +931,7 @@ const AppInputBar = React.memo(
                             queuedMessages.length < 5
                           ) {
                             enqueueCurrentMessage(message.trim());
-                            clearContent();
+                            clearMessage();
                           }
                         }
                       }}
@@ -985,7 +982,7 @@ const AppInputBar = React.memo(
                   <Button
                     disabled={!message || isClassifying}
                     icon={SvgX}
-                    onClick={() => clearContent()}
+                    onClick={() => clearMessage()}
                     prominence="tertiary"
                   />
                   <Button

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -21,6 +21,7 @@ import { ChatState } from "@/app/app/interfaces";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
+import { getTextContent } from "@/lib/contentEditable";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
@@ -423,7 +424,7 @@ const AppInputBar = React.memo(
     const handleContentEditableInput = useCallback(
       (event: React.FormEvent<HTMLDivElement>) => {
         handleInput(event);
-        const text = event.currentTarget.innerText ?? "";
+        const text = getTextContent(event.currentTarget as HTMLElement);
         if (text.startsWith("/")) {
           setShowPrompts(true);
           setPromptFilterQuery(text.slice(1));

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -823,7 +823,7 @@ const AppInputBar = React.memo(
                       onCompositionStart={handleCompositionStart}
                       onCompositionEnd={handleCompositionEnd}
                       className="p-[2px] w-full h-full outline-none bg-transparent whitespace-pre-wrap break-words overflow-y-auto"
-                      tabIndex={0}
+                      tabIndex={disabled ? -1 : 0}
                       style={{
                         scrollbarWidth: "thin",
                         scrollbarColor: "var(--border-02) transparent",

--- a/web/tests/e2e/admin/llm_provider_setup.spec.ts
+++ b/web/tests/e2e/admin/llm_provider_setup.spec.ts
@@ -130,7 +130,7 @@ async function exitAdminToChat(page: Page): Promise<void> {
   await page.goto("/app");
   await page.waitForURL("**/app**");
   await page
-    .locator("#onyx-chat-input-textarea")
+    .locator("#onyx-chat-input-textbox")
     .waitFor({ state: "visible", timeout: 15000 });
 }
 
@@ -439,7 +439,7 @@ test.describe("LLM Provider Setup @exclusive", () => {
     await page.goto("/app");
     await page.waitForLoadState("networkidle");
     await page
-      .locator("#onyx-chat-input-textarea")
+      .locator("#onyx-chat-input-textbox")
       .waitFor({ state: "visible", timeout: 15000 });
 
     await expect
@@ -503,7 +503,7 @@ test.describe("LLM Provider Setup @exclusive", () => {
     await page.goto("/app");
     await page.waitForLoadState("networkidle");
     await page
-      .locator("#onyx-chat-input-textarea")
+      .locator("#onyx-chat-input-textbox")
       .waitFor({ state: "visible", timeout: 15000 });
 
     await expect

--- a/web/tests/e2e/chat/ChatPage.ts
+++ b/web/tests/e2e/chat/ChatPage.ts
@@ -27,7 +27,7 @@ export class ChatPage {
     this.page = page;
     this.container = page.locator("[data-main-container]");
     this.scrollContainer = page.getByTestId("chat-scroll-container");
-    this.chatInputTextarea = page.locator("#onyx-chat-input-textarea");
+    this.chatInputTextarea = page.locator("#onyx-chat-input-textbox");
     this.sendButton = page.locator("#onyx-chat-input-send-button");
     this.humanMessages = page.locator("#onyx-human-message");
     this.aiMessages = page.getByTestId("onyx-ai-message");

--- a/web/tests/e2e/chat/file_preview_modal.spec.ts
+++ b/web/tests/e2e/chat/file_preview_modal.spec.ts
@@ -92,8 +92,8 @@ async function sendMessageWithMockResponse(
     });
   });
 
-  await page.locator("#onyx-chat-input-textarea").click();
-  await page.locator("#onyx-chat-input-textarea").fill(userMessage);
+  await page.locator("#onyx-chat-input-textbox").click();
+  await page.locator("#onyx-chat-input-textbox").fill(userMessage);
   await page.locator("#onyx-chat-input-send-button").click();
 
   // Wait for the AI message to appear

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -628,7 +628,9 @@ test.describe("Keyboard Edge Cases", () => {
     });
     await page.keyboard.press("Enter");
     const messageEl = page.locator(HUMAN_MESSAGE_SELECTOR);
-    await expect(messageEl).toContainText("hello tile world");
+    const text = await messageEl.textContent();
+    expect(text).toContain("hello tile world");
+    expect(text).not.toMatch(/hello\n.*tile/);
   });
 });
 

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -619,6 +619,18 @@ test.describe("Keyboard Edge Cases", () => {
     const text = await input.textContent();
     expect(text?.trim()).toBe("x");
   });
+
+  test("inline spans do not produce spurious newlines", async ({ page }) => {
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+    await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.innerHTML = 'hello <span contenteditable="false">tile</span> world';
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await page.keyboard.press("Enter");
+    const messageEl = page.locator(HUMAN_MESSAGE_SELECTOR);
+    await expect(messageEl).toContainText("hello tile world");
+  });
 });
 
 test.describe("Visual Regression", () => {

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -461,8 +461,7 @@ test.describe("Auto-Resize", () => {
     await page.waitForTimeout(200);
     const isScrollable = await page.evaluate(() => {
       const el = document.getElementById("onyx-chat-input-textbox")!;
-      const wrapper = el.parentElement!;
-      return wrapper.scrollHeight > wrapper.clientHeight;
+      return el.scrollHeight > el.clientHeight;
     });
     expect(isScrollable).toBe(true);
   });
@@ -543,9 +542,9 @@ test.describe("Focus Management", () => {
     await input.focus();
     await expect(input).toBeFocused();
 
-    const button = page.locator("[data-main-container] button").first();
-    await button.waitFor({ state: "visible", timeout: 5000 });
-    await button.click();
+    await page
+      .locator("[data-main-container]")
+      .click({ position: { x: 5, y: 5 } });
     await expect(input).not.toBeFocused();
 
     await input.click();

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -1,0 +1,678 @@
+import { test, expect } from "@playwright/test";
+import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import {
+  buildMockStream,
+  mockChatEndpoint,
+  resetTurnCounter,
+} from "@tests/e2e/utils/chatMock";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
+import { setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+
+const INPUT_SELECTOR = "#onyx-chat-input-textbox";
+const SEND_BUTTON_SELECTOR = "#onyx-chat-input-send-button";
+const INPUT_CONTAINER_SELECTOR = "#onyx-chat-input";
+const HUMAN_MESSAGE_SELECTOR = "#onyx-human-message";
+
+test.describe("Core Text Input & Submission", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+  });
+
+  test("typing and pressing Enter sends the message", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("hello");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText("hello");
+  });
+
+  test("typing and clicking send button sends the message", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("hello");
+    await page.locator(SEND_BUTTON_SELECTOR).click();
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText("hello");
+  });
+
+  test("pressing Enter with empty input does not send a message", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(500);
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("pressing Enter with only spaces does not send a message", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("   ");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(500);
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("input is cleared after sending a message", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("hello");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText("hello");
+    await expect(input).toHaveAttribute("data-empty", "");
+    const text = await input.textContent();
+    expect(text?.trim()).toBe("");
+  });
+
+  test("sends a long message (2000+ characters)", async ({ page }) => {
+    const longText = "a".repeat(2100);
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill(longText);
+    await page.keyboard.press("Enter");
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText(longText);
+  });
+});
+
+test.describe("Multiline Input", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+  });
+
+  test("Shift+Enter creates a new line and increases input height", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("line1");
+    await page.keyboard.press("Shift+Enter");
+    await page.keyboard.type("line2");
+
+    const height = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      return el.parentElement!.getBoundingClientRect().height;
+    });
+    expect(height).toBeGreaterThan(44);
+  });
+
+  test("Shift+Enter does not send the message", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("some text");
+    await page.keyboard.press("Shift+Enter");
+    await page.waitForTimeout(500);
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("multiline message is sent with newlines preserved", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("line1");
+    await page.keyboard.press("Shift+Enter");
+    await page.keyboard.type("line2");
+    await page.keyboard.press("Enter");
+    const messageEl = page.locator(HUMAN_MESSAGE_SELECTOR);
+    await expect(messageEl).toContainText("line1");
+    await expect(messageEl).toContainText("line2");
+  });
+});
+
+test.describe("Paste Behavior", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("pasting plain text appears in the input", async ({ page }) => {
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, "hello world");
+
+    const input = page.locator(INPUT_SELECTOR);
+    await expect(input).toContainText("hello world");
+  });
+
+  test("pasting rich HTML strips formatting and pastes plain text only", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/html", "<b>bold</b> <i>italic</i>");
+      dt.setData("text/plain", "bold italic");
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    });
+
+    const input = page.locator(INPUT_SELECTOR);
+    await expect(input).toContainText("bold italic");
+    const innerHTML = await input.innerHTML();
+    expect(innerHTML).not.toContain("<b>");
+    expect(innerHTML).not.toContain("<i>");
+  });
+
+  test("select all then paste replaces content", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("original text");
+    await page.keyboard.press("ControlOrMeta+a");
+
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, "replacement");
+
+    await expect(input).toContainText("replacement");
+  });
+
+  test("pasting multiline text increases input height", async ({ page }) => {
+    const multilineText = "line1\nline2\nline3\nline4";
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, multilineText);
+
+    await page.waitForTimeout(200);
+    const height = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      return el.parentElement!.getBoundingClientRect().height;
+    });
+    expect(height).toBeGreaterThan(44);
+  });
+});
+
+test.describe("Paste Security", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("pasting script tags does not execute code", async ({ page }) => {
+    const xssPayload = '<script>window.__xss_fired=true</script>alert("xss")';
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/html", text);
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, xssPayload);
+
+    const input = page.locator(INPUT_SELECTOR);
+    const innerHTML = await input.innerHTML();
+    expect(innerHTML).not.toContain("<script");
+    expect(innerHTML).not.toContain("</script>");
+
+    const xssFired = await page.evaluate(() => (window as any).__xss_fired);
+    expect(xssFired).toBeFalsy();
+  });
+
+  test("pasting img onerror does not execute code", async ({ page }) => {
+    const xssPayload = '<img src=x onerror="window.__xss_img=true">';
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/html", text);
+      dt.setData("text/plain", "image");
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, xssPayload);
+
+    await page.waitForTimeout(500);
+    const input = page.locator(INPUT_SELECTOR);
+    const innerHTML = await input.innerHTML();
+    expect(innerHTML).not.toContain("<img");
+    expect(innerHTML).not.toContain("onerror");
+
+    const xssFired = await page.evaluate(() => (window as any).__xss_img);
+    expect(xssFired).toBeFalsy();
+  });
+
+  test("pasting event handler attributes does not execute code", async ({
+    page,
+  }) => {
+    const xssPayload =
+      '<div onmouseover="window.__xss_div=true">hover me</div>';
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/html", text);
+      dt.setData("text/plain", "hover me");
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, xssPayload);
+
+    const input = page.locator(INPUT_SELECTOR);
+    const innerHTML = await input.innerHTML();
+    expect(innerHTML).not.toContain("onmouseover");
+    expect(innerHTML).not.toContain("<div");
+    await expect(input).toContainText("hover me");
+  });
+
+  test("only plain text is inserted regardless of HTML clipboard content", async ({
+    page,
+  }) => {
+    const richHtml =
+      '<a href="javascript:alert(1)">click</a><style>body{display:none}</style><iframe src="evil.com"></iframe>';
+    await page.evaluate((html) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/html", html);
+      dt.setData("text/plain", "click");
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, richHtml);
+
+    const input = page.locator(INPUT_SELECTOR);
+    const innerHTML = await input.innerHTML();
+    expect(innerHTML).not.toContain("<a");
+    expect(innerHTML).not.toContain("<style");
+    expect(innerHTML).not.toContain("<iframe");
+    expect(innerHTML).not.toContain("javascript:");
+    await expect(input).toContainText("click");
+  });
+});
+
+test.describe("Auto-Resize", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("grows taller when multiple lines are pasted", async ({ page }) => {
+    const multilineText = "line1\nline2\nline3\nline4";
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, multilineText);
+
+    await page.waitForTimeout(200);
+    const height = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      return el.parentElement!.getBoundingClientRect().height;
+    });
+    expect(height).toBeGreaterThan(44);
+  });
+
+  test("shrinks back to baseline when content is deleted", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    const multilineText = "line1\nline2\nline3\nline4";
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, multilineText);
+
+    await page.waitForTimeout(200);
+
+    await input.focus();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+
+    await page.waitForTimeout(200);
+    const height = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      return el.parentElement!.getBoundingClientRect().height;
+    });
+    expect(height).toBeLessThanOrEqual(50);
+  });
+
+  test("does not exceed max height with many lines", async ({ page }) => {
+    const manyLines = Array.from(
+      { length: 60 },
+      (_, i) => `line ${i + 1}`
+    ).join("\n");
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, manyLines);
+
+    await page.waitForTimeout(200);
+    const height = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      return el.parentElement!.getBoundingClientRect().height;
+    });
+    expect(height).toBeLessThanOrEqual(200);
+  });
+
+  test("content is scrollable when exceeding max height", async ({ page }) => {
+    const manyLines = Array.from(
+      { length: 60 },
+      (_, i) => `line ${i + 1}`
+    ).join("\n");
+    await page.evaluate((text) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      const event = new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      el.dispatchEvent(event);
+    }, manyLines);
+
+    await page.waitForTimeout(200);
+    const isScrollable = await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      const wrapper = el.parentElement!;
+      return wrapper.scrollHeight > wrapper.clientHeight;
+    });
+    expect(isScrollable).toBe(true);
+  });
+});
+
+test.describe("Placeholder", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("shows placeholder text on load", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    const placeholder = await input.getAttribute("data-placeholder");
+    expect(placeholder).toContain("How can I help you today?");
+  });
+
+  test("hides placeholder when text is entered", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("a");
+    const dataEmpty = await input.getAttribute("data-empty");
+    expect(dataEmpty).toBeNull();
+  });
+
+  test("restores placeholder when text is deleted", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("a");
+    await input.focus();
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+    await expect(input).toHaveAttribute("data-empty", "");
+  });
+
+  test("restores placeholder after sending a message", async ({ page }) => {
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("test");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText("test");
+    await expect(input).toHaveAttribute("data-empty", "");
+  });
+});
+
+test.describe("Focus Management", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("input is focused on page load", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await expect(input).toBeFocused();
+  });
+
+  test("input is re-focused after sending a message", async ({ page }) => {
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("test");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toContainText("test");
+    await expect(input).toBeFocused();
+  });
+
+  test("clicking away and back restores focus", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await expect(input).toBeFocused();
+
+    const button = page.locator("[data-main-container] button").first();
+    await button.waitFor({ state: "visible", timeout: 5000 });
+    await button.click();
+    await expect(input).not.toBeFocused();
+
+    await input.click();
+    await expect(input).toBeFocused();
+  });
+});
+
+test.describe("Prompt Shortcuts", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("typing / triggers shortcut UI", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("/");
+    await page.waitForTimeout(300);
+    const popover = page.locator("[data-radix-popper-content-wrapper]");
+    const popoverCount = await popover.count();
+    // If prompt shortcuts are configured, a popover should appear.
+    // If not, we just verify no crash occurred.
+    expect(popoverCount).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test.describe("Keyboard Edge Cases", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("Backspace deletes the last character", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("abc");
+    await page.keyboard.press("Backspace");
+    await expect(input).toContainText("ab");
+  });
+
+  test("Ctrl+A then Backspace clears the input", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("abc");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("Backspace");
+    const text = await input.textContent();
+    expect(text?.trim()).toBe("");
+  });
+
+  test("Ctrl+A then typing replaces all content", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("abc");
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.type("x");
+    await expect(input).toContainText("x");
+    const text = await input.textContent();
+    expect(text?.trim()).toBe("x");
+  });
+});
+
+test.describe("Visual Regression", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("empty input bar", async ({ page }) => {
+    const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
+    await expectElementScreenshot(inputBar, { name: "input-bar-empty" });
+  });
+
+  test("input bar with text", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.fill("Hello, this is a test message");
+    const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
+    await expectElementScreenshot(inputBar, { name: "input-bar-with-text" });
+  });
+
+  test("input bar with multiline text", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("line one");
+    await page.keyboard.press("Shift+Enter");
+    await page.keyboard.type("line two");
+    await page.keyboard.press("Shift+Enter");
+    await page.keyboard.type("line three");
+    const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
+    await expectElementScreenshot(inputBar, { name: "input-bar-multiline" });
+  });
+});
+
+test.describe("Visual Regression - Dark Mode", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await setThemeBeforeNavigation(page, "dark");
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+  });
+
+  test("dark mode input bar", async ({ page }) => {
+    const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
+    await expectElementScreenshot(inputBar, { name: "input-bar-dark-mode" });
+  });
+});

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -6,7 +6,6 @@ import {
   resetTurnCounter,
 } from "@tests/e2e/utils/chatMock";
 import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
-import { setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
 
 const INPUT_SELECTOR = "#onyx-chat-input-textbox";
 const SEND_BUTTON_SELECTOR = "#onyx-chat-input-send-button";
@@ -667,24 +666,5 @@ test.describe("Visual Regression", () => {
     await page.keyboard.type("line three");
     const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
     await expectElementScreenshot(inputBar, { name: "input-bar-multiline" });
-  });
-});
-
-test.describe("Visual Regression - Dark Mode", () => {
-  test.beforeEach(async ({ page }, testInfo) => {
-    resetTurnCounter();
-    await page.context().clearCookies();
-    await loginAsWorkerUser(page, testInfo.workerIndex);
-    await setThemeBeforeNavigation(page, "dark");
-    await page.goto("/app");
-    await page.waitForLoadState("networkidle");
-    await page
-      .locator(INPUT_SELECTOR)
-      .waitFor({ state: "visible", timeout: 10000 });
-  });
-
-  test("dark mode input bar", async ({ page }) => {
-    const inputBar = page.locator(INPUT_CONTAINER_SELECTOR);
-    await expectElementScreenshot(inputBar, { name: "input-bar-dark-mode" });
   });
 });

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -542,11 +542,12 @@ test.describe("Focus Management", () => {
     await input.focus();
     await expect(input).toBeFocused();
 
-    await page
-      .locator("[data-main-container]")
-      .click({ position: { x: 5, y: 5 } });
+    const button = page.locator("[data-main-container] button").first();
+    await button.waitFor({ state: "visible", timeout: 5000 });
+    await button.click();
     await expect(input).not.toBeFocused();
 
+    await page.keyboard.press("Escape");
     await input.click();
     await expect(input).toBeFocused();
   });

--- a/web/tests/e2e/chat/input_focus_retention.spec.ts
+++ b/web/tests/e2e/chat/input_focus_retention.spec.ts
@@ -10,7 +10,7 @@ test.describe(`Chat Input Focus Retention`, () => {
   });
 
   test("clicking empty space retains focus on chat input", async ({ page }) => {
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     await textarea.waitFor({ state: "visible", timeout: 10000 });
 
     // Focus the textarea and type something
@@ -29,7 +29,7 @@ test.describe(`Chat Input Focus Retention`, () => {
   test("clicking interactive elements still moves focus away", async ({
     page,
   }) => {
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     await textarea.waitFor({ state: "visible", timeout: 10000 });
 
     // Focus the textarea

--- a/web/tests/e2e/chat/llm_ordering.spec.ts
+++ b/web/tests/e2e/chat/llm_ordering.spec.ts
@@ -42,7 +42,7 @@ test.describe("LLM Ordering", () => {
     await ensureImageGenerationEnabled(page);
 
     await page.goto("/app");
-    await page.waitForSelector("#onyx-chat-input-textarea", { timeout: 10000 });
+    await page.waitForSelector("#onyx-chat-input-textbox", { timeout: 10000 });
 
     const trigger = page.getByTestId("model-selector").locator("button").last();
     const originalTriggerText = (await trigger.textContent())?.trim() ?? "";

--- a/web/tests/e2e/chat/llm_runtime_selection.spec.ts
+++ b/web/tests/e2e/chat/llm_runtime_selection.spec.ts
@@ -21,6 +21,12 @@ function uniqueName(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+async function openChat(page: Page): Promise<void> {
+  await page.goto("/app");
+  await page.waitForLoadState("networkidle");
+  await page.waitForSelector("#onyx-chat-input-textbox", { timeout: 15000 });
+}
+
 async function loginWithCleanCookies(
   page: Page,
   user: "admin" | number
@@ -241,7 +247,7 @@ test.describe("LLM Runtime Selection", () => {
 
     await page.reload();
     await page.waitForLoadState("networkidle");
-    await page.waitForSelector("#onyx-chat-input-textarea", { timeout: 15000 });
+    await page.waitForSelector("#onyx-chat-input-textbox", { timeout: 15000 });
 
     await verifyCurrentModel(page, selectedModelDisplay);
 
@@ -420,7 +426,7 @@ test.describe("LLM Runtime Selection", () => {
     // Use a new session so runtime selection is not overwritten by the previous
     // chat session's persisted model override.
     await startNewChat(page);
-    await page.waitForSelector("#onyx-chat-input-textarea", { timeout: 15000 });
+    await page.waitForSelector("#onyx-chat-input-textbox", { timeout: 15000 });
 
     await page.getByTestId("model-selector").locator("button").last().click();
     await page.waitForSelector('[role="dialog"]', { state: "visible" });

--- a/web/tests/e2e/chat/queued_messages.spec.ts
+++ b/web/tests/e2e/chat/queued_messages.spec.ts
@@ -28,12 +28,12 @@ async function sendAndHoldResponse(
 
   await page.route(routePattern, handler);
 
-  const textarea = page.locator("#onyx-chat-input-textarea");
+  const textarea = page.locator("#onyx-chat-input-textbox");
   await textarea.fill(message);
   await page.locator("#onyx-chat-input-send-button").click();
 
   // Wait for the submit flow to process (textarea cleared by resetInputBar)
-  await expect(textarea).toHaveValue("", { timeout: 5000 });
+  await expect(textarea).toHaveText("", { timeout: 5000 });
 
   return () => {
     release();
@@ -41,10 +41,10 @@ async function sendAndHoldResponse(
 }
 
 async function queueMessage(page: Page, message: string) {
-  const textarea = page.locator("#onyx-chat-input-textarea");
+  const textarea = page.locator("#onyx-chat-input-textbox");
   await textarea.fill(message);
   await textarea.press("Enter");
-  await expect(textarea).toHaveValue("", { timeout: 2000 });
+  await expect(textarea).toHaveText("", { timeout: 2000 });
 }
 
 test.describe("Queued Messages", () => {
@@ -144,7 +144,7 @@ test.describe("Queued Messages", () => {
     await queueMessage(page, "First queued");
     await queueMessage(page, "Second queued");
 
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     const queueBars = page.locator("[data-testid='queued-message-bar']");
 
     // Up arrow: highlights last bar
@@ -162,7 +162,7 @@ test.describe("Queued Messages", () => {
 
     // Enter: move highlighted message into textarea
     await textarea.press("Enter");
-    await expect(textarea).toHaveValue("Second queued");
+    await expect(textarea).toHaveText("Second queued");
     await expect(queueBars).toHaveCount(1);
     await expect(queueBars.first()).toContainText("First queued");
 
@@ -177,7 +177,7 @@ test.describe("Queued Messages", () => {
     await queueMessage(page, "First queued");
     await queueMessage(page, "Second queued");
 
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     const queueBars = page.locator("[data-testid='queued-message-bar']");
 
     // Highlight last bar and delete it
@@ -200,7 +200,7 @@ test.describe("Queued Messages", () => {
 
     await queueMessage(page, "Queued message");
 
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     const queueBars = page.locator("[data-testid='queued-message-bar']");
 
     // Enter navigation, then escape
@@ -221,9 +221,9 @@ test.describe("Queued Messages", () => {
 
     await queueMessage(page, "Queued message");
 
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     await expect(textarea).toHaveAttribute(
-      "placeholder",
+      "data-placeholder",
       "Press up to edit queued messages"
     );
 
@@ -243,11 +243,11 @@ test.describe("Queued Messages", () => {
     await expect(queueBars).toHaveCount(5);
 
     // 6th message should NOT queue — textarea keeps the text
-    const textarea = page.locator("#onyx-chat-input-textarea");
+    const textarea = page.locator("#onyx-chat-input-textbox");
     await textarea.fill("Message 6");
     await textarea.press("Enter");
 
-    await expect(textarea).toHaveValue("Message 6");
+    await expect(textarea).toHaveText("Message 6");
     await expect(queueBars).toHaveCount(5);
 
     release();

--- a/web/tests/e2e/chat/share_chat.spec.ts
+++ b/web/tests/e2e/chat/share_chat.spec.ts
@@ -4,8 +4,8 @@ import { loginAsRandomUser } from "../utils/auth";
 import { expectElementScreenshot } from "../utils/visualRegression";
 
 async function sendMessageAndWaitForChat(page: Page, message: string) {
-  await page.locator("#onyx-chat-input-textarea").click();
-  await page.locator("#onyx-chat-input-textarea").fill(message);
+  await page.locator("#onyx-chat-input-textbox").click();
+  await page.locator("#onyx-chat-input-textbox").fill(message);
   await page.locator("#onyx-chat-input-send-button").click();
 
   await page.waitForFunction(

--- a/web/tests/e2e/chat/welcome_page.spec.ts
+++ b/web/tests/e2e/chat/welcome_page.spec.ts
@@ -74,7 +74,7 @@ for (const theme of THEMES) {
     });
 
     test("chat input is visible and focusable", async ({ page }) => {
-      const textarea = page.locator("#onyx-chat-input-textarea");
+      const textarea = page.locator("#onyx-chat-input-textbox");
       await expect(textarea).toBeVisible({ timeout: 10000 });
 
       await textarea.click();

--- a/web/tests/e2e/utils/chatActions.ts
+++ b/web/tests/e2e/utils/chatActions.ts
@@ -37,8 +37,8 @@ export async function sendMessage(page: Page, message: string) {
     .locator('[data-testid="onyx-ai-message"]')
     .count();
 
-  await page.locator("#onyx-chat-input-textarea").click();
-  await page.locator("#onyx-chat-input-textarea").fill(message);
+  await page.locator("#onyx-chat-input-textbox").click();
+  await page.locator("#onyx-chat-input-textbox").fill(message);
   await page.locator("#onyx-chat-input-send-button").click();
 
   // Wait for a NEW AI message to appear (count should increase)

--- a/web/tests/e2e/utils/chatStream.ts
+++ b/web/tests/e2e/utils/chatStream.ts
@@ -112,8 +112,8 @@ export async function sendMessageAndCaptureStreamPackets(
     if (waitForAiMessage) {
       await sendMessage(page, message);
     } else {
-      await page.locator("#onyx-chat-input-textarea").click();
-      await page.locator("#onyx-chat-input-textarea").fill(message);
+      await page.locator("#onyx-chat-input-textbox").click();
+      await page.locator("#onyx-chat-input-textbox").fill(message);
       await page.locator("#onyx-chat-input-send-button").click();
       await page
         .waitForFunction(() => window.location.href.includes("chatId="), null, {

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
@@ -21,11 +25,21 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"],
-      "@tests/*": ["./tests/*"],
-      "@public/*": ["./public/*"],
-      "@opal/*": ["./lib/opal/src/*"],
-      "@opal/types/*": ["./lib/opal/src/types/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ],
+      "@public/*": [
+        "./public/*"
+      ],
+      "@opal/*": [
+        "./lib/opal/src/*"
+      ],
+      "@opal/types/*": [
+        "./lib/opal/src/types/*"
+      ]
     }
   },
   "include": [
@@ -35,5 +49,8 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "lib/opal"]
+  "exclude": [
+    "node_modules",
+    "lib/opal"
+  ]
 }


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

- Type text → appears in input, message state syncs
- Enter → submits message (message appears in chat)
- Shift+Enter → inserts newline (no submission)
- Paste plain text → inserts at cursor position
- Paste formatted HTML → only plain text appears
- Paste files (image) → file upload dialog, no text
- Backspace → deletes characters normally
- Select-all + delete → input is empty, placeholder shows
- Up arrow (empty input + queued messages) → enters queue navigation
- Queue nav: Arrow keys cycle, Enter loads, Delete removes, Escape exits
- Type / → prompt shortcut popover appears
- Tab/Arrow in popover → navigates, Enter selects → text replaces input
- Input grows as content increases (up to max height, then scrolls)
- Input shrinks as content is deleted
- Placeholder visible when empty, hidden when content present
- Disabled state → cannot type or edit
- ref.focus() → input is focused, cursor at end
- ref.reset() → input clears, placeholder shows
- CJK composition (e.g. pinyin) → Enter does NOT submit during composition
- CJK composition → composed text syncs to state after confirmation
- Search mode → clear button and submit button work
- Dark mode → all colors correct (Onyx tokens)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the chat input in app and craft to a `contentEditable` textbox for rich text, IME-safe typing, cursor-accurate pasting, and smooth auto-resize (44–200px). Adds `@/hooks/useContentEditable`, `@/lib/contentEditable`, a CSS placeholder, and updates focus restore and E2E tests.

- **New Features**
  - Replaced textarea with a contentEditable div (`#onyx-chat-input-textbox`). Enter submits (not during IME); Shift+Enter inserts a newline. Auto-focus on mount and after send; `focus()` places the cursor at the end. Wrapper height clamps to 44–200px; content scrolls past max.
  - Paste: plain text inserts at the cursor; pasting only files uploads them; HTML is ignored. Hook exposes set/clear content, insert at cursor, set cursor to end, and resize; `getTextContent` preserves newlines and cleans stray `<br>`. Placeholder via `data-placeholder` + `[data-empty]::before`. Focus retention now targets `#onyx-chat-input-textbox`. Added `input_bar_behaviors.spec.ts` covering typing, paste security, multiline, auto-resize, focus, placeholder, and visuals; updated E2E selectors and assertions.

- **Migration**
  - Update selectors from `#onyx-chat-input-textarea` to `#onyx-chat-input-textbox`.
  - Tests and utilities should read text content and use `data-placeholder`/`[data-empty]` instead of `placeholder`/`value`.

<sup>Written for commit cfe56cfd19c53562b5647270ac2c55b3d30973ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



