### PR TITLE
Fix Cohere embed-v4 response format handling

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -237,6 +237,17 @@ def format_embedding_error(
     )
 
 
+def _extract_cohere_embeddings(response_embeddings: Any) -> list[Embedding]:
+    if isinstance(response_embeddings, list):
+        return cast(list[Embedding], response_embeddings)
+
+    float_embeddings = getattr(response_embeddings, "float_", None)
+    if isinstance(float_embeddings, list):
+        return cast(list[Embedding], float_embeddings)
+
+    raise RuntimeError("Unsupported Cohere embedding response format.")
+
+
 # Custom exception for authentication errors
 class AuthenticationError(Exception):
     """Raised when authentication fails with a provider."""
@@ -309,7 +320,7 @@ class CloudEmbedding:
                 input_type=embedding_type,
                 truncate="END",
             )
-            final_embeddings.extend(cast(list[Embedding], response.embeddings))
+            final_embeddings.extend(_extract_cohere_embeddings(response.embeddings))
         return final_embeddings
 
     async def _embed_voyage(

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -85,3 +85,60 @@ async def test_rate_limit_handling() -> None:
                 model_name="fake-model",
                 text_type=EmbedTextType.QUERY,
             )
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_supports_v3_response_format(
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.embeddings = sample_embeddings
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-english-v3.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_supports_v4_response_format(
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        embeddings_by_type = MagicMock()
+        embeddings_by_type.float_ = sample_embeddings
+
+        mock_response = MagicMock()
+        mock_response.embeddings = embeddings_by_type
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-v4.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings


### PR DESCRIPTION
## Description

Fix Cohere embed-v4 response handling so we support both legacy v3 responses and the embed-v4 embeddings-by-type response shape.

This PR:
- normalizes Cohere embedding responses so both v3 and v4 formats are accepted
- keeps existing v3 users working while allowing embed-v4 users to work correctly
- adds unit coverage for both response shapes

Linear: [ENG-4039](https://linear.app/onyx-app/issue/ENG-4039/fix-cohere-embed-v4-response-format-handling)

## How Has This Been Tested?

- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && pytest -q backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && ruff check backend/onyx/natural_language_processing/search_nlp_models.py backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [ ] live Cohere integration test

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
