### PR TITLE
fix: sharepoint members recursion

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import requests as _requests
+from office365.directory.object_collection import DirectoryObjectCollection
 from office365.graph_client import GraphClient
 from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.runtime.client_request import ClientRequestException
@@ -357,10 +358,14 @@ def _get_azuread_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_members(members: list[Any]) -> None:
+    def process_members(members: DirectoryObjectCollection) -> None:
         nonlocal groups, user_emails
 
-        for member in members:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `members` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for member in members.current_page:
             member_data = member.to_json()
             logger.debug(f"Member: {member_data}")
             # Check for user-specific attributes

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -13,6 +13,7 @@ from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.runtime.client_request import ClientRequestException
 from office365.sharepoint.client_context import ClientContext
 from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection
+from office365.sharepoint.principal.users.collection import UserCollection
 from pydantic import BaseModel
 
 from ee.onyx.db.external_perm import ExternalUserGroup
@@ -304,10 +305,14 @@ def _get_sharepoint_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_users(users: list[Any]) -> None:
+    def process_users(users: UserCollection) -> None:
         nonlocal groups, user_emails
 
-        for user in users:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `users` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for user in users.current_page:
             logger.debug(f"User: {user.to_json()}")
             if user.principal_type == USER_PRINCIPAL_TYPE and hasattr(
                 user, "user_principal_name"
@@ -527,7 +532,11 @@ def get_external_access_from_sharepoint(
         role_assignments: RoleAssignmentCollection,
     ) -> None:
         nonlocal user_emails, groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             logger.debug(f"Assignment: {assignment.to_json()}")
             if assignment.role_definition_bindings:
                 is_limited_access = True
@@ -718,7 +727,11 @@ def get_sharepoint_external_groups(
 
     def add_group_to_sets(role_assignments: RoleAssignmentCollection) -> None:
         nonlocal groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             if assignment.role_definition_bindings:
                 is_limited_access = True
                 for role_definition_binding in assignment.role_definition_bindings:


### PR DESCRIPTION
## Description

We were hitting RecursionError: maximum recursion depth exceeded from SharePoint permission sync on customers with large groups (long stack of alternating permission_utils.py:process_members ↔ office365 client_object_collection.__iter__).

The cause: callbacks passed to office365's collection.get_all(page_loaded=...) were iterating the collection itself (for x in collection:). The collection's __iter__ walks pages by calling _get_next().execute_query(), which fires _page_loaded.notify(self) — re‑entering the same callback before the previous frame returns. One stack frame per page, until we hit Python's recursion limit.

Fix: In backend/ee/onyx/external_permissions/sharepoint/permission_utils.py, switched all four page_loaded callbacks to iterate collection.current_page (a pure _data slice — no I/O) instead of the collection itself

## How Has This Been Tested?

relying on CI

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RecursionError in SharePoint permission sync on tenants with large groups by iterating `current_page` in `page_loaded` callbacks instead of the full collection. This prevents re-entrant iteration in `office365` and stabilizes large syncs.

- **Bug Fixes**
  - Updated four `page_loaded` callbacks in `backend/ee/onyx/external_permissions/sharepoint/permission_utils.py` to iterate `current_page` on `UserCollection`, `DirectoryObjectCollection`, and `RoleAssignmentCollection`.
  - Affected flows: `_get_sharepoint_groups`, `_get_azuread_groups`, `add_user_and_group_to_sets`, and `get_sharepoint_external_groups`.
  - Eliminates recursion depth errors caused by `collection.__iter__` triggering nested `page_loaded` calls.

<sup>Written for commit e722bc14c335ef1697cec67a678e1de38543d6e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

