### PR TITLE
feat(admin-agents): Agent ordering

### DIFF
--- a/web/lib/opal/src/components/table/TableBody.tsx
+++ b/web/lib/opal/src/components/table/TableBody.tsx
@@ -1,16 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
-import {
-  DndContext,
-  DragOverlay,
-  type DragStartEvent,
-  type DragEndEvent,
-  type CollisionDetection,
-  type Modifier,
-  type SensorDescriptor,
-  type SensorOptions,
-} from "@dnd-kit/core";
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -22,59 +11,31 @@ import type { WithoutStyles } from "@/types";
 // ---------------------------------------------------------------------------
 
 interface DraggableProps {
-  dndContextProps: {
-    sensors: SensorDescriptor<SensorOptions>[];
-    collisionDetection: CollisionDetection;
-    modifiers: Modifier[];
-    onDragStart: (event: DragStartEvent) => void;
-    onDragEnd: (event: DragEndEvent) => void;
-    onDragCancel: () => void;
-  };
   sortableItems: string[];
-  activeId: string | null;
   isEnabled: boolean;
 }
 
 interface TableBodyProps
   extends WithoutStyles<React.HTMLAttributes<HTMLTableSectionElement>> {
   ref?: React.Ref<HTMLTableSectionElement>;
-  /** DnD context props from useDraggableRows — enables drag-and-drop reordering */
+  /** DnD sortable context — enables drag-and-drop reordering */
   dndSortable?: DraggableProps;
-  /** Render function for the drag overlay row */
-  renderDragOverlay?: (activeId: string) => ReactNode;
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-function TableBody({
-  ref,
-  dndSortable,
-  renderDragOverlay,
-  ...props
-}: TableBodyProps) {
+function TableBody({ ref, dndSortable, ...props }: TableBodyProps) {
   if (dndSortable?.isEnabled) {
-    const { dndContextProps, sortableItems, activeId } = dndSortable;
+    const { sortableItems } = dndSortable;
     return (
-      <DndContext
-        sensors={dndContextProps.sensors}
-        collisionDetection={dndContextProps.collisionDetection}
-        modifiers={dndContextProps.modifiers}
-        onDragStart={dndContextProps.onDragStart}
-        onDragEnd={dndContextProps.onDragEnd}
-        onDragCancel={dndContextProps.onDragCancel}
+      <SortableContext
+        items={sortableItems}
+        strategy={verticalListSortingStrategy}
       >
-        <SortableContext
-          items={sortableItems}
-          strategy={verticalListSortingStrategy}
-        >
-          <tbody ref={ref} {...props} />
-        </SortableContext>
-        <DragOverlay dropAnimation={null}>
-          {activeId && renderDragOverlay ? renderDragOverlay(activeId) : null}
-        </DragOverlay>
-      </DndContext>
+        <tbody ref={ref} {...props} />
+      </SortableContext>
     );
   }
 

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -42,6 +42,7 @@ function SortableTableRow({
     attributes,
     listeners,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
     isDragging,
@@ -75,6 +76,7 @@ function SortableTableRow({
           }}
         >
           <button
+            ref={setActivatorNodeRef}
             type="button"
             className={cn(
               "absolute right-0 top-1/2 -translate-y-1/2 cursor-grab",

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { cn } from "@opal/utils";
-import { useTableSize } from "@opal/components/table/TableSizeContext";
 import type { WithoutStyles } from "@/types";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { SvgHandle } from "@opal/icons";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,8 +16,6 @@ export interface TableRowProps
   disabled?: boolean;
   /** When provided, makes this row sortable via @dnd-kit */
   sortableId?: string;
-  /** Show drag handle overlay. Defaults to true when sortableId is set. */
-  showDragHandle?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -29,20 +24,16 @@ export interface TableRowProps
 
 function SortableTableRow({
   sortableId,
-  showDragHandle = true,
   selected,
   disabled,
   ref: _externalRef,
   children,
   ...props
 }: TableRowProps) {
-  const resolvedSize = useTableSize();
-
   const {
     attributes,
     listeners,
     setNodeRef,
-    setActivatorNodeRef,
     transform,
     transition,
     isDragging,
@@ -59,41 +50,13 @@ function SortableTableRow({
       ref={setNodeRef}
       style={style}
       className="tbl-row group/row"
-      data-drag-handle={showDragHandle || undefined}
       data-selected={selected || undefined}
       data-disabled={disabled || undefined}
       {...attributes}
+      {...listeners}
       {...props}
     >
       {children}
-      {showDragHandle && (
-        <td
-          style={{
-            width: 0,
-            padding: 0,
-            position: "relative",
-            zIndex: 20,
-          }}
-        >
-          <button
-            ref={setActivatorNodeRef}
-            type="button"
-            className={cn(
-              "absolute right-0 top-1/2 -translate-y-1/2 cursor-grab",
-              "opacity-0 group-hover/row:opacity-100 transition-opacity",
-              "flex items-center justify-center rounded"
-            )}
-            aria-label="Drag to reorder"
-            onMouseDown={(e) => e.preventDefault()}
-            {...listeners}
-          >
-            <SvgHandle
-              size={resolvedSize === "md" ? 12 : 16}
-              className="text-border-02"
-            />
-          </button>
-        </td>
-      )}
     </tr>
   );
 }
@@ -104,7 +67,6 @@ function SortableTableRow({
 
 export default function TableRow({
   sortableId,
-  showDragHandle,
   selected,
   disabled,
   ref,
@@ -114,7 +76,6 @@ export default function TableRow({
     return (
       <SortableTableRow
         sortableId={sortableId}
-        showDragHandle={showDragHandle}
         selected={selected}
         disabled={disabled}
         ref={ref}

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -52,7 +52,6 @@ function SortableTableRow({
       className="tbl-row group/row"
       data-selected={selected || undefined}
       data-disabled={disabled || undefined}
-      {...attributes}
       {...listeners}
       {...props}
     >

--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -350,29 +350,24 @@ export function Table<TData>(props: DataTableProps<TData>) {
         >
           {children}
           <DragOverlay dropAnimation={null}>
-            {draggableReturn.activeId && (
-              <table>
-                <tbody>
-                  {(() => {
-                    const row = table
-                      .getRowModel()
-                      .rows.find(
-                        (r) => getRowId(r.original) === draggableReturn.activeId
-                      );
-                    if (!row) return null;
-                    return (
-                      <DragOverlayRow
-                        row={row}
-                        columnWidths={columnWidths}
-                        columnKindMap={columnKindMap}
-                        qualifierColumn={qualifierColumn}
-                        isSelectable={isSelectable}
-                      />
-                    );
-                  })()}
-                </tbody>
-              </table>
-            )}
+            {draggableReturn.activeId &&
+              (() => {
+                const row = table
+                  .getRowModel()
+                  .rows.find(
+                    (r) => getRowId(r.original) === draggableReturn.activeId
+                  );
+                if (!row) return null;
+                return (
+                  <DragOverlayRow
+                    row={row}
+                    columnWidths={columnWidths}
+                    columnKindMap={columnKindMap}
+                    qualifierColumn={qualifierColumn}
+                    isSelectable={isSelectable}
+                  />
+                );
+              })()}
           </DragOverlay>
         </DndContext>
       )

--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -4,6 +4,7 @@
 import "@opal/components/table/styles.css";
 
 import { useEffect, useMemo } from "react";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { flexRender } from "@tanstack/react-table";
 import useDataTable, {
   toOnyxSortDirection,
@@ -335,277 +336,304 @@ export function Table<TData>(props: DataTableProps<TData>) {
     );
   }
 
+  const dndContextWrapper = hasDraggable
+    ? (children: React.ReactNode) => (
+        <DndContext
+          sensors={draggableReturn.dndContextProps.sensors}
+          collisionDetection={
+            draggableReturn.dndContextProps.collisionDetection
+          }
+          modifiers={draggableReturn.dndContextProps.modifiers}
+          onDragStart={draggableReturn.dndContextProps.onDragStart}
+          onDragEnd={draggableReturn.dndContextProps.onDragEnd}
+          onDragCancel={draggableReturn.dndContextProps.onDragCancel}
+        >
+          {children}
+          <DragOverlay dropAnimation={null}>
+            {draggableReturn.activeId && (
+              <table>
+                <tbody>
+                  {(() => {
+                    const row = table
+                      .getRowModel()
+                      .rows.find(
+                        (r) => getRowId(r.original) === draggableReturn.activeId
+                      );
+                    if (!row) return null;
+                    return (
+                      <DragOverlayRow
+                        row={row}
+                        columnWidths={columnWidths}
+                        columnKindMap={columnKindMap}
+                        qualifierColumn={qualifierColumn}
+                        isSelectable={isSelectable}
+                      />
+                    );
+                  })()}
+                </tbody>
+              </table>
+            )}
+          </DragOverlay>
+        </DndContext>
+      )
+    : (children: React.ReactNode) => children;
+
   return (
     <TableSizeProvider size={size}>
-      <div>
-        <div
-          className={cn(
-            "overflow-x-auto transition-opacity duration-150",
-            isServerLoading && "opacity-50 pointer-events-none"
-          )}
-          ref={containerRef}
-          style={{
-            ...(height != null
-              ? {
-                  maxHeight:
-                    typeof height === "number" ? `${height}px` : height,
-                  overflowY: "auto" as const,
-                }
-              : undefined),
-          }}
-        >
-          <TableElement
-            variant={variant}
-            selectionBehavior={selectionBehavior}
-            width={
-              Object.keys(columnWidths).length > 0
-                ? Object.values(columnWidths).reduce((sum, w) => sum + w, 0)
-                : undefined
-            }
-          >
-            <colgroup>
-              {table.getVisibleLeafColumns().map((col) => (
-                <col
-                  key={col.id}
-                  style={
-                    columnWidths[col.id] != null
-                      ? { width: columnWidths[col.id] }
-                      : undefined
+      {dndContextWrapper(
+        <div>
+          <div
+            className={cn(
+              "overflow-x-auto transition-opacity duration-150",
+              isServerLoading && "opacity-50 pointer-events-none"
+            )}
+            ref={containerRef}
+            style={{
+              ...(height != null
+                ? {
+                    maxHeight:
+                      typeof height === "number" ? `${height}px` : height,
+                    overflowY: "auto" as const,
                   }
-                />
-              ))}
-            </colgroup>
-            <TableHeader>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header, headerIndex) => {
-                    const colDef = columnKindMap.get(header.id);
-
-                    // Qualifier header — select-all checkbox only for multi-select
-                    if (colDef?.kind === "qualifier") {
-                      return (
-                        <QualifierContainer key={header.id} type="head">
-                          {isMultiSelect && (
-                            <Checkbox
-                              checked={isAllRowsSelected}
-                              indeterminate={
-                                !isAllRowsSelected && selectedCount > 0
-                              }
-                              onCheckedChange={(checked) => {
-                                // Indeterminate → clear all; otherwise toggle normally
-                                if (!isAllRowsSelected && selectedCount > 0) {
-                                  toggleAllRowsSelected(false);
-                                } else {
-                                  toggleAllRowsSelected(checked);
-                                }
-                              }}
-                            />
-                          )}
-                        </QualifierContainer>
-                      );
-                    }
-
-                    // Actions header
-                    if (colDef?.kind === "actions") {
-                      const actionsDef = colDef as OnyxActionsColumn<TData>;
-                      return (
-                        <ActionsContainer key={header.id} type="head">
-                          {actionsDef.showColumnVisibility !== false && (
-                            <ColumnVisibilityPopover
-                              table={table}
-                              columnVisibility={
-                                table.getState().columnVisibility
-                              }
-                            />
-                          )}
-                          {actionsDef.showSorting !== false && (
-                            <SortingPopover
-                              table={table}
-                              sorting={table.getState().sorting}
-                              footerText={actionsDef.sortingFooterText}
-                            />
-                          )}
-                        </ActionsContainer>
-                      );
-                    }
-
-                    // Data / Display header
-                    const canSort = header.column.getCanSort();
-                    const sortDir = header.column.getIsSorted();
-                    const nextHeader = headerGroup.headers[headerIndex + 1];
-                    const canResize =
-                      header.column.getCanResize() &&
-                      !!nextHeader &&
-                      !widthConfig.fixedColumnIds.has(nextHeader.id);
-
-                    const dataCol =
-                      colDef?.kind === "data"
-                        ? (colDef as OnyxDataColumn<TData>)
-                        : null;
-
-                    return (
-                      <TableHead
-                        key={header.id}
-                        width={columnWidths[header.id]}
-                        sorted={
-                          canSort ? toOnyxSortDirection(sortDir) : undefined
-                        }
-                        onSort={
-                          canSort
-                            ? () => header.column.toggleSorting()
-                            : undefined
-                        }
-                        icon={dataCol?.icon}
-                        resizable={canResize}
-                        onResizeStart={
-                          canResize
-                            ? createResizeHandler(header.id, nextHeader.id)
-                            : undefined
-                        }
-                      >
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                      </TableHead>
-                    );
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-
-            <TableBody
-              dndSortable={hasDraggable ? draggableReturn : undefined}
-              renderDragOverlay={
-                hasDraggable
-                  ? (activeId) => {
-                      const row = table
-                        .getRowModel()
-                        .rows.find((r) => getRowId(r.original) === activeId);
-                      if (!row) return null;
-                      return (
-                        <DragOverlayRow
-                          row={row}
-                          columnWidths={columnWidths}
-                          columnKindMap={columnKindMap}
-                          qualifierColumn={qualifierColumn}
-                          isSelectable={isSelectable}
-                        />
-                      );
-                    }
+                : undefined),
+            }}
+          >
+            <TableElement
+              variant={variant}
+              selectionBehavior={selectionBehavior}
+              width={
+                Object.keys(columnWidths).length > 0
+                  ? Object.values(columnWidths).reduce((sum, w) => sum + w, 0)
                   : undefined
               }
             >
-              {emptyState && table.getRowModel().rows.length === 0 && (
-                <tr>
-                  <td colSpan={table.getVisibleLeafColumns().length}>
-                    {emptyState}
-                  </td>
-                </tr>
-              )}
-              {table.getRowModel().rows.map((row) => {
-                const rowId = hasDraggable ? getRowId(row.original) : undefined;
+              <colgroup>
+                {table.getVisibleLeafColumns().map((col) => (
+                  <col
+                    key={col.id}
+                    style={
+                      columnWidths[col.id] != null
+                        ? { width: columnWidths[col.id] }
+                        : undefined
+                    }
+                  />
+                ))}
+              </colgroup>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header, headerIndex) => {
+                      const colDef = columnKindMap.get(header.id);
 
-                return (
-                  <TableRow
-                    key={row.id}
-                    sortableId={rowId}
-                    selected={row.getIsSelected()}
-                    onClick={() => {
-                      if (
-                        hasDraggable &&
-                        draggableReturn.wasDraggingRef.current
-                      ) {
-                        return;
-                      }
-                      if (onRowClick) {
-                        onRowClick(row.original);
-                      } else if (isSelectable) {
-                        if (!isMultiSelect) {
-                          // single-select: clear all, then select this row
-                          table.toggleAllRowsSelected(false);
-                        }
-                        row.toggleSelected();
-                      }
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => {
-                      const cellColDef = columnKindMap.get(cell.column.id);
-
-                      // Qualifier cell
-                      if (cellColDef?.kind === "qualifier") {
-                        const qDef = cellColDef as OnyxQualifierColumn<TData>;
-
+                      // Qualifier header — select-all checkbox only for multi-select
+                      if (colDef?.kind === "qualifier") {
                         return (
-                          <QualifierContainer
-                            key={cell.id}
-                            type="cell"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <TableQualifier
-                              content={qDef.content}
-                              icon={qDef.getContent?.(row.original)}
-                              imageSrc={qDef.getImageSrc?.(row.original)}
-                              imageAlt={qDef.getImageAlt?.(row.original)}
-                              background={qDef.background}
-                              iconSize={qDef.iconSize}
-                              selectable={showQualifierCheckbox}
-                              selected={
-                                showQualifierCheckbox && row.getIsSelected()
-                              }
-                              onSelectChange={
-                                showQualifierCheckbox
-                                  ? (checked) => {
-                                      if (!isMultiSelect) {
-                                        table.toggleAllRowsSelected(false);
-                                      }
-                                      row.toggleSelected(checked);
-                                    }
-                                  : undefined
-                              }
-                            />
+                          <QualifierContainer key={header.id} type="head">
+                            {isMultiSelect && (
+                              <Checkbox
+                                checked={isAllRowsSelected}
+                                indeterminate={
+                                  !isAllRowsSelected && selectedCount > 0
+                                }
+                                onCheckedChange={(checked) => {
+                                  // Indeterminate → clear all; otherwise toggle normally
+                                  if (!isAllRowsSelected && selectedCount > 0) {
+                                    toggleAllRowsSelected(false);
+                                  } else {
+                                    toggleAllRowsSelected(checked);
+                                  }
+                                }}
+                              />
+                            )}
                           </QualifierContainer>
                         );
                       }
 
-                      // Actions cell
-                      if (cellColDef?.kind === "actions") {
+                      // Actions header
+                      if (colDef?.kind === "actions") {
+                        const actionsDef = colDef as OnyxActionsColumn<TData>;
                         return (
-                          <ActionsContainer
-                            key={cell.id}
-                            type="cell"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            {flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext()
+                          <ActionsContainer key={header.id} type="head">
+                            {actionsDef.showColumnVisibility !== false && (
+                              <ColumnVisibilityPopover
+                                table={table}
+                                columnVisibility={
+                                  table.getState().columnVisibility
+                                }
+                              />
+                            )}
+                            {actionsDef.showSorting !== false && (
+                              <SortingPopover
+                                table={table}
+                                sorting={table.getState().sorting}
+                                footerText={actionsDef.sortingFooterText}
+                              />
                             )}
                           </ActionsContainer>
                         );
                       }
 
-                      // Data / Display cell
+                      // Data / Display header
+                      const canSort = header.column.getCanSort();
+                      const sortDir = header.column.getIsSorted();
+                      const nextHeader = headerGroup.headers[headerIndex + 1];
+                      const canResize =
+                        header.column.getCanResize() &&
+                        !!nextHeader &&
+                        !widthConfig.fixedColumnIds.has(nextHeader.id);
+
+                      const dataCol =
+                        colDef?.kind === "data"
+                          ? (colDef as OnyxDataColumn<TData>)
+                          : null;
+
                       return (
-                        <TableCell
-                          key={cell.id}
-                          data-column-id={cell.column.id}
+                        <TableHead
+                          key={header.id}
+                          width={columnWidths[header.id]}
+                          sorted={
+                            canSort ? toOnyxSortDirection(sortDir) : undefined
+                          }
+                          onSort={
+                            canSort
+                              ? () => header.column.toggleSorting()
+                              : undefined
+                          }
+                          icon={dataCol?.icon}
+                          resizable={canResize}
+                          onResizeStart={
+                            canResize
+                              ? createResizeHandler(header.id, nextHeader.id)
+                              : undefined
+                          }
                         >
                           {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
+                            header.column.columnDef.header,
+                            header.getContext()
                           )}
-                        </TableCell>
+                        </TableHead>
                       );
                     })}
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </TableElement>
-        </div>
+                ))}
+              </TableHeader>
 
-        {footer && renderFooter(footer)}
-      </div>
+              <TableBody
+                dndSortable={hasDraggable ? draggableReturn : undefined}
+              >
+                {emptyState && table.getRowModel().rows.length === 0 && (
+                  <tr>
+                    <td colSpan={table.getVisibleLeafColumns().length}>
+                      {emptyState}
+                    </td>
+                  </tr>
+                )}
+                {table.getRowModel().rows.map((row) => {
+                  const rowId = hasDraggable
+                    ? getRowId(row.original)
+                    : undefined;
+
+                  return (
+                    <TableRow
+                      key={row.id}
+                      sortableId={rowId}
+                      selected={row.getIsSelected()}
+                      onClick={() => {
+                        if (
+                          hasDraggable &&
+                          draggableReturn.wasDraggingRef.current
+                        ) {
+                          return;
+                        }
+                        if (onRowClick) {
+                          onRowClick(row.original);
+                        } else if (isSelectable) {
+                          if (!isMultiSelect) {
+                            // single-select: clear all, then select this row
+                            table.toggleAllRowsSelected(false);
+                          }
+                          row.toggleSelected();
+                        }
+                      }}
+                    >
+                      {row.getVisibleCells().map((cell) => {
+                        const cellColDef = columnKindMap.get(cell.column.id);
+
+                        // Qualifier cell
+                        if (cellColDef?.kind === "qualifier") {
+                          const qDef = cellColDef as OnyxQualifierColumn<TData>;
+
+                          return (
+                            <QualifierContainer
+                              key={cell.id}
+                              type="cell"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <TableQualifier
+                                content={qDef.content}
+                                icon={qDef.getContent?.(row.original)}
+                                imageSrc={qDef.getImageSrc?.(row.original)}
+                                imageAlt={qDef.getImageAlt?.(row.original)}
+                                background={qDef.background}
+                                iconSize={qDef.iconSize}
+                                selectable={showQualifierCheckbox}
+                                selected={
+                                  showQualifierCheckbox && row.getIsSelected()
+                                }
+                                onSelectChange={
+                                  showQualifierCheckbox
+                                    ? (checked) => {
+                                        if (!isMultiSelect) {
+                                          table.toggleAllRowsSelected(false);
+                                        }
+                                        row.toggleSelected(checked);
+                                      }
+                                    : undefined
+                                }
+                              />
+                            </QualifierContainer>
+                          );
+                        }
+
+                        // Actions cell
+                        if (cellColDef?.kind === "actions") {
+                          return (
+                            <ActionsContainer
+                              key={cell.id}
+                              type="cell"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext()
+                              )}
+                            </ActionsContainer>
+                          );
+                        }
+
+                        // Data / Display cell
+                        return (
+                          <TableCell
+                            key={cell.id}
+                            data-column-id={cell.column.id}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </TableElement>
+          </div>
+
+          {footer && renderFooter(footer)}
+        </div>
+      )}
     </TableSizeProvider>
   );
 }

--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -6,6 +6,7 @@ import { useUser } from "@/providers/UserProvider";
 import { checkUserOwnsAgent as checkUserOwnsAgent } from "@/lib/agents";
 import { useAgents } from "@/hooks/useAgents";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
+import { personaComparator } from "@/app/admin/agents/lib";
 import Text from "@/refresh-components/texts/Text";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
@@ -52,11 +53,9 @@ function AgentsSection({ title, description, agents }: AgentsSectionProps) {
         </Text>
       </div>
       <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-2">
-        {agents
-          .sort((a, b) => b.id - a.id)
-          .map((agent) => (
-            <AgentCard key={agent.id} agent={agent} />
-          ))}
+        {agents.sort(personaComparator).map((agent) => (
+          <AgentCard key={agent.id} agent={agent} />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Ensures the agent display order set by admins (via drag-and-drop in the admin agents table) is reflected in the user-facing explore agents page (`AgentsNavigationPage`).

Previously, agents were sorted by `b.id - a.id` (newest first). Now they use `personaComparator` which respects the `display_priority` field — agents with lower priority values appear first, and agents without a priority appear at the end sorted by ID.

Also includes fixes to the Opal Table's drag-and-drop implementation:
- Move `DndContext` outside `<table>` to fix invalid HTML nesting (`<div>` inside `<table>`)
- Make entire row the drag target instead of a hidden drag handle button
- Remove dnd-kit attributes from `<tr>` that interfered with pointer events

**Stack:** 3/3 — stacked on #10518.

## How Has This Been Tested?

- Type check passes (`bun run types:check`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check