### PR TITLE
chore(CI): Temporarily disable 2 tests which depend on Anthropic

### DIFF
--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -28,7 +28,7 @@ from tests.external_dependency_unit.conftest import create_test_user
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test to begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause a CI run to fail if this test passes, acting as a reminder to re-enable this test.",
 )
 def test_answer_with_only_anthropic_provider(
     db_session: Session,

--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -28,7 +28,7 @@ from tests.external_dependency_unit.conftest import create_test_user
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test will begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test to begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
 )
 def test_answer_with_only_anthropic_provider(
     db_session: Session,

--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from onyx.chat.models import AnswerStreamPart
@@ -25,6 +26,10 @@ from onyx.server.query_and_chat.streaming_models import Packet
 from tests.external_dependency_unit.conftest import create_test_user
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test will begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
+)
 def test_answer_with_only_anthropic_provider(
     db_session: Session,
     full_deployment_setup: None,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -271,7 +271,7 @@ def test_openai_prompt_caching_reduces_costs(
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test to begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause a CI run to fail if this test passes, acting as a reminder to re-enable this test.",
 )
 # @pytest.mark.skipif(
 #     not os.environ.get("ANTHROPIC_API_KEY"),

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -271,7 +271,7 @@ def test_openai_prompt_caching_reduces_costs(
 
 @pytest.mark.xfail(
     strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test will begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test to begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
 )
 # @pytest.mark.skipif(
 #     not os.environ.get("ANTHROPIC_API_KEY"),

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -269,10 +269,14 @@ def test_openai_prompt_caching_reduces_costs(
     ), f"Expected at least one success. 0 of {attempts} attempts used prompt caching."
 
 
-@pytest.mark.skipif(
-    not os.environ.get("ANTHROPIC_API_KEY"),
-    reason="Anthropic API key not available",
+@pytest.mark.xfail(
+    strict=True,
+    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause this test will begin passing which will cause a CI run to fail, acting as a reminder to re-enable this test.",
 )
+# @pytest.mark.skipif(
+#     not os.environ.get("ANTHROPIC_API_KEY"),
+#     reason="Anthropic API key not available",
+# )
 def test_anthropic_prompt_caching_reduces_costs(
     db_session: Session,  # noqa: ARG001
 ) -> None:


### PR DESCRIPTION
## Description
`strict=True` will cause CI to fail when this test passes, which will happen once the Anthropic issue is resolved, and which will act as a hard reminder to re-enable these tests.

## How Has This Been Tested?
My CI should pass now.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily mark two Anthropic-dependent tests with `pytest.mark.xfail(strict=True)` to unblock CI while Anthropic key issues are resolved. Replaces the previous `skipif` in the prompt-caching test; `strict=True` will fail CI when these tests start passing to remind us to re-enable them.

<sup>Written for commit da856e0962799cc10e143c13a2af1c837312f1b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

