### PR TITLE
feat: google oauth scope overrides

### DIFF
--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -42,6 +42,8 @@ from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
 from onyx.auth.users import fastapi_users
 from onyx.configs.app_configs import AUTH_TYPE
+from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
+from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import USER_AUTH_SECRET
@@ -95,11 +97,18 @@ def get_application() -> FastAPI:
         # For Google OAuth, refresh tokens are requested by:
         # 1. Adding the right scopes
         # 2. Properly configuring OAuth in Google Cloud Console to allow offline access
+        try:
+            google_login_scopes = list(
+                GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
+            )
+        except Exception as e:
+            logger.warning(f"Error configuring Google OAuth login scopes: {e}")
+            google_login_scopes = list(GOOGLE_LOGIN_BASE_SCOPES)
+
         oauth_client = GoogleOAuth2(
             OAUTH_CLIENT_ID,
             OAUTH_CLIENT_SECRET,
-            # Use standard scopes that include profile and email
-            scopes=["openid", "email", "profile"],
+            scopes=google_login_scopes,
         )
         include_auth_router_with_prefix(
             application,

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -97,13 +97,9 @@ def get_application() -> FastAPI:
         # For Google OAuth, refresh tokens are requested by:
         # 1. Adding the right scopes
         # 2. Properly configuring OAuth in Google Cloud Console to allow offline access
-        try:
-            google_login_scopes = list(
-                GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
-            )
-        except Exception as e:
-            logger.warning(f"Error configuring Google OAuth login scopes: {e}")
-            google_login_scopes = list(GOOGLE_LOGIN_BASE_SCOPES)
+        google_login_scopes = list(
+            GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
+        )
 
         oauth_client = GoogleOAuth2(
             OAUTH_CLIENT_ID,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -200,6 +200,28 @@ OAUTH_CLIENT_SECRET = (
 # Whether Google OAuth is enabled (requires both client ID and secret)
 OAUTH_ENABLED = bool(OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET)
 
+# Default scopes requested when signing in with Google (AUTH_TYPE=google_oauth
+# or AUTH_TYPE=cloud, and the BASIC + OAuth fallback path). These are the
+# minimum required to identify the user via OpenID Connect.
+GOOGLE_LOGIN_BASE_SCOPES = ["openid", "email", "profile"]
+
+# Applicable for Google OAuth login, allows you to override the scopes that
+# are requested from Google. Mirrors OIDC_SCOPE_OVERRIDE; useful when the
+# access token needs to be passed through to tool calls that require
+# additional Google API scopes.
+GOOGLE_OAUTH_SCOPE_OVERRIDE: list[str] | None = None
+_GOOGLE_OAUTH_SCOPE_OVERRIDE = os.environ.get("GOOGLE_OAUTH_SCOPE_OVERRIDE")
+
+if _GOOGLE_OAUTH_SCOPE_OVERRIDE:
+    try:
+        GOOGLE_OAUTH_SCOPE_OVERRIDE = [
+            scope.strip() for scope in _GOOGLE_OAUTH_SCOPE_OVERRIDE.split(",")
+        ]
+    except Exception:
+        logger.exception(
+            f"Error configuring Google OAuth login scopes: {_GOOGLE_OAUTH_SCOPE_OVERRIDE}"
+        )
+
 # OpenID Connect configuration URL for OIDC integrations
 OPENID_CONFIG_URL = os.environ.get("OPENID_CONFIG_URL") or ""
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -558,13 +558,9 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     if AUTH_TYPE == AuthType.GOOGLE_OAUTH or (
         AUTH_TYPE == AuthType.BASIC and OAUTH_ENABLED
     ):
-        try:
-            google_login_scopes = list(
-                GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
-            )
-        except Exception as e:
-            logger.warning(f"Error configuring Google OAuth login scopes: {e}")
-            google_login_scopes = list(GOOGLE_LOGIN_BASE_SCOPES)
+        google_login_scopes = list(
+            GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
+        )
 
         oauth_client = GoogleOAuth2(
             OAUTH_CLIENT_ID,

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -40,6 +40,8 @@ from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
+from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
@@ -556,10 +558,18 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     if AUTH_TYPE == AuthType.GOOGLE_OAUTH or (
         AUTH_TYPE == AuthType.BASIC and OAUTH_ENABLED
     ):
+        try:
+            google_login_scopes = list(
+                GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
+            )
+        except Exception as e:
+            logger.warning(f"Error configuring Google OAuth login scopes: {e}")
+            google_login_scopes = list(GOOGLE_LOGIN_BASE_SCOPES)
+
         oauth_client = GoogleOAuth2(
             OAUTH_CLIENT_ID,
             OAUTH_CLIENT_SECRET,
-            scopes=["openid", "email", "profile"],
+            scopes=google_login_scopes,
         )
         include_auth_router_with_prefix(
             application,


### PR DESCRIPTION
## Description

allow users to change what scopes they request from google during the login flow. useful mostly for pass-through OAuth so users don't have to authenticate twice (on login and when using an MCP server that uses google as Idp)

## How Has This Been Tested?

n/a pretty basic

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Google OAuth login scopes via `GOOGLE_OAUTH_SCOPE_OVERRIDE`, with safe defaults in `GOOGLE_LOGIN_BASE_SCOPES`. Enables pass-through OAuth so users don’t re-consent when tools need extra Google scopes.

- **New Features**
  - Default login scopes: `["openid", "email", "profile"]` via `GOOGLE_LOGIN_BASE_SCOPES`.
  - Override scopes with `GOOGLE_OAUTH_SCOPE_OVERRIDE` (comma-separated).
  - OSS and EE apps now pass computed `google_login_scopes` to Google OAuth.
  - On bad overrides, logs an error and falls back to base scopes.

- **Migration**
  - To request extra scopes, set `GOOGLE_OAUTH_SCOPE_OVERRIDE="openid,email,profile,https://www.googleapis.com/auth/calendar"`.
  - Leave unset to use defaults.

<sup>Written for commit 9bcd5493bfa812806c10e0103a9a04938f136fa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

