### PR TITLE
fix(opensearch): Add an index refresh between delete and index in the doc idx class `index` method

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -696,6 +696,9 @@ class OpenSearchIndexClient(OpenSearchClient):
             Exception: There was an error during the bulk index. This
                 includes the case where a document with the same ID already
                 exists if update_if_exists is False.
+            BulkIndexError: There was an error during the bulk index. This is a
+                known specific error type that is raised by the opensearchpy
+                library's bulk function.
         """
         if not documents:
             return

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import httpx
 from opensearchpy import NotFoundError
+from opensearchpy.helpers.errors import BulkIndexError
 
 from onyx.access.models import DocumentAccess
 from onyx.configs.app_configs import MAX_CHUNKS_PER_DOC_BATCH
@@ -724,17 +725,29 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         already_existed=num_chunks_deleted > 0,
                     )
                 )
-                # Refresh the index because deletion may take a little to
-                # propagate, and if a chunk's deletion still has not propagated
-                # by the time we try to index the new chunk below, an exception
-                # will be raised.
-                self._client.refresh_index()
             # Now index. This will raise if a chunk of the same ID exists, which
             # we do not expect because we should have deleted all chunks.
-            self._client.bulk_index_documents(
-                documents=chunk_batch,
-                tenant_state=self._tenant_state,
-            )
+            try:
+                self._client.bulk_index_documents(
+                    documents=chunk_batch,
+                    tenant_state=self._tenant_state,
+                )
+            except BulkIndexError as e:
+                # There are several reasons why this might be raised, but the
+                # most likely one is if the deletion has not had enough time to
+                # propogate throughout the index, in which case this would be
+                # raised with some form of "version_conflict_engine_exception
+                # version conflict, document already exists" messaging.
+                # Refresh the index and try one more time. We do not refresh
+                # after every delete because this may become expensive.
+                logger.warning(
+                    f"Failed to bulk index documents: {e}. Refreshing index and trying again."
+                )
+                self._client.refresh_index()
+                self._client.bulk_index_documents(
+                    documents=chunk_batch,
+                    tenant_state=self._tenant_state,
+                )
 
         for chunk in chunks:
             doc_id = chunk.source_document.id

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -747,6 +747,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 self._client.bulk_index_documents(
                     documents=chunk_batch,
                     tenant_state=self._tenant_state,
+                    # At this point we know for sure some docs from this batch
+                    # may exist, so we don't want to fail in that case.
+                    update_if_exists=True,
                 )
 
         for chunk in chunks:

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -724,6 +724,11 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         already_existed=num_chunks_deleted > 0,
                     )
                 )
+                # Refresh the index because deletion may take a little to
+                # propagate, and if a chunk's deletion still has not propagated
+                # by the time we try to index the new chunk below, an exception
+                # will be raised.
+                self._client.refresh_index()
             # Now index. This will raise if a chunk of the same ID exists, which
             # we do not expect because we should have deleted all chunks.
             self._client.bulk_index_documents(


### PR DESCRIPTION
## Description
I'm seeing `backend/tests/external_dependency_unit/document_index/test_document_index.py::TestDocumentIndexNew::test_index_existing_doc_already_existed_true` be flaky with the following issue: `version conflict, document already exists`. This is likely caused because when we try to index a chunk, we first try to delete any existing chunks with the same ID, but if that deletion takes longer to propagate throughout the document index than the index code gets to the bulk indexing step, we will error with the chunk already exist error above.

## How Has This Been Tested?
'twas not explicitly but when this merges I will rebase #10446 and hope `test_index_existing_doc_already_existed_true` passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a safe retry for bulk indexing after deletes to prevent version conflicts when re-indexing chunks. On a conflict, we refresh the index and retry once with `update_if_exists=True` to reduce flakiness.

- **Bug Fixes**
  - In `_flush_chunks`, catch `BulkIndexError`, log, call `self._client.refresh_index()`, then retry once with `update_if_exists=True`; fixes "document already exists" errors in `TestDocumentIndexNew::test_index_existing_doc_already_existed_true`.
  - Updated `client.bulk_index_documents` docstring to note it can raise `BulkIndexError` from `opensearchpy`.

<sup>Written for commit b9b873d64008f125b07b593ef9e6da914725029b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



