### PR TITLE
fix(indexing): short-circuit get_old_index_attempt_ids

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -42,7 +42,7 @@ from onyx.background.indexing.checkpointing_utils import (
     get_index_attempts_with_old_checkpoints,
 )
 from onyx.background.indexing.index_attempt_utils import cleanup_index_attempts
-from onyx.background.indexing.index_attempt_utils import get_old_index_attempts
+from onyx.background.indexing.index_attempt_utils import get_old_index_attempt_ids
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import MANAGED_VESPA
 from onyx.configs.app_configs import VESPA_CLOUD_CERT_PATH
@@ -1250,25 +1250,25 @@ def check_for_index_attempt_cleanup(self: Task, *, tenant_id: str) -> None:
         locked = True
         batch_size = INDEX_ATTEMPT_BATCH_SIZE
         with get_session_with_current_tenant() as db_session:
-            old_attempts = get_old_index_attempts(db_session)
+            old_attempt_ids = get_old_index_attempt_ids(db_session)
             # We need to batch this because during the initial run, the system might have a large number
             # of index attempts since they were never deleted. After that, the number will be
             # significantly lower.
-            if len(old_attempts) == 0:
+            if len(old_attempt_ids) == 0:
                 task_logger.info(
                     "check_for_index_attempt_cleanup - No index attempts to cleanup"
                 )
                 return
 
-            for i in range(0, len(old_attempts), batch_size):
-                batch = old_attempts[i : i + batch_size]
+            for i in range(0, len(old_attempt_ids), batch_size):
+                batch = old_attempt_ids[i : i + batch_size]
                 task_logger.info(
                     f"check_for_index_attempt_cleanup - Cleaning up index attempts {len(batch)}"
                 )
                 self.app.send_task(
                     OnyxCeleryTask.CLEANUP_INDEX_ATTEMPT,
                     kwargs={
-                        "index_attempt_ids": [attempt.id for attempt in batch],
+                        "index_attempt_ids": batch,
                         "tenant_id": tenant_id,
                     },
                     queue=OnyxCeleryQueues.INDEX_ATTEMPT_CLEANUP,

--- a/backend/onyx/background/indexing/index_attempt_utils.py
+++ b/backend/onyx/background/indexing/index_attempt_utils.py
@@ -13,14 +13,22 @@ from onyx.db.models import IndexAttemptError
 NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP = 10
 
 
-def get_old_index_attempts(
+def get_old_index_attempt_ids(
     db_session: Session, days_to_keep: int = NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS
-) -> list[IndexAttempt]:
+) -> list[int]:
     """
-    Get index attempts older than the specified number of days while retaining
+    Get IDs of index attempts older than the specified number of days while retaining
     the latest NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP per connector/search settings pair.
     """
     cutoff_date = get_db_current_time(db_session) - timedelta(days=days_to_keep)
+
+    # Short-circuit using the index on time_created. The window query below
+    # cannot use an index (ROW_NUMBER must rank every row before WHERE can
+    # filter), so when nothing is old enough to clean we skip it entirely.
+    oldest = db_session.query(func.min(IndexAttempt.time_created)).scalar()
+    if oldest is None or oldest >= cutoff_date:
+        return []
+
     ranked_attempts = (
         db_session.query(
             IndexAttempt.id.label("attempt_id"),
@@ -37,8 +45,8 @@ def get_old_index_attempts(
         )
     ).subquery()
 
-    return (
-        db_session.query(IndexAttempt)
+    rows = (
+        db_session.query(IndexAttempt.id)
         .join(
             ranked_attempts,
             IndexAttempt.id == ranked_attempts.c.attempt_id,
@@ -49,6 +57,7 @@ def get_old_index_attempts(
         )
         .all()
     )
+    return [row[0] for row in rows]
 
 
 def cleanup_index_attempts(db_session: Session, index_attempt_ids: list[int]) -> None:

--- a/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
+++ b/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
@@ -1,0 +1,129 @@
+"""External dependency unit tests for `get_old_index_attempt_ids`.
+
+Validates the cleanup-query logic against real Postgres:
+
+- Short-circuits (returns []) when no rows exist OR when the oldest row is
+  within the retention window. The short-circuit relies on the index on
+  `time_created` to avoid the full-table window-function scan that dominated
+  AAS on the cloud cluster.
+- When stale rows exist, returns their IDs while retaining the most recent
+  NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP per (cc_pair, search_settings) group.
+- Returns plain `int`s, not hydrated ORM objects.
+"""
+
+from collections.abc import Generator
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from onyx.background.indexing.index_attempt_utils import (
+    get_old_index_attempt_ids,
+)
+from onyx.background.indexing.index_attempt_utils import (
+    NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP,
+)
+from onyx.configs.constants import NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS
+from onyx.db.engine.time_utils import get_db_current_time
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        # index_attempt has no ON DELETE CASCADE from cc_pair; drop first.
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _make_attempt(
+    db_session: Session,
+    cc_pair_id: int,
+    days_old: float,
+) -> int:
+    """Insert an IndexAttempt whose `time_created` is `days_old` days before db now."""
+    target_time = get_db_current_time(db_session) - timedelta(days=days_old)
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair_id,
+        search_settings_id=None,
+        from_beginning=False,
+        status=IndexingStatus.NOT_STARTED,
+    )
+    db_session.add(attempt)
+    db_session.flush()
+    # server_default=func.now() fires on INSERT; override to the target time.
+    db_session.execute(
+        update(IndexAttempt)
+        .where(IndexAttempt.id == attempt.id)
+        .values(time_created=target_time)
+    )
+    db_session.commit()
+    return attempt.id
+
+
+class TestShortCircuit:
+    def test_no_attempts_returns_empty(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,  # noqa: ARG002
+    ) -> None:
+        assert get_old_index_attempt_ids(db_session) == []
+
+    def test_all_recent_returns_empty(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+    ) -> None:
+        for _ in range(15):
+            _make_attempt(db_session, cc_pair.id, days_old=1)
+
+        assert get_old_index_attempt_ids(db_session) == []
+
+
+class TestWindowQuery:
+    def test_old_beyond_keep_count_returned(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+    ) -> None:
+        recent_days = max(1, NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS - 1)
+        old_days = NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS + 1
+
+        for _ in range(NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP):
+            _make_attempt(db_session, cc_pair.id, days_old=recent_days)
+
+        old_ids: list[int] = [
+            _make_attempt(db_session, cc_pair.id, days_old=old_days) for _ in range(3)
+        ]
+
+        result = get_old_index_attempt_ids(db_session)
+        assert sorted(result) == sorted(old_ids)
+        assert all(isinstance(i, int) for i in result)
+
+    def test_old_within_keep_count_not_returned(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+    ) -> None:
+        # Fewer rows than NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP: even if every one
+        # of them is past the retention window, none are eligible because the
+        # rank filter (rank > keep_count) excludes them all.
+        old_days = NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS + 5
+        for _ in range(5):
+            _make_attempt(db_session, cc_pair.id, days_old=old_days)
+
+        assert get_old_index_attempt_ids(db_session) == []

--- a/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
+++ b/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
@@ -18,9 +18,7 @@ import pytest
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
-from onyx.background.indexing.index_attempt_utils import (
-    get_old_index_attempt_ids,
-)
+from onyx.background.indexing.index_attempt_utils import get_old_index_attempt_ids
 from onyx.background.indexing.index_attempt_utils import (
     NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP,
 )


### PR DESCRIPTION
## Description

On the multi-tenant cloud cluster we see a sharp RDS spike every 4h dominated by `SELECT tenant_<uuid>.index_attempt.id AS index_attempt_id, ...` queries fanned out across many tenant schemas in quick succession. The source is `check-for-index-attempt-cleanup`, a beat task with a 30-minute base schedule that becomes 4 hours in cloud (`CLOUD_BEAT_MULTIPLIER_DEFAULT = 8`) and fans out to every tenant via `cloud_beat_task_generator` (the template sets `skip_gated=False`, so both active and gated tenants run it — ~20k per cycle on the managed cluster).

The per-tenant query in `get_old_index_attempts` used a `ROW_NUMBER() OVER (PARTITION BY cc_pair_id, search_settings_id ORDER BY time_created DESC)` with the retention/rank filters applied **after** the window. Postgres has to scan and sort the whole `index_attempt` table before it can filter, regardless of indexes on `time_created` and `connector_credential_pair_id`. Multiplied across ~20k tenant schemas converging within seconds of each other, this produced the :25-of-the-hour stacked-AAS pattern.

This PR makes two narrow changes:

1. Add a `MIN(time_created)` short-circuit up front using the existing `ix_index_attempt_time_created` index. If the oldest row is already within the retention window (true for almost every tenant almost every cycle, and for every gated tenant after the first couple of cycles), return `[]` without touching the window query. One cheap indexed lookup replaces the full-table scan.
2. Change `get_old_index_attempts(...) -> list[IndexAttempt]` to `get_old_index_attempt_ids(...) -> list[int]`. The only caller already discards everything except `.id` — no reason to hydrate full ORM rows (including `error_msg` / `full_exception_trace TEXT` columns).

This is a targeted perf fix, not a rearchitecture. A follow-up will move to event-driven cleanup scoped per `(cc_pair_id, search_settings_id)` on `IndexAttempt` status finalization, plus wiring this template into the tenant work-gating set so the periodic sweep only visits active tenants.

## How Has This Been Tested?

Added `backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py` with four cases covering both the short-circuit path and the window-query path:

- `test_no_attempts_returns_empty` — empty table returns `[]` via the short-circuit.
- `test_all_recent_returns_empty` — 15 rows all within the retention window, short-circuit still fires (`MIN(time_created) >= cutoff`).
- `test_old_beyond_keep_count_returned` — 10 recent + 3 old. The 3 old IDs are returned; return value is `list[int]`.
- `test_old_within_keep_count_not_returned` — 5 rows all beyond the retention window. None are returned because the `rank > NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP` filter keeps every row in the "most recent 10" bucket.

Run locally with:

```
python -m dotenv -f .vscode/.env run -- pytest backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Short-circuits the index attempt cleanup query and returns only attempt IDs to avoid full-table window scans, reducing DB load during the 4‑hour multi-tenant sweep. No change to which attempts are cleaned.

- **Refactors**
  - Add a MIN(time_created) indexed check; if the oldest row is within the retention window, skip the window query and return [].
  - Rename get_old_index_attempts → get_old_index_attempt_ids and update the Celery task to pass IDs directly (no ORM hydration).
  - Add tests for empty-table, all-recent short-circuit, and stale rows with/without keep-count thresholds.

<sup>Written for commit 8782e0665062fb0d83bea3ae15fa71402d9fc4d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

