### PR TITLE
feat: openapi tool user placeholder

### DIFF
--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -148,6 +148,8 @@ class ChatMinimalTextMessage(BaseModel):
 class DynamicSchemaInfo(BaseModel):
     chat_session_id: UUID | None
     message_id: int | None
+    user_id: UUID | None = None
+    user_email: str | None = None
 
 
 class WebSearchToolOverrideKwargs(BaseModel):
@@ -252,6 +254,8 @@ class ToolCallInfo(BaseModel):
 
 CHAT_SESSION_ID_PLACEHOLDER = "CHAT_SESSION_ID"
 MESSAGE_ID_PLACEHOLDER = "MESSAGE_ID"
+USER_ID_PLACEHOLDER = "USER_ID"
+USER_EMAIL_PLACEHOLDER = "USER_EMAIL"
 
 
 class BaseCiteableToolResult(BaseModel):

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -368,8 +368,8 @@ def _construct_tools_impl(
                     dynamic_schema_info=DynamicSchemaInfo(
                         chat_session_id=custom_tool_config.chat_session_id,
                         message_id=custom_tool_config.message_id,
-                        user_id=None if user.is_anonymous else user.id,
-                        user_email=None if user.is_anonymous else user.email,
+                        user_id=user.id,
+                        user_email="anonymous" if user.is_anonymous else user.email,
                     ),
                     custom_headers=(db_tool_model.custom_headers or [])
                     + (

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -368,6 +368,8 @@ def _construct_tools_impl(
                     dynamic_schema_info=DynamicSchemaInfo(
                         chat_session_id=custom_tool_config.chat_session_id,
                         message_id=custom_tool_config.message_id,
+                        user_id=None if user.is_anonymous else user.id,
+                        user_email=None if user.is_anonymous else user.email,
                     ),
                     custom_headers=(db_tool_model.custom_headers or [])
                     + (

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -28,6 +28,8 @@ from onyx.tools.models import DynamicSchemaInfo
 from onyx.tools.models import MESSAGE_ID_PLACEHOLDER
 from onyx.tools.models import ToolCallException
 from onyx.tools.models import ToolResponse
+from onyx.tools.models import USER_EMAIL_PLACEHOLDER
+from onyx.tools.models import USER_ID_PLACEHOLDER
 from onyx.tools.tool_implementations.custom.openapi_parsing import MethodSpec
 from onyx.tools.tool_implementations.custom.openapi_parsing import (
     openapi_to_method_specs,
@@ -285,6 +287,8 @@ def build_custom_tools_from_openapi_schema_and_headers(
         placeholders = {
             CHAT_SESSION_ID_PLACEHOLDER: dynamic_schema_info.chat_session_id,
             MESSAGE_ID_PLACEHOLDER: dynamic_schema_info.message_id,
+            USER_ID_PLACEHOLDER: dynamic_schema_info.user_id,
+            USER_EMAIL_PLACEHOLDER: dynamic_schema_info.user_email,
         }
 
         for placeholder, value in placeholders.items():

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -281,8 +281,24 @@ def build_custom_tools_from_openapi_schema_and_headers(
     dynamic_schema_info: DynamicSchemaInfo | None = None,
     user_oauth_token: str | None = None,
 ) -> list[CustomTool]:
+    """Build CustomTool instances from an OpenAPI schema.
+
+    Placeholder substitution: when ``dynamic_schema_info`` is provided, the
+    JSON-serialized schema is scanned for the following literal strings and
+    each is replaced with the corresponding per-request value before the tool
+    is built:
+
+      - ``CHAT_SESSION_ID``  -> current chat session UUID
+      - ``MESSAGE_ID``       -> current chat message id
+      - ``USER_ID``          -> current user UUID (skipped for anonymous users)
+      - ``USER_EMAIL``       -> current user email (skipped for anonymous users)
+
+    Placeholders whose value is ``None`` (e.g. an anonymous user's identity)
+    are left untouched in the schema rather than substituted with an empty
+    string. Substitution only happens inside the OpenAPI schema; static
+    ``custom_headers`` are not templated.
+    """
     if dynamic_schema_info:
-        # Process dynamic schema information
         schema_str = json.dumps(openapi_schema)
         placeholders = {
             CHAT_SESSION_ID_PLACEHOLDER: dynamic_schema_info.chat_session_id,

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -241,6 +241,139 @@ class TestCustomTool(unittest.TestCase):
         with self.assertRaises(ValueError) as _:
             validate_openapi_schema(invalid_schema)
 
+    @patch("onyx.tools.tool_implementations.custom.custom_tool.requests.request")
+    def test_custom_tool_user_placeholders(
+        self, mock_request: unittest.mock.MagicMock
+    ) -> None:
+        """USER_ID and USER_EMAIL placeholders are substituted across the
+        OpenAPI schema (server URL, paths, headers) at tool-build time."""
+        mock_response = unittest.mock.MagicMock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"ok": True}
+        mock_request.return_value = mock_response
+
+        user_id = uuid.uuid4()
+        user_email = "alice@example.com"
+
+        schema: dict[str, Any] = {
+            "openapi": "3.0.0",
+            "info": {
+                "version": "1.0.0",
+                "title": "User-aware API",
+                "description": "Schema with USER_ID/USER_EMAIL placeholders",
+            },
+            "servers": [{"url": "http://localhost:8080/users/USER_ID"}],
+            "paths": {
+                "/by-email/{email}": {
+                    "GET": {
+                        "summary": "Lookup by email",
+                        "operationId": "lookupByEmail",
+                        "parameters": [
+                            {
+                                "name": "email",
+                                "in": "path",
+                                "required": True,
+                                "schema": {
+                                    "type": "string",
+                                    "default": "USER_EMAIL",
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+        }
+        validate_openapi_schema(schema)
+
+        tools = build_custom_tools_from_openapi_schema_and_headers(
+            tool_id=-1,
+            openapi_schema=schema,
+            custom_headers=[
+                {"key": "X-Onyx-User-Id", "value": "USER_ID"},
+                {
+                    "key": "X-Onyx-User-Email",  # pragma: allowlist secret
+                    "value": "USER_EMAIL",
+                },
+            ],
+            dynamic_schema_info=DynamicSchemaInfo(
+                chat_session_id=None,
+                message_id=None,
+                user_id=user_id,
+                user_email=user_email,
+            ),
+        )
+
+        tools[0].run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=None,
+            email=user_email,
+        )
+
+        expected_url = f"http://localhost:8080/users/{user_id}/by-email/{user_email}"
+        # Custom headers do NOT receive placeholder substitution today;
+        # only the OpenAPI schema string is templated.
+        expected_headers = {
+            "X-Onyx-User-Id": "USER_ID",
+            "X-Onyx-User-Email": "USER_EMAIL",
+        }
+        mock_request.assert_called_once_with(
+            "GET", expected_url, json=None, headers=expected_headers
+        )
+
+    @patch("onyx.tools.tool_implementations.custom.custom_tool.requests.request")
+    def test_custom_tool_user_placeholders_unset_are_left_alone(
+        self, mock_request: unittest.mock.MagicMock
+    ) -> None:
+        """When user_id/user_email aren't provided (e.g. anonymous user),
+        the literal placeholders remain in the schema rather than being
+        replaced with empty strings."""
+        mock_response = unittest.mock.MagicMock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"ok": True}
+        mock_request.return_value = mock_response
+
+        schema: dict[str, Any] = {
+            "openapi": "3.0.0",
+            "info": {
+                "version": "1.0.0",
+                "title": "User-aware API",
+                "description": "Schema with USER_ID placeholder but no user",
+            },
+            "servers": [{"url": "http://localhost:8080/users/USER_ID"}],
+            "paths": {
+                "/ping": {
+                    "GET": {
+                        "summary": "Ping",
+                        "operationId": "ping",
+                    }
+                }
+            },
+        }
+        validate_openapi_schema(schema)
+
+        tools = build_custom_tools_from_openapi_schema_and_headers(
+            tool_id=-1,
+            openapi_schema=schema,
+            dynamic_schema_info=DynamicSchemaInfo(
+                chat_session_id=None,
+                message_id=None,
+                user_id=None,
+                user_email=None,
+            ),
+        )
+
+        tools[0].run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=None,
+        )
+
+        mock_request.assert_called_once_with(
+            "GET",
+            "http://localhost:8080/users/USER_ID/ping",
+            json=None,
+            headers={},
+        )
+
     def test_custom_tool_final_result(self) -> None:
         """
         Test extracting the final result from a custom tool response.

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -238,7 +238,11 @@ function FormContent({
           withLabel="definition"
           title="OpenAPI Schema Definition"
           subDescription={markdown(
-            `Specify an OpenAPI schema that defines the APIs you want to make available as part of this action. Learn more about [OpenAPI actions](${DOCS_ADMINS_PATH}/actions/openapi).`
+            `Specify an OpenAPI schema that defines the APIs you want to make available as part of this action. ` +
+              `You can use the placeholders \`CHAT_SESSION_ID\`, \`MESSAGE_ID\`, \`USER_ID\`, and \`USER_EMAIL\` ` +
+              `anywhere in the schema (e.g. server URL, paths, parameter defaults) and they will be replaced with the ` +
+              `current request's values at call time. ` +
+              `Learn more about [OpenAPI actions](${DOCS_ADMINS_PATH}/actions/openapi).`
           )}
         >
           <Hoverable.Root group="definitionField" width="full">


### PR DESCRIPTION
## Description

Let users pass user id and email in their openapi tool specs

## How Has This Been Tested?

added test (will push in a sec)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable per-user context in OpenAPI custom tools with `USER_ID` and `USER_EMAIL` placeholders, substituted across the schema at call time. Placeholders are left as-is for anonymous users; headers are not templated.

- **New Features**
  - Added optional `user_id` and `user_email` to `DynamicSchemaInfo`; populated in `_build_search_tool` from the authenticated user and skipped when unset.
  - Supported `USER_ID` and `USER_EMAIL` placeholders across the OpenAPI schema (servers, paths, parameter defaults); skipped when the value is `None`.
  - Kept `custom_headers` untouched (no placeholder templating).
  - Updated the Add OpenAPI Action modal to document `CHAT_SESSION_ID`, `MESSAGE_ID`, `USER_ID`, `USER_EMAIL`; added unit tests for substitution and anonymous behavior.

<sup>Written for commit e468047ca0deadbe72d3ee737425bd0e9d10f2f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

