### PR TITLE
fix: hide unlisted agents from AgentsNavigationPage

### DIFF
--- a/web/src/refresh-pages/AgentsNavigationPage.tsx
+++ b/web/src/refresh-pages/AgentsNavigationPage.tsx
@@ -328,6 +328,8 @@ export default function AgentsNavigationPage() {
         activeTab === "your" ? checkUserOwnsAgent(user, agent) : true;
       const isNotUnifiedAgent = agent.id !== 0;
 
+      const listedFilter = agent.is_listed || checkUserOwnsAgent(user, agent);
+
       const creatorFilter =
         selectedCreatorIds.size === 0 ||
         (agent.owner && selectedCreatorIds.has(agent.owner.id));
@@ -346,6 +348,7 @@ export default function AgentsNavigationPage() {
         (nameMatches || labelMatches) &&
         mineFilter &&
         isNotUnifiedAgent &&
+        listedFilter &&
         creatorFilter &&
         actionsFilter
       );


### PR DESCRIPTION
## Description

Fixes a bug where unlisting an agent from the admin panel did not hide it from the user-facing explore agents page (`AgentsNavigationPage`).

Adds an `is_listed` filter to the visible agents computation. Unlisted agents are now hidden from the browse page unless the current user is the agent's owner.

**Stack:** 2/3 — stacked on #10506 (merged).

## How Has This Been Tested?

- Type check passes (`bun run types:check`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide unlisted agents from the explore page (`AgentsNavigationPage`). Owners can still see their own unlisted agents.

- **Bug Fixes**
  - Added `listedFilter` to visible agents: `agent.is_listed || checkUserOwnsAgent(user, agent)` to reflect admin unlisting on the browse page.

<sup>Written for commit 5f0e39c77abac0787a4525dd2052e71531f8ccd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

