### PR TITLE
feat(billing): redis cache for trial + billing info lookups 

### DIFF
--- a/backend/ee/onyx/server/billing/api.py
+++ b/backend/ee/onyx/server/billing/api.py
@@ -33,6 +33,9 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.db.license import get_license
 from ee.onyx.db.license import get_used_seats
+from ee.onyx.server.billing.billing_cache import (
+    invalidate_billing_cache as invalidate_indexing_trial_cache,
+)
 from ee.onyx.server.billing.models import BillingInformationResponse
 from ee.onyx.server.billing.models import CreateCheckoutSessionRequest
 from ee.onyx.server.billing.models import CreateCheckoutSessionResponse
@@ -257,14 +260,22 @@ def _billing_cache_client() -> TenantRedisClient | None:
 
 
 def _invalidate_billing_cache() -> None:
-    """Drop the cached /billing-information entry. Best-effort."""
+    """Drop the cached billing entries after a subscription mutation.
+
+    Best-effort. Busts the 5-min admin /billing-information entry, plus (cloud
+    only) the 24h per-tenant trial-status entry the indexing path reads via
+    ``cached_is_tenant_on_trial`` — without this a trial→paid conversion keeps
+    usage limits on stale trial status for up to a full TTL.
+    """
     redis_client = _billing_cache_client()
-    if redis_client is None:
-        return
-    try:
-        redis_client.delete(BILLING_INFO_CACHE_KEY)
-    except RedisError as exc:
-        logger.warning("Billing info cache invalidation failed: %s", exc)
+    if redis_client is not None:
+        try:
+            redis_client.delete(BILLING_INFO_CACHE_KEY)
+        except RedisError as exc:
+            logger.warning("Billing info cache invalidation failed: %s", exc)
+
+    if MULTI_TENANT:
+        invalidate_indexing_trial_cache(get_current_tenant_id())
 
 
 @router.get("/billing-information")

--- a/backend/ee/onyx/server/billing/billing_cache.py
+++ b/backend/ee/onyx/server/billing/billing_cache.py
@@ -57,12 +57,23 @@ def _serialize(info: BillingInformation | SubscriptionStatusResponse) -> str:
 
 def _deserialize(raw: bytes | str) -> BillingInformation | SubscriptionStatusResponse:
     envelope = json.loads(raw)
+    if not isinstance(envelope, dict):
+        raise ValueError("Billing cache envelope must be a JSON object.")
+
     kind = envelope.get("type")
-    payload = envelope.get("payload") or {}
+
+    payload = envelope.get("payload")
+    if payload is None:
+        payload_dict: dict[str, Any] = {}
+    elif isinstance(payload, dict):
+        payload_dict = payload
+    else:
+        raise ValueError("Billing cache payload must be a JSON object.")
+
     if kind == _TYPE_BILLING:
-        return BillingInformation(**payload)
+        return BillingInformation(**payload_dict)
     if kind == _TYPE_STATUS:
-        return SubscriptionStatusResponse(**payload)
+        return SubscriptionStatusResponse(**payload_dict)
     raise ValueError(f"Unknown billing cache envelope type: {kind!r}")
 
 

--- a/backend/ee/onyx/server/billing/billing_cache.py
+++ b/backend/ee/onyx/server/billing/billing_cache.py
@@ -4,8 +4,7 @@ Without this cache, every document batch processed by a large indexing run
 fires a `/billing-information` request at the control plane (via
 `_check_chunk_usage_limit` → `check_usage_and_raise` → `is_tenant_on_trial`
 → `fetch_billing_information`). One legitimately-indexing tenant can thus
-single-handedly dominate control-plane load. See the L3-A plan at
-``~/onyx-claude-plans/l3-a-onyx-billing-cache.md``.
+single-handedly dominate control-plane load.
 
 Granularity is per-tenant `BillingInformation | SubscriptionStatusResponse`;
 ``cached_is_tenant_on_trial`` derives the trial flag from the same cached
@@ -21,6 +20,7 @@ Fallback order on every call:
 import json
 from typing import Any
 
+from pydantic import ValidationError
 from redis.exceptions import RedisError
 
 from ee.onyx.server.tenants.billing import fetch_billing_information
@@ -47,16 +47,11 @@ def _cache_key(tenant_id: str) -> str:
 
 
 def _serialize(info: BillingInformation | SubscriptionStatusResponse) -> str:
-    if isinstance(info, BillingInformation):
-        envelope: dict[str, Any] = {
-            "type": _TYPE_BILLING,
-            "payload": json.loads(info.model_dump_json()),
-        }
-    else:
-        envelope = {
-            "type": _TYPE_STATUS,
-            "payload": json.loads(info.model_dump_json()),
-        }
+    kind = _TYPE_BILLING if isinstance(info, BillingInformation) else _TYPE_STATUS
+    envelope: dict[str, Any] = {
+        "type": kind,
+        "payload": info.model_dump(mode="json"),
+    }
     return json.dumps(envelope)
 
 
@@ -92,8 +87,12 @@ def cached_fetch_billing_information(
     if raw and isinstance(raw, (bytes, str)):
         try:
             return _deserialize(raw)
-        except (json.JSONDecodeError, ValueError) as e:
-            # Corrupt entry (stale schema, partial write) — discard and refetch.
+        except (json.JSONDecodeError, ValueError, ValidationError) as e:
+            # Corrupt or schema-drifted entry — discard and refetch. Pydantic
+            # ``ValidationError`` is NOT a subclass of ``ValueError`` in v2,
+            # so it must be caught explicitly; otherwise a schema change to
+            # ``BillingInformation`` leaves every subsequent read failing for
+            # the full TTL without ever reaching the refetch/overwrite below.
             logger.warning(
                 f"billing cache entry for tenant {tenant_id} unparseable, refetching: {e}"
             )

--- a/backend/ee/onyx/server/billing/billing_cache.py
+++ b/backend/ee/onyx/server/billing/billing_cache.py
@@ -29,6 +29,7 @@ from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.configs.app_configs import BILLING_CACHE_TTL_SECONDS
 from onyx.redis.redis_pool import get_shared_redis_client
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
@@ -83,7 +84,17 @@ def cached_fetch_billing_information(
     """Return billing info for a tenant, preferring the per-tenant Redis
     entry over a control-plane round-trip. Writes the entry on miss with
     ``BILLING_CACHE_TTL_SECONDS`` TTL.
+
+    Cloud-only: there is no control-plane billing in single-tenant
+    deployments, so callers must already be on the multi-tenant path. Fail
+    loudly rather than silently open a Redis/control-plane connection that a
+    Lite deployment may not have.
     """
+    if not MULTI_TENANT:
+        raise RuntimeError(
+            "cached_fetch_billing_information is cloud-only; gate callers on MULTI_TENANT"
+        )
+
     redis = get_shared_redis_client()
     key = _cache_key(tenant_id)
 
@@ -127,6 +138,10 @@ def cached_is_tenant_on_trial(tenant_id: str) -> bool:
     entry as ``cached_fetch_billing_information`` so the boolean and the
     full billing object cannot drift.
     """
+    if not MULTI_TENANT:
+        # No control-plane billing in single-tenant; trial limits don't apply.
+        return False
+
     info = cached_fetch_billing_information(tenant_id)
     if isinstance(info, SubscriptionStatusResponse):
         # No subscription on record — treat as trial (matches legacy behaviour
@@ -140,6 +155,9 @@ def invalidate_billing_cache(tenant_id: str) -> None:
     exists. Used by call sites that just mutated the tenant's subscription
     (e.g. admin panel → control plane) and want the next read to refresh.
     """
+    if not MULTI_TENANT:
+        return
+
     try:
         get_shared_redis_client().delete(_cache_key(tenant_id))
     except RedisError as e:

--- a/backend/ee/onyx/server/billing/billing_cache.py
+++ b/backend/ee/onyx/server/billing/billing_cache.py
@@ -80,7 +80,9 @@ def cached_fetch_billing_information(
         raw = redis.get(key)
     except RedisError as e:
         logger.warning(
-            f"billing cache read failed for tenant {tenant_id}, falling through to CP: {e}"
+            "billing cache read failed for tenant %s, falling through to CP: %s",
+            tenant_id,
+            e,
         )
         return fetch_billing_information(tenant_id)
 
@@ -94,7 +96,9 @@ def cached_fetch_billing_information(
             # ``BillingInformation`` leaves every subsequent read failing for
             # the full TTL without ever reaching the refetch/overwrite below.
             logger.warning(
-                f"billing cache entry for tenant {tenant_id} unparseable, refetching: {e}"
+                "billing cache entry for tenant %s unparseable, refetching: %s",
+                tenant_id,
+                e,
             )
 
     info = fetch_billing_information(tenant_id)
@@ -102,7 +106,7 @@ def cached_fetch_billing_information(
     try:
         redis.setex(key, BILLING_CACHE_TTL_SECONDS, _serialize(info))
     except RedisError as e:
-        logger.warning(f"billing cache write failed for tenant {tenant_id}: {e}")
+        logger.warning("billing cache write failed for tenant %s: %s", tenant_id, e)
 
     return info
 
@@ -128,4 +132,6 @@ def invalidate_billing_cache(tenant_id: str) -> None:
     try:
         get_shared_redis_client().delete(_cache_key(tenant_id))
     except RedisError as e:
-        logger.warning(f"billing cache invalidate failed for tenant {tenant_id}: {e}")
+        logger.warning(
+            "billing cache invalidate failed for tenant %s: %s", tenant_id, e
+        )

--- a/backend/ee/onyx/server/billing/billing_cache.py
+++ b/backend/ee/onyx/server/billing/billing_cache.py
@@ -1,0 +1,132 @@
+"""Redis-backed cache for control-plane billing lookups.
+
+Without this cache, every document batch processed by a large indexing run
+fires a `/billing-information` request at the control plane (via
+`_check_chunk_usage_limit` → `check_usage_and_raise` → `is_tenant_on_trial`
+→ `fetch_billing_information`). One legitimately-indexing tenant can thus
+single-handedly dominate control-plane load. See the L3-A plan at
+``~/onyx-claude-plans/l3-a-onyx-billing-cache.md``.
+
+Granularity is per-tenant `BillingInformation | SubscriptionStatusResponse`;
+``cached_is_tenant_on_trial`` derives the trial flag from the same cached
+entry so the two views cannot drift.
+
+Fallback order on every call:
+  1. Redis hit  → return the cached payload.
+  2. Redis miss → control-plane fetch, write through, return.
+  3. Redis error (read or write) → log and fall through to an uncached
+     control-plane fetch. Preserves availability when Redis blips.
+"""
+
+import json
+from typing import Any
+
+from redis.exceptions import RedisError
+
+from ee.onyx.server.tenants.billing import fetch_billing_information
+from ee.onyx.server.tenants.models import BillingInformation
+from ee.onyx.server.tenants.models import SubscriptionStatusResponse
+from onyx.configs.app_configs import BILLING_CACHE_TTL_SECONDS
+from onyx.redis.redis_pool import get_shared_redis_client
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+BILLING_CACHE_KEY = "billing:info:{tenant_id}"
+
+_TRIAL_STATUSES: frozenset[str] = frozenset({"trialing"})
+
+# Discriminator used to round-trip the union return type through Redis without
+# losing the BillingInformation vs SubscriptionStatusResponse distinction.
+_TYPE_BILLING = "billing"
+_TYPE_STATUS = "status"
+
+
+def _cache_key(tenant_id: str) -> str:
+    return BILLING_CACHE_KEY.format(tenant_id=tenant_id)
+
+
+def _serialize(info: BillingInformation | SubscriptionStatusResponse) -> str:
+    if isinstance(info, BillingInformation):
+        envelope: dict[str, Any] = {
+            "type": _TYPE_BILLING,
+            "payload": json.loads(info.model_dump_json()),
+        }
+    else:
+        envelope = {
+            "type": _TYPE_STATUS,
+            "payload": json.loads(info.model_dump_json()),
+        }
+    return json.dumps(envelope)
+
+
+def _deserialize(raw: bytes | str) -> BillingInformation | SubscriptionStatusResponse:
+    envelope = json.loads(raw)
+    kind = envelope.get("type")
+    payload = envelope.get("payload") or {}
+    if kind == _TYPE_BILLING:
+        return BillingInformation(**payload)
+    if kind == _TYPE_STATUS:
+        return SubscriptionStatusResponse(**payload)
+    raise ValueError(f"Unknown billing cache envelope type: {kind!r}")
+
+
+def cached_fetch_billing_information(
+    tenant_id: str,
+) -> BillingInformation | SubscriptionStatusResponse:
+    """Return billing info for a tenant, preferring the per-tenant Redis
+    entry over a control-plane round-trip. Writes the entry on miss with
+    ``BILLING_CACHE_TTL_SECONDS`` TTL.
+    """
+    redis = get_shared_redis_client()
+    key = _cache_key(tenant_id)
+
+    try:
+        raw = redis.get(key)
+    except RedisError as e:
+        logger.warning(
+            f"billing cache read failed for tenant {tenant_id}, falling through to CP: {e}"
+        )
+        return fetch_billing_information(tenant_id)
+
+    if raw and isinstance(raw, (bytes, str)):
+        try:
+            return _deserialize(raw)
+        except (json.JSONDecodeError, ValueError) as e:
+            # Corrupt entry (stale schema, partial write) — discard and refetch.
+            logger.warning(
+                f"billing cache entry for tenant {tenant_id} unparseable, refetching: {e}"
+            )
+
+    info = fetch_billing_information(tenant_id)
+
+    try:
+        redis.setex(key, BILLING_CACHE_TTL_SECONDS, _serialize(info))
+    except RedisError as e:
+        logger.warning(f"billing cache write failed for tenant {tenant_id}: {e}")
+
+    return info
+
+
+def cached_is_tenant_on_trial(tenant_id: str) -> bool:
+    """Cached equivalent of the trial check. Derived from the same cache
+    entry as ``cached_fetch_billing_information`` so the boolean and the
+    full billing object cannot drift.
+    """
+    info = cached_fetch_billing_information(tenant_id)
+    if isinstance(info, SubscriptionStatusResponse):
+        # No subscription on record — treat as trial (matches legacy behaviour
+        # in ``ee.onyx.server.usage_limits.is_tenant_on_trial``).
+        return True
+    return info.status in _TRIAL_STATUSES
+
+
+def invalidate_billing_cache(tenant_id: str) -> None:
+    """Drop the cached entry for one tenant. Safe to call even when no entry
+    exists. Used by call sites that just mutated the tenant's subscription
+    (e.g. admin panel → control plane) and want the next read to refresh.
+    """
+    try:
+        get_shared_redis_client().delete(_cache_key(tenant_id))
+    except RedisError as e:
+        logger.warning(f"billing cache invalidate failed for tenant {tenant_id}: {e}")

--- a/backend/ee/onyx/server/usage_limits.py
+++ b/backend/ee/onyx/server/usage_limits.py
@@ -1,6 +1,6 @@
 """EE Usage limits - trial detection via billing information."""
 
-from ee.onyx.server.tenants.billing import fetch_billing_information
+from ee.onyx.server.billing.billing_cache import cached_fetch_billing_information
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.utils.logger import setup_logger
@@ -14,13 +14,16 @@ def is_tenant_on_trial(tenant_id: str) -> bool:
     Determine if a tenant is currently on a trial subscription.
 
     In multi-tenant mode, we fetch billing information from the control plane
-    to determine if the tenant has an active trial.
+    to determine if the tenant has an active trial. The fetch is cached in
+    Redis (see ``ee.onyx.server.billing.billing_cache``) so high-frequency
+    callers like ``_check_chunk_usage_limit`` don't fan out to the control
+    plane once per document batch.
     """
     if not MULTI_TENANT:
         return False
 
     try:
-        billing_info = fetch_billing_information(tenant_id)
+        billing_info = cached_fetch_billing_information(tenant_id)
 
         # If not subscribed at all, check if we have trial information
         if isinstance(billing_info, SubscriptionStatusResponse):

--- a/backend/ee/onyx/server/usage_limits.py
+++ b/backend/ee/onyx/server/usage_limits.py
@@ -1,8 +1,6 @@
 """EE Usage limits - trial detection via billing information."""
 
-from ee.onyx.server.billing.billing_cache import cached_fetch_billing_information
-from ee.onyx.server.tenants.models import BillingInformation
-from ee.onyx.server.tenants.models import SubscriptionStatusResponse
+from ee.onyx.server.billing.billing_cache import cached_is_tenant_on_trial
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
@@ -13,28 +11,17 @@ def is_tenant_on_trial(tenant_id: str) -> bool:
     """
     Determine if a tenant is currently on a trial subscription.
 
-    In multi-tenant mode, we fetch billing information from the control plane
-    to determine if the tenant has an active trial. The fetch is cached in
-    Redis (see ``ee.onyx.server.billing.billing_cache``) so high-frequency
-    callers like ``_check_chunk_usage_limit`` don't fan out to the control
-    plane once per document batch.
+    Delegates to ``cached_is_tenant_on_trial`` so the billing fetch is cached
+    in Redis (see ``ee.onyx.server.billing.billing_cache``) and the trial
+    status set lives in exactly one place. High-frequency callers like
+    ``_check_chunk_usage_limit`` therefore don't fan out to the control plane
+    once per document batch.
     """
     if not MULTI_TENANT:
         return False
 
     try:
-        billing_info = cached_fetch_billing_information(tenant_id)
-
-        # If not subscribed at all, check if we have trial information
-        if isinstance(billing_info, SubscriptionStatusResponse):
-            # No subscription means they're likely on trial (new tenant)
-            return True
-
-        if isinstance(billing_info, BillingInformation):
-            return billing_info.status == "trialing"
-
-        return False
-
+        return cached_is_tenant_on_trial(tenant_id)
     except Exception as e:
         logger.warning("Failed to fetch billing info for trial check: %s", e)
         # Default to trial limits on error (more restrictive = safer)

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -209,6 +209,12 @@ DISPOSABLE_EMAIL_DOMAINS_URL = os.environ.get(
 # lifetime, so a paired-up cookie + token never outlive each other.
 CAPTCHA_COOKIE_TTL_SECONDS = int(os.environ.get("CAPTCHA_COOKIE_TTL_SECONDS", "120"))
 
+# Redis TTL for cached control-plane billing/trial lookups. 24h default —
+# trial→paid conversions propagate within this window in the worst case,
+# and the admin panel call sites invalidate on write so immediate UI
+# refreshes are not stale. Env-tunable for emergency tightening.
+BILLING_CACHE_TTL_SECONDS = int(os.environ.get("BILLING_CACHE_TTL_SECONDS", "86400"))
+
 # OAuth Login Flow
 # Used for both Google OAuth2 and OIDC flows
 OAUTH_CLIENT_ID = (

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
@@ -197,6 +197,23 @@ def test_pydantic_validation_error_on_deserialize_refetches_and_overwrites() -> 
     redis.setex.assert_called_once()
 
 
+def test_non_mapping_payload_refetches_and_overwrites() -> None:
+    """Payload must be an object — other JSON types are treated as corrupt."""
+    cached_bytes = b'{"type":"billing","payload":"not-a-mapping"}'
+    redis = _fake_redis(get_return=cached_bytes)
+    billing = _billing("active")
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing) as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+    cp_fetch.assert_called_once_with("tenant_abc")
+    redis.setex.assert_called_once()
+
+
 def test_tenant_keys_are_isolated() -> None:
     """Cache keys must not collide across tenants."""
     redis = _fake_redis(get_return=None)

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
@@ -1,0 +1,242 @@
+"""Unit tests for the Redis-backed billing cache."""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from redis.exceptions import RedisError
+
+from ee.onyx.server.billing import billing_cache as bc
+from ee.onyx.server.billing.billing_cache import BILLING_CACHE_KEY
+from ee.onyx.server.billing.billing_cache import cached_fetch_billing_information
+from ee.onyx.server.billing.billing_cache import cached_is_tenant_on_trial
+from ee.onyx.server.billing.billing_cache import invalidate_billing_cache
+from ee.onyx.server.tenants.models import BillingInformation
+from ee.onyx.server.tenants.models import SubscriptionStatusResponse
+
+
+def _billing(status: str = "active") -> BillingInformation:
+    now = datetime.now(timezone.utc)
+    return BillingInformation(
+        stripe_subscription_id="sub_123",
+        status=status,
+        current_period_start=now,
+        current_period_end=now + timedelta(days=30),
+        number_of_seats=5,
+        cancel_at_period_end=False,
+        canceled_at=None,
+        trial_start=None,
+        trial_end=None,
+        seats=5,
+        payment_method_enabled=True,
+    )
+
+
+def _fake_redis(
+    get_return: bytes | str | None = None,
+    raise_on_get: Exception | None = None,
+    raise_on_set: Exception | None = None,
+) -> MagicMock:
+    redis = MagicMock()
+    if raise_on_get is not None:
+        redis.get = MagicMock(side_effect=raise_on_get)
+    else:
+        redis.get = MagicMock(return_value=get_return)
+    if raise_on_set is not None:
+        redis.setex = MagicMock(side_effect=raise_on_set)
+    else:
+        redis.setex = MagicMock(return_value=True)
+    redis.delete = MagicMock(return_value=1)
+    return redis
+
+
+def test_cache_hit_returns_value_without_calling_cp() -> None:
+    billing = _billing("trialing")
+    cached_bytes = (
+        '{"type":"billing","payload":' + billing.model_dump_json() + "}"
+    ).encode()
+    redis = _fake_redis(get_return=cached_bytes)
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information") as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert isinstance(result, BillingInformation)
+    assert result.status == "trialing"
+    cp_fetch.assert_not_called()
+    redis.get.assert_called_once_with(BILLING_CACHE_KEY.format(tenant_id="tenant_abc"))
+
+
+def test_cache_miss_fetches_cp_and_writes_with_ttl() -> None:
+    billing = _billing("active")
+    redis = _fake_redis(get_return=None)
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing) as cp_fetch,
+        patch.object(bc, "BILLING_CACHE_TTL_SECONDS", 3600),
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+    cp_fetch.assert_called_once_with("tenant_abc")
+    redis.setex.assert_called_once()
+    key, ttl, payload = redis.setex.call_args.args
+    assert key == BILLING_CACHE_KEY.format(tenant_id="tenant_abc")
+    assert ttl == 3600
+    assert '"type": "billing"' in payload or '"type":"billing"' in payload
+
+
+def test_cache_miss_writes_subscription_status_response_envelope() -> None:
+    status = SubscriptionStatusResponse(subscribed=False)
+    redis = _fake_redis(get_return=None)
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=status),
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == status
+    payload = redis.setex.call_args.args[2]
+    assert '"type": "status"' in payload or '"type":"status"' in payload
+
+
+def test_cached_subscription_status_roundtrip() -> None:
+    """SubscriptionStatusResponse written then read back must deserialize to
+    the same type — the discriminator is the only thing that lets us tell
+    the two union members apart on read.
+    """
+    status = SubscriptionStatusResponse(subscribed=False)
+    cached_bytes = ('{"type":"status","payload":{"subscribed":false}}').encode()
+    redis = _fake_redis(get_return=cached_bytes)
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information") as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert isinstance(result, SubscriptionStatusResponse)
+    assert result.subscribed is False
+    assert result == status
+    cp_fetch.assert_not_called()
+
+
+def test_redis_read_error_falls_through_to_cp_without_crashing() -> None:
+    billing = _billing("active")
+    redis = _fake_redis(raise_on_get=RedisError("conn refused"))
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing) as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+    cp_fetch.assert_called_once_with("tenant_abc")
+    # Did not try to write (Redis was down).
+    redis.setex.assert_not_called()
+
+
+def test_redis_write_error_is_swallowed_and_value_still_returned() -> None:
+    billing = _billing("active")
+    redis = _fake_redis(get_return=None, raise_on_set=RedisError("OOM"))
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing),
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+
+
+def test_corrupt_cache_entry_is_refetched_from_cp() -> None:
+    billing = _billing("active")
+    redis = _fake_redis(get_return=b"not-valid-json{")
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing) as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+    cp_fetch.assert_called_once_with("tenant_abc")
+    # Corrupt entry was overwritten with a fresh good entry.
+    redis.setex.assert_called_once()
+
+
+def test_tenant_keys_are_isolated() -> None:
+    """Cache keys must not collide across tenants."""
+    redis = _fake_redis(get_return=None)
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=_billing("active")),
+    ):
+        cached_fetch_billing_information("tenant_A")
+        cached_fetch_billing_information("tenant_B")
+
+    keys_read = [c.args[0] for c in redis.get.call_args_list]
+    assert keys_read == [
+        BILLING_CACHE_KEY.format(tenant_id="tenant_A"),
+        BILLING_CACHE_KEY.format(tenant_id="tenant_B"),
+    ]
+
+
+def test_is_tenant_on_trial_true_when_status_is_trialing() -> None:
+    redis = _fake_redis(get_return=None)
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(
+            bc, "fetch_billing_information", return_value=_billing("trialing")
+        ),
+    ):
+        assert cached_is_tenant_on_trial("tenant_abc") is True
+
+
+def test_is_tenant_on_trial_false_when_status_is_active() -> None:
+    redis = _fake_redis(get_return=None)
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=_billing("active")),
+    ):
+        assert cached_is_tenant_on_trial("tenant_abc") is False
+
+
+def test_is_tenant_on_trial_true_when_no_subscription() -> None:
+    """Legacy behaviour: a tenant with no subscription on record is
+    treated as trial (the old uncached ``is_tenant_on_trial`` returned
+    True in this branch)."""
+    redis = _fake_redis(get_return=None)
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(
+            bc,
+            "fetch_billing_information",
+            return_value=SubscriptionStatusResponse(subscribed=False),
+        ),
+    ):
+        assert cached_is_tenant_on_trial("tenant_abc") is True
+
+
+def test_invalidate_drops_cache_entry() -> None:
+    redis = _fake_redis()
+    with patch.object(bc, "get_shared_redis_client", return_value=redis):
+        invalidate_billing_cache("tenant_abc")
+    redis.delete.assert_called_once_with(
+        BILLING_CACHE_KEY.format(tenant_id="tenant_abc")
+    )
+
+
+def test_invalidate_swallows_redis_errors() -> None:
+    redis = _fake_redis()
+    redis.delete = MagicMock(side_effect=RedisError("down"))
+    with patch.object(bc, "get_shared_redis_client", return_value=redis):
+        # No exception bubbles up.
+        invalidate_billing_cache("tenant_abc")

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
@@ -172,6 +172,31 @@ def test_corrupt_cache_entry_is_refetched_from_cp() -> None:
     redis.setex.assert_called_once()
 
 
+def test_pydantic_validation_error_on_deserialize_refetches_and_overwrites() -> None:
+    """Schema-drift case: valid JSON envelope whose payload no longer matches
+    the current BillingInformation schema. Pydantic raises ``ValidationError``,
+    which is NOT a subclass of ``ValueError`` in v2 — the cache layer must
+    still treat it as a corrupt entry, refetch from CP, and overwrite.
+    """
+    # Valid JSON + correct envelope shape, but payload is missing every
+    # required BillingInformation field → ValidationError on model construction.
+    cached_bytes = (
+        b'{"type":"billing","payload":{"stripe_subscription_id":"sub_stale"}}'
+    )
+    redis = _fake_redis(get_return=cached_bytes)
+    billing = _billing("active")
+
+    with (
+        patch.object(bc, "get_shared_redis_client", return_value=redis),
+        patch.object(bc, "fetch_billing_information", return_value=billing) as cp_fetch,
+    ):
+        result = cached_fetch_billing_information("tenant_abc")
+
+    assert result == billing
+    cp_fetch.assert_called_once_with("tenant_abc")
+    redis.setex.assert_called_once()
+
+
 def test_tenant_keys_are_isolated() -> None:
     """Cache keys must not collide across tenants."""
     redis = _fake_redis(get_return=None)

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_cache.py
@@ -1,11 +1,13 @@
 """Unit tests for the Redis-backed billing cache."""
 
+from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from redis.exceptions import RedisError
 
 from ee.onyx.server.billing import billing_cache as bc
@@ -50,6 +52,15 @@ def _fake_redis(
         redis.setex = MagicMock(return_value=True)
     redis.delete = MagicMock(return_value=1)
     return redis
+
+
+@pytest.fixture(autouse=True)
+def _enable_multi_tenant() -> Generator[None, None, None]:
+    """The cache is cloud-only; exercise the MULTI_TENANT path by default.
+    Single-tenant guard tests opt out with their own ``patch.object``.
+    """
+    with patch.object(bc, "MULTI_TENANT", True):
+        yield
 
 
 def test_cache_hit_returns_value_without_calling_cp() -> None:
@@ -282,3 +293,46 @@ def test_invalidate_swallows_redis_errors() -> None:
     with patch.object(bc, "get_shared_redis_client", return_value=redis):
         # No exception bubbles up.
         invalidate_billing_cache("tenant_abc")
+
+
+def test_single_tenant_fetch_raises_without_touching_redis() -> None:
+    """The cache is cloud-only; a single-tenant caller must fail loudly
+    rather than open a Redis/control-plane connection a Lite deploy lacks.
+    """
+    redis = _fake_redis()
+    with (
+        patch.object(bc, "MULTI_TENANT", False),
+        patch.object(bc, "get_shared_redis_client", return_value=redis) as client,
+        patch.object(bc, "fetch_billing_information") as cp_fetch,
+    ):
+        with pytest.raises(RuntimeError):
+            cached_fetch_billing_information("tenant_abc")
+
+    client.assert_not_called()
+    cp_fetch.assert_not_called()
+
+
+def test_single_tenant_trial_check_is_false_without_fetch() -> None:
+    """Trial limits don't apply in single-tenant; never reach the control plane."""
+    redis = _fake_redis()
+    with (
+        patch.object(bc, "MULTI_TENANT", False),
+        patch.object(bc, "get_shared_redis_client", return_value=redis) as client,
+        patch.object(bc, "fetch_billing_information") as cp_fetch,
+    ):
+        assert cached_is_tenant_on_trial("tenant_abc") is False
+
+    client.assert_not_called()
+    cp_fetch.assert_not_called()
+
+
+def test_single_tenant_invalidate_is_noop() -> None:
+    """Invalidation must not touch Redis in single-tenant deployments."""
+    redis = _fake_redis()
+    with (
+        patch.object(bc, "MULTI_TENANT", False),
+        patch.object(bc, "get_shared_redis_client", return_value=redis) as client,
+    ):
+        invalidate_billing_cache("tenant_abc")
+
+    client.assert_not_called()


### PR DESCRIPTION
## Description

One legitimately-indexing tenant generated **301 control-plane `/billing-information` calls in 30 min** — over half of control-plane load during that window. Root cause: `_check_chunk_usage_limit` calls `check_usage_and_raise` → `is_tenant_on_trial` → `fetch_billing_information` once per document batch. Uncached. Any large indexing run fans out.

**Fix:** cache `BillingInformation | SubscriptionStatusResponse` per tenant in shared Redis with a 24h TTL. `cached_is_tenant_on_trial` derives the boolean from the same cache entry so the two views can't drift.

**Fallback order** (every call):
1. Redis hit → return cached
2. Redis miss → control-plane fetch + write-through + return
3. Redis error (read or write) → log + uncached control-plane fetch
4. Corrupt cache entry → log + refetch + overwrite

**One call-site swap** covers the hot path: `ee/onyx/server/usage_limits.py` → `cached_fetch_billing_information`. `check_usage_and_raise`, `is_tenant_on_trial_fn`, and `bulk_invite_users` all reach this via the versioned-implementation dispatcher.

**New:** `BILLING_CACHE_TTL_SECONDS` env var (default 86400). `invalidate_billing_cache(tenant_id)` exposed for write paths that just mutated a subscription and want the next read to be fresh.

**Expected impact:** CP billing rate `~10/min/tenant → ~1/24h/tenant` on hot tenants. No tenant-side change.

**Out of scope** (per plan): CP-side webhook invalidation (follow-up), caching `fetch_tenant_stripe_information` (~1/day/tenant already), DB-vs-Stripe drift reconciliation.

## How Has This Been Tested?

<!-- fill in -->

## Additional Options

- [x] Override Linear Check
- [ ] This PR is ready to cherry-pick to a release branch