### PR TITLE
chore(indexing): add support for Gemini embedding-2-preview in admin embeddings

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -72,6 +72,11 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_text_embedding_005",
     ),
     _BaseEmbeddingModel(
+        name="google/gemini-embedding-2-preview",
+        dim=3072,
+        index_name="danswer_chunk_gemini_embedding_2_preview",
+    ),
+    _BaseEmbeddingModel(
         name="voyage/voyage-large-2-instruct",
         dim=1024,
         index_name="danswer_chunk_voyage_large_2_instruct",

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -237,6 +237,35 @@ def format_embedding_error(
     )
 
 
+_GEMINI_EMBEDDING_2_MODEL_PREFIX = "gemini-embedding-2"
+_GEMINI_EMBEDDING_2_PROMPTS = {
+    "RETRIEVAL_QUERY": "Represent this query for retrieving relevant documents.",
+    "RETRIEVAL_DOCUMENT": "Represent this document for retrieval.",
+}
+
+
+def _is_gemini_embedding_2_model(model: str) -> bool:
+    return (
+        model.split("/")[-1]
+        .strip()
+        .lower()
+        .startswith(_GEMINI_EMBEDDING_2_MODEL_PREFIX)
+    )
+
+
+def _get_vertex_embedding_text(text: str, model: str, embedding_type: str) -> str:
+    if not _is_gemini_embedding_2_model(model):
+        return text
+
+    instruction = _GEMINI_EMBEDDING_2_PROMPTS.get(embedding_type)
+    if instruction is None:
+        raise RuntimeError(
+            f"Unsupported Gemini embedding-2 task type: {embedding_type}"
+        )
+
+    return f"{instruction}\n\n{text}"
+
+
 # Custom exception for authentication errors
 class AuthenticationError(Exception):
     """Raised when authentication fails with a provider."""
@@ -356,8 +385,7 @@ class CloudEmbedding:
         from google import genai
         from google.genai import types as genai_types
 
-        if not model:
-            model = DEFAULT_VERTEX_MODEL
+        resolved_model = model or DEFAULT_VERTEX_MODEL
 
         service_account_info = json.loads(self.api_key)
         credentials = service_account.Credentials.from_service_account_info(
@@ -378,19 +406,35 @@ class CloudEmbedding:
             credentials=credentials,
         )
 
-        embed_config = genai_types.EmbedContentConfig(
-            task_type=embedding_type,
-            output_dimensionality=reduced_dimension,
-            auto_truncate=True,
-        )
+        if _is_gemini_embedding_2_model(resolved_model):
+            embed_config = genai_types.EmbedContentConfig(
+                output_dimensionality=reduced_dimension,
+                auto_truncate=True,
+            )
+        else:
+            embed_config = genai_types.EmbedContentConfig(
+                task_type=embedding_type,
+                output_dimensionality=reduced_dimension,
+                auto_truncate=True,
+            )
 
         async def _embed_batch(batch_texts: list[str]) -> list[Embedding]:
             content_requests: list[Any] = [
-                genai_types.Content(parts=[genai_types.Part(text=text)])
+                genai_types.Content(
+                    parts=[
+                        genai_types.Part(
+                            text=_get_vertex_embedding_text(
+                                text=text,
+                                model=resolved_model,
+                                embedding_type=embedding_type,
+                            )
+                        )
+                    ]
+                )
                 for text in batch_texts
             ]
             response = await client.aio.models.embed_content(
-                model=model,
+                model=resolved_model,
                 contents=content_requests,
                 config=embed_config,
             )

--- a/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
+++ b/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
@@ -1,0 +1,12 @@
+from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
+
+
+def test_supported_embedding_models_include_gemini_embedding_2_preview() -> None:
+    gemini_embedding_2_models = [
+        model
+        for model in SUPPORTED_EMBEDDING_MODELS
+        if model.name == "google/gemini-embedding-2-preview"
+    ]
+
+    assert len(gemini_embedding_2_models) == 2
+    assert {model.dim for model in gemini_embedding_2_models} == {3072}

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -29,6 +29,16 @@ def sample_embeddings() -> List[List[float]]:
     return [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
 
 
+def _build_google_embed_response(
+    sample_embeddings: List[List[float]],
+) -> MagicMock:
+    response = MagicMock()
+    response.embeddings = [
+        MagicMock(values=embedding) for embedding in sample_embeddings
+    ]
+    return response
+
+
 @pytest.mark.asyncio
 async def test_cloud_embedding_context_manager() -> None:
     async with CloudEmbedding("fake-key", EmbeddingProvider.OPENAI) as embedding:
@@ -84,4 +94,109 @@ async def test_rate_limit_handling() -> None:
                 texts=["test"],
                 model_name="fake-model",
                 text_type=EmbedTextType.QUERY,
+            )
+
+
+@pytest.mark.asyncio
+async def test_vertex_embed_keeps_task_type_for_existing_models(
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info"
+    ) as mock_credentials:
+        mock_credentials.return_value = MagicMock()
+
+        with patch("google.genai.Client") as mock_genai_client:
+            mock_client = MagicMock()
+            mock_client.aio.models.embed_content = AsyncMock(
+                return_value=_build_google_embed_response(sample_embeddings[:1])
+            )
+            mock_client.aio.aclose = AsyncMock()
+            mock_genai_client.return_value = mock_client
+
+            embedding = CloudEmbedding(
+                '{"project_id":"test-project"}',
+                EmbeddingProvider.GOOGLE,
+            )
+            try:
+                result = await embedding._embed_vertex(
+                    ["query text"],
+                    "text-embedding-005",
+                    "RETRIEVAL_QUERY",
+                    128,
+                )
+            finally:
+                await embedding.aclose()
+
+            assert result == sample_embeddings[:1]
+
+            embed_call = mock_client.aio.models.embed_content.await_args
+            assert embed_call is not None
+            config = embed_call.kwargs["config"]
+            contents = embed_call.kwargs["contents"]
+
+            assert config.task_type == "RETRIEVAL_QUERY"
+            assert config.output_dimensionality == 128
+            assert config.auto_truncate is True
+            assert contents[0].parts[0].text == "query text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("embedding_type", "expected_instruction"),
+    [
+        (
+            "RETRIEVAL_QUERY",
+            "Represent this query for retrieving relevant documents.",
+        ),
+        (
+            "RETRIEVAL_DOCUMENT",
+            "Represent this document for retrieval.",
+        ),
+    ],
+)
+async def test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2(
+    embedding_type: str,
+    expected_instruction: str,
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info"
+    ) as mock_credentials:
+        mock_credentials.return_value = MagicMock()
+
+        with patch("google.genai.Client") as mock_genai_client:
+            mock_client = MagicMock()
+            mock_client.aio.models.embed_content = AsyncMock(
+                return_value=_build_google_embed_response(sample_embeddings[:1])
+            )
+            mock_client.aio.aclose = AsyncMock()
+            mock_genai_client.return_value = mock_client
+
+            embedding = CloudEmbedding(
+                '{"project_id":"test-project"}',
+                EmbeddingProvider.GOOGLE,
+            )
+            try:
+                result = await embedding._embed_vertex(
+                    ["document text"],
+                    "google/gemini-embedding-2",
+                    embedding_type,
+                    256,
+                )
+            finally:
+                await embedding.aclose()
+
+            assert result == sample_embeddings[:1]
+
+            embed_call = mock_client.aio.models.embed_content.await_args
+            assert embed_call is not None
+            config = embed_call.kwargs["config"]
+            contents = embed_call.kwargs["contents"]
+
+            assert config.task_type is None
+            assert config.output_dimensionality == 256
+            assert config.auto_truncate is True
+            assert (
+                contents[0].parts[0].text == f"{expected_instruction}\n\ndocument text"
             )

--- a/web/src/components/embedding/interfaces.tsx
+++ b/web/src/components/embedding/interfaces.tsx
@@ -269,6 +269,20 @@ export const AVAILABLE_CLOUD_PROVIDERS: CloudEmbeddingProvider[] = [
     embedding_models: [
       {
         provider_type: EmbeddingProvider.GOOGLE,
+        model_name: "gemini-embedding-2-preview",
+        description:
+          "Google's newest multimodal embedding model. Onyx uses the default 3072-dimension output for highest-quality retrieval.",
+        pricePerMillion: 0.025,
+        model_dim: 3072,
+        normalize: false,
+        query_prefix: "",
+        passage_prefix: "",
+        index_name: "",
+        api_key: null,
+        api_url: null,
+      },
+      {
+        provider_type: EmbeddingProvider.GOOGLE,
         model_name: "gemini-embedding-001",
         description: "Google's Gemini embedding model. Powerful and efficient.",
         pricePerMillion: 0.025,


### PR DESCRIPTION
## Description

Support Google `gemini-embedding-2-preview` end-to-end in the admin embedding settings.

This PR:
- adds model-specific runtime handling for `gemini-embedding-2*` so we stop sending `task_type` and use instruction-prefixed content instead
- adds `gemini-embedding-2-preview` to the backend supported embedding model registry with a fixed 3072-dimension default
- adds `gemini-embedding-2-preview` to the frontend cloud embedding model picker
- adds targeted backend coverage for both the runtime handling and the new config entry

Linear: [ENG-4040](https://linear.app/onyx-app/issue/ENG-4040/fix-gemini-embedding-2-task-type-handling)
Combined from duplicate follow-up: [ENG-4075](https://linear.app/onyx-app/issue/ENG-4075/add-support-for-gemini-embedding-2-preview-cloud-model)

## How Has This Been Tested?

- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && pytest -q backend/tests/unit/onyx/configs/test_google_embedding_configs.py backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && ruff check backend/onyx/configs/embedding_configs.py backend/tests/unit/onyx/configs/test_google_embedding_configs.py backend/onyx/natural_language_processing/search_nlp_models.py backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [x] `cd web && npx prettier --check src/components/embedding/interfaces.tsx`
- [ ] full frontend typecheck/build

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
