### PR TITLE
chore(indexing): add support for Cohere embed-v4 in admin embeddings

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -42,6 +42,16 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_embed_english_light_v3_0",
     ),
     _BaseEmbeddingModel(
+        name="cohere/embed-v4.0",
+        dim=1536,
+        index_name="danswer_chunk_cohere_embed_v4_0",
+    ),
+    _BaseEmbeddingModel(
+        name="embed-v4.0",
+        dim=1536,
+        index_name="danswer_chunk_embed_v4_0",
+    ),
+    _BaseEmbeddingModel(
         name="openai/text-embedding-3-large",
         dim=3072,
         index_name="danswer_chunk_openai_text_embedding_3_large",

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -237,6 +237,17 @@ def format_embedding_error(
     )
 
 
+def _extract_cohere_embeddings(response_embeddings: Any) -> list[Embedding]:
+    if isinstance(response_embeddings, list):
+        return cast(list[Embedding], response_embeddings)
+
+    float_embeddings = getattr(response_embeddings, "float_", None)
+    if isinstance(float_embeddings, list):
+        return cast(list[Embedding], float_embeddings)
+
+    raise RuntimeError("Unsupported Cohere embedding response format.")
+
+
 # Custom exception for authentication errors
 class AuthenticationError(Exception):
     """Raised when authentication fails with a provider."""
@@ -309,7 +320,7 @@ class CloudEmbedding:
                 input_type=embedding_type,
                 truncate="END",
             )
-            final_embeddings.extend(cast(list[Embedding], response.embeddings))
+            final_embeddings.extend(_extract_cohere_embeddings(response.embeddings))
         return final_embeddings
 
     async def _embed_voyage(

--- a/backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py
+++ b/backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py
@@ -1,0 +1,12 @@
+from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
+
+
+def test_supported_embedding_models_include_cohere_embed_v4() -> None:
+    cohere_embed_v4_models = [
+        model
+        for model in SUPPORTED_EMBEDDING_MODELS
+        if model.name == "cohere/embed-v4.0"
+    ]
+
+    assert len(cohere_embed_v4_models) == 2
+    assert {model.dim for model in cohere_embed_v4_models} == {1536}

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -85,3 +85,60 @@ async def test_rate_limit_handling() -> None:
                 model_name="fake-model",
                 text_type=EmbedTextType.QUERY,
             )
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_supports_v3_response_format(
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.embeddings = sample_embeddings
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-english-v3.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_supports_v4_response_format(
+    sample_embeddings: List[List[float]],
+) -> None:
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        embeddings_by_type = MagicMock()
+        embeddings_by_type.float_ = sample_embeddings
+
+        mock_response = MagicMock()
+        mock_response.embeddings = embeddings_by_type
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-v4.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings

--- a/web/src/components/embedding/interfaces.tsx
+++ b/web/src/components/embedding/interfaces.tsx
@@ -189,6 +189,20 @@ export const AVAILABLE_CLOUD_PROVIDERS: CloudEmbeddingProvider[] = [
     embedding_models: [
       {
         provider_type: EmbeddingProvider.COHERE,
+        model_name: "embed-v4.0",
+        description:
+          "Cohere's latest embedding model. Onyx uses the default 1536-dimension output for stronger retrieval quality.",
+        pricePerMillion: 0.1,
+        model_dim: 1536,
+        normalize: false,
+        query_prefix: "",
+        passage_prefix: "",
+        index_name: "",
+        api_key: null,
+        api_url: null,
+      },
+      {
+        provider_type: EmbeddingProvider.COHERE,
         model_name: "embed-english-v3.0",
         description:
           "Cohere's English embedding model. Good performance for English-language tasks.",


### PR DESCRIPTION
## Description

Support Cohere `embed-v4.0` end-to-end in the admin embedding settings.

This PR:
- handles both the legacy v3 Cohere embedding response shape and the `embed-v4.0` embeddings-by-type response shape
- adds Cohere `embed-v4.0` to the backend supported embedding model registry with a fixed 1536-dimension default
- adds Cohere `embed-v4.0` to the frontend cloud embedding model picker
- adds targeted backend coverage for both the runtime handling and the new config entry

Linear: [ENG-4039](https://linear.app/onyx-app/issue/ENG-4039/fix-cohere-embed-v4-response-format-handling)
Combined from duplicate follow-up: [ENG-4074](https://linear.app/onyx-app/issue/ENG-4074/add-support-for-cohere-embed-v4-cloud-model)

## How Has This Been Tested?

- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && pytest -q backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [x] `source /Users/jessicasingh/Documents/work/onyx/.venv/bin/activate && ruff check backend/onyx/configs/embedding_configs.py backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py backend/onyx/natural_language_processing/search_nlp_models.py backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py`
- [x] `cd web && npx prettier --check src/components/embedding/interfaces.tsx`
- [ ] full frontend typecheck/build

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
