### PR TITLE
chore(deps): upgrade `node`: 20->24

### DIFF
--- a/.github/workflows/pr-jest-tests.yml
+++ b/.github/workflows/pr-jest-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm" # zizmor: ignore[cache-poisoning] test-only workflow; no deploy artifacts
           cache-dependency-path: ./web/package-lock.json
 

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -274,7 +274,7 @@ jobs:
         # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm" # zizmor: ignore[cache-poisoning]
           cache-dependency-path: ./web/package-lock.json
 
@@ -616,7 +616,7 @@ jobs:
         # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm" # zizmor: ignore[cache-poisoning]
           cache-dependency-path: ./web/package-lock.json
 

--- a/.github/workflows/pr-quality-checks.yml
+++ b/.github/workflows/pr-quality-checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6
         with: # zizmor: ignore[cache-poisoning]
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: ./web/package-lock.json
       - name: Install node dependencies

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: ./web/package-lock.json
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: "npm"
           cache-dependency-path: ./web/package-lock.json
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS base
 
 LABEL com.onyx.maintainer="founders@onyx.app"
 LABEL com.onyx.description="This image is the web/frontend container of Onyx which \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -162,7 +162,7 @@ ENV NEXT_PUBLIC_RECAPTCHA_SITE_KEY=${NEXT_PUBLIC_RECAPTCHA_SITE_KEY}
 ARG SENTRY_RELEASE
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
-# Default ONYX_VERSION, typically overriden during builds by GitHub Actions.
+# Default ONYX_VERSION, typically overridden during builds by GitHub Actions.
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -110,7 +110,7 @@
         "@types/jest": "^29.5.14",
         "@types/js-cookie": "^3.0.6",
         "@types/lodash": "^4.17.20",
-        "@types/node": "18.15.11",
+        "@types/node": "24.12.2",
         "@types/react": "19.2.10",
         "@types/react-dom": "19.2.3",
         "@types/stats.js": "^0.17.4",
@@ -6893,7 +6893,18 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10494,7 +10494,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package.json
+++ b/web/package.json
@@ -129,7 +129,7 @@
     "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.20",
-    "@types/node": "18.15.11",
+    "@types/node": "24.12.2",
     "@types/react": "19.2.10",
     "@types/react-dom": "19.2.3",
     "@types/stats.js": "^0.17.4",

--- a/web/src/sections/AppHealthBanner.tsx
+++ b/web/src/sections/AppHealthBanner.tsx
@@ -22,8 +22,12 @@ export default function AppHealthBanner() {
   const [expired, setExpired] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   const pathname = usePathname();
-  const expirationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const refreshIntervalRef = useRef<NodeJS.Timer | null>(null);
+  const expirationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null
+  );
   // Latches true once we see an authed user — separates mid-session logout
   // from a fresh unauth load.
   const hasSeenAuthenticatedUserRef = useRef(false);


### PR DESCRIPTION
## Description



## How Has This Been Tested?

Captured by existing

## Additional Options

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the web Docker base image to `node:24-alpine` with a pinned digest and update all CI workflows to Node 24. Bump `@types/node` to 24 and use `ReturnType<typeof setTimeout/setInterval>` in `AppHealthBanner`; also fix a minor Dockerfile comment typo.

<sup>Written for commit 919e8dbdecde89c6202b2ebd4721345d33236ef3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

