### PR TITLE
fix(deep_research): emit synthetic tool_result on failed research call

### DIFF
--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -728,10 +728,25 @@ def run_deep_research_llm_loop(
                         research_results.intermediate_reports
                     ):
                         if report is None:
-                            # The LLM will not see that this research was even attempted, it may try
-                            # something similar again but this is not bad.
+                            # Every tool_use id in the preceding assistant message must have a
+                            # matching TOOL_CALL_RESPONSE or strict providers (e.g. AWS Bedrock
+                            # Converse) reject the next request with 400 "Expected toolResult
+                            # blocks at messages.N.content for the following Ids: ...". Emit a
+                            # synthetic failure response so the invariant holds and the LLM
+                            # knows the call failed.
                             logger.error(
-                                f"Research agent call at tab_index {tab_index} failed, skipping"
+                                f"Research agent call at tab_index {tab_index} failed; emitting synthetic failure response"
+                            )
+                            failed_tool_call = research_agent_calls[tab_index]
+                            failure_message = "Research agent call failed. Try a different approach or continue without this result."
+                            simple_chat_history.append(
+                                ChatMessageSimple(
+                                    message=failure_message,
+                                    token_count=token_counter(failure_message),
+                                    message_type=MessageType.TOOL_CALL_RESPONSE,
+                                    tool_call_id=failed_tool_call.tool_call_id,
+                                    image_files=None,
+                                )
                             )
                             continue
 


### PR DESCRIPTION
## Description

When a parallel research agent call fails (returns `None`), the orchestrator in `dr_loop.py` appends the assistant message containing **all N** `tool_use` blocks, then skips the `TOOL_CALL_RESPONSE` append for the failed ones. That leaves dangling `tool_use` ids with no matching `tool_result`.

AWS Bedrock Converse enforces that every `toolUse` in an assistant turn must be answered by a `toolResult` with the same id in the following user turn. On the next orchestrator cycle, the constructed history is rejected with:

```
BedrockException - Expected toolResult blocks at messages.N.content for the following Ids: tooluse_<id>
```

The whole deep research turn fails. Retries only work when the transient sub-agent failure doesn't recur.

**Fix:** in the `if report is None` branch, append a synthetic `TOOL_CALL_RESPONSE` tied to the failed `tool_call_id` so every `tool_use` has a matching `tool_result`. The LLM is told the call failed and can continue without it.

State container (`add_tool_call`) is intentionally still skipped on failure — no fake row in the saved tool-call log or UI. The synthetic message only lives in the orchestrator's in-memory history for provider compatibility.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check