### PR TITLE
fix: Enforce `is_listed` filter for all non-owner agent access

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -107,9 +107,11 @@ def _add_user_filters(
     - if we are not editing, we return all Personas directly connected to the user
     """
 
-    # Anonymous users only see public Personas
+    # Anonymous users only see public, listed Personas
     if user.is_anonymous:
-        where_clause = Persona.is_public == True  # noqa: E712
+        where_clause = (Persona.is_public == True) & (  # noqa: E712
+            Persona.is_listed == True  # noqa: E712
+        )
         return stmt.where(where_clause)
 
     # If curator ownership restriction is enabled, curators can only access their own assistants

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -134,14 +134,21 @@ def _add_user_filters(
             .correlate(Persona)
         )
     else:
-        # Group the public persona conditions
-        public_condition = (Persona.is_public == True) & (  # noqa: E712
-            Persona.is_listed == True  # noqa: E712
-        )
+        listed = Persona.is_listed == True  # noqa: E712
+
+        # Group membership — only listed agents
+        where_clause &= listed
+
+        # Public agents — must be listed
+        public_condition = (Persona.is_public == True) & listed  # noqa: E712
+
+        # Directly shared — only listed agents
+        shared_condition = (Persona__User.user_id == user.id) & listed
 
         where_clause |= public_condition
-        where_clause |= Persona__User.user_id == user.id
+        where_clause |= shared_condition
 
+    # Owner always sees their own agents (regardless of is_listed)
     where_clause |= Persona.user_id == user.id
 
     return stmt.where(where_clause)


### PR DESCRIPTION
## Description

Fixes a bug where unlisted agents still appeared for users who had access via group membership or direct sharing. Previously, `is_listed` was only enforced for **public** agents in the backend's `_add_user_filters`. Now all non-owner access paths (group membership, public, direct sharing) require `is_listed=True`.

Owners always see their own agents regardless of `is_listed`.

Closes: https://linear.app/onyx-app/issue/ENG-3873/unlisting-agent-does-not-hide-it-from-the-agentsnavigationpage.

## Screenshots + Videos

In the admin panel, we unlist an agent:

<img width="1655" height="1826" alt="image" src="https://github.com/user-attachments/assets/e13b2dc7-2ca3-4cab-b425-d502397e738a" />

Then, for a non-creator of that agent, this is what we see:

<img width="1655" height="1831" alt="image" src="https://github.com/user-attachments/assets/804bea6c-7baf-45fd-9b71-48fa3f6e8fc7" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `is_listed=True` for all non-owner access paths (public, group, direct share, anonymous) so unlisted agents never appear to others. Fixes ENG-3873; owners always see their own agents regardless of listing status.

<sup>Written for commit 5b5eca02c8f320e6595436c7698bf40c735538cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

