### PR TITLE
fix(slack): catch wrapped UndefinedTable in slack bot tenant iteration

### DIFF
--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -23,6 +23,7 @@ from slack_sdk.http_retry import RateLimitErrorRetryHandler
 from slack_sdk.http_retry import RetryHandler
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DEV_MODE
@@ -350,10 +351,19 @@ class SlackbotHandler:
                     except KvKeyNotFoundError:
                         # No Slackbot tokens, pass
                         pass
-                    except psycopg2.errors.UndefinedTable:
-                        logger.error(
-                            "Undefined table error in fetch_slack_bots. Tenant schema may need fixing."
-                        )
+                    except ProgrammingError as e:
+                        # SQLAlchemy wraps psycopg2 errors; UndefinedTable is
+                        # expected when a pre-provisioned tenant's slack_bot
+                        # migration has not completed yet.
+                        if isinstance(e.orig, psycopg2.errors.UndefinedTable):
+                            logger.warning(
+                                f"Tenant {tenant_id} missing slack_bot table "
+                                "(likely mid-provisioning); will retry next cycle."
+                            )
+                        else:
+                            logger.exception(
+                                f"Error fetching Slack bots for tenant {tenant_id}: {e}"
+                            )
                     except Exception as e:
                         logger.exception(
                             f"Error fetching Slack bots for tenant {tenant_id}: {e}"
@@ -409,6 +419,15 @@ class SlackbotHandler:
                         bots = list(fetch_slack_bots(db_session=db_session))
                     except KvKeyNotFoundError:
                         # No Slackbot tokens, pass (and remove below)
+                        bots = []
+                    except ProgrammingError as e:
+                        if isinstance(e.orig, psycopg2.errors.UndefinedTable):
+                            logger.warning(
+                                f"Tenant {tenant_id} missing slack_bot table "
+                                "(likely mid-provisioning); will retry next cycle."
+                            )
+                        else:
+                            logger.exception(f"Error handling tenant {tenant_id}: {e}")
                         bots = []
                     except Exception as e:
                         logger.exception(f"Error handling tenant {tenant_id}: {e}")


### PR DESCRIPTION
## Description

SQLAlchemy wraps `psycopg2` errors in `sqlalchemy.exc.ProgrammingError`, so the existing `except psycopg2.errors.UndefinedTable` clause in `SlackbotHandler` never matched. Every iteration over a tenant whose `slack_bot` migration had not yet completed (normal mid-provisioning state) fell through to the generic `except Exception` handler and was shipped to Sentry via `logger.exception`.

On the cloud cluster this was the top error-event source — Sentry issue `ONYX-BACKEND-7` had ~4.87M events (first seen 2025-09-11). Investigation confirmed the errors fire during the window between schema creation and the `slack_bot` migration completing; once the tenant enters the `available_tenant` pool the errors stop.

Fix: catch `sqlalchemy.exc.ProgrammingError`, inspect `e.orig` for `psycopg2.errors.UndefinedTable`, and log a warning instead of an exception (this is expected during tenant provisioning, not actionable). Applied to both `fetch_slack_bots` call sites in `listener.py`.

## How Has This Been Tested?

- Pre-commit, `ty`, `ruff`, `black` pass.
- Verified the SQLAlchemy `ProgrammingError.orig` type assertion matches the actual Sentry event stack (`error.type: "UndefinedTable, ProgrammingError"` chain).
- Separately cleaned up 73 orphan tenant schemas on the cloud cluster (hygiene — not contributing to this issue's event rate).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack listener spam by correctly handling `UndefinedTable` during tenant provisioning. We now catch `sqlalchemy.exc.ProgrammingError` and downgrade expected cases to warnings to avoid noisy Sentry errors.

- **Bug Fixes**
  - Catch `sqlalchemy.exc.ProgrammingError`; if `e.orig` is `psycopg2.errors.UndefinedTable`, log a warning and skip, otherwise log the exception.
  - Applied to both `fetch_slack_bots` paths; when errors occur, set `bots = []` to continue iteration.

<sup>Written for commit 66eb0cacaccf7f95161a8cc5898f0257178de225. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

