### PR TITLE
fix: enforce is_listed filter for all non-owner agent access

### DIFF
--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -107,9 +107,11 @@ def _add_user_filters(
     - if we are not editing, we return all Personas directly connected to the user
     """
 
-    # Anonymous users only see public Personas
+    # Anonymous users only see public, listed Personas
     if user.is_anonymous:
-        where_clause = Persona.is_public == True  # noqa: E712
+        where_clause = (Persona.is_public == True) & (  # noqa: E712
+            Persona.is_listed == True  # noqa: E712
+        )
         return stmt.where(where_clause)
 
     # If curator ownership restriction is enabled, curators can only access their own assistants

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -134,14 +134,21 @@ def _add_user_filters(
             .correlate(Persona)
         )
     else:
-        # Group the public persona conditions
-        public_condition = (Persona.is_public == True) & (  # noqa: E712
-            Persona.is_listed == True  # noqa: E712
-        )
+        listed = Persona.is_listed == True  # noqa: E712
+
+        # Group membership — only listed agents
+        where_clause &= listed
+
+        # Public agents — must be listed
+        public_condition = (Persona.is_public == True) & listed  # noqa: E712
+
+        # Directly shared — only listed agents
+        shared_condition = (Persona__User.user_id == user.id) & listed
 
         where_clause |= public_condition
-        where_clause |= Persona__User.user_id == user.id
+        where_clause |= shared_condition
 
+    # Owner always sees their own agents (regardless of is_listed)
     where_clause |= Persona.user_id == user.id
 
     return stmt.where(where_clause)


### PR DESCRIPTION
## Description

Fixes a bug where unlisted agents still appeared for users who had access via group membership or direct sharing. Previously, `is_listed` was only enforced for **public** agents in the backend's `_add_user_filters`. Now all non-owner access paths (group membership, public, direct sharing, anonymous) require `is_listed=True`.

Owners always see their own agents regardless of `is_listed`. Admins see everything (admin endpoints use `get_editable=True` which bypasses this filter).

Changes in `backend/onyx/db/persona.py` — `_add_user_filters()`:
- Group membership condition now gated on `is_listed == True`
- Direct sharing condition now gated on `is_listed == True`
- Anonymous user condition now requires `is_listed == True` (was only checking `is_public`)
- Owner condition (`user_id == user.id`) unchanged — owners always see their own agents

## How Has This Been Tested?

- Unit tests pass (`pytest backend/tests/unit`)
- Manual verification planned: unlist an agent as admin, confirm it disappears from the explore page for non-owner users

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces is_listed=True for all non-owner access paths so unlisted agents no longer appear via public, group, direct share, or anonymous access. Owners still see their own agents; admin endpoints remain unaffected.

- **Bug Fixes**
  - Gate group membership, direct sharing, and anonymous access on is_listed (previously only applied to public).
  - Keep owner visibility regardless of is_listed; admin endpoints bypass via get_editable=True.
  - Update _add_user_filters to apply a single listed check across all non-owner paths.

<sup>Written for commit 5b5eca02c8f320e6595436c7698bf40c735538cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

