### PR TITLE
feat(helm): add per-deployment extraEnv hook

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.47
+version: 0.4.48
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -96,6 +96,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- $apiVolumeMounts := include "onyx.renderVolumeMounts" (dict "ctx" . "volumeMounts" .Values.api.volumeMounts) }}
           {{- if $apiVolumeMounts }}
           {{- $apiVolumeMounts | nindent 10 }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -72,6 +72,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_beat.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_beat.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -84,6 +84,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_docfetching.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_docfetching.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -86,6 +86,9 @@ spec:
             - name: ENABLE_MULTIPASS_INDEXING
               value: "{{ .Values.celery_worker_docprocessing.enableMiniChunk }}"
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_docprocessing.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_docprocessing.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -81,6 +81,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_heavy.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_heavy.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -81,6 +81,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_light.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_light.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -81,6 +81,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_monitoring.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_monitoring.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -81,6 +81,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_primary.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_primary.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -77,6 +77,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.celery_worker_user_file_processing.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.celery_worker_user_file_processing.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/discordbot.yaml
+++ b/deployment/helm/charts/onyx/templates/discordbot.yaml
@@ -70,6 +70,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.discordbot.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             # Discord bot token - required for bot to connect
             {{- if .Values.discordbot.botToken }}
             - name: DISCORD_BOT_TOKEN

--- a/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/indexing-model-deployment.yaml
@@ -68,6 +68,9 @@ spec:
           - name: INDEXING_ONLY
             value: "{{ default "True" .Values.indexCapability.indexingOnly }}"
           {{- include "onyx.envSecrets" . | nindent 10}}
+          {{- with .Values.indexCapability.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- if .Values.indexCapability.securityContext }}
         securityContext:
           {{- toYaml .Values.indexCapability.securityContext | nindent 10 }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -57,6 +57,9 @@ spec:
             name: {{ .Values.config.envConfigMapName }}
         env:
           {{- include "onyx.envSecrets" . | nindent 12}}
+          {{- with .Values.inferenceCapability.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- if .Values.inferenceCapability.securityContext }}
         securityContext:
           {{- toYaml .Values.inferenceCapability.securityContext | nindent 10 }}

--- a/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/inference-model-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         env:
           {{- include "onyx.envSecrets" . | nindent 12}}
           {{- with .Values.inferenceCapability.extraEnv }}
-          {{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- if .Values.inferenceCapability.securityContext }}
         securityContext:

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -99,6 +99,9 @@ spec:
             - name: API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
               value: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }}"
             {{- include "onyx.envSecrets" . | nindent 12 }}
+            {{- with .Values.mcpServer.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.mcpServer.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/slackbot.yaml
+++ b/deployment/helm/charts/onyx/templates/slackbot.yaml
@@ -64,6 +64,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.slackbot.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.slackbot.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/webserver-deployment.yaml
@@ -82,6 +82,9 @@ spec:
                 name: {{ .Values.config.envConfigMapName }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- with .Values.webserver.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.webserver.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -138,7 +138,6 @@ autoscaling:
   engine: hpa
 
 inferenceCapability:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   service:
     portName: modelserver
@@ -194,7 +193,6 @@ inferenceCapability:
 
 
 indexCapability:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   service:
     portName: modelserver
@@ -336,7 +334,6 @@ nginx:
         http: http
 
 webserver:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   image:
@@ -425,7 +422,6 @@ webserver:
   affinity: {}
 
 api:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   image:
@@ -564,7 +560,6 @@ celery_shared:
     runAsUser: 0
 
 celery_beat:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -587,7 +582,6 @@ celery_beat:
   affinity: {}
 
 celery_worker_heavy:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -623,7 +617,6 @@ celery_worker_heavy:
   affinity: {}
 
 celery_worker_docprocessing:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -659,7 +652,6 @@ celery_worker_docprocessing:
   affinity: {}
 
 celery_worker_light:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -695,7 +687,6 @@ celery_worker_light:
   affinity: {}
 
 celery_worker_monitoring:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -731,7 +722,6 @@ celery_worker_monitoring:
   affinity: {}
 
 celery_worker_primary:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -767,7 +757,6 @@ celery_worker_primary:
   affinity: {}
 
 celery_worker_user_file_processing:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO
@@ -805,7 +794,6 @@ celery_worker_user_file_processing:
 # Discord bot for Onyx
 # The bot offloads message processing to scalable API pods via HTTP requests.
 discordbot:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   enabled: false  # Disabled by default - requires bot token configuration
   # Bot token can be provided directly or via a Kubernetes secret
@@ -842,7 +830,6 @@ discordbot:
   affinity: {}
 
 slackbot:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   enabled: true
   replicaCount: 1
@@ -872,7 +859,6 @@ slackbot:
 # Onyx Model Context Protocol (MCP) Server
 # Allows LLMs to use Onyx like invoking tools or accessing resources
 mcpServer:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   enabled: false  # Disabled by default
   replicaCount: 1
@@ -920,7 +906,6 @@ mcpServer:
   affinity: {}
 
 celery_worker_docfetching:
-  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
   extraEnv: []
   replicaCount: 1
   logLevel: INFO

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -138,6 +138,8 @@ autoscaling:
   engine: hpa
 
 inferenceCapability:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   service:
     portName: modelserver
     type: ClusterIP
@@ -192,6 +194,8 @@ inferenceCapability:
 
 
 indexCapability:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   service:
     portName: modelserver
     type: ClusterIP
@@ -332,6 +336,8 @@ nginx:
         http: http
 
 webserver:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   image:
     repository: onyxdotapp/onyx-web-server
@@ -419,6 +425,8 @@ webserver:
   affinity: {}
 
 api:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   image:
     repository: onyxdotapp/onyx-backend
@@ -556,6 +564,8 @@ celery_shared:
     runAsUser: 0
 
 celery_beat:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   podAnnotations: {}
@@ -577,6 +587,8 @@ celery_beat:
   affinity: {}
 
 celery_worker_heavy:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -611,6 +623,8 @@ celery_worker_heavy:
   affinity: {}
 
 celery_worker_docprocessing:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -645,6 +659,8 @@ celery_worker_docprocessing:
   affinity: {}
 
 celery_worker_light:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -679,6 +695,8 @@ celery_worker_light:
   affinity: {}
 
 celery_worker_monitoring:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -713,6 +731,8 @@ celery_worker_monitoring:
   affinity: {}
 
 celery_worker_primary:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -747,6 +767,8 @@ celery_worker_primary:
   affinity: {}
 
 celery_worker_user_file_processing:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:
@@ -783,6 +805,8 @@ celery_worker_user_file_processing:
 # Discord bot for Onyx
 # The bot offloads message processing to scalable API pods via HTTP requests.
 discordbot:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   enabled: false  # Disabled by default - requires bot token configuration
   # Bot token can be provided directly or via a Kubernetes secret
   # Option 1: Direct token (not recommended for production)
@@ -818,6 +842,8 @@ discordbot:
   affinity: {}
 
 slackbot:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   enabled: true
   replicaCount: 1
   image:
@@ -846,6 +872,8 @@ slackbot:
 # Onyx Model Context Protocol (MCP) Server
 # Allows LLMs to use Onyx like invoking tools or accessing resources
 mcpServer:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   enabled: false  # Disabled by default
   replicaCount: 1
   image:
@@ -892,6 +920,8 @@ mcpServer:
   affinity: {}
 
 celery_worker_docfetching:
+  # Extra env vars to append to the container (e.g. per-service SENTRY_DSN scoping)
+  extraEnv: []
   replicaCount: 1
   logLevel: INFO
   autoscaling:


### PR DESCRIPTION
## Description

Adds `extraEnv` hook to every workload deployment template in the onyx helm chart (15 total). Each template appends user-supplied env vars from `.Values.<workload>.extraEnv` after the existing `envSecrets` include. Defaults to `[]` — backwards-compatible.

Unblocks per-workload env scoping via values.yaml (e.g. SENTRY_DSN on indexing workloads only). Chart bumped 0.4.47 → 0.4.48.

## How Has This Been Tested?

- `helm lint` passes
- `helm template` with defaults renders no extraEnv
- `helm template` with `--set <workload>.extraEnv[0].name=... --set ...value=...` renders the var on that deployment only (verified for `api`, `inferenceCapability`, `indexCapability`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check