### PR TITLE
fix(slack): bail early on all Slack auth errors in listener

### DIFF
--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -496,11 +496,20 @@ class SlackbotHandler:
                     #     f"Started socket client for Slackbot with name '{bot_name}' (tenant: {tenant_id}, app: {slack_bot_id})"
                     # )
         except SlackApiError as e:
-            # Only error out if we get a not_authed error
-            if "not_authed" in str(e):
-                # for some reason we want to add the tenant to the list when this happens?
-                logger.error(
-                    f"Authentication error - Invalid or expired credentials: {tenant_id=} {slack_bot_id=}. Error: {e}"
+            # Any auth failure means connect() will also fail — bail early
+            # so slack_sdk's socket_mode client never logs its own error.
+            if any(
+                code in str(e)
+                for code in (
+                    "not_authed",
+                    "invalid_auth",
+                    "token_expired",
+                    "token_revoked",
+                    "account_inactive",
+                )
+            ):
+                logger.warning(
+                    f"Slack auth failed, skipping bot: {tenant_id=} {slack_bot_id=} error={e}"
                 )
                 return None
 
@@ -520,14 +529,19 @@ class SlackbotHandler:
             process_slack_event  # ty: ignore[invalid-argument-type]
         )
 
-        # Establish a WebSocket connection to the Socket Mode servers
-        # logger.debug(
-        #     f"Connecting socket client for tenant: {tenant_id}, app: {slack_bot_id}"
-        # )
-        socket_client.connect()
-        # logger.info(
-        #     f"Started SocketModeClient for tenant: {tenant_id}, app: {slack_bot_id}"
-        # )
+        # Establish a WebSocket connection to the Socket Mode servers.
+        # connect() internally calls apps.connections.open; on auth failure
+        # slack_sdk's socket_mode client logs its own error (shipped to
+        # Sentry as ONYX-BACKEND-4) and re-raises. The common case is
+        # caught above by the auth_test guard — this wrapper covers the
+        # rarer path where bot_token is valid but app_token is not.
+        try:
+            socket_client.connect()
+        except SlackApiError as e:
+            logger.warning(
+                f"Failed to open Slack socket connection: {tenant_id=} {slack_bot_id=} error={e}"
+            )
+            return None
 
         return socket_client
 


### PR DESCRIPTION
## Description

The `SlackbotHandler.start_socket_client` auth guard only short-circuited on `"not_authed"` — all other auth failures (`invalid_auth`, `token_expired`, `token_revoked`, `account_inactive`) fell through to `socket_client.connect()`, which internally re-called `apps.connections.open` against the same bad credentials. `slack_sdk`'s socket-mode client then logged `"Failed to retrieve WSS URL: ..."` and re-raised.

That log is the source of Sentry issue `ONYX-BACKEND-4` (~659K events since 2025-09-11, still firing ~240/day). Individual event messages consistently show `'error': 'invalid_auth'`.

Changes:
- Expand the auth-error early-return to cover the full known set of expired/revoked token codes.
- Downgrade the log level to `warning` — a bot with a dead token is an expected operational state, not an actionable alert.
- Wrap `socket_client.connect()` in `try/except SlackApiError` for the rarer path where `auth_test` (bot_token) succeeds but the app_token has expired. The listener loop should not unwind for one bad tenant.

Follow-up (separate PR): the rare path above still triggers one Sentry event per bad app_token because `slack_sdk.socket_mode.builtin.client` logs before re-raising. A targeted `ignore_logger(...)` in the sentry init sites (or a before_send filter) would silence that residual noise.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavioral change is narrow: auth failures that previously continued into `connect()` (and logged twice) now early-return once at warning level. Bots with valid credentials are unaffected.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bail early on Slack auth errors in the listener to stop redundant `connect()` attempts and cut Sentry noise. Auth failures now log warnings and do not unwind the listener loop.

- **Bug Fixes**
  - Short-circuit on `not_authed`, `invalid_auth`, `token_expired`, `token_revoked`, `account_inactive` from `auth_test` before `connect()`.
  - Wrap `socket_client.connect()` in `try/except SlackApiError` to handle cases where the app token is invalid while the bot token passes.
  - Downgrade auth-related logs to warning; prevents noisy `slack_sdk` Socket Mode errors (addresses Sentry ONYX-BACKEND-4).

<sup>Written for commit ff72d3f23a680000a2ddba51bd69cdc8702558c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

