### PR TITLE
fix(slack): set TenantSocketModeClient attrs before super().__init__

### DIFF
--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -720,10 +720,15 @@ def get_feedback_visibility() -> FeedbackVisibility:
 
 class TenantSocketModeClient(SocketModeClient):
     def __init__(self, tenant_id: str, slack_bot_id: int, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+        # Set these BEFORE calling super().__init__ — the base class starts
+        # the message_processor IntervalRunner thread during init, which can
+        # race into our overridden process_message/enqueue_message methods
+        # before these attributes exist (ONYX-BACKEND-1: AttributeError on
+        # _tenant_id).
         self._tenant_id = tenant_id
         self.slack_bot_id = slack_bot_id
         self.bot_name: str = "Unnamed"
+        super().__init__(*args, **kwargs)
 
     @contextmanager
     def _set_tenant_context(self) -> Generator[None, None, None]:


### PR DESCRIPTION
## Description

`slack_sdk.socket_mode.builtin.client.SocketModeClient.__init__` starts a background `message_processor` `IntervalRunner` thread during initialization. That thread runs `process_messages` → `self.process_message()`, and our subclass overrides `process_message` to wrap the call with `self._set_tenant_context()` which reads `self._tenant_id`.

Because `self._tenant_id = tenant_id` ran **after** `super().__init__`, the processor thread could race into our override before the attribute existed:

```
AttributeError: 'TenantSocketModeClient' object has no attribute '_tenant_id'
```

Sentry issue `ONYX-BACKEND-1` — 23,912 events since 2025-09-11, still firing.

Fix: assign `_tenant_id`, `slack_bot_id`, `bot_name` before calling `super().__init__`. The base class doesn't read these attrs during its own init.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Straightforward attribute-ordering change — no behavior change for any code path other than the startup race window.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup race in Slack tenant socket mode by setting instance attrs before calling base `SocketModeClient` init. Prevents `_tenant_id` AttributeError when the background message processor runs during init.

- **Bug Fixes**
  - Set `_tenant_id`, `slack_bot_id`, and `bot_name` before `super().__init__` since `slack_sdk.socket_mode.builtin.client.SocketModeClient.__init__` starts an `IntervalRunner` that can call our overridden `process_message` early.
  - No behavior change after init; this only closes the race window.

<sup>Written for commit 113526daff2ac2d080f811be4d1a401afd2dd42b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

