### PR TITLE
fix(alembic): set tenant contextvar around per-schema migrations

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -25,6 +25,7 @@ from shared_configs.configs import (
     POSTGRES_DEFAULT_SCHEMA,
     TENANT_ID_PREFIX,
 )
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from onyx.db.models import Base
 from celery.backends.database.session import (  # ty: ignore[unresolved-import]
     ResultModelBase,
@@ -218,8 +219,15 @@ def do_run_migrations(
         script_location=config.get_main_option("script_location"),
     )
 
-    with context.begin_transaction():
-        context.run_migrations()
+    # Migrations may call into code that reads CURRENT_TENANT_ID_CONTEXTVAR
+    # (e.g. get_kv_store().load() in 4ee1287bd26a). search_path alone is not
+    # enough — set the Python contextvar to match.
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(schema_name)
+    try:
+        with context.begin_transaction():
+            context.run_migrations()
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 def provide_iam_token_for_alembic(


### PR DESCRIPTION
## Description

`alembic/env.py:do_run_migrations` configures the Postgres `search_path` for the target tenant schema but never sets `CURRENT_TENANT_ID_CONTEXTVAR`. Migrations that call into application code reading that contextvar break.

The offender is `4ee1287bd26a_add_multiple_slack_bot_support.py:66`:

```python
tokens = cast(dict, get_kv_store().load("slack_bot_tokens_config_key"))
```

`get_kv_store().load(...)` attempts a Redis cache lookup, which resolves the tenant id off the contextvar → `RuntimeError: "Tenant ID is not set. This should never happen."` The KV store's `except Exception` catches and re-logs via `logger.error`, which ships the event to Sentry as **ONYX-BACKEND-H4MZ** (4,649 events since 2026-03-04). The migration itself continues (the call is wrapped in its own try/except), so this is pure Sentry noise.

`cloud_check_available_tenants` → `_migrate_stale_pool_tenants` runs `run_alembic_migrations(tenant_id)` on every pool tenant each cycle, so the leak is continuous.

Fix: set `CURRENT_TENANT_ID_CONTEXTVAR` to the target `schema_name` for the duration of `context.run_migrations()` and reset after (try/finally to be safe against mid-migration exceptions). Narrowly scoped — no behavior change for migrations that don't touch the contextvar.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. The fix is a narrow wrap around the existing `run_migrations()` call and is idempotent (resetting the token even if it was already set elsewhere upstream).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the tenant context var during per-schema Alembic runs to match the target schema and prevent context-dependent code from failing. This stops Redis lookup errors during migrations and removes the related Sentry noise.

- **Bug Fixes**
  - Wrap `context.run_migrations()` with `CURRENT_TENANT_ID_CONTEXTVAR.set(schema_name)` and reset via try/finally.
  - Prevents failures when migrations call `get_kv_store().load()` by ensuring the tenant ID is available.
  - No behavior change for migrations that don’t read the context var.

<sup>Written for commit 479e7f04334c991d219daed0040f4969ac3ac0a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

