### PR TITLE
fix(redis): retry BusyLoadingError and other transient Redis errors

### DIFF
--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -11,8 +11,13 @@ from typing import Optional
 import redis
 from fastapi import Request
 from redis import asyncio as aioredis
+from redis.backoff import ExponentialBackoff
 from redis.client import Redis
+from redis.exceptions import BusyLoadingError
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from redis.lock import Lock as RedisLock
+from redis.retry import Retry
 
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import REDIS_DB_NUMBER
@@ -37,6 +42,24 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 SCAN_ITER_COUNT_DEFAULT = 4096
+
+# Retry transient Redis errors — in particular BusyLoadingError, which is
+# raised while Redis is loading its RDB snapshot after a restart or
+# failover. redis-py's default retry policy only covers ConnectionError,
+# so these surface as uncaught exceptions and ship to Sentry
+# (ONYX-BACKEND-H4NT / H43M).
+_RETRYABLE_ERRORS: list[type[Exception]] = [
+    BusyLoadingError,
+    RedisConnectionError,
+    RedisTimeoutError,
+]
+
+
+def _client_retry_kwargs() -> dict[str, Any]:
+    return {
+        "retry": Retry(ExponentialBackoff(cap=2.0, base=0.1), retries=3),
+        "retry_on_error": _RETRYABLE_ERRORS,
+    }
 
 
 class TenantRedis(redis.Redis):
@@ -167,24 +190,28 @@ class RedisPool:
         )
 
     def get_client(self, tenant_id: str) -> Redis:
-        return TenantRedis(tenant_id, connection_pool=self._pool)
+        return TenantRedis(
+            tenant_id, connection_pool=self._pool, **_client_retry_kwargs()
+        )
 
     def get_replica_client(self, tenant_id: str) -> Redis:
-        return TenantRedis(tenant_id, connection_pool=self._replica_pool)
+        return TenantRedis(
+            tenant_id, connection_pool=self._replica_pool, **_client_retry_kwargs()
+        )
 
     def get_raw_client(self) -> Redis:
         """
         Returns a Redis client with direct access to the primary connection pool,
         without tenant prefixing.
         """
-        return redis.Redis(connection_pool=self._pool)
+        return redis.Redis(connection_pool=self._pool, **_client_retry_kwargs())
 
     def get_raw_replica_client(self) -> Redis:
         """
         Returns a Redis client with direct access to the replica connection pool,
         without tenant prefixing.
         """
-        return redis.Redis(connection_pool=self._replica_pool)
+        return redis.Redis(connection_pool=self._replica_pool, **_client_retry_kwargs())
 
     @staticmethod
     def create_pool(


### PR DESCRIPTION
## Description

`redis-py`'s default retry policy only covers `ConnectionError`, so `BusyLoadingError` (raised while Redis loads its RDB snapshot after a restart or replica failover — the "Redis is loading the dataset in memory" message) and `TimeoutError` propagate straight up to callers.

In the slack listener's product-gating path this surfaces as **ONYX-BACKEND-H4NT** (230 events, still firing) and **ONYX-BACKEND-H43M** (106 events) in Sentry. Same root cause; slightly different call paths explain the two groups.

Fix: add a shared `_client_retry_kwargs()` helper that returns a `Retry(ExponentialBackoff(cap=2.0, base=0.1), retries=3)` plus `retry_on_error=[BusyLoadingError, ConnectionError, TimeoutError]`, and pass it to every Redis client constructed by `RedisPool`. Four call sites updated.

Conservative retry bounds (3 attempts, cap 2s) keep worst-case latency acceptable while covering the typical few-hundred-ms RDB load window.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Change is purely additive to client construction — no behavior change on the happy path. Callers that previously saw BusyLoadingError will now see retries followed by either success or the same exception if it persists beyond the retry budget.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retries for transient Redis errors across all `RedisPool` clients using exponential backoff. This smooths over restart/failover windows and reduces Sentry noise (ONYX-BACKEND-H4NT/H43M).

- **Bug Fixes**
  - Added `_client_retry_kwargs()` with `Retry(ExponentialBackoff(cap=2.0, base=0.1), retries=3)` and `retry_on_error=[BusyLoadingError, ConnectionError, TimeoutError]`.
  - Applied to `get_client`, `get_replica_client`, `get_raw_client`, and `get_raw_replica_client`.
  - Conservative bounds: 3 attempts, max ~2s backoff. No change on the happy path.

<sup>Written for commit ecfc0d31051272a04c356e22db892e61267589b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

