### PR TITLE
fix(slack): silence LockNotOwnedError on tenant lock release

### DIFF
--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -14,6 +14,7 @@ from typing import Dict
 import psycopg2.errors
 from prometheus_client import Gauge
 from prometheus_client import start_http_server
+from redis.exceptions import LockNotOwnedError
 from redis.lock import Lock
 from redis.lock import Lock as RedisLock
 from slack_sdk import WebClient
@@ -390,11 +391,15 @@ class SlackbotHandler:
                 if tenant_id in self.redis_locks and not DEV_MODE:
                     try:
                         self.redis_locks[tenant_id].release()
-                        del self.redis_locks[tenant_id]
+                    except LockNotOwnedError:
+                        # Expected: lock expired or was stolen; nothing to release.
+                        pass
                     except Exception as e:
-                        logger.error(
+                        logger.warning(
                             f"Error releasing lock for gated tenant {tenant_id}: {e}"
                         )
+                    finally:
+                        self.redis_locks.pop(tenant_id, None)
                 continue
 
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(
@@ -424,12 +429,16 @@ class SlackbotHandler:
                         if tenant_id in self.redis_locks and not DEV_MODE:
                             try:
                                 self.redis_locks[tenant_id].release()
-                                del self.redis_locks[tenant_id]
                                 logger.info(f"Released lock for tenant {tenant_id}")
+                            except LockNotOwnedError:
+                                # Expected: lock expired or was stolen.
+                                pass
                             except Exception as e:
-                                logger.error(
+                                logger.warning(
                                     f"Error releasing lock for tenant {tenant_id}: {e}"
                                 )
+                            finally:
+                                self.redis_locks.pop(tenant_id, None)
                     else:
                         # Manage or reconnect Slack bot sockets
                         for bot in bots:
@@ -573,8 +582,11 @@ class SlackbotHandler:
                 try:
                     self.redis_locks[tenant_id].release()
                     logger.info(f"Released lock for tenant {tenant_id}")
+                except LockNotOwnedError:
+                    # Expected during shutdown: lock expired or was stolen.
+                    pass
                 except Exception as e:
-                    logger.error(f"Error releasing lock for tenant {tenant_id}: {e}")
+                    logger.warning(f"Error releasing lock for tenant {tenant_id}: {e}")
                 finally:
                     del self.redis_locks[tenant_id]
 


### PR DESCRIPTION
## Description

`SlackbotHandler` has three lock-release sites (gated-tenant cleanup, no-bots cleanup, shutdown) that all log release failures at `logger.error`. `redis.exceptions.LockNotOwnedError` fires routinely when a Redis lock's TTL expires between acquisition and release — expected steady-state behavior, nothing to actually release.

Because each message embeds the tenant UUID as a literal, Sentry fingerprints each event as a distinct issue, producing the whole **H4J1 / H6FR-H6FZ** family (9 issues, same root cause).

Fix:
- Catch `LockNotOwnedError` silently at all three sites (the lock is already gone — our goal is achieved).
- Downgrade other unexpected failures to `warning` (we're cleaning up, not operating).
- Consolidate the `del self.redis_locks[tenant_id]` into a `finally` so we never leak the dict entry when release errors.

Precedent: `tests/unit/onyx/background/celery/tasks/tenant_provisioning/test_check_available_tenants.py` already documents that "`LockNotOwnedError` on release should be caught, not propagated" — that pattern was missing in `listener.py`.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change is narrow: exceptions during lock release now either disappear (LockNotOwnedError) or log at warning instead of error. Lock lifecycle is unchanged.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences `redis.exceptions.LockNotOwnedError` during tenant lock releases in Slackbot to cut Sentry noise and avoid false errors. Other release failures are now warnings, and lock dict entries are always cleaned up.

- **Bug Fixes**
  - Catch `LockNotOwnedError` without logging in gated-tenant cleanup, no-bots cleanup, and shutdown paths.
  - Downgrade other release exceptions from error to warning.
  - Always remove lock from `self.redis_locks` in `finally` (via `pop(..., None)`) to prevent leaks.

<sup>Written for commit 0ab9b0f1f7c932aafdba6519b99e75460deb49ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

