### PR TITLE
fix(tracing): downgrade "No active trace" log from error to debug

### DIFF
--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -270,9 +270,11 @@ class DefaultTraceProvider(TraceProvider):
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
-                logger.error(
-                    "No active trace. Make sure to start a trace with `trace()` first Returning NoOpSpan."
-                )
+                # Expected when tracing is disabled or a caller creates a span
+                # outside an active trace context (e.g. celery tasks with
+                # SENTRY_CELERY_TRACES_SAMPLE_RATE=0). Fall through to NoOpSpan
+                # silently — matches the other no-op branches below.
+                logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 return NoOpSpan(span_data)
             elif isinstance(current_trace, NoOpTrace) or isinstance(
                 current_span, NoOpSpan


### PR DESCRIPTION
## Description

`DefaultTraceProvider.create_span` logs `"No active trace. Make sure to start a trace with trace() first Returning NoOpSpan."` at `ERROR` level when no trace is active, then returns a `NoOpSpan` and continues normally.

That ERROR is inconsistent with the three sibling no-op branches in the same function (lines 280, 290, 296), which all log at `debug`. The fallback to `NoOpSpan` is a legitimate operational state — in our cloud setup it fires whenever `docprocessing_task` creates a span, because `SENTRY_CELERY_TRACES_SAMPLE_RATE=0` means celery tasks never have an active trace context.

The result: Sentry issue **ONYX-BACKEND-H6F5** — 235 events in 3 hours and growing, pure library chatter.

Fix: downgrade to `debug`, add a comment explaining why this is expected.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior is unchanged — same `NoOpSpan` returned, same caller flow. Only the log level on the fallback path changes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded the “No active trace” log in `DefaultTraceProvider.create_span` from error to debug, so returning a `NoOpSpan` when no trace is active is logged quietly. This reduces Sentry noise and aligns with the other no-op branches; runtime behavior is unchanged.

<sup>Written for commit 1ab3b9eee53775c27d0b1356048e3dd586b61f49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

