### PR TITLE
fix(indexing): handle trial/paid usage-limit as a clean attempt-failure

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -13,7 +13,6 @@ from celery import Celery
 from celery import shared_task
 from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
-from fastapi import HTTPException
 from pydantic import BaseModel
 from redis import Redis
 from redis.lock import Lock as RedisLock
@@ -93,6 +92,7 @@ from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.document_index.factory import get_all_document_indices
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
 from onyx.file_store.document_batch_storage import get_document_batch_storage
 from onyx.file_store.staging import cleanup_staged_files_for_attempt
@@ -1471,14 +1471,18 @@ def _docprocessing_task(
     if tenant_id:
         CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-    # Check if chunk indexing usage limit has been exceeded before processing
+    # Check if chunk indexing usage limit has been exceeded before processing.
+    # check_usage_and_raise raises OnyxError; hitting a trial/paid usage limit
+    # is an expected user-facing condition (not an actionable error), so we
+    # mark the attempt failed and return cleanly instead of raising (which
+    # would ship ONYX-BACKEND-H6ED to Sentry on every queued batch of an
+    # over-limit tenant).
     if USAGE_LIMITS_ENABLED:
         try:
             _check_chunk_usage_limit(tenant_id)
-        except HTTPException as e:
-            # Log the error and fail the indexing attempt
-            task_logger.error(
-                f"Chunk indexing usage limit exceeded for tenant {tenant_id}: {e}"
+        except OnyxError as e:
+            task_logger.warning(
+                f"Chunk indexing usage limit exceeded for tenant {tenant_id}: {e.detail}"
             )
             with get_session_with_current_tenant() as db_session:
                 from onyx.db.index_attempt import mark_attempt_failed
@@ -1486,9 +1490,9 @@ def _docprocessing_task(
                 mark_attempt_failed(
                     index_attempt_id=index_attempt_id,
                     db_session=db_session,
-                    failure_reason=str(e),
+                    failure_reason=e.detail,
                 )
-            raise
+            return
 
     task_logger.info(
         f"Processing document batch: attempt={index_attempt_id} batch_num={batch_num} "


### PR DESCRIPTION
## Description

`_docprocessing_task` has a usage-limit pre-check at the top of every batch: `_check_chunk_usage_limit(tenant_id)`. The limit-check raises `OnyxError` (from `check_usage_and_raise`), but the catch clause in the caller expected `HTTPException`:

```python
try:
    _check_chunk_usage_limit(tenant_id)
except HTTPException as e:   # OnyxError does not inherit from HTTPException
    task_logger.error(...)
    mark_attempt_failed(...)
    raise
```

Every batch for an over-limit tenant therefore:

1. Calls the check
2. Raises uncaught `OnyxError`
3. Bubbles out of the task, celery logs via Sentry

Result: **ONYX-BACKEND-H6ED — 153 events/hour, 3.7K/day**, all from the same "trial limit exceeded" message.

Hitting a usage limit is an expected user-facing condition (the UI surfaces the detail string to the tenant), not an actionable backend error:

- Catch `OnyxError` so the handler actually fires.
- Log at `WARNING` instead of `ERROR`.
- Mark the attempt failed with the detail string (unchanged behavior).
- `return` instead of `raise` — the attempt record in DB is the source of truth. Subsequent queued batches of the same attempt will hit the same short-circuit and exit silently, no Sentry spam.

Also drops the now-unused `from fastapi import HTTPException` import.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change is intentional: previously the task raised and Sentry-ed on over-limit; now it marks the attempt failed in DB and exits the batch. The `mark_attempt_failed` side effect is preserved, and celery doesn't retry this task (no `autoretry_for`), so the observable outcome to the tenant is identical except for the reduced Sentry noise.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle indexing usage-limit (trial/paid) as an expected condition by failing the attempt and exiting cleanly. This stops ONYX-BACKEND-H6ED Sentry noise and keeps the attempt record as the source of truth.

- **Bug Fixes**
  - Catch `OnyxError` from `_check_chunk_usage_limit` in `_docprocessing_task`, log a warning with `e.detail`, mark the attempt failed, and return without raising.
  - Preserve the failure detail in the attempt; subsequent batches short-circuit without errors or retries.
  - Remove unused `fastapi.HTTPException` import.

<sup>Written for commit dcddc8d33d29eb629ea82afc71e249793d4bed81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

