### PR TITLE
fix(embedding): log retryable provider errors at warning, not error

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -515,7 +515,12 @@ class CloudEmbedding:
                 sanitized_api_key=self.sanitized_api_key,
                 status_code=e.response.status_code,
             )
-            logger.error(error_string)
+            # Log at warning because the @retry decorator will re-invoke us
+            # on failure — an ERROR-level log here floods Sentry with up to
+            # _RETRY_TRIES duplicate events per failing batch (rate limits,
+            # transient provider outages). The final failure surfaces via
+            # the RuntimeError below and is logged by the caller.
+            logger.warning(error_string)
             logger.debug(f"Exception texts: {texts}")
 
             raise RuntimeError(error_string)
@@ -530,7 +535,7 @@ class CloudEmbedding:
                 self.provider,
                 sanitized_api_key=self.sanitized_api_key,
             )
-            logger.error(error_string)
+            logger.warning(error_string)
             logger.debug(f"Exception texts: {texts}")
 
             raise RuntimeError(error_string)


### PR DESCRIPTION
## Description

`CloudEmbedding.embed` is wrapped with `@retry(tries=_RETRY_TRIES, delay=_RETRY_DELAY)` — for indexing that's up to **10 attempts** per embedding batch with a 10-second delay (100s of total retry budget). Each failed attempt runs through the `except` blocks inside `embed`, which call `logger.error(...)` *before* re-raising. Every retry attempt therefore ships a Sentry event.

A single failed batch caused by Gemini `429 RESOURCE_EXHAUSTED` or Cohere `502` floods Sentry with up to 10 duplicate events. The retry path is also why the same root cause shows up under 5 distinct fingerprints (stack variations across `_embed_vertex`, `_embed_cohere`, the wrapping RuntimeError, etc.).

**Fix:** downgrade the two catch-site logs to `WARNING`. The retry decorator handles backoff; the final failure still propagates as `RuntimeError` (message unchanged), and the caller's existing logging covers the terminal error at ERROR level exactly once.

Issues affected:
- `ONYX-BACKEND-H6EG` (37 events)
- `ONYX-BACKEND-H6EE` (21)
- `ONYX-BACKEND-H6F4` (6)
- `ONYX-BACKEND-H6FE` (4)
- `ONYX-BACKEND-H6G1` (1)

~24 events/hour combined today; should drop by ~10x after this lands.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. The change is a log-level downgrade only — the RuntimeError contract with callers is preserved, and the format string is unchanged. No behavior change on the happy path or for other callers.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered log level for retryable embedding provider errors to WARNING to prevent Sentry floods during `@retry` attempts. Final failures still raise `RuntimeError`, so callers log a single ERROR.

- Bug Fixes
  - Changed two catch-site logs in `search_nlp_models.embed` from error to warning to handle transient Gemini 429 and Cohere 502 cases without duplicate events.
  - Reduces noise by ~10x and cuts fragmented fingerprints; relates to Linear ONYX-BACKEND-H6EG, H6EE, H6F4, H6FE, H6G1.

<sup>Written for commit cc848d80f47190570e616708b3726697e31e6c4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

