### PR TITLE
fix(indexing): demote PDF parsing failures to warning

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -360,10 +360,17 @@ def read_pdf_file(
 
         return text, metadata, extracted_images
 
-    except PdfStreamError:
-        logger.exception("Invalid PDF file")
-    except Exception:
-        logger.exception("Failed to read PDF")
+    except PdfStreamError as e:
+        # Malformed/truncated PDF content — a per-document content issue, not
+        # a platform bug. The function returns empty text and the connector
+        # continues with the next doc; no need to ship a stack trace to
+        # Sentry for every corrupt file we encounter.
+        logger.warning(f"Invalid PDF file, skipping content extraction: {e}")
+    except Exception as e:
+        # Unknown PDF parsing failure — elevate just the message, not a
+        # traceback, for the same reason. Callers treat empty text as a
+        # non-fatal skip.
+        logger.warning(f"Failed to read PDF, skipping content extraction: {e}")
 
     return "", metadata, []
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -365,12 +365,12 @@ def read_pdf_file(
         # a platform bug. The function returns empty text and the connector
         # continues with the next doc; no need to ship a stack trace to
         # Sentry for every corrupt file we encounter.
-        logger.warning(f"Invalid PDF file, skipping content extraction: {e}")
+        logger.warning("Invalid PDF file, skipping content extraction: %s", e)
     except Exception as e:
         # Unknown PDF parsing failure — elevate just the message, not a
         # traceback, for the same reason. Callers treat empty text as a
         # non-fatal skip.
-        logger.warning(f"Failed to read PDF, skipping content extraction: {e}")
+        logger.warning("Failed to read PDF, skipping content extraction: %s", e)
 
     return "", metadata, []
 


### PR DESCRIPTION
## Description

`read_pdf_file` in `onyx/file_processing/extract_file_text.py` catches `PdfStreamError` and a generic `Exception` and logs both at `logger.exception(...)`, which ships the full traceback to Sentry. Every corrupt or malformed PDF encountered during connector indexing therefore becomes a Sentry event.

These are per-document content issues, not platform bugs. The function returns empty text + empty images and the indexing pipeline moves on to the next document — no fallback logic downstream depends on the error. Stack traces aren't actionable.

**Fix:** downgrade both handlers to `logger.warning` with the exception message. Operators still see what's happening in logs; Sentry is not flooded.

Issues covered:
- `ONYX-BACKEND-H6EH` — `PdfStreamError: Stream has ended unexpectedly` (~8 events/hour)
- `ONYX-BACKEND-H6F3` — `DependencyError: jbig2dec binary is not available` (~5/hour) — falls into the generic `Exception` branch from the pypdf internals

Combined ~13 events/hour today; should disappear from Sentry after this lands.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change is log-level only — the function's return contract (empty text on failure) is unchanged.

Note on `jbig2dec`: that is a secondary image-extraction binary for JBIG2-compressed PDF images. If we want actual JBIG2 support we should install the binary in the image (separate deploy change). This PR just stops the missing-dependency from being a Sentry-level event; the content extraction already degrades gracefully.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded PDF parsing errors in `read_pdf_file` to warnings to stop flooding Sentry with stack traces. Indexing still returns empty text and moves on; operators see clear log messages.

- **Bug Fixes**
  - In `backend/onyx/file_processing/extract_file_text.py`, replaced `logger.exception` with `logger.warning` for `PdfStreamError` and other exceptions; message only, no traceback.
  - Cuts noisy events from corrupt PDFs and missing `jbig2dec`; caller behavior unchanged (empty text, skip doc).
  - Switched to %s-style logger formatting for the warning messages to avoid eager string interpolation.

Addresses Linear issues `ONYX-BACKEND-H6EH` and `ONYX-BACKEND-H6F3`.

<sup>Written for commit 6f1c1831ebac2c2c4e91e7085c53fd5b18a9540e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10543?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

