### PR TITLE
fix(slack): cache users.info failures and demote to warning

### DIFF
--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -199,10 +199,16 @@ class SlackTextCleaner:
                     or response["user"]["profile"]["real_name"]
                 )
             except SlackApiError as e:
-                logger.exception(
+                # Common per-message condition: user was deleted, workspace
+                # migrated, bot lacks users:read, etc. Cache the raw id as a
+                # fallback so we don't re-hit the API for the same bad id on
+                # every message, and keep the event out of Sentry — the
+                # message indexing path continues with the id in place of
+                # the display name (ONYX-BACKEND-H6FN).
+                logger.warning(
                     f"Error fetching data for user {user_id}: {e.response['error']}"
                 )
-                raise
+                self._id_to_name_map[user_id] = user_id
 
         return self._id_to_name_map[user_id]
 
@@ -220,9 +226,12 @@ class SlackTextCleaner:
 
                 # Replace the user ID with the username in the message
                 message = message.replace(f"<@{user_id}>", f"@{user_name}")
-            except Exception:
-                logger.exception(
-                    f"Unable to replace user ID with username for user_id '{user_id}'"
+            except Exception as e:
+                # _get_slack_name no longer raises on SlackApiError, so this
+                # only fires on unexpected errors (e.g. malformed response);
+                # still defensive, but not actionable per-message — warn.
+                logger.warning(
+                    f"Unable to replace user ID with username for user_id '{user_id}': {e}"
                 )
 
         return message


### PR DESCRIPTION
## Description

`SlackTextCleaner._get_slack_name` (used during Slack message indexing to replace `<@U12345>` with `@DisplayName`) logs at `logger.exception` and re-raises when Slack's `users.info` fails. The outer caller `_replace_user_ids_with_names` has its own `except Exception: logger.exception(...)`, so every unresolvable user id in an indexed message produces **two Sentry events**.

`users.info` failing is an expected per-message condition — user deleted, bot removed from workspace, missing `users:read` scope, etc. It's not actionable.

**Fix:** cache the raw user id as the fallback mapping and return it instead of raising. Result:

- Subsequent references to the same bad id skip the API entirely (cache hit).
- The message still gets a sensible substitution (`@U12345` instead of nothing).
- No exception propagates, so the caller's defensive handler stays quiet for this case.
- The caller's `except` still covers genuinely unexpected errors (malformed response) but logs at `warning`.

Issue: **ONYX-BACKEND-H6FN** — 20 events/hr, new issue surfacing today.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change:
- Previously: bad user id → 2 Sentry events + `@None` or partial replacement in message.
- Now: bad user id → 0 Sentry events + `@U12345` in message (same raw id caller would have fallen back to anyway). Caching also cuts Slack API traffic for repeated offenders.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache failed Slack `users.info` lookups and return the raw user id so indexing continues without raising. Demotes logs to warnings to remove duplicate Sentry events. Addresses ONYX-BACKEND-H6FN.

- **Bug Fixes**
  - `_get_slack_name`: on `SlackApiError`, log a warning and cache `user_id -> user_id` instead of raising.
  - `_replace_user_ids_with_names`: warn only on unexpected errors; normal missing users no longer trigger exceptions.
  - Repeated unresolved ids bypass the API; messages substitute `<@U12345>` with `@U12345`.

<sup>Written for commit 186b30cbe958796032f33d0d864b9c57b7dad3bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

