### PR TITLE
fix(fireflies): retry transient 5xx with exponential backoff

### DIFF
--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
@@ -27,6 +28,8 @@ _FIREFLIES_ID_PREFIX = "FIREFLIES_"
 _FIREFLIES_API_URL = "https://api.fireflies.ai/graphql"
 
 _FIREFLIES_TRANSCRIPT_QUERY_SIZE = 50  # Max page size is 50
+_FIREFLIES_MAX_RETRIES = 3
+_FIREFLIES_RETRY_BASE_DELAY_SECONDS = 2
 
 _FIREFLIES_API_QUERY = """
     query Transcripts($fromDate: DateTime, $toDate: DateTime, $limit: Int!, $skip: Int!) {
@@ -169,12 +172,28 @@ class FirefliesConnector(PollConnector, LoadConnector):
 
         while True:
             variables["skip"] = skip
-            response = requests.post(
-                _FIREFLIES_API_URL,
-                headers=headers,
-                json={"query": _FIREFLIES_API_QUERY, "variables": variables},
-            )
+            # Retry 5xx with exponential backoff — Fireflies occasionally
+            # returns 500 / 504 for transient errors (ONYX-BACKEND-H6FJ/H6FH).
+            # 4xx still raises immediately because those are not retryable.
+            response: requests.Response | None = None
+            for attempt in range(_FIREFLIES_MAX_RETRIES):
+                response = requests.post(
+                    _FIREFLIES_API_URL,
+                    headers=headers,
+                    json={
+                        "query": _FIREFLIES_API_QUERY,
+                        "variables": variables,
+                    },
+                )
+                if response.status_code < 500 or attempt == _FIREFLIES_MAX_RETRIES - 1:
+                    break
+                logger.warning(
+                    f"Fireflies returned {response.status_code} on attempt "
+                    f"{attempt + 1}/{_FIREFLIES_MAX_RETRIES}, retrying"
+                )
+                time.sleep(_FIREFLIES_RETRY_BASE_DELAY_SECONDS * (2**attempt))
 
+            assert response is not None  # loop always runs at least once
             response.raise_for_status()
 
             if response.status_code == 204:


### PR DESCRIPTION
## Description

The Fireflies GraphQL endpoint occasionally returns `500` or `504` for transient errors (~8 events/hour in Sentry). Each one currently raises `HTTPError` immediately, fails the indexing attempt, and ships **two Sentry events**: `ONYX-BACKEND-H6FJ` (the raw `HTTPError: 500 Server Error`) and `ONYX-BACKEND-H6FH` (the connector framework's `Error in connector. type: HTTPError` wrapper).

Transient upstream — retrying would succeed most of the time. Add a small retry loop (3 attempts, 2s/4s/8s exponential backoff) scoped to 5xx responses only; 4xx still raises immediately because client errors aren't retryable. Retry attempts log at `warning`; the final failure after retries raises `HTTPError` with existing semantics.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Happy path unchanged. The only behavior change is up to ~14s retry budget for transient 5xx.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add exponential-backoff retries for transient 5xx responses from the Fireflies GraphQL endpoint. This reduces failed indexing attempts and noisy Sentry events while keeping 4xx behavior unchanged.

- **Bug Fixes**
  - Retry 5xx up to 3 times with 2s/4s/8s delays; final failure still raises `HTTPError`.
  - Log retries at warning; adds up to ~14s max per request in transient cases.

<sup>Written for commit f1eb578f3f61564923c0720a71e171af33d6d015. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

