### PR TITLE
fix(indexing): raise CSV field size limit to 128 MiB

### DIFF
--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -4,6 +4,15 @@ from collections.abc import Generator
 
 from pydantic import BaseModel
 
+# Python's csv default field size limit is 131072 bytes (128 KiB), which
+# real-world data (long descriptions, pasted docs, base64 blobs) routinely
+# exceeds — the parser then raises `Error: field larger than field limit
+# (131072)` and fails the whole row, aborting indexing of the CSV section
+# (ONYX-BACKEND-H6FM). Bump to 128 MiB, matching the order of magnitude the
+# salesforce connector already opts into for bulk exports.
+_CSV_FIELD_SIZE_LIMIT_BYTES = 128 * 1024 * 1024
+csv.field_size_limit(_CSV_FIELD_SIZE_LIMIT_BYTES)
+
 _NEWLINE_CSV_ERROR = "new-line character seen in unquoted field"
 
 


### PR DESCRIPTION
## Description

Python's `csv` module default field size limit is 131072 bytes (128 KiB). Real customer CSVs routinely have single cells larger than that (long descriptions, pasted documents, embedded base64 blobs) — when `parse_csv_string` in the chunker hits one, Python raises:

```
Error: field larger than field limit (131072)
```

Stack: `docprocessing_task → index_doc_batch → _handle_single_document → chunk → chunk_section → parse_csv_string`

That aborts the whole section mid-row and fails indexing. Sentry issue **ONYX-BACKEND-H6FM** (~3 events/hour from `docprocessing_task`).

Fix: bump `csv.field_size_limit` to 128 MiB at module import of `onyx.utils.csv_utils`. `csv.field_size_limit` is process-wide, which is fine here — larger is simply more permissive and no call site benefits from the tighter cap. This matches the order of magnitude the salesforce connector already opts into (`16 * 1024 * 1024` at `sqlite_functions.py:563`).

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change: CSV rows with fields between 128 KiB and 128 MiB now parse successfully instead of aborting. Fields > 128 MiB still raise, but those are not real user data.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise Python `csv` field size limit to 128 MiB so large cells in customer CSVs don’t break indexing. Prevents the "field larger than field limit (131072)" error in the chunker.

- **Bug Fixes**
  - Set process-wide limit at import in `backend/onyx/utils/csv_utils.py` via `_CSV_FIELD_SIZE_LIMIT_BYTES = 128 * 1024 * 1024`.
  - Stops mid-row aborts seen in Sentry ONYX-BACKEND-H6FM; aligns with the Salesforce connector’s more permissive limits (16 MiB order of magnitude). Fields >128 MiB still error.

<sup>Written for commit ee141a5055e04149c60038248e65ce71ea2dfd79. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

