### PR TITLE
fix(web): tolerate null document.body in auto-scroll step

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -602,26 +602,38 @@ class WebConnector(LoadConnector, SlimConnector):
 
             # If we got here, the request was successful
             if not slim and self.scroll_before_scraping:
-                scroll_attempts = 0
-                previous_height = page.evaluate("document.body.scrollHeight")
-                while scroll_attempts < WEB_CONNECTOR_MAX_SCROLL_ATTEMPTS:
-                    page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-                    # Wait for content to load, but catch timeout if page never reaches networkidle
-                    # (e.g., CloudFlare protection keeps making requests)
-                    try:
-                        page.wait_for_load_state(
-                            "networkidle", timeout=PAGE_RENDER_TIMEOUT_MS
-                        )
-                    except TimeoutError:
-                        # If networkidle times out, just give it a moment for content to render
-                        time.sleep(1)
-                    time.sleep(0.5)  # let javascript run
+                try:
+                    # document.body can be null for non-HTML responses,
+                    # transient frame-nav states, or pages rendered without
+                    # a body (e.g. pure XML, some SPAs mid-navigation). That
+                    # surfaces as "Page.evaluate: TypeError: Cannot read
+                    # properties of null (reading 'scrollHeight')"
+                    # (ONYX-BACKEND-H6G5). Skip auto-scroll in that case and
+                    # fall back to whatever content the initial load gave us.
+                    scroll_attempts = 0
+                    previous_height = page.evaluate("document.body.scrollHeight")
+                    while scroll_attempts < WEB_CONNECTOR_MAX_SCROLL_ATTEMPTS:
+                        page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                        # Wait for content to load, but catch timeout if page never reaches networkidle
+                        # (e.g., CloudFlare protection keeps making requests)
+                        try:
+                            page.wait_for_load_state(
+                                "networkidle", timeout=PAGE_RENDER_TIMEOUT_MS
+                            )
+                        except TimeoutError:
+                            # If networkidle times out, just give it a moment for content to render
+                            time.sleep(1)
+                        time.sleep(0.5)  # let javascript run
 
-                    new_height = page.evaluate("document.body.scrollHeight")
-                    if new_height == previous_height:
-                        break  # Stop scrolling when no more content is loaded
-                    previous_height = new_height
-                    scroll_attempts += 1
+                        new_height = page.evaluate("document.body.scrollHeight")
+                        if new_height == previous_height:
+                            break  # Stop scrolling when no more content is loaded
+                        previous_height = new_height
+                        scroll_attempts += 1
+                except Exception as scroll_err:
+                    logger.warning(
+                        f"{index}: auto-scroll skipped for {initial_url}: {scroll_err}"
+                    )
 
             content = page.content()
             soup = BeautifulSoup(content, "html.parser")


### PR DESCRIPTION
## Description

`WebConnector._do_scrape`'s auto-scroll block runs `page.evaluate("document.body.scrollHeight")` unguarded before the main content extraction. `document.body` can legitimately be `null` — non-HTML responses, pure XML, pages served with no body element, transient frame-nav states mid-navigation — producing:

```
Page.evaluate: TypeError: Cannot read properties of null (reading 'scrollHeight')
```

The outer `try/except` in `load_from_state` catches it, calls `logger.exception`, retries with exponential backoff (wasted attempts since body is still null), then gives up on the URL. Sentry issue **ONYX-BACKEND-H6G5** (~5/hr, newly firing) — every failing URL ships a traceback.

**Fix:** wrap the entire `scroll_before_scraping` block in `try/except`. On failure, skip auto-scroll and fall back to whatever content the initial `page.goto(...)` gave us — the connector already extracts content from `page.content()` right below the scroll block, so the content-extraction path is unaffected. Log at `warning` with URL context.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change: pages where `document.body` evaluates to null previously failed with retries and a Sentry event; now they fall through to normal content extraction with a warning. Pages with a valid body are unaffected.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in WebConnector auto-scroll when `document.body` is null. We now skip scrolling on failure and continue with normal content extraction, reducing retries and Sentry noise.

- **Bug Fixes**
  - Wrap auto-scroll in try/except; if `document.body` access fails, skip scrolling.
  - Continue with `page.content()` extraction unchanged.
  - Log a warning with URL context instead of raising, avoiding unnecessary retries and Sentry events (ONYX-BACKEND-H6G5).

<sup>Written for commit 4767b2235518f69abff77731c54b43678915ee3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

