### PR TITLE
fix(connector): Disable unused eager loading in indexing status endpoint

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -546,6 +546,9 @@ def get_latest_index_attempts_parallel(
     eager_load_cc_pair: bool = False,
     only_finished: bool = False,
 ) -> Sequence[IndexAttempt]:
+    # The session closes before returning, so only set eager_load_cc_pair=True if the
+    # caller actually accesses those relationships — otherwise it loads data for nothing
+    # and error_rows in particular can be very expensive on large deployments.
     with get_session_with_current_tenant() as db_session:
         return get_latest_index_attempts(
             secondary_index,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -1134,14 +1134,14 @@ def get_connector_indexing_status(
         # Get most recent index attempts
         (
             lambda: get_latest_index_attempts_parallel(
-                request.secondary_index, True, False
+                request.secondary_index, False, False
             ),
             (),
         ),
         # Get most recent finished index attempts
         (
             lambda: get_latest_index_attempts_parallel(
-                request.secondary_index, True, True
+                request.secondary_index, False, True
             ),
             (),
         ),


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

The /admin/connector/indexing-status endpoint was eager-loading connector_credential_pair and error_rows on every IndexAttempt query, but neither relationship is ever accessed — all fields read are plain scalars. The error_rows join in particular pulls ~52k rows / 22 MB, causing the endpoint to take 3.6–8.3 s per poll. Flipping eager_load_cc_pair to False on both call sites drops those queries from ~1.8 s each to ~3 ms. Added a comment on the eager load block warning about the DetachedInstanceError risk and the cost of error_rows.

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
n/a
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable unused eager loading in the indexing status endpoint to avoid loading `connector_credential_pair` and `error_rows`. Polls drop from ~1.8s to ~3ms and ~22MB less data per request, supporting Linear ENG-3954.

- **Refactors**
  - Pass `eager_load_cc_pair=False` in both `get_latest_index_attempts_parallel` calls for `/admin/connector/indexing-status` (latest and finished attempts).
  - Add a note in `get_latest_index_attempts_parallel` about the closed session and high cost of `error_rows`; only enable eager loading when relationships are actually used.

<sup>Written for commit 8cb59b93efdeccd9ae7249ecbdbb966426b5ddf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

