### PR TITLE
fix(install): handle empty prompt and piped stdin in Windows install.ps1

### DIFF
--- a/deployment/docker_compose/install.ps1
+++ b/deployment/docker_compose/install.ps1
@@ -57,15 +57,23 @@ function Print-Step {
 }
 
 function Test-Interactive {
-    return -not $NoPrompt
+    if ($NoPrompt) { return $false }
+    # Detect piped stdin (e.g. `irm ... | iex`): Read-Host fails when stdin is redirected
+    try { if ([Console]::IsInputRedirected) { return $false } } catch {}
+    return $true
 }
 
 function Prompt-OrDefault {
     param([string]$PromptText, [string]$DefaultValue)
     if (-not (Test-Interactive)) { return $DefaultValue }
-    $reply = Read-Host $PromptText
-    if ([string]::IsNullOrWhiteSpace($reply)) { return $DefaultValue }
-    return $reply
+    try {
+        # Read-Host with an empty prompt throws "name cannot be null or empty" on some systems
+        $reply = if ([string]::IsNullOrEmpty($PromptText)) { Read-Host } else { Read-Host -Prompt $PromptText }
+        if ([string]::IsNullOrWhiteSpace($reply)) { return $DefaultValue }
+        return $reply
+    } catch {
+        return $DefaultValue
+    }
 }
 
 function Confirm-Action {


### PR DESCRIPTION
Fixes #9977
Fixes #9922

## Problem

The Windows installer (`install.ps1`) fails with `Read-Host : name cannot be null or empty` in two scenarios:

**Scenario 1 — piped execution (`irm ... | iex`)**

When the script is downloaded and executed via `irm https://onyx.app/install_onyx.ps1 | iex`, stdin is redirected (piped). PowerShell's `Read-Host` fails in a piped context. `Test-Interactive` only checked `$NoPrompt`, so it returned `$true` even in piped mode, causing the subsequent `Read-Host` call to throw.

**Scenario 2 — empty prompt string**

The acknowledgement gate calls `Prompt-OrDefault "" ""` (empty prompt). `Read-Host ""` with an empty string throws `name cannot be null or empty` on certain Windows/PowerShell configurations (observed on Windows Server and some Windows 10/11 builds).

## Solution

1. **`Test-Interactive`**: added `[Console]::IsInputRedirected` check — returns `$false` when stdin is a pipe, so all `Read-Host` calls are bypassed and the script proceeds automatically (same as `--NoPrompt`). The check is wrapped in `try/catch` for environments where the property may not exist.

2. **`Prompt-OrDefault`**: call `Read-Host` without arguments when `$PromptText` is empty/null (avoids the empty-string rejection). Wrapped in `try/catch` so any residual failure gracefully returns the default value instead of crashing.

## Testing

- Interactive run (direct `.ps1` call): prompts work normally with named `-Prompt` parameter.
- Piped run (`irm ... | iex`): `[Console]::IsInputRedirected` is `$true`, non-interactive path taken, no `Read-Host` called.
- `--NoPrompt` flag: unchanged, still bypasses all prompts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows `install.ps1` crashes by handling piped stdin and empty prompt strings. Prompts are now skipped when stdin is redirected, and `Read-Host` is called safely when the prompt text is empty.

- **Bug Fixes**
  - `Test-Interactive`: detect redirected stdin via `[Console]::IsInputRedirected`; skip prompts; wrapped in try/catch.
  - `Prompt-OrDefault`: call `Read-Host` without `-Prompt` when the prompt text is empty; fall back to default on any error.

<sup>Written for commit bee4af47b777e25db45003c8f991a2eb24920f48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

