### PR TITLE
fix(permissions): demote per-entity "no email" logs to warning

### DIFF
--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -413,7 +413,10 @@ def get_external_user_group(
             if collab.email:
                 user_emails.add(collab.email)
             else:
-                logger.error(f"Collaborator {collab.login} has no email")
+                # Expected per-user condition (login without a public email);
+                # skip and warn so the login in the message doesn't explode
+                # Sentry fingerprinting.
+                logger.warning(f"Collaborator {collab.login} has no email")
 
         if user_emails:
             collaborators_group = ExternalUserGroup(
@@ -429,7 +432,7 @@ def get_external_user_group(
             if collab.email:
                 user_emails.add(collab.email)
             else:
-                logger.error(f"Outside collaborator {collab.login} has no email")
+                logger.warning(f"Outside collaborator {collab.login} has no email")
 
         if user_emails:
             outside_collaborators_group = ExternalUserGroup(
@@ -448,7 +451,7 @@ def get_external_user_group(
                 if member.email:
                     user_emails.add(member.email)
                 else:
-                    logger.error(f"Team member {member.login} has no email")
+                    logger.warning(f"Team member {member.login} has no email")
 
             if user_emails:
                 team_group = ExternalUserGroup(

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -164,7 +164,12 @@ def get_external_access_for_raw_gdrive_file(
             if permission.email_address:
                 user_emails.add(permission.email_address)
             else:
-                logger.error(
+                # Expected per-doc condition when a Drive permission is
+                # attached to an account without a surfaced email (service
+                # accounts, deleted users, external share links). We just
+                # skip the permission — warn instead of error so the doc_id
+                # in the message doesn't explode Sentry fingerprinting.
+                logger.warning(
                     f"Permission is type `user` but no email address is provided for document {doc_id}\n {permission}"
                 )
         elif permission.type == PermissionType.GROUP:
@@ -172,7 +177,7 @@ def get_external_access_for_raw_gdrive_file(
             if permission.email_address:
                 group_emails.add(permission.email_address)
             else:
-                logger.error(
+                logger.warning(
                     f"Permission is type `group` but no email address is provided for document {doc_id}\n {permission}"
                 )
         elif permission.type == PermissionType.DOMAIN and company_domain:


### PR DESCRIPTION
## Description

Two callsites log at `error` level when a permission or group member is missing an email address:

- `ee/onyx/external_permissions/google_drive/doc_sync.py:167,175` — `Permission is type 'user' but no email address is provided for document <DOC_ID>`
- `ee/onyx/external_permissions/github/utils.py:416,432,451` — `Collaborator/Outside collaborator/Team member <login> has no email`

These are expected per-entity conditions (service accounts, deleted users, external share links, GitHub logins with private emails) — the surrounding code already handles each by simply skipping the entry. Nothing is actionable.

Because each message embeds the unique `doc_id` / `login`, Sentry fingerprints every occurrence as a separate issue. During a permission-sync burst, this is currently:

- `connector_permission_sync_generator_task`: **~382 events in 30 min across ~100 distinct fingerprints** (~760/hr)
- `connector_external_group_sync_generator_task`: **~100 events in 30 min across ~15+ fingerprints** (~200/hr)

Combined, this is now the single largest Sentry event source after our recent noise-reduction deploys (Apr 24): ~960/hr, ~46% of all backend events.

Fix: downgrade all five `logger.error` calls to `logger.warning`. Sentry's `LoggingIntegration` default captures at `ERROR` and above, so warnings become breadcrumbs (visible in events but don't themselves create issues). Log lines remain visible to operators.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Behavior change is log-level only — the flow (skip entries with no email, continue building the permission list) is unchanged.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted per-entity “no email” logs from error to warning in Google Drive document sync and GitHub external group sync. This stops Sentry from creating many separate issues for expected cases while keeping the logs visible; no behavior change.

<sup>Written for commit 62f3f796cb1e70cee7cea16f033a87619ef13c53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

