### PR TITLE
fix(opensearch): tolerate chunk_count=0 as tolerated race

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -88,6 +88,15 @@ class ChunkCountNotFoundError(ValueError):
     """Raised when a document has no chunk count."""
 
 
+class ChunkCountZeroError(ValueError):
+    """Raised when a document update is requested but its chunk count is 0.
+
+    This typically indicates a race between document deletion and a concurrent
+    metadata sync: the row still exists in the relational DB with
+    ``chunk_count=0`` while cleanup is in flight.
+    """
+
+
 def generate_opensearch_filtered_access_control_list(
     access: DocumentAccess,
 ) -> list[str]:
@@ -477,6 +486,12 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
                 f"Tried to update document {doc_id} but its chunk count is not known. We tolerate this for now "
                 "but this will not be an acceptable state once OpenSearch is the primary document index and the "
                 "indexing/updating race condition is fixed."
+            )
+            return
+        except ChunkCountZeroError:
+            logger.warning(
+                f"Tried to update document {doc_id} but its chunk count is 0. "
+                "Likely a race between delete and metadata sync; skipping update."
             )
             return
 
@@ -910,8 +925,11 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         "updated shortly."
                     )
                 if doc_chunk_count == 0:
-                    raise ValueError(
-                        f"Bug: Tried to update document {doc_id} but its chunk count was 0."
+                    raise ChunkCountZeroError(
+                        f"Tried to update document {doc_id} but its chunk count was 0. "
+                        "This typically indicates a race between a concurrent delete "
+                        "and metadata sync — the DB row exists with chunk_count=0 "
+                        "while cleanup is in flight."
                     )
 
                 for chunk_index in range(doc_chunk_count):

--- a/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_update_chunk_count.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_opensearch_update_chunk_count.py
@@ -1,0 +1,85 @@
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.document_index.interfaces import VespaDocumentFields
+from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.opensearch_document_index import (
+    ChunkCountNotFoundError,
+)
+from onyx.document_index.opensearch.opensearch_document_index import ChunkCountZeroError
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchOldDocumentIndex,
+)
+
+
+def _make_real_index() -> OpenSearchDocumentIndex:
+    index = OpenSearchDocumentIndex.__new__(OpenSearchDocumentIndex)
+    index._index_name = "test_index"
+    index._client = MagicMock()
+    index._tenant_state = TenantState(tenant_id="test_tenant", multitenant=False)
+    return index
+
+
+def _make_old_index_wrapper() -> OpenSearchOldDocumentIndex:
+    """Skips __init__ so we can plug in mocked inner indices directly."""
+    wrapper = OpenSearchOldDocumentIndex.__new__(OpenSearchOldDocumentIndex)
+    wrapper.index_name = "test_index"
+    wrapper.secondary_index_name = None
+    wrapper._real_index = MagicMock(spec=OpenSearchDocumentIndex)
+    wrapper._secondary_real_index = None
+    return wrapper
+
+
+def test_update_raises_chunk_count_zero_error_when_count_is_zero() -> None:
+    """``update()`` must raise ``ChunkCountZeroError`` (not a bare ``ValueError``)
+    when a doc's chunk count is 0, so callers can treat the known-zero case
+    distinctly from the unknown-count race."""
+    index = _make_real_index()
+    doc_id = "race-doc"
+    request = MetadataUpdateRequest(
+        document_ids=[doc_id],
+        doc_id_to_chunk_cnt={doc_id: 0},
+        hidden=True,
+    )
+
+    with pytest.raises(ChunkCountZeroError):
+        index.update([request])
+
+    # No per-chunk update attempted for this doc.
+    client_mock = cast(MagicMock, index._client)
+    client_mock.update_document.assert_not_called()
+
+
+def test_chunk_count_zero_error_is_subclass_of_value_error() -> None:
+    """``ChunkCountZeroError`` must remain a ``ValueError`` subclass so any
+    broad ``except ValueError`` handlers still swallow it. It must also be
+    distinct from ``ChunkCountNotFoundError`` (known-zero vs unknown)."""
+    assert issubclass(ChunkCountZeroError, ValueError)
+    assert not issubclass(ChunkCountZeroError, ChunkCountNotFoundError)
+    assert not issubclass(ChunkCountNotFoundError, ChunkCountZeroError)
+
+
+def test_update_single_swallows_chunk_count_zero_error() -> None:
+    """``OpenSearchOldDocumentIndex.update_single`` must catch
+    ``ChunkCountZeroError`` raised by the inner ``update()`` and return
+    cleanly, matching the existing ``ChunkCountNotFoundError`` behaviour."""
+    wrapper = _make_old_index_wrapper()
+    real_index_mock = cast(MagicMock, wrapper._real_index)
+    real_index_mock.update.side_effect = ChunkCountZeroError("race: chunk_count=0")
+
+    # No exception should propagate out.
+    wrapper.update_single(
+        "race-doc",
+        tenant_id="test_tenant",
+        chunk_count=0,
+        fields=VespaDocumentFields(hidden=True),
+        user_fields=None,
+    )
+
+    real_index_mock.update.assert_called_once()


### PR DESCRIPTION
## Description

Distinguish known-zero from unknown chunk count in `OpenSearchDocumentIndex.update()`.

`ChunkCountNotFoundError` already handles the unknown-count race between indexing and updating steps (doc row exists but `chunk_count` not yet set). The equivalent known-zero case (`chunk_count == 0`) was previously a hard `raise ValueError`, which Sentry flagged at ~99 errors/hr on `vespa_metadata_sync_task` and ~12/hr on `process_single_user_file_project_sync` — Sentry: `ONYX-BACKEND-H6GA`, `ONYX-BACKEND-H6GG`.

Changes:
- Add `ChunkCountZeroError(ValueError)` in `opensearch_document_index.py`.
- Raise it (instead of bare `ValueError`) when a doc's chunk count is 0.
- Catch it alongside `ChunkCountNotFoundError` in `update_single`, log at warning, return cleanly.

A `chunk_count=0` row means a concurrent delete and metadata sync raced — the DB row still exists with 0 chunks while cleanup is in flight. Skipping the update is the correct behaviour. Retaining `ChunkCountZeroError as ValueError` preserves backward compatibility with any broad `except ValueError` handlers.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check