### PR TITLE
fix(sharepoint): demote 404 in sleep_and_retry to warning

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -285,10 +285,13 @@ def sleep_and_retry(
                 continue
 
             # Non-retryable error or retries exhausted — log details and raise.
+            # 404 means the requested resource is gone (e.g. an Azure AD group
+            # deleted while still referenced by SharePoint). Callers commonly
+            # handle this case; log at warning to avoid Sentry noise while
+            # still keeping the event visible.
             if e.response is not None:
-                logger.error(
-                    f"SharePoint request failed for {method_name}: status={status}, "
-                )
+                log = logger.warning if status == 404 else logger.error
+                log(f"SharePoint request failed for {method_name}: status={status}, ")
             raise e
 
 
@@ -535,7 +538,6 @@ def _convert_driveitem_to_document_with_permissions(
     treat_sharing_link_as_public: bool = False,
     raw_file_callback: RawFileCallback | None = None,
 ) -> Document | ConnectorFailure | None:
-
     if not driveitem.name or not driveitem.id:
         raise ValueError("DriveItem name/id is required")
 
@@ -2206,7 +2208,6 @@ class SharepointConnector(
         checkpoint: SharepointConnectorCheckpoint,
         include_permissions: bool = False,
     ) -> CheckpointOutput[SharepointConnectorCheckpoint]:
-
         if self._graph_client is None:
             raise ConnectorMissingCredentialError("Sharepoint")
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_sleep_and_retry_log_level.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_sleep_and_retry_log_level.py
@@ -1,0 +1,53 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from office365.runtime.client_request import (  # type: ignore[import-untyped]
+    ClientRequestException,
+)
+
+from onyx.connectors.sharepoint.connector import sleep_and_retry
+
+
+def _make_query_raising(status_code: int) -> MagicMock:
+    query = MagicMock()
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {"Content-Type": "text/plain"}
+    response.content = b""
+    err = ClientRequestException(response=response)
+    query.execute_query.side_effect = err
+    return query
+
+
+def test_sleep_and_retry_logs_404_at_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """404 on a non-retryable call should log at WARNING level (not ERROR) so
+    Sentry doesn't flag deleted-resource cases that callers routinely handle."""
+    query = _make_query_raising(404)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ClientRequestException):
+            sleep_and_retry(query, "get_azuread_groups", max_retries=0)
+
+    records = [
+        r for r in caplog.records if "SharePoint request failed" in r.getMessage()
+    ]
+    assert records, "expected a 'SharePoint request failed' log record"
+    assert all(r.levelno == logging.WARNING for r in records)
+
+
+def test_sleep_and_retry_logs_non_404_at_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-404 non-retryable failures should still log at ERROR level."""
+    query = _make_query_raising(500)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ClientRequestException):
+            sleep_and_retry(query, "get_azuread_groups", max_retries=0)
+
+    records = [
+        r for r in caplog.records if "SharePoint request failed" in r.getMessage()
+    ]
+    assert records
+    assert all(r.levelno == logging.ERROR for r in records)


### PR DESCRIPTION
## Description

A non-retryable 404 from SharePoint typically means a referenced resource (e.g. an Azure AD group still referenced by SharePoint but deleted from AAD) is gone. Callers in external group sync already handle this case (see `_get_groups_and_members_recursively` — catches `ClientRequestException`, checks `status_code == 404`, logs warning + continues), but the inner `sleep_and_retry` logged at ERROR level first, flagging Sentry ~13 events/hr on `get_azuread_groups` — Sentry: `ONYX-BACKEND-H6GB`.

Log 404 at WARNING; keep ERROR for every other non-retryable status so real failures remain visible. The exception itself continues to propagate unchanged, so caller handling is preserved.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check