### PR TITLE
fix(google-drive): tolerate 403 on primary admin lookup in group sync

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -194,7 +194,7 @@ def _get_drive_members(
         # (primary admin is not an admin, or delegation isn't granted).
         # Raise PermissionError so the caller marks the sync attempt as a
         # clean failure instead of treating this as an unhandled crash.
-        if e.resp.status == 403:
+        if e.status_code == 403:
             raise PermissionError(
                 f"Primary admin {google_drive_connector.primary_admin_email} "
                 "is not authorized on the Google Workspace directory API. "

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -182,11 +182,26 @@ def _get_drive_members(
         google_drive_connector.primary_admin_email,
     )
 
-    admin_user_info = (
-        admin_service.users()  # ty: ignore[unresolved-attribute]
-        .get(userKey=google_drive_connector.primary_admin_email)
-        .execute()
-    )
+    try:
+        admin_user_info = (
+            admin_service.users()  # ty: ignore[unresolved-attribute]
+            .get(userKey=google_drive_connector.primary_admin_email)
+            .execute()
+        )
+    except HttpError as e:
+        # A 403 here means the configured primary admin lacks authority on
+        # the Google Workspace directory — the connector is misconfigured
+        # (primary admin is not an admin, or delegation isn't granted).
+        # Raise PermissionError so the caller marks the sync attempt as a
+        # clean failure instead of treating this as an unhandled crash.
+        if e.resp.status == 403:
+            raise PermissionError(
+                f"Primary admin {google_drive_connector.primary_admin_email} "
+                "is not authorized on the Google Workspace directory API. "
+                "Reconnect the connector with an account that has admin "
+                "directory access."
+            ) from e
+        raise
     is_admin = admin_user_info.get("isAdmin", False) or admin_user_info.get(
         "isDelegatedAdmin", False
     )
@@ -213,11 +228,12 @@ def _get_drive_members(
                 elif permission["type"] == PermissionType.USER:
                     user_emails.add(permission["emailAddress"])
         except HttpError as e:
-            if e.status_code == 404:
+            if e.status_code in (403, 404):
                 logger.warning(
                     f"Error getting permissions for drive id {drive_id}. "
                     f"User '{google_drive_connector.primary_admin_email}' likely "
-                    f"does not have access to this drive. Exception: {e}"
+                    f"does not have access to this drive (status={e.status_code}). "
+                    f"Exception: {e}"
                 )
             else:
                 raise e

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_drive_members_admin_403.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_drive_members_admin_403.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from ee.onyx.external_permissions.google_drive.group_sync import _get_drive_members
+
+
+def _make_http_error(status: int) -> HttpError:
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = "Forbidden" if status == 403 else "Not Found"
+    return HttpError(resp=resp, content=b"{}")
+
+
+def _make_connector() -> MagicMock:
+    connector = MagicMock()
+    connector.creds = MagicMock()
+    connector.primary_admin_email = "admin@example.com"
+    connector.get_all_drive_ids.return_value = ["drive-1"]
+    return connector
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_drive_members_admin_403_raises_permission_error(
+    mock_get_drive_service: MagicMock,
+) -> None:
+    """A 403 on the primary-admin lookup must become a PermissionError so
+    the caller in external_group_syncing can mark the attempt as a clean
+    credential failure instead of an unhandled Celery exception."""
+    mock_get_drive_service.return_value = MagicMock()
+    connector = _make_connector()
+    admin_service = MagicMock()
+    admin_service.users.return_value.get.return_value.execute.side_effect = (
+        _make_http_error(403)
+    )
+
+    with pytest.raises(PermissionError) as exc_info:
+        _get_drive_members(connector, admin_service)
+
+    assert "primary admin" in str(exc_info.value).lower()
+    assert connector.primary_admin_email in str(exc_info.value)
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_drive_members_admin_non_403_reraised(
+    mock_get_drive_service: MagicMock,
+) -> None:
+    """A non-403 HttpError on the admin lookup (e.g. 500) should still
+    propagate as the original exception — only 403 gets the clean
+    credential-invalid conversion."""
+    mock_get_drive_service.return_value = MagicMock()
+    connector = _make_connector()
+    admin_service = MagicMock()
+    admin_service.users.return_value.get.return_value.execute.side_effect = (
+        _make_http_error(500)
+    )
+
+    with pytest.raises(HttpError):
+        _get_drive_members(connector, admin_service)


### PR DESCRIPTION
## Description

`_get_drive_members` calls `admin_service.users().get(userKey=primary_admin_email).execute()` to determine whether the configured primary admin has directory-level admin rights. When that account is not actually authorized on the Google Workspace directory API, the SDK returns HTTP 403 and the exception bubbled as an unhandled Celery error — Sentry: `ONYX-BACKEND-H6GC` (~6 events/hr for `connector_external_group_sync_generator_task`).

- Wrap the primary-admin lookup in `try/except HttpError`; on `status == 403`, raise a `PermissionError` with a message pointing to reconnecting the connector. The existing `PermissionError` handler in `_timed_perform_external_group_sync` marks the attempt as a clean failure and logs at warning.
- Broaden the per-drive `permissions().list` `HttpError` handler from `status_code == 404` to `status_code in (403, 404)` — both cases mean the primary admin can't see that drive's permissions; skip and continue rather than crash the whole sync.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check