### PR TITLE
fix(db): default POSTGRES_POOL_PRE_PING to true

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -440,8 +440,13 @@ POSTGRES_API_SERVER_READ_ONLY_POOL_OVERFLOW = int(
 # generally should only be used for
 POSTGRES_USE_NULL_POOL = os.environ.get("POSTGRES_USE_NULL_POOL", "").lower() == "true"
 
-# defaults to False
-POSTGRES_POOL_PRE_PING = os.environ.get("POSTGRES_POOL_PRE_PING", "").lower() == "true"
+# defaults to True — pre-pings pooled connections with SELECT 1 at checkout
+# to avoid `psycopg2.OperationalError: server closed the connection
+# unexpectedly` when PgBouncer / Postgres drops an idle connection that's
+# still in the pool. Set POSTGRES_POOL_PRE_PING=false to opt out.
+POSTGRES_POOL_PRE_PING = (
+    os.environ.get("POSTGRES_POOL_PRE_PING", "true").lower() == "true"
+)
 
 # recycle timeout in seconds
 POSTGRES_POOL_RECYCLE_DEFAULT = 60 * 20  # 20 minutes

--- a/backend/tests/unit/onyx/configs/test_postgres_pool_pre_ping.py
+++ b/backend/tests/unit/onyx/configs/test_postgres_pool_pre_ping.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+from types import ModuleType
+from unittest.mock import patch
+
+
+def _reload_app_configs() -> ModuleType:
+    """Reload the module so the env var is re-read at import time."""
+    import onyx.configs.app_configs as module
+
+    return importlib.reload(module)
+
+
+def test_postgres_pool_pre_ping_defaults_to_true() -> None:
+    """Default should be True — pre-pings pooled connections at checkout to
+    survive PgBouncer / Postgres dropping idle connections. Preventing
+    `psycopg2.OperationalError: server closed the connection unexpectedly`."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("POSTGRES_POOL_PRE_PING", None)
+        module = _reload_app_configs()
+        assert module.POSTGRES_POOL_PRE_PING is True
+
+
+def test_postgres_pool_pre_ping_can_be_disabled() -> None:
+    """Explicit `POSTGRES_POOL_PRE_PING=false` still opts out."""
+    with patch.dict(os.environ, {"POSTGRES_POOL_PRE_PING": "false"}):
+        module = _reload_app_configs()
+        assert module.POSTGRES_POOL_PRE_PING is False
+
+
+def test_postgres_pool_pre_ping_case_insensitive_true() -> None:
+    """Explicit `POSTGRES_POOL_PRE_PING=TRUE` is recognised."""
+    with patch.dict(os.environ, {"POSTGRES_POOL_PRE_PING": "TRUE"}):
+        module = _reload_app_configs()
+        assert module.POSTGRES_POOL_PRE_PING is True


### PR DESCRIPTION
## Description

`pool_pre_ping` issues a lightweight `SELECT 1` against each pooled connection at checkout, transparently discarding and replacing any that PgBouncer or Postgres has dropped while idle — the standard defense against `psycopg2.OperationalError: server closed the connection unexpectedly`.

The setting was already wired through `ENGINE.init_engine(...)` via the `POSTGRES_POOL_PRE_PING` config, but the default was `False`, so prod pools kept handing out stale connections. Celery workers (most visibly `vespa_metadata_sync_task`) paid the cost — Sentry: `ONYX-BACKEND-H6JQ`.

Flip the default to `True`. Deployments that want to opt out can still set `POSTGRES_POOL_PRE_PING=false` explicitly.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check