### PR TITLE
fix(permissions): downgrade Org-member "no email" log to warning

### DIFF
--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -481,7 +481,7 @@ def get_external_user_group(
             if member.email:
                 user_emails.add(member.email)
             else:
-                logger.error(f"Org member {member.login} has no email")
+                logger.warning(f"Org member {member.login} has no email")
 
         org_group = ExternalUserGroup(
             id=org_group_id,


### PR DESCRIPTION
## Description

Follow-up to #10561. Missed a fourth GitHub callsite — `ee/onyx/external_permissions/github/utils.py:484` logs `Org member {login} has no email` at `error` level. Same rationale as the other three callsites in #10561 (Collaborator / Outside collaborator / Team member):

- Per-user condition (GitHub login without a surfaced public email)
- Code already handles it by skipping that entry
- `{login}` in the message makes Sentry fingerprint each distinct user as a new issue

Currently ~9 events / 2h (~100/day) in `onyx-vl` Sentry.

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Log-level-only change.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded the GitHub permissions log "Org member {login} has no email" from error to warning. This prevents per-user missing-email cases from spamming Sentry and aligns with the other collaborator/team callsites; the code already skips those users.

<sup>Written for commit a84ceb91ef94346294140327d7709214126ff414. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

