### PR TITLE
fix(sharepoint): downgrade sleep_and_retry final-failure log to warning

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -284,9 +284,14 @@ def sleep_and_retry(
                 time.sleep(sleep_time)
                 continue
 
-            # Non-retryable error or retries exhausted — log details and raise.
+            # Non-retryable error or retries exhausted. The exception is
+            # re-raised for the caller to handle — several callers already
+            # swallow expected statuses (e.g. 404 for deleted Azure AD
+            # groups in permission_utils.py:503). Log at warning so the
+            # helper isn't the source of Sentry events for conditions the
+            # caller intentionally handles.
             if e.response is not None:
-                logger.error(
+                logger.warning(
                     f"SharePoint request failed for {method_name}: status={status}, "
                 )
             raise e


### PR DESCRIPTION
## Description

`sleep_and_retry` in `onyx/connectors/sharepoint/connector.py:289` logs at `error` before re-raising on non-retryable (or retries-exhausted) failures. Callers already swallow expected statuses — e.g. `permission_utils.py:503` handles 404 for deleted Azure AD groups with a `logger.warning` + `continue`. Logging at `error` inside the helper ships Sentry events for conditions the caller has already deemed non-actionable.

Dominant pattern in Sentry right now: `[t:fba40daa] SharePoint request failed for get_azuread_groups: status=404,` — ~14 events / 2h, all swallowed downstream.

**Fix:** downgrade to `warning` in the helper. The `raise` is unchanged, so callers that want to treat it as an error still can (and none do today).

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Log-level-only change. The `raise` is unchanged.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrade final-failure logging in SharePoint connector `sleep_and_retry` from error to warning while still re-raising the exception. This stops Sentry noise for expected statuses (e.g., 404 from `get_azuread_groups`) so it aligns with caller handling and addresses the reported 404 event spam.

<sup>Written for commit dc127bbe9be779924355c6b77c27430bd56beb04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

