### PR TITLE
fix(indexing): demote vector-db batch-fallback log to warning

### DIFF
--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -53,8 +53,14 @@ def write_chunks_to_vector_db_with_backoff(
             [],
         )
     except Exception as e:
-        logger.exception(
-            "Failed to write chunk batch to vector db. Trying individual docs."
+        # The batch write failing just means we fall back to the per-doc
+        # retry loop below. It's only a real failure if the per-doc retry
+        # also fails — that path already logs/captures to Sentry per doc.
+        # Use warning here so a transient OpenSearch ReadTimeout on the
+        # batch call doesn't ship an event for every indexing batch.
+        logger.warning(
+            f"Failed to write chunk batch to vector db. Trying individual docs. "
+            f"Batch error: {type(e).__name__}: {e}"
         )
 
         # give some specific logging on this common failure case.

--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -56,8 +56,13 @@ def write_chunks_to_vector_db_with_backoff(
         # The batch write failing just means we fall back to the per-doc
         # retry loop below. It's only a real failure if the per-doc retry
         # also fails — that path already logs/captures to Sentry per doc.
-        # Use warning here so a transient OpenSearch ReadTimeout on the
-        # batch call doesn't ship an event for every indexing batch.
+        # Use warning here so a transient OpenSearch response timeout on
+        # the bulk write doesn't ship an event for every indexing batch.
+        # (urllib3 surfaces this as ReadTimeoutError because it has no
+        # separate write-timeout class; the client has already sent the
+        # bulk request and is waiting on OpenSearch's response, which is
+        # where the 60s read timeout fires when the server is slow to
+        # finish the bulk index.)
         logger.warning(
             f"Failed to write chunk batch to vector db. Trying individual docs. "
             f"Batch error: {type(e).__name__}: {e}"


### PR DESCRIPTION
## Description

`write_chunks_to_vector_db_with_backoff` (`onyx/indexing/vector_db_insertion.py:56`) logs the batch-write failure at `logger.exception` — a full Sentry event with traceback per batch. But the function immediately falls back to a per-doc retry loop; only the per-doc retries represent actual failures, and those already call `sentry_sdk.capture_exception` with proper fingerprinting (`["vector-db-write-failure", type(e).__name__]`) at line 95.

Transient OpenSearch read-timeouts on the batch call (`ConnectionTimeout caused by - ReadTimeoutError(... vpc-onyx-managed-services-...`, ~15 events/2h) therefore ship a traceback to Sentry even when the per-doc retry succeeds — the outcome the user experiences is "indexing completed normally."

**Fix:** downgrade to `logger.warning` with the exception type + message (keeps the diagnostic info in logs without shipping a Sentry event and without losing the "trying individual docs" breadcrumb). The per-doc retry path is unchanged and remains the real signal for "this doc could not be indexed."

## How Has This Been Tested?

Pre-commit, `ty`, `ruff`, `black` pass. Log-level-only change on the batch-fallback path. Per-doc failure path at line 97 is untouched.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded the batch write failure log in `write_chunks_to_vector_db_with_backoff` to a warning and included the exception type and message. Clarified the inline comment to note this is a response timeout on the OpenSearch bulk write, reducing noisy Sentry events while real per-doc failures remain captured via `sentry_sdk`.

<sup>Written for commit bb45a425c1e52e9c3ae87fef149a154e9df4e99e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

