### PR TITLE
fix(opensearch): treat chunk_count=0 as a no-op instead of raising [ENG-4076]

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -909,10 +909,11 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         "likely just added to the indexing pipeline and the chunk count will be "
                         "updated shortly."
                     )
-                if doc_chunk_count == 0:
-                    raise ValueError(
-                        f"Bug: Tried to update document {doc_id} but its chunk count was 0."
-                    )
+                # A chunk_count of 0 is a legitimate terminal state for a doc
+                # that had no extractable chunks (empty file, stop-word-only
+                # HTML, filtered content, etc.) — `update_docs_chunk_count`
+                # writes 0 in that case. There are no chunks in OpenSearch to
+                # update, so range(0) below is a clean no-op. See ENG-4076.
 
                 for chunk_index in range(doc_chunk_count):
                     document_chunk_id = get_opensearch_doc_chunk_id(


### PR DESCRIPTION
## Description

When `vespa_metadata_sync_task` dispatches a metadata update for a doc whose `Document.chunk_count` in Postgres is `0`, `OpenSearchDocumentIndex.update` raises:

```python
raise ValueError(
    f"Bug: Tried to update document {doc_id} but its chunk count was 0."
)
```

(`backend/onyx/document_index/opensearch/opensearch_document_index.py:912`)

`chunk_count=0` is actually a legitimate terminal state — `update_docs_chunk_count__no_commit` (`backend/onyx/db/document.py:822`) writes the final chunk count after indexing, including `0` for docs with no extractable chunks (empty files, stop-word-only HTML, filtered-out content, etc.).

The loop directly below the raise — `for chunk_index in range(doc_chunk_count):` — already handles `count=0` cleanly: `range(0)` is an empty iteration, so the function naturally no-ops (no chunks exist in the index to update). Dropping the raise lets the existing no-op behavior kick in.

Keeps the `ChunkCountNotFoundError` branch for `count<0` unchanged — that path *is* a real race, per the `TODO(andrei)` comment.

## Why this matters

This is currently Sentry's **top event source** on the cloud backend — ~800 events / 2h, ~10K/day, across ~25+ distinct `doc_id`-keyed fingerprints, and ~50–60% of all backend Sentry events. Each occurrence also triggers a Celery retry cycle via exponential backoff, multiplying the event count for stuck docs.

## Scope note

Happy to expand the scope based on review feedback — possible followups (listed in ENG-4076):

- Skip dispatching `vespa_metadata_sync_task` entirely when `doc.chunk_count == 0` at the caller (`backend/onyx/background/celery/tasks/vespa/tasks.py:500-512`).
- Reconcile with the `ChunkCountNotFoundError` handler at line 475–481, which still calls `logger.exception(...)` for the `count < 0` race (separate, smaller Sentry noise source).

Keeping this PR minimal so @andrei-onyx can sanity-check the semantics before we expand.

Refs: ENG-4076

## How Has This Been Tested?

Pre-commit, \`ty\`, \`ruff\`, \`black\` pass. Behavior change is narrow: the \`count==0\` path that previously raised now falls through to the existing empty-loop no-op and returns normally. Callers that actually need chunk data (\`count > 0\`) are untouched.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `chunk_count=0` as a no-op in `OpenSearchDocumentIndex.update` instead of raising, so metadata syncs for docs with no extractable chunks complete quietly. Addresses ENG-4076 by stopping the “chunk count was 0” ValueError from spamming Sentry and triggering Celery retries; negative counts still follow the existing `ChunkCountNotFoundError` path.

<sup>Written for commit 2e999aa5b846725df40ea4360b1f2d27e9116f4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

