### PR TITLE
fix(files): allow connector file previews through /chat/file (#10498) to release v3.0

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -1,15 +1,27 @@
 from collections.abc import Callable
 from typing import cast
 
+from sqlalchemy import cast as sa_cast
+from sqlalchemy import or_
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from onyx.access.models import DocumentAccess
 from onyx.access.utils import prefix_user_email
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import PUBLIC_DOC_PAT
 from onyx.db.document import get_access_info_for_document
 from onyx.db.document import get_access_info_for_documents
+from onyx.db.models import ChatMessage
+from onyx.db.models import ChatSession
+from onyx.db.models import ChatSessionSharedStatus
+from onyx.db.models import Connector
+from onyx.db.models import DocumentByConnectorCredentialPair
+from onyx.db.models import FileRecord
+from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -148,3 +160,150 @@ def get_access_for_user_files(
         )
         for user_file in user_files
     }
+
+
+def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> bool:
+    """Return True if `user` can read `file_id` via `GET /chat/file/{file_id}`.
+
+    The endpoint is overloaded across several asset classes, so we check
+    each in turn (cheapest first, so common paths short-circuit before the
+    JSONB scan in `_documents_from_file_connector_config`):
+
+    - `UserFile` owned by the user.
+    - `Persona.uploaded_image_id` (avatars are public to authenticated users).
+    - `ChatMessage.files` of a session the user owns or that is shared as
+      `ChatSessionSharedStatus.PUBLIC`.
+    - `FileRecord` with origin `CHAT_IMAGE_GEN` (see inline TODO).
+    - `Document` whose ACL grants access (covers connector-ingested files).
+
+    TODO(auth-perf): split `/chat/file` into per-asset-class endpoints so the
+    URL carries the access context and one indexed lookup suffices, instead
+    of fanning out 4–5 queries across unrelated classes on every request.
+    """
+    owns_user_file = db_session.query(
+        select(UserFile.id)
+        .where(UserFile.file_id == file_id, UserFile.user_id == user.id)
+        .exists()
+    ).scalar()
+    if owns_user_file:
+        return True
+
+    # TODO: move persona avatars to a dedicated endpoint so this branch
+    # can go away. Restrict to CHAT_UPLOAD-origin for now so an attacker
+    # cannot bind another user's USER_FILE to their persona and read it
+    # through this check.
+    is_persona_avatar = db_session.query(
+        select(Persona.id)
+        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
+        .where(
+            Persona.uploaded_image_id == file_id,
+            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
+        )
+        .exists()
+    ).scalar()
+    if is_persona_avatar:
+        return True
+
+    chat_file_stmt = (
+        select(ChatMessage.id)
+        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
+        .where(ChatMessage.files.op("@>")([{"id": file_id}]))
+        .where(
+            or_(
+                ChatSession.user_id == user.id,
+                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
+            )
+        )
+        .limit(1)
+    )
+    if db_session.execute(chat_file_stmt).first() is not None:
+        return True
+
+    # TODO: CHAT_IMAGE_GEN files are public because the bytes land in the
+    # store before the linking tool-call row is written; tightening this
+    # requires reordering the streaming/tool-call writes. Kept above the
+    # connector branch so previews hit a PK lookup, not the JSONB scan.
+    is_chat_image_gen = db_session.query(
+        select(FileRecord.file_id)
+        .where(
+            FileRecord.file_id == file_id,
+            FileRecord.file_origin == FileOrigin.CHAT_IMAGE_GEN,
+        )
+        .exists()
+    ).scalar()
+    if is_chat_image_gen:
+        return True
+
+    return _user_can_access_connector_file(file_id, user, db_session)
+
+
+def _user_can_access_connector_file(
+    file_id: str, user: User, db_session: Session
+) -> bool:
+    """Mirror retrieval-time ACL: grant access if any `Document` referencing
+    `file_id` has an ACL the user satisfies.
+
+    v3.0 covers only File-connector uploads via
+    `Connector.connector_specific_config['file_locations']`. Other connector
+    files (Google Drive / SharePoint / Confluence images) have no
+    Postgres-level linkage from `file_id` to a document on this branch
+    (`Document.file_id` does not exist until #10299), so previews of those
+    still fail closed. Documents under one cc_pair share its ACL, so any
+    one representative document answers the question.
+    """
+    document_ids = _documents_from_file_connector_config(file_id, db_session)
+    if not document_ids:
+        return False
+
+    user_acl = get_acl_for_user(user, db_session)
+    doc_access = get_access_for_documents(document_ids, db_session)
+    return any(
+        not user_acl.isdisjoint(access.to_acl()) for access in doc_access.values()
+    )
+
+
+def _documents_from_file_connector_config(
+    file_id: str, db_session: Session
+) -> list[str]:
+    """Return one representative document per cc_pair (connector +
+    credential) whose `Connector.connector_specific_config['file_locations']`
+    lists `file_id`. Sampling per cc_pair (not per connector) is required
+    because ACLs are scoped to the cc_pair: the same connector paired with
+    different credentials can have different ACLs, and a user with access
+    via one credential must not be denied because we sampled a doc from
+    another.
+
+    The `@>` lookup can't use a btree index, so every call is a JSONB scan.
+    """
+    cc_pair_keys = db_session.execute(
+        select(
+            DocumentByConnectorCredentialPair.connector_id,
+            DocumentByConnectorCredentialPair.credential_id,
+        )
+        .join(
+            Connector,
+            Connector.id == DocumentByConnectorCredentialPair.connector_id,
+        )
+        .where(
+            Connector.connector_specific_config["file_locations"].op("@>")(
+                sa_cast([file_id], postgresql.JSONB)
+            )
+        )
+        .distinct()
+    ).all()
+    if not cc_pair_keys:
+        return []
+
+    document_ids: list[str] = []
+    for connector_id, credential_id in cc_pair_keys:
+        doc_id = db_session.execute(
+            select(DocumentByConnectorCredentialPair.id)
+            .where(
+                DocumentByConnectorCredentialPair.connector_id == connector_id,
+                DocumentByConnectorCredentialPair.credential_id == credential_id,
+            )
+            .limit(1)
+        ).scalar()
+        if doc_id is not None:
+            document_ids.append(doc_id)
+    return document_ids

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -2,17 +2,10 @@ import datetime
 from uuid import UUID
 
 from sqlalchemy import func
-from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import FileOrigin
-from onyx.db.models import ChatMessage
-from onyx.db.models import ChatSession
-from onyx.db.models import ChatSessionSharedStatus
-from onyx.db.models import FileRecord
-from onyx.db.models import Persona
 from onyx.db.models import Project__UserFile
 from onyx.db.models import UserFile
 
@@ -124,79 +117,6 @@ def get_file_id_by_user_file_id(
     if user_file:
         return user_file.file_id
     return None
-
-
-def user_can_access_chat_file(file_id: str, user_id: UUID, db_session: Session) -> bool:
-    """Return True if `user_id` is allowed to read the raw `file_id` served by
-    `GET /chat/file/{file_id}`. Access is granted when any of:
-
-    - The `file_id` is the storage id of a `UserFile` owned by the user.
-    - The `file_id` is a persona avatar (`Persona.uploaded_image_id`); avatars
-      are visible to any authenticated user.
-    - The `file_id` appears in a `ChatMessage.files` descriptor of a chat
-      session the user owns or a session publicly shared via
-      `ChatSessionSharedStatus.PUBLIC`.
-    - TODO: An CHAT_IMAGE_GEN file is uploaded to the file store before a
-      tool call database entry is added. This the file is there and the FE can
-      request it despite us not having the linking tool call. We currently
-      hackily get around this by making these files public, but this will need
-      to change with a larger refactor.
-    """
-    owns_user_file = db_session.query(
-        select(UserFile.id)
-        .where(UserFile.file_id == file_id, UserFile.user_id == user_id)
-        .exists()
-    ).scalar()
-    if owns_user_file:
-        return True
-
-    # TODO: move persona avatars to a dedicated endpoint (e.g.
-    # /assistants/{id}/avatar) so this branch can be removed. /chat/file is
-    # currently overloaded with multiple asset classes (user files, chat
-    # attachments, tool outputs, avatars), forcing this access-check fan-out.
-    #
-    # Restrict the avatar path to CHAT_UPLOAD-origin files so an attacker
-    # cannot bind another user's USER_FILE (or any other origin) to their
-    # own persona and read it through this check.
-    is_persona_avatar = db_session.query(
-        select(Persona.id)
-        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
-        .where(
-            Persona.uploaded_image_id == file_id,
-            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
-        )
-        .exists()
-    ).scalar()
-    if is_persona_avatar:
-        return True
-
-    chat_file_stmt = (
-        select(ChatMessage.id)
-        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
-        .where(ChatMessage.files.op("@>")([{"id": file_id}]))
-        .where(
-            or_(
-                ChatSession.user_id == user_id,
-                ChatSession.shared_status == ChatSessionSharedStatus.PUBLIC,
-            )
-        )
-        .limit(1)
-    )
-    if db_session.execute(chat_file_stmt).first() is not None:
-        return True
-
-    # TODO: Chat image generated images are currently public
-    # We will want to make this private but it requires a larger
-    # refactor.
-    is_chat_image_gen = db_session.query(
-        select(FileRecord.file_id)
-        .where(
-            FileRecord.file_id == file_id,
-            FileRecord.file_origin == FileOrigin.CHAT_IMAGE_GEN,
-        )
-        .exists()
-    ).scalar()
-    return bool(is_chat_image_gen)
 
 
 def get_file_ids_by_user_file_ids(

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -14,6 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.access.access import user_can_access_chat_file
 from onyx.auth.api_key import get_hashed_api_key_from_request
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.users import current_chat_accessible_user
@@ -60,7 +61,6 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.usage import increment_usage
 from onyx.db.usage import UsageType
 from onyx.db.user_file import get_file_id_by_user_file_id
-from onyx.db.user_file import user_can_access_chat_file
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
@@ -807,7 +807,7 @@ def fetch_chat_file(
     file_id_from_user_file = get_file_id_by_user_file_id(file_id, user.id, db_session)
     if file_id_from_user_file:
         file_id = file_id_from_user_file
-    elif not user_can_access_chat_file(file_id, user.id, db_session):
+    elif not user_can_access_chat_file(file_id, user, db_session):
         # Return 404 (rather than 403) so callers cannot probe for file
         # existence across ownership boundaries.
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "File not found")

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -5,6 +5,11 @@ This file tests user file permissions in different scenarios:
 3. Image-generation tool outputs - files persisted on `ToolCall.generated_images`
    must be downloadable by the chat session owner (and by anyone if the session
    is publicly shared), but not by other users on private sessions.
+4. Connector-ingested files (File-connector only on v3.0) - files whose
+   `file_id` appears in a File-connector's
+   `connector_specific_config['file_locations']` must be fetchable via
+   `GET /chat/file/{file_id}` by any user whose ACL covers at least one
+   `Document` under that cc_pair, and must be denied otherwise.
 """
 
 import io
@@ -16,18 +21,25 @@ import pytest
 import requests
 
 from onyx.configs.constants import FileOrigin
+from onyx.connectors.models import InputType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
 from onyx.db.enums import ChatSessionSharedStatus
 from onyx.db.models import ChatSession
 from onyx.db.models import ToolCall
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import FileDescriptor
+from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.api_key import APIKeyManager
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
+from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestChatSession
 from tests.integration.common_utils.test_models import DATestPersona
 from tests.integration.common_utils.test_models import DATestUser
@@ -302,3 +314,128 @@ def test_non_owner_can_download_image_gen_file_in_public_session(
         f"got {response.status_code}: {response.text}"
     )
     assert response.content == _IMAGE_GEN_PNG_BYTES
+
+
+_CONNECTOR_FILE_BYTES = b"connector-ingested document contents"
+
+
+# File-connector uploads (txt/pdf/docx/...) leave no direct linkage from
+# `file_id` to a Document on this release branch (`Document.file_id` ships
+# in #10299, not backported here), so access falls back to matching
+# against `Connector.connector_specific_config['file_locations']`. These
+# tests pin that fallback. `FileOrigin.CONNECTOR` is the stamp in prod;
+# `FileOrigin.OTHER` is the legacy stamp used by pre-#10484 uploads and is
+# kept here to guard against a regression that re-introduces an origin
+# filter on the access check.
+_FILE_CONNECTOR_ORIGINS = [
+    FileOrigin.CONNECTOR,
+    FileOrigin.OTHER,
+]
+
+
+def _seed_file_connector_cc_pair(
+    *,
+    admin_user: DATestUser,
+    file_id: str,
+    access_type: AccessType,
+    groups: list[int] | None = None,
+) -> DATestCCPair:
+    """Build a File-source cc_pair pointing at `file_id`."""
+    return CCPairManager.create_from_scratch(
+        user_performing_action=admin_user,
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "file_locations": [file_id],
+            "file_names": ["connector_upload.txt"],
+            "zip_metadata_file_id": None,
+        },
+        access_type=access_type,
+        groups=groups,
+    )
+
+
+def _save_file_connector_bytes(file_id: str, file_origin: FileOrigin) -> None:
+    """Save bytes under the exact `file_id` listed in the cc_pair's
+    `file_locations`."""
+    file_store = get_default_file_store()
+    file_store.save_file(
+        content=io.BytesIO(_CONNECTOR_FILE_BYTES),
+        display_name="connector_upload.txt",
+        file_origin=file_origin,
+        file_type="text/plain",
+        file_id=file_id,
+    )
+
+
+@pytest.mark.parametrize("file_origin", _FILE_CONNECTOR_ORIGINS)
+def test_file_connector_file_is_accessible_via_chat_file_endpoint(
+    reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
+) -> None:
+    """PUBLIC File-connector upload: the JSONB fallback in
+    `_user_can_access_connector_file` lets any user fetch it."""
+    admin_user: DATestUser = UserManager.create(name="file_connector_admin")
+    basic_user: DATestUser = UserManager.create(name="file_connector_basic")
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+
+    file_id = str(uuid4())
+    public_cc_pair = _seed_file_connector_cc_pair(
+        admin_user=admin_user,
+        file_id=file_id,
+        access_type=AccessType.PUBLIC,
+    )
+    DocumentManager.seed_doc_with_content(
+        cc_pair=public_cc_pair,
+        content="file connector body text",
+        api_key=api_key,
+    )
+    _save_file_connector_bytes(file_id, file_origin)
+
+    for user in (admin_user, basic_user):
+        response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=user.headers,
+        )
+        assert response.status_code == 200, (
+            f"User {user.email} must access a PUBLIC File-connector file "
+            f"(origin={file_origin}), got {response.status_code}: "
+            f"{response.text}"
+        )
+        assert response.content == _CONNECTOR_FILE_BYTES
+
+
+@pytest.mark.parametrize("file_origin", _FILE_CONNECTOR_ORIGINS)
+def test_file_connector_file_denied_for_users_without_access(
+    reset: None,  # noqa: ARG001
+    file_origin: FileOrigin,
+) -> None:
+    """PRIVATE File-connector upload: ACL still gates access even though
+    the JSONB fallback locates the file."""
+    admin_user: DATestUser = UserManager.create(name="file_connector_priv_admin")
+    basic_user: DATestUser = UserManager.create(name="file_connector_priv_basic")
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+
+    file_id = str(uuid4())
+    private_cc_pair = _seed_file_connector_cc_pair(
+        admin_user=admin_user,
+        file_id=file_id,
+        access_type=AccessType.PRIVATE,
+    )
+    DocumentManager.seed_doc_with_content(
+        cc_pair=private_cc_pair,
+        content="file connector private content",
+        api_key=api_key,
+    )
+    _save_file_connector_bytes(file_id, file_origin)
+
+    basic_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{file_id}",
+        headers=basic_user.headers,
+    )
+    assert basic_response.status_code in (403, 404), (
+        f"Non-member should be denied on PRIVATE File-connector file "
+        f"(origin={file_origin}), got {basic_response.status_code}: "
+        f"{basic_response.text}"
+    )
+    assert basic_response.content != _CONNECTOR_FILE_BYTES


### PR DESCRIPTION
Cherry-pick of commit 338091c35c8d86e33232396070b8c62f885fd3a3 to release/v3.0 branch.

Original PR: #10498

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file preview failures for File-connector uploads via `/chat/file` by enforcing document ACLs. Users with access can now preview connector files; others are denied.

- **Bug Fixes**
  - Added `user_can_access_chat_file` in `onyx/access/access.py` to allow `/chat/file` when the user owns the file, the file is a persona avatar (`CHAT_UPLOAD`), a chat attachment (owned or `PUBLIC` session), `CHAT_IMAGE_GEN`, or a File-connector match gated by document ACLs.
  - Resolved File-connector files by scanning `Connector.connector_specific_config['file_locations']` and checking ACLs for a representative document per cc_pair.
  - Updated `fetch_chat_file` to use the new access check and removed the old helper from `onyx/db/user_file.py`.
  - Added integration tests for public/private File-connector uploads (both `CONNECTOR` and legacy `OTHER` origins) and ensured non-authorized users are denied.
  - Scope note: only File-connector assets are supported on v3.0; other connector sources remain unchanged.

<sup>Written for commit 78b4b9bf292423ff14d8818ece4c4f07767e0a8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

