### PR TITLE
fix(themes): custom backgrounds switch preferrred dark/light theme

### DIFF
--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -11,6 +11,7 @@ import { useTheme } from "next-themes";
 import {
   CHAT_BACKGROUND_OPTIONS,
   CHAT_BACKGROUND_NONE,
+  ChatBackgroundOption,
 } from "@/lib/constants/chatBackgrounds";
 
 interface SettingRowProps {
@@ -95,7 +96,8 @@ export const SettingsPanel = ({
 }) => {
   const { useOnyxAsNewTab } = useNRFPreferences();
   const { theme, setTheme } = useTheme();
-  const { user, updateUserChatBackground } = useUser();
+  const { user, updateUserChatBackground, updateUserThemePreference } =
+    useUser();
 
   const currentBackgroundId = user?.preferences?.chat_background ?? "none";
   const isDark = theme === "dark";
@@ -104,10 +106,12 @@ export const SettingsPanel = ({
     setTheme(isDark ? "light" : "dark");
   };
 
-  const handleBackgroundChange = (backgroundId: string) => {
-    updateUserChatBackground(
-      backgroundId === CHAT_BACKGROUND_NONE ? null : backgroundId
-    );
+  const handleBackgroundChange = (bg: ChatBackgroundOption) => {
+    updateUserChatBackground(bg.id === CHAT_BACKGROUND_NONE ? null : bg.id);
+    if (bg.theme) {
+      setTheme(bg.theme);
+      updateUserThemePreference(bg.theme);
+    }
   };
 
   return (
@@ -191,7 +195,7 @@ export const SettingsPanel = ({
                   label={bg.label}
                   isNone={bg.src === CHAT_BACKGROUND_NONE}
                   isSelected={currentBackgroundId === bg.id}
-                  onClick={() => handleBackgroundChange(bg.id)}
+                  onClick={() => handleBackgroundChange(bg)}
                 />
               ))}
             </div>

--- a/web/src/app/components/nrf/SettingsPanel.tsx
+++ b/web/src/app/components/nrf/SettingsPanel.tsx
@@ -106,11 +106,18 @@ export const SettingsPanel = ({
     setTheme(isDark ? "light" : "dark");
   };
 
-  const handleBackgroundChange = (bg: ChatBackgroundOption) => {
-    updateUserChatBackground(bg.id === CHAT_BACKGROUND_NONE ? null : bg.id);
-    if (bg.theme) {
-      setTheme(bg.theme);
-      updateUserThemePreference(bg.theme);
+  const handleBackgroundChange = async (bg: ChatBackgroundOption) => {
+    try {
+      await updateUserChatBackground(
+        bg.id === CHAT_BACKGROUND_NONE ? null : bg.id
+      );
+      if (bg.theme) {
+        setTheme(bg.theme);
+        await updateUserThemePreference(bg.theme);
+      }
+    } catch {
+      // errors are already logged and state is rolled back via refreshUser
+      // inside the update functions
     }
   };
 

--- a/web/src/lib/constants/chatBackgrounds.ts
+++ b/web/src/lib/constants/chatBackgrounds.ts
@@ -1,5 +1,7 @@
 // Default chat background images
 
+import { ThemePreference } from "@/lib/types";
+
 export const CHAT_BACKGROUND_NONE = "none";
 
 export interface ChatBackgroundOption {
@@ -7,6 +9,7 @@ export interface ChatBackgroundOption {
   src: string;
   thumbnail: string;
   label: string;
+  theme?: ThemePreference;
 }
 
 // Curated collection of scenic backgrounds that work well as chat backgrounds
@@ -22,30 +25,35 @@ export const CHAT_BACKGROUND_OPTIONS: ChatBackgroundOption[] = [
     src: "/chat-backgrounds/clouds.jpg",
     thumbnail: "/chat-backgrounds/thumbnails/clouds.jpg",
     label: "Clouds",
+    theme: ThemePreference.LIGHT,
   },
   {
     id: "hills",
     src: "/chat-backgrounds/hills.jpg",
     thumbnail: "/chat-backgrounds/thumbnails/hills.jpg",
     label: "Hills",
+    theme: ThemePreference.LIGHT,
   },
   {
     id: "plant",
     src: "/chat-backgrounds/plant.jpg",
     thumbnail: "/chat-backgrounds/thumbnails/plant.jpg",
     label: "Plants",
+    theme: ThemePreference.DARK,
   },
   {
     id: "mountains",
     src: "/chat-backgrounds/mountains.jpg",
     thumbnail: "/chat-backgrounds/thumbnails/mountains.jpg",
     label: "Mountains",
+    theme: ThemePreference.DARK,
   },
   {
     id: "night",
     src: "/chat-backgrounds/night.jpg",
     thumbnail: "/chat-backgrounds/thumbnails/night.jpg",
     label: "Night",
+    theme: ThemePreference.DARK,
   },
 ];
 

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -192,6 +192,17 @@ function GeneralSettings() {
     updateUserChatBackground,
   } = useUser();
   const { theme, setTheme, systemTheme } = useTheme();
+
+  const applyBackground = useCallback(
+    (bg: (typeof CHAT_BACKGROUND_OPTIONS)[number]) => {
+      updateUserChatBackground(bg.id === CHAT_BACKGROUND_NONE ? null : bg.id);
+      if (bg.theme) {
+        setTheme(bg.theme);
+        updateUserThemePreference(bg.theme);
+      }
+    },
+    [updateUserChatBackground, setTheme, updateUserThemePreference]
+  );
   const { refreshChatSessions } = useChatSessions();
   const router = useRouter();
   const pathname = usePathname();
@@ -395,11 +406,7 @@ function GeneralSettings() {
                   return (
                     <button
                       key={bg.id}
-                      onClick={() =>
-                        updateUserChatBackground(
-                          bg.id === CHAT_BACKGROUND_NONE ? null : bg.id
-                        )
-                      }
+                      onClick={() => applyBackground(bg)}
                       className="relative overflow-hidden rounded-lg transition-all w-[90px] h-[68px] cursor-pointer border-none p-0 bg-transparent group"
                       title={bg.label}
                       aria-label={`${bg.label} background${

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -194,11 +194,18 @@ function GeneralSettings() {
   const { theme, setTheme, systemTheme } = useTheme();
 
   const applyBackground = useCallback(
-    (bg: (typeof CHAT_BACKGROUND_OPTIONS)[number]) => {
-      updateUserChatBackground(bg.id === CHAT_BACKGROUND_NONE ? null : bg.id);
-      if (bg.theme) {
-        setTheme(bg.theme);
-        updateUserThemePreference(bg.theme);
+    async (bg: (typeof CHAT_BACKGROUND_OPTIONS)[number]) => {
+      try {
+        await updateUserChatBackground(
+          bg.id === CHAT_BACKGROUND_NONE ? null : bg.id
+        );
+        if (bg.theme) {
+          setTheme(bg.theme);
+          await updateUserThemePreference(bg.theme);
+        }
+      } catch {
+        // errors are already logged and state is rolled back via refreshUser
+        // inside the update functions
       }
     },
     [updateUserChatBackground, setTheme, updateUserThemePreference]


### PR DESCRIPTION
## Description

Automatically switch the dark/light theme to the custom backgrounds preferred theme. 

Helps with cases where users switch the background to one which is less compatible with their current theme.

## How Has This Been Tested?

Will check the preview

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selecting a chat background now auto-switches to that background’s preferred light or dark theme and saves the choice. This avoids clashing backgrounds and improves readability.

- **New Features**
  - Added a `theme` field to background options; set preferred themes for Clouds/Hills (light) and Plant/Mountains/Night (dark).
  - Updated the Settings panel and refreshed Settings page to apply the background and, when present, set and persist the theme via `setTheme` and `updateUserThemePreference`.

<sup>Written for commit 2c18d11732ec8cbfe81352a32425115cda6debe9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

