### PR TITLE
fix(opensearch): Warn on chunk count 0

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -88,6 +88,10 @@ class ChunkCountNotFoundError(ValueError):
     """Raised when a document has no chunk count."""
 
 
+class ChunkCountZeroError(ValueError):
+    """Raised when a document has a chunk count of 0."""
+
+
 def generate_opensearch_filtered_access_control_list(
     access: DocumentAccess,
 ) -> list[str]:
@@ -473,10 +477,15 @@ class OpenSearchOldDocumentIndex(OldDocumentIndex):
             )
             return
         except ChunkCountNotFoundError:
-            logger.exception(
+            logger.warning(
                 f"Tried to update document {doc_id} but its chunk count is not known. We tolerate this for now "
                 "but this will not be an acceptable state once OpenSearch is the primary document index and the "
                 "indexing/updating race condition is fixed."
+            )
+            return
+        except ChunkCountZeroError:
+            logger.warning(
+                f"Tried to update document {doc_id} but its chunk count was 0."
             )
             return
 
@@ -910,8 +919,8 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         "updated shortly."
                     )
                 if doc_chunk_count == 0:
-                    raise ValueError(
-                        f"Bug: Tried to update document {doc_id} but its chunk count was 0."
+                    raise ChunkCountZeroError(
+                        f"Tried to update document {doc_id} but its chunk count was 0."
                     )
 
                 for chunk_index in range(doc_chunk_count):


### PR DESCRIPTION
## Description
Sentry spam.

## How Has This Been Tested?
It wasn't.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded OpenSearch update errors for unknown or zero chunk counts to warnings to cut Sentry noise and tolerate transient indexing states. Added a dedicated `ChunkCountZeroError` and handled it with a warning and early return.

- **Bug Fixes**
  - Introduced `ChunkCountZeroError` and raised it when `doc_chunk_count == 0`; caught and logged with `logger.warning`.
  - Changed `ChunkCountNotFoundError` logging from `logger.exception` to `logger.warning`.
  - Skips updates for these cases instead of emitting error-level logs.

<sup>Written for commit 5c6210ca947210f2f2ee2f5bfd24c5a58ec8fc76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

