### PR TITLE
chore(devtools): upgrade `ods`: 0.7.5->0.7.6

### DIFF
--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -310,7 +310,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-onyx-devtools==0.7.5
+onyx-devtools==0.7.6
 openai==2.14.0
     # via
     #   litellm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ dev = [
     "manygo==0.2.0",
     "matplotlib==3.10.8",
     "ty==0.0.31",
-    "onyx-devtools==0.7.5",
+    "onyx-devtools==0.7.6",
     "openapi-generator-cli==7.17.0",
     "pandas-stubs~=2.3.3",
     "pre-commit==3.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -4643,7 +4643,7 @@ dev = [
     { name = "ipykernel", specifier = "==6.29.5" },
     { name = "manygo", specifier = "==0.2.0" },
     { name = "matplotlib", specifier = "==3.10.8" },
-    { name = "onyx-devtools", specifier = "==0.7.5" },
+    { name = "onyx-devtools", specifier = "==0.7.6" },
     { name = "openapi-generator-cli", specifier = "==7.17.0" },
     { name = "pandas-stubs", specifier = "~=2.3.3" },
     { name = "pre-commit", specifier = "==3.2.2" },
@@ -4687,19 +4687,19 @@ model-server = [
 
 [[package]]
 name = "onyx-devtools"
-version = "0.7.5"
+version = "0.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "openapi-generator-cli" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/f8/844e34f5126ae40fff0d012bba0b28f031f8871062759bb3789eae4f5e0a/onyx_devtools-0.7.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3cd434c722ae48a1f651748a9f094711b29d1a9f37fbbadef3144f2cdb0f16d", size = 4238900, upload-time = "2026-04-10T07:02:16.382Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/97/d1db725f900b199fa3f7a7a7c9b51ae75d4b18755c924f00f06a7703e552/onyx_devtools-0.7.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c50e3d76d4f8cc4faa6250e758d42f0249067f0e17bc82b99c6c00dd48114393", size = 3913672, upload-time = "2026-04-10T07:02:17.46Z" },
-    { url = "https://files.pythonhosted.org/packages/31/83/e11bedb0a1321b63c844a418be1990c172ed363c6ee612978c3a38df71f1/onyx_devtools-0.7.5-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:ec01aeaaa14854b0933bb85bbfc51184599d3dbf1c0097ff59c1c72db8222a5a", size = 3779585, upload-time = "2026-04-10T07:02:16.31Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/85/128d25cd35c1adc436dcff9ab4f2c20cf29528d09415280c1230ff0ca993/onyx_devtools-0.7.5-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:586d50ecb6dcea95611135e4cd4529ebedd8ab84a41b1adf3be1280a48dc52af", size = 4201962, upload-time = "2026-04-10T07:02:14.466Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5d/83c80f918b399fea998cd41bfe90bda733eda77e133ca4dc1e9ce18a9b4a/onyx_devtools-0.7.5-py3-none-win_amd64.whl", hash = "sha256:c45d80f0093ba738120b77c4c0bde13843e33d786ae8608eb10490f06183d89b", size = 4320088, upload-time = "2026-04-10T07:02:17.09Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bf/b9c85cc61981bd71c0f1cbb50192763b11788a7c8636b1e01f750251c92c/onyx_devtools-0.7.5-py3-none-win_arm64.whl", hash = "sha256:9852a7cc29939371e016b794f2cffdb88680280d857d24c191c5188884416a3d", size = 3858839, upload-time = "2026-04-10T07:02:20.098Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e5/cbb5fb2a4c0211180b6378bb37e3e59acfa1714b51a610d3f2897c3ab996/onyx_devtools-0.7.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8d51f7471592ccaf3a593366f18b10cb7d9ce903106f1ff1f0a5af62c5dae4b1", size = 4254929, upload-time = "2026-04-24T02:31:58.409Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/6b7b09729fa8b65aa027b61bb1bcbde723cfdeb3fbe8f05a24cb71682cc2/onyx_devtools-0.7.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:289d126f5e0d42cea8c164a0b8be4ca7948fe3b6a5afd72e2b4868da4ed6a7f7", size = 3925618, upload-time = "2026-04-24T02:32:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7b/fd0d4f7f57c4d8e2c87283c37a1a222ae82a76db1638c1dc59f908339175/onyx_devtools-0.7.6-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:1aca8681a00bce984f7b9639be00e6b2a90718d5872d3e3781922423940cc915", size = 3791309, upload-time = "2026-04-24T02:31:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/5c/b47887f90eff14666f888e1993bc03fae7eaac5becd6ec6b6a84b0b9853b/onyx_devtools-0.7.6-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:2f4cc8d1cbaa116f54c7556206cfd2c029ed7faeb16c02fcfdee12f525cf5aab", size = 4215980, upload-time = "2026-04-24T02:31:57.629Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6c/96ee0a26673b09d0c254e8af25e69c19e45887216ca508fc3b9dd8a6214c/onyx_devtools-0.7.6-py3-none-win_amd64.whl", hash = "sha256:2f82951d5470e4c05f64760282e59ef086a0640c4f5584e517f94a8c5d3a60d4", size = 4333866, upload-time = "2026-04-24T02:31:57.973Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b9/ce77376bc57bdfa08acbc4088904d6d737538e277a3bb8a0bd35a67e17fe/onyx_devtools-0.7.6-py3-none-win_arm64.whl", hash = "sha256:821b1aee102b8f3f2874a2cb774e59c31513d6c471c9c84f85b408d5a9c4524a", size = 3872019, upload-time = "2026-04-24T02:31:57.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Pulls in `ods dev tunnel` and `ods install-skill`

## How Has This Been Tested?

```
uv sync 
ods --version
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `onyx-devtools` from 0.7.5 to 0.7.6 to add the new `ods dev tunnel` and `ods install-skill` commands for local development. Dev-only change; updates `pyproject.toml`, `backend/requirements/dev.txt`, and `uv.lock`.

<sup>Written for commit e0d2bc3d925cf75add975f1f041caa86ca60b8f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

