### PR TITLE
fix(api): fetch agent avatars from dedicated `/api/persona/{id}/avatar`

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -222,7 +222,6 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     TODO(auth-perf): split `/chat/file` into per-asset-class endpoints so the
     URL carries the access context and one indexed lookup suffices, instead
     of fanning out 4–5 queries across unrelated classes on every request.
-    Persona avatars already moved to `GET /persona/{persona_id}/avatar`.
     """
     owns_user_file = db_session.query(
         select(UserFile.id)

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -21,7 +21,6 @@ from onyx.db.models import Connector
 from onyx.db.models import Document
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import FileRecord
-from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.user_file import fetch_user_files_with_access_relationships
@@ -215,7 +214,6 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     JSONB scan in `_documents_from_file_connector_config`):
 
     - `UserFile` owned by the user.
-    - `Persona.uploaded_image_id` (avatars are public to authenticated users).
     - `ChatMessage.files` of a session the user owns or that is shared as
       `ChatSessionSharedStatus.PUBLIC`.
     - `FileRecord` with origin `CHAT_IMAGE_GEN` (see inline TODO).
@@ -224,6 +222,7 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     TODO(auth-perf): split `/chat/file` into per-asset-class endpoints so the
     URL carries the access context and one indexed lookup suffices, instead
     of fanning out 4–5 queries across unrelated classes on every request.
+    Persona avatars already moved to `GET /persona/{persona_id}/avatar`.
     """
     owns_user_file = db_session.query(
         select(UserFile.id)
@@ -231,22 +230,6 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
         .exists()
     ).scalar()
     if owns_user_file:
-        return True
-
-    # TODO: move persona avatars to a dedicated endpoint so this branch
-    # can go away. Restrict to CHAT_UPLOAD-origin for now so an attacker
-    # cannot bind another user's USER_FILE to their persona and read it
-    # through this check.
-    is_persona_avatar = db_session.query(
-        select(Persona.id)
-        .join(FileRecord, FileRecord.file_id == Persona.uploaded_image_id)
-        .where(
-            Persona.uploaded_image_id == file_id,
-            FileRecord.file_origin == FileOrigin.CHAT_UPLOAD,
-        )
-        .exists()
-    ).scalar()
-    if is_persona_avatar:
         return True
 
     chat_file_stmt = (

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -573,6 +573,10 @@ def get_persona_avatar(
     # to another user's USER_FILE / CHAT_IMAGE_GEN asset.
     file_record = get_filerecord_by_file_id_optional(file_id, db_session)
     if not file_record:
+        logger.warning(
+            f"Persona {persona_id} references avatar file {file_id} with no "
+            f"matching FileRecord; rejecting."
+        )
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
     if file_record.file_origin != FileOrigin.CHAT_UPLOAD:
         logger.warning(

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -572,7 +572,13 @@ def get_persona_avatar(
     # avatar upload endpoint, so a crafted PATCH cannot rebind a persona
     # to another user's USER_FILE / CHAT_IMAGE_GEN asset.
     file_record = get_filerecord_by_file_id_optional(file_id, db_session)
-    if not file_record or file_record.file_origin != FileOrigin.CHAT_UPLOAD:
+    if not file_record:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
+    if file_record.file_origin != FileOrigin.CHAT_UPLOAD:
+        logger.warning(
+            f"Persona {persona_id} avatar references file {file_id} with "
+            f"unexpected origin {file_record.file_origin}; rejecting."
+        )
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
 
     etag = f'"{file_id}"'

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -4,7 +4,10 @@ from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import Query
+from fastapi import Request
+from fastapi import Response
 from fastapi import UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -19,6 +22,7 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import User
 from onyx.db.persona import create_assistant_label
 from onyx.db.persona import create_update_persona
@@ -38,6 +42,8 @@ from onyx.db.persona import update_persona_public_status
 from onyx.db.persona import update_persona_shared
 from onyx.db.persona import update_persona_visibility
 from onyx.db.persona import update_personas_display_priority
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType
 from onyx.server.documents.models import PaginatedReturn
@@ -537,3 +543,49 @@ def get_persona(
             db_session.commit()
 
     return FullPersonaSnapshot.from_model(persona)
+
+
+@basic_router.get("/{persona_id}/avatar")
+def get_persona_avatar(
+    persona_id: int,
+    request: Request,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    # Mirror `fetch_chat_file`: return 404 (not 403) for any failure so
+    # callers cannot probe persona existence or avatar ownership.
+    try:
+        persona = get_persona_by_id(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            is_for_edit=False,
+        )
+    except ValueError:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
+
+    file_id = persona.uploaded_image_id
+    if not file_id:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
+
+    # Defense-in-depth: reject file_ids that weren't produced by the
+    # avatar upload endpoint, so a crafted PATCH cannot rebind a persona
+    # to another user's USER_FILE / CHAT_IMAGE_GEN asset.
+    file_record = get_filerecord_by_file_id_optional(file_id, db_session)
+    if not file_record or file_record.file_origin != FileOrigin.CHAT_UPLOAD:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Avatar not found")
+
+    etag = f'"{file_id}"'
+    cache_headers = {
+        "Cache-Control": "private, max-age=31536000, immutable",
+        "ETag": etag,
+        "Vary": "Cookie",
+    }
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=cache_headers)
+
+    file_store = get_default_file_store()
+    file_io = file_store.read_file(file_id, mode="b")
+    return StreamingResponse(
+        file_io, media_type=file_record.file_type, headers=cache_headers
+    )

--- a/backend/tests/integration/tests/personas/test_persona_avatar.py
+++ b/backend/tests/integration/tests/personas/test_persona_avatar.py
@@ -1,0 +1,180 @@
+"""
+Tests for the persona avatar endpoint (`GET /persona/{persona_id}/avatar`).
+
+Covers:
+1. Round-trip upload + fetch for the persona owner.
+2. Cross-user access honoring the persona's own ACL (public readable by
+   everyone, private gated to owner/allowed members).
+3. 404 responses for personas without a configured avatar or that do not
+   exist at all.
+"""
+
+import base64
+import io
+from typing import NamedTuple
+
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestUser
+
+# Minimal valid 1x1 PNG — small, parses cleanly, and lets us assert the
+# served bytes equal what we uploaded.
+_AVATAR_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "YAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+)
+
+
+class PersonaAvatarSetup(NamedTuple):
+    owner: DATestUser
+    other_user: DATestUser
+    public_persona_id: int
+    private_persona_id: int
+    no_avatar_persona_id: int
+
+
+def _upload_persona_avatar(user: DATestUser) -> str:
+    """Upload avatar bytes via the admin upload-image endpoint and return
+    the storage file_id the frontend would receive."""
+    response = requests.post(
+        f"{API_SERVER_URL}/admin/persona/upload-image",
+        files={
+            "file": ("avatar.png", io.BytesIO(_AVATAR_PNG_BYTES), "image/png"),
+        },
+        headers={k: v for k, v in user.headers.items() if k.lower() != "content-type"},
+    )
+    response.raise_for_status()
+    return response.json()["file_id"]
+
+
+def _create_persona_with_avatar(
+    *,
+    owner: DATestUser,
+    name: str,
+    is_public: bool,
+    uploaded_image_id: str | None,
+) -> int:
+    """Create a persona with (or without) a configured avatar and return its
+    id. Built from a raw payload rather than `PersonaManager` so the avatar
+    field flows straight through the API shape under test."""
+    payload = {
+        "name": name,
+        "description": f"{name} description",
+        "system_prompt": "",
+        "task_prompt": "",
+        "document_set_ids": [],
+        "tool_ids": [],
+        "is_public": is_public,
+        "datetime_aware": False,
+        "uploaded_image_id": uploaded_image_id,
+    }
+    response = requests.post(
+        f"{API_SERVER_URL}/persona",
+        json=payload,
+        headers=owner.headers,
+    )
+    response.raise_for_status()
+    return response.json()["id"]
+
+
+@pytest.fixture
+def persona_avatar_setup(reset: None) -> PersonaAvatarSetup:  # noqa: ARG001
+    """Owner with three personas — public + avatar, private + avatar, and a
+    no-avatar control — plus a second authenticated user for cross-user
+    access checks."""
+    owner: DATestUser = UserManager.create(name="avatar_owner")
+    other: DATestUser = UserManager.create(name="avatar_other")
+
+    public_file_id = _upload_persona_avatar(owner)
+    public_persona_id = _create_persona_with_avatar(
+        owner=owner,
+        name="public avatar persona",
+        is_public=True,
+        uploaded_image_id=public_file_id,
+    )
+
+    private_file_id = _upload_persona_avatar(owner)
+    private_persona_id = _create_persona_with_avatar(
+        owner=owner,
+        name="private avatar persona",
+        is_public=False,
+        uploaded_image_id=private_file_id,
+    )
+
+    no_avatar_persona_id = _create_persona_with_avatar(
+        owner=owner,
+        name="no avatar persona",
+        is_public=True,
+        uploaded_image_id=None,
+    )
+
+    return PersonaAvatarSetup(
+        owner=owner,
+        other_user=other,
+        public_persona_id=public_persona_id,
+        private_persona_id=private_persona_id,
+        no_avatar_persona_id=no_avatar_persona_id,
+    )
+
+
+def test_persona_owner_can_fetch_their_avatar(
+    persona_avatar_setup: PersonaAvatarSetup,
+) -> None:
+    response = requests.get(
+        f"{API_SERVER_URL}/persona/{persona_avatar_setup.public_persona_id}/avatar",
+        headers=persona_avatar_setup.owner.headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("image/")
+    assert response.content == _AVATAR_PNG_BYTES
+
+
+def test_public_persona_avatar_is_accessible_to_other_users(
+    persona_avatar_setup: PersonaAvatarSetup,
+) -> None:
+    response = requests.get(
+        f"{API_SERVER_URL}/persona/{persona_avatar_setup.public_persona_id}/avatar",
+        headers=persona_avatar_setup.other_user.headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.content == _AVATAR_PNG_BYTES
+
+
+def test_private_persona_avatar_is_denied_to_other_users(
+    persona_avatar_setup: PersonaAvatarSetup,
+) -> None:
+    response = requests.get(
+        f"{API_SERVER_URL}/persona/"
+        f"{persona_avatar_setup.private_persona_id}/avatar",
+        headers=persona_avatar_setup.other_user.headers,
+    )
+    assert response.status_code == 404, (
+        f"Non-member should not be able to read a private persona's avatar, "
+        f"got {response.status_code}: {response.text}"
+    )
+    assert response.content != _AVATAR_PNG_BYTES
+
+
+def test_persona_avatar_returns_404_when_no_avatar_configured(
+    persona_avatar_setup: PersonaAvatarSetup,
+) -> None:
+    response = requests.get(
+        f"{API_SERVER_URL}/persona/"
+        f"{persona_avatar_setup.no_avatar_persona_id}/avatar",
+        headers=persona_avatar_setup.owner.headers,
+    )
+    assert response.status_code == 404, response.text
+
+
+def test_persona_avatar_returns_404_for_missing_persona(
+    reset: None,  # noqa: ARG001
+) -> None:
+    user: DATestUser = UserManager.create(name="missing_persona_user")
+    response = requests.get(
+        f"{API_SERVER_URL}/persona/99999999/avatar",
+        headers=user.headers,
+    )
+    assert response.status_code == 404, response.text

--- a/web/src/app/app/components/files/images/utils.ts
+++ b/web/src/app/app/components/files/images/utils.ts
@@ -5,6 +5,10 @@ export function buildImgUrl(fileId: string) {
   return `/api/chat/file/${fileId}`;
 }
 
+export function buildAgentAvatarUrl(agentId: number) {
+  return `/api/persona/${agentId}/avatar`;
+}
+
 /**
  * If `href` points to a chat file and `linkText` ends with an image extension,
  * returns the file ID. Otherwise returns null.

--- a/web/src/refresh-components/avatars/AgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/AgentAvatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
-import { buildImgUrl } from "@/app/app/components/files/images/utils";
+import { buildAgentAvatarUrl } from "@/app/app/components/files/images/utils";
 import { SvgOnyxLogo } from "@opal/logos";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { DEFAULT_AVATAR_SIZE_PX, DEFAULT_AGENT_ID } from "@/lib/constants";
@@ -42,11 +42,7 @@ export default function AgentAvatar({
   return (
     <CustomAgentAvatar
       name={agent.name}
-      src={
-        agent.uploaded_image_id
-          ? buildImgUrl(agent.uploaded_image_id)
-          : undefined
-      }
+      src={agent.uploaded_image_id ? buildAgentAvatarUrl(agent.id) : undefined}
       iconName={agent.icon_name}
       size={size}
       {...props}

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -7,7 +7,7 @@ import * as GeneralLayouts from "@/layouts/general-layouts";
 import { Button, Card, Divider, MessageCard } from "@opal/components";
 import { Hoverable, Disabled } from "@opal/core";
 import { FullPersona } from "@/app/admin/agents/interfaces";
-import { buildImgUrl } from "@/app/app/components/files/images/utils";
+import { buildAgentAvatarUrl } from "@/app/app/components/files/images/utils";
 import { Formik, Form, FieldArray } from "formik";
 import * as Yup from "yup";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
@@ -176,14 +176,14 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
 
   const imageSrc = uploadedImagePreview
     ? uploadedImagePreview
-    : values.uploaded_image_id
-      ? buildImgUrl(values.uploaded_image_id)
+    : values.uploaded_image_id && existingAgent?.id
+      ? buildAgentAvatarUrl(existingAgent.id)
       : values.icon_name
         ? undefined
         : values.remove_image
           ? undefined
           : existingAgent?.uploaded_image_id
-            ? buildImgUrl(existingAgent.uploaded_image_id)
+            ? buildAgentAvatarUrl(existingAgent.id)
             : undefined;
 
   function handleIconClick(iconName: string | null) {

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -176,7 +176,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
 
   const imageSrc = uploadedImagePreview
     ? uploadedImagePreview
-    : values.uploaded_image_id && existingAgent?.id
+    : values.uploaded_image_id && existingAgent?.id != null
       ? buildAgentAvatarUrl(existingAgent.id)
       : values.icon_name
         ? undefined

--- a/web/tests/e2e/agents/persona_avatar.spec.ts
+++ b/web/tests/e2e/agents/persona_avatar.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, Browser } from "@playwright/test";
+import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+
+// Minimal valid 1x1 red PNG so we can verify served bytes equal what we uploaded.
+const TINY_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64"
+);
+
+test.describe("Persona avatar dedicated endpoint", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let agentId: number | null = null;
+  let avatarFileId: string | null = null;
+  const agentName = `E2E Avatar Agent ${Date.now()}`;
+
+  test.afterAll(async ({ browser }: { browser: Browser }) => {
+    if (agentId === null) return;
+    const context = await browser.newContext({
+      storageState: "admin_auth.json",
+    });
+    const page = await context.newPage();
+    const cleanupClient = new OnyxApiClient(page.request);
+    await cleanupClient.deleteAgent(agentId);
+    await context.close();
+  });
+
+  test("serves avatar from /api/persona/{id}/avatar and closes /api/chat/file/ access", async ({
+    page,
+  }) => {
+    const uploadResp = await page.request.post(
+      "/api/admin/persona/upload-image",
+      {
+        multipart: {
+          file: {
+            name: "avatar.png",
+            mimeType: "image/png",
+            buffer: TINY_PNG,
+          },
+        },
+      }
+    );
+    expect(uploadResp.ok()).toBeTruthy();
+    const uploadJson = (await uploadResp.json()) as { file_id: string };
+    avatarFileId = uploadJson.file_id;
+    expect(avatarFileId).toBeTruthy();
+
+    const createResp = await page.request.post("/api/persona", {
+      data: {
+        name: agentName,
+        description: "Persona used to verify the avatar endpoint.",
+        document_set_ids: [],
+        is_public: true,
+        tool_ids: [],
+        uploaded_image_id: avatarFileId,
+        system_prompt: "",
+        task_prompt: "",
+        datetime_aware: true,
+      },
+    });
+    expect(createResp.ok()).toBeTruthy();
+    const persona = (await createResp.json()) as { id: number };
+    agentId = persona.id;
+
+    const avatarResp = await page.request.get(
+      `/api/persona/${agentId}/avatar`
+    );
+    expect(avatarResp.status()).toBe(200);
+    expect(avatarResp.headers()["content-type"]).toContain("image/png");
+    const servedBytes = await avatarResp.body();
+    expect(servedBytes.toString("base64")).toBe(TINY_PNG.toString("base64"));
+
+    // Regression: the old overloaded path used to serve any persona avatar
+    // by file_id. The new endpoint is the only way in — the chat-file route
+    // no longer exposes avatars.
+    const chatFileResp = await page.request.get(
+      `/api/chat/file/${avatarFileId}`
+    );
+    expect(chatFileResp.status()).toBe(404);
+  });
+
+  test("returns 404 for a non-existent persona id", async ({ page }) => {
+    const resp = await page.request.get("/api/persona/99999999/avatar");
+    expect(resp.status()).toBe(404);
+  });
+
+  test("returns 404 for a persona that has no uploaded avatar", async ({
+    page,
+  }) => {
+    // The default assistant (id=0) ships without an uploaded_image_id.
+    const resp = await page.request.get("/api/persona/0/avatar");
+    expect(resp.status()).toBe(404);
+  });
+
+  test("another authenticated user can read a public persona's avatar", async ({
+    page,
+  }, testInfo) => {
+    expect(agentId).not.toBeNull();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+
+    const avatarResp = await page.request.get(
+      `/api/persona/${agentId}/avatar`
+    );
+    expect(avatarResp.status()).toBe(200);
+    const bytes = await avatarResp.body();
+    expect(bytes.toString("base64")).toBe(TINY_PNG.toString("base64"));
+
+    // Re-auth as admin so afterAll cleanup uses the owner's session.
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test("AgentAvatar renders the new avatar URL in the DOM", async ({
+    page,
+  }) => {
+    expect(agentId).not.toBeNull();
+    await page.goto(`/app?agentId=${agentId}`);
+    await page.waitForLoadState("networkidle");
+
+    const avatarImg = page
+      .locator(`img[src="/api/persona/${agentId}/avatar"]`)
+      .first();
+    await expect(avatarImg).toBeVisible({ timeout: 10000 });
+
+    // No <img> should still be pointing at the legacy /chat/file path for
+    // this persona's avatar file id.
+    if (avatarFileId) {
+      const legacyImg = page.locator(
+        `img[src="/api/chat/file/${avatarFileId}"]`
+      );
+      await expect(legacyImg).toHaveCount(0);
+    }
+  });
+});

--- a/web/tests/e2e/agents/persona_avatar.spec.ts
+++ b/web/tests/e2e/agents/persona_avatar.spec.ts
@@ -1,18 +1,13 @@
 import { test, expect, Browser } from "@playwright/test";
 import { loginAs, loginAsWorkerUser } from "@tests/e2e/utils/auth";
+import { CHECKERED_PNG } from "@tests/e2e/fixtures/images";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
-// Minimal valid 1x1 red PNG so we can verify served bytes equal what we uploaded.
-const TINY_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-  "base64"
-);
-
-test.describe("Persona avatar dedicated endpoint", () => {
+test.describe("Persona avatar", () => {
   test.describe.configure({ mode: "serial" });
 
   let agentId: number | null = null;
-  let avatarFileId: string | null = null;
   const agentName = `E2E Avatar Agent ${Date.now()}`;
 
   test.afterAll(async ({ browser }: { browser: Browser }) => {
@@ -26,7 +21,7 @@ test.describe("Persona avatar dedicated endpoint", () => {
     await context.close();
   });
 
-  test("serves avatar from /api/persona/{id}/avatar and closes /api/chat/file/ access", async ({
+  test("uploads an avatar and serves the exact bytes back to the owner", async ({
     page,
   }) => {
     const uploadResp = await page.request.post(
@@ -36,20 +31,20 @@ test.describe("Persona avatar dedicated endpoint", () => {
           file: {
             name: "avatar.png",
             mimeType: "image/png",
-            buffer: TINY_PNG,
+            buffer: CHECKERED_PNG,
           },
         },
       }
     );
     expect(uploadResp.ok()).toBeTruthy();
     const uploadJson = (await uploadResp.json()) as { file_id: string };
-    avatarFileId = uploadJson.file_id;
+    const avatarFileId = uploadJson.file_id;
     expect(avatarFileId).toBeTruthy();
 
     const createResp = await page.request.post("/api/persona", {
       data: {
         name: agentName,
-        description: "Persona used to verify the avatar endpoint.",
+        description: "Persona used to verify avatar serving.",
         document_set_ids: [],
         is_public: true,
         tool_ids: [],
@@ -63,29 +58,21 @@ test.describe("Persona avatar dedicated endpoint", () => {
     const persona = (await createResp.json()) as { id: number };
     agentId = persona.id;
 
-    const avatarResp = await page.request.get(
-      `/api/persona/${agentId}/avatar`
-    );
+    const avatarResp = await page.request.get(`/api/persona/${agentId}/avatar`);
     expect(avatarResp.status()).toBe(200);
     expect(avatarResp.headers()["content-type"]).toContain("image/png");
     const servedBytes = await avatarResp.body();
-    expect(servedBytes.toString("base64")).toBe(TINY_PNG.toString("base64"));
-
-    // Regression: the old overloaded path used to serve any persona avatar
-    // by file_id. The new endpoint is the only way in — the chat-file route
-    // no longer exposes avatars.
-    const chatFileResp = await page.request.get(
-      `/api/chat/file/${avatarFileId}`
+    expect(servedBytes.toString("base64")).toBe(
+      CHECKERED_PNG.toString("base64")
     );
-    expect(chatFileResp.status()).toBe(404);
   });
 
-  test("returns 404 for a non-existent persona id", async ({ page }) => {
+  test("returns 404 for a non-existent persona", async ({ page }) => {
     const resp = await page.request.get("/api/persona/99999999/avatar");
     expect(resp.status()).toBe(404);
   });
 
-  test("returns 404 for a persona that has no uploaded avatar", async ({
+  test("returns 404 when a persona has no avatar configured", async ({
     page,
   }) => {
     // The default assistant (id=0) ships without an uploaded_image_id.
@@ -93,28 +80,24 @@ test.describe("Persona avatar dedicated endpoint", () => {
     expect(resp.status()).toBe(404);
   });
 
-  test("another authenticated user can read a public persona's avatar", async ({
+  test("serves a public persona's avatar to other authenticated users", async ({
     page,
   }, testInfo) => {
     expect(agentId).not.toBeNull();
     await page.context().clearCookies();
     await loginAsWorkerUser(page, testInfo.workerIndex);
 
-    const avatarResp = await page.request.get(
-      `/api/persona/${agentId}/avatar`
-    );
+    const avatarResp = await page.request.get(`/api/persona/${agentId}/avatar`);
     expect(avatarResp.status()).toBe(200);
     const bytes = await avatarResp.body();
-    expect(bytes.toString("base64")).toBe(TINY_PNG.toString("base64"));
+    expect(bytes.toString("base64")).toBe(CHECKERED_PNG.toString("base64"));
 
     // Re-auth as admin so afterAll cleanup uses the owner's session.
     await page.context().clearCookies();
     await loginAs(page, "admin");
   });
 
-  test("AgentAvatar renders the new avatar URL in the DOM", async ({
-    page,
-  }) => {
+  test("renders the persona avatar in the chat UI", async ({ page }) => {
     expect(agentId).not.toBeNull();
     await page.goto(`/app?agentId=${agentId}`);
     await page.waitForLoadState("networkidle");
@@ -124,13 +107,11 @@ test.describe("Persona avatar dedicated endpoint", () => {
       .first();
     await expect(avatarImg).toBeVisible({ timeout: 10000 });
 
-    // No <img> should still be pointing at the legacy /chat/file path for
-    // this persona's avatar file id.
-    if (avatarFileId) {
-      const legacyImg = page.locator(
-        `img[src="/api/chat/file/${avatarFileId}"]`
-      );
-      await expect(legacyImg).toHaveCount(0);
-    }
+    // Capture the rendered avatar so we catch regressions in how the bytes
+    // are decoded, cropped, and framed by the AgentAvatar component.
+    const avatarContainer = avatarImg.locator("..");
+    await expectElementScreenshot(avatarContainer, {
+      name: "persona-avatar-chat",
+    });
   });
 });

--- a/web/tests/e2e/agents/persona_chat.spec.ts
+++ b/web/tests/e2e/agents/persona_chat.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect, Browser } from "@playwright/test";
+import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { CHECKERED_PNG } from "@tests/e2e/fixtures/images";
+import { sendMessage } from "@tests/e2e/utils/chatActions";
+import {
+  buildMockStream,
+  mockChatEndpoint,
+  resetTurnCounter,
+} from "@tests/e2e/utils/chatMock";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+
+const USER_MESSAGE = "Hi there";
+const AI_RESPONSE = "Hello, I'm a custom persona!";
+
+test.describe("Chatting with a custom persona", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let agentId: number | null = null;
+  const agentName = `E2E Persona Chat ${Date.now()}`;
+
+  test.beforeAll(async ({ browser }: { browser: Browser }) => {
+    const context = await browser.newContext({
+      storageState: "admin_auth.json",
+    });
+    const page = await context.newPage();
+
+    const uploadResp = await page.request.post(
+      "/api/admin/persona/upload-image",
+      {
+        multipart: {
+          file: {
+            name: "avatar.png",
+            mimeType: "image/png",
+            buffer: CHECKERED_PNG,
+          },
+        },
+      }
+    );
+    expect(uploadResp.ok()).toBeTruthy();
+    const { file_id: avatarFileId } = (await uploadResp.json()) as {
+      file_id: string;
+    };
+
+    const createResp = await page.request.post("/api/persona", {
+      data: {
+        name: agentName,
+        description: "Persona used for chat rendering tests.",
+        document_set_ids: [],
+        is_public: true,
+        tool_ids: [],
+        uploaded_image_id: avatarFileId,
+        system_prompt: "",
+        task_prompt: "",
+        datetime_aware: true,
+      },
+    });
+    expect(createResp.ok()).toBeTruthy();
+    const persona = (await createResp.json()) as { id: number };
+    agentId = persona.id;
+
+    await context.close();
+  });
+
+  test.afterAll(async ({ browser }: { browser: Browser }) => {
+    if (agentId === null) return;
+    const context = await browser.newContext({
+      storageState: "admin_auth.json",
+    });
+    const page = await context.newPage();
+    const cleanupClient = new OnyxApiClient(page.request);
+    await cleanupClient.deleteAgent(agentId);
+    await context.close();
+  });
+
+  test.beforeEach(() => {
+    resetTurnCounter();
+  });
+
+  test("welcome page renders the selected persona", async ({ page }) => {
+    expect(agentId).not.toBeNull();
+    const chat = new ChatPage(page);
+
+    await page.goto(`/app?agentId=${agentId}`);
+    await chat.chatInputTextarea.waitFor({ state: "visible", timeout: 15000 });
+
+    const nameDisplay = page.getByTestId("agent-name-display");
+    await expect(nameDisplay).toBeVisible({ timeout: 10000 });
+    await expect(nameDisplay).toContainText(agentName);
+
+    await chat.screenshotContainer("persona-chat-welcome");
+  });
+
+  test("sends a message and renders the AI response", async ({ page }) => {
+    expect(agentId).not.toBeNull();
+    const chat = new ChatPage(page);
+
+    await page.goto(`/app?agentId=${agentId}`);
+    await chat.chatInputTextarea.waitFor({ state: "visible", timeout: 15000 });
+    await mockChatEndpoint(page, buildMockStream(AI_RESPONSE));
+
+    await sendMessage(page, USER_MESSAGE);
+
+    const userMessage = chat.humanMessage(0);
+    await expect(userMessage).toBeVisible();
+    await expect(userMessage).toContainText(USER_MESSAGE);
+
+    const aiMessage = chat.aiMessage(0);
+    await expect(aiMessage).toBeVisible();
+    await expect(aiMessage).toContainText(AI_RESPONSE);
+
+    await chat.screenshotContainer("persona-chat-response");
+  });
+});

--- a/web/tests/e2e/chat/ChatPage.ts
+++ b/web/tests/e2e/chat/ChatPage.ts
@@ -56,7 +56,9 @@ export class ChatPage {
 
   async screenshotContainer(name: string): Promise<void> {
     await expect(this.container).toBeVisible();
-    await this.scrollTo("bottom");
+    if ((await this.scrollContainer.count()) > 0) {
+      await this.scrollTo("bottom");
+    }
     await expectElementScreenshot(this.container, { name });
   }
 

--- a/web/tests/e2e/chat/chat_file_uploads.spec.ts
+++ b/web/tests/e2e/chat/chat_file_uploads.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page, test } from "@playwright/test";
 import { ChatPage } from "@tests/e2e/chat/ChatPage";
+import { CHECKERED_PNG } from "@tests/e2e/fixtures/images";
 import { loginAsWorkerUser } from "@tests/e2e/utils/auth";
 import { sendMessage } from "@tests/e2e/utils/chatActions";
 import {
@@ -12,15 +13,6 @@ import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
 const SHORT_AI_RESPONSE = "I've reviewed the file you uploaded.";
 const IMAGE_GEN_AI_MESSAGE = "Here is the image I generated for you.";
-
-// 50x50 black/white checkered PNG — clearly a test artifact, used both as a
-// user-uploaded image and as the mocked response for LLM-generated image
-// fetches. The bytes pass PIL validation (which the upload endpoint runs to
-// reject malformed images).
-const CHECKERED_PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJUuHylcFApyWhTVc1rkkOzczwZLCwsrN9YuXXH+1lLxMLCwtpz5XV5fwsLC0uX1+WxsLCwdHldHgsLC+uxLK9hJFqMAN43AAAAAElFTkSuQmCC",
-  "base64"
-);
 
 const PYTHON_CODE = `def greet(name: str) -> str:
     return f"Hello, {name}!"

--- a/web/tests/e2e/fixtures/images.ts
+++ b/web/tests/e2e/fixtures/images.ts
@@ -1,0 +1,7 @@
+// 50x50 black/white checkered PNG — clearly a test artifact. The bytes pass
+// PIL validation (which upload endpoints run to reject malformed images), so
+// it works for any test that needs a real, small, valid image upload.
+export const CHECKERED_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAVElEQVR42u3WwQkAIAwDQOP+O9cN+lJUuHylcFApyWhTVc1rkkOzczwZLCwsrN9YuXXH+1lLxMLCwtpz5XV5fwsLC0uX1+WxsLCwdHldHgsLC+uxLK9hJFqMAN43AAAAAElFTkSuQmCC",
+  "base64"
+);


### PR DESCRIPTION
## Description

Implements a dedicated endpoint for fetching agent/persona/assistant avatars.

## How Has This Been Tested?

Included playwright tests and integration tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve agent/persona avatars from a dedicated `/api/persona/{id}/avatar` endpoint instead of `/api/chat/file`. Avatars now follow persona ACLs and use private, immutable caching with ETags; the UI loads them from the new URL.

- **Bug Fixes**
  - Added `GET /api/persona/{id}/avatar` with persona-based access checks; returns 304 via ETag, correct media type, and 404 for missing/no-avatar or non-`CHAT_UPLOAD` files to prevent probing.
  - Removed avatar access via `/api/chat/file` and deleted the avatar special-case in backend access control.
  - Added `buildAgentAvatarUrl`; updated `AgentAvatar` and `AgentEditorPage` to use it. Added backend integration tests and Playwright E2E tests (including chat rendering via a custom persona). Moved image fixture to `@tests/e2e/fixtures/images`.

- **Migration**
  - Use `buildAgentAvatarUrl(agentId)` for avatars; stop using `buildImgUrl(uploaded_image_id)` for avatars.

<sup>Written for commit 21ca8f33735e268ab30f89c83cf81be6159366ad. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10597?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



