### PR TITLE
chore(devtools): upgrade `tsgo`, fix `.next/types/validator.ts` errors

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10518,7 +10518,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -115,7 +115,7 @@
         "@types/react-dom": "19.2.3",
         "@types/stats.js": "^0.17.4",
         "@types/uuid": "^9.0.8",
-        "@typescript/native-preview": "7.0.0-dev.20251222.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260424.2",
         "babel-plugin-react-compiler": "^1.0.0",
         "baseline-browser-mapping": "^2.9.19",
         "eslint": "^9.39.1",
@@ -7274,28 +7274,31 @@
       }
     },
     "node_modules/@typescript/native-preview": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-/9Xrcwb1vkJX+Wdj57ckixQBgF+I1DwEi1PEwgu13i/q5gs1AWVxOGg318sibuZu/33ZfvxRZZXOS24UzqDwWw==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-NhxfO8WQHrv7SAqOVaY1NBKkWO5dKFoakvqBKiUDBiY27atZfoDkMQpOXyoPfuW3COVxHZKzm0vAZuiA7kF73g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsgo": "bin/tsgo.js"
       },
+      "engines": {
+        "node": ">=16.20.0"
+      },
       "optionalDependencies": {
-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251222.1",
-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20251222.1"
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260424.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260424.2"
       }
     },
     "node_modules/@typescript/native-preview-darwin-arm64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-wq2sTeZzexOrGYKKsMODvL/9+HF4nqyHt/h7hW55ikHU5gscby5xkhG4/oA8KECLTYVdDfAQM+Yfnku76SQBPw==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-Fk0pY4FaPpmYfmLG0xowocG3Q+Bo78WkTg33+OjctzkM1w8hp/d6jo3m4ROCFYBiH2EwY5RZ7cECX6el5FVPtA==",
       "cpu": [
         "arm64"
       ],
@@ -7304,12 +7307,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-darwin-x64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-CQZFFdH7f/LkGRWqWBK1jwVwQi3XlWTYeu9MdaDpWafM4PJEjMHh1ZuGYp7cjI8SUk07oJRE8P4BMQ1moPe57g==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-/37FW1CUcUT51oGIrWyC92+pstzW+v4l9alSyLSxY62crJt+GiOff7wIau34xrfEx7VE2gRpUGs9ld25Pr9VHw==",
       "cpu": [
         "x64"
       ],
@@ -7318,12 +7324,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-WkxQVLJB9XuvsTMdrks3gaGc22HnuQrFknrkBRy7dqgjervN12h8UzaNCsU7FrAs955NJIAdXuTa6cKFxYhkbA==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-xNBtutVYBKeA1iJan2La98hEt5e8HxSlLMicIaq7XwWb6lok7a3qppnk7gFrTMx3JBgFXlN/7cafV4Nxwq8DJQ==",
       "cpu": [
         "arm"
       ],
@@ -7332,12 +7341,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-arm64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-wN+IfT/KZfsq1g3Imd50+3k4qCgAwD8N7qU82tJDa9BNj6GtXE/za05N8LBFFq624FBiiqabazsTdE2e/m4OKw==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-/XoSdXZEkz5TGimjAXhC7SwbqceOgaGsFP6ChmcDPsdsSZUtFP+7jh+WnDWyACcGu289VTNmfKDoG9szFiZ9TQ==",
       "cpu": [
         "arm64"
       ],
@@ -7346,12 +7358,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-linux-x64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-yra1TDTzBEI8DjV2BPuQR6PbLJJZPAMWvfCWOxETEbJfKRsz4kBKBG9cPgALeUdjvM6I8ah/CwvJtVc+9oVDGw==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-pJzvZ6uaKCBNphipzAgxvNAbmj++EIAO1CpUZsUoL9GVpGZ0whyvFXIDqdlUnKcOdQMiDYB+HlKc6ahiH0OKkg==",
       "cpu": [
         "x64"
       ],
@@ -7360,12 +7375,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-arm64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-iatfzkhAlbQeLKxmFrhW6zyKIPo7IK5xgsa/6pL/GZb2x3zXGCPDa3LBt8DxNGUlnET20Itge1YEvj1iA9gOrA==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-4aHRCE1w77xQOn013E5/gkYkNQwNYvZfE8YR5cTeHimFZ5MB2kmoB0iLABaKXYbsMNPXixN5xeu8HdabrAuhag==",
       "cpu": [
         "arm64"
       ],
@@ -7374,12 +7392,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/native-preview-win32-x64": {
-      "version": "7.0.0-dev.20251222.1",
-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20251222.1.tgz",
-      "integrity": "sha512-9wRuExH/aJq0sWm20DVhg1Ciu3M8jgegOfjSGqweaREp1toMEmVkyhXp7xH1y69LMuXZFmzjy2kmHiUZgOE6lQ==",
+      "version": "7.0.0-dev.20260424.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260424.2.tgz",
+      "integrity": "sha512-mVQXT6/F8d51zKOBmaWdUcT0z3WZ6kAlv/tGLTixM6HKlc8lIqzVnTuTqv7ixKcle18M+r0dn951uL6Bhb3Fjg==",
       "cpu": [
         "x64"
       ],
@@ -7388,7 +7409,10 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -10494,6 +10518,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "@types/react-dom": "19.2.3",
     "@types/stats.js": "^0.17.4",
     "@types/uuid": "^9.0.8",
-    "@typescript/native-preview": "7.0.0-dev.20251222.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260424.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "baseline-browser-mapping": "^2.9.19",
     "eslint": "^9.39.1",

--- a/web/src/hooks/useVoiceRecorder.ts
+++ b/web/src/hooks/useVoiceRecorder.ts
@@ -426,7 +426,7 @@ class VoiceRecorderSession {
     return output;
   }
 
-  private float32ToInt16(float32: Float32Array): Int16Array {
+  private float32ToInt16(float32: Float32Array): Int16Array<ArrayBuffer> {
     const int16 = new Int16Array(float32.length);
     for (let i = 0; i < float32.length; i++) {
       const s = Math.max(-1, Math.min(1, float32[i]!));

--- a/web/tsconfig.types.json
+++ b/web/tsconfig.types.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "ES2017",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": ["./src/*"],
       "@tests/*": ["./tests/*"],


### PR DESCRIPTION
## Description

Typescript 7.0 which uses `tsgo` instead of `tsc` is in beta now, so figured I'd upgrade our version of `tsgo`.

Also updates the module resolution configuration to hopefully fix those,

```
  .next/types/validator.ts:215:39 - error TS2307: Cannot find module '../../src/app/admin/configuration/index-settings/page.js' or its corresponding type declarations.   
                                                                                                                                                                          
    215   const handler = {} as typeof import("../../src/app/admin/configuration/index-settings/page.js")                                                                 
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                  
                                                                                                                                                                          
                                                                                                                                                                          
    Found 1 error in .next/types/validator.ts:215   
```
errors

## How Has This Been Tested?

`prek run --all-files`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `@typescript/native-preview` (tsgo) to v7 dev preview and updated TypeScript config to fix Next.js `.next/types/validator.ts` import resolution errors. This unblocks the TS 7 toolchain and removes those failures.

- **Dependencies**
  - Bumped `@typescript/native-preview` to `^7.0.0-dev.20260424.2` and updated platform binaries.

- **Bug Fixes**
  - Set `moduleResolution: "bundler"` and `target: "ES2017"` in `tsconfig.types.json`.
  - Adjusted `useVoiceRecorder` return type for `float32ToInt16`.
  - Resolves `.next/types/validator.ts` "Cannot find module ...page.js" errors.

<sup>Written for commit 29ff67f86852a51a011be41e45b12f644bffc2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

