### PR TITLE
fix(security): enforce agent access on chat session creation

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -28,7 +28,9 @@ from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import Persona
 from onyx.db.models import SearchDoc as DbSearchDoc
+from onyx.db.models import User
 from onyx.db.models import UserFile
+from onyx.db.persona import user_can_access_persona
 from onyx.db.projects import check_project_ownership
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.file_store import get_default_file_store
@@ -111,29 +113,41 @@ def build_file_context(
 
 def create_chat_session_from_request(
     chat_session_request: ChatSessionCreationRequest,
-    user_id: UUID | None,
+    user: User | None,
     db_session: Session,
 ) -> ChatSession:
     """Create a chat session from a ChatSessionCreationRequest.
 
-    Includes project ownership validation when project_id is provided.
+    Includes project ownership and persona access validation.
 
     Args:
         chat_session_request: The request containing persona_id, description, and project_id
-        user_id: The ID of the user creating the session (can be None for anonymous)
+        user: The user creating the session (can be None for system-initiated sessions)
         db_session: The database session
 
     Returns:
         The newly created ChatSession
 
     Raises:
-        ValueError: If user lacks access to the specified project
+        ValueError: If user lacks access to the specified project or persona
         Exception: If the persona is invalid
     """
+    user_id = user.id if user is not None else None
+
     project_id = chat_session_request.project_id
     if project_id:
         if not check_project_ownership(project_id, user_id, db_session):
             raise ValueError("User does not have access to project")
+
+    persona_id = chat_session_request.persona_id
+    if persona_id != DEFAULT_PERSONA_ID and user is not None:
+        if not user_can_access_persona(
+            db_session=db_session,
+            persona_id=persona_id,
+            user=user,
+            get_editable=False,
+        ):
+            raise ValueError("User does not have access to persona")
 
     return create_chat_session(
         db_session=db_session,

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -113,7 +113,7 @@ def build_file_context(
 
 def create_chat_session_from_request(
     chat_session_request: ChatSessionCreationRequest,
-    user: User | None,
+    user: User,
     db_session: Session,
 ) -> ChatSession:
     """Create a chat session from a ChatSessionCreationRequest.
@@ -122,7 +122,10 @@ def create_chat_session_from_request(
 
     Args:
         chat_session_request: The request containing persona_id, description, and project_id
-        user: The user creating the session (can be None for system-initiated sessions)
+        user: The user creating the session. Anonymous users are represented as a
+            User with is_anonymous=True (never None); the access-check helpers
+            handle that case. A real User is required so the persona access check
+            always runs — do not introduce a None-tolerant caller.
         db_session: The database session
 
     Returns:
@@ -132,15 +135,13 @@ def create_chat_session_from_request(
         ValueError: If user lacks access to the specified project or persona
         Exception: If the persona is invalid
     """
-    user_id = user.id if user is not None else None
-
     project_id = chat_session_request.project_id
     if project_id:
-        if not check_project_ownership(project_id, user_id, db_session):
+        if not check_project_ownership(project_id, user.id, db_session):
             raise ValueError("User does not have access to project")
 
     persona_id = chat_session_request.persona_id
-    if persona_id != DEFAULT_PERSONA_ID and user is not None:
+    if persona_id != DEFAULT_PERSONA_ID:
         if not user_can_access_persona(
             db_session=db_session,
             persona_id=persona_id,
@@ -152,7 +153,7 @@ def create_chat_session_from_request(
     return create_chat_session(
         db_session=db_session,
         description=chat_session_request.description or "",
-        user_id=user_id,
+        user_id=user.id,
         persona_id=chat_session_request.persona_id,
         project_id=chat_session_request.project_id,
     )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -639,7 +639,7 @@ def build_chat_turn(
             raise RuntimeError("Must specify a chat session id or chat session info")
         chat_session = create_chat_session_from_request(
             chat_session_request=new_msg_req.chat_session_info,
-            user_id=user_id,
+            user=user,
             db_session=db_session,
         )
         yield CreateChatSessionID(chat_session_id=chat_session.id)

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -381,16 +381,14 @@ def create_new_chat_session(
     user: User = Depends(current_chat_accessible_user),
     db_session: Session = Depends(get_session),
 ) -> CreateChatSessionID:
-    user_id = user.id
-
     try:
         new_chat_session = create_chat_session_from_request(
             chat_session_request=chat_session_creation_request,
-            user_id=user_id,
+            user=user,
             db_session=db_session,
         )
     except ValueError as e:
-        # Project access denied
+        # Project or persona access denied
         raise HTTPException(status_code=403, detail=str(e))
     except Exception as e:
         logger.exception(e)

--- a/backend/tests/external_dependency_unit/answer/stream_test_utils.py
+++ b/backend/tests/external_dependency_unit/answer/stream_test_utils.py
@@ -67,7 +67,7 @@ def create_chat_session(
 ) -> ChatSession:
     return create_chat_session_from_request(
         chat_session_request=ChatSessionCreationRequest(),
-        user_id=user.id,
+        user=user,
         db_session=db_session,
     )
 

--- a/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
@@ -16,6 +16,11 @@ from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
 
+# The fix in `create_chat_session_from_request` runs unconditionally, including
+# on CE. Group-restricted personas only exist under EE, though — on CE every
+# non-admin sees public personas and admins see everything, so no CE user is
+# ever locked out by the access check. These tests therefore only exercise the
+# EE code path where a meaningful block can occur.
 pytestmark = pytest.mark.skipif(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Persona group restrictions are enterprise only",

--- a/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
@@ -1,0 +1,177 @@
+"""Integration tests for persona access enforcement on chat session creation.
+
+Covers the `/chat/create-chat-session` endpoint and the implicit session-creation
+path inside `/chat/send-chat-message` when `chat_session_info` is provided.
+"""
+
+import json
+import os
+
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Persona group restrictions are enterprise only",
+)
+
+
+@pytest.fixture()
+def admin_and_basic_user(
+    reset: None,  # noqa: ARG001
+) -> tuple[DATestUser, DATestUser]:
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+    return admin_user, basic_user
+
+
+def test_create_chat_session_with_unauthorized_persona_returns_403(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    restricted_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="restricted_group",
+        user_ids=[],  # basic_user is NOT in this group
+    )
+    restricted_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Restricted Persona",
+        description="Only accessible to restricted_group",
+        is_public=False,
+        groups=[restricted_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": restricted_persona.id, "description": "Attempted bypass"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 403
+    assert "persona" in response.json()["detail"].lower()
+
+
+def test_create_chat_session_with_authorized_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    allowed_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="allowed_group",
+        user_ids=[basic_user.id],
+    )
+    allowed_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Allowed Persona",
+        description="Accessible to basic_user",
+        is_public=False,
+        groups=[allowed_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": allowed_persona.id, "description": "Authorized"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+    assert "chat_session_id" in response.json()
+
+
+def test_create_chat_session_with_public_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    public_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Public Persona",
+        description="Visible to all",
+        is_public=True,
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": public_persona.id, "description": "Public access"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+
+
+def test_create_chat_session_with_default_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    _, basic_user = admin_and_basic_user
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": 0, "description": "Default persona"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+
+
+def test_send_chat_message_with_unauthorized_persona_in_session_info_is_blocked(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    """The same check must apply when a session is created implicitly via send-chat-message."""
+    admin_user, basic_user = admin_and_basic_user
+
+    restricted_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="restricted_group_send",
+        user_ids=[],
+    )
+    restricted_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Restricted Persona For Send",
+        description="Only accessible to restricted_group_send",
+        is_public=False,
+        groups=[restricted_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/send-chat-message",
+        json={
+            "message": "hello",
+            "chat_session_info": {
+                "persona_id": restricted_persona.id,
+                "description": "Attempted bypass via message send",
+            },
+            "stream": True,
+        },
+        headers=basic_user.headers,
+        stream=True,
+    )
+
+    # Streaming endpoint always returns 200 and emits an error packet inside the stream.
+    # The important property is that the unauthorized persona never produces a valid
+    # response — a packet containing an access-denied error is surfaced.
+    saw_access_error = False
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        err = payload.get("error")
+        if isinstance(err, str) and "persona" in err.lower():
+            saw_access_error = True
+            break
+
+    assert saw_access_error, (
+        "Expected an access-denied error in the stream when sending a message "
+        "with an unauthorized persona in chat_session_info."
+    )


### PR DESCRIPTION
## Description

Close an API-layer bypass where any authenticated user could create a chat session with a persona they had no access to (including personas restricted to other user groups). The access-check helper `user_can_access_persona` already existed but was never called in the session-creation path — persona group restrictions were effectively UI-only.

Affected entrypoints (both now gated):
- `POST /chat/create-chat-session`
- `POST /chat/send-chat-message` when `chat_session_info` is supplied (creates a session implicitly)

`create_chat_session_from_request` now calls `user_can_access_persona(..., get_editable=False)` for any non-default `persona_id`. Unauthorized requests raise `ValueError`, which the `/create-chat-session` endpoint converts to a 403. Default persona (`persona_id=0`) remains accessible to all users.

Signature change: `create_chat_session_from_request` now takes `user: User | None` instead of `user_id: UUID | None` so the access check can run — callers updated.

Note: document-set-filter bypass (finding 2 from the same analysis) is addressed in a follow-up PR.

## How Has This Been Tested?

- Pre-commit (`black`, `ruff`, `ty`) passes.
- New integration tests in `backend/tests/integration/tests/chat/test_chat_session_persona_access.py`:
  - `test_create_chat_session_with_unauthorized_persona_returns_403` — direct endpoint bypass blocked.
  - `test_create_chat_session_with_authorized_persona_succeeds` — group-member access still works.
  - `test_create_chat_session_with_public_persona_succeeds` — public personas still accessible.
  - `test_create_chat_session_with_default_persona_succeeds` — default persona unaffected.
  - `test_send_chat_message_with_unauthorized_persona_in_session_info_is_blocked` — covers the implicit-creation path through `/send-chat-message`.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces persona access on chat session creation to close an API bypass that allowed using restricted personas. Applies to `POST /chat/create-chat-session` and implicit creation via `POST /chat/send-chat-message`; unauthorized requests now return 403, default persona remains accessible.

- **Bug Fixes**
  - Call `user_can_access_persona(..., get_editable=False)` in `create_chat_session_from_request` for any non-default `persona_id`.
  - Map access failures to 403 in `/chat/create-chat-session`; stream path surfaces an error in `/send-chat-message`.
  - Added integration tests covering unauthorized, authorized, public, and default personas, plus the implicit creation path.

- **Migration**
  - `create_chat_session_from_request` now takes `user: User` (non-optional) instead of `user_id: UUID | None`; anonymous users should be passed as `User(is_anonymous=True)`. Update callers accordingly.

<sup>Written for commit e2a87f8bec27f60e5f16571e9e6a80c32a1432f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

