### PR TITLE
fix(security): enforce document set access in search filters

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -69,6 +69,7 @@ from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_or_create_root_message
 from onyx.db.chat import reserve_message_id
 from onyx.db.chat import reserve_multi_model_message_ids
+from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.enums import HookPoint
 from onyx.db.memory import get_memories
 from onyx.db.models import ChatMessage
@@ -1431,6 +1432,31 @@ def _stream_chat_turn(
     setup: ChatTurnSetup | None = None
 
     try:
+        # Enforce document-set access on any user-supplied filters before setup
+        # or any tool invocation. Running here (rather than inside SearchTool.run())
+        # means the OnyxError propagates to the StreamingError handler below
+        # instead of being swallowed by the tool runner's catch-all.
+        if (
+            not bypass_acl
+            and new_msg_req.internal_search_filters is not None
+            and new_msg_req.internal_search_filters.document_set is not None
+        ):
+            accessible_names = filter_document_set_names_by_user_access(
+                db_session=db_session,
+                document_set_names=new_msg_req.internal_search_filters.document_set,
+                user=user,
+            )
+            unauthorized = sorted(
+                name
+                for name in new_msg_req.internal_search_filters.document_set
+                if name not in accessible_names
+            )
+            if unauthorized:
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    f"User does not have access to document sets: {unauthorized}",
+                )
+
         setup = yield from build_chat_turn(
             new_msg_req=new_msg_req,
             user=user,

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -15,6 +15,7 @@ from onyx.context.search.preprocessing.access_filters import (
 )
 from onyx.context.search.retrieval.search_runner import search_chunks
 from onyx.context.search.utils import inference_section_from_chunks
+from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.models import User
 from onyx.document_index.interfaces import DocumentIndex
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
@@ -57,6 +58,29 @@ def _build_index_filters(
         raise RuntimeError("LLM and query are required for auto detect filters")
 
     base_filters = user_provided_filters or BaseFilters()
+
+    # When the caller supplies document set names, enforce that the user has view
+    # access to each one. This closes the API-layer bypass where a user could
+    # override the persona's configured document sets with arbitrary names.
+    # Skipped when bypass_acl is set (system callers) or when no db_session is
+    # available for the lookup.
+    if (
+        base_filters.document_set is not None
+        and not bypass_acl
+        and db_session is not None
+    ):
+        accessible_names = filter_document_set_names_by_user_access(
+            db_session=db_session,
+            document_set_names=base_filters.document_set,
+            user=user,
+        )
+        unauthorized = sorted(
+            name for name in base_filters.document_set if name not in accessible_names
+        )
+        if unauthorized:
+            raise ValueError(
+                f"User does not have access to document sets: {unauthorized}"
+            )
 
     document_set_filter = (
         base_filters.document_set

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -18,6 +18,8 @@ from onyx.context.search.utils import inference_section_from_chunks
 from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.models import User
 from onyx.document_index.interfaces import DocumentIndex
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
 from onyx.llm.interfaces import LLM
 from onyx.natural_language_processing.english_stopwords import strip_stopwords
@@ -78,8 +80,9 @@ def _build_index_filters(
             name for name in base_filters.document_set if name not in accessible_names
         )
         if unauthorized:
-            raise ValueError(
-                f"User does not have access to document sets: {unauthorized}"
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                f"User does not have access to document sets: {unauthorized}",
             )
 
     document_set_filter = (

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -160,6 +160,24 @@ def get_document_sets_by_name(
     ).all()
 
 
+def filter_document_set_names_by_user_access(
+    db_session: Session,
+    document_set_names: list[str],
+    user: User,
+) -> set[str]:
+    """Return the subset of ``document_set_names`` the user has view access to.
+
+    Names that don't match an existing document set are omitted from the result.
+    """
+    if not document_set_names:
+        return set()
+    stmt = select(DocumentSetDBModel.name).where(
+        DocumentSetDBModel.name.in_(document_set_names)
+    )
+    stmt = _add_user_filters(stmt, user, get_editable=False)
+    return set(db_session.scalars(stmt).all())
+
+
 def get_document_sets_by_ids(
     db_session: Session, document_set_ids: list[int]
 ) -> Sequence[DocumentSetDBModel]:

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -73,6 +73,8 @@ from onyx.db.models import User
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.slack_bot import fetch_slack_bots
 from onyx.document_index.interfaces import DocumentIndex
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
 from onyx.federated_connectors.federated_retrieval import (
     get_federated_retrieval_functions,
@@ -570,8 +572,9 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                     if name not in accessible_names
                 )
                 if unauthorized:
-                    raise ValueError(
-                        f"User does not have access to document sets: {unauthorized}"
+                    raise OnyxError(
+                        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        f"User does not have access to document sets: {unauthorized}",
                     )
 
             # ACL filters

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -62,6 +62,7 @@ from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.context.search.utils import populate_file_ids_on_sections
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
+from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
     get_federated_connector_document_set_mappings_by_document_set_names,
@@ -546,6 +547,33 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         # Pre-fetch all DB data in a single short-lived session so that
         # parallel search workers need zero DB connections.
         with get_session_with_current_tenant() as db_session:
+            # Enforce document-set access before any search runs. _build_index_filters
+            # has a matching guard, but it is only reached when a db_session is passed
+            # through — this path closes the session before calling search_pipeline,
+            # so the check has to happen here (see PR discussion on #10602).
+            # Skipped for project-mode searches (user_selected_filters are dropped
+            # downstream) and for bypass_acl system callers.
+            if (
+                not self.bypass_acl
+                and self.project_id_filter is None
+                and self.user_selected_filters is not None
+                and self.user_selected_filters.document_set is not None
+            ):
+                accessible_names = filter_document_set_names_by_user_access(
+                    db_session=db_session,
+                    document_set_names=self.user_selected_filters.document_set,
+                    user=self.user,
+                )
+                unauthorized = sorted(
+                    name
+                    for name in self.user_selected_filters.document_set
+                    if name not in accessible_names
+                )
+                if unauthorized:
+                    raise ValueError(
+                        f"User does not have access to document sets: {unauthorized}"
+                    )
+
             # ACL filters
             acl_filters: list[str] | None = (
                 None

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -62,7 +62,6 @@ from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.context.search.utils import populate_file_ids_on_sections
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
-from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
     get_federated_connector_document_set_mappings_by_document_set_names,
@@ -73,8 +72,6 @@ from onyx.db.models import User
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.slack_bot import fetch_slack_bots
 from onyx.document_index.interfaces import DocumentIndex
-from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
 from onyx.federated_connectors.federated_retrieval import (
     get_federated_retrieval_functions,
@@ -549,34 +546,6 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         # Pre-fetch all DB data in a single short-lived session so that
         # parallel search workers need zero DB connections.
         with get_session_with_current_tenant() as db_session:
-            # Enforce document-set access before any search runs. _build_index_filters
-            # has a matching guard, but it is only reached when a db_session is passed
-            # through — this path closes the session before calling search_pipeline,
-            # so the check has to happen here (see PR discussion on #10602).
-            # Skipped for project-mode searches (user_selected_filters are dropped
-            # downstream) and for bypass_acl system callers.
-            if (
-                not self.bypass_acl
-                and self.project_id_filter is None
-                and self.user_selected_filters is not None
-                and self.user_selected_filters.document_set is not None
-            ):
-                accessible_names = filter_document_set_names_by_user_access(
-                    db_session=db_session,
-                    document_set_names=self.user_selected_filters.document_set,
-                    user=self.user,
-                )
-                unauthorized = sorted(
-                    name
-                    for name in self.user_selected_filters.document_set
-                    if name not in accessible_names
-                )
-                if unauthorized:
-                    raise OnyxError(
-                        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                        f"User does not have access to document sets: {unauthorized}",
-                    )
-
             # ACL filters
             acl_filters: list[str] | None = (
                 None

--- a/backend/tests/integration/tests/chat/test_chat_document_set_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_document_set_access.py
@@ -1,0 +1,177 @@
+"""Integration tests for document set access enforcement in search filters.
+
+Covers the bypass where a user could override a persona's configured document
+sets by supplying `internal_search_filters.document_set` on a chat message.
+"""
+
+import json
+import os
+from uuid import UUID
+
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.chat import ChatSessionManager
+from tests.integration.common_utils.managers.document_set import DocumentSetManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Document set group restrictions are enterprise only",
+)
+
+
+def _send_message_with_document_set_filter(
+    user: DATestUser,
+    chat_session_id: UUID,
+    document_set_names: list[str],
+) -> requests.Response:
+    return requests.post(
+        f"{API_SERVER_URL}/chat/send-chat-message",
+        json={
+            "message": "hello",
+            "chat_session_id": str(chat_session_id),
+            "stream": True,
+            "internal_search_filters": {"document_set": document_set_names},
+        },
+        headers=user.headers,
+        stream=True,
+        cookies=user.cookies,
+    )
+
+
+def _stream_contains_error(response: requests.Response, needle: str) -> bool:
+    needle_lower = needle.lower()
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        err = payload.get("error")
+        if isinstance(err, str) and needle_lower in err.lower():
+            return True
+    return False
+
+
+def test_document_set_filter_blocks_unauthorized_names(
+    reset: None,  # noqa: ARG001
+) -> None:
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+
+    restricted_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="restricted_doc_set_group",
+        user_ids=[],  # basic_user is NOT in this group
+    )
+    restricted_doc_set = DocumentSetManager.create(
+        user_performing_action=admin_user,
+        name="restricted_doc_set",
+        is_public=False,
+        groups=[restricted_group.id],
+    )
+
+    chat_session = ChatSessionManager.create(
+        user_performing_action=basic_user,
+        persona_id=0,
+    )
+
+    response = _send_message_with_document_set_filter(
+        user=basic_user,
+        chat_session_id=chat_session.id,
+        document_set_names=[restricted_doc_set.name],
+    )
+
+    assert _stream_contains_error(response, "document set"), (
+        "Expected an access-denied error in the stream when filtering with an "
+        "unauthorized document set name."
+    )
+
+
+def test_document_set_filter_allows_authorized_names(
+    reset: None,  # noqa: ARG001
+) -> None:
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+
+    allowed_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="allowed_doc_set_group",
+        user_ids=[basic_user.id],
+    )
+    allowed_doc_set = DocumentSetManager.create(
+        user_performing_action=admin_user,
+        name="allowed_doc_set",
+        is_public=False,
+        groups=[allowed_group.id],
+    )
+
+    chat_session = ChatSessionManager.create(
+        user_performing_action=basic_user,
+        persona_id=0,
+    )
+
+    response = _send_message_with_document_set_filter(
+        user=basic_user,
+        chat_session_id=chat_session.id,
+        document_set_names=[allowed_doc_set.name],
+    )
+
+    # No access-denied error should surface for an authorized document set.
+    assert not _stream_contains_error(
+        response, "document set"
+    ), "Did not expect an access-denied error for an authorized document set."
+
+
+def test_public_document_set_is_accessible_to_any_user(
+    reset: None,  # noqa: ARG001
+) -> None:
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+
+    public_doc_set = DocumentSetManager.create(
+        user_performing_action=admin_user,
+        name="public_doc_set",
+        is_public=True,
+    )
+
+    chat_session = ChatSessionManager.create(
+        user_performing_action=basic_user,
+        persona_id=0,
+    )
+
+    response = _send_message_with_document_set_filter(
+        user=basic_user,
+        chat_session_id=chat_session.id,
+        document_set_names=[public_doc_set.name],
+    )
+
+    assert not _stream_contains_error(response, "document set")
+
+
+def test_nonexistent_document_set_name_is_blocked(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Names that don't correspond to any existing document set are treated as
+    inaccessible — callers shouldn't be able to probe for existence by getting
+    silent acceptance."""
+    UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+
+    chat_session = ChatSessionManager.create(
+        user_performing_action=basic_user,
+        persona_id=0,
+    )
+
+    response = _send_message_with_document_set_filter(
+        user=basic_user,
+        chat_session_id=chat_session.id,
+        document_set_names=["this_document_set_does_not_exist"],
+    )
+
+    assert _stream_contains_error(response, "document set")

--- a/backend/tests/integration/tests/chat/test_chat_document_set_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_document_set_access.py
@@ -2,6 +2,11 @@
 
 Covers the bypass where a user could override a persona's configured document
 sets by supplying `internal_search_filters.document_set` on a chat message.
+
+The SearchTool is only invoked when the LLM decides to call it, so these tests
+force the call with `forced_tool_id` + `mock_llm_response` to make coverage
+deterministic. They also need a seeded connector because DocumentSetManager
+rejects creation with no connectors.
 """
 
 import json
@@ -11,9 +16,15 @@ from uuid import UUID
 import pytest
 import requests
 
+from onyx.configs.constants import DocumentSource
+from onyx.tools.constants import SEARCH_TOOL_ID
 from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.tool import ToolManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestUser
@@ -23,11 +34,39 @@ pytestmark = pytest.mark.skipif(
     reason="Document set group restrictions are enterprise only",
 )
 
+_MOCK_SEARCH_TOOL_CALL = (
+    '{"name":"internal_search","arguments":{"queries":["test query"]}}'
+)
+
+
+def _get_internal_search_tool_id(admin_user: DATestUser) -> int:
+    tools = ToolManager.list_tools(user_performing_action=admin_user)
+    for tool in tools:
+        if tool.in_code_tool_id == SEARCH_TOOL_ID:
+            return tool.id
+    raise AssertionError("SearchTool must exist for this test")
+
+
+def _setup_search_infrastructure() -> tuple[DATestUser, DATestUser, int, int]:
+    """Admin + basic user, a seeded connector, an LLM provider, and the
+    SearchTool id. Required because DocumentSetManager rejects empty connector
+    fields and SearchTool is only exposed when at least one connector exists."""
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+    LLMProviderManager.create(user_performing_action=admin_user)
+    cc_pair = CCPairManager.create_from_scratch(
+        source=DocumentSource.INGESTION_API,
+        user_performing_action=admin_user,
+    )
+    search_tool_id = _get_internal_search_tool_id(admin_user)
+    return admin_user, basic_user, cc_pair.id, search_tool_id
+
 
 def _send_message_with_document_set_filter(
     user: DATestUser,
     chat_session_id: UUID,
     document_set_names: list[str],
+    forced_tool_id: int,
 ) -> requests.Response:
     return requests.post(
         f"{API_SERVER_URL}/chat/send-chat-message",
@@ -36,6 +75,8 @@ def _send_message_with_document_set_filter(
             "chat_session_id": str(chat_session_id),
             "stream": True,
             "internal_search_filters": {"document_set": document_set_names},
+            "forced_tool_id": forced_tool_id,
+            "mock_llm_response": _MOCK_SEARCH_TOOL_CALL,
         },
         headers=user.headers,
         stream=True,
@@ -58,11 +99,27 @@ def _stream_contains_error(response: requests.Response, needle: str) -> bool:
     return False
 
 
+def _create_search_persona_chat_session(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+    search_tool_id: int,
+) -> UUID:
+    persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="search_persona",
+        tool_ids=[search_tool_id],
+    )
+    chat_session = ChatSessionManager.create(
+        user_performing_action=basic_user,
+        persona_id=persona.id,
+    )
+    return chat_session.id
+
+
 def test_document_set_filter_blocks_unauthorized_names(
     reset: None,  # noqa: ARG001
 ) -> None:
-    admin_user = UserManager.create(name="admin_user")
-    basic_user = UserManager.create(name="basic_user")
+    admin_user, basic_user, cc_pair_id, search_tool_id = _setup_search_infrastructure()
 
     restricted_group = UserGroupManager.create(
         user_performing_action=admin_user,
@@ -74,17 +131,18 @@ def test_document_set_filter_blocks_unauthorized_names(
         name="restricted_doc_set",
         is_public=False,
         groups=[restricted_group.id],
+        cc_pair_ids=[cc_pair_id],
     )
 
-    chat_session = ChatSessionManager.create(
-        user_performing_action=basic_user,
-        persona_id=0,
+    chat_session_id = _create_search_persona_chat_session(
+        admin_user, basic_user, search_tool_id
     )
 
     response = _send_message_with_document_set_filter(
         user=basic_user,
-        chat_session_id=chat_session.id,
+        chat_session_id=chat_session_id,
         document_set_names=[restricted_doc_set.name],
+        forced_tool_id=search_tool_id,
     )
 
     assert _stream_contains_error(response, "document set"), (
@@ -96,8 +154,7 @@ def test_document_set_filter_blocks_unauthorized_names(
 def test_document_set_filter_allows_authorized_names(
     reset: None,  # noqa: ARG001
 ) -> None:
-    admin_user = UserManager.create(name="admin_user")
-    basic_user = UserManager.create(name="basic_user")
+    admin_user, basic_user, cc_pair_id, search_tool_id = _setup_search_infrastructure()
 
     allowed_group = UserGroupManager.create(
         user_performing_action=admin_user,
@@ -109,20 +166,20 @@ def test_document_set_filter_allows_authorized_names(
         name="allowed_doc_set",
         is_public=False,
         groups=[allowed_group.id],
+        cc_pair_ids=[cc_pair_id],
     )
 
-    chat_session = ChatSessionManager.create(
-        user_performing_action=basic_user,
-        persona_id=0,
+    chat_session_id = _create_search_persona_chat_session(
+        admin_user, basic_user, search_tool_id
     )
 
     response = _send_message_with_document_set_filter(
         user=basic_user,
-        chat_session_id=chat_session.id,
+        chat_session_id=chat_session_id,
         document_set_names=[allowed_doc_set.name],
+        forced_tool_id=search_tool_id,
     )
 
-    # No access-denied error should surface for an authorized document set.
     assert not _stream_contains_error(
         response, "document set"
     ), "Did not expect an access-denied error for an authorized document set."
@@ -131,24 +188,24 @@ def test_document_set_filter_allows_authorized_names(
 def test_public_document_set_is_accessible_to_any_user(
     reset: None,  # noqa: ARG001
 ) -> None:
-    admin_user = UserManager.create(name="admin_user")
-    basic_user = UserManager.create(name="basic_user")
+    admin_user, basic_user, cc_pair_id, search_tool_id = _setup_search_infrastructure()
 
     public_doc_set = DocumentSetManager.create(
         user_performing_action=admin_user,
         name="public_doc_set",
         is_public=True,
+        cc_pair_ids=[cc_pair_id],
     )
 
-    chat_session = ChatSessionManager.create(
-        user_performing_action=basic_user,
-        persona_id=0,
+    chat_session_id = _create_search_persona_chat_session(
+        admin_user, basic_user, search_tool_id
     )
 
     response = _send_message_with_document_set_filter(
         user=basic_user,
-        chat_session_id=chat_session.id,
+        chat_session_id=chat_session_id,
         document_set_names=[public_doc_set.name],
+        forced_tool_id=search_tool_id,
     )
 
     assert not _stream_contains_error(response, "document set")
@@ -160,18 +217,17 @@ def test_nonexistent_document_set_name_is_blocked(
     """Names that don't correspond to any existing document set are treated as
     inaccessible — callers shouldn't be able to probe for existence by getting
     silent acceptance."""
-    UserManager.create(name="admin_user")
-    basic_user = UserManager.create(name="basic_user")
+    admin_user, basic_user, _, search_tool_id = _setup_search_infrastructure()
 
-    chat_session = ChatSessionManager.create(
-        user_performing_action=basic_user,
-        persona_id=0,
+    chat_session_id = _create_search_persona_chat_session(
+        admin_user, basic_user, search_tool_id
     )
 
     response = _send_message_with_document_set_filter(
         user=basic_user,
-        chat_session_id=chat_session.id,
+        chat_session_id=chat_session_id,
         document_set_names=["this_document_set_does_not_exist"],
+        forced_tool_id=search_tool_id,
     )
 
     assert _stream_contains_error(response, "document set")


### PR DESCRIPTION
## Description

Close an API-layer bypass where a user sending a chat message could override the persona's configured document sets by supplying arbitrary names in `internal_search_filters.document_set`. The Vespa ACL still gated individual documents, but PUBLIC documents that were meant to be scoped to a specific document set were reachable outside of it — leaking the persona's scoping.

In `_build_index_filters` (`backend/onyx/context/search/pipeline.py`), when the caller supplies `document_set` names, reject with `ValueError` for any names the user does not have view access to. The check is skipped when `bypass_acl=True` (system callers) or when no `db_session` is available for the lookup. A new helper `filter_document_set_names_by_user_access` in `backend/onyx/db/document_set.py` reuses the existing `_add_user_filters` logic with `get_editable=False`.

Names that don't map to any existing document set are treated as inaccessible, so callers can't probe for existence by watching for silent acceptance.

UX note: on the streaming chat endpoint the `ValueError` currently surfaces as an error payload inside the SSE stream (HTTP 200 with `{"error": "..."}`) rather than a 403, because that's how the existing error path is wired. The bypass is blocked either way; converting this to a clean 403 is a small separate follow-up.

Companion to #10601 (persona access enforcement on chat session creation) — together these close both API-layer bypasses from the `087002f` ACL analysis.

## How Has This Been Tested?

- Pre-commit (`black`, `ruff`, `ty`) passes.
- New integration tests in `backend/tests/integration/tests/chat/test_chat_document_set_access.py`:
  - `test_document_set_filter_blocks_unauthorized_names` — unauthorized name rejected.
  - `test_document_set_filter_allows_authorized_names` — group-member access still works.
  - `test_public_document_set_is_accessible_to_any_user` — public sets still accessible.
  - `test_nonexistent_document_set_name_is_blocked` — unknown names don't leak via silent acceptance.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces document set access in search filters so users can’t override a persona’s document sets via `internal_search_filters.document_set`. The check now runs earlier in chat streaming so denials return clear permission errors and public docs outside the sets are blocked.

- **Bug Fixes**
  - Enforce `document_set` access in `_stream_chat_turn` before tool execution; keep a matching check in `_build_index_filters` for other callers; skip for `bypass_acl`.
  - Raise `OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS)` on denials; 403 on non-streaming APIs and an error packet in SSE streams.
  - Add `filter_document_set_names_by_user_access`; unknown names are treated as inaccessible.
  - Update integration tests: seed a connector and force `internal_search` invocation; cover unauthorized, authorized, public, and nonexistent names.

<sup>Written for commit 87a13680947279447f04bca28c92367016034a2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

