### PR TITLE
fix(storybook): add global `TooltipProvider` decorator to Storybook for `Opal`

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -36,6 +36,13 @@ const config: StorybookConfig = {
     config.css = config.css ?? {};
     config.css.postcss = path.resolve(__dirname, "..");
 
+    // Provide `process.env` for modules that reference it at the top level
+    // (e.g. src/lib/constants.ts). Vite doesn't polyfill Node globals.
+    config.define = {
+      ...config.define,
+      "process.env": JSON.stringify({}),
+    };
+
     return config;
   },
 };

--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from "@storybook/react";
 import { withThemeByClassName } from "@storybook/addon-themes";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import React from "react";
 import "../src/app/globals.css";
 
 const preview: Preview = {
@@ -21,6 +23,12 @@ const preview: Preview = {
       },
       defaultTheme: "light",
     }),
+    (Story) =>
+      React.createElement(
+        TooltipPrimitive.Provider,
+        null,
+        React.createElement(Story)
+      ),
   ],
 };
 

--- a/web/lib/opal/src/components/buttons/button/Button.stories.tsx
+++ b/web/lib/opal/src/components/buttons/button/Button.stories.tsx
@@ -2,19 +2,11 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@opal/components";
 import { SvgPlus, SvgArrowRight, SvgSettings } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta: Meta<typeof Button> = {
   title: "opal/components/Button",
   component: Button,
   tags: ["autodocs"],
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 };
 
 export default meta;

--- a/web/lib/opal/src/components/buttons/filter-button/FilterButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/filter-button/FilterButton.stories.tsx
@@ -2,19 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { FilterButton } from "@opal/components";
 import { Disabled as DisabledProvider } from "@opal/core";
 import { SvgUser, SvgActions, SvgTag } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta: Meta<typeof FilterButton> = {
   title: "opal/components/FilterButton",
   component: FilterButton,
   tags: ["autodocs"],
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 };
 
 export default meta;

--- a/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
@@ -1,19 +1,11 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { LinkButton } from "@opal/components";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta: Meta<typeof LinkButton> = {
   title: "opal/components/LinkButton",
   component: LinkButton,
   tags: ["autodocs"],
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 };
 
 export default meta;

--- a/web/lib/opal/src/components/buttons/open-button/OpenButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/open-button/OpenButton.stories.tsx
@@ -2,19 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { OpenButton } from "@opal/components";
 import { Disabled as DisabledProvider } from "@opal/core";
 import { SvgSettings } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta: Meta<typeof OpenButton> = {
   title: "opal/components/OpenButton",
   component: OpenButton,
   tags: ["autodocs"],
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 };
 
 export default meta;

--- a/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.stories.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/SidebarTab.stories.tsx
@@ -8,7 +8,6 @@ import {
   SvgTrash,
 } from "@opal/icons";
 import { Button } from "@opal/components";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta: Meta<typeof SidebarTab> = {
   title: "opal/components/SidebarTab",
@@ -16,11 +15,9 @@ const meta: Meta<typeof SidebarTab> = {
   tags: ["autodocs"],
   decorators: [
     (Story) => (
-      <TooltipPrimitive.Provider>
-        <div style={{ width: 260, background: "var(--background-neutral-01)" }}>
-          <Story />
-        </div>
-      </TooltipPrimitive.Provider>
+      <div style={{ width: 260, background: "var(--background-neutral-01)" }}>
+        <Story />
+      </div>
     ),
   ],
 };

--- a/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
+++ b/web/lib/opal/src/components/cards/select-card/SelectCard.stories.tsx
@@ -11,14 +11,6 @@ import {
   SvgUnplug,
 } from "@opal/icons";
 import { Interactive } from "@opal/core";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import type { Decorator } from "@storybook/react";
-
-const withTooltipProvider: Decorator = (Story) => (
-  <TooltipPrimitive.Provider>
-    <Story />
-  </TooltipPrimitive.Provider>
-);
 
 const STATES = ["empty", "filled", "selected"] as const;
 const PADDING_VARIANTS = ["fit", "2xs", "xs", "sm", "md", "lg"] as const;
@@ -28,7 +20,7 @@ const meta = {
   title: "opal/components/SelectCard",
   component: SelectCard,
   tags: ["autodocs"],
-  decorators: [withTooltipProvider],
+
   parameters: {
     layout: "centered",
   },

--- a/web/lib/opal/src/components/checkbox/Checkbox.stories.tsx
+++ b/web/lib/opal/src/components/checkbox/Checkbox.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Checkbox, Text } from "@opal/components";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta = {
   title: "Components/Checkbox",
@@ -9,13 +8,6 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 } satisfies Meta<typeof Checkbox>;
 
 export default meta;

--- a/web/lib/opal/src/components/tooltip/Tooltip.stories.tsx
+++ b/web/lib/opal/src/components/tooltip/Tooltip.stories.tsx
@@ -1,19 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import type { Decorator } from "@storybook/react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { Tooltip, Button, Card } from "@opal/components";
-
-const withTooltipProvider: Decorator = (Story) => (
-  <TooltipPrimitive.Provider>
-    <Story />
-  </TooltipPrimitive.Provider>
-);
 
 const meta: Meta<typeof Tooltip> = {
   title: "opal/components/Tooltip",
   component: Tooltip,
   tags: ["autodocs"],
-  decorators: [withTooltipProvider],
 };
 
 export default meta;

--- a/web/lib/opal/src/core/disabled/Disabled.stories.tsx
+++ b/web/lib/opal/src/core/disabled/Disabled.stories.tsx
@@ -1,20 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import type { Decorator } from "@storybook/react";
 import { Disabled } from "@opal/core";
 import { Card, Button } from "@opal/components";
-
-const withTooltipProvider: Decorator = (Story) => (
-  <TooltipPrimitive.Provider>
-    <Story />
-  </TooltipPrimitive.Provider>
-);
 
 const meta: Meta<typeof Disabled> = {
   title: "opal/core/Disabled",
   component: Disabled,
   tags: ["autodocs"],
-  decorators: [withTooltipProvider],
 };
 
 export default meta;

--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -8,20 +8,12 @@ import {
   SvgSettings,
   SvgUnplug,
 } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import type { Decorator } from "@storybook/react";
-
-const withTooltipProvider: Decorator = (Story) => (
-  <TooltipPrimitive.Provider>
-    <Story />
-  </TooltipPrimitive.Provider>
-);
 
 const meta = {
   title: "Layouts/Card.Header",
   component: Card.Header,
   tags: ["autodocs"],
-  decorators: [withTooltipProvider],
+
   parameters: {
     layout: "centered",
   },

--- a/web/lib/opal/src/layouts/content-action/ContentAction.stories.tsx
+++ b/web/lib/opal/src/layouts/content-action/ContentAction.stories.tsx
@@ -2,20 +2,12 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
 import { SvgSettings } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import type { Decorator } from "@storybook/react";
-
-const withTooltipProvider: Decorator = (Story) => (
-  <TooltipPrimitive.Provider>
-    <Story />
-  </TooltipPrimitive.Provider>
-);
 
 const meta = {
   title: "Layouts/ContentAction",
   component: ContentAction,
   tags: ["autodocs"],
-  decorators: [withTooltipProvider],
+
   parameters: {
     layout: "centered",
   },

--- a/web/lib/opal/src/layouts/content/Content.stories.tsx
+++ b/web/lib/opal/src/layouts/content/Content.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Content } from "@opal/layouts";
 import { SvgSettings, SvgStar, SvgRefreshCw } from "@opal/icons";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
 const meta = {
   title: "Layouts/Content",
@@ -10,13 +9,6 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  decorators: [
-    (Story) => (
-      <TooltipPrimitive.Provider>
-        <Story />
-      </TooltipPrimitive.Provider>
-    ),
-  ],
 } satisfies Meta<typeof Content>;
 
 export default meta;


### PR DESCRIPTION
## Description

Adds `TooltipPrimitive.Provider` as a global Storybook decorator in `.storybook/preview.ts` so all stories automatically have tooltip context. Removes the per-story `TooltipProvider` decorators from all 12 opal story files that were duplicating it.

Previously, any story using a component with a tooltip (Button, SidebarTab, etc.) would crash with `"Tooltip must be used within TooltipProvider"` unless it manually added the decorator.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global `TooltipPrimitive.Provider` from `@radix-ui/react-tooltip` in `.storybook/preview.ts` so all Opal stories have tooltip context; removed per-story providers from 12 stories (kept layout wrappers like SidebarTab’s container).
Also define `process.env` in `.storybook/main.ts` to stop Vite/Storybook crashes when modules read env.

<sup>Written for commit 9fe38a4a59e1022211edbc2b7746ba50c6f552fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

