### PR TITLE
chore(docker): install `torch` into dedicated layer

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -9,6 +9,13 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 RUN mkdir -p /app/.cache/huggingface
 
 COPY ./requirements/model_server.txt /tmp/requirements.txt
+
+# Install torch + CUDA/GPU deps in a dedicated layer: together they are ~3GB,
+# and isolating them avoids a single oversized layer that is unreliable to push.
+RUN grep -E '^(torch|nvidia-[a-z0-9-]+|triton)==' /tmp/requirements.txt \
+        | uv pip install --system --no-cache-dir -r /dev/stdin && \
+    rm -rf ~/.cache/uv
+
 RUN uv pip install --system --no-cache-dir --upgrade \
         -r /tmp/requirements.txt && \
     rm -rf ~/.cache/uv /tmp/*.txt

--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -16,7 +16,7 @@ RUN grep -E '^(torch|nvidia-[a-z0-9-]+|triton)==' /tmp/requirements.txt \
         | uv pip install --system --no-cache-dir -r /dev/stdin && \
     rm -rf ~/.cache/uv
 
-RUN uv pip install --system --no-cache-dir --upgrade \
+RUN uv pip install --system --no-cache-dir \
         -r /tmp/requirements.txt && \
     rm -rf ~/.cache/uv /tmp/*.txt
 


### PR DESCRIPTION
## Description

Hopefully avoids 400s from Dockerhub when uploading model_server images,

```
 #32 ERROR: failed to push ***/onyx-model-server: unexpected status from PUT request to https://registry-1.docker.io/v2/***/onyx-model-server/blobs/uploads/...: 400 Bad request: <html><body><h1>400 Bad request</h1>
Your browser sent an invalid request.
</body></html>
```

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/24910457593

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `torch`, `nvidia-*`, and `triton` from `requirements.txt` in a dedicated Docker layer in `backend/Dockerfile.model_server`. This isolates ~3GB of GPU deps to reduce Docker Hub 400s on push and improve layer cache reuse.

<sup>Written for commit b164642000e9d606efeb97aee741c1bf0dc90203. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

