### PR TITLE
fix: sharepoint members recursion (#10505) to release v3.0

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -7,11 +7,13 @@ from typing import Any
 from urllib.parse import urlparse
 
 import requests as _requests
+from office365.directory.object_collection import DirectoryObjectCollection  # type: ignore[import-untyped]
 from office365.graph_client import GraphClient  # type: ignore[import-untyped]
 from office365.onedrive.driveitems.driveItem import DriveItem  # type: ignore[import-untyped]
 from office365.runtime.client_request import ClientRequestException  # type: ignore
 from office365.sharepoint.client_context import ClientContext  # type: ignore[import-untyped]
 from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection  # type: ignore[import-untyped]
+from office365.sharepoint.principal.users.collection import UserCollection  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
 from ee.onyx.db.external_perm import ExternalUserGroup
@@ -301,10 +303,14 @@ def _get_sharepoint_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_users(users: list[Any]) -> None:
+    def process_users(users: UserCollection) -> None:
         nonlocal groups, user_emails
 
-        for user in users:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `users` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for user in users.current_page:
             logger.debug(f"User: {user.to_json()}")
             if user.principal_type == USER_PRINCIPAL_TYPE and hasattr(
                 user, "user_principal_name"
@@ -355,10 +361,14 @@ def _get_azuread_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_members(members: list[Any]) -> None:
+    def process_members(members: DirectoryObjectCollection) -> None:
         nonlocal groups, user_emails
 
-        for member in members:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `members` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for member in members.current_page:
             member_data = member.to_json()
             logger.debug(f"Member: {member_data}")
             # Check for user-specific attributes
@@ -519,7 +529,11 @@ def get_external_access_from_sharepoint(
         role_assignments: RoleAssignmentCollection,
     ) -> None:
         nonlocal user_emails, groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             logger.debug(f"Assignment: {assignment.to_json()}")
             if assignment.role_definition_bindings:
                 is_limited_access = True
@@ -711,7 +725,11 @@ def get_sharepoint_external_groups(
 
     def add_group_to_sets(role_assignments: RoleAssignmentCollection) -> None:
         nonlocal groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             if assignment.role_definition_bindings:
                 is_limited_access = True
                 for role_definition_binding in assignment.role_definition_bindings:


### PR DESCRIPTION
Cherry-pick of commit bbc38ff8175302a9129fecaf2a12daa27fddd5d1 to release/v3.0 branch.

Original PR: #10505

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a recursion bug in SharePoint/Azure AD member and role assignment retrieval by iterating `current_page` instead of the full collection, preventing max recursion depth errors and stuck syncs in v3.0.

- **Bug Fixes**
  - Iterate `UserCollection`, `DirectoryObjectCollection`, and `RoleAssignmentCollection` via `current_page` inside page-loaded callbacks to avoid re-entrancy from `_get_next().execute_query()`.
  - Tightened type hints and imports to the concrete collection types used.

<sup>Written for commit aa43e3f939130431a2c506ea1326fb9c2be11d3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

