### PR TITLE
fix(storybook): use render functions for RichStr markdown stories

### DIFF
--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -154,53 +154,53 @@ export const InvertedColors: Story = {
 // ---------------------------------------------------------------------------
 
 export const MarkdownBold: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown("This is **bold** text"),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown("This is **bold** text")}
+    </Text>
+  ),
 };
 
 export const MarkdownItalic: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown("This is *italic* text"),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown("This is *italic* text")}
+    </Text>
+  ),
 };
 
 export const MarkdownCode: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown("Run `npm install` to get started"),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown("Run `npm install` to get started")}
+    </Text>
+  ),
 };
 
 export const MarkdownLink: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown("Visit [Onyx](https://www.onyx.app/) for more info"),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown("Visit [Onyx](https://www.onyx.app/) for more info")}
+    </Text>
+  ),
 };
 
 export const MarkdownStrikethrough: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown("This is ~~deleted~~ text"),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown("This is ~~deleted~~ text")}
+    </Text>
+  ),
 };
 
 export const MarkdownCombined: Story = {
-  args: {
-    font: "main-ui-body",
-    color: "text-05",
-    children: markdown(
-      "*Hello*, **world**! Check out [Onyx](https://www.onyx.app/) and run `onyx start` to begin."
-    ),
-  },
+  render: () => (
+    <Text font="main-ui-body" color="text-05">
+      {markdown(
+        "*Hello*, **world**! Check out [Onyx](https://www.onyx.app/) and run `onyx start` to begin."
+      )}
+    </Text>
+  ),
 };
 
 export const MarkdownAtDifferentSizes: Story = {

--- a/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
+++ b/web/lib/opal/src/layouts/cards/CardHeaderLayout.stories.tsx
@@ -6,7 +6,6 @@ import {
   SvgCheckSquare,
   SvgGlobe,
   SvgSettings,
-  SvgUnplug,
 } from "@opal/icons";
 
 const meta = {
@@ -30,69 +29,47 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
-      <Card.Header
-        headerPadding="sm"
-        children={
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={SvgGlobe}
-            title="Google Search"
-            description="Web search provider"
-            padding="fit"
-            rightChildren={
-              <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
-                Connect
-              </Button>
-            }
-          />
-        }
-      />
+      <Card.Header>
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgGlobe}
+          title="Google Search"
+          description="Web search provider"
+          padding="fit"
+          rightChildren={
+            <Button prominence="tertiary" rightIcon={SvgArrowExchange}>
+              Connect
+            </Button>
+          }
+        />
+      </Card.Header>
     </div>
   ),
 };
 
-export const WithBottomRightSlot: Story = {
+export const WithCurrentDefault: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
-      <Card.Header
-        headerPadding="sm"
-        children={
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={SvgGlobe}
-            title="Google Search"
-            description="Currently the default provider."
-            padding="fit"
-            rightChildren={
-              <Button
-                variant="action"
-                prominence="tertiary"
-                icon={SvgCheckSquare}
-              >
-                Current Default
-              </Button>
-            }
-          />
-        }
-        bottomRightChildren={
-          <>
+      <Card.Header>
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgGlobe}
+          title="Google Search"
+          description="Currently the default provider."
+          padding="fit"
+          rightChildren={
             <Button
-              icon={SvgUnplug}
-              tooltip="Disconnect"
+              variant="action"
               prominence="tertiary"
-              size="sm"
-            />
-            <Button
-              icon={SvgSettings}
-              tooltip="Edit"
-              prominence="tertiary"
-              size="sm"
-            />
-          </>
-        }
-      />
+              icon={SvgCheckSquare}
+            >
+              Current Default
+            </Button>
+          }
+        />
+      </Card.Header>
     </div>
   ),
 };
@@ -100,19 +77,53 @@ export const WithBottomRightSlot: Story = {
 export const NoRightAction: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
+      <Card.Header>
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgGlobe}
+          title="Section Header"
+          description="No actions on the right."
+          padding="fit"
+        />
+      </Card.Header>
+    </div>
+  ),
+};
+
+export const WithBottomChildren: Story = {
+  render: () => (
+    <div className="w-[28rem] border rounded-16">
       <Card.Header
-        headerPadding="sm"
-        children={
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={SvgGlobe}
-            title="Section Header"
-            description="No actions on the right."
-            padding="fit"
-          />
+        bottomChildren={
+          <div className="flex gap-1 px-2 pb-2">
+            <Button
+              icon={SvgSettings}
+              tooltip="Edit"
+              prominence="tertiary"
+              size="sm"
+            />
+          </div>
         }
-      />
+      >
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgGlobe}
+          title="MCP Server"
+          description="12 tools available"
+          padding="fit"
+          rightChildren={
+            <Button
+              variant="action"
+              prominence="tertiary"
+              icon={SvgCheckSquare}
+            >
+              Current Default
+            </Button>
+          }
+        />
+      </Card.Header>
     </div>
   ),
 };
@@ -120,44 +131,25 @@ export const NoRightAction: Story = {
 export const LongContent: Story = {
   render: () => (
     <div className="w-[28rem] border rounded-16">
-      <Card.Header
-        headerPadding="sm"
-        children={
-          <ContentAction
-            sizePreset="main-ui"
-            variant="section"
-            icon={SvgGlobe}
-            title="Very Long Provider Name That Should Truncate"
-            description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
-            padding="fit"
-            rightChildren={
-              <Button
-                variant="action"
-                prominence="tertiary"
-                icon={SvgCheckSquare}
-              >
-                Current Default
-              </Button>
-            }
-          />
-        }
-        bottomRightChildren={
-          <>
+      <Card.Header>
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgGlobe}
+          title="Very Long Provider Name That Should Truncate"
+          description="This is a much longer description that tests how the layout handles overflow when the content area needs to shrink."
+          padding="fit"
+          rightChildren={
             <Button
-              icon={SvgUnplug}
+              variant="action"
               prominence="tertiary"
-              size="sm"
-              tooltip="Disconnect"
-            />
-            <Button
-              icon={SvgSettings}
-              prominence="tertiary"
-              size="sm"
-              tooltip="Edit"
-            />
-          </>
-        }
-      />
+              icon={SvgCheckSquare}
+            >
+              Current Default
+            </Button>
+          }
+        />
+      </Card.Header>
     </div>
   ),
 };

--- a/web/lib/opal/src/layouts/cards/README.md
+++ b/web/lib/opal/src/layouts/cards/README.md
@@ -6,28 +6,25 @@ A namespace of card layout primitives. Each sub-component handles a specific reg
 
 ## Card.Header
 
-A card header layout with a main content slot, an optional right-aligned column below, and a full-width `bottomChildren` slot.
+A card header layout with a main content slot and a full-width `bottomChildren` slot.
 
 ### Why Card.Header?
 
-`Card.Header` is layout-only — it provides `children` for the main content area plus `bottomRightChildren` and `bottomChildren` for secondary slots. For the typical icon/title/description + right-action pattern, pass a `<ContentAction />` into `children` with `rightChildren` for the action button.
+`Card.Header` is layout-only — it provides `children` for the main content area plus `bottomChildren` for a secondary slot. For the typical icon/title/description + right-action pattern, pass a `<ContentAction />` into `children` with `rightChildren` for the action button.
 
 ### Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `children` | `ReactNode` | `undefined` | Content rendered in the header slot — typically a `<ContentAction />` block. |
-| `bottomRightChildren` | `ReactNode` | `undefined` | Content rendered below `children` in a right-aligned column. Laid out as `flex flex-row`. |
 | `bottomChildren` | `ReactNode` | `undefined` | Content rendered below the entire header, spanning the full width. |
 
 ### Layout Structure
 
 ```
 +-----------------------------------+
-| children                    |
-+                  +----------------+
-|                  | bottomRight    |
-+------------------+----------------+
+| children                          |
++-----------------------------------+
 | bottomChildren (full width)       |
 +-----------------------------------+
 ```
@@ -35,101 +32,83 @@ A card header layout with a main content slot, an optional right-aligned column 
 - Outer wrapper: `flex flex-col w-full`
 - Header row: `flex flex-row items-start w-full` — columns are independent in height
 - Left column (children wrapper): `self-start grow min-w-0` — grows to fill available space
-- Right column: `flex flex-col items-end shrink-0` — only rendered when `bottomRightChildren` is provided
 - `bottomChildren` wrapper: `w-full` — only rendered when provided
 
 ### Usage
 
-#### Card with right action and bottom-right actions
+#### Card with right action
 
 ```tsx
 import { Card, ContentAction } from "@opal/layouts";
 import { Button } from "@opal/components";
-import { SvgGlobe, SvgSettings, SvgUnplug, SvgCheckSquare } from "@opal/icons";
+import { SvgGlobe, SvgCheckSquare } from "@opal/icons";
 
-<Card.Header
-
-  children={
-    <ContentAction
-      icon={SvgGlobe}
-      title="Google Search"
-      description="Web search provider"
-      sizePreset="main-ui"
-      variant="section"
-      padding="fit"
-      rightChildren={
-        <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
-          Current Default
-        </Button>
-      }
-    />
-  }
-  bottomRightChildren={
-    <>
-      <Button icon={SvgUnplug} size="sm" prominence="tertiary" tooltip="Disconnect" />
-      <Button icon={SvgSettings} size="sm" prominence="tertiary" tooltip="Edit" />
-    </>
-  }
-/>
+<Card.Header>
+  <ContentAction
+    icon={SvgGlobe}
+    title="Google Search"
+    description="Web search provider"
+    sizePreset="main-ui"
+    variant="section"
+    padding="fit"
+    rightChildren={
+      <Button icon={SvgCheckSquare} variant="action" prominence="tertiary">
+        Current Default
+      </Button>
+    }
+  />
+</Card.Header>
 ```
 
 #### Card with only a connect action
 
 ```tsx
-<Card.Header
-
-  children={
-    <ContentAction
-      icon={SvgCloud}
-      title="OpenAI"
-      description="Not configured"
-      sizePreset="main-ui"
-      variant="section"
-      padding="fit"
-      rightChildren={
-        <Button rightIcon={SvgArrowExchange} prominence="tertiary">
-          Connect
-        </Button>
-      }
-    />
-  }
-/>
+<Card.Header>
+  <ContentAction
+    icon={SvgCloud}
+    title="OpenAI"
+    description="Not configured"
+    sizePreset="main-ui"
+    variant="section"
+    padding="fit"
+    rightChildren={
+      <Button rightIcon={SvgArrowExchange} prominence="tertiary">
+        Connect
+      </Button>
+    }
+  />
+</Card.Header>
 ```
 
 #### Card with bottom children
 
 ```tsx
 <Card.Header
-
-  children={
-    <ContentAction
-      icon={SvgServer}
-      title="MCP Server"
-      description="12 tools available"
-      sizePreset="main-ui"
-      variant="section"
-      padding="fit"
-      rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
-    />
-  }
   bottomChildren={<SearchBar placeholder="Search tools..." />}
-/>
+>
+  <ContentAction
+    icon={SvgServer}
+    title="MCP Server"
+    description="12 tools available"
+    sizePreset="main-ui"
+    variant="section"
+    padding="fit"
+    rightChildren={<Button icon={SvgSettings} prominence="tertiary" />}
+  />
+</Card.Header>
 ```
 
 #### No actions
 
 ```tsx
-<Card.Header
-
-  children={
-    <ContentAction
-      icon={SvgInfo}
-      title="Section Header"
-      description="Description text"
-      sizePreset="main-content"
-      variant="section"
-      padding="fit"
-    />
-  }
-/>
+<Card.Header>
+  <ContentAction
+    icon={SvgInfo}
+    title="Section Header"
+    description="Description text"
+    sizePreset="main-content"
+    variant="section"
+    padding="fit"
+  />
+</Card.Header>
 ```

--- a/web/lib/opal/src/layouts/cards/components.tsx
+++ b/web/lib/opal/src/layouts/cards/components.tsx
@@ -6,9 +6,6 @@ interface CardHeaderProps {
   /** Content rendered in the header slot — typically a {@link ContentAction} block. */
   children?: React.ReactNode;
 
-  /** Content rendered below `children`, in a right-aligned column. */
-  bottomRightChildren?: React.ReactNode;
-
   /**
    * Content rendered below the entire header (left + right columns),
    * spanning the full width. Use for expandable sections, search bars, or
@@ -22,15 +19,13 @@ interface CardHeaderProps {
 // ---------------------------------------------------------------------------
 
 /**
- * A card header layout with a main content slot, an optional right-aligned
- * column below, and a full-width `bottomChildren` slot.
+ * A card header layout with a main content slot and a full-width
+ * `bottomChildren` slot.
  *
  * ```
  * +-----------------------------------+
- * | children                    |
- * +                  +----------------+
- * |                  | bottomRight    |
- * +------------------+----------------+
+ * | children                          |
+ * +-----------------------------------+
  * | bottomChildren (full width)       |
  * +-----------------------------------+
  * ```
@@ -41,14 +36,7 @@ interface CardHeaderProps {
  *
  * @example
  * ```tsx
- * <Card.Header
- *   bottomRightChildren={
- *     <>
- *       <Button icon={SvgUnplug} size="sm" prominence="tertiary" />
- *       <Button icon={SvgSettings} size="sm" prominence="tertiary" />
- *     </>
- *   }
- * >
+ * <Card.Header>
  *   <ContentAction
  *     icon={SvgGlobe}
  *     title="Google"
@@ -61,24 +49,15 @@ interface CardHeaderProps {
  * </Card.Header>
  * ```
  */
-function Header({
-  children,
-  bottomRightChildren,
-  bottomChildren,
-}: CardHeaderProps) {
+function Header({ children, bottomChildren }: CardHeaderProps) {
   return (
     <div className="flex flex-col w-full">
       <div className="flex flex-row items-start w-full">
         {children != null && (
           <div className="self-start grow min-w-0">{children}</div>
         )}
-        {bottomRightChildren != null && (
-          <div className="flex flex-col items-end shrink-0">
-            <div className="flex flex-row">{bottomRightChildren}</div>
-          </div>
-        )}
       </div>
-      {bottomChildren != null && <div className="w-full">{bottomChildren}</div>}
+      {bottomChildren && <div className="w-full">{bottomChildren}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Storybook's autodocs serializer crashes when `RichStr` objects (`{__brand, raw}` from `markdown()`) are passed via `args` — it tries to serialize them as React children and fails with "Objects are not valid as a React child."

Switches all 6 markdown stories in `Text.stories.tsx` from `args`-based to `render`-based so the `RichStr` is created inside the render function rather than being serialized by autodocs.

## How Has This Been Tested?

- `bun run types:check` passes
- Storybook renders MarkdownBold and all other markdown stories without errors

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Storybook autodocs crash by switching `RichStr` markdown stories to render functions, and updates `Card.Header` docs and stories to remove the obsolete `bottomRightChildren` slot.

- **Bug Fixes**
  - Prevents "Objects are not valid as a React child" by avoiding autodocs serialization of `RichStr` in markdown stories (Bold, Italic, Code, Link, Strikethrough, Combined).

- **Refactors**
  - Aligns `Card.Header` API and examples by removing `bottomRightChildren` and using `children` (and optional `bottomChildren`) in stories and README.

<sup>Written for commit 6ea69396baf98c2104d8d14fffeaed9e1ab86d87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

