### PR TITLE
refactor(doc-index-sync): rename vespa_metadata_sync_task

### DIFF
--- a/backend/onyx/background/celery/tasks/vespa/document_sync.py
+++ b/backend/onyx/background/celery/tasks/vespa/document_sync.py
@@ -117,7 +117,7 @@ def generate_document_sync_tasks(
 
         # Create the Celery task
         celery_app.send_task(
-            OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,
+            OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
             kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
             queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
             task_id=custom_task_id,

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -447,13 +447,15 @@ def monitor_document_set_taskset(
 
 
 @shared_task(
-    name=OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,
+    name=OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
     bind=True,
     soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
     time_limit=LIGHT_TIME_LIMIT,
     max_retries=3,
 )
-def vespa_metadata_sync_task(self: Task, document_id: str, *, tenant_id: str) -> bool:
+def document_index_metadata_sync_task(
+    self: Task, document_id: str, *, tenant_id: str
+) -> bool:
     start = time.monotonic()
 
     completion_status = OnyxCeleryTaskCompletionStatus.UNDEFINED
@@ -547,7 +549,7 @@ def vespa_metadata_sync_task(self: Task, document_id: str, *, tenant_id: str) ->
                 break
 
             task_logger.exception(
-                f"vespa_metadata_sync_task exceptioned: doc={document_id}"
+                f"document_index_metadata_sync_task exceptioned: doc={document_id}"
             )
 
             completion_status = OnyxCeleryTaskCompletionStatus.RETRYABLE_EXCEPTION
@@ -565,7 +567,7 @@ def vespa_metadata_sync_task(self: Task, document_id: str, *, tenant_id: str) ->
             break  # we won't hit this, but it looks weird not to have it
     finally:
         task_logger.info(
-            f"vespa_metadata_sync_task completed: status={completion_status.value} doc={document_id}"
+            f"document_index_metadata_sync_task completed: status={completion_status.value} doc={document_id}"
         )
 
     return completion_status == OnyxCeleryTaskCompletionStatus.SUCCEEDED

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -446,7 +446,14 @@ def monitor_document_set_taskset(
     rds.reset()
 
 
-def _run_document_index_metadata_sync(
+@shared_task(
+    name=OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
+    bind=True,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=3,
+)
+def document_index_metadata_sync_task(
     self: Task, document_id: str, *, tenant_id: str
 ) -> bool:
     start = time.monotonic()
@@ -564,30 +571,3 @@ def _run_document_index_metadata_sync(
         )
 
     return completion_status == OnyxCeleryTaskCompletionStatus.SUCCEEDED
-
-
-@shared_task(
-    name=OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
-    bind=True,
-    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
-    time_limit=LIGHT_TIME_LIMIT,
-    max_retries=3,
-)
-def document_index_metadata_sync_task(
-    self: Task, document_id: str, *, tenant_id: str
-) -> bool:
-    return _run_document_index_metadata_sync(self, document_id, tenant_id=tenant_id)
-
-
-# Legacy wire-name alias. Older releases enqueue this task under the
-# previous name; keep it registered so in-flight items from those releases
-# still route to the same handler across the rename rollout.
-@shared_task(
-    name="vespa_metadata_sync_task",
-    bind=True,
-    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
-    time_limit=LIGHT_TIME_LIMIT,
-    max_retries=3,
-)
-def vespa_metadata_sync_task(self: Task, document_id: str, *, tenant_id: str) -> bool:
-    return _run_document_index_metadata_sync(self, document_id, tenant_id=tenant_id)

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -446,14 +446,7 @@ def monitor_document_set_taskset(
     rds.reset()
 
 
-@shared_task(
-    name=OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
-    bind=True,
-    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
-    time_limit=LIGHT_TIME_LIMIT,
-    max_retries=3,
-)
-def document_index_metadata_sync_task(
+def _run_document_index_metadata_sync(
     self: Task, document_id: str, *, tenant_id: str
 ) -> bool:
     start = time.monotonic()
@@ -571,3 +564,30 @@ def document_index_metadata_sync_task(
         )
 
     return completion_status == OnyxCeleryTaskCompletionStatus.SUCCEEDED
+
+
+@shared_task(
+    name=OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
+    bind=True,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=3,
+)
+def document_index_metadata_sync_task(
+    self: Task, document_id: str, *, tenant_id: str
+) -> bool:
+    return _run_document_index_metadata_sync(self, document_id, tenant_id=tenant_id)
+
+
+# Legacy wire-name alias. Older releases enqueue this task under the
+# previous name; keep it registered so in-flight items from those releases
+# still route to the same handler across the rename rollout.
+@shared_task(
+    name="vespa_metadata_sync_task",
+    bind=True,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=3,
+)
+def vespa_metadata_sync_task(self: Task, document_id: str, *, tenant_id: str) -> bool:
+    return _run_document_index_metadata_sync(self, document_id, tenant_id=tenant_id)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -603,7 +603,7 @@ class OnyxCeleryTask:
     CONNECTOR_PRUNING_GENERATOR_TASK = "connector_pruning_generator_task"
     CONNECTOR_HIERARCHY_FETCHING_TASK = "connector_hierarchy_fetching_task"
     DOCUMENT_BY_CC_PAIR_CLEANUP_TASK = "document_by_cc_pair_cleanup_task"
-    VESPA_METADATA_SYNC_TASK = "vespa_metadata_sync_task"
+    DOCUMENT_INDEX_METADATA_SYNC_TASK = "document_index_metadata_sync_task"
 
     # chat retention
     CHECK_TTL_MANAGEMENT_TASK = "check_ttl_management_task"

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -481,8 +481,8 @@ class VespaDocumentIndex(DocumentIndex):
         self,
         update_requests: list[MetadataUpdateRequest],
     ) -> None:
-        # WARNING: This method can be called by vespa_metadata_sync_task, which
-        # is kicked off by check_for_vespa_sync_task, notably before a document
+        # WARNING: This method can be called by document_index_metadata_sync_task,
+        # which is kicked off by check_for_vespa_sync_task, notably before a document
         # has finished indexing. In this way, chunk_count below could be unknown
         # even for chunks not on the "old" chunk ID system; i.e. there could be
         # a race condition. Passing in None to _enrich_basic_chunk_info should

--- a/backend/onyx/redis/redis_document_set.py
+++ b/backend/onyx/redis/redis_document_set.py
@@ -87,7 +87,7 @@ class RedisDocumentSet(RedisObjectHelper):
             redis_client.expire(self.taskset_key, self.TASKSET_TTL)
 
             celery_app.send_task(
-                OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,
+                OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
                 kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
                 queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
                 task_id=custom_task_id,

--- a/backend/onyx/redis/redis_usergroup.py
+++ b/backend/onyx/redis/redis_usergroup.py
@@ -101,7 +101,7 @@ class RedisUserGroup(RedisObjectHelper):
             redis_client.expire(self.taskset_key, self.TASKSET_TTL)
 
             celery_app.send_task(
-                OnyxCeleryTask.VESPA_METADATA_SYNC_TASK,
+                OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
                 kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
                 queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
                 task_id=custom_task_id,


### PR DESCRIPTION
## Description

The task writes to every registered `DocumentIndex` (Vespa today, OpenSearch going forward) — the `vespa_` prefix no longer reflects scope. Rename:

- `OnyxCeleryTask.VESPA_METADATA_SYNC_TASK` → `DOCUMENT_INDEX_METADATA_SYNC_TASK`
- Wire name: `"vespa_metadata_sync_task"` → `"document_index_metadata_sync_task"`
- Function: `vespa_metadata_sync_task` → `document_index_metadata_sync_task`
- Log strings and one stale comment in `vespa_document_index.py` updated

The `VESPA_METADATA_SYNC` queue name is intentionally unchanged in this PR — separate rename.

**Deploy note:** tasks queued under the old wire name before the rollout will fail on new workers until the queue drains. `check_for_vespa_sync_task` re-enqueues every 20s, so the transition window is brief.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check