### PR TITLE
fix(asana): Stop duping asana tasks

### DIFF
--- a/backend/onyx/connectors/asana/asana_api.py
+++ b/backend/onyx/connectors/asana/asana_api.py
@@ -53,6 +53,7 @@ class AsanaAPI:
         self.api_error_count = 0
         self.configuration.access_token = api_token
         self.task_count = 0
+        self.duplicate_task_count = 0
 
     def get_tasks(
         self, project_gids: list[str] | None, start_date: str
@@ -82,19 +83,30 @@ class AsanaAPI:
                 logger.info(f"Processed {project_count} projects")
 
         logger.info(f"Found {len(projects_list)} projects to process")
+        # Asana tasks can belong to multiple projects and thus tasks
+        # can get reported multiple times
+        seen_task_gids: set[str] = set()
         for project_gid in projects_list:
             for task in self._get_tasks_for_project(
-                project_gid, start_date, start_seconds
+                project_gid, start_date, start_seconds, seen_task_gids
             ):
                 yield task
-        logger.info(f"Completed fetching {self.task_count} tasks from Asana")
+        logger.info(
+            f"Completed fetching {self.task_count} tasks from Asana "
+            f"(skipped {self.duplicate_task_count} duplicate task occurrences "
+            f"across projects)"
+        )
         if self.api_error_count > 0:
             logger.warning(
                 f"Encountered {self.api_error_count} API errors during task fetching"
             )
 
     def _get_tasks_for_project(
-        self, project_gid: str, start_date: str, start_seconds: int
+        self,
+        project_gid: str,
+        start_date: str,
+        start_seconds: int,
+        seen_task_gids: set[str],
     ) -> Iterator[AsanaTask]:
         project = self.project_api.get_project(project_gid, opts={})
         project_name = project.get("name", project_gid)
@@ -133,6 +145,16 @@ class AsanaAPI:
         }
         tasks_from_api = self.tasks_api.get_tasks_for_project(project_gid, opts)
         for data in tasks_from_api:
+            gid = data["gid"]
+            if gid in seen_task_gids:
+                self.duplicate_task_count += 1
+                logger.debug(
+                    f"Skipping duplicate Asana task {gid} "
+                    f"(already yielded for another project)"
+                )
+                continue
+            seen_task_gids.add(gid)
+
             self.task_count += 1
             if self.task_count % 10 == 0:
                 end_seconds = time.mktime(datetime.now().timetuple())

--- a/backend/onyx/connectors/asana/asana_api.py
+++ b/backend/onyx/connectors/asana/asana_api.py
@@ -53,7 +53,6 @@ class AsanaAPI:
         self.api_error_count = 0
         self.configuration.access_token = api_token
         self.task_count = 0
-        self.duplicate_task_count = 0
 
     def get_tasks(
         self, project_gids: list[str] | None, start_date: str
@@ -91,11 +90,7 @@ class AsanaAPI:
                 project_gid, start_date, start_seconds, seen_task_gids
             ):
                 yield task
-        logger.info(
-            f"Completed fetching {self.task_count} tasks from Asana "
-            f"(skipped {self.duplicate_task_count} duplicate task occurrences "
-            f"across projects)"
-        )
+        logger.info(f"Completed fetching {self.task_count} tasks from Asana")
         if self.api_error_count > 0:
             logger.warning(
                 f"Encountered {self.api_error_count} API errors during task fetching"
@@ -147,7 +142,6 @@ class AsanaAPI:
         for data in tasks_from_api:
             gid = data["gid"]
             if gid in seen_task_gids:
-                self.duplicate_task_count += 1
                 logger.debug(
                     f"Skipping duplicate Asana task {gid} "
                     f"(already yielded for another project)"

--- a/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
+++ b/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
@@ -1,8 +1,19 @@
 """Tests for Asana connector configuration parsing."""
 
+from typing import Any
+from typing import NamedTuple
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import pytest
 
+from onyx.connectors.asana.asana_api import AsanaAPI
 from onyx.connectors.asana.connector import AsanaConnector
+
+
+class _AsanaTestSetup(NamedTuple):
+    api: AsanaAPI
+    stories_api: MagicMock
 
 
 @pytest.mark.parametrize(
@@ -48,3 +59,104 @@ def test_asana_connector_team_id_normalization(
     )
 
     assert connector.asana_team_id == expected
+
+
+def _make_task_data(gid: str, name: str | None = None) -> dict[str, Any]:
+    """Minimal Asana task payload covering the fields the connector reads."""
+    return {
+        "gid": gid,
+        "name": name or f"task-{gid}",
+        "notes": "",
+        "created_by": None,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "due_on": None,
+        "completed_at": None,
+        "modified_at": "2026-01-01T00:00:00+00:00",
+        "permalink_url": f"https://app.asana.com/0/{gid}",
+    }
+
+
+def _build_api_with_mocks(
+    project_to_tasks: dict[str, list[dict[str, Any]]],
+) -> _AsanaTestSetup:
+    """Construct an AsanaAPI with all SDK clients replaced by mocks.
+
+    `project_to_tasks` defines, in iteration order, the tasks each project
+    listing returns from `tasks_api.get_tasks_for_project`. Returns the api
+    plus the stories-api mock so tests can introspect call counts without
+    fighting `ty` type inference on the original SDK attributes.
+    """
+    with patch("onyx.connectors.asana.asana_api.asana"):
+        api = AsanaAPI(api_token="token", workspace_gid="ws", team_gid=None)
+
+    project_api = MagicMock()
+    tasks_api = MagicMock()
+    stories_api = MagicMock()
+    users_api = MagicMock()
+
+    api.project_api = project_api
+    api.tasks_api = tasks_api
+    api.stories_api = stories_api
+    api.users_api = users_api
+
+    project_api.get_projects.return_value = iter(
+        [{"gid": gid} for gid in project_to_tasks]
+    )
+    project_api.get_project.return_value = {
+        "name": "p",
+        "team": {"gid": "T1"},
+        "archived": False,
+        "privacy_setting": "public",
+    }
+    tasks_api.get_tasks_for_project.side_effect = [
+        iter(tasks) for tasks in project_to_tasks.values()
+    ]
+    stories_api.get_stories_for_task.return_value = iter([])
+
+    return _AsanaTestSetup(api=api, stories_api=stories_api)
+
+
+def test_get_tasks_dedupes_task_appearing_in_multiple_projects() -> None:
+    """An Asana task in N projects is yielded once per poll, and the expensive
+    `_fetch_and_add_comments` call only fires for unique tasks."""
+    setup = _build_api_with_mocks(
+        {
+            "P1": [_make_task_data("X"), _make_task_data("Y")],
+            "P2": [_make_task_data("X"), _make_task_data("Z")],
+        }
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert [t.id for t in yielded] == ["X", "Y", "Z"]
+    assert setup.api.duplicate_task_count == 1
+    assert setup.api.task_count == 3
+    # Comments fetched only for unique tasks; the duplicate X is skipped before
+    # `_fetch_and_add_comments` runs.
+    assert setup.stories_api.get_stories_for_task.call_count == 3
+    fetched_gids = [
+        call.args[0] for call in setup.stories_api.get_stories_for_task.call_args_list
+    ]
+    assert sorted(fetched_gids) == ["X", "Y", "Z"]
+
+
+def test_get_tasks_no_duplicates_unchanged() -> None:
+    """When projects don't share tasks, every task is yielded and counters
+    reflect zero duplicates."""
+    setup = _build_api_with_mocks(
+        {
+            "P1": [_make_task_data("A"), _make_task_data("B")],
+            "P2": [_make_task_data("C")],
+        }
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert [t.id for t in yielded] == ["A", "B", "C"]
+    assert setup.api.duplicate_task_count == 0
+    assert setup.api.task_count == 3
+    assert setup.stories_api.get_stories_for_task.call_count == 3

--- a/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
+++ b/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
@@ -131,7 +131,6 @@ def test_get_tasks_dedupes_task_appearing_in_multiple_projects() -> None:
     )
 
     assert [t.id for t in yielded] == ["X", "Y", "Z"]
-    assert setup.api.duplicate_task_count == 1
     assert setup.api.task_count == 3
     # Comments fetched only for unique tasks; the duplicate X is skipped before
     # `_fetch_and_add_comments` runs.
@@ -157,6 +156,5 @@ def test_get_tasks_no_duplicates_unchanged() -> None:
     )
 
     assert [t.id for t in yielded] == ["A", "B", "C"]
-    assert setup.api.duplicate_task_count == 0
     assert setup.api.task_count == 3
     assert setup.stories_api.get_stories_for_task.call_count == 3


### PR DESCRIPTION
## Description
In asana, a single task can belong to multiple projects. This results in the same task being emitted multiple times with the same doc id. This leads to a case where 2 tasks with the same doc id end up in the same batch during doc processing, resulting in a runtime error.

This solves that problem by deduping tasks at the connector level.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Asana tasks across projects so each task is processed once per sync, preventing batch-time runtime errors. Each task is now yielded once per poll.

- **Bug Fixes**
  - Deduplicate by task `gid` across projects using a shared `seen_task_gids` set; skip duplicates before fetching comments.
  - Ensure `task_count` reflects unique tasks; log skipped duplicates at debug level.
  - Add unit tests for multi-project duplicates and non-duplicate paths; verify comments are fetched once per unique task.

<sup>Written for commit c5ce6656f887690d72147140ca33c3c5aff82beb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

