### PR TITLE
fix(hubspot): make connector more efficient with fewer api calls - phase 1

### DIFF
--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -201,7 +201,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
             return []
         if assoc_collection.paging and assoc_collection.paging.next:
             return None
-        return [r.id for r in (assoc_collection.results or [])]
+        return list(dict.fromkeys(r.id for r in (assoc_collection.results or [])))
 
     def _get_associated_objects(
         self,
@@ -222,7 +222,11 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     object_id=object_id,
                     to_object_type=to_object_type,
                 )
-                object_ids = [str(assoc.to_object_id) for assoc in associations_iter]
+                object_ids = list(
+                    dict.fromkeys(
+                        str(assoc.to_object_id) for assoc in associations_iter
+                    )
+                )
 
             associated_objects: list[dict[str, Any]] = []
 

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -181,23 +181,48 @@ class HubSpotConnector(LoadConnector, PollConnector):
         else:
             return f"{HUBSPOT_BASE_URL}/contacts/{self.portal_id}/{object_type}/{object_id}"
 
+    def _extract_inline_association_ids(
+        self,
+        obj: Any,
+        assoc_type: str,
+    ) -> list[str] | None:
+        """Extract association IDs already returned inline by get_page.
+
+        Returns None when the inline data is incomplete (overflow) or when
+        associations is not a dict (not fetched or unexpected SDK type), so the
+        caller falls back to a dedicated v4 associations API call instead.
+        Returns [] when the type simply has no associations.
+        """
+        associations = getattr(obj, "associations", None)
+        if not isinstance(associations, dict):
+            return None
+        assoc_collection = associations.get(assoc_type)
+        if assoc_collection is None:
+            return []
+        if assoc_collection.paging and assoc_collection.paging.next:
+            return None
+        return [r.id for r in (assoc_collection.results or [])]
+
     def _get_associated_objects(
         self,
         api_client: HubSpot,
         object_id: str,
         from_object_type: str,
         to_object_type: str,
+        inline_association_ids: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Get associated objects for a given object"""
         try:
-            associations_iter = self._paginated_results(
-                api_client.crm.associations.v4.basic_api.get_page,
-                object_type=from_object_type,
-                object_id=object_id,
-                to_object_type=to_object_type,
-            )
-
-            object_ids = [assoc.to_object_id for assoc in associations_iter]
+            if inline_association_ids is not None:
+                object_ids = inline_association_ids
+            else:
+                associations_iter = self._paginated_results(
+                    api_client.crm.associations.v4.basic_api.get_page,
+                    object_type=from_object_type,
+                    object_id=object_id,
+                    to_object_type=to_object_type,
+                )
+                object_ids = [str(assoc.to_object_id) for assoc in associations_iter]
 
             associated_objects: list[dict[str, Any]] = []
 
@@ -446,7 +471,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated contacts
             associated_contacts = self._get_associated_objects(
-                api_client, ticket.id, "tickets", "contacts"
+                api_client,
+                ticket.id,
+                "tickets",
+                "contacts",
+                inline_association_ids=self._extract_inline_association_ids(
+                    ticket, "contacts"
+                ),
             )
             for contact in associated_contacts:
                 sections.append(self._create_object_section(contact, "contacts"))
@@ -454,7 +485,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated companies
             associated_companies = self._get_associated_objects(
-                api_client, ticket.id, "tickets", "companies"
+                api_client,
+                ticket.id,
+                "tickets",
+                "companies",
+                inline_association_ids=self._extract_inline_association_ids(
+                    ticket, "companies"
+                ),
             )
             for company in associated_companies:
                 sections.append(self._create_object_section(company, "companies"))
@@ -462,7 +499,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated deals
             associated_deals = self._get_associated_objects(
-                api_client, ticket.id, "tickets", "deals"
+                api_client,
+                ticket.id,
+                "tickets",
+                "deals",
+                inline_association_ids=self._extract_inline_association_ids(
+                    ticket, "deals"
+                ),
             )
             for deal in associated_deals:
                 sections.append(self._create_object_section(deal, "deals"))
@@ -578,7 +621,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated contacts
             associated_contacts = self._get_associated_objects(
-                api_client, company.id, "companies", "contacts"
+                api_client,
+                company.id,
+                "companies",
+                "contacts",
+                inline_association_ids=self._extract_inline_association_ids(
+                    company, "contacts"
+                ),
             )
             for contact in associated_contacts:
                 sections.append(self._create_object_section(contact, "contacts"))
@@ -586,7 +635,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated deals
             associated_deals = self._get_associated_objects(
-                api_client, company.id, "companies", "deals"
+                api_client,
+                company.id,
+                "companies",
+                "deals",
+                inline_association_ids=self._extract_inline_association_ids(
+                    company, "deals"
+                ),
             )
             for deal in associated_deals:
                 sections.append(self._create_object_section(deal, "deals"))
@@ -594,7 +649,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated tickets
             associated_tickets = self._get_associated_objects(
-                api_client, company.id, "companies", "tickets"
+                api_client,
+                company.id,
+                "companies",
+                "tickets",
+                inline_association_ids=self._extract_inline_association_ids(
+                    company, "tickets"
+                ),
             )
             for ticket in associated_tickets:
                 sections.append(self._create_object_section(ticket, "tickets"))
@@ -710,7 +771,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated contacts
             associated_contacts = self._get_associated_objects(
-                api_client, deal.id, "deals", "contacts"
+                api_client,
+                deal.id,
+                "deals",
+                "contacts",
+                inline_association_ids=self._extract_inline_association_ids(
+                    deal, "contacts"
+                ),
             )
             for contact in associated_contacts:
                 sections.append(self._create_object_section(contact, "contacts"))
@@ -718,7 +785,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated companies
             associated_companies = self._get_associated_objects(
-                api_client, deal.id, "deals", "companies"
+                api_client,
+                deal.id,
+                "deals",
+                "companies",
+                inline_association_ids=self._extract_inline_association_ids(
+                    deal, "companies"
+                ),
             )
             for company in associated_companies:
                 sections.append(self._create_object_section(company, "companies"))
@@ -726,7 +799,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated tickets
             associated_tickets = self._get_associated_objects(
-                api_client, deal.id, "deals", "tickets"
+                api_client,
+                deal.id,
+                "deals",
+                "tickets",
+                inline_association_ids=self._extract_inline_association_ids(
+                    deal, "tickets"
+                ),
             )
             for ticket in associated_tickets:
                 sections.append(self._create_object_section(ticket, "tickets"))
@@ -858,7 +937,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated companies
             associated_companies = self._get_associated_objects(
-                api_client, contact.id, "contacts", "companies"
+                api_client,
+                contact.id,
+                "contacts",
+                "companies",
+                inline_association_ids=self._extract_inline_association_ids(
+                    contact, "companies"
+                ),
             )
             for company in associated_companies:
                 sections.append(self._create_object_section(company, "companies"))
@@ -866,7 +951,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated deals
             associated_deals = self._get_associated_objects(
-                api_client, contact.id, "contacts", "deals"
+                api_client,
+                contact.id,
+                "contacts",
+                "deals",
+                inline_association_ids=self._extract_inline_association_ids(
+                    contact, "deals"
+                ),
             )
             for deal in associated_deals:
                 sections.append(self._create_object_section(deal, "deals"))
@@ -874,7 +965,13 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             # Get associated tickets
             associated_tickets = self._get_associated_objects(
-                api_client, contact.id, "contacts", "tickets"
+                api_client,
+                contact.id,
+                "contacts",
+                "tickets",
+                inline_association_ids=self._extract_inline_association_ids(
+                    contact, "tickets"
+                ),
             )
             for ticket in associated_tickets:
                 sections.append(self._create_object_section(ticket, "tickets"))

--- a/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
+++ b/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.hubspot.connector import HubSpotConnector
+
+
+def _make_connector() -> HubSpotConnector:
+    c = HubSpotConnector()
+    c._access_token = "token"
+    c._portal_id = "portal"
+    return c
+
+
+def _make_assoc_collection(ids: list[str], has_next: bool = False) -> MagicMock:
+    """Build a mock CollectionResponseAssociatedId."""
+    results = [MagicMock(id=id_) for id_ in ids]
+    paging = MagicMock()
+    paging.next = MagicMock() if has_next else None
+    collection = MagicMock()
+    collection.results = results
+    collection.paging = paging
+    return collection
+
+
+class TestExtractInlineAssociationIds:
+    def test_returns_ids_when_no_overflow(self) -> None:
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = {"contacts": _make_assoc_collection(["1", "2", "3"])}
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result == ["1", "2", "3"]
+
+    def test_returns_empty_list_when_type_not_present(self) -> None:
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = {"companies": _make_assoc_collection(["5"])}
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result == []
+
+    def test_returns_none_when_associations_is_none(self) -> None:
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = None
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result is None
+
+    def test_returns_none_when_associations_is_not_a_dict(self) -> None:
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = MagicMock()  # truthy non-dict
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result is None
+
+    def test_returns_none_on_overflow(self) -> None:
+        """When paging.next is set the inline data is truncated; caller must fall back to v4 API."""
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = {
+            "contacts": _make_assoc_collection(["1", "2"], has_next=True)
+        }
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result is None
+
+
+class TestGetAssociatedObjectsSkipsV4Call:
+    def test_inline_ids_drive_object_fetch_and_skip_v4(self) -> None:
+        """Inline IDs are used to fetch objects; the v4 association lookup is never called."""
+        connector = _make_connector()
+        mock_client = MagicMock()
+
+        def make_contact(id_: str) -> MagicMock:
+            m = MagicMock()
+            m.to_dict.return_value = {"id": id_, "properties": {"firstname": "A"}}
+            return m
+
+        mock_client.crm.contacts.basic_api.get_by_id.side_effect = [
+            make_contact("11"),
+            make_contact("22"),
+        ]
+
+        with patch.object(connector, "_paginated_results") as mock_paginated:
+            result = connector._get_associated_objects(
+                mock_client,
+                object_id="ticket1",
+                from_object_type="tickets",
+                to_object_type="contacts",
+                inline_association_ids=["11", "22"],
+            )
+
+        mock_paginated.assert_not_called()
+        assert mock_client.crm.contacts.basic_api.get_by_id.call_count == 2
+        assert [r["id"] for r in result] == ["11", "22"]
+
+    def test_v4_api_called_when_inline_ids_is_none(self) -> None:
+        """None signals overflow — connector falls back to the v4 associations API."""
+        connector = _make_connector()
+        mock_client = MagicMock()
+
+        with patch.object(
+            connector, "_paginated_results", return_value=iter([])
+        ) as mock_paginated:
+            connector._get_associated_objects(
+                mock_client,
+                object_id="obj1",
+                from_object_type="tickets",
+                to_object_type="contacts",
+                inline_association_ids=None,
+            )
+
+        mock_paginated.assert_called_once()


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Problem: The _process_* methods already request associations=[...] in their get_page call, so HubSpot returns associated object IDs inline in the page response. Despite this, _get_associated_objects() ignored that data and made a redundant crm.associations.v4.basic_api.get_page call to re-fetch the  same IDs — 3 extra API calls per record (one per association type), across all 4 object types.

Fix: Added _extract_inline_association_ids(obj, assoc_type) which reads IDs directly from obj.associations — the data already in memory. Returns None on overflow (when paging.next is set), which triggers the existing v4 fallback. Updated all 12 call sites across _process_tickets, _process_companies,  _process_deals, and _process_contacts to pass inline IDs.

Impact: Eliminates 3 API calls per record in the common case (no overflow), reducing total HubSpot API calls by ~40–50%. The notes v4 call is unaffected since notes are not included in the inline associations response.

https://linear.app/onyx-app/issue/ENG-4077/hubspot-connector-more-efficient-indexing
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
No logic change, all are covered with existing changes.

Added log and tested from local, connector was added and indexed correctly. logs show the extracted inline association IDs

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce HubSpot connector API calls by using inline association IDs from `get_page`, avoiding redundant `crm.associations.v4` lookups, and de-duplicating IDs. Cuts ~3 calls per record in most cases (~40–50% fewer total), supporting ENG-4077.

- **Performance**
  - Added `_extract_inline_association_ids(obj, assoc_type)` to read IDs from `obj.associations`.
  - Updated `_get_associated_objects(...)` to accept `inline_association_ids`, de-duplicate IDs, and fall back to `crm.associations.v4.basic_api.get_page` only on overflow.
  - Applied across tickets, companies, deals, and contacts; notes unchanged. Added unit tests for inline extraction, v4 fallback, and skipping v4 when inline IDs are present.

<sup>Written for commit e82b1dbfaa67b4eb330778792708c3bcd3d09136. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10616?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

