### PR TITLE
fix(auth): stop /api/auth/refresh request loop on SAML deployments

### DIFF
--- a/web/src/hooks/useTokenRefresh.test.tsx
+++ b/web/src/hooks/useTokenRefresh.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useTokenRefresh } from "@/hooks/useTokenRefresh";
+import { AuthTypeMetadata } from "@/hooks/useAuthTypeMetadata";
+import { AuthType } from "@/lib/constants";
+import { User } from "@/lib/types";
+
+const baseAuthMetadata = (authType: AuthType): AuthTypeMetadata => ({
+  authType,
+  autoRedirect: false,
+  requiresVerification: false,
+  anonymousUserEnabled: null,
+  passwordMinLength: 0,
+  hasUsers: true,
+  oauthEnabled: false,
+});
+
+const fakeUser = { id: "user-1" } as User;
+
+describe("useTokenRefresh", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  test("does not call /api/auth/refresh while auth type metadata is loading", () => {
+    renderHook(() =>
+      useTokenRefresh(
+        fakeUser,
+        baseAuthMetadata(AuthType.BASIC),
+        true,
+        jest.fn()
+      )
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("does not call /api/auth/refresh for SAML deployments", () => {
+    renderHook(() =>
+      useTokenRefresh(
+        fakeUser,
+        baseAuthMetadata(AuthType.SAML),
+        false,
+        jest.fn()
+      )
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("does not call /api/auth/refresh for OIDC deployments", () => {
+    renderHook(() =>
+      useTokenRefresh(
+        fakeUser,
+        baseAuthMetadata(AuthType.OIDC),
+        false,
+        jest.fn()
+      )
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("calls /api/auth/refresh once when auth type is BASIC and user is present", async () => {
+    renderHook(() =>
+      useTokenRefresh(
+        fakeUser,
+        baseAuthMetadata(AuthType.BASIC),
+        false,
+        jest.fn()
+      )
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+  });
+
+  test("does not loop when /api/auth/refresh returns 404 and parent re-renders", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    const onRefreshFail = jest.fn().mockResolvedValue(undefined);
+
+    const { rerender } = renderHook(
+      ({ user }: { user: User }) =>
+        useTokenRefresh(
+          user,
+          baseAuthMetadata(AuthType.BASIC),
+          false,
+          onRefreshFail
+        ),
+      { initialProps: { user: { ...fakeUser } } }
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Simulate the parent re-render storm that occurs when onRefreshFail
+    // -> mutateUser produces a new user object identity.
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        rerender({ user: { ...fakeUser } });
+      });
+    }
+
+    // The time-gate should suppress every follow-up attempt; the original
+    // bug fired ~one extra call per re-render.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/useTokenRefresh.ts
+++ b/web/src/hooks/useTokenRefresh.ts
@@ -1,64 +1,62 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { User } from "@/lib/types";
 import { NO_AUTH_USER_ID } from "@/lib/extension/constants";
 import { AuthTypeMetadata } from "@/hooks/useAuthTypeMetadata";
 import { AuthType } from "@/lib/constants";
 
-// Refresh token every 10 minutes (600000ms)
-// This is shorter than the session expiry time to ensure tokens stay valid
 const REFRESH_INTERVAL = 600000;
+const MIN_REFRESH_GAP_MS = REFRESH_INTERVAL - 60000;
+const VISIBILITY_REFRESH_GAP_MS = 60000;
 
-//  Custom hook for handling JWT token refresh for current user
 export function useTokenRefresh(
   user: User | null,
   authTypeMetadata: AuthTypeMetadata,
+  authTypeMetadataLoading: boolean,
   onRefreshFail: () => Promise<void>
 ) {
-  // Track last refresh time to avoid unnecessary calls
-  const [lastTokenRefresh, setLastTokenRefresh] = useState<number>(Date.now());
-
-  // Use a ref to track first load
-  const isFirstLoad = useRef(true);
+  // Refs (not state) so updates do not retrigger the effect. lastAttemptRef
+  // is bumped on every attempt — including failures — so that a 404 cannot
+  // compound into a re-render loop with the gate permanently open.
+  const lastAttemptRef = useRef<number>(Date.now());
+  const isFirstLoadRef = useRef(true);
 
   useEffect(() => {
+    // The SWR fallback for auth type defaults to BASIC; bail until the real
+    // value loads, otherwise SAML/OIDC users will hit /api/auth/refresh
+    // (which is not registered for those auth types) and 404.
+    if (authTypeMetadataLoading) return;
+
     if (
       !user ||
       user.id === NO_AUTH_USER_ID ||
       authTypeMetadata.authType === AuthType.OIDC ||
       authTypeMetadata.authType === AuthType.SAML
-    )
+    ) {
       return;
+    }
 
     const refreshTokenPeriodically = async () => {
+      const isTimeToRefresh =
+        isFirstLoadRef.current ||
+        Date.now() - lastAttemptRef.current > MIN_REFRESH_GAP_MS;
+
+      if (!isTimeToRefresh) return;
+
+      isFirstLoadRef.current = false;
+      lastAttemptRef.current = Date.now();
+
       try {
-        // Skip time check if this is first load - we always refresh on first load
-        const isTimeToRefresh =
-          isFirstLoad.current ||
-          Date.now() - lastTokenRefresh > REFRESH_INTERVAL - 60000;
-
-        if (!isTimeToRefresh) {
-          return;
-        }
-
-        // Reset first load flag
-        if (isFirstLoad.current) {
-          isFirstLoad.current = false;
-        }
-
         const response = await fetch("/api/auth/refresh", {
           method: "POST",
           credentials: "include",
         });
 
         if (response.ok) {
-          // Update last refresh time on success
-          setLastTokenRefresh(Date.now());
           console.debug("Auth token refreshed successfully");
         } else {
           console.warn("Failed to refresh auth token:", response.status);
-          // If token refresh fails, try to get current user info
           await onRefreshFail();
         }
       } catch (error) {
@@ -66,18 +64,14 @@ export function useTokenRefresh(
       }
     };
 
-    // Always attempt to refresh on first component mount
-    // This helps ensure tokens are fresh, especially after browser refresh
     refreshTokenPeriodically();
 
-    // Set up interval for periodic refreshes
     const intervalId = setInterval(refreshTokenPeriodically, REFRESH_INTERVAL);
 
-    // Also refresh token on window focus, but no more than once per minute
     const handleVisibilityChange = () => {
       if (
         document.visibilityState === "visible" &&
-        Date.now() - lastTokenRefresh > 60000
+        Date.now() - lastAttemptRef.current > VISIBILITY_REFRESH_GAP_MS
       ) {
         refreshTokenPeriodically();
       }
@@ -89,7 +83,5 @@ export function useTokenRefresh(
       clearInterval(intervalId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [user, lastTokenRefresh, onRefreshFail]);
-
-  return { lastTokenRefresh };
+  }, [user, authTypeMetadata, authTypeMetadataLoading, onRefreshFail]);
 }

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -61,7 +61,8 @@ const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
   const { user: fetchedUser, mutateUser } = useCurrentUser();
-  const { authTypeMetadata } = useAuthTypeMetadata();
+  const { authTypeMetadata, isLoading: authTypeMetadataLoading } =
+    useAuthTypeMetadata();
   const updatedSettings = useContext(SettingsContext);
   const posthog = usePostHog();
 
@@ -116,7 +117,12 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const onRefreshFail = useCallback(async () => {
     await mutateUser();
   }, [mutateUser]);
-  useTokenRefresh(upToDateUser, authTypeMetadata, onRefreshFail);
+  useTokenRefresh(
+    upToDateUser,
+    authTypeMetadata,
+    authTypeMetadataLoading,
+    onRefreshFail
+  );
 
   // Sync user's theme preference from DB to next-themes on load
   const { setTheme, theme } = useTheme();


### PR DESCRIPTION
## Description

`useTokenRefresh` was hammering `POST /api/auth/refresh` (~1.4 req/sec per user) on SAML deployments, generating a steady stream of 404s in api-server logs.

**Two compounding bugs, both regressions from #9529 (SSR → CSR migration):**

1. **SAML/OIDC guard misses during SWR loading.** The hook checks `authTypeMetadata.authType === AuthType.SAML` to bail, but `useAuthTypeMetadata` returns a `BASIC` default while its SWR call is in flight. The hook fires its first refresh before the real auth type loads, hitting `/api/auth/refresh` — which the backend (`backend/onyx/main.py:635-646`) only registers for `CLOUD | BASIC | GOOGLE_OAUTH | OIDC`. SAML deployments 404 by design.

2. **Time-gate fails on every 404.** `lastTokenRefresh` was only updated on success. On 404 → `onRefreshFail()` → `mutateUser()` → fresh `User` identity → effect re-runs → `refreshTokenPeriodically()` fires immediately again because the gate `Date.now() - lastTokenRefresh > 9 min` is still satisfied. Loop.

### Fix

- Wait until `useAuthTypeMetadata`'s `isLoading` is false before attempting any refresh.
- Move `lastTokenRefresh` to a `useRef` and bump it on every attempt (success or failure), so the time-gate suppresses re-render-induced retries instead of re-firing.


## How Has This Been Tested?

- Added `web/src/hooks/useTokenRefresh.test.tsx` — covers the loading guard, SAML/OIDC bail, the BASIC happy path, and a regression test that re-renders the parent 10× after a 404 and asserts that `fetch` is still only called once.
- `npx jest src/hooks/useTokenRefresh.test.tsx` → 5/5 passing.
- Pre-commit + TypeScript check pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check