### PR TITLE
fix: omit empty tools in LiteLLM completion requests

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -651,22 +651,25 @@ class LitellmLLM(LLM):
                 if tools and tool_choice is not None:
                     optional_kwargs["tool_choice"] = tool_choice
 
-                response = litellm.completion(
-                    mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
-                    model=model,
-                    base_url=self._api_base or None,
-                    api_version=self._api_version or None,
-                    custom_llm_provider=self._custom_llm_provider or None,
-                    messages=messages,
-                    tools=tools,
-                    stream=stream,
-                    temperature=temperature,
-                    timeout=timeout_override or self._timeout,
-                    max_tokens=max_tokens,
-                    client=client,
+                completion_kwargs = {
+                    "mock_response": get_llm_mock_response() or MOCK_LLM_RESPONSE,
+                    "model": model,
+                    "base_url": self._api_base or None,
+                    "api_version": self._api_version or None,
+                    "custom_llm_provider": self._custom_llm_provider or None,
+                    "messages": messages,
+                    "stream": stream,
+                    "temperature": temperature,
+                    "timeout": timeout_override or self._timeout,
+                    "max_tokens": max_tokens,
+                    "client": client,
                     **optional_kwargs,
                     **passthrough_kwargs,
-                )
+                }
+                if tools:
+                    completion_kwargs["tools"] = tools
+
+                response = litellm.completion(**completion_kwargs)
             return response
         except Exception as e:
             # for break pointing

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1466,6 +1466,37 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         ), "tool_choice must not be sent to providers when no tools are provided"
 
 
+def test_empty_tools_are_omitted_from_completion_request(
+    default_multi_llm: LitellmLLM,
+) -> None:
+    """Regression test for providers like Dashscope that reject tools=[]."""
+    messages: LanguageModelInput = [UserMessage(content="Plan a deep research run")]
+
+    mock_stream_chunks = [
+        litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hello!"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="gpt-3.5-turbo",
+        ),
+    ]
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_stream_chunks
+
+        list(default_multi_llm.stream(messages, tools=[]))
+
+        _, kwargs = mock_completion.call_args
+        assert (
+            "tools" not in kwargs
+        ), "empty tool definitions must not be sent to providers"
+
+
 def test_bifrost_normalizes_api_base_in_model_kwargs() -> None:
     llm = LitellmLLM(
         api_key="test_key",


### PR DESCRIPTION
## Summary
- omit the `tools` argument entirely when the tool definition list is empty
- add a regression test covering the empty-tools completion path that Deep Research can hit with Dashscope
- keep the change scoped to LiteLLM request construction

## Testing
- `.venv/bin/pytest --noconftest backend/tests/unit/onyx/llm/test_multi_llm.py -k 'no_tool_choice_sent_when_no_tools or empty_tools_are_omitted_from_completion_request' -q`
- `.venv/bin/pytest --noconftest backend/tests/unit/onyx/llm/test_multi_llm.py -q`
- `.venv/bin/ruff check backend/onyx/llm/multi_llm.py backend/tests/unit/onyx/llm/test_multi_llm.py`

Closes #10577


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit the tools argument in `litellm` completion calls when the tools list is empty. This prevents provider errors (e.g., Dashscope) seen in Deep Research flows.

- Bug Fixes
  - Build `litellm.completion` kwargs and only include `tools` when non-empty.
  - Add a regression test to ensure empty tool lists are omitted.

<sup>Written for commit 5a9edc0d4e5b9b92878bf4fa5adb2d43c8619034. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

