### PR TITLE
Mm base 10612

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -25,6 +25,7 @@ from shared_configs.configs import (
     POSTGRES_DEFAULT_SCHEMA,
     TENANT_ID_PREFIX,
 )
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from onyx.db.models import Base
 from celery.backends.database.session import (  # ty: ignore[unresolved-import]
     ResultModelBase,
@@ -218,8 +219,15 @@ def do_run_migrations(
         script_location=config.get_main_option("script_location"),
     )
 
-    with context.begin_transaction():
-        context.run_migrations()
+    # Migrations may call into code that reads CURRENT_TENANT_ID_CONTEXTVAR
+    # (e.g. get_kv_store().load() in 4ee1287bd26a). search_path alone is not
+    # enough — set the Python contextvar to match.
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(schema_name)
+    try:
+        with context.begin_transaction():
+            context.run_migrations()
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 def provide_iam_token_for_alembic(

--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -10,7 +10,6 @@ from ee.onyx.server.query_history.api import ONYX_ANONYMIZED_EMAIL
 from ee.onyx.server.query_history.models import QuestionAnswerPairSnapshot
 from onyx.background.task_utils import construct_query_history_report_name
 from onyx.configs.app_configs import JOB_TIMEOUT
-from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
 from onyx.configs.constants import OnyxCeleryTask
@@ -20,6 +19,7 @@ from onyx.db.tasks import delete_task_with_id
 from onyx.db.tasks import mark_task_as_finished_with_id
 from onyx.db.tasks import mark_task_as_started_with_id
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 
@@ -66,8 +66,9 @@ def export_query_history_task(
                 end=end,
             )
 
+            query_history_type = load_settings().query_history_type
             for snapshot in snapshot_generator:
-                if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+                if query_history_type == QueryHistoryType.ANONYMIZED:
                     snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
                 writer.writerows(

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -413,7 +413,10 @@ def get_external_user_group(
             if collab.email:
                 user_emails.add(collab.email)
             else:
-                logger.error(f"Collaborator {collab.login} has no email")
+                # Expected per-user condition (login without a public email);
+                # skip and warn so the login in the message doesn't explode
+                # Sentry fingerprinting.
+                logger.warning(f"Collaborator {collab.login} has no email")
 
         if user_emails:
             collaborators_group = ExternalUserGroup(
@@ -429,7 +432,7 @@ def get_external_user_group(
             if collab.email:
                 user_emails.add(collab.email)
             else:
-                logger.error(f"Outside collaborator {collab.login} has no email")
+                logger.warning(f"Outside collaborator {collab.login} has no email")
 
         if user_emails:
             outside_collaborators_group = ExternalUserGroup(
@@ -448,7 +451,7 @@ def get_external_user_group(
                 if member.email:
                     user_emails.add(member.email)
                 else:
-                    logger.error(f"Team member {member.login} has no email")
+                    logger.warning(f"Team member {member.login} has no email")
 
             if user_emails:
                 team_group = ExternalUserGroup(

--- a/backend/ee/onyx/external_permissions/github/utils.py
+++ b/backend/ee/onyx/external_permissions/github/utils.py
@@ -481,7 +481,7 @@ def get_external_user_group(
             if member.email:
                 user_emails.add(member.email)
             else:
-                logger.error(f"Org member {member.login} has no email")
+                logger.warning(f"Org member {member.login} has no email")
 
         org_group = ExternalUserGroup(
             id=org_group_id,

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -164,7 +164,12 @@ def get_external_access_for_raw_gdrive_file(
             if permission.email_address:
                 user_emails.add(permission.email_address)
             else:
-                logger.error(
+                # Expected per-doc condition when a Drive permission is
+                # attached to an account without a surfaced email (service
+                # accounts, deleted users, external share links). We just
+                # skip the permission — warn instead of error so the doc_id
+                # in the message doesn't explode Sentry fingerprinting.
+                logger.warning(
                     f"Permission is type `user` but no email address is provided for document {doc_id}\n {permission}"
                 )
         elif permission.type == PermissionType.GROUP:
@@ -172,7 +177,7 @@ def get_external_access_for_raw_gdrive_file(
             if permission.email_address:
                 group_emails.add(permission.email_address)
             else:
-                logger.error(
+                logger.warning(
                     f"Permission is type `group` but no email address is provided for document {doc_id}\n {permission}"
                 )
         elif permission.type == PermissionType.DOMAIN and company_domain:

--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -7,11 +7,13 @@ from typing import Any
 from urllib.parse import urlparse
 
 import requests as _requests
+from office365.directory.object_collection import DirectoryObjectCollection
 from office365.graph_client import GraphClient
 from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.runtime.client_request import ClientRequestException
 from office365.sharepoint.client_context import ClientContext
 from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection
+from office365.sharepoint.principal.users.collection import UserCollection
 from pydantic import BaseModel
 
 from ee.onyx.db.external_perm import ExternalUserGroup
@@ -303,10 +305,14 @@ def _get_sharepoint_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_users(users: list[Any]) -> None:
+    def process_users(users: UserCollection) -> None:
         nonlocal groups, user_emails
 
-        for user in users:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `users` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for user in users.current_page:
             logger.debug(f"User: {user.to_json()}")
             if user.principal_type == USER_PRINCIPAL_TYPE and hasattr(
                 user, "user_principal_name"
@@ -357,10 +363,14 @@ def _get_azuread_groups(
     groups: set[SharepointGroup] = set()
     user_emails: set[str] = set()
 
-    def process_members(members: list[Any]) -> None:
+    def process_members(members: DirectoryObjectCollection) -> None:
         nonlocal groups, user_emails
 
-        for member in members:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `members` directly: iterating the collection itself walks pages via
+        # `_get_next().execute_query()`, which re-fires this `page_loaded` callback
+        # and recurses until Python hits its max recursion depth.
+        for member in members.current_page:
             member_data = member.to_json()
             logger.debug(f"Member: {member_data}")
             # Check for user-specific attributes
@@ -522,7 +532,11 @@ def get_external_access_from_sharepoint(
         role_assignments: RoleAssignmentCollection,
     ) -> None:
         nonlocal user_emails, groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             logger.debug(f"Assignment: {assignment.to_json()}")
             if assignment.role_definition_bindings:
                 is_limited_access = True
@@ -713,7 +727,11 @@ def get_sharepoint_external_groups(
 
     def add_group_to_sets(role_assignments: RoleAssignmentCollection) -> None:
         nonlocal groups
-        for assignment in role_assignments:
+        # iterate `current_page` (the items just loaded by this page) instead of
+        # `role_assignments` directly: iterating the collection itself walks pages
+        # via `_get_next().execute_query()`, which re-fires this `page_loaded`
+        # callback and recurses until Python hits its max recursion depth.
+        for assignment in role_assignments.current_page:
             if assignment.role_definition_bindings:
                 is_limited_access = True
                 for role_definition_binding in assignment.role_definition_bindings:

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -25,7 +25,6 @@ from onyx.auth.users import get_display_email
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.task_utils import construct_query_history_report_name
 from onyx.chat.chat_utils import create_chat_history_chain
-from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
 from onyx.configs.constants import MessageType
@@ -46,10 +45,13 @@ from onyx.db.models import ChatSession
 from onyx.db.models import User
 from onyx.db.tasks import get_task_with_id
 from onyx.db.tasks import register_task
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.query_and_chat.models import ChatSessionDetails
 from onyx.server.query_and_chat.models import ChatSessionsResponse
+from onyx.server.settings.store import load_settings
 from onyx.utils.threadpool_concurrency import parallel_yield
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -60,12 +62,14 @@ ONYX_ANONYMIZED_EMAIL = "anonymous@anonymous.invalid"
 
 def ensure_query_history_is_enabled(
     disallowed: list[QueryHistoryType],
-) -> None:
-    if ONYX_QUERY_HISTORY_TYPE in disallowed:
-        raise HTTPException(
-            status_code=HTTPStatus.FORBIDDEN,
-            detail="Query history has been disabled by the administrator.",
+) -> QueryHistoryType:
+    query_history_type = load_settings().query_history_type or QueryHistoryType.NORMAL
+    if query_history_type in disallowed:
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Query history has been disabled by the administrator.",
         )
+    return query_history_type
 
 
 def yield_snapshot_from_chat_session(
@@ -200,7 +204,9 @@ def get_chat_session_history(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedReturn[ChatSessionMinimal]:
-    ensure_query_history_is_enabled(disallowed=[QueryHistoryType.DISABLED])
+    query_history_type = ensure_query_history_is_enabled(
+        disallowed=[QueryHistoryType.DISABLED]
+    )
 
     page_of_chat_sessions = get_page_of_chat_sessions(
         page_num=page_num,
@@ -222,7 +228,7 @@ def get_chat_session_history(
 
     for chat_session in page_of_chat_sessions:
         minimal_chat_session = ChatSessionMinimal.from_chat_session(chat_session)
-        if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+        if query_history_type == QueryHistoryType.ANONYMIZED:
             minimal_chat_session.user_email = ONYX_ANONYMIZED_EMAIL
         minimal_chat_sessions.append(minimal_chat_session)
 
@@ -238,7 +244,9 @@ def get_chat_session_admin(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ChatSessionSnapshot:
-    ensure_query_history_is_enabled(disallowed=[QueryHistoryType.DISABLED])
+    query_history_type = ensure_query_history_is_enabled(
+        disallowed=[QueryHistoryType.DISABLED]
+    )
 
     try:
         chat_session = get_chat_session_by_id(
@@ -262,7 +270,7 @@ def get_chat_session_admin(
             f"Could not create snapshot for chat session with id '{chat_session_id}'",
         )
 
-    if ONYX_QUERY_HISTORY_TYPE == QueryHistoryType.ANONYMIZED:
+    if query_history_type == QueryHistoryType.ANONYMIZED:
         snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
     return snapshot

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -13,7 +13,6 @@ from celery import Celery
 from celery import shared_task
 from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
-from fastapi import HTTPException
 from pydantic import BaseModel
 from redis import Redis
 from redis.lock import Lock as RedisLock
@@ -93,6 +92,7 @@ from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.document_index.factory import get_all_document_indices
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.document_batch_storage import DocumentBatchStorage
 from onyx.file_store.document_batch_storage import get_document_batch_storage
 from onyx.httpx.httpx_pool import HttpxPool
@@ -1453,14 +1453,18 @@ def _docprocessing_task(
     if tenant_id:
         CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-    # Check if chunk indexing usage limit has been exceeded before processing
+    # Check if chunk indexing usage limit has been exceeded before processing.
+    # check_usage_and_raise raises OnyxError; hitting a trial/paid usage limit
+    # is an expected user-facing condition (not an actionable error), so we
+    # mark the attempt failed and return cleanly instead of raising (which
+    # would ship ONYX-BACKEND-H6ED to Sentry on every queued batch of an
+    # over-limit tenant).
     if USAGE_LIMITS_ENABLED:
         try:
             _check_chunk_usage_limit(tenant_id)
-        except HTTPException as e:
-            # Log the error and fail the indexing attempt
-            task_logger.error(
-                f"Chunk indexing usage limit exceeded for tenant {tenant_id}: {e}"
+        except OnyxError as e:
+            task_logger.warning(
+                f"Chunk indexing usage limit exceeded for tenant {tenant_id}: {e.detail}"
             )
             with get_session_with_current_tenant() as db_session:
                 from onyx.db.index_attempt import mark_attempt_failed
@@ -1468,9 +1472,9 @@ def _docprocessing_task(
                 mark_attempt_failed(
                     index_attempt_id=index_attempt_id,
                     db_session=db_session,
-                    failure_reason=str(e),
+                    failure_reason=e.detail,
                 )
-            raise
+            return
 
     task_logger.info(
         f"Processing document batch: attempt={index_attempt_id} batch_num={batch_num} "

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -25,7 +25,9 @@ from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
 from onyx.db.models import Persona
 from onyx.db.models import SearchDoc as DbSearchDoc
+from onyx.db.models import User
 from onyx.db.models import UserFile
+from onyx.db.persona import user_can_access_persona
 from onyx.db.projects import check_project_ownership
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.file_store import get_default_file_store
@@ -108,34 +110,47 @@ def build_file_context(
 
 def create_chat_session_from_request(
     chat_session_request: ChatSessionCreationRequest,
-    user_id: UUID | None,
+    user: User,
     db_session: Session,
 ) -> ChatSession:
     """Create a chat session from a ChatSessionCreationRequest.
 
-    Includes project ownership validation when project_id is provided.
+    Includes project ownership and persona access validation.
 
     Args:
         chat_session_request: The request containing persona_id, description, and project_id
-        user_id: The ID of the user creating the session (can be None for anonymous)
+        user: The user creating the session. Anonymous users are represented as a
+            User with is_anonymous=True (never None); the access-check helpers
+            handle that case. A real User is required so the persona access check
+            always runs — do not introduce a None-tolerant caller.
         db_session: The database session
 
     Returns:
         The newly created ChatSession
 
     Raises:
-        ValueError: If user lacks access to the specified project
+        ValueError: If user lacks access to the specified project or persona
         Exception: If the persona is invalid
     """
     project_id = chat_session_request.project_id
     if project_id:
-        if not check_project_ownership(project_id, user_id, db_session):
+        if not check_project_ownership(project_id, user.id, db_session):
             raise ValueError("User does not have access to project")
+
+    persona_id = chat_session_request.persona_id
+    if persona_id != DEFAULT_PERSONA_ID:
+        if not user_can_access_persona(
+            db_session=db_session,
+            persona_id=persona_id,
+            user=user,
+            get_editable=False,
+        ):
+            raise ValueError("User does not have access to persona")
 
     return create_chat_session(
         db_session=db_session,
         description=chat_session_request.description or "",
-        user_id=user_id,
+        user_id=user.id,
         persona_id=chat_session_request.persona_id,
         project_id=chat_session_request.project_id,
     )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -528,7 +528,7 @@ def build_chat_turn(
             raise RuntimeError("Must specify a chat session id or chat session info")
         chat_session = create_chat_session_from_request(
             chat_session_request=new_msg_req.chat_session_info,
-            user_id=user_id,
+            user=user,
             db_session=db_session,
         )
         yield CreateChatSessionID(chat_session_id=chat_session.id)

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -868,6 +868,15 @@ MAX_EMBEDDED_IMAGES_PER_UPLOAD = max(
     0, int(os.environ.get("MAX_EMBEDDED_IMAGES_PER_UPLOAD") or 1000)
 )
 
+# Maximum non-empty cells to extract from a single xlsx worksheet. Protects
+# from OOM on honestly-huge spreadsheets: memory cost in the extractor is
+# roughly proportional to this count. Once exceeded, the scan stops and a
+# truncation marker row is appended to the sheet's CSV.
+# Peak Memory ~= 100 B * MAX_CELLS
+MAX_XLSX_CELLS_PER_SHEET = max(
+    0, int(os.environ.get("MAX_XLSX_CELLS_PER_SHEET") or 10_000_000)
+)
+
 # Use document summary for contextual rag
 USE_DOCUMENT_SUMMARY = os.environ.get("USE_DOCUMENT_SUMMARY", "true").lower() == "true"
 # Use chunk summary for contextual rag

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -1,3 +1,4 @@
+import time
 from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
@@ -27,6 +28,8 @@ _FIREFLIES_ID_PREFIX = "FIREFLIES_"
 _FIREFLIES_API_URL = "https://api.fireflies.ai/graphql"
 
 _FIREFLIES_TRANSCRIPT_QUERY_SIZE = 50  # Max page size is 50
+_FIREFLIES_MAX_RETRIES = 3
+_FIREFLIES_RETRY_BASE_DELAY_SECONDS = 2
 
 _FIREFLIES_API_QUERY = """
     query Transcripts($fromDate: DateTime, $toDate: DateTime, $limit: Int!, $skip: Int!) {
@@ -169,12 +172,28 @@ class FirefliesConnector(PollConnector, LoadConnector):
 
         while True:
             variables["skip"] = skip
-            response = requests.post(
-                _FIREFLIES_API_URL,
-                headers=headers,
-                json={"query": _FIREFLIES_API_QUERY, "variables": variables},
-            )
+            # Retry 5xx with exponential backoff — Fireflies occasionally
+            # returns 500 / 504 for transient errors (ONYX-BACKEND-H6FJ/H6FH).
+            # 4xx still raises immediately because those are not retryable.
+            response: requests.Response | None = None
+            for attempt in range(_FIREFLIES_MAX_RETRIES):
+                response = requests.post(
+                    _FIREFLIES_API_URL,
+                    headers=headers,
+                    json={
+                        "query": _FIREFLIES_API_QUERY,
+                        "variables": variables,
+                    },
+                )
+                if response.status_code < 500 or attempt == _FIREFLIES_MAX_RETRIES - 1:
+                    break
+                logger.warning(
+                    f"Fireflies returned {response.status_code} on attempt "
+                    f"{attempt + 1}/{_FIREFLIES_MAX_RETRIES}, retrying"
+                )
+                time.sleep(_FIREFLIES_RETRY_BASE_DELAY_SECONDS * (2**attempt))
 
+            assert response is not None  # loop always runs at least once
             response.raise_for_status()
 
             if response.status_code == 204:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -278,9 +278,14 @@ def sleep_and_retry(
                 time.sleep(sleep_time)
                 continue
 
-            # Non-retryable error or retries exhausted — log details and raise.
+            # Non-retryable error or retries exhausted. The exception is
+            # re-raised for the caller to handle — several callers already
+            # swallow expected statuses (e.g. 404 for deleted Azure AD
+            # groups in permission_utils.py:503). Log at warning so the
+            # helper isn't the source of Sentry events for conditions the
+            # caller intentionally handles.
             if e.response is not None:
-                logger.error(
+                logger.warning(
                     f"SharePoint request failed for {method_name}: status={status}, "
                 )
             raise e

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -199,10 +199,16 @@ class SlackTextCleaner:
                     or response["user"]["profile"]["real_name"]
                 )
             except SlackApiError as e:
-                logger.exception(
+                # Common per-message condition: user was deleted, workspace
+                # migrated, bot lacks users:read, etc. Cache the raw id as a
+                # fallback so we don't re-hit the API for the same bad id on
+                # every message, and keep the event out of Sentry — the
+                # message indexing path continues with the id in place of
+                # the display name (ONYX-BACKEND-H6FN).
+                logger.warning(
                     f"Error fetching data for user {user_id}: {e.response['error']}"
                 )
-                raise
+                self._id_to_name_map[user_id] = user_id
 
         return self._id_to_name_map[user_id]
 
@@ -220,9 +226,12 @@ class SlackTextCleaner:
 
                 # Replace the user ID with the username in the message
                 message = message.replace(f"<@{user_id}>", f"@{user_name}")
-            except Exception:
-                logger.exception(
-                    f"Unable to replace user ID with username for user_id '{user_id}'"
+            except Exception as e:
+                # _get_slack_name no longer raises on SlackApiError, so this
+                # only fires on unexpected errors (e.g. malformed response);
+                # still defensive, but not actionable per-message — warn.
+                logger.warning(
+                    f"Unable to replace user ID with username for user_id '{user_id}': {e}"
                 )
 
         return message

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -728,10 +728,25 @@ def run_deep_research_llm_loop(
                         research_results.intermediate_reports
                     ):
                         if report is None:
-                            # The LLM will not see that this research was even attempted, it may try
-                            # something similar again but this is not bad.
+                            # Every tool_use id in the preceding assistant message must have a
+                            # matching TOOL_CALL_RESPONSE or strict providers (e.g. AWS Bedrock
+                            # Converse) reject the next request with 400 "Expected toolResult
+                            # blocks at messages.N.content for the following Ids: ...". Emit a
+                            # synthetic failure response so the invariant holds and the LLM
+                            # knows the call failed.
                             logger.error(
-                                f"Research agent call at tab_index {tab_index} failed, skipping"
+                                f"Research agent call at tab_index {tab_index} failed; emitting synthetic failure response"
+                            )
+                            failed_tool_call = research_agent_calls[tab_index]
+                            failure_message = "Research agent call failed. Try a different approach or continue without this result."
+                            simple_chat_history.append(
+                                ChatMessageSimple(
+                                    message=failure_message,
+                                    token_count=token_counter(failure_message),
+                                    message_type=MessageType.TOOL_CALL_RESPONSE,
+                                    tool_call_id=failed_tool_call.tool_call_id,
+                                    image_files=None,
+                                )
                             )
                             continue
 

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -12,6 +12,7 @@ from email.parser import Parser as EmailParser
 from io import BytesIO
 from pathlib import Path
 from typing import Any
+from typing import cast
 from typing import IO
 from typing import NamedTuple
 from typing import Optional
@@ -20,7 +21,7 @@ from zipfile import BadZipFile
 
 import chardet
 import openpyxl
-from openpyxl.worksheet.worksheet import Worksheet
+from openpyxl.worksheet._read_only import ReadOnlyWorksheet
 from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
@@ -448,104 +449,68 @@ def pptx_to_text(file: IO[Any], file_name: str = "") -> str:
     return presentation.markdown
 
 
-def _worksheet_to_matrix(
-    worksheet: Worksheet,
-) -> list[list[str]]:
-    """
-    Converts a singular worksheet to a matrix of values.
-
-    Rows are padded to a uniform width. In openpyxl's read_only mode,
-    iter_rows can yield rows of differing lengths (trailing empty cells
-    are sometimes omitted), and downstream column cleanup assumes a
-    rectangular matrix.
-    """
-    rows: list[list[str]] = []
-    max_len = 0
-    for worksheet_row in worksheet.iter_rows(min_row=1, values_only=True):
-        row = ["" if cell is None else str(cell) for cell in worksheet_row]
-        if len(row) > max_len:
-            max_len = len(row)
-        rows.append(row)
-
-    for row in rows:
-        if len(row) < max_len:
-            row.extend([""] * (max_len - len(row)))
-
-    return rows
-
-
-def _clean_worksheet_matrix(matrix: list[list[str]]) -> list[list[str]]:
-    """
-    Cleans a worksheet matrix by removing rows if there are N consecutive empty
-    rows and removing cols if there are M consecutive empty columns
-    """
-    MAX_EMPTY_ROWS = 2  # Runs longer than this are capped to max_empty; shorter runs are preserved as-is
-    MAX_EMPTY_COLS = 2
-
-    # Row cleanup
-    matrix = _remove_empty_runs(matrix, max_empty=MAX_EMPTY_ROWS)
-
-    if not matrix:
-        return matrix
-
-    # Column cleanup — determine which columns to keep without transposing.
-    num_cols = len(matrix[0])
-    keep_cols = _columns_to_keep(matrix, num_cols, max_empty=MAX_EMPTY_COLS)
-    if len(keep_cols) < num_cols:
-        matrix = [[row[c] for c in keep_cols] for row in matrix]
-
-    return matrix
-
-
-def _columns_to_keep(
-    matrix: list[list[str]], num_cols: int, max_empty: int
-) -> list[int]:
-    """Return the indices of columns to keep after removing empty-column runs.
-
-    Uses the same logic as ``_remove_empty_runs`` but operates on column
-    indices so no transpose is needed.
-    """
+def _columns_to_keep(col_has_data: bytearray, max_empty: int) -> list[int]:
+    """Keep non-empty columns, plus runs of up to ``max_empty`` empty columns
+    between them. Trailing empty columns are dropped."""
     kept: list[int] = []
     empty_buffer: list[int] = []
-
-    for col_idx in range(num_cols):
-        col_is_empty = all(not row[col_idx] for row in matrix)
-        if col_is_empty:
-            empty_buffer.append(col_idx)
-        else:
+    for c, has in enumerate(col_has_data):
+        if has:
             kept.extend(empty_buffer[:max_empty])
-            kept.append(col_idx)
+            kept.append(c)
             empty_buffer = []
-
+        else:
+            empty_buffer.append(c)
     return kept
 
 
-def _remove_empty_runs(
-    rows: list[list[str]],
-    max_empty: int,
-) -> list[list[str]]:
-    """Removes entire runs of empty rows when the run length exceeds max_empty.
+def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
+    """Stream worksheet rows into CSV text without materializing a dense matrix.
 
-    Leading empty runs are capped to max_empty, just like interior runs.
-    Trailing empty rows are always dropped since there is no subsequent
-    non-empty row to flush them.
+    Empty rows are never stored. Column occupancy is tracked as a ``bytearray``
+    bitmap so column trimming needs no transpose or copy. Runs of empty
+    rows/columns longer than 2 are collapsed; shorter runs are preserved.
     """
-    result: list[list[str]] = []
-    empty_buffer: list[list[str]] = []
+    MAX_EMPTY_ROWS_IN_OUTPUT = 2
+    MAX_EMPTY_COLS_IN_OUTPUT = 2
 
-    for row in rows:
-        # Check if empty
-        if not any(row):
-            if len(empty_buffer) < max_empty:
-                empty_buffer.append(row)
-        else:
-            # Add upto max empty rows onto the result - that's what we allow
-            result.extend(empty_buffer[:max_empty])
-            # Add the new non-empty row
-            result.append(row)
-            empty_buffer = []
+    non_empty_rows: list[tuple[int, list[str]]] = []
+    col_has_data = bytearray()
 
-    return result
+    for row_idx, row_vals in enumerate(rows):
+        # Fast-reject empty rows before allocating a list of "".
+        if not any(v is not None and v != "" for v in row_vals):
+            continue
+
+        cells = ["" if v is None else str(v) for v in row_vals]
+        non_empty_rows.append((row_idx, cells))
+
+        if len(cells) > len(col_has_data):
+            col_has_data.extend(b"\x00" * (len(cells) - len(col_has_data)))
+        for i, v in enumerate(cells):
+            if v:
+                col_has_data[i] = 1
+
+    if not non_empty_rows:
+        return ""
+
+    keep_cols = _columns_to_keep(col_has_data, MAX_EMPTY_COLS_IN_OUTPUT)
+    if not keep_cols:
+        return ""
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    blank_row = [""] * len(keep_cols)
+    last_idx = -1
+    for row_idx, cells in non_empty_rows:
+        gap = row_idx - last_idx - 1
+        if gap > 0:
+            for _ in range(min(gap, MAX_EMPTY_ROWS_IN_OUTPUT)):
+                writer.writerow(blank_row)
+        writer.writerow([cells[c] if c < len(cells) else "" for c in keep_cols])
+        last_idx = row_idx
+
+    return buf.getvalue().rstrip("\n")
 
 
 def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str, str]]:
@@ -573,20 +538,24 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
         raise
 
     sheets: list[tuple[str, str]] = []
-    for sheet in workbook.worksheets:
-        sheet_matrix = _clean_worksheet_matrix(_worksheet_to_matrix(sheet))
-        buf = io.StringIO()
-        writer = csv.writer(buf, lineterminator="\n")
-        writer.writerows(sheet_matrix)
-        csv_text = buf.getvalue().rstrip("\n")
-        if csv_text.strip():
-            sheets.append((csv_text, sheet.title))
+    try:
+        for sheet in workbook.worksheets:
+            # Declared dimensions can be different to what is actually there
+            ro_sheet = cast(ReadOnlyWorksheet, sheet)
+            ro_sheet.reset_dimensions()
+            csv_text = _sheet_to_csv(ro_sheet.iter_rows(values_only=True))
+            sheets.append((csv_text.strip(), ro_sheet.title))
+    finally:
+        workbook.close()
+
     return sheets
 
 
 def xlsx_to_text(file: IO[Any], file_name: str = "") -> str:
     sheets = xlsx_sheet_extraction(file, file_name)
-    return TEXT_SECTION_SEPARATOR.join(csv_text for csv_text, _title in sheets)
+    return TEXT_SECTION_SEPARATOR.join(
+        csv_text for csv_text, _title in sheets if csv_text
+    )
 
 
 def eml_to_text(file: IO[Any]) -> str:

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -25,6 +25,7 @@ from openpyxl.worksheet._read_only import ReadOnlyWorksheet
 from PIL import Image
 
 from onyx.configs.app_configs import MAX_EMBEDDED_IMAGES_PER_FILE
+from onyx.configs.app_configs import MAX_XLSX_CELLS_PER_SHEET
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import OnyxFileExtensions
@@ -470,12 +471,19 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
     Empty rows are never stored. Column occupancy is tracked as a ``bytearray``
     bitmap so column trimming needs no transpose or copy. Runs of empty
     rows/columns longer than 2 are collapsed; shorter runs are preserved.
+
+    Scanning stops once ``MAX_XLSX_CELLS_PER_SHEET`` non-empty cells have been
+    seen; the output gets a truncation marker row appended so downstream
+    indexing sees that the sheet was cut off.
     """
     MAX_EMPTY_ROWS_IN_OUTPUT = 2
     MAX_EMPTY_COLS_IN_OUTPUT = 2
+    TRUNCATION_MARKER = "[truncated: sheet exceeded cell limit]"
 
     non_empty_rows: list[tuple[int, list[str]]] = []
     col_has_data = bytearray()
+    total_non_empty = 0
+    truncated = False
 
     for row_idx, row_vals in enumerate(rows):
         # Fast-reject empty rows before allocating a list of "".
@@ -490,6 +498,11 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
         for i, v in enumerate(cells):
             if v:
                 col_has_data[i] = 1
+                total_non_empty += 1
+
+        if total_non_empty > MAX_XLSX_CELLS_PER_SHEET:
+            truncated = True
+            break
 
     if not non_empty_rows:
         return ""
@@ -509,6 +522,9 @@ def _sheet_to_csv(rows: Iterator[tuple[Any, ...]]) -> str:
                 writer.writerow(blank_row)
         writer.writerow([cells[c] if c < len(cells) else "" for c in keep_cols])
         last_idx = row_idx
+
+    if truncated:
+        writer.writerow([TRUNCATION_MARKER])
 
     return buf.getvalue().rstrip("\n")
 

--- a/backend/onyx/indexing/vector_db_insertion.py
+++ b/backend/onyx/indexing/vector_db_insertion.py
@@ -54,8 +54,19 @@ def write_chunks_to_vector_db_with_backoff(
             [],
         )
     except Exception as e:
-        logger.exception(
-            "Failed to write chunk batch to vector db. Trying individual docs."
+        # The batch write failing just means we fall back to the per-doc
+        # retry loop below. It's only a real failure if the per-doc retry
+        # also fails — that path already logs/captures to Sentry per doc.
+        # Use warning here so a transient OpenSearch response timeout on
+        # the bulk write doesn't ship an event for every indexing batch.
+        # (urllib3 surfaces this as ReadTimeoutError because it has no
+        # separate write-timeout class; the client has already sent the
+        # bulk request and is waiting on OpenSearch's response, which is
+        # where the 60s read timeout fires when the server is slow to
+        # finish the bulk index.)
+        logger.warning(
+            f"Failed to write chunk batch to vector db. Trying individual docs. "
+            f"Batch error: {type(e).__name__}: {e}"
         )
 
         # give some specific logging on this common failure case.

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -1,6 +1,7 @@
 import copy
 import re
 from collections.abc import Callable
+from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any
 from typing import cast
@@ -327,16 +328,105 @@ def check_number_of_tokens(
     return len(encode_fn(text))
 
 
+# Substrings that mark a `custom_config` key as containing credential material.
+# Source of truth shared by:
+#   - response masking in `onyx.server.manage.llm.api`
+#   - error-message scrubbing in `scrub_sensitive_values` (below)
+SENSITIVE_CUSTOM_CONFIG_KEY_FRAGMENTS: frozenset[str] = frozenset(
+    {
+        "vertex_credentials",
+        "aws_secret_access_key",
+        "aws_access_key_id",
+        "aws_bearer_token_bedrock",
+        "private_key",
+        "api_key",
+        "secret",
+        "password",
+        "token",
+        "credential",
+    }
+)
+
+
+def is_sensitive_custom_config_key(key: str) -> bool:
+    """True when `key` looks like a credential-bearing custom_config field."""
+    key_lower = key.lower()
+    return any(
+        fragment in key_lower for fragment in SENSITIVE_CUSTOM_CONFIG_KEY_FRAGMENTS
+    )
+
+
+_SCRUB_PLACEHOLDER = "[REDACTED]"
+
+
+def scrub_sensitive_values(message: str, secrets: Iterable[str | None]) -> str:
+    """Replace every literal secret in `message` with `[REDACTED]`.
+
+    Defense in depth on top of `litellm_exception_to_error_msg` — that helper
+    already maps known LiteLLM exception types to friendly messages and
+    swallows unknown ones, but a few branches (`RateLimitError`, `APIError`,
+    `ServiceUnavailableError`) still embed `str(core_exception)`. This pass
+    strips any credential we already know about (typically the values pulled
+    off `llm.config` via `collect_llm_credential_values`) before the message
+    is surfaced to a client.
+
+    Short / empty secrets are ignored so we don't accidentally eat common
+    substrings.
+    """
+    if not message:
+        return message
+
+    scrubbed = message
+    for secret in secrets:
+        if not secret or len(secret) < 4:
+            continue
+        scrubbed = scrubbed.replace(secret, _SCRUB_PLACEHOLDER)
+
+    return scrubbed
+
+
+def collect_llm_credential_values(llm: LLM | None) -> list[str]:
+    """Pull every credential-looking value out of an LLM's config.
+
+    Used to build the `secrets` argument for `scrub_sensitive_values`.
+    """
+    if llm is None:
+        return []
+    config_secrets: list[str] = []
+    if llm.config.api_key:
+        config_secrets.append(llm.config.api_key)
+    custom_config = llm.config.custom_config or {}
+    for key, value in custom_config.items():
+        if isinstance(value, str) and value and is_sensitive_custom_config_key(key):
+            config_secrets.append(value)
+    return config_secrets
+
+
 def test_llm(llm: LLM) -> str | None:
+    """Probe an LLM and return either `None` (success) or a sanitized error.
+
+    The returned message is intended to be safe to surface to admin callers:
+    raw upstream exception text is *not* echoed verbatim. Known LiteLLM
+    exception types are mapped to friendly messages via
+    `litellm_exception_to_error_msg`, and the result is then scrubbed of any
+    credential values pulled from `llm.config` plus common header/JSON
+    credential patterns.
+
+    The full raw error is still logged at WARNING for ops debugging.
+    """
+    secrets = collect_llm_credential_values(llm)
+    error_msg: str | None = None
     # try for up to 2 timeouts (e.g. 10 seconds in total)
-    error_msg = None
     for _ in range(2):
         try:
             llm.invoke(UserMessage(content="Do not respond"), max_tokens=50)
             return None
         except Exception as e:
-            error_msg = str(e)
-            logger.warning(f"Failed to call LLM with the following error: {error_msg}")
+            logger.warning(f"Failed to call LLM with the following error: {e!s}")
+            safe_msg, _, _ = litellm_exception_to_error_msg(
+                e, llm, fallback_to_error_msg=False
+            )
+            error_msg = scrub_sensitive_values(safe_msg, secrets)
 
     return error_msg
 

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -743,7 +743,13 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
             model_name,
         )
         if model_obj and "supports_reasoning" in model_obj:
-            return model_obj["supports_reasoning"]
+            reasoning = model_obj["supports_reasoning"]
+            if reasoning is None:
+                logger.error(
+                    f"Cannot find reasoning for name={model_name} and provider={model_provider}"
+                )
+                reasoning = False
+            return reasoning
 
         # Fallback: try using litellm.supports_reasoning() for newer models
         try:

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -531,11 +531,13 @@ def llm_max_input_tokens(
         )
         return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 
-    if "max_input_tokens" in model_obj:
-        return model_obj["max_input_tokens"]
+    max_input_tokens = model_obj.get("max_input_tokens")
+    if max_input_tokens is not None:
+        return max_input_tokens
 
-    if "max_tokens" in model_obj:
-        return model_obj["max_tokens"]
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return max_tokens
 
     logger.warning(
         f"No max tokens found for '{model_name}'. Falling back to {GEN_AI_MODEL_FALLBACK_MAX_TOKENS} tokens."
@@ -561,12 +563,14 @@ def get_llm_max_output_tokens(
         )
         return default_output_tokens
 
-    if "max_output_tokens" in model_obj:
-        return model_obj["max_output_tokens"]
+    max_output_tokens = model_obj.get("max_output_tokens")
+    if max_output_tokens is not None:
+        return max_output_tokens
 
     # Fallback to a fraction of max_tokens if max_output_tokens is not specified
-    if "max_tokens" in model_obj:
-        return int(model_obj["max_tokens"] * 0.1)
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return int(max_tokens * 0.1)
 
     logger.warning(
         f"No max output tokens found for '{model_name}'. Falling back to {default_output_tokens} output tokens."
@@ -663,10 +667,12 @@ def get_bedrock_token_limit(model_id: str) -> int:
         for key in [f"bedrock/{model_id}", model_id]:
             if key in model_map:
                 model_info = model_map[key]
-                if "max_input_tokens" in model_info:
-                    return model_info["max_input_tokens"]
-                if "max_tokens" in model_info:
-                    return model_info["max_tokens"]
+                max_input_tokens = model_info.get("max_input_tokens")
+                if max_input_tokens is not None:
+                    return max_input_tokens
+                max_tokens = model_info.get("max_tokens")
+                if max_tokens is not None:
+                    return max_tokens
     except Exception:
         pass  # Fall through to mapping
 

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -515,7 +515,12 @@ class CloudEmbedding:
                 sanitized_api_key=self.sanitized_api_key,
                 status_code=e.response.status_code,
             )
-            logger.error(error_string)
+            # Log at warning because the @retry decorator will re-invoke us
+            # on failure — an ERROR-level log here floods Sentry with up to
+            # _RETRY_TRIES duplicate events per failing batch (rate limits,
+            # transient provider outages). The final failure surfaces via
+            # the RuntimeError below and is logged by the caller.
+            logger.warning(error_string)
             logger.debug(f"Exception texts: {texts}")
 
             raise RuntimeError(error_string)
@@ -530,7 +535,7 @@ class CloudEmbedding:
                 self.provider,
                 sanitized_api_key=self.sanitized_api_key,
             )
-            logger.error(error_string)
+            logger.warning(error_string)
             logger.debug(f"Exception texts: {texts}")
 
             raise RuntimeError(error_string)

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -23,6 +23,7 @@ from slack_sdk.http_retry import RateLimitErrorRetryHandler
 from slack_sdk.http_retry import RetryHandler
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.socket_mode.response import SocketModeResponse
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DEV_MODE
@@ -354,10 +355,19 @@ class SlackbotHandler:
                     except KvKeyNotFoundError:
                         # No Slackbot tokens, pass
                         pass
-                    except psycopg2.errors.UndefinedTable:
-                        logger.error(
-                            "Undefined table error in fetch_slack_bots. Tenant schema may need fixing."
-                        )
+                    except ProgrammingError as e:
+                        # SQLAlchemy wraps psycopg2 errors; UndefinedTable is
+                        # expected when a pre-provisioned tenant's slack_bot
+                        # migration has not completed yet.
+                        if isinstance(e.orig, psycopg2.errors.UndefinedTable):
+                            logger.warning(
+                                f"Tenant {tenant_id} missing slack_bot table "
+                                "(likely mid-provisioning); will retry next cycle."
+                            )
+                        else:
+                            logger.exception(
+                                f"Error fetching Slack bots for tenant {tenant_id}: {e}"
+                            )
                     except Exception as e:
                         logger.exception(
                             f"Error fetching Slack bots for tenant {tenant_id}: {e}"
@@ -413,6 +423,15 @@ class SlackbotHandler:
                         bots = list(fetch_slack_bots(db_session=db_session))
                     except KvKeyNotFoundError:
                         # No Slackbot tokens, pass (and remove below)
+                        bots = []
+                    except ProgrammingError as e:
+                        if isinstance(e.orig, psycopg2.errors.UndefinedTable):
+                            logger.warning(
+                                f"Tenant {tenant_id} missing slack_bot table "
+                                "(likely mid-provisioning); will retry next cycle."
+                            )
+                        else:
+                            logger.exception(f"Error handling tenant {tenant_id}: {e}")
                         bots = []
                     except Exception as e:
                         logger.exception(f"Error handling tenant {tenant_id}: {e}")

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -14,6 +14,7 @@ from typing import Dict
 import psycopg2.errors
 from prometheus_client import Gauge
 from prometheus_client import start_http_server
+from redis.exceptions import LockNotOwnedError
 from redis.lock import Lock
 from redis.lock import Lock as RedisLock
 from slack_sdk import WebClient
@@ -404,11 +405,15 @@ class SlackbotHandler:
                 if tenant_id in self.redis_locks and not DEV_MODE:
                     try:
                         self.redis_locks[tenant_id].release()
-                        del self.redis_locks[tenant_id]
+                    except LockNotOwnedError:
+                        # Expected: lock expired or was stolen; nothing to release.
+                        pass
                     except Exception as e:
-                        logger.error(
+                        logger.warning(
                             f"Error releasing lock for gated tenant {tenant_id}: {e}"
                         )
+                    finally:
+                        self.redis_locks.pop(tenant_id, None)
                 continue
 
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(
@@ -447,12 +452,16 @@ class SlackbotHandler:
                         if tenant_id in self.redis_locks and not DEV_MODE:
                             try:
                                 self.redis_locks[tenant_id].release()
-                                del self.redis_locks[tenant_id]
                                 logger.info(f"Released lock for tenant {tenant_id}")
+                            except LockNotOwnedError:
+                                # Expected: lock expired or was stolen.
+                                pass
                             except Exception as e:
-                                logger.error(
+                                logger.warning(
                                     f"Error releasing lock for tenant {tenant_id}: {e}"
                                 )
+                            finally:
+                                self.redis_locks.pop(tenant_id, None)
                     else:
                         # Manage or reconnect Slack bot sockets
                         for bot in bots:
@@ -610,8 +619,11 @@ class SlackbotHandler:
                 try:
                     self.redis_locks[tenant_id].release()
                     logger.info(f"Released lock for tenant {tenant_id}")
+                except LockNotOwnedError:
+                    # Expected during shutdown: lock expired or was stolen.
+                    pass
                 except Exception as e:
-                    logger.error(f"Error releasing lock for tenant {tenant_id}: {e}")
+                    logger.warning(f"Error releasing lock for tenant {tenant_id}: {e}")
                 finally:
                     del self.redis_locks[tenant_id]
 

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -500,11 +500,20 @@ class SlackbotHandler:
                     #     f"Started socket client for Slackbot with name '{bot_name}' (tenant: {tenant_id}, app: {slack_bot_id})"
                     # )
         except SlackApiError as e:
-            # Only error out if we get a not_authed error
-            if "not_authed" in str(e):
-                # for some reason we want to add the tenant to the list when this happens?
-                logger.error(
-                    f"Authentication error - Invalid or expired credentials: {tenant_id=} {slack_bot_id=}. Error: {e}"
+            # Any auth failure means connect() will also fail — bail early
+            # so slack_sdk's socket_mode client never logs its own error.
+            if any(
+                code in str(e)
+                for code in (
+                    "not_authed",
+                    "invalid_auth",
+                    "token_expired",
+                    "token_revoked",
+                    "account_inactive",
+                )
+            ):
+                logger.warning(
+                    f"Slack auth failed, skipping bot: {tenant_id=} {slack_bot_id=} error={e}"
                 )
                 return None
 
@@ -524,14 +533,19 @@ class SlackbotHandler:
             process_slack_event  # ty: ignore[invalid-argument-type]
         )
 
-        # Establish a WebSocket connection to the Socket Mode servers
-        # logger.debug(
-        #     f"Connecting socket client for tenant: {tenant_id}, app: {slack_bot_id}"
-        # )
-        socket_client.connect()
-        # logger.info(
-        #     f"Started SocketModeClient for tenant: {tenant_id}, app: {slack_bot_id}"
-        # )
+        # Establish a WebSocket connection to the Socket Mode servers.
+        # connect() internally calls apps.connections.open; on auth failure
+        # slack_sdk's socket_mode client logs its own error (shipped to
+        # Sentry as ONYX-BACKEND-4) and re-raises. The common case is
+        # caught above by the auth_test guard — this wrapper covers the
+        # rarer path where bot_token is valid but app_token is not.
+        try:
+            socket_client.connect()
+        except SlackApiError as e:
+            logger.warning(
+                f"Failed to open Slack socket connection: {tenant_id=} {slack_bot_id=} error={e}"
+            )
+            return None
 
         return socket_client
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -724,10 +724,15 @@ def get_feedback_visibility() -> FeedbackVisibility:
 
 class TenantSocketModeClient(SocketModeClient):
     def __init__(self, tenant_id: str, slack_bot_id: int, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+        # Set these BEFORE calling super().__init__ — the base class starts
+        # the message_processor IntervalRunner thread during init, which can
+        # race into our overridden process_message/enqueue_message methods
+        # before these attributes exist (ONYX-BACKEND-1: AttributeError on
+        # _tenant_id).
         self._tenant_id = tenant_id
         self.slack_bot_id = slack_bot_id
         self.bot_name: str = "Unnamed"
+        super().__init__(*args, **kwargs)
 
     @contextmanager
     def _set_tenant_context(self) -> Generator[None, None, None]:

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -11,8 +11,13 @@ from typing import Optional
 import redis
 from fastapi import Request
 from redis import asyncio as aioredis
+from redis.backoff import ExponentialBackoff
 from redis.client import Redis
+from redis.exceptions import BusyLoadingError
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from redis.lock import Lock as RedisLock
+from redis.retry import Retry
 
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import REDIS_DB_NUMBER
@@ -37,6 +42,24 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 SCAN_ITER_COUNT_DEFAULT = 4096
+
+# Retry transient Redis errors — in particular BusyLoadingError, which is
+# raised while Redis is loading its RDB snapshot after a restart or
+# failover. redis-py's default retry policy only covers ConnectionError,
+# so these surface as uncaught exceptions and ship to Sentry
+# (ONYX-BACKEND-H4NT / H43M).
+_RETRYABLE_ERRORS: list[type[Exception]] = [
+    BusyLoadingError,
+    RedisConnectionError,
+    RedisTimeoutError,
+]
+
+
+def _client_retry_kwargs() -> dict[str, Any]:
+    return {
+        "retry": Retry(ExponentialBackoff(cap=2.0, base=0.1), retries=3),
+        "retry_on_error": _RETRYABLE_ERRORS,
+    }
 
 
 class TenantRedis(redis.Redis):
@@ -167,24 +190,28 @@ class RedisPool:
         )
 
     def get_client(self, tenant_id: str) -> Redis:
-        return TenantRedis(tenant_id, connection_pool=self._pool)
+        return TenantRedis(
+            tenant_id, connection_pool=self._pool, **_client_retry_kwargs()
+        )
 
     def get_replica_client(self, tenant_id: str) -> Redis:
-        return TenantRedis(tenant_id, connection_pool=self._replica_pool)
+        return TenantRedis(
+            tenant_id, connection_pool=self._replica_pool, **_client_retry_kwargs()
+        )
 
     def get_raw_client(self) -> Redis:
         """
         Returns a Redis client with direct access to the primary connection pool,
         without tenant prefixing.
         """
-        return redis.Redis(connection_pool=self._pool)
+        return redis.Redis(connection_pool=self._pool, **_client_retry_kwargs())
 
     def get_raw_replica_client(self) -> Redis:
         """
         Returns a Redis client with direct access to the replica connection pool,
         without tenant prefixing.
         """
-        return redis.Redis(connection_pool=self._replica_pool)
+        return redis.Redis(connection_pool=self._replica_pool, **_client_retry_kwargs())
 
     @staticmethod
     def create_pool(

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -47,6 +47,7 @@ from onyx.llm.factory import get_llm
 from onyx.llm.factory import get_max_input_tokens_from_llm_provider
 from onyx.llm.utils import get_bedrock_token_limit
 from onyx.llm.utils import get_llm_contextual_cost
+from onyx.llm.utils import is_sensitive_custom_config_key
 from onyx.llm.utils import test_llm
 from onyx.llm.well_known_providers.auto_update_service import (
     fetch_llm_recommendations_from_github,
@@ -176,21 +177,6 @@ def _sync_fetched_models(
         logger.warning(f"Failed to sync {source_label} models to DB: {e}")
 
 
-# Keys in custom_config that contain sensitive credentials
-_SENSITIVE_CONFIG_KEYS = {
-    "vertex_credentials",
-    "aws_secret_access_key",
-    "aws_access_key_id",
-    "aws_bearer_token_bedrock",
-    "private_key",
-    "api_key",
-    "secret",
-    "password",
-    "token",
-    "credential",
-}
-
-
 def _mask_provider_credentials(provider_view: LLMProviderView) -> None:
     """Mask sensitive credentials in provider view including api_key and custom_config."""
     # Mask the API key
@@ -201,28 +187,18 @@ def _mask_provider_credentials(provider_view: LLMProviderView) -> None:
     if provider_view.custom_config:
         masked_config: dict[str, Any] = {}
         for key, value in provider_view.custom_config.items():
-            # Check if key matches any sensitive pattern (case-insensitive)
-            key_lower = key.lower()
-            is_sensitive = any(
-                sensitive_key in key_lower for sensitive_key in _SENSITIVE_CONFIG_KEYS
-            )
-            if is_sensitive and isinstance(value, str) and value:
+            if is_sensitive_custom_config_key(key) and isinstance(value, str) and value:
                 masked_config[key] = _mask_string(value)
             else:
                 masked_config[key] = value
         provider_view.custom_config = masked_config
 
 
-def _is_sensitive_custom_config_key(key: str) -> bool:
-    key_lower = key.lower()
-    return any(sensitive_key in key_lower for sensitive_key in _SENSITIVE_CONFIG_KEYS)
-
-
 def _is_masked_value_for_existing(
     incoming_value: str, existing_value: str, key: str
 ) -> bool:
     """Return True when incoming_value is a masked round-trip of existing_value."""
-    if not _is_sensitive_custom_config_key(key):
+    if not is_sensitive_custom_config_key(key):
         return False
 
     masked_candidates = {

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -380,16 +380,14 @@ def create_new_chat_session(
     user: User = Depends(current_chat_accessible_user),
     db_session: Session = Depends(get_session),
 ) -> CreateChatSessionID:
-    user_id = user.id
-
     try:
         new_chat_session = create_chat_session_from_request(
             chat_session_request=chat_session_creation_request,
-            user_id=user_id,
+            user=user,
             db_session=db_session,
         )
     except ValueError as e:
-        # Project access denied
+        # Project or persona access denied
         raise HTTPException(status_code=403, detail=str(e))
     except Exception as e:
         logger.exception(e)

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -52,7 +52,8 @@ def load_settings() -> Settings:
         anonymous_user_enabled = False
 
     settings.anonymous_user_enabled = anonymous_user_enabled
-    settings.query_history_type = ONYX_QUERY_HISTORY_TYPE
+    if settings.query_history_type is None:
+        settings.query_history_type = ONYX_QUERY_HISTORY_TYPE
 
     if DISABLE_USER_KNOWLEDGE:
         settings.user_knowledge_enabled = False

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -21,10 +21,9 @@ def explicit_tool_calling_supported(model_provider: str, model_name: str) -> boo
         model_name=model_name,
     )
 
-    model_supports = (
-        model_obj.get("supports_function_calling", False) if model_obj else False
-    )
-    return model_supports
+    if not model_obj:
+        return False
+    return bool(model_obj.get("supports_function_calling"))
 
 
 def compute_tool_tokens(tool: Tool, llm_tokenizer: BaseTokenizer) -> int:

--- a/backend/onyx/tracing/framework/provider.py
+++ b/backend/onyx/tracing/framework/provider.py
@@ -269,9 +269,11 @@ class DefaultTraceProvider(TraceProvider):
             current_span = Scope.get_current_span()
             current_trace = Scope.get_current_trace()
             if current_trace is None:
-                logger.error(
-                    "No active trace. Make sure to start a trace with `trace()` first Returning NoOpSpan."
-                )
+                # Expected when tracing is disabled or a caller creates a span
+                # outside an active trace context (e.g. celery tasks with
+                # SENTRY_CELERY_TRACES_SAMPLE_RATE=0). Fall through to NoOpSpan
+                # silently — matches the other no-op branches below.
+                logger.debug("No active trace; returning NoOpSpan for %s", span_data)
                 return NoOpSpan(span_data)
             elif isinstance(current_trace, NoOpTrace) or isinstance(
                 current_span, NoOpSpan

--- a/backend/tests/external_dependency_unit/answer/stream_test_utils.py
+++ b/backend/tests/external_dependency_unit/answer/stream_test_utils.py
@@ -67,7 +67,7 @@ def create_chat_session(
 ) -> ChatSession:
     return create_chat_session_from_request(
         chat_session_request=ChatSessionCreationRequest(),
-        user_id=user.id,
+        user=user,
         db_session=db_session,
     )
 

--- a/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_persona_access.py
@@ -1,0 +1,182 @@
+"""Integration tests for persona access enforcement on chat session creation.
+
+Covers the `/chat/create-chat-session` endpoint and the implicit session-creation
+path inside `/chat/send-chat-message` when `chat_session_info` is provided.
+"""
+
+import json
+import os
+
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+
+# The fix in `create_chat_session_from_request` runs unconditionally, including
+# on CE. Group-restricted personas only exist under EE, though — on CE every
+# non-admin sees public personas and admins see everything, so no CE user is
+# ever locked out by the access check. These tests therefore only exercise the
+# EE code path where a meaningful block can occur.
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Persona group restrictions are enterprise only",
+)
+
+
+@pytest.fixture()
+def admin_and_basic_user(
+    reset: None,  # noqa: ARG001
+) -> tuple[DATestUser, DATestUser]:
+    admin_user = UserManager.create(name="admin_user")
+    basic_user = UserManager.create(name="basic_user")
+    return admin_user, basic_user
+
+
+def test_create_chat_session_with_unauthorized_persona_returns_403(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    restricted_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="restricted_group",
+        user_ids=[],  # basic_user is NOT in this group
+    )
+    restricted_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Restricted Persona",
+        description="Only accessible to restricted_group",
+        is_public=False,
+        groups=[restricted_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": restricted_persona.id, "description": "Attempted bypass"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 403
+    assert "persona" in response.json()["detail"].lower()
+
+
+def test_create_chat_session_with_authorized_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    allowed_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="allowed_group",
+        user_ids=[basic_user.id],
+    )
+    allowed_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Allowed Persona",
+        description="Accessible to basic_user",
+        is_public=False,
+        groups=[allowed_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": allowed_persona.id, "description": "Authorized"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+    assert "chat_session_id" in response.json()
+
+
+def test_create_chat_session_with_public_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    admin_user, basic_user = admin_and_basic_user
+
+    public_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Public Persona",
+        description="Visible to all",
+        is_public=True,
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": public_persona.id, "description": "Public access"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+
+
+def test_create_chat_session_with_default_persona_succeeds(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    _, basic_user = admin_and_basic_user
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/create-chat-session",
+        json={"persona_id": 0, "description": "Default persona"},
+        headers=basic_user.headers,
+    )
+
+    assert response.status_code == 200
+
+
+def test_send_chat_message_with_unauthorized_persona_in_session_info_is_blocked(
+    admin_and_basic_user: tuple[DATestUser, DATestUser],
+) -> None:
+    """The same check must apply when a session is created implicitly via send-chat-message."""
+    admin_user, basic_user = admin_and_basic_user
+
+    restricted_group = UserGroupManager.create(
+        user_performing_action=admin_user,
+        name="restricted_group_send",
+        user_ids=[],
+    )
+    restricted_persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        name="Restricted Persona For Send",
+        description="Only accessible to restricted_group_send",
+        is_public=False,
+        groups=[restricted_group.id],
+    )
+
+    response = requests.post(
+        f"{API_SERVER_URL}/chat/send-chat-message",
+        json={
+            "message": "hello",
+            "chat_session_info": {
+                "persona_id": restricted_persona.id,
+                "description": "Attempted bypass via message send",
+            },
+            "stream": True,
+        },
+        headers=basic_user.headers,
+        stream=True,
+    )
+
+    # Streaming endpoint always returns 200 and emits an error packet inside the stream.
+    # The important property is that the unauthorized persona never produces a valid
+    # response — a packet containing an access-denied error is surfaced.
+    saw_access_error = False
+    for raw_line in response.iter_lines():
+        if not raw_line:
+            continue
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        err = payload.get("error")
+        if isinstance(err, str) and "persona" in err.lower():
+            saw_access_error = True
+            break
+
+    assert saw_access_error, (
+        "Expected an access-denied error in the stream when sending a message "
+        "with an unauthorized persona in chat_session_info."
+    )

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -339,6 +339,42 @@ class TestSheetToCsvStreaming:
         # 5 leading empty rows collapsed to 2
         assert csv_text.split("\n") == [",", ",", "A,B"]
 
+    def test_cell_cap_truncates_and_appends_marker(self) -> None:
+        """When total non-empty cells exceeds the cap, scanning stops and
+        a truncation marker row is appended so downstream indexing sees
+        the sheet was cut off."""
+        with patch(
+            "onyx.file_processing.extract_file_text.MAX_XLSX_CELLS_PER_SHEET", 5
+        ):
+            csv_text = _sheet_to_csv(
+                iter(
+                    [
+                        ("A", "B", "C"),
+                        ("D", "E", "F"),
+                        ("G", "H", "I"),
+                        ("J", "K", "L"),
+                    ]
+                )
+            )
+        lines = csv_text.split("\n")
+        assert lines[-1] == "[truncated: sheet exceeded cell limit]"
+        # First two rows (6 cells) trip the cap=5 check after row 2; the
+        # third and fourth rows are never scanned.
+        assert "G" not in csv_text
+        assert "J" not in csv_text
+
+    def test_cell_cap_not_hit_no_marker(self) -> None:
+        """Under the cap, no truncation marker is appended."""
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    ("C", "D"),
+                ]
+            )
+        )
+        assert "[truncated" not in csv_text
+
 
 class TestXlsxSheetExtraction:
     def test_one_tuple_per_sheet(self) -> None:

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -1,13 +1,11 @@
 import io
 from typing import cast
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import openpyxl
 from openpyxl.worksheet.worksheet import Worksheet
 
-from onyx.file_processing.extract_file_text import _clean_worksheet_matrix
-from onyx.file_processing.extract_file_text import _worksheet_to_matrix
+from onyx.file_processing.extract_file_text import _sheet_to_csv
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.extract_file_text import xlsx_to_text
 
@@ -203,50 +201,143 @@ class TestXlsxToText:
         assert "r3c1" in lines[2] and "r3c2" in lines[2]
 
 
-class TestWorksheetToMatrixJaggedRows:
-    """openpyxl read_only mode can yield rows of differing widths when
-    trailing cells are empty. The matrix must be padded to a rectangle
-    so downstream column cleanup can index safely."""
+class TestSheetToCsvJaggedRows:
+    """openpyxl's read-only mode yields rows of differing widths when
+    trailing cells are empty. These tests exercise ``_sheet_to_csv``
+    directly because ``_make_xlsx`` (via ``ws.append``) normalizes row
+    widths, so jagged input can only be produced in-memory."""
 
-    def test_pads_shorter_trailing_rows(self) -> None:
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A", "B", "C"),
-                ("X", "Y"),
-                ("P",),
-            ]
+    def test_shorter_trailing_rows_padded_in_output(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B", "C"),
+                    ("X", "Y"),
+                    ("P",),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        assert matrix == [["A", "B", "C"], ["X", "Y", ""], ["P", "", ""]]
+        assert csv_text.split("\n") == ["A,B,C", "X,Y,", "P,,"]
 
-    def test_pads_when_first_row_is_shorter(self) -> None:
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A",),
-                ("X", "Y", "Z"),
-            ]
+    def test_shorter_leading_row_padded_in_output(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A",),
+                    ("X", "Y", "Z"),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        assert matrix == [["A", "", ""], ["X", "Y", "Z"]]
+        assert csv_text.split("\n") == ["A,,", "X,Y,Z"]
 
-    def test_clean_worksheet_matrix_no_index_error_on_jagged_rows(self) -> None:
-        """Regression: previously raised IndexError when a later row was
-        shorter than the first row and the out-of-range column on the
-        first row was empty (so the short-circuit in `all()` did not
-        save us)."""
-        ws = MagicMock()
-        ws.iter_rows.return_value = iter(
-            [
-                ("A", "", "", "B"),
-                ("X", "Y"),
-            ]
+    def test_no_index_error_on_jagged_rows(self) -> None:
+        """Regression: the original dense-matrix version raised IndexError
+        when a later row was shorter than an earlier row whose out-of-range
+        columns happened to be empty."""
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "", "", "B"),
+                    ("X", "Y"),
+                ]
+            )
         )
-        matrix = _worksheet_to_matrix(ws)
-        # Must not raise.
-        cleaned = _clean_worksheet_matrix(matrix)
-        assert cleaned == [["A", "", "", "B"], ["X", "Y", "", ""]]
+        assert csv_text.split("\n") == ["A,,,B", "X,Y,,"]
+
+
+class TestSheetToCsvStreaming:
+    """Pin the memory-safe streaming contract: empty rows are skipped
+    cheaply, empty-row/column runs are collapsed to at most 2, and sheets
+    with no data return the empty string."""
+
+    def test_empty_rows_between_data_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    ("C", "D"),
+                ]
+            )
+        )
+        # 5 empty rows collapsed to 2
+        assert csv_text.split("\n") == ["A,B", ",", ",", "C,D"]
+
+    def test_empty_rows_at_or_below_cap_preserved(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", "B"),
+                    (None, None),
+                    (None, None),
+                    ("C", "D"),
+                ]
+            )
+        )
+        assert csv_text.split("\n") == ["A,B", ",", ",", "C,D"]
+
+    def test_empty_column_run_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A", None, None, None, None, "B"),
+                    ("C", None, None, None, None, "D"),
+                ]
+            )
+        )
+        # 4 empty cols between A and B collapsed to 2
+        assert csv_text.split("\n") == ["A,,,B", "C,,,D"]
+
+    def test_completely_empty_stream_returns_empty_string(self) -> None:
+        assert _sheet_to_csv(iter([])) == ""
+
+    def test_all_rows_empty_returns_empty_string(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    (None, None),
+                    ("", ""),
+                    (None,),
+                ]
+            )
+        )
+        assert csv_text == ""
+
+    def test_trailing_empty_rows_dropped(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    ("A",),
+                    ("B",),
+                    (None,),
+                    (None,),
+                    (None,),
+                ]
+            )
+        )
+        # Trailing empties are never emitted (no subsequent non-empty row
+        # to flush them against).
+        assert csv_text.split("\n") == ["A", "B"]
+
+    def test_leading_empty_rows_capped_at_two(self) -> None:
+        csv_text = _sheet_to_csv(
+            iter(
+                [
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    (None, None),
+                    ("A", "B"),
+                ]
+            )
+        )
+        # 5 leading empty rows collapsed to 2
+        assert csv_text.split("\n") == [",", ",", "A,B"]
 
 
 class TestXlsxSheetExtraction:
@@ -281,10 +372,9 @@ class TestXlsxSheetExtraction:
         assert "a" in csv_text
         assert "b" in csv_text
 
-    def test_empty_sheet_is_skipped(self) -> None:
-        """A sheet whose CSV output is empty/whitespace-only should NOT
-        appear in the result — the `if csv_text.strip():` guard filters
-        it out."""
+    def test_empty_sheet_included_with_empty_csv(self) -> None:
+        """Every sheet in the workbook appears in the result; an empty
+        sheet contributes an empty csv_text alongside its title."""
         xlsx = _make_xlsx(
             {
                 "Data": [["a", "b"]],
@@ -292,14 +382,17 @@ class TestXlsxSheetExtraction:
             }
         )
         sheets = xlsx_sheet_extraction(xlsx)
-        assert len(sheets) == 1
-        assert sheets[0][1] == "Data"
+        assert len(sheets) == 2
+        titles = [title for _csv, title in sheets]
+        assert titles == ["Data", "Empty"]
+        empty_csv = next(csv_text for csv_text, title in sheets if title == "Empty")
+        assert empty_csv == ""
 
-    def test_empty_workbook_returns_empty_list(self) -> None:
-        """All sheets empty → empty list (not a list of empty tuples)."""
+    def test_empty_workbook_returns_one_tuple_per_sheet(self) -> None:
+        """All sheets empty → one empty-csv tuple per sheet."""
         xlsx = _make_xlsx({"Sheet1": [], "Sheet2": []})
         sheets = xlsx_sheet_extraction(xlsx)
-        assert sheets == []
+        assert sheets == [("", "Sheet1"), ("", "Sheet2")]
 
     def test_single_sheet(self) -> None:
         xlsx = _make_xlsx({"Only": [["x", "y"], ["1", "2"]]})

--- a/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
+++ b/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
@@ -1,0 +1,242 @@
+"""Unit tests for `onyx.llm.utils` helpers, focused on the secret-scrubbing
+behavior that protects `/admin/llm/test` (and `validate_existing_genai_api_key`)
+from echoing API keys back through error messages.
+"""
+
+from collections.abc import Iterable
+from typing import Any
+
+from onyx.llm.interfaces import LLM
+from onyx.llm.interfaces import LLMConfig
+from onyx.llm.utils import collect_llm_credential_values
+from onyx.llm.utils import is_sensitive_custom_config_key
+from onyx.llm.utils import scrub_sensitive_values
+from onyx.llm.utils import (
+    test_llm as run_test_llm,
+)  # aliased to avoid pytest collection
+
+
+_SECRET_KEY = "sk-anthropic-supersecret-DO-NOT-LEAK-1234567890"
+_SECRET_VERTEX_BLOB = (
+    '{"private_key":"-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----"}'
+)
+
+
+class _StubLLM(LLM):
+    """Minimal LLM that lets us drive `test_llm` through both success and
+    failure paths without going anywhere near LiteLLM."""
+
+    def __init__(
+        self,
+        config: LLMConfig,
+        *,
+        raise_on_invoke: Exception | None = None,
+    ) -> None:
+        self._config = config
+        self._raise_on_invoke = raise_on_invoke
+        self.invoke_calls = 0
+
+    @property
+    def config(self) -> LLMConfig:
+        return self._config
+
+    def invoke(self, *_: Any, **__: Any) -> Any:  # noqa: D401, ANN401
+        self.invoke_calls += 1
+        if self._raise_on_invoke is not None:
+            raise self._raise_on_invoke
+        return None
+
+
+def _make_config(
+    *,
+    api_key: str | None = _SECRET_KEY,
+    custom_config: dict[str, str] | None = None,
+) -> LLMConfig:
+    return LLMConfig(
+        model_provider="anthropic",
+        model_name="claude-3-5-sonnet",
+        temperature=0.0,
+        api_key=api_key,
+        api_base=None,
+        api_version=None,
+        deployment_name=None,
+        custom_config=custom_config,
+        max_input_tokens=200_000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_sensitive_custom_config_key
+# ---------------------------------------------------------------------------
+
+
+def test_is_sensitive_custom_config_key_matches_known_fragments() -> None:
+    assert is_sensitive_custom_config_key("api_key")
+    assert is_sensitive_custom_config_key("API_KEY")
+    assert is_sensitive_custom_config_key("aws_secret_access_key")
+    assert is_sensitive_custom_config_key("vertex_credentials")
+    assert is_sensitive_custom_config_key("my_password")
+    assert is_sensitive_custom_config_key("auth_token")
+
+
+def test_is_sensitive_custom_config_key_rejects_benign_keys() -> None:
+    assert not is_sensitive_custom_config_key("api_base")
+    assert not is_sensitive_custom_config_key("region")
+    assert not is_sensitive_custom_config_key("model")
+    assert not is_sensitive_custom_config_key("deployment_name")
+
+
+# ---------------------------------------------------------------------------
+# scrub_sensitive_values
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_replaces_literal_secrets() -> None:
+    msg = f"AuthError: provided key {_SECRET_KEY} was rejected"
+    assert _SECRET_KEY in msg
+
+    scrubbed = scrub_sensitive_values(msg, [_SECRET_KEY])
+
+    assert _SECRET_KEY not in scrubbed
+    assert "[REDACTED]" in scrubbed
+
+
+def test_scrub_ignores_empty_and_short_secrets() -> None:
+    # short / empty / None secrets must be ignored so we don't accidentally
+    # eat common substrings like "ok" or "id".
+    msg = "id=abc okOk Token=foo"
+
+    scrubbed = scrub_sensitive_values(msg, [None, "", "ok", "id"])
+
+    assert scrubbed == msg
+
+
+def test_scrub_replaces_multiple_occurrences_of_same_secret() -> None:
+    msg = f"sent {_SECRET_KEY} then retried with {_SECRET_KEY}"
+
+    scrubbed = scrub_sensitive_values(msg, [_SECRET_KEY])
+
+    assert _SECRET_KEY not in scrubbed
+    assert scrubbed.count("[REDACTED]") == 2
+
+
+def test_scrub_handles_empty_message() -> None:
+    assert scrub_sensitive_values("", [_SECRET_KEY]) == ""
+
+
+def test_scrub_leaves_message_untouched_when_no_secrets_present() -> None:
+    msg = "Authentication failed: Please check your API key and credentials."
+
+    assert scrub_sensitive_values(msg, [_SECRET_KEY]) == msg
+
+
+def test_scrub_accepts_iterable_secrets() -> None:
+    secrets: Iterable[str | None] = iter([_SECRET_KEY])
+    msg = f"upstream said: {_SECRET_KEY}"
+
+    scrubbed = scrub_sensitive_values(msg, secrets)
+
+    assert _SECRET_KEY not in scrubbed
+
+
+# ---------------------------------------------------------------------------
+# collect_llm_credential_values
+# ---------------------------------------------------------------------------
+
+
+def test_collect_llm_credential_values_includes_api_key_and_sensitive_config() -> None:
+    config = _make_config(
+        custom_config={
+            "api_base": "https://api.example.com",
+            "vertex_credentials": _SECRET_VERTEX_BLOB,
+            "aws_secret_access_key": "AWSSECRET123456",
+        },
+    )
+    llm = _StubLLM(config)
+
+    values = collect_llm_credential_values(llm)
+
+    assert _SECRET_KEY in values
+    assert _SECRET_VERTEX_BLOB in values
+    assert "AWSSECRET123456" in values
+    assert "https://api.example.com" not in values
+
+
+def test_collect_llm_credential_values_returns_empty_for_none() -> None:
+    assert collect_llm_credential_values(None) == []
+
+
+def test_collect_llm_credential_values_skips_missing_api_key() -> None:
+    config = _make_config(api_key=None, custom_config={"region": "us-east-1"})
+    llm = _StubLLM(config)
+
+    assert collect_llm_credential_values(llm) == []
+
+
+# ---------------------------------------------------------------------------
+# test_llm — end-to-end sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_run_test_llm_returns_none_on_success() -> None:
+    llm = _StubLLM(_make_config())
+
+    assert run_test_llm(llm) is None
+    assert llm.invoke_calls == 1
+
+
+def test_run_test_llm_redacts_api_key_from_unknown_exception() -> None:
+    # An unknown exception subclass falls into the `fallback_to_error_msg=False`
+    # branch of `litellm_exception_to_error_msg`, which already returns a
+    # generic message. The key thing we verify here is that even if the raw
+    # exception text contained the API key, it does NOT make it into the
+    # returned message.
+    boom = RuntimeError(
+        f"upstream blew up. Authorization: Bearer {_SECRET_KEY}; "
+        f"raw key={_SECRET_KEY}"
+    )
+    llm = _StubLLM(_make_config(), raise_on_invoke=boom)
+
+    error_msg = run_test_llm(llm)
+
+    assert error_msg is not None
+    assert _SECRET_KEY not in error_msg
+    # `test_llm` retries up to twice on failure.
+    assert llm.invoke_calls == 2
+
+
+def test_run_test_llm_redacts_litellm_authentication_error_payload() -> None:
+    # Use the real LiteLLM AuthenticationError so we exercise the
+    # litellm_exception_to_error_msg mapping path.
+    from litellm.exceptions import AuthenticationError
+
+    err = AuthenticationError(
+        message=(
+            f"AnthropicException - 401: invalid api key. "
+            f"Authorization: Bearer {_SECRET_KEY}"
+        ),
+        llm_provider="anthropic",
+        model="claude-3-5-sonnet",
+    )
+    llm = _StubLLM(_make_config(), raise_on_invoke=err)
+
+    error_msg = run_test_llm(llm)
+
+    assert error_msg is not None
+    assert _SECRET_KEY not in error_msg
+    # Friendly fallback message should still surface.
+    assert "Authentication failed" in error_msg
+
+
+def test_run_test_llm_redacts_custom_config_secret_from_error() -> None:
+    config = _make_config(
+        api_key=None,
+        custom_config={"aws_secret_access_key": "AWSSECRET-LEAKED-9999"},
+    )
+    boom = RuntimeError("BotoError: signing failed using key AWSSECRET-LEAKED-9999")
+    llm = _StubLLM(config, raise_on_invoke=boom)
+
+    error_msg = run_test_llm(llm)
+
+    assert error_msg is not None
+    assert "AWSSECRET-LEAKED-9999" not in error_msg

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -28,6 +28,7 @@ import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import { extractChatImageFileId } from "@/app/app/components/files/images/utils";
 import { cn, transformLinkUri } from "@/lib/utils";
+import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
 
 /** Maps a visible-char count to a markdown index (skips formatting chars,
  *  extends to word boundary). Used by the voice-sync reveal path only. */
@@ -96,6 +97,8 @@ export const MessageTextRenderer: MessageRenderer<
   stopReason,
   children,
 }) => {
+  const { enabled: smoothStreamingEnabled } = useSmoothStreaming();
+
   const lastStableSyncedContentRef = useRef("");
   const lastVisibleContentRef = useRef("");
 
@@ -247,7 +250,8 @@ export const MessageTextRenderer: MessageRenderer<
   const isStreamingAnimationEnabled =
     animate &&
     !shouldUseAutoPlaybackSync &&
-    stopReason !== StopReason.USER_CANCELLED;
+    stopReason !== StopReason.USER_CANCELLED &&
+    smoothStreamingEnabled;
 
   const isStreamFinished = isFinalAnswerComplete(packets);
 

--- a/web/src/hooks/useSmoothStreaming.ts
+++ b/web/src/hooks/useSmoothStreaming.ts
@@ -1,0 +1,42 @@
+import Cookies from "js-cookie";
+import { useCallback, useEffect, useState } from "react";
+
+import { SMOOTH_STREAMING_COOKIE_NAME } from "@/lib/constants";
+
+const CHANGE_EVENT = "smoothStreaming:change";
+const DEFAULT_ENABLED = true;
+const COOKIE_EXPIRES_DAYS = 365;
+
+function readCookie(): boolean {
+  const value = Cookies.get(SMOOTH_STREAMING_COOKIE_NAME);
+  if (value === undefined) return DEFAULT_ENABLED;
+  return value !== "false";
+}
+
+interface UseSmoothStreamingResult {
+  enabled: boolean;
+  setEnabled: (next: boolean) => void;
+}
+
+export function useSmoothStreaming(): UseSmoothStreamingResult {
+  const [enabled, setEnabledState] = useState<boolean>(() =>
+    typeof window === "undefined" ? DEFAULT_ENABLED : readCookie()
+  );
+
+  useEffect(() => {
+    setEnabledState(readCookie());
+    const handler = () => setEnabledState(readCookie());
+    window.addEventListener(CHANGE_EVENT, handler);
+    return () => window.removeEventListener(CHANGE_EVENT, handler);
+  }, []);
+
+  const setEnabled = useCallback((next: boolean) => {
+    Cookies.set(SMOOTH_STREAMING_COOKIE_NAME, String(next), {
+      expires: COOKIE_EXPIRES_DAYS,
+    });
+    setEnabledState(next);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }, []);
+
+  return { enabled, setEnabled };
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -81,6 +81,10 @@ export const NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED =
 export const NEXT_PUBLIC_TEST_ENV =
   process.env.NEXT_PUBLIC_TEST_ENV?.toLowerCase() === "true";
 
+// Cookie controlling the per-character typewriter reveal in chat.
+// "false" disables smooth streaming — chunks render as they arrive.
+export const SMOOTH_STREAMING_COOKIE_NAME = "smoothStreamingEnabled";
+
 export const NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK =
   process.env.NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK?.toLowerCase() ===
   "true";

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -67,6 +67,7 @@ import { usePaidEnterpriseFeaturesEnabled } from "@/components/settings/usePaidE
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { Tooltip } from "@opal/components";
 import { useCloudSubscription } from "@/hooks/useCloudSubscription";
+import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
 
 interface PAT {
   id: number;
@@ -763,6 +764,10 @@ function ChatPreferencesSettings() {
   const settings = useSettingsContext();
   const { isSearchModeAvailable: searchUiEnabled } = settings;
   const llmManager = useLlmManager();
+  const {
+    enabled: smoothStreamingEnabled,
+    setEnabled: setSmoothStreamingEnabled,
+  } = useSmoothStreaming();
 
   const {
     personalizationValues,
@@ -857,6 +862,17 @@ function ChatPreferencesSettings() {
               onCheckedChange={(checked) => {
                 updateUserAutoScroll(checked);
               }}
+            />
+          </InputHorizontal>
+
+          <InputHorizontal
+            title="Smooth Streaming"
+            description="Animate streamed responses character-by-character. Disable to render chunks as they arrive."
+            withLabel
+          >
+            <Switch
+              checked={smoothStreamingEnabled}
+              onCheckedChange={setSmoothStreamingEnabled}
             />
           </InputHorizontal>
 

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -38,7 +38,7 @@ import {
 import useCCPairs from "@/hooks/useCCPairs";
 import { getSourceMetadata } from "@/lib/sources";
 import { EmptyMessageCard } from "@opal/components";
-import { Settings } from "@/interfaces/settings";
+import { QueryHistoryType, Settings } from "@/interfaces/settings";
 import { toast } from "@/hooks/useToast";
 import { useAvailableTools } from "@/hooks/useAvailableTools";
 import {
@@ -929,36 +929,79 @@ export default function ChatPreferencesPage() {
             <SimpleCollapsible.Content>
               <Section gap={1}>
                 <Card border="solid" rounding="lg">
-                  <InputHorizontal
-                    title="Keep Chat History"
-                    description="Specify how long Onyx should retain chats in your organization."
-                    withLabel
-                  >
-                    <InputSelect
-                      value={
-                        s.maximum_chat_retention_days?.toString() ?? "forever"
-                      }
-                      onValueChange={(value) => {
-                        void saveSettings({
-                          maximum_chat_retention_days:
-                            value === "forever" ? null : parseInt(value, 10),
-                        });
-                      }}
+                  <Section>
+                    <InputHorizontal
+                      title="Keep Chat History"
+                      description="Specify how long Onyx should retain chats in your organization."
+                      withLabel
                     >
-                      <InputSelect.Trigger />
-                      <InputSelect.Content>
-                        <InputSelect.Item value="forever">
-                          Forever
-                        </InputSelect.Item>
-                        <InputSelect.Item value="7">7 days</InputSelect.Item>
-                        <InputSelect.Item value="30">30 days</InputSelect.Item>
-                        <InputSelect.Item value="90">90 days</InputSelect.Item>
-                        <InputSelect.Item value="365">
-                          365 days
-                        </InputSelect.Item>
-                      </InputSelect.Content>
-                    </InputSelect>
-                  </InputHorizontal>
+                      <InputSelect
+                        value={
+                          s.maximum_chat_retention_days?.toString() ?? "forever"
+                        }
+                        onValueChange={(value) => {
+                          void saveSettings({
+                            maximum_chat_retention_days:
+                              value === "forever" ? null : parseInt(value, 10),
+                          });
+                        }}
+                      >
+                        <InputSelect.Trigger />
+                        <InputSelect.Content>
+                          <InputSelect.Item value="forever">
+                            Forever
+                          </InputSelect.Item>
+                          <InputSelect.Item value="7">7 days</InputSelect.Item>
+                          <InputSelect.Item value="30">
+                            30 days
+                          </InputSelect.Item>
+                          <InputSelect.Item value="90">
+                            90 days
+                          </InputSelect.Item>
+                          <InputSelect.Item value="365">
+                            365 days
+                          </InputSelect.Item>
+                        </InputSelect.Content>
+                      </InputSelect>
+                    </InputHorizontal>
+
+                    <InputHorizontal
+                      title="Query History Visibility"
+                      description="Control how your organization's full chat history appears in the Admin Panel."
+                      withLabel
+                    >
+                      <InputSelect
+                        value={s.query_history_type ?? QueryHistoryType.NORMAL}
+                        onValueChange={(value) => {
+                          void saveSettings({
+                            query_history_type: value as QueryHistoryType,
+                          });
+                        }}
+                      >
+                        <InputSelect.Trigger />
+                        <InputSelect.Content>
+                          <InputSelect.Item
+                            value={QueryHistoryType.NORMAL}
+                            description="All queries are visible to admins and linked to individual users."
+                          >
+                            Show with User Info
+                          </InputSelect.Item>
+                          <InputSelect.Item
+                            value={QueryHistoryType.ANONYMIZED}
+                            description="Queries are visible to admins with user identity removed"
+                          >
+                            Anonymized
+                          </InputSelect.Item>
+                          <InputSelect.Item
+                            value={QueryHistoryType.DISABLED}
+                            description="Query history reporting is disabled."
+                          >
+                            Hidden
+                          </InputSelect.Item>
+                        </InputSelect.Content>
+                      </InputSelect>
+                    </InputHorizontal>
+                  </Section>
                 </Card>
 
                 <Card border="solid" rounding="lg">

--- a/web/tests/e2e/admin/query_history_toggle.spec.ts
+++ b/web/tests/e2e/admin/query_history_toggle.spec.ts
@@ -1,0 +1,147 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "@tests/e2e/fixtures/eeFeatures";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+async function expandAdvancedOptions(page: Page): Promise<void> {
+  await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
+    timeout: 10000,
+  });
+
+  const header = page.getByText("Advanced Options", { exact: true });
+  await expect(header).toBeVisible({ timeout: 10000 });
+
+  const queryHistoryTrigger = page
+    .locator("label")
+    .filter({ hasText: "Query History Visibility" })
+    .first();
+
+  const alreadyVisible = await queryHistoryTrigger
+    .isVisible()
+    .catch(() => false);
+  if (alreadyVisible) return;
+
+  await header.scrollIntoViewIfNeeded();
+  await header.click();
+
+  await expect(queryHistoryTrigger).toBeVisible({ timeout: 5000 });
+}
+
+async function getQueryHistoryValue(page: Page): Promise<string> {
+  await expandAdvancedOptions(page);
+
+  const trigger = page
+    .locator("label")
+    .filter({ hasText: "Query History Visibility" })
+    .locator('[role="combobox"]');
+
+  const text = (await trigger.textContent()) ?? "";
+  for (const label of ["Show with User Info", "Anonymized", "Hidden"]) {
+    if (text.includes(label)) return label;
+  }
+  return text;
+}
+
+async function setQueryHistoryType(
+  page: Page,
+  value: "Show with User Info" | "Anonymized" | "Hidden"
+): Promise<void> {
+  await page.goto("/admin/configuration/chat-preferences");
+  await page.waitForLoadState("networkidle");
+  await expandAdvancedOptions(page);
+
+  const currentValue = await getQueryHistoryValue(page);
+  if (currentValue === value) return;
+
+  const trigger = page
+    .locator("label")
+    .filter({ hasText: "Query History Visibility" })
+    .locator('[role="combobox"]');
+
+  await trigger.scrollIntoViewIfNeeded();
+  await trigger.click();
+
+  const option = page.locator('[role="option"]').filter({ hasText: value });
+  await expect(option).toBeVisible({ timeout: 3000 });
+  await option.click();
+
+  await expect(page.getByText("Settings updated")).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+test.describe("Query History Toggle @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test.afterEach(async ({ page }) => {
+    await setQueryHistoryType(page, "Show with User Info");
+  });
+
+  test("dropdown shows current value and persists after reload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/configuration/chat-preferences");
+    await page.waitForLoadState("networkidle");
+
+    const currentValue = await getQueryHistoryValue(page);
+    expect(["Show with User Info", "Anonymized", "Hidden"]).toContain(
+      currentValue
+    );
+
+    await setQueryHistoryType(page, "Anonymized");
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const newValue = await getQueryHistoryValue(page);
+    expect(newValue).toBe("Anonymized");
+  });
+
+  test("setting to Hidden hides query history sidebar link", async ({
+    page,
+    eeEnabled,
+  }) => {
+    test.skip(!eeEnabled, "Query History page requires enterprise license");
+
+    await setQueryHistoryType(page, "Show with User Info");
+
+    await page.goto("/admin/performance/usage");
+    await page.waitForLoadState("networkidle");
+
+    const sidebar = page.locator('[class*="group/SidebarWrapper"]');
+    const queryHistoryLink = sidebar.locator(
+      'a[href="/admin/performance/query-history"]'
+    );
+    await expect(queryHistoryLink).toBeVisible({ timeout: 5000 });
+
+    await setQueryHistoryType(page, "Hidden");
+
+    await page.goto("/admin/performance/usage");
+    await page.waitForLoadState("networkidle");
+
+    const sidebarAfter = page.locator('[class*="group/SidebarWrapper"]');
+    const queryHistoryLinkAfter = sidebarAfter.locator(
+      'a[href="/admin/performance/query-history"]'
+    );
+    await expect(queryHistoryLinkAfter).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test("can cycle through all three options", async ({ page }) => {
+    await setQueryHistoryType(page, "Show with User Info");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Show with User Info");
+
+    await setQueryHistoryType(page, "Anonymized");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Anonymized");
+
+    await setQueryHistoryType(page, "Hidden");
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    expect(await getQueryHistoryValue(page)).toBe("Hidden");
+  });
+});


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add admin controls for Query History visibility and a user setting to disable smooth streaming, improving privacy and UX. Tighten security and stability across chat session access, Excel extraction, LLM error scrubbing, and third‑party integrations.

- New Features
  - Query History Visibility: Normal / Anonymized / Hidden. Enforced in admin APIs and exports; UI added under Admin → Chat Preferences; includes E2E test.
  - Smooth Streaming toggle: per-user setting (cookie-backed) to disable the character-by-character animation; renderer respects it; default on.

- Bug Fixes
  - Enforce persona access on chat session creation (direct and via send-message); adds integration tests.
  - XLSX extraction: stream rows to reduce peak memory; cap scanned cells per sheet via `MAX_XLSX_CELLS_PER_SHEET` (default 10M) with truncation marker; expanded unit tests.
  - LLM test endpoint: scrub API keys and sensitive custom_config values from error messages; helpers added and unit tested; safer, user-visible errors.
  - Redis: retry transient `BusyLoadingError`/timeouts with exponential backoff.
  - Fireflies connector: retry transient 5xx with exponential backoff.
  - SharePoint: fix pagination callbacks to avoid recursion; iterate `current_page`; several permission logs downgraded to warnings.
  - Slack: handle auth failures early, cache `users.info` failures, avoid race in `TenantSocketModeClient`, silence `LockNotOwnedError`, and reduce noisy logs.
  - Deep Research: emit synthetic tool_result on failed agent calls to satisfy strict providers.
  - Indexing: treat usage-limit exceedance as a clean attempt failure (no Sentry spam); demote bulk-write fallback log to warning.
  - Embeddings: retryable provider errors logged at warning (not error).
  - Migrations: set tenant contextvar around per-schema runs to match search_path.
  - Tracing: downgrade “No active trace” to debug.

<sup>Written for commit fd7ee3edde4bacc984d889a8557bb0f2cc111d65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

