### PR TITLE
fix(llm): preserve user metadata passthrough

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -583,6 +583,12 @@ class LitellmLLM(LLM):
         if structured_response_format:
             optional_kwargs["response_format"] = structured_response_format
 
+        # Passthrough kwargs
+        passthrough_kwargs = build_litellm_passthrough_kwargs(
+            model_kwargs=self._model_kwargs,
+            user_identity=user_identity,
+        )
+
         if (
             not (is_claude_model or is_ollama or is_mistral)
             or is_openai_compatible_proxy
@@ -593,13 +599,15 @@ class LitellmLLM(LLM):
             # routed through Bifrost's OpenAI-compatible endpoint.
             # Additionally, tool_choice is not supported by Ollama and causes warnings if included.
             # See also, https://github.com/ollama/ollama/issues/11171
-            optional_kwargs["allowed_openai_params"] = ["tool_choice"]
-
-        # Passthrough kwargs
-        passthrough_kwargs = build_litellm_passthrough_kwargs(
-            model_kwargs=self._model_kwargs,
-            user_identity=user_identity,
-        )
+            allowed_openai_params = ["tool_choice"]
+            # LiteLLM also drops some OpenAI-compatible passthrough fields for
+            # non-whitelisted models. Preserve user/session metadata only when
+            # the caller explicitly enabled and populated it.
+            if "user" in passthrough_kwargs:
+                allowed_openai_params.append("user")
+            if "metadata" in passthrough_kwargs:
+                allowed_openai_params.append("metadata")
+            optional_kwargs["allowed_openai_params"] = allowed_openai_params
 
         try:
             # NOTE: must pass in None instead of empty strings otherwise litellm

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1671,3 +1671,43 @@ def test_bifrost_claude_includes_allowed_openai_params() -> None:
         assert kwargs["base_url"] == "https://bifrost.example.com/v1"
         assert kwargs["custom_llm_provider"] == "openai"
         assert kwargs["allowed_openai_params"] == ["tool_choice"]
+
+
+def test_user_metadata_passthrough_allowed_for_openai_compatible_provider(
+    default_multi_llm: LitellmLLM,
+) -> None:
+    messages: LanguageModelInput = [UserMessage(content="Hello!")]
+    user_identity = LLMUserIdentity(
+        user_id="user@example.com",
+        session_id="session-123",
+    )
+    mock_stream_chunks = [
+        litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hello!"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="gpt-3.5-turbo",
+        ),
+    ]
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.utils.SEND_USER_METADATA_TO_LLM_PROVIDER", True),
+    ):
+        mock_completion.return_value = mock_stream_chunks
+
+        default_multi_llm.invoke(messages, tools=None, user_identity=user_identity)
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["user"] == "user@example.com"
+        assert kwargs["metadata"] == {"session_id": "session-123"}
+        assert kwargs["allowed_openai_params"] == [
+            "tool_choice",
+            "user",
+            "metadata",
+        ]


### PR DESCRIPTION
## Summary
- preserve opted-in `user` passthrough for LiteLLM OpenAI-compatible requests
- preserve opted-in `metadata.session_id` passthrough alongside `user`
- add regression coverage for `SEND_USER_METADATA_TO_LLM_PROVIDER=true`

## Why
When `SEND_USER_METADATA_TO_LLM_PROVIDER=true`, Onyx builds `user` and `metadata.session_id`, but LiteLLM can filter these fields for OpenAI-compatible non-whitelisted models unless they are included in `allowed_openai_params`. That makes requests indistinguishable to downstream routing/auditing proxies.

## Tests
- `python3 -m py_compile backend/onyx/llm/multi_llm.py backend/onyx/llm/utils.py`
- `python3 -m py_compile backend/tests/unit/onyx/llm/test_multi_llm.py`

Could not run the targeted pytest locally because this machine has ~600MB free disk and `uv run pytest` attempted to download multi-GB dependencies, then failed with `No space left on device`.

Fixes #10461


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves opted-in user and session metadata passthrough to OpenAI-compatible providers via `litellm`, so downstream routing/auditing keeps identity when SEND_USER_METADATA_TO_LLM_PROVIDER=true. Adds unit tests to lock this behavior.

- **Bug Fixes**
  - Forward `user` and `metadata.session_id` when passthrough is enabled.
  - Extend `allowed_openai_params` to include `user` and `metadata` (alongside `tool_choice`) so `litellm` doesn’t drop them for non-whitelisted OpenAI-compatible models.

<sup>Written for commit c09bfbd75b297dcd3bc6e20abe5f8ec0c3790caf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

