### PR TITLE
fix(deep-research): handle missing research task

### DIFF
--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -243,6 +243,10 @@ def run_research_agent_call(
                     RESEARCH_AGENT_TASK_KEY,
                     research_agent_call.tool_args,
                 )
+                # No ResearchAgentStart packet has been emitted yet, so there is
+                # no client-side research slot to close with a PacketException.
+                # Returning None matches the orchestrator's existing invalid-call
+                # handling without surfacing an internal malformed tool call to users.
                 return None
             research_topic = research_topic.strip()
 

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -236,8 +236,15 @@ def run_research_agent_call(
             reasoning_cycles = 0
             just_ran_web_search = False
 
-            # If this fails to parse, we can't run the loop anyway, let this one fail in that case
-            research_topic = research_agent_call.tool_args[RESEARCH_AGENT_TASK_KEY]
+            research_topic = research_agent_call.tool_args.get(RESEARCH_AGENT_TASK_KEY)
+            if not isinstance(research_topic, str) or not research_topic.strip():
+                logger.warning(
+                    "Research agent tool call missing non-empty '%s' argument: %s",
+                    RESEARCH_AGENT_TASK_KEY,
+                    research_agent_call.tool_args,
+                )
+                return None
+            research_topic = research_topic.strip()
 
             emitter.emit(
                 Packet(


### PR DESCRIPTION
## Summary
- avoid a raw KeyError when a research_agent tool call is missing the required task argument
- log the malformed arguments and return a failed research-agent result so the orchestrator can continue gracefully
- trim valid task strings before running the research agent

## Tests
- python3 -m py_compile backend/onyx/tools/fake_tools/research_agent.py

Fixes #8463

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents crashes in deep-research when `research_agent` is called without a task. Logs invalid args, fails the call gracefully, trims valid task strings, and documents the early-exit behavior.

- **Bug Fixes**
  - Validate `RESEARCH_AGENT_TASK_KEY` via safe lookup; warn and return None if missing or empty.
  - Strip whitespace from the task before running the agent.

<sup>Written for commit 7097fe1b4d5a2a9b78e2603e8223079556c9a5f0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10630?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

