### PR TITLE
fix(mcp): namespace tool names for LLM calls

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import re
 from typing import Any
@@ -42,7 +43,13 @@ def _safe_llm_tool_name(mcp_server_id: int, tool_name: str) -> str:
         safe_tool_name = "tool"
 
     prefix = f"mcp_{mcp_server_id}_"
-    return f"{prefix}{safe_tool_name}"[:64]
+    name = f"{prefix}{safe_tool_name}"
+    if len(name) <= 64:
+        return name
+
+    digest = hashlib.sha1(safe_tool_name.encode()).hexdigest()[:8]
+    suffix = f"_{digest}"
+    return f"{prefix}{safe_tool_name[: 64 - len(prefix) - len(suffix)]}{suffix}"
 
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 
 from mcp.client.auth import OAuthClientProvider
@@ -26,6 +27,21 @@ logger = setup_logger()
 DENYLISTED_MCP_HEADERS = {
     "host",  # Prevents Host Header Injection attacks
 }
+
+
+def _safe_llm_tool_name(mcp_server_id: int, tool_name: str) -> str:
+    """Return a provider-safe, per-server MCP tool name.
+
+    OpenAI/Anthropic-compatible function names must be alphanumeric, underscore,
+    or hyphen. MCP servers commonly expose generic names like `search` and
+    `fetch`, so namespace by the stable numeric server id to avoid collisions.
+    """
+
+    safe_tool_name = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_")
+    if not safe_tool_name:
+        safe_tool_name = "tool"
+    return f"mcp_{mcp_server_id}_{safe_tool_name}"
+
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class
 # In the future we may want custom handling for MCP tool responses
@@ -79,7 +95,7 @@ class MCPTool(Tool[None]):
         self._tool_definition = tool_definition
         self._description = tool_description
         self._display_name = tool_definition.get("displayName", tool_name)
-        self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
+        self._llm_name = _safe_llm_tool_name(mcp_server.id, tool_name)
 
     @property
     def id(self) -> int:
@@ -87,7 +103,7 @@ class MCPTool(Tool[None]):
 
     @property
     def name(self) -> str:
-        return self._name
+        return self._llm_name
 
     @property
     def description(self) -> str:
@@ -107,7 +123,7 @@ class MCPTool(Tool[None]):
         return {
             "type": "function",
             "function": {
-                "name": self._name,
+                "name": self._llm_name,
                 "description": self._description,
                 "parameters": _normalize_parameters_schema(self._tool_definition),
             },

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -37,10 +37,12 @@ def _safe_llm_tool_name(mcp_server_id: int, tool_name: str) -> str:
     `fetch`, so namespace by the stable numeric server id to avoid collisions.
     """
 
-    safe_tool_name = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_")
+    safe_tool_name = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_name).strip("_-")
     if not safe_tool_name:
         safe_tool_name = "tool"
-    return f"mcp_{mcp_server_id}_{safe_tool_name}"
+
+    prefix = f"mcp_{mcp_server_id}_"
+    return f"{prefix}{safe_tool_name}"[:64]
 
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -23,7 +23,7 @@ class TestSafeLLMToolName:
     def test_strips_edge_hyphens_and_underscores(self) -> None:
         assert _safe_llm_tool_name(7, "-search_") == "mcp_7_search"
 
-    def test_truncates_to_provider_tool_name_limit(self) -> None:
+    def test_long_names_are_capped_at_64_chars(self) -> None:
         safe_name = _safe_llm_tool_name(123, "aws___retrieve_and_generate_with_additional_model_response_fields")
 
         assert len(safe_name) == 64

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -29,6 +29,14 @@ class TestSafeLLMToolName:
         assert len(safe_name) == 64
         assert safe_name.startswith("mcp_123_")
 
+    def test_long_names_keep_hash_suffix_to_avoid_collisions(self) -> None:
+        first_name = _safe_llm_tool_name(1, f"{'a' * 80}_first")
+        second_name = _safe_llm_tool_name(1, f"{'a' * 80}_second")
+
+        assert len(first_name) == 64
+        assert len(second_name) == 64
+        assert first_name != second_name
+
 
 class TestNormalizeParametersSchema:
     def test_empty_dict_gets_object_shell(self) -> None:

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -15,7 +15,19 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.tools.tool_implementations.mcp.mcp_tool import _normalize_parameters_schema
+from onyx.tools.tool_implementations.mcp.mcp_tool import _safe_llm_tool_name
 from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+class TestSafeLLMToolName:
+    def test_strips_edge_hyphens_and_underscores(self) -> None:
+        assert _safe_llm_tool_name(7, "-search_") == "mcp_7_search"
+
+    def test_truncates_to_provider_tool_name_limit(self) -> None:
+        safe_name = _safe_llm_tool_name(123, "aws___retrieve_and_generate_with_additional_model_response_fields")
+
+        assert len(safe_name) == 64
+        assert safe_name.startswith("mcp_123_")
 
 
 class TestNormalizeParametersSchema:


### PR DESCRIPTION
## Summary
- namespace MCP tool names sent to LLM providers by MCP server id
- replace provider-invalid characters with underscores so generated names match OpenAI/Anthropic function-name constraints
- keep the original MCP protocol tool name for server execution and UI labels

## Tests
- python3 -m py_compile backend/onyx/tools/tool_implementations/mcp/mcp_tool.py

Fixes #9229

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespaces MCP tool names for LLM calls by server ID and sanitizes them to provider-safe function names, with hash-suffixed truncation to avoid collisions. Original MCP names stay for display and server execution (fixes #9229).

- **Bug Fixes**
  - Added `_safe_llm_tool_name` to build `mcp_{serverId}_{safeToolName}`, replacing invalid chars with underscores, trimming edge separators, defaulting to `tool` if empty, capping length at 64, and appending an 8-char hash when truncated to keep names unique.
  - Used the sanitized, namespaced name for LLM `function.name` and tool `name`, while keeping display/original names for UI and server calls.
  - Added and clarified unit tests for edge trimming, the 64-char cap, and collision-safe truncation with a hash suffix.

<sup>Written for commit 35497b9208a3cef557a5bf736968628df54db8eb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10631?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

