### PR TITLE
chore: demote noisy sentry logs

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -409,9 +409,9 @@ def connector_external_group_sync_generator_task(
 
     acquired = lock.acquire(blocking=False)
     if not acquired:
-        msg = f"External group sync task already running, exiting...: cc_pair={cc_pair_id}"
-        emit_background_error(msg, cc_pair_id=cc_pair_id)
-        task_logger.error(msg)
+        task_logger.warning(
+            f"External group sync task already running, exiting...: cc_pair={cc_pair_id}"
+        )
         return None
 
     try:

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -111,8 +111,16 @@ def _get_all_folders(
             _get_all_folders_for_user(
                 google_drive_connector, skip_folders_without_permissions, user_email
             )
-        except Exception:
-            logger.exception(f"Error getting folders for user {user_email}")
+        except Exception as e:
+            # 401 indicates a customer-side credential issue (token revoked /
+            # expired), not a bug — surface as a warning instead of an error.
+            if isinstance(e, HttpError) and e.status_code == 401:
+                logger.warning(
+                    f"Google Drive returned 401 for user {user_email}; "
+                    f"credentials may need to be reconnected. {e}"
+                )
+            else:
+                logger.exception(f"Error getting folders for user {user_email}")
             failed_count += 1
 
             if failed_count > MAX_FAILED_PERCENTAGE * len(user_emails):

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -591,7 +591,7 @@ def xlsx_sheet_extraction(file: IO[Any], file_name: str = "") -> list[tuple[str,
         return []
     except Exception as e:
         if any(s in str(e) for s in KNOWN_OPENPYXL_BUGS):
-            logger.error(
+            logger.warning(
                 f"Failed to extract text from {file_name or 'xlsx file'}. This happens due to a bug in openpyxl. {e}"
             )
             return []


### PR DESCRIPTION
## Description

these logs aren't real errors; demote to warnings

## How Has This Been Tested?

n/a basic change

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted expected error cases to warnings to cut noisy Sentry alerts. Reduces false errors from group sync lock contention, Google Drive 401s, and a known `openpyxl` issue.

- **Refactors**
  - External group sync: if lock is held, log warning and exit; remove `emit_background_error`.
  - Google Drive group sync: treat 401 as warning with reconnect hint; keep other exceptions as errors.
  - XLSX extraction: log known `openpyxl` bug as warning.

<sup>Written for commit 66d9cd8e37156299bdbb19af3c69a70076cdf747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

