### PR TITLE
fix: opensearch redis lock contention

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -83,12 +83,11 @@ logger = setup_logger(__name__)
 VERIFY_INDEX_LOCK_TTL_S = 60
 VERIFY_INDEX_LOCK_BLOCKING_TIMEOUT_S = 60
 
-# Per-process cache of indices that have already been verified/created. Verify
-# is idempotent and the schema only changes on deploys (which restart the
-# process), so once we've verified an index once we can skip the redis lock
-# and the OpenSearch round-trip on subsequent constructions. Without this,
-# every vespa_metadata_sync_task acquires the lock and contends with all
-# sibling threads, producing RedisSharedLockAcquisitionError under load.
+# Per-process cache of indices we've already created/applied the mapping for.
+# The schema only changes on deploys (which restart the process), so we only
+# need to do that work once per process. We still ping the index on every call
+# so that OpenSearch outages or a deleted-out-from-under-us index surface at
+# construction time instead of being deferred to the next indexing/search op.
 _verified_index_names: set[str] = set()
 
 
@@ -640,6 +639,13 @@ class OpenSearchDocumentIndex(DocumentIndex):
             Exception: There was an error verifying or creating the index or
                 search pipelines.
         """
+        # Cheap existence check on every call. Surfaces OpenSearch outages
+        # at construction time and detects the rare case where the index was
+        # deleted out from under us — invalidating the cache so we'll
+        # recreate it under the lock below.
+        if not self._client.index_exists():
+            _verified_index_names.discard(self._index_name)
+
         if self._index_name in _verified_index_names:
             return
 

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -83,6 +83,14 @@ logger = setup_logger(__name__)
 VERIFY_INDEX_LOCK_TTL_S = 60
 VERIFY_INDEX_LOCK_BLOCKING_TIMEOUT_S = 60
 
+# Per-process cache of indices that have already been verified/created. Verify
+# is idempotent and the schema only changes on deploys (which restart the
+# process), so once we've verified an index once we can skip the redis lock
+# and the OpenSearch round-trip on subsequent constructions. Without this,
+# every vespa_metadata_sync_task acquires the lock and contends with all
+# sibling threads, producing RedisSharedLockAcquisitionError under load.
+_verified_index_names: set[str] = set()
+
 
 class ChunkCountNotFoundError(ValueError):
     """Raised when a document has no chunk count."""
@@ -632,6 +640,9 @@ class OpenSearchDocumentIndex(DocumentIndex):
             Exception: There was an error verifying or creating the index or
                 search pipelines.
         """
+        if self._index_name in _verified_index_names:
+            return
+
         logger.debug(
             f"[OpenSearchDocumentIndex] Verifying and creating index {self._index_name} if "
             f"necessary, with embedding dimension {embedding_dim}."
@@ -643,31 +654,39 @@ class OpenSearchDocumentIndex(DocumentIndex):
             wait_for_lock_s=VERIFY_INDEX_LOCK_BLOCKING_TIMEOUT_S,
             logger=logger,
         ):
-            if not self._tenant_state.multitenant:
-                set_cluster_state(self._client)
+            # Re-check once we hold the lock — another worker (or thread) may
+            # have completed the verify while we were waiting.
+            if self._index_name in _verified_index_names:
+                return
+            self._verify_and_create_index(embedding_dim)
+            _verified_index_names.add(self._index_name)
 
-            expected_mappings = DocumentSchema.get_document_schema(
-                embedding_dim, self._tenant_state.multitenant
+    def _verify_and_create_index(self, embedding_dim: int) -> None:
+        """Performs the actual verify/create work. Caller must hold the
+        shared verify-index redis lock."""
+        if not self._tenant_state.multitenant:
+            set_cluster_state(self._client)
+
+        expected_mappings = DocumentSchema.get_document_schema(
+            embedding_dim, self._tenant_state.multitenant
+        )
+
+        if not self._client.index_exists():
+            index_settings = DocumentSchema.get_index_settings_based_on_environment()
+            self._client.create_index(
+                mappings=expected_mappings,
+                settings=index_settings,
             )
-
-            if not self._client.index_exists():
-                index_settings = (
-                    DocumentSchema.get_index_settings_based_on_environment()
+        else:
+            # Ensure schema is up to date by applying the current mappings.
+            try:
+                self._client.put_mapping(expected_mappings)
+            except Exception as e:
+                logger.error(
+                    f"Failed to update mappings for index {self._index_name}. This likely means a "
+                    f"field type was changed which requires reindexing. Error: {e}"
                 )
-                self._client.create_index(
-                    mappings=expected_mappings,
-                    settings=index_settings,
-                )
-            else:
-                # Ensure schema is up to date by applying the current mappings.
-                try:
-                    self._client.put_mapping(expected_mappings)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to update mappings for index {self._index_name}. This likely means a "
-                        f"field type was changed which requires reindexing. Error: {e}"
-                    )
-                    raise
+                raise
 
     def index(
         self,


### PR DESCRIPTION
## Description

We were seeing some contention for the lock which was being acquired on every index __init__, so to resolve that and save round trips to the index we can cache whether it looked fine when the process started. 

At the moment I have it set so we still check the index whenever a DocumentIndex is created, but there's some argument that it should actually be only a single request per process start OR maybe even a full validation whenever a DocumentIndex object is created. lmk ur thoughts

## How Has This Been Tested?

TBD based on the approach we take

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces Redis lock contention during OpenSearch index verification by caching verified index names per process and pinging the index on each construction. Skips repeated locks and round-trips while surfacing outages or deleted indices; prevents `RedisSharedLockAcquisitionError` under load.

- **Bug Fixes**
  - Added per-process `_verified_index_names` cache with early return.
  - Check index existence on every call; drop from cache if missing to recreate under the lock.
  - Re-check after acquiring the shared lock; extracted `_verify_and_create_index` for the locked path.
  - Keep schema current: create index if missing, otherwise `put_mapping`; log and raise on incompatible changes.

<sup>Written for commit 776d334b7aa60004f3732a7056fc3840ee6aee40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

