### PR TITLE
feat: data models for index attempt metrics

### DIFF
--- a/backend/alembic/versions/14162713706c_add_index_attempt_stage_metric_table.py
+++ b/backend/alembic/versions/14162713706c_add_index_attempt_stage_metric_table.py
@@ -1,0 +1,92 @@
+"""add index_attempt_stage_metric table
+
+Revision ID: 14162713706c
+Revises: a7c3e2b1d4f8
+Create Date: 2026-04-26 18:51:46.914793
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "14162713706c"
+down_revision = "a7c3e2b1d4f8"
+branch_labels = None
+depends_on = None
+
+
+# Stage names are stored as VARCHAR (native_enum=False) to match the
+# codebase-wide convention; new stages can be added without an enum-altering
+# migration. Keep this list in sync with onyx.db.index_attempt_metrics.IndexAttemptStage.
+_INDEX_ATTEMPT_STAGE_VALUES = (
+    "CONNECTOR_VALIDATION",
+    "PERMISSION_VALIDATION",
+    "CHECKPOINT_LOAD",
+    "CONNECTOR_FETCH",
+    "HIERARCHY_UPSERT",
+    "DOC_BATCH_STORE",
+    "DOC_BATCH_ENQUEUE",
+    "QUEUE_WAIT",
+    "DOCPROCESSING_SETUP",
+    "BATCH_LOAD",
+    "DOC_DB_PREPARE",
+    "IMAGE_PROCESSING",
+    "CHUNKING",
+    "CONTEXTUAL_RAG",
+    "EMBEDDING",
+    "VECTOR_DB_WRITE",
+    "POST_INDEX_DB_UPDATE",
+    "COORDINATION_UPDATE",
+    "BATCH_TOTAL",
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "index_attempt_stage_metric",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "index_attempt_id",
+            sa.Integer(),
+            sa.ForeignKey("index_attempt.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "stage",
+            sa.Enum(
+                *_INDEX_ATTEMPT_STAGE_VALUES,
+                name="indexattemptstage",
+                native_enum=False,
+                length=40,
+            ),
+            nullable=False,
+        ),
+        sa.Column("event_count", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "total_duration_ms",
+            sa.BigInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "m2_duration_ms",
+            sa.Float(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("min_duration_ms", sa.BigInteger(), nullable=True),
+        sa.Column("max_duration_ms", sa.BigInteger(), nullable=True),
+        sa.Column("time_first_event", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("time_last_event", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "index_attempt_id",
+            "stage",
+            name="uq_index_attempt_stage_metric_attempt_stage",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("index_attempt_stage_metric")

--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -1,0 +1,99 @@
+"""Stage-level metric primitives for an `IndexAttempt`.
+
+This module owns the canonical taxonomy of pipeline stages we measure during
+docfetching + docprocessing, plus the per-stage scope that the API/UI use to
+decide how to display each stage. Storage and write helpers live alongside
+the SQLAlchemy model in `onyx.db.models` and (in a follow-up phase) in this
+module.
+
+The ordering of `IndexAttemptStage` members is intentional and represents
+the natural pipeline order — the API surfaces this order to the frontend so
+it can render the "Pipeline order" sort mode without duplicating the
+sequence client-side.
+"""
+
+from enum import Enum as PyEnum
+
+
+class IndexAttemptStage(str, PyEnum):
+    """Canonical pipeline stages for an `IndexAttempt`.
+
+    Member declaration order matches the natural temporal order of the
+    pipeline (docfetching first, then docprocessing). Both backend
+    serialization and frontend "Pipeline order" display rely on this.
+    """
+
+    # --- Docfetching (one process per attempt) ---
+    CONNECTOR_VALIDATION = "CONNECTOR_VALIDATION"
+    PERMISSION_VALIDATION = "PERMISSION_VALIDATION"
+    CHECKPOINT_LOAD = "CHECKPOINT_LOAD"
+    CONNECTOR_FETCH = "CONNECTOR_FETCH"
+    HIERARCHY_UPSERT = "HIERARCHY_UPSERT"
+    DOC_BATCH_STORE = "DOC_BATCH_STORE"
+    DOC_BATCH_ENQUEUE = "DOC_BATCH_ENQUEUE"
+
+    # --- Docprocessing (one task per batch, many tasks per attempt) ---
+    QUEUE_WAIT = "QUEUE_WAIT"
+    DOCPROCESSING_SETUP = "DOCPROCESSING_SETUP"
+    BATCH_LOAD = "BATCH_LOAD"
+    DOC_DB_PREPARE = "DOC_DB_PREPARE"
+    IMAGE_PROCESSING = "IMAGE_PROCESSING"
+    CHUNKING = "CHUNKING"
+    CONTEXTUAL_RAG = "CONTEXTUAL_RAG"
+    EMBEDDING = "EMBEDDING"
+    VECTOR_DB_WRITE = "VECTOR_DB_WRITE"
+    POST_INDEX_DB_UPDATE = "POST_INDEX_DB_UPDATE"
+    COORDINATION_UPDATE = "COORDINATION_UPDATE"
+
+    # --- Aggregate ---
+    BATCH_TOTAL = "BATCH_TOTAL"
+
+
+class StageScope(str, PyEnum):
+    """How often a stage fires per attempt.
+
+    Used by the admin UI to decide where to render each stage:
+
+    - `ATTEMPT_LEVEL` stages have at most one event per attempt and are
+      shown as a small "Attempt overhead" disclosure.
+    - `BATCH_LEVEL` stages have many events per attempt and contribute to
+      the per-batch stacked bar / detail table.
+    """
+
+    ATTEMPT_LEVEL = "ATTEMPT_LEVEL"
+    BATCH_LEVEL = "BATCH_LEVEL"
+
+
+# Single source of truth for stage scope. The API serializes this onto each
+# row so the frontend never has to duplicate the mapping.
+STAGE_SCOPE: dict[IndexAttemptStage, StageScope] = {
+    IndexAttemptStage.CONNECTOR_VALIDATION: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.PERMISSION_VALIDATION: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.CHECKPOINT_LOAD: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.CONNECTOR_FETCH: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.HIERARCHY_UPSERT: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_BATCH_STORE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_BATCH_ENQUEUE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.QUEUE_WAIT: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOCPROCESSING_SETUP: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.BATCH_LOAD: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_DB_PREPARE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.IMAGE_PROCESSING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.CHUNKING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.CONTEXTUAL_RAG: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.EMBEDDING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.VECTOR_DB_WRITE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.POST_INDEX_DB_UPDATE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.COORDINATION_UPDATE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.BATCH_TOTAL: StageScope.BATCH_LEVEL,
+}
+
+
+# Defensive sanity check: every enum member must have a scope. This runs at
+# import time so a future contributor adding a stage but forgetting the
+# scope mapping fails fast rather than at API serialization.
+_missing_scopes = set(IndexAttemptStage) - set(STAGE_SCOPE)
+if _missing_scopes:
+    raise RuntimeError(
+        f"IndexAttemptStage members missing from STAGE_SCOPE: {_missing_scopes}"
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -89,6 +89,7 @@ from onyx.db.enums import SyncType
 from onyx.db.enums import TaskStatus
 from onyx.db.enums import ThemePreference
 from onyx.db.enums import UserFileStatus
+from onyx.db.index_attempt_metrics import IndexAttemptStage
 from onyx.db.pydantic_type import PydanticListType
 from onyx.db.pydantic_type import PydanticType
 from onyx.file_store.models import FileDescriptor
@@ -2289,6 +2290,12 @@ class IndexAttempt(Base):
         cascade="all, delete-orphan",
     )
 
+    stage_metrics: Mapped[list["IndexAttemptStageMetric"]] = relationship(
+        "IndexAttemptStageMetric",
+        back_populates="index_attempt",
+        cascade="all, delete-orphan",
+    )
+
     __table_args__ = (
         Index(
             "ix_index_attempt_latest_for_connector_credential_pair",
@@ -2431,6 +2438,67 @@ class IndexAttemptError(Base):
 
     # This is the reverse side of the relationship
     index_attempt = relationship("IndexAttempt", back_populates="error_rows")
+
+
+class IndexAttemptStageMetric(Base):
+    """Per-stage timing aggregate for an `IndexAttempt`.
+
+    One row per `(index_attempt_id, stage)` pair. The row holds running
+    aggregates (count, sum, min, max, and Welford/Chan M2 accumulator) so we
+    can derive average and standard deviation at read time without storing
+    individual samples. See `plans/index-attempt-stage-metrics.md` for the
+    write-path SQL and `onyx.db.index_attempt_metrics.STAGE_SCOPE` for the
+    per-stage display scope.
+    """
+
+    __tablename__ = "index_attempt_stage_metric"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    index_attempt_id: Mapped[int] = mapped_column(
+        ForeignKey("index_attempt.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    stage: Mapped[IndexAttemptStage] = mapped_column(
+        Enum(IndexAttemptStage, native_enum=False, length=40),
+        nullable=False,
+    )
+
+    event_count: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    total_duration_ms: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    # Welford / Chan running sum of squared deviations from the mean. Stored
+    # as Float (DOUBLE PRECISION on PostgreSQL) so the SQL upsert can apply
+    # Chan's parallel-combination formula without rounding drift.
+    m2_duration_ms: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    min_duration_ms: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
+    max_duration_ms: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
+
+    time_first_event: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    time_last_event: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    index_attempt: Mapped["IndexAttempt"] = relationship(
+        "IndexAttempt", back_populates="stage_metrics"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "index_attempt_id",
+            "stage",
+            name="uq_index_attempt_stage_metric_attempt_stage",
+        ),
+    )
 
 
 class SyncRecord(Base):


### PR DESCRIPTION
## Description

data models for the new index attempt metrics display

## How Has This Been Tested?

tests in future PRs

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical stage enums and a DB model for index attempt metrics to power the new metrics UI. Creates the `index_attempt_stage_metric` table and links it to `IndexAttempt`.

- New Features
  - Introduced `IndexAttemptStage` (pipeline-ordered) and `StageScope` mapping for UI grouping and sorting.
  - Added `IndexAttemptStageMetric` with aggregates: count, total/ms, min/max, M2 (for std dev), and first/last event timestamps.
  - Linked via `IndexAttempt.stage_metrics`; unique per `(index_attempt_id, stage)` with cascade on attempt deletion.
  - Alembic migration creates `index_attempt_stage_metric` using non-native enum storage to allow adding stages without enum migrations.

- Migration
  - Run DB migrations (alembic upgrade).
  - No backfill required; table starts empty.

<sup>Written for commit 019d956ecc8f300be5b44865f623448813a826af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

