### PR TITLE
feat: supporting utils for index attempt metrics

### DIFF
--- a/backend/alembic/versions/14162713706c_add_index_attempt_stage_metric_table.py
+++ b/backend/alembic/versions/14162713706c_add_index_attempt_stage_metric_table.py
@@ -17,7 +17,8 @@ depends_on = None
 
 # Stage names are stored as VARCHAR (native_enum=False) to match the
 # codebase-wide convention; new stages can be added without an enum-altering
-# migration. Keep this list in sync with onyx.db.index_attempt_metrics.IndexAttemptStage.
+# migration. Keep this list in sync with
+# onyx.db.index_attempt_metrics_models.IndexAttemptStage.
 _INDEX_ATTEMPT_STAGE_VALUES = (
     "CONNECTOR_VALIDATION",
     "PERMISSION_VALIDATION",

--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -1,27 +1,24 @@
-"""Stage-level metric primitives for an `IndexAttempt`.
+"""Stage-level metric write helpers for an `IndexAttempt`.
 
-This module owns the canonical taxonomy of pipeline stages we measure during
-docfetching + docprocessing, the per-stage scope that the API/UI use to
-decide how to display each stage, and the write helpers used by the
-indexing pipeline to record stage timings.
+The canonical pipeline-stage taxonomy (``IndexAttemptStage``,
+``StageScope``, ``STAGE_SCOPE``) lives in
+``onyx.db.index_attempt_metrics_models`` so that ``onyx.db.models`` can
+import the enum as a column type without creating a circular dependency
+through this module. This module is the home of the *runtime* helpers
+that record stage events — the upsert, the timing context manager, and
+the in-memory aggregation buffer.
 
-The ordering of `IndexAttemptStage` members is intentional and represents
-the natural pipeline order — the API surfaces this order to the frontend so
-it can render the "Pipeline order" sort mode without duplicating the
-sequence client-side.
-
-Recording must NEVER fail an indexing attempt. The consumer-facing helpers
-(``time_stage`` and ``StageEventBuffer.flush``) wrap the underlying upsert
-in a try/except that logs and swallows. The lower-level
-``record_stage_aggregate`` and ``record_single_event`` raise on failure so
-they remain testable in isolation.
+Recording must NEVER fail an indexing attempt. The consumer-facing
+helpers (``time_stage`` and ``StageEventBuffer.flush``) wrap the
+underlying upsert in a try/except that logs and swallows. The lower-level
+``record_stage_aggregate`` and ``record_single_event`` raise on failure
+so they remain testable in isolation.
 """
 
 import datetime
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
-from enum import Enum as PyEnum
 
 from sqlalchemy import case
 from sqlalchemy import cast
@@ -31,6 +28,8 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.index_attempt_metrics_models import IndexAttemptStage
+from onyx.db.models import IndexAttemptStageMetric
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -40,90 +39,6 @@ logger = setup_logger()
 # meaningful and would corrupt aggregates; protect against monotonic clock
 # weirdness that could in theory yield a negative delta.
 _MIN_DURATION_MS = 0
-
-
-class IndexAttemptStage(str, PyEnum):
-    """Canonical pipeline stages for an `IndexAttempt`.
-
-    Member declaration order matches the natural temporal order of the
-    pipeline (docfetching first, then docprocessing). Both backend
-    serialization and frontend "Pipeline order" display rely on this.
-    """
-
-    # --- Docfetching (one process per attempt) ---
-    CONNECTOR_VALIDATION = "CONNECTOR_VALIDATION"
-    PERMISSION_VALIDATION = "PERMISSION_VALIDATION"
-    CHECKPOINT_LOAD = "CHECKPOINT_LOAD"
-    CONNECTOR_FETCH = "CONNECTOR_FETCH"
-    HIERARCHY_UPSERT = "HIERARCHY_UPSERT"
-    DOC_BATCH_STORE = "DOC_BATCH_STORE"
-    DOC_BATCH_ENQUEUE = "DOC_BATCH_ENQUEUE"
-
-    # --- Docprocessing (one task per batch, many tasks per attempt) ---
-    QUEUE_WAIT = "QUEUE_WAIT"
-    DOCPROCESSING_SETUP = "DOCPROCESSING_SETUP"
-    BATCH_LOAD = "BATCH_LOAD"
-    DOC_DB_PREPARE = "DOC_DB_PREPARE"
-    IMAGE_PROCESSING = "IMAGE_PROCESSING"
-    CHUNKING = "CHUNKING"
-    CONTEXTUAL_RAG = "CONTEXTUAL_RAG"
-    EMBEDDING = "EMBEDDING"
-    VECTOR_DB_WRITE = "VECTOR_DB_WRITE"
-    POST_INDEX_DB_UPDATE = "POST_INDEX_DB_UPDATE"
-    COORDINATION_UPDATE = "COORDINATION_UPDATE"
-
-    # --- Aggregate ---
-    BATCH_TOTAL = "BATCH_TOTAL"
-
-
-class StageScope(str, PyEnum):
-    """How often a stage fires per attempt.
-
-    Used by the admin UI to decide where to render each stage:
-
-    - `ATTEMPT_LEVEL` stages have at most one event per attempt and are
-      shown as a small "Attempt overhead" disclosure.
-    - `BATCH_LEVEL` stages have many events per attempt and contribute to
-      the per-batch stacked bar / detail table.
-    """
-
-    ATTEMPT_LEVEL = "ATTEMPT_LEVEL"
-    BATCH_LEVEL = "BATCH_LEVEL"
-
-
-# Single source of truth for stage scope. The API serializes this onto each
-# row so the frontend never has to duplicate the mapping.
-STAGE_SCOPE: dict[IndexAttemptStage, StageScope] = {
-    IndexAttemptStage.CONNECTOR_VALIDATION: StageScope.ATTEMPT_LEVEL,
-    IndexAttemptStage.PERMISSION_VALIDATION: StageScope.ATTEMPT_LEVEL,
-    IndexAttemptStage.CHECKPOINT_LOAD: StageScope.ATTEMPT_LEVEL,
-    IndexAttemptStage.CONNECTOR_FETCH: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.HIERARCHY_UPSERT: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.DOC_BATCH_STORE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.DOC_BATCH_ENQUEUE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.QUEUE_WAIT: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.DOCPROCESSING_SETUP: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.BATCH_LOAD: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.DOC_DB_PREPARE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.IMAGE_PROCESSING: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.CHUNKING: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.CONTEXTUAL_RAG: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.EMBEDDING: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.VECTOR_DB_WRITE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.POST_INDEX_DB_UPDATE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.COORDINATION_UPDATE: StageScope.BATCH_LEVEL,
-    IndexAttemptStage.BATCH_TOTAL: StageScope.BATCH_LEVEL,
-}
-
-
-# Defensive sanity check: every enum member must have a scope. This runs at
-# import time so a future contributor adding a stage but forgetting the
-# scope mapping fails fast rather than at API serialization.
-_missing_scopes = set(IndexAttemptStage) - set(STAGE_SCOPE)
-if _missing_scopes:
-    raise RuntimeError(
-        f"IndexAttemptStage members missing from STAGE_SCOPE: {_missing_scopes}"
-    )
 
 
 def record_stage_aggregate(
@@ -153,10 +68,6 @@ def record_stage_aggregate(
     """
     if event_count <= 0:
         return
-
-    # Imported here to avoid a circular dependency: ``onyx.db.models`` imports
-    # ``IndexAttemptStage`` from this module.
-    from onyx.db.models import IndexAttemptStageMetric
 
     if now is None:
         now = datetime.datetime.now(datetime.timezone.utc)

--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -1,18 +1,45 @@
 """Stage-level metric primitives for an `IndexAttempt`.
 
 This module owns the canonical taxonomy of pipeline stages we measure during
-docfetching + docprocessing, plus the per-stage scope that the API/UI use to
-decide how to display each stage. Storage and write helpers live alongside
-the SQLAlchemy model in `onyx.db.models` and (in a follow-up phase) in this
-module.
+docfetching + docprocessing, the per-stage scope that the API/UI use to
+decide how to display each stage, and the write helpers used by the
+indexing pipeline to record stage timings.
 
 The ordering of `IndexAttemptStage` members is intentional and represents
 the natural pipeline order — the API surfaces this order to the frontend so
 it can render the "Pipeline order" sort mode without duplicating the
 sequence client-side.
+
+Recording must NEVER fail an indexing attempt. The consumer-facing helpers
+(``time_stage`` and ``StageEventBuffer.flush``) wrap the underlying upsert
+in a try/except that logs and swallows. The lower-level
+``record_stage_aggregate`` and ``record_single_event`` raise on failure so
+they remain testable in isolation.
 """
 
+import datetime
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
 from enum import Enum as PyEnum
+
+from sqlalchemy import case
+from sqlalchemy import cast
+from sqlalchemy import Float
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# Defensive lower bound on a recorded duration (ms). Negative values are not
+# meaningful and would corrupt aggregates; protect against monotonic clock
+# weirdness that could in theory yield a negative delta.
+_MIN_DURATION_MS = 0
 
 
 class IndexAttemptStage(str, PyEnum):
@@ -97,3 +124,268 @@ if _missing_scopes:
     raise RuntimeError(
         f"IndexAttemptStage members missing from STAGE_SCOPE: {_missing_scopes}"
     )
+
+
+def record_stage_aggregate(
+    db_session: Session,
+    *,
+    index_attempt_id: int,
+    stage: IndexAttemptStage,
+    event_count: int,
+    total_duration_ms: int,
+    m2_duration_ms: float,
+    min_duration_ms: int,
+    max_duration_ms: int,
+    now: datetime.datetime | None = None,
+) -> None:
+    """Upsert a stage aggregate row for an attempt.
+
+    Combines the incoming aggregate ``(event_count, total_duration_ms,
+    m2_duration_ms, min, max)`` with the existing row using Chan's parallel
+    combination formula (numerically stable variance accumulation without
+    needing per-sample storage). Implemented as a single
+    ``INSERT ... ON CONFLICT DO UPDATE`` so we don't need a SELECT-then-write
+    transaction or row lock — the DB handles concurrent writers correctly.
+
+    Raises on DB errors. Callers that must not fail (i.e. all instrumentation
+    call sites) should use ``time_stage`` or ``StageEventBuffer`` instead,
+    which wrap this in a try/except.
+    """
+    if event_count <= 0:
+        return
+
+    # Imported here to avoid a circular dependency: ``onyx.db.models`` imports
+    # ``IndexAttemptStage`` from this module.
+    from onyx.db.models import IndexAttemptStageMetric
+
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+    insert_stmt = pg_insert(IndexAttemptStageMetric).values(
+        index_attempt_id=index_attempt_id,
+        stage=stage,
+        event_count=event_count,
+        total_duration_ms=total_duration_ms,
+        m2_duration_ms=m2_duration_ms,
+        min_duration_ms=min_duration_ms,
+        max_duration_ms=max_duration_ms,
+        time_first_event=now,
+        time_last_event=now,
+    )
+
+    excluded = insert_stmt.excluded
+    metric = IndexAttemptStageMetric
+
+    # Chan's parallel combination of M2 (sum of squared deviations from the
+    # mean) for two aggregates A (existing row) and B (incoming):
+    #
+    #   M2_new = M2_a + M2_b + (mean_b - mean_a)^2 * (n_a * n_b / (n_a + n_b))
+    #
+    # In Postgres, all SET expressions in an UPDATE are evaluated against the
+    # row's pre-update values regardless of their order in the SET list, so
+    # we can reference ``metric.event_count`` / ``metric.total_duration_ms``
+    # freely even though they're also being updated below.
+    new_count = metric.event_count + excluded.event_count
+    delta_means = cast(excluded.total_duration_ms, Float) / cast(
+        excluded.event_count, Float
+    ) - cast(metric.total_duration_ms, Float) / case(
+        (metric.event_count == 0, 1),
+        else_=metric.event_count,
+    )
+    cross_term = (
+        func.power(delta_means, 2)
+        * cast(metric.event_count, Float)
+        * cast(excluded.event_count, Float)
+        / cast(new_count, Float)
+    )
+    new_m2 = (
+        metric.m2_duration_ms
+        + excluded.m2_duration_ms
+        + case(
+            (metric.event_count == 0, 0.0),
+            else_=cross_term,
+        )
+    )
+
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=["index_attempt_id", "stage"],
+        set_=dict(
+            m2_duration_ms=new_m2,
+            event_count=new_count,
+            total_duration_ms=metric.total_duration_ms + excluded.total_duration_ms,
+            min_duration_ms=func.least(
+                metric.min_duration_ms, excluded.min_duration_ms
+            ),
+            max_duration_ms=func.greatest(
+                metric.max_duration_ms, excluded.max_duration_ms
+            ),
+            time_last_event=excluded.time_last_event,
+        ),
+    )
+
+    db_session.execute(upsert_stmt)
+    db_session.commit()
+
+
+def record_single_event(
+    db_session: Session,
+    *,
+    index_attempt_id: int,
+    stage: IndexAttemptStage,
+    duration_ms: int,
+    now: datetime.datetime | None = None,
+) -> None:
+    """Convenience wrapper for the single-sample case.
+
+    Equivalent to ``record_stage_aggregate(..., event_count=1,
+    m2_duration_ms=0.0, min=duration_ms, max=duration_ms)``. The Chan
+    formula collapses correctly for an incoming aggregate of size 1 (a
+    standard Welford update).
+    """
+    duration_ms = max(_MIN_DURATION_MS, duration_ms)
+    record_stage_aggregate(
+        db_session,
+        index_attempt_id=index_attempt_id,
+        stage=stage,
+        event_count=1,
+        total_duration_ms=duration_ms,
+        m2_duration_ms=0.0,
+        min_duration_ms=duration_ms,
+        max_duration_ms=duration_ms,
+        now=now,
+    )
+
+
+@contextmanager
+def time_stage(
+    stage: IndexAttemptStage,
+    index_attempt_id: int,
+) -> Generator[None, None, None]:
+    """Time the wrapped block and record a single stage event on exit.
+
+    Records the duration even if the wrapped block raises — a stage that
+    runs for 30 seconds and then crashes still has meaningful timing. The
+    caller's exception is re-raised after the recording attempt.
+
+    Recording errors are swallowed and logged; they must never fail an
+    indexing attempt.
+    """
+    start = time.monotonic()
+    try:
+        yield
+    finally:
+        duration_ms = max(_MIN_DURATION_MS, int((time.monotonic() - start) * 1000))
+        try:
+            with get_session_with_current_tenant() as db_session:
+                record_single_event(
+                    db_session,
+                    index_attempt_id=index_attempt_id,
+                    stage=stage,
+                    duration_ms=duration_ms,
+                )
+        except Exception:
+            logger.exception(
+                f"Failed to record stage event {stage.value} "
+                f"for attempt {index_attempt_id}"
+            )
+
+
+class StageEventBuffer:
+    """In-memory accumulator for many small stage events.
+
+    Use this when a stage fires hundreds or thousands of times per pipeline
+    batch (e.g. per ``EmbeddingModel.encode`` call) and we want to flush a
+    single aggregate upsert at the end of the batch instead of paying the
+    DB round-trip per event.
+
+    Maintains a Welford-style running ``(count, mean, M2)`` plus exact
+    integer ``total``, ``min``, and ``max``. ``flush()`` performs a single
+    ``record_stage_aggregate`` call and resets the buffer. Recording
+    errors during flush are swallowed and logged.
+    """
+
+    def __init__(
+        self,
+        stage: IndexAttemptStage,
+        index_attempt_id: int,
+    ) -> None:
+        self.stage = stage
+        self.index_attempt_id = index_attempt_id
+        self._count = 0
+        self._total = 0
+        # `_mean` is a float used only by Welford's variance update; the
+        # canonical mean for downstream consumers is `_total / _count`,
+        # which is exact.
+        self._mean = 0.0
+        self._m2 = 0.0
+        self._min: int | None = None
+        self._max: int | None = None
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+    def record(self, duration_ms: int) -> None:
+        """Add one sample to the buffer using Welford's online update."""
+        duration_ms = max(_MIN_DURATION_MS, duration_ms)
+        self._count += 1
+        self._total += duration_ms
+        delta = duration_ms - self._mean
+        self._mean += delta / self._count
+        delta2 = duration_ms - self._mean
+        self._m2 += delta * delta2
+        self._min = duration_ms if self._min is None else min(self._min, duration_ms)
+        self._max = duration_ms if self._max is None else max(self._max, duration_ms)
+
+    @contextmanager
+    def time(self) -> Generator[None, None, None]:
+        """Context manager that times a block and records the duration."""
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            self.record(int((time.monotonic() - start) * 1000))
+
+    def flush(self) -> None:
+        """Flush the buffer to a single DB upsert, then reset.
+
+        Swallows and logs DB errors. Resets the buffer regardless so a
+        repeated flush after a transient DB failure doesn't double-count.
+        """
+        if self._count == 0:
+            return
+
+        # Snapshot before reset so a re-entrant ``record()`` during the DB
+        # call (unlikely but defensive) doesn't corrupt the in-flight values.
+        count = self._count
+        total = self._total
+        m2 = self._m2
+        min_d = self._min if self._min is not None else 0
+        max_d = self._max if self._max is not None else 0
+        self._reset()
+
+        try:
+            with get_session_with_current_tenant() as db_session:
+                record_stage_aggregate(
+                    db_session,
+                    index_attempt_id=self.index_attempt_id,
+                    stage=self.stage,
+                    event_count=count,
+                    total_duration_ms=total,
+                    m2_duration_ms=m2,
+                    min_duration_ms=min_d,
+                    max_duration_ms=max_d,
+                )
+        except Exception:
+            logger.exception(
+                f"Failed to flush StageEventBuffer for "
+                f"{self.stage.value} / attempt {self.index_attempt_id}"
+            )
+
+    def _reset(self) -> None:
+        self._count = 0
+        self._total = 0
+        self._mean = 0.0
+        self._m2 = 0.0
+        self._min = None
+        self._max = None

--- a/backend/onyx/db/index_attempt_metrics_models.py
+++ b/backend/onyx/db/index_attempt_metrics_models.py
@@ -1,0 +1,102 @@
+"""Stage taxonomy for `IndexAttempt` metrics.
+
+This module owns the canonical pipeline-stage enum, its display-scope
+companion enum, and the static mapping between them. It is intentionally
+a leaf module — it imports nothing from the rest of the Onyx codebase —
+so it can be safely imported by both ``onyx.db.models`` (which needs the
+enum as a column type on ``IndexAttemptStageMetric``) and
+``onyx.db.index_attempt_metrics`` (which uses the taxonomy when writing
+stage timing aggregates) without creating a circular import.
+
+The ordering of `IndexAttemptStage` members is intentional and represents
+the natural temporal order of the pipeline (docfetching first, then
+docprocessing). Both the API ordering and the frontend "Pipeline order"
+sort rely on this ordering, so do not reorder members without updating
+those consumers.
+"""
+
+from enum import Enum as PyEnum
+
+
+class IndexAttemptStage(str, PyEnum):
+    """Canonical pipeline stages for an `IndexAttempt`.
+
+    Member declaration order matches the natural temporal order of the
+    pipeline (docfetching first, then docprocessing). Both backend
+    serialization and frontend "Pipeline order" display rely on this.
+    """
+
+    # --- Docfetching (one process per attempt) ---
+    CONNECTOR_VALIDATION = "CONNECTOR_VALIDATION"
+    PERMISSION_VALIDATION = "PERMISSION_VALIDATION"
+    CHECKPOINT_LOAD = "CHECKPOINT_LOAD"
+    CONNECTOR_FETCH = "CONNECTOR_FETCH"
+    HIERARCHY_UPSERT = "HIERARCHY_UPSERT"
+    DOC_BATCH_STORE = "DOC_BATCH_STORE"
+    DOC_BATCH_ENQUEUE = "DOC_BATCH_ENQUEUE"
+
+    # --- Docprocessing (one task per batch, many tasks per attempt) ---
+    QUEUE_WAIT = "QUEUE_WAIT"
+    DOCPROCESSING_SETUP = "DOCPROCESSING_SETUP"
+    BATCH_LOAD = "BATCH_LOAD"
+    DOC_DB_PREPARE = "DOC_DB_PREPARE"
+    IMAGE_PROCESSING = "IMAGE_PROCESSING"
+    CHUNKING = "CHUNKING"
+    CONTEXTUAL_RAG = "CONTEXTUAL_RAG"
+    EMBEDDING = "EMBEDDING"
+    VECTOR_DB_WRITE = "VECTOR_DB_WRITE"
+    POST_INDEX_DB_UPDATE = "POST_INDEX_DB_UPDATE"
+    COORDINATION_UPDATE = "COORDINATION_UPDATE"
+
+    # --- Aggregate ---
+    BATCH_TOTAL = "BATCH_TOTAL"
+
+
+class StageScope(str, PyEnum):
+    """How often a stage fires per attempt.
+
+    Used by the admin UI to decide where to render each stage:
+
+    - `ATTEMPT_LEVEL` stages have at most one event per attempt and are
+      shown as a small "Attempt overhead" disclosure.
+    - `BATCH_LEVEL` stages have many events per attempt and contribute to
+      the per-batch stacked bar / detail table.
+    """
+
+    ATTEMPT_LEVEL = "ATTEMPT_LEVEL"
+    BATCH_LEVEL = "BATCH_LEVEL"
+
+
+# Single source of truth for stage scope. The API serializes this onto each
+# row so the frontend never has to duplicate the mapping.
+STAGE_SCOPE: dict[IndexAttemptStage, StageScope] = {
+    IndexAttemptStage.CONNECTOR_VALIDATION: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.PERMISSION_VALIDATION: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.CHECKPOINT_LOAD: StageScope.ATTEMPT_LEVEL,
+    IndexAttemptStage.CONNECTOR_FETCH: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.HIERARCHY_UPSERT: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_BATCH_STORE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_BATCH_ENQUEUE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.QUEUE_WAIT: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOCPROCESSING_SETUP: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.BATCH_LOAD: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.DOC_DB_PREPARE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.IMAGE_PROCESSING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.CHUNKING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.CONTEXTUAL_RAG: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.EMBEDDING: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.VECTOR_DB_WRITE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.POST_INDEX_DB_UPDATE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.COORDINATION_UPDATE: StageScope.BATCH_LEVEL,
+    IndexAttemptStage.BATCH_TOTAL: StageScope.BATCH_LEVEL,
+}
+
+
+# Defensive sanity check: every enum member must have a scope. This runs at
+# import time so a future contributor adding a stage but forgetting the
+# scope mapping fails fast rather than at API serialization.
+_missing_scopes = set(IndexAttemptStage) - set(STAGE_SCOPE)
+if _missing_scopes:
+    raise RuntimeError(
+        f"IndexAttemptStage members missing from STAGE_SCOPE: {_missing_scopes}"
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -89,7 +89,7 @@ from onyx.db.enums import SyncType
 from onyx.db.enums import TaskStatus
 from onyx.db.enums import ThemePreference
 from onyx.db.enums import UserFileStatus
-from onyx.db.index_attempt_metrics import IndexAttemptStage
+from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.pydantic_type import PydanticListType
 from onyx.db.pydantic_type import PydanticType
 from onyx.file_store.models import FileDescriptor
@@ -2447,8 +2447,8 @@ class IndexAttemptStageMetric(Base):
     aggregates (count, sum, min, max, and Welford/Chan M2 accumulator) so we
     can derive average and standard deviation at read time without storing
     individual samples. See `plans/index-attempt-stage-metrics.md` for the
-    write-path SQL and `onyx.db.index_attempt_metrics.STAGE_SCOPE` for the
-    per-stage display scope.
+    write-path SQL and `onyx.db.index_attempt_metrics_models.STAGE_SCOPE`
+    for the per-stage display scope.
     """
 
     __tablename__ = "index_attempt_stage_metric"

--- a/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
+++ b/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
@@ -1,0 +1,355 @@
+"""External dependency unit tests for stage-metric write helpers.
+
+Validates the upsert + Chan-combination logic against real Postgres:
+
+- ``record_single_event`` produces the right aggregate for a fresh row and
+  for repeated events on the same ``(attempt, stage)`` key.
+- The upsert correctly preserves ``time_first_event`` across updates while
+  refreshing ``time_last_event``.
+- ``record_stage_aggregate`` with pre-aggregated buffers (Chan parallel
+  combination) produces a numerically identical M2 to streaming the same
+  samples one at a time. This is the test that protects the SQL formula
+  from regressions.
+- Concurrent ``record_single_event`` writers do not lose updates and do
+  not raise — Postgres ``INSERT ... ON CONFLICT DO UPDATE`` handles row
+  contention correctly.
+- ``StageEventBuffer.flush`` produces a single DB write with the correct
+  aggregated values.
+- Records with ``event_count <= 0`` are no-ops.
+"""
+
+import math
+import statistics
+from collections.abc import Generator
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import IndexingStatus
+from onyx.db.index_attempt_metrics import IndexAttemptStage
+from onyx.db.index_attempt_metrics import record_single_event
+from onyx.db.index_attempt_metrics import record_stage_aggregate
+from onyx.db.index_attempt_metrics import StageEventBuffer
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptStageMetric
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        # IndexAttempt has no ON DELETE CASCADE from cc_pair, but
+        # IndexAttemptStageMetric does cascade from IndexAttempt — so
+        # deleting the attempt cleans up its metric rows automatically.
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+@pytest.fixture
+def index_attempt(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+) -> IndexAttempt:
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=None,
+        from_beginning=False,
+        status=IndexingStatus.NOT_STARTED,
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    return attempt
+
+
+def _get_metric(
+    db_session: Session,
+    attempt_id: int,
+    stage: IndexAttemptStage,
+) -> IndexAttemptStageMetric | None:
+    db_session.expire_all()
+    return db_session.execute(
+        select(IndexAttemptStageMetric)
+        .where(IndexAttemptStageMetric.index_attempt_id == attempt_id)
+        .where(IndexAttemptStageMetric.stage == stage)
+    ).scalar_one_or_none()
+
+
+class TestRecordSingleEvent:
+    def test_first_event_creates_row(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        record_single_event(
+            db_session,
+            index_attempt_id=index_attempt.id,
+            stage=IndexAttemptStage.CHUNKING,
+            duration_ms=42,
+        )
+
+        row = _get_metric(db_session, index_attempt.id, IndexAttemptStage.CHUNKING)
+        assert row is not None
+        assert row.event_count == 1
+        assert row.total_duration_ms == 42
+        assert row.m2_duration_ms == pytest.approx(0.0)
+        assert row.min_duration_ms == 42
+        assert row.max_duration_ms == 42
+        assert row.time_first_event is not None
+        assert row.time_last_event is not None
+        assert row.time_first_event == row.time_last_event
+
+    def test_streamed_samples_match_welford(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        """Feeding samples one at a time should yield the same M2 as
+        ``statistics.variance(samples) * (n - 1)``."""
+        samples = [10, 20, 30, 40, 50]
+        for s in samples:
+            record_single_event(
+                db_session,
+                index_attempt_id=index_attempt.id,
+                stage=IndexAttemptStage.EMBEDDING,
+                duration_ms=s,
+            )
+
+        row = _get_metric(db_session, index_attempt.id, IndexAttemptStage.EMBEDDING)
+        assert row is not None
+        assert row.event_count == len(samples)
+        assert row.total_duration_ms == sum(samples)
+        assert row.min_duration_ms == min(samples)
+        assert row.max_duration_ms == max(samples)
+
+        expected_m2 = statistics.variance(samples) * (len(samples) - 1)
+        assert math.isclose(row.m2_duration_ms, expected_m2, rel_tol=1e-9)
+
+    def test_time_first_event_preserved_across_updates(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        """``time_first_event`` is set on insert and never moves; only
+        ``time_last_event`` advances on subsequent upserts."""
+        record_single_event(
+            db_session,
+            index_attempt_id=index_attempt.id,
+            stage=IndexAttemptStage.VECTOR_DB_WRITE,
+            duration_ms=10,
+        )
+        first_row = _get_metric(
+            db_session, index_attempt.id, IndexAttemptStage.VECTOR_DB_WRITE
+        )
+        assert first_row is not None
+        first_seen = first_row.time_first_event
+        first_last = first_row.time_last_event
+        assert first_seen is not None
+        assert first_last is not None
+
+        # A small wallclock delay between events keeps the timestamps
+        # distinct without slowing the test meaningfully.
+        import time as _time
+
+        _time.sleep(0.01)
+
+        record_single_event(
+            db_session,
+            index_attempt_id=index_attempt.id,
+            stage=IndexAttemptStage.VECTOR_DB_WRITE,
+            duration_ms=20,
+        )
+        second_row = _get_metric(
+            db_session, index_attempt.id, IndexAttemptStage.VECTOR_DB_WRITE
+        )
+        assert second_row is not None
+        assert second_row.time_first_event == first_seen
+        assert second_row.time_last_event is not None
+        assert second_row.time_last_event > first_last
+
+
+class TestChanCombination:
+    """The Chan parallel-combination formula encoded in the upsert SQL must
+    yield the same M2 whether samples are fed one at a time or as multiple
+    pre-aggregated buffers."""
+
+    def test_chunked_aggregates_match_streamed(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        samples = [10, 20, 30, 40, 50]
+        chunk_a = samples[:2]  # [10, 20]
+        chunk_b = samples[2:]  # [30, 40, 50]
+
+        # Pre-aggregate each chunk, then submit the two aggregates to the
+        # same ``(attempt, stage)`` key.
+        for chunk in (chunk_a, chunk_b):
+            record_stage_aggregate(
+                db_session,
+                index_attempt_id=index_attempt.id,
+                stage=IndexAttemptStage.CONTEXTUAL_RAG,
+                event_count=len(chunk),
+                total_duration_ms=sum(chunk),
+                m2_duration_ms=(
+                    statistics.variance(chunk) * (len(chunk) - 1)
+                    if len(chunk) > 1
+                    else 0.0
+                ),
+                min_duration_ms=min(chunk),
+                max_duration_ms=max(chunk),
+            )
+
+        row = _get_metric(
+            db_session, index_attempt.id, IndexAttemptStage.CONTEXTUAL_RAG
+        )
+        assert row is not None
+        assert row.event_count == len(samples)
+        assert row.total_duration_ms == sum(samples)
+        assert row.min_duration_ms == min(samples)
+        assert row.max_duration_ms == max(samples)
+
+        expected_m2 = statistics.variance(samples) * (len(samples) - 1)
+        assert math.isclose(row.m2_duration_ms, expected_m2, rel_tol=1e-9)
+
+
+class TestNoOpInputs:
+    def test_zero_event_count_is_noop(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        record_stage_aggregate(
+            db_session,
+            index_attempt_id=index_attempt.id,
+            stage=IndexAttemptStage.IMAGE_PROCESSING,
+            event_count=0,
+            total_duration_ms=0,
+            m2_duration_ms=0.0,
+            min_duration_ms=0,
+            max_duration_ms=0,
+        )
+        row = _get_metric(
+            db_session, index_attempt.id, IndexAttemptStage.IMAGE_PROCESSING
+        )
+        assert row is None
+
+    def test_negative_event_count_is_noop(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+    ) -> None:
+        record_stage_aggregate(
+            db_session,
+            index_attempt_id=index_attempt.id,
+            stage=IndexAttemptStage.IMAGE_PROCESSING,
+            event_count=-1,
+            total_duration_ms=10,
+            m2_duration_ms=0.0,
+            min_duration_ms=10,
+            max_duration_ms=10,
+        )
+        row = _get_metric(
+            db_session, index_attempt.id, IndexAttemptStage.IMAGE_PROCESSING
+        )
+        assert row is None
+
+
+class TestStageEventBuffer:
+    def test_flush_writes_single_aggregate(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+        tenant_context: None,  # noqa: ARG002 — buffer.flush() needs the tenant context
+    ) -> None:
+        samples = [5, 15, 25, 35, 45]
+        buf = StageEventBuffer(
+            stage=IndexAttemptStage.EMBEDDING,
+            index_attempt_id=index_attempt.id,
+        )
+        for s in samples:
+            buf.record(s)
+        assert buf.count == len(samples)
+
+        buf.flush()
+        # Buffer is reset post-flush.
+        assert buf.count == 0
+
+        row = _get_metric(db_session, index_attempt.id, IndexAttemptStage.EMBEDDING)
+        assert row is not None
+        assert row.event_count == len(samples)
+        assert row.total_duration_ms == sum(samples)
+        assert row.min_duration_ms == min(samples)
+        assert row.max_duration_ms == max(samples)
+
+        expected_m2 = statistics.variance(samples) * (len(samples) - 1)
+        assert math.isclose(row.m2_duration_ms, expected_m2, rel_tol=1e-9)
+
+    def test_empty_flush_is_noop(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        buf = StageEventBuffer(
+            stage=IndexAttemptStage.CHUNKING,
+            index_attempt_id=index_attempt.id,
+        )
+        buf.flush()  # nothing recorded; should not write a row
+        assert (
+            _get_metric(db_session, index_attempt.id, IndexAttemptStage.CHUNKING)
+            is None
+        )
+
+
+class TestConcurrentUpserts:
+    def test_concurrent_record_single_event_no_lost_updates(
+        self,
+        db_session: Session,
+        index_attempt: IndexAttempt,
+        tenant_context: None,  # noqa: ARG002 — child threads need the tenant context
+    ) -> None:
+        """N threads each record one event for the same (attempt, stage).
+        The final row must have event_count == N and total == N * duration.
+        """
+        n_workers = 16
+        per_event_ms = 7
+
+        def worker() -> None:
+            with get_session_with_current_tenant() as session:
+                record_single_event(
+                    session,
+                    index_attempt_id=index_attempt.id,
+                    stage=IndexAttemptStage.CHUNKING,
+                    duration_ms=per_event_ms,
+                )
+
+        with ThreadPoolExecutor(max_workers=n_workers) as ex:
+            futures = [ex.submit(worker) for _ in range(n_workers)]
+            for f in as_completed(futures):
+                # Re-raise any worker exception so a failed upsert surfaces.
+                f.result()
+
+        row = _get_metric(db_session, index_attempt.id, IndexAttemptStage.CHUNKING)
+        assert row is not None
+        assert row.event_count == n_workers
+        assert row.total_duration_ms == n_workers * per_event_ms
+        assert row.min_duration_ms == per_event_ms
+        assert row.max_duration_ms == per_event_ms
+        # All samples are equal, so variance and therefore M2 must be 0.
+        assert math.isclose(row.m2_duration_ms, 0.0, abs_tol=1e-9)

--- a/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
+++ b/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
@@ -30,10 +30,10 @@ from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
-from onyx.db.index_attempt_metrics import IndexAttemptStage
 from onyx.db.index_attempt_metrics import record_single_event
 from onyx.db.index_attempt_metrics import record_stage_aggregate
 from onyx.db.index_attempt_metrics import StageEventBuffer
+from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptStageMetric


### PR DESCRIPTION
## Description

some utils around collecting index attempt metrics

## How Has This Been Tested?

some tests for concurrency and tricky cases

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat/index-attempt-ui-metrics1","parentHead":"019d956ecc8f300be5b44865f623448813a826af","parentPull":10635,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stage-metric write helpers and the `IndexAttemptStageMetric` table to power index attempt UI metrics. Uses concurrency-safe Postgres upserts and an in-memory buffer; moves stage enums to `onyx.db.index_attempt_metrics_models` to remove circular imports.

- **New Features**
  - `record_stage_aggregate`: single-statement Postgres upsert with Chan M2; concurrency-safe.
  - `record_single_event`: single-sample wrapper with non-negative duration guard.
  - `time_stage`: context manager that records duration on exit; never fails the pipeline.
  - `StageEventBuffer`: Welford accumulator with `time()` and `flush()` to batch writes; flush swallows errors.
  - `IndexAttemptStageMetric` model + Alembic migration; stage stored as `VARCHAR`.
  - Tests cover Chan vs streamed math, timestamp semantics, no-op inputs, buffer flush, and concurrent writers.

- **Refactors**
  - Moved `IndexAttemptStage`, `StageScope`, and `STAGE_SCOPE` to `onyx.db.index_attempt_metrics_models`; updated `onyx.db.models` import and migration comments.

<sup>Written for commit 9a5655160c37c08df941595be818a5e3e66eb7f4. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10636?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

