### PR TITLE
feat: docprocessing index attempt metrics

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -81,6 +81,9 @@ from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.db.index_attempt import mark_attempt_failed
 from onyx.db.index_attempt import mark_attempt_partially_succeeded
 from onyx.db.index_attempt import mark_attempt_succeeded
+from onyx.db.index_attempt_metrics import IndexAttemptStage
+from onyx.db.index_attempt_metrics import safe_record_single_event
+from onyx.db.index_attempt_metrics import time_stage
 from onyx.db.indexing_coordination import CoordinationStatus
 from onyx.db.indexing_coordination import INDEXING_PROGRESS_TIMEOUT_HOURS
 from onyx.db.indexing_coordination import IndexingCoordination
@@ -1436,18 +1439,26 @@ def docprocessing_task(
     cc_pair_id: int,
     tenant_id: str,
     batch_num: int,
+    enqueue_time_ms: int | None = None,
 ) -> None:
     """Process a batch of documents through the indexing pipeline.
 
     This task retrieves documents from storage and processes them through
     the indexing pipeline (embedding + vector store indexing).
+
+    ``enqueue_time_ms`` is the wall-clock millisecond timestamp at which
+    docfetching enqueued this task. Used to compute the QUEUE_WAIT stage
+    metric. Optional + defaults to None so in-flight tasks queued by an older
+    docfetching deployment continue to work across rolling deploys.
     """
     # Start heartbeat for this indexing attempt
     heartbeat_thread, stop_event = start_heartbeat(index_attempt_id)
     try:
         # Cannot use the TaskSingleton approach here because the worker is multithreaded
         token = INDEX_ATTEMPT_INFO_CONTEXTVAR.set((cc_pair_id, index_attempt_id))
-        _docprocessing_task(index_attempt_id, cc_pair_id, tenant_id, batch_num)
+        _docprocessing_task(
+            index_attempt_id, cc_pair_id, tenant_id, batch_num, enqueue_time_ms
+        )
     finally:
         stop_heartbeat(heartbeat_thread, stop_event)  # Stop heartbeat before exiting
         INDEX_ATTEMPT_INFO_CONTEXTVAR.reset(token)
@@ -1478,11 +1489,28 @@ def _docprocessing_task(
     cc_pair_id: int,
     tenant_id: str,
     batch_num: int,
+    enqueue_time_ms: int | None = None,
 ) -> None:
     start_time = time.monotonic()
 
     if tenant_id:
         CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+
+    # Record queue wait latency before any other instrumented work. Tenant
+    # context must be set first so the metric write lands in the correct
+    # schema. If ``enqueue_time_ms`` is missing (older docfetching
+    # deployment during a rolling deploy), skip silently.
+    if enqueue_time_ms is not None:
+        queue_wait_ms = max(0, int(time.time() * 1000) - enqueue_time_ms)
+        safe_record_single_event(
+            IndexAttemptStage.QUEUE_WAIT, index_attempt_id, queue_wait_ms
+        )
+
+    # ``setup_start`` anchors DOCPROCESSING_SETUP. ``batch_load_ms`` is
+    # subtracted at the end of setup so DOCPROCESSING_SETUP only reflects
+    # genuine setup overhead (and not the document-load cost, which is
+    # captured separately as BATCH_LOAD).
+    setup_start = time.monotonic()
 
     # Check if chunk indexing usage limit has been exceeded before processing.
     # check_usage_and_raise raises OnyxError; hitting a trial/paid usage limit
@@ -1541,8 +1569,15 @@ def _docprocessing_task(
             },
         )
 
-        # Retrieve documents from storage
+        # Retrieve documents from storage. Time recorded as BATCH_LOAD; we
+        # also keep the millisecond delta so DOCPROCESSING_SETUP can subtract
+        # it to avoid double-counting.
+        batch_load_start = time.monotonic()
         documents = storage.get_batch(batch_num)
+        batch_load_ms = max(0, int((time.monotonic() - batch_load_start) * 1000))
+        safe_record_single_event(
+            IndexAttemptStage.BATCH_LOAD, index_attempt_id, batch_load_ms
+        )
         if not documents:
             task_logger.error(f"No documents found for batch {batch_num}")
             return
@@ -1637,6 +1672,19 @@ def _docprocessing_task(
                 index_attempt_metadata=index_attempt_metadata,
             )
 
+            # Setup is complete. Record DOCPROCESSING_SETUP (everything from the
+            # top of the task minus BATCH_LOAD, which is tracked separately).
+            # BATCH_TOTAL starts immediately after; it spans run_indexing_pipeline
+            # plus all post-indexing bookkeeping in this try block.
+            setup_total_ms = max(0, int((time.monotonic() - setup_start) * 1000))
+            docprocessing_setup_ms = max(0, setup_total_ms - batch_load_ms)
+            safe_record_single_event(
+                IndexAttemptStage.DOCPROCESSING_SETUP,
+                index_attempt_id,
+                docprocessing_setup_ms,
+            )
+            batch_total_start = time.monotonic()
+
             # real work happens here!
             index_pipeline_result = run_indexing_pipeline(
                 embedder=embedding_model,
@@ -1669,13 +1717,14 @@ def _docprocessing_task(
         # Update batch completion and document counts atomically using database coordination
 
         with get_session_with_current_tenant() as db_session, cross_batch_db_lock:
-            IndexingCoordination.update_batch_completion_and_docs(
-                db_session=db_session,
-                index_attempt_id=index_attempt_id,
-                total_docs_indexed=index_pipeline_result.total_docs,
-                new_docs_indexed=index_pipeline_result.new_docs,
-                total_chunks=index_pipeline_result.total_chunks,
-            )
+            with time_stage(IndexAttemptStage.COORDINATION_UPDATE, index_attempt_id):
+                IndexingCoordination.update_batch_completion_and_docs(
+                    db_session=db_session,
+                    index_attempt_id=index_attempt_id,
+                    total_docs_indexed=index_pipeline_result.total_docs,
+                    new_docs_indexed=index_pipeline_result.new_docs,
+                    total_chunks=index_pipeline_result.total_chunks,
+                )
 
             _resolve_indexing_document_errors(
                 cc_pair_id,
@@ -1749,6 +1798,15 @@ def _docprocessing_task(
                 "batch_num": batch_num,
                 "chunks_processed": index_pipeline_result.total_chunks,
             },
+        )
+
+        # Record BATCH_TOTAL on the successful path. We deliberately do not
+        # record on the exception path -- a partially-completed batch's total
+        # would skew the average. BATCH_TOTAL spans run_indexing_pipeline and
+        # all post-indexing bookkeeping (coord update, telemetry, cleanup).
+        batch_total_ms = max(0, int((time.monotonic() - batch_total_start) * 1000))
+        safe_record_single_event(
+            IndexAttemptStage.BATCH_TOTAL, index_attempt_id, batch_total_ms
         )
 
         elapsed_time = time.monotonic() - start_time

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -847,12 +847,15 @@ def connector_document_extraction(
                     ):
                         batch_storage.store_batch(batch_num, doc_batch_cleaned)
 
-                    # Create processing task data
+                    # Create processing task data. ``enqueue_time_ms`` is captured
+                    # right before send so QUEUE_WAIT measures the broker latency
+                    # and any docprocessing scheduling delay (not our own bookkeeping).
                     processing_batch_data = {
                         "index_attempt_id": index_attempt_id,
                         "cc_pair_id": cc_pair_id,
                         "tenant_id": tenant_id,
                         "batch_num": batch_num,  # 0-indexed
+                        "enqueue_time_ms": int(time.time() * 1000),
                     }
 
                     # Queue document processing task
@@ -1057,6 +1060,10 @@ def reissue_old_batches(
                 "cc_pair_id": cc_pair_id,
                 "tenant_id": tenant_id,
                 "batch_num": path_info.batch_num,  # use same batch num as previously
+                # Use current time (not the original send time) so QUEUE_WAIT
+                # measures wait time for *this* reissue, not stale latency from
+                # the prior attempt.
+                "enqueue_time_ms": int(time.time() * 1000),
             },
             queue=OnyxCeleryQueues.DOCPROCESSING,
             priority=priority,

--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -194,6 +194,42 @@ def safe_record_single_event(
         )
 
 
+def safe_record_single_event_if_set(
+    stage: IndexAttemptStage,
+    index_attempt_id: int | None,
+    duration_ms: int,
+) -> None:
+    """No-op when ``index_attempt_id`` is None, otherwise delegates to
+    ``safe_record_single_event``.
+
+    Use from pipeline call sites that may run outside the context of an
+    ``IndexAttempt`` (e.g. the direct ingestion API), where there's no
+    attempt to attribute the metric to.
+    """
+    if index_attempt_id is None:
+        return
+    safe_record_single_event(stage, index_attempt_id, duration_ms)
+
+
+@contextmanager
+def time_stage_if_set(
+    stage: IndexAttemptStage,
+    index_attempt_id: int | None,
+) -> Generator[None, None, None]:
+    """No-op context manager when ``index_attempt_id`` is None, otherwise
+    behaves like ``time_stage``.
+
+    Use from pipeline call sites that may run outside the context of an
+    ``IndexAttempt`` (e.g. the direct ingestion API), where there's no
+    attempt to attribute the metric to.
+    """
+    if index_attempt_id is None:
+        yield
+        return
+    with time_stage(stage, index_attempt_id):
+        yield
+
+
 @contextmanager
 def time_stage(
     stage: IndexAttemptStage,

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Generator
@@ -37,6 +38,9 @@ from onyx.db.document import upsert_document_by_connector_credential_pair
 from onyx.db.document import upsert_documents
 from onyx.db.enums import HookPoint
 from onyx.db.hierarchy import link_hierarchy_nodes_to_documents
+from onyx.db.index_attempt_metrics import IndexAttemptStage
+from onyx.db.index_attempt_metrics import safe_record_single_event_if_set
+from onyx.db.index_attempt_metrics import time_stage_if_set
 from onyx.db.models import Document as DBDocument
 from onyx.db.models import IndexModelStatus
 from onyx.db.search_settings import get_active_search_settings
@@ -250,11 +254,18 @@ def embed_and_stream(
     embedder: IndexingEmbedder,
     tenant_id: str,
     request_id: str | None,
+    attempt_id: int | None = None,
 ) -> Generator[tuple[ChunkEmbeddingResult, ChunkBatchStore], None, None]:
     """Embed chunks to disk and yield a ``(result, store)`` pair.
 
     The store owns the temp directory — files are cleaned up when the context
     manager exits.
+
+    When ``attempt_id`` is provided, records the EMBEDDING stage timing for
+    just the actual embedding call (which finishes before ``yield``). Doing
+    this inside the context manager avoids the caller's ``with``-body work
+    (vector-db writes, post_index, etc.) being included in the embedding
+    measurement.
 
     Usage::
 
@@ -263,12 +274,17 @@ def embed_and_stream(
                 ...
     """
     with ChunkBatchStore() as store:
+        embed_start = time.monotonic()
         result = _embed_chunks_to_store(
             chunks=chunks,
             embedder=embedder,
             tenant_id=tenant_id,
             request_id=request_id,
             store=store,
+        )
+        embed_duration_ms = max(0, int((time.monotonic() - embed_start) * 1000))
+        safe_record_single_event_if_set(
+            IndexAttemptStage.EMBEDDING, attempt_id, embed_duration_ms
         )
         yield result, store
 
@@ -1029,15 +1045,36 @@ def index_doc_batch(
         f"num_docs={len(document_batch)}"
     )
 
+    # Pull the attempt id off the adapter (when present) so per-stage metrics
+    # can be attributed to the right ``IndexAttempt``. The protocol does not
+    # mandate an ``index_attempt_metadata`` field, so non-attempt callers
+    # (ingestion API, user file processing) get None and the
+    # ``*_if_set`` helpers no-op.
+    _attempt_metadata = getattr(adapter, "index_attempt_metadata", None)
+    attempt_id: int | None = (
+        _attempt_metadata.attempt_id if _attempt_metadata is not None else None
+    )
+
     filtered_documents = filter_fnc(document_batch)
     filtered_documents = _apply_document_ingestion_hook(filtered_documents, db_session)
-    context = adapter.prepare(filtered_documents, ignore_time_skip)
+    with time_stage_if_set(IndexAttemptStage.DOC_DB_PREPARE, attempt_id):
+        context = adapter.prepare(filtered_documents, ignore_time_skip)
     if not context:
         return IndexingPipelineResult.empty(len(filtered_documents))
 
-    # Convert documents to IndexingDocument objects with processed section
-    # logger.debug("Processing image sections")
-    context.indexable_docs = process_image_sections(context.updatable_docs)
+    # Convert documents to IndexingDocument objects with processed section.
+    # Only record IMAGE_PROCESSING when there's actually image work to do --
+    # otherwise the average/stddev gets polluted with no-op zero events.
+    has_image_section = any(
+        section.type == SectionType.IMAGE
+        for document in context.updatable_docs
+        for section in document.sections
+    )
+    if has_image_section:
+        with time_stage_if_set(IndexAttemptStage.IMAGE_PROCESSING, attempt_id):
+            context.indexable_docs = process_image_sections(context.updatable_docs)
+    else:
+        context.indexable_docs = process_image_sections(context.updatable_docs)
 
     doc_descriptors = [
         {
@@ -1051,7 +1088,8 @@ def index_doc_batch(
     logger.debug("Starting chunking")
     # NOTE: no special handling for failures here, since the chunker is not
     # a common source of failure for the indexing pipeline
-    chunks: list[DocAwareChunk] = chunker.chunk(context.indexable_docs)
+    with time_stage_if_set(IndexAttemptStage.CHUNKING, attempt_id):
+        chunks: list[DocAwareChunk] = chunker.chunk(context.indexable_docs)
     llm_tokenizer: BaseTokenizer | None = None
 
     # contextual RAG
@@ -1064,15 +1102,21 @@ def index_doc_batch(
 
         # Because the chunker's tokens are different from the LLM's tokens,
         # We add a fudge factor to ensure we truncate prompts to the LLM's token limit
-        chunks = add_contextual_summaries(
-            chunks=chunks,
-            llm=llm,
-            tokenizer=llm_tokenizer,
-            chunk_token_limit=chunker.chunk_token_limit * 2,
-        )
+        with time_stage_if_set(IndexAttemptStage.CONTEXTUAL_RAG, attempt_id):
+            chunks = add_contextual_summaries(
+                chunks=chunks,
+                llm=llm,
+                tokenizer=llm_tokenizer,
+                chunk_token_limit=chunker.chunk_token_limit * 2,
+            )
 
     logger.debug("Starting embedding")
-    with embed_and_stream(chunks, embedder, tenant_id, request_id) as (
+    # ``embed_and_stream`` records EMBEDDING internally so the timer captures
+    # only the actual embedding work (which finishes before ``yield``), not
+    # the surrounding vector-db write loop in the ``with`` body.
+    with embed_and_stream(
+        chunks, embedder, tenant_id, request_id, attempt_id=attempt_id
+    ) as (
         embedding_result,
         chunk_store,
     ):
@@ -1120,18 +1164,28 @@ def index_doc_batch(
                 None
             )
 
+            # Sum vector-db write time across all configured indices and
+            # record once per batch. Most deployments have a single index
+            # (primary), but during a switchover both primary and secondary
+            # are written; we want a single combined number per batch rather
+            # than one event per index (avoids inflating event_count).
+            vector_db_write_ms = 0
             for document_index in document_indices:
 
                 def _enriched_stream() -> Iterator[DocMetadataAwareIndexChunk]:
                     for chunk in chunk_store.stream():
                         yield enricher.enrich_chunk(chunk, 1.0)
 
+                vector_db_write_start = time.monotonic()
                 insertion_records, write_failures = (
                     write_chunks_to_vector_db_with_backoff(
                         document_index=document_index,
                         make_chunks=_enriched_stream,
                         index_batch_params=index_batch_params,
                     )
+                )
+                vector_db_write_ms += max(
+                    0, int((time.monotonic() - vector_db_write_start) * 1000)
                 )
 
                 _verify_indexing_completeness(
@@ -1148,12 +1202,17 @@ def index_doc_batch(
                 if primary_doc_idx_vector_db_write_failures is None:
                     primary_doc_idx_vector_db_write_failures = write_failures
 
-            adapter.post_index(
-                context=context,
-                updatable_chunk_data=updatable_chunk_data,
-                filtered_documents=filtered_documents,
-                enrichment=enricher,
+            safe_record_single_event_if_set(
+                IndexAttemptStage.VECTOR_DB_WRITE, attempt_id, vector_db_write_ms
             )
+
+            with time_stage_if_set(IndexAttemptStage.POST_INDEX_DB_UPDATE, attempt_id):
+                adapter.post_index(
+                    context=context,
+                    updatable_chunk_data=updatable_chunk_data,
+                    filtered_documents=filtered_documents,
+                    enrichment=enricher,
+                )
 
     assert primary_doc_idx_insertion_records is not None
     assert primary_doc_idx_vector_db_write_failures is not None


### PR DESCRIPTION
## Description

Added per stage metrics to docprocessing

## How Has This Been Tested?

testing coming soon trust

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat/index-attempt-ui-metrics3","parentHead":"ec94aab26176b2245447e1c4ae14635dbbc8f49a","parentPull":10637,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-stage metrics for docprocessing and the indexing pipeline to power the index attempt UI. Measures queue wait, setup, batch load, batch total, coordination updates, and fine-grained pipeline timings with safe fallbacks.

- New Features
  - Docprocessing: record QUEUE_WAIT, BATCH_LOAD, DOCPROCESSING_SETUP (excludes load), BATCH_TOTAL (success only), and COORDINATION_UPDATE. `enqueue_time_ms` is sent from `run_docfetching` at enqueue (and refreshed on reissue); optional for rolling deploy compatibility.
  - Indexing pipeline: attempt-aware timings for DOC_DB_PREPARE, IMAGE_PROCESSING (only when present), CHUNKING, CONTEXTUAL_RAG, EMBEDDING (measured inside `embed_and_stream`), VECTOR_DB_WRITE (summed across indices as one event), and POST_INDEX_DB_UPDATE. Attempt ID is read from adapter `index_attempt_metadata` when available.
  - Helpers: `safe_record_single_event_if_set` and `time_stage_if_set` no-op when no attempt ID, keeping ingestion paths without an `IndexAttempt` unchanged.

<sup>Written for commit f7c6c6a1ce8d76d5eee69c6f181be422990ab155. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10638?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

