### PR TITLE
feat: endpoint for index attempt metrics

### DIFF
--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -24,6 +24,7 @@ from sqlalchemy import case
 from sqlalchemy import cast
 from sqlalchemy import Float
 from sqlalchemy import func
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -363,3 +364,39 @@ class StageEventBuffer:
         self._m2 = 0.0
         self._min = None
         self._max = None
+
+
+# --- Read helpers ---------------------------------------------------------
+
+# Cached lookup from stage -> declaration index. Used to sort query results
+# in the natural pipeline order so the API response order is the canonical
+# "Pipeline order" the frontend renders by default.
+_STAGE_PIPELINE_ORDER: dict[IndexAttemptStage, int] = {
+    stage: idx for idx, stage in enumerate(IndexAttemptStage)
+}
+
+
+def get_stage_metrics_for_attempt(
+    db_session: Session,
+    index_attempt_id: int,
+) -> list["IndexAttemptStageMetric"]:
+    """Return all stage metric rows for an attempt, in pipeline order.
+
+    Pipeline order matches the declaration order of ``IndexAttemptStage`` so
+    the frontend can render the default "Pipeline order" sort by simply
+    rendering the response as-is.
+    """
+    # Imported here to avoid a circular dependency: ``onyx.db.models`` imports
+    # ``IndexAttemptStage`` from this module.
+    from onyx.db.models import IndexAttemptStageMetric
+
+    rows = list(
+        db_session.execute(
+            select(IndexAttemptStageMetric).where(
+                IndexAttemptStageMetric.index_attempt_id == index_attempt_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sorted(rows, key=lambda r: _STAGE_PIPELINE_ORDER[r.stage])

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -38,10 +38,12 @@ from onyx.db.enums import Permission
 from onyx.db.enums import PermissionSyncStatus
 from onyx.db.index_attempt import count_index_attempt_errors_for_cc_pair
 from onyx.db.index_attempt import count_index_attempts_for_cc_pair
+from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_index_attempt_errors_for_cc_pair
 from onyx.db.index_attempt import get_latest_index_attempt_for_cc_pair_id
 from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
 from onyx.db.index_attempt import get_paginated_index_attempts_for_cc_pair_id
+from onyx.db.index_attempt_metrics import get_stage_metrics_for_attempt
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import User
@@ -51,6 +53,8 @@ from onyx.db.permission_sync_attempt import (
 from onyx.db.permission_sync_attempt import (
     get_recent_doc_permission_sync_attempts_for_cc_pair,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_utils import get_deletion_attempt_snapshot
 from onyx.redis.redis_pool import get_redis_client
@@ -62,6 +66,8 @@ from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.server.documents.models import ConnectorCredentialPairMetadata
 from onyx.server.documents.models import DocumentSyncStatus
 from onyx.server.documents.models import IndexAttemptSnapshot
+from onyx.server.documents.models import IndexAttemptStageMetricSnapshot
+from onyx.server.documents.models import IndexAttemptStageMetricsResponse
 from onyx.server.documents.models import PaginatedReturn
 from onyx.server.documents.models import PermissionSyncAttemptSnapshot
 from onyx.server.models import StatusResponse
@@ -106,6 +112,47 @@ def get_cc_pair_index_attempts(
             for index_attempt in index_attempts
         ],
         total_items=total_count,
+    )
+
+
+@router.get("/admin/index-attempt/{index_attempt_id}/stage-metrics")
+def get_index_attempt_stage_metrics(
+    index_attempt_id: int,
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> IndexAttemptStageMetricsResponse:
+    """Return the per-stage timing breakdown for a single ``IndexAttempt``.
+
+    Returned in pipeline (enum declaration) order. The frontend renders this
+    order verbatim for the default "Pipeline order" sort and re-sorts
+    client-side for the "Time taken" sort. Auth: caller must have at least
+    read access to the cc-pair that owns the attempt.
+    """
+    index_attempt = get_index_attempt(
+        db_session=db_session,
+        index_attempt_id=index_attempt_id,
+    )
+    if index_attempt is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Index attempt not found")
+
+    if user and not verify_user_has_access_to_cc_pair(
+        index_attempt.connector_credential_pair_id,
+        db_session,
+        user,
+        get_editable=False,
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You do not have access to this index attempt",
+        )
+
+    metrics = get_stage_metrics_for_attempt(
+        db_session=db_session,
+        index_attempt_id=index_attempt_id,
+    )
+    return IndexAttemptStageMetricsResponse(
+        index_attempt_id=index_attempt_id,
+        stages=[IndexAttemptStageMetricSnapshot.from_db_model(m) for m in metrics],
     )
 
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -135,7 +135,7 @@ def get_index_attempt_stage_metrics(
     if index_attempt is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Index attempt not found")
 
-    if user and not verify_user_has_access_to_cc_pair(
+    if not verify_user_has_access_to_cc_pair(
         index_attempt.connector_credential_pair_id,
         db_session,
         user,

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -247,7 +247,7 @@ class IndexAttemptStageMetricSnapshot(BaseModel):
             else None
         )
         std_dev = (
-            (metric.m2_duration_ms / (metric.event_count - 1)) ** 0.5
+            max(0.0, metric.m2_duration_ms / (metric.event_count - 1)) ** 0.5
             if metric.event_count > 1
             else None
         )

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -19,12 +19,16 @@ from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import PermissionSyncStatus
 from onyx.db.enums import ProcessingMode
+from onyx.db.index_attempt_metrics import IndexAttemptStage
+from onyx.db.index_attempt_metrics import STAGE_SCOPE
+from onyx.db.index_attempt_metrics import StageScope
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import DocPermissionSyncAttempt
 from onyx.db.models import Document as DbDocument
 from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptStageMetric
 from onyx.db.models import IndexingStatus
 from onyx.db.models import TaskStatus
 from onyx.server.federated.models import FederatedConnectorStatus
@@ -208,6 +212,70 @@ class IndexAttemptSnapshot(BaseModel):
             poll_range_start=index_attempt.poll_range_start,
             poll_range_end=index_attempt.poll_range_end,
         )
+
+
+class IndexAttemptStageMetricSnapshot(BaseModel):
+    """Per-stage timing aggregate for a single ``IndexAttempt``.
+
+    ``avg_duration_ms`` and ``std_dev_duration_ms`` are derived at
+    serialization time from the stored ``total_duration_ms`` and
+    ``m2_duration_ms`` (Welford / Chan accumulator). ``std_dev_duration_ms``
+    is undefined for ``event_count <= 1`` and is reported as ``None`` in
+    that case so the frontend can render "avg" without "± std dev".
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    stage: IndexAttemptStage
+    scope: StageScope
+    event_count: int
+    total_duration_ms: int
+    avg_duration_ms: float | None
+    std_dev_duration_ms: float | None
+    min_duration_ms: int | None
+    max_duration_ms: int | None
+    time_first_event: datetime | None
+    time_last_event: datetime | None
+
+    @classmethod
+    def from_db_model(
+        cls, metric: IndexAttemptStageMetric
+    ) -> "IndexAttemptStageMetricSnapshot":
+        avg = (
+            metric.total_duration_ms / metric.event_count
+            if metric.event_count > 0
+            else None
+        )
+        std_dev = (
+            (metric.m2_duration_ms / (metric.event_count - 1)) ** 0.5
+            if metric.event_count > 1
+            else None
+        )
+        return IndexAttemptStageMetricSnapshot(
+            stage=metric.stage,
+            scope=STAGE_SCOPE[metric.stage],
+            event_count=metric.event_count,
+            total_duration_ms=metric.total_duration_ms,
+            avg_duration_ms=avg,
+            std_dev_duration_ms=std_dev,
+            min_duration_ms=metric.min_duration_ms,
+            max_duration_ms=metric.max_duration_ms,
+            time_first_event=metric.time_first_event,
+            time_last_event=metric.time_last_event,
+        )
+
+
+class IndexAttemptStageMetricsResponse(BaseModel):
+    """Response payload for the per-attempt stage-metrics endpoint.
+
+    ``stages`` is returned in the canonical pipeline order (the declaration
+    order of ``IndexAttemptStage``); the frontend renders that order
+    verbatim for the default "Pipeline order" sort and re-sorts client-side
+    for the "Time taken" sort.
+    """
+
+    index_attempt_id: int
+    stages: list[IndexAttemptStageMetricSnapshot]
 
 
 # These are the types currently supported by the pagination hook

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -19,9 +19,9 @@ from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import PermissionSyncStatus
 from onyx.db.enums import ProcessingMode
-from onyx.db.index_attempt_metrics import IndexAttemptStage
-from onyx.db.index_attempt_metrics import STAGE_SCOPE
-from onyx.db.index_attempt_metrics import StageScope
+from onyx.db.index_attempt_metrics_models import IndexAttemptStage
+from onyx.db.index_attempt_metrics_models import STAGE_SCOPE
+from onyx.db.index_attempt_metrics_models import StageScope
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential


### PR DESCRIPTION
## Description

adds an endpoint for fetching index attempt metrics

## How Has This Been Tested?

e2e tests coming

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat/index-attempt-ui-metrics4","parentHead":"b122dd7f6b679a36ec0efeed53161e9803b49189","parentPull":10638,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin endpoint to fetch per-stage timing metrics for a single index attempt, returned in pipeline order for the UI. Includes scope and timing aggregates to help compare stages.

- **New Features**
  - Added `GET /admin/index-attempt/{index_attempt_id}/stage-metrics` returning `IndexAttemptStageMetricsResponse` with `stages: IndexAttemptStageMetricSnapshot[]` in pipeline (enum) order.
  - Each stage includes `scope`, `event_count`, `total_duration_ms`, `avg_duration_ms`, `std_dev_duration_ms`, `min/max_duration_ms`, `time_first_event`, `time_last_event`; std dev is `null` when `< 2` events and is derived from `m2_duration_ms`.
  - Enforces access: curator/admin and read access to the owning cc-pair; returns `NOT_FOUND` or `INSUFFICIENT_PERMISSIONS`.
  - Added DB helper `get_stage_metrics_for_attempt` to load rows and sort by pipeline order while avoiding circular imports.

<sup>Written for commit ceb37e3213ecfdd9a3ae8244ba467499c342d943. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10639?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

