### PR TITLE
feat(metrics): Adding model information to Generated Report

### DIFF
--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -46,10 +46,10 @@ def get_empty_chat_messages_entries__paginated(
     for chat_session in chat_sessions:
         flow_type = FlowType.SLACK if chat_session.onyxbot_flow else FlowType.CHAT
 
-        # Group assistant messages by their parent (user) message id so we can
-        # report the model that answered each user prompt. A user message can
-        # have multiple assistant children in multi-model branches; we prefer
-        # `preferred_response_id` and fall back to the earliest child.
+        # Group assistant messages by their parent (user) message id. A user
+        # message can have multiple assistant children in multi-model branches
+        # (e.g. "compare models") — we emit one row per branch so every model
+        # invocation is represented in the report.
         assistant_children_by_parent: dict[int, list[ChatMessage]] = {}
         for message in chat_session.messages:
             if (
@@ -73,35 +73,37 @@ def get_empty_chat_messages_entries__paginated(
             if chat_session.persona:
                 assistant_name = chat_session.persona.name
 
-            # Resolve the paired assistant reply and its model display name.
-            paired_assistant = None
-            children = assistant_children_by_parent.get(message.id, [])
-            if children:
-                if message.preferred_response_id is not None:
-                    paired_assistant = next(
-                        (c for c in children if c.id == message.preferred_response_id),
-                        None,
-                    )
-                if paired_assistant is None:
-                    paired_assistant = min(children, key=lambda c: c.id)
-
-            llm_model = (
-                paired_assistant.model_display_name if paired_assistant else None
+            children = sorted(
+                assistant_children_by_parent.get(message.id, []),
+                key=lambda c: c.id,
+            )
+            # Emit one row per assistant child so multi-model branches each
+            # contribute their own model. If there is no assistant reply
+            # (orphan / errored / still streaming), still emit a row with
+            # llm_model=None so the user prompt is not dropped.
+            paired_assistants: list[ChatMessage | None] = (
+                list(children) if children else [None]
             )
 
-            message_skeletons.append(
-                ChatMessageSkeleton(
-                    message_id=message.id,
-                    chat_session_id=chat_session.id,
-                    user_id=str(chat_session.user_id) if chat_session.user_id else None,
-                    flow_type=flow_type,
-                    time_sent=message.time_sent,
-                    assistant_name=assistant_name,
-                    user_email=user_email,
-                    number_of_tokens=message.token_count,
-                    llm_model=llm_model,
+            for paired_assistant in paired_assistants:
+                llm_model = (
+                    paired_assistant.model_display_name if paired_assistant else None
                 )
-            )
+                message_skeletons.append(
+                    ChatMessageSkeleton(
+                        message_id=message.id,
+                        chat_session_id=chat_session.id,
+                        user_id=(
+                            str(chat_session.user_id) if chat_session.user_id else None
+                        ),
+                        flow_type=flow_type,
+                        time_sent=message.time_sent,
+                        assistant_name=assistant_name,
+                        user_email=user_email,
+                        number_of_tokens=message.token_count,
+                        llm_model=llm_model,
+                    )
+                )
     if len(chat_sessions) == 0:
         return None, []
 

--- a/backend/ee/onyx/db/usage_export.py
+++ b/backend/ee/onyx/db/usage_export.py
@@ -14,6 +14,7 @@ from ee.onyx.server.reporting.usage_export_models import ChatMessageSkeleton
 from ee.onyx.server.reporting.usage_export_models import FlowType
 from ee.onyx.server.reporting.usage_export_models import UsageReportMetadata
 from onyx.configs.constants import MessageType
+from onyx.db.models import ChatMessage
 from onyx.db.models import UsageReport
 from onyx.db.models import User
 from onyx.file_store.file_store import get_default_file_store
@@ -45,6 +46,20 @@ def get_empty_chat_messages_entries__paginated(
     for chat_session in chat_sessions:
         flow_type = FlowType.SLACK if chat_session.onyxbot_flow else FlowType.CHAT
 
+        # Group assistant messages by their parent (user) message id so we can
+        # report the model that answered each user prompt. A user message can
+        # have multiple assistant children in multi-model branches; we prefer
+        # `preferred_response_id` and fall back to the earliest child.
+        assistant_children_by_parent: dict[int, list[ChatMessage]] = {}
+        for message in chat_session.messages:
+            if (
+                message.message_type == MessageType.ASSISTANT
+                and message.parent_message_id is not None
+            ):
+                assistant_children_by_parent.setdefault(
+                    message.parent_message_id, []
+                ).append(message)
+
         for message in chat_session.messages:
             # Only count user messages
             if message.message_type != MessageType.USER:
@@ -58,6 +73,22 @@ def get_empty_chat_messages_entries__paginated(
             if chat_session.persona:
                 assistant_name = chat_session.persona.name
 
+            # Resolve the paired assistant reply and its model display name.
+            paired_assistant = None
+            children = assistant_children_by_parent.get(message.id, [])
+            if children:
+                if message.preferred_response_id is not None:
+                    paired_assistant = next(
+                        (c for c in children if c.id == message.preferred_response_id),
+                        None,
+                    )
+                if paired_assistant is None:
+                    paired_assistant = min(children, key=lambda c: c.id)
+
+            llm_model = (
+                paired_assistant.model_display_name if paired_assistant else None
+            )
+
             message_skeletons.append(
                 ChatMessageSkeleton(
                     message_id=message.id,
@@ -68,6 +99,7 @@ def get_empty_chat_messages_entries__paginated(
                     assistant_name=assistant_name,
                     user_email=user_email,
                     number_of_tokens=message.token_count,
+                    llm_model=llm_model,
                 )
             )
     if len(chat_sessions) == 0:

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -57,6 +57,7 @@ def generate_chat_messages_report(
                 "assistant_name",
                 "user_email",
                 "number_of_tokens",
+                "llm_model",
             ]
         )
         for chat_message_skeleton_batch in get_all_empty_chat_message_entries(
@@ -72,6 +73,7 @@ def generate_chat_messages_report(
                         chat_message_skeleton.assistant_name,
                         chat_message_skeleton.user_email,
                         chat_message_skeleton.number_of_tokens,
+                        chat_message_skeleton.llm_model,
                     ]
                 )
 

--- a/backend/ee/onyx/server/reporting/usage_export_models.py
+++ b/backend/ee/onyx/server/reporting/usage_export_models.py
@@ -19,6 +19,10 @@ class ChatMessageSkeleton(BaseModel):
     assistant_name: str | None
     user_email: str | None
     number_of_tokens: int
+    # Display name of the LLM that generated the assistant reply paired with
+    # this user message. None if no assistant reply exists yet or the model
+    # was never recorded.
+    llm_model: str | None
 
 
 class UserSkeleton(BaseModel):

--- a/backend/ee/onyx/server/reporting/usage_export_models.py
+++ b/backend/ee/onyx/server/reporting/usage_export_models.py
@@ -19,9 +19,10 @@ class ChatMessageSkeleton(BaseModel):
     assistant_name: str | None
     user_email: str | None
     number_of_tokens: int
-    # Display name of the LLM that generated the assistant reply paired with
-    # this user message. None if no assistant reply exists yet or the model
-    # was never recorded.
+    # Display name of the LLM that generated the assistant reply this row
+    # represents. Multi-model branches produce one row per assistant child of
+    # the same user message. None when there is no assistant reply yet
+    # (orphan / errored / still streaming) or the model was never recorded.
     llm_model: str | None
 
 

--- a/backend/onyx/db/seeding/chat_history_seeding.py
+++ b/backend/onyx/db/seeding/chat_history_seeding.py
@@ -75,6 +75,9 @@ def seed_chat_history(
                     minutes=random.randint(0, 10)
                 )
 
+                if current_message_type == MessageType.ASSISTANT:
+                    chat_message.model_display_name = "pytest-model"
+
                 db_session.commit()
 
                 current_message_type = (

--- a/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
+++ b/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
@@ -52,10 +52,13 @@ def _make_assistant_message(
     return msg
 
 
-def test_pairing_prefers_preferred_response_when_set(db_session: Session) -> None:
-    """Multi-model branch: user message has two assistant children with different
-    models. `preferred_response_id` should determine which model is reported."""
-    user = create_test_user(db_session, "usage-export-preferred")
+def test_multi_model_branch_emits_row_per_assistant_child(
+    db_session: Session,
+) -> None:
+    """A user message answered by multiple models (multi-model branch) must
+    produce one report row per assistant child so no model invocation is
+    dropped — even non-preferred branches."""
+    user = create_test_user(db_session, "usage-export-branch")
     chat_session = create_chat_session(
         db_session=db_session,
         description="multi-model branch",
@@ -70,6 +73,7 @@ def test_pairing_prefers_preferred_response_when_set(db_session: Session) -> Non
         db_session, chat_session.id, user_msg, "model-b"
     )
 
+    # Even when one branch is marked preferred, both must still be reported.
     user_msg.preferred_response_id = assistant_b.id
     db_session.commit()
 
@@ -78,27 +82,25 @@ def test_pairing_prefers_preferred_response_when_set(db_session: Session) -> Non
     )
 
     matching = [s for s in skeletons if s.message_id == user_msg.id]
-    assert len(matching) == 1
-    assert matching[0].llm_model == "model-b"
+    assert {s.llm_model for s in matching} == {"model-a", "model-b"}
+    assert len(matching) == 2
 
 
-def test_pairing_falls_back_to_earliest_child_when_no_preference(
-    db_session: Session,
-) -> None:
-    """No `preferred_response_id` set: pick the earliest assistant child (the
-    original reply, before any retries)."""
-    user = create_test_user(db_session, "usage-export-fallback")
+def test_single_assistant_child_emits_single_row(db_session: Session) -> None:
+    """The common case (one assistant reply per user message) still produces
+    exactly one row with that model. Guards against the per-pair change
+    inflating row counts in non-branched conversations."""
+    user = create_test_user(db_session, "usage-export-single")
     chat_session = create_chat_session(
         db_session=db_session,
-        description="multi-model fallback",
+        description="single reply",
         user_id=user.id,
         persona_id=None,
     )
     root = get_or_create_root_message(chat_session.id, db_session)
 
     user_msg = _make_user_message(db_session, chat_session.id, root)
-    _make_assistant_message(db_session, chat_session.id, user_msg, "first-model")
-    _make_assistant_message(db_session, chat_session.id, user_msg, "second-model")
+    _make_assistant_message(db_session, chat_session.id, user_msg, "only-model")
 
     _, skeletons = get_empty_chat_messages_entries__paginated(
         db_session, _full_period()
@@ -106,12 +108,12 @@ def test_pairing_falls_back_to_earliest_child_when_no_preference(
 
     matching = [s for s in skeletons if s.message_id == user_msg.id]
     assert len(matching) == 1
-    assert matching[0].llm_model == "first-model"
+    assert matching[0].llm_model == "only-model"
 
 
-def test_pairing_returns_none_for_orphan_user_message(db_session: Session) -> None:
-    """User message with no assistant reply (e.g. still streaming, errored) gets
-    a None llm_model rather than crashing."""
+def test_orphan_user_message_emits_row_with_null_model(db_session: Session) -> None:
+    """User message with no assistant reply (still streaming, errored) gets a
+    single row with `llm_model=None` rather than being dropped."""
     user = create_test_user(db_session, "usage-export-orphan")
     chat_session = create_chat_session(
         db_session=db_session,

--- a/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
+++ b/backend/tests/external_dependency_unit/db/test_usage_export_pairing.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+from datetime import timezone
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.usage_export import get_empty_chat_messages_entries__paginated
+from onyx.configs.constants import MessageType
+from onyx.db.chat import create_chat_session
+from onyx.db.chat import create_new_chat_message
+from onyx.db.chat import get_or_create_root_message
+from onyx.db.models import ChatMessage
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _full_period() -> tuple[datetime, datetime]:
+    return (
+        datetime.fromtimestamp(0, tz=timezone.utc),
+        datetime.now(tz=timezone.utc),
+    )
+
+
+def _make_user_message(
+    db_session: Session, chat_session_id: UUID, parent: ChatMessage
+) -> ChatMessage:
+    return create_new_chat_message(
+        chat_session_id=chat_session_id,
+        parent_message=parent,
+        message="user prompt",
+        token_count=0,
+        message_type=MessageType.USER,
+        db_session=db_session,
+    )
+
+
+def _make_assistant_message(
+    db_session: Session,
+    chat_session_id: UUID,
+    parent: ChatMessage,
+    model_display_name: str,
+) -> ChatMessage:
+    msg = create_new_chat_message(
+        chat_session_id=chat_session_id,
+        parent_message=parent,
+        message="assistant reply",
+        token_count=0,
+        message_type=MessageType.ASSISTANT,
+        db_session=db_session,
+    )
+    msg.model_display_name = model_display_name
+    db_session.commit()
+    return msg
+
+
+def test_pairing_prefers_preferred_response_when_set(db_session: Session) -> None:
+    """Multi-model branch: user message has two assistant children with different
+    models. `preferred_response_id` should determine which model is reported."""
+    user = create_test_user(db_session, "usage-export-preferred")
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="multi-model branch",
+        user_id=user.id,
+        persona_id=None,
+    )
+    root = get_or_create_root_message(chat_session.id, db_session)
+
+    user_msg = _make_user_message(db_session, chat_session.id, root)
+    _make_assistant_message(db_session, chat_session.id, user_msg, "model-a")
+    assistant_b = _make_assistant_message(
+        db_session, chat_session.id, user_msg, "model-b"
+    )
+
+    user_msg.preferred_response_id = assistant_b.id
+    db_session.commit()
+
+    _, skeletons = get_empty_chat_messages_entries__paginated(
+        db_session, _full_period()
+    )
+
+    matching = [s for s in skeletons if s.message_id == user_msg.id]
+    assert len(matching) == 1
+    assert matching[0].llm_model == "model-b"
+
+
+def test_pairing_falls_back_to_earliest_child_when_no_preference(
+    db_session: Session,
+) -> None:
+    """No `preferred_response_id` set: pick the earliest assistant child (the
+    original reply, before any retries)."""
+    user = create_test_user(db_session, "usage-export-fallback")
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="multi-model fallback",
+        user_id=user.id,
+        persona_id=None,
+    )
+    root = get_or_create_root_message(chat_session.id, db_session)
+
+    user_msg = _make_user_message(db_session, chat_session.id, root)
+    _make_assistant_message(db_session, chat_session.id, user_msg, "first-model")
+    _make_assistant_message(db_session, chat_session.id, user_msg, "second-model")
+
+    _, skeletons = get_empty_chat_messages_entries__paginated(
+        db_session, _full_period()
+    )
+
+    matching = [s for s in skeletons if s.message_id == user_msg.id]
+    assert len(matching) == 1
+    assert matching[0].llm_model == "first-model"
+
+
+def test_pairing_returns_none_for_orphan_user_message(db_session: Session) -> None:
+    """User message with no assistant reply (e.g. still streaming, errored) gets
+    a None llm_model rather than crashing."""
+    user = create_test_user(db_session, "usage-export-orphan")
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="orphan user message",
+        user_id=user.id,
+        persona_id=None,
+    )
+    root = get_or_create_root_message(chat_session.id, db_session)
+
+    user_msg = _make_user_message(db_session, chat_session.id, root)
+
+    _, skeletons = get_empty_chat_messages_entries__paginated(
+        db_session, _full_period()
+    )
+
+    matching = [s for s in skeletons if s.message_id == user_msg.id]
+    assert len(matching) == 1
+    assert matching[0].llm_model is None

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -315,6 +315,7 @@ class TestUsageExportAPI:
                     "assistant_name",
                     "user_email",
                     "number_of_tokens",
+                    "llm_model",
                 }
                 actual_columns = set(csv_reader.fieldnames or [])
                 assert (
@@ -342,6 +343,9 @@ class TestUsageExportAPI:
                 assert (
                     int(first_row["number_of_tokens"]) >= 0
                 ), "number_of_tokens should be non-negative"
+                assert (
+                    first_row["llm_model"] == "pytest-model"
+                ), "llm_model should reflect the assistant reply's model"
 
     def test_read_nonexistent_report(
         self,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding the specific LLM Model used by the users to the Usage Metrics for easy tracking

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally and also added new tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the LLM model used for each assistant reply to the chat messages usage export. The report now outputs one row per assistant reply (multi-model branches) and still includes user messages with no reply (with `llm_model` blank).

- **New Features**
  - Adds `llm_model` column to the CSV (header and rows).
  - Emits one row per assistant child of a user message; if no reply, emits a single row with `llm_model` blank.
  - Extends the export schema (`ChatMessageSkeleton.llm_model`), seeds assistant messages with `model_display_name`, and adds tests for multi-model branches, single replies, and orphan user messages.

<sup>Written for commit 634e35932f6fed665bd70d47896db2f1a945a873. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10648?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

