### PR TITLE
fix(opal): Notification text is always light

### DIFF
--- a/web/lib/opal/src/icons/notification-bubble.tsx
+++ b/web/lib/opal/src/icons/notification-bubble.tsx
@@ -46,7 +46,7 @@ const SvgNotificationBubble = ({
         }}
       >
         <span
-          className="text-text-inverted-05 font-medium leading-none"
+          className="text-text-light-05 font-medium leading-none"
           style={{ fontSize: 10 }}
         >
           {displayCount}


### PR DESCRIPTION
## Description

Changes the notification bubble count text color from `text-text-inverted-05` to `text-text-light-05`.

## Screenshots + Videos

### Before

Before, the colour changed, depending on the theme.

<img width="242" height="48" alt="image" src="https://github.com/user-attachments/assets/a25d89f6-2d9a-404d-9290-27d877839c6e" />

<img width="241" height="58" alt="image" src="https://github.com/user-attachments/assets/e598a9aa-bfec-48e4-a52d-f457e197b977" />

### After

With this change, the notification text (i.e., the `"1"` in this case) is always light coloured now.

<img width="242" height="55" alt="image" src="https://github.com/user-attachments/assets/24ab3114-ea23-44db-8968-baec1b035e26" />

<img width="245" height="64" alt="image" src="https://github.com/user-attachments/assets/44145a68-7e34-4c04-8da9-40e72561b744" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the notification bubble count text color from `text-text-inverted-05` to `text-text-light-05` to match the light theme token and improve readability. This aligns the badge text with the design system and fixes contrast on light backgrounds.

<sup>Written for commit 5866c933fb4299bccd8260c5205487284247c538. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10649?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->