### PR TITLE
fix(opal): `toPlainString` strips markdown

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -149,6 +149,7 @@ module.exports = {
         "**/src/refresh-pages/**/*.test.ts",
         "**/src/sections/**/*.test.ts",
         "**/src/components/**/*.test.ts",
+        "**/lib/opal/**/*.test.ts",
         // Add more patterns here as you add more unit tests
       ],
     },

--- a/web/lib/opal/src/components/text/InlineMarkdown.test.ts
+++ b/web/lib/opal/src/components/text/InlineMarkdown.test.ts
@@ -42,6 +42,10 @@ describe("toPlainString", () => {
     expect(toPlainString(markdown("snake_case_word"))).toBe("snake_case_word");
   });
 
+  it("preserves double underscores inside identifiers", () => {
+    expect(toPlainString(markdown("foo__bar__baz"))).toBe("foo__bar__baz");
+  });
+
   it("strips strikethrough syntax", () => {
     expect(toPlainString(markdown("~~struck~~"))).toBe("struck");
   });

--- a/web/lib/opal/src/components/text/InlineMarkdown.test.ts
+++ b/web/lib/opal/src/components/text/InlineMarkdown.test.ts
@@ -1,0 +1,74 @@
+import { markdown } from "@opal/utils";
+import { toPlainString } from "@opal/components/text/InlineMarkdown";
+
+describe("toPlainString", () => {
+  it("returns plain strings unchanged", () => {
+    expect(toPlainString("Hello world")).toBe("Hello world");
+  });
+
+  it("returns empty plain strings unchanged", () => {
+    expect(toPlainString("")).toBe("");
+  });
+
+  it("returns RichStr without markdown unchanged", () => {
+    expect(toPlainString(markdown("Hello world"))).toBe("Hello world");
+  });
+
+  it("strips link syntax, keeping the label", () => {
+    expect(
+      toPlainString(
+        markdown("[Onyx 0.0.0-dev](https://docs.onyx.app/changelog)")
+      )
+    ).toBe("Onyx 0.0.0-dev");
+  });
+
+  it("strips bold (**) syntax", () => {
+    expect(toPlainString(markdown("**bold text**"))).toBe("bold text");
+  });
+
+  it("strips bold (__) syntax", () => {
+    expect(toPlainString(markdown("__bold text__"))).toBe("bold text");
+  });
+
+  it("strips italic (*) syntax", () => {
+    expect(toPlainString(markdown("*italic*"))).toBe("italic");
+  });
+
+  it("strips italic (_) syntax", () => {
+    expect(toPlainString(markdown("_italic_"))).toBe("italic");
+  });
+
+  it("preserves underscores inside identifiers", () => {
+    expect(toPlainString(markdown("snake_case_word"))).toBe("snake_case_word");
+  });
+
+  it("strips strikethrough syntax", () => {
+    expect(toPlainString(markdown("~~struck~~"))).toBe("struck");
+  });
+
+  it("strips inline code syntax", () => {
+    expect(toPlainString(markdown("`code`"))).toBe("code");
+  });
+
+  it("collapses newlines into single spaces", () => {
+    expect(toPlainString(markdown("line one", "line two"))).toBe(
+      "line one line two"
+    );
+  });
+
+  it("strips combined inline syntax", () => {
+    expect(
+      toPlainString(markdown("**bold** and *italic* and `code` and ~~struck~~"))
+    ).toBe("bold and italic and code and struck");
+  });
+
+  it("strips link with bold label", () => {
+    expect(toPlainString(markdown("[**bold link**](https://onyx.app)"))).toBe(
+      "bold link"
+    );
+  });
+
+  it("trims leading and trailing whitespace", () => {
+    expect(toPlainString(markdown("  hello  "))).toBe("hello");
+  });
+});

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -77,7 +77,17 @@ export function resolveStr(value: string | RichStr): ReactNode {
   return isRichStr(value) ? <InlineMarkdown content={value.raw} /> : value;
 }
 
-/** Extracts the plain string from `string | RichStr`. */
+/** Extracts the plain string from `string | RichStr`, stripping markdown syntax. */
 export function toPlainString(value: string | RichStr): string {
-  return isRichStr(value) ? value.raw : value;
+  if (!isRichStr(value)) return value;
+  return value.raw
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/__([^_]+)__/g, "$1")
+    .replace(/~~([^~]+)~~/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s*\n\s*/g, " ")
+    .trim();
 }

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -83,7 +83,7 @@ export function toPlainString(value: string | RichStr): string {
   return value.raw
     .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
     .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/__([^_]+)__/g, "$1")
+    .replace(/(?<!\w)__([^_]+)__(?!\w)/g, "$1")
     .replace(/~~([^~]+)~~/g, "$1")
     .replace(/\*([^*]+)\*/g, "$1")
     .replace(/(?<!\w)_([^_]+)_(?!\w)/g, "$1")


### PR DESCRIPTION
## Description

Updates `toPlainString` to strip the resolved markdown.

Some `titles` currently incorrectly display raw markdown rather than plain-text. For example, the changelog link.

<img width="1572" height="2085" alt="20260427_11h25m36s_grim" src="https://github.com/user-attachments/assets/7080ccf6-4df0-4f9d-b7ab-d3eb03ffca1b" />

## How Has This Been Tested?

Unit test included

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes titles showing raw markdown by improving `toPlainString` in `@opal/components/text/InlineMarkdown` to return clean plain text. Titles like the changelog link now render labels (e.g., “Onyx 0.0.0-dev”) instead of raw markdown.

- **Bug Fixes**
  - `toPlainString` now strips links (keeps label), bold (`**`/`__`), italic (`*`/`_`), strikethrough (`~~`), inline code (`` ` ``), collapses newlines, and trims whitespace; preserves underscores in identifiers.
  - Added unit tests for these cases and updated Jest to discover `**/lib/opal/**/*.test.ts`.

<sup>Written for commit b748ea0de7744ea7df73fbe8dd9971c2506158bb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10650?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

