### PR TITLE
feat(sidebar): revamp NotificationsPopover with New/Older sections

### DIFF
--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -3,7 +3,7 @@
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { Notification } from "@/interfaces/settings";
+import type { Notification } from "@/lib/notifications/interfaces";
 
 /**
  * Fetches the current user's notifications.

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -79,30 +79,10 @@ export interface Settings {
   default_file_token_count_threshold_k?: number;
 }
 
-export enum NotificationType {
-  PERSONA_SHARED = "persona_shared",
-  REINDEX = "reindex",
-  TRIAL_ENDS_TWO_DAYS = "two_day_trial_ending",
-  ASSISTANT_FILES_READY = "assistant_files_ready",
-  RELEASE_NOTES = "release_notes",
-  FEATURE_ANNOUNCEMENT = "feature_announcement",
-}
+export { NotificationType } from "@/lib/notifications/interfaces";
+export type { Notification } from "@/lib/notifications/interfaces";
 
-export interface Notification {
-  id: number;
-  notif_type: string;
-  title: string;
-  description: string | null;
-  dismissed: boolean;
-  first_shown: string;
-  last_shown: string;
-  additional_data?: {
-    persona_id?: number;
-    link?: string;
-    version?: string; // For release notes notifications
-    [key: string]: any;
-  };
-}
+import type { Notification } from "@/lib/notifications/interfaces";
 
 export interface NavigationItem {
   link: string;

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -1,3 +1,5 @@
+import type { Notification } from "@/lib/notifications/interfaces";
+
 export enum ApplicationStatus {
   PAYMENT_REMINDER = "payment_reminder",
   GATED_ACCESS = "gated_access",
@@ -78,11 +80,6 @@ export interface Settings {
   default_user_file_max_upload_size_mb?: number;
   default_file_token_count_threshold_k?: number;
 }
-
-export { NotificationType } from "@/lib/notifications/interfaces";
-export type { Notification } from "@/lib/notifications/interfaces";
-
-import type { Notification } from "@/lib/notifications/interfaces";
 
 export interface NavigationItem {
   link: string;

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -1,0 +1,24 @@
+import { SvgAlertCircle, SvgAlertTriangle, SvgBullhorn } from "@opal/icons";
+import type { IconProps } from "@opal/types";
+import { NotificationType } from "@/lib/notifications/interfaces";
+
+export function getNotificationIcon(
+  notifType: string
+): React.FunctionComponent<IconProps> {
+  switch (notifType) {
+    case NotificationType.PERSONA_SHARED:
+    case NotificationType.REINDEX:
+    case NotificationType.ASSISTANT_FILES_READY:
+      return SvgAlertCircle;
+
+    case NotificationType.TRIAL_ENDS_TWO_DAYS:
+      return SvgAlertTriangle;
+
+    case NotificationType.RELEASE_NOTES:
+    case NotificationType.FEATURE_ANNOUNCEMENT:
+      return SvgBullhorn;
+
+    default:
+      return SvgAlertCircle;
+  }
+}

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -1,0 +1,29 @@
+export enum NotificationType {
+  // SvgAlertCircle
+  PERSONA_SHARED = "persona_shared",
+  REINDEX = "reindex",
+  ASSISTANT_FILES_READY = "assistant_files_ready",
+
+  // SvgAlertTriangle
+  TRIAL_ENDS_TWO_DAYS = "two_day_trial_ending",
+
+  // SvgBullhorn
+  RELEASE_NOTES = "release_notes",
+  FEATURE_ANNOUNCEMENT = "feature_announcement",
+}
+
+export interface Notification {
+  id: number;
+  notif_type: string;
+  title: string;
+  description: string | null;
+  dismissed: boolean;
+  first_shown: string;
+  last_shown: string;
+  additional_data?: {
+    persona_id?: number;
+    link?: string;
+    version?: string; // For release notes notifications
+    [key: string]: any;
+  };
+}

--- a/web/src/refresh-components/Popover.tsx
+++ b/web/src/refresh-components/Popover.tsx
@@ -107,13 +107,14 @@ const PopoverClose = PopoverPrimitive.Close;
  * </Popover.Content>
  * ```
  */
-type PopoverWidths = "fit" | "sm" | "md" | "lg" | "xl" | "trigger";
+type PopoverWidths = "fit" | "sm" | "md" | "lg" | "xl" | "2xl" | "trigger";
 const widthClasses: Record<PopoverWidths, string> = {
   fit: "w-fit",
   sm: "w-[10rem]",
   md: "w-[12rem]",
   lg: "w-[15rem]",
   xl: "w-[18rem]",
+  "2xl": "w-[25rem]",
   trigger: "w-[var(--radix-popover-trigger-width)]",
 };
 interface PopoverContentProps

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -235,7 +235,7 @@ export default function AccountPopover({
       <Popover.Content
         align="end"
         side="right"
-        width={popupState === "Notifications" ? "xl" : "lg"}
+        width={popupState === "Notifications" ? "2xl" : "lg"}
       >
         {popupState === "Settings" && (
           <SettingsPopover

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -73,7 +73,7 @@ import { CRAFT_PATH } from "@/app/craft/v1/constants";
 import { usePostHog } from "posthog-js/react";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { motion, AnimatePresence } from "motion/react";
-import { NotificationType } from "@/interfaces/settings";
+import { NotificationType } from "@/lib/notifications/interfaces";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
 import ChatSearchCommandMenu from "@/sections/sidebar/ChatSearchCommandMenu";
 import { useQueryController } from "@/providers/QueryControllerProvider";

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -3,21 +3,28 @@
 import { useRouter } from "next/navigation";
 import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
-import { Notification, NotificationType } from "@/interfaces/settings";
+import {
+  Notification as NotificationData,
+  NotificationType,
+} from "@/interfaces/settings";
 import useNotifications from "@/hooks/useNotifications";
 import {
   SvgSparkle,
   SvgRefreshCw,
   SvgX,
-  SvgNotificationBubble,
+  SvgBullhorn,
+  SvgCheckAll,
 } from "@opal/icons";
-import { IconProps } from "@opal/types";
-import { Button, Divider, LineItemButton } from "@opal/components";
+import type { IconProps } from "@opal/types";
+import { Button, Divider, LineItemButton, Text } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction, IllustrationContent } from "@opal/layouts";
 import { SvgEmpty } from "@opal/illustrations";
-import { markdown } from "@opal/utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function getNotificationIcon(
   notifType: string
@@ -25,10 +32,79 @@ function getNotificationIcon(
   switch (notifType) {
     case NotificationType.REINDEX:
       return SvgRefreshCw;
+    case NotificationType.RELEASE_NOTES:
+      return SvgBullhorn;
     default:
       return SvgSparkle;
   }
 }
+
+function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ---------------------------------------------------------------------------
+// NotificationItem
+// ---------------------------------------------------------------------------
+
+interface NotificationItemProps {
+  notification: NotificationData;
+  onClick: () => void;
+  onDismiss: (id: number, e?: React.MouseEvent) => void;
+}
+
+function NotificationItem({
+  notification,
+  onClick,
+  onDismiss,
+}: NotificationItemProps) {
+  const isNew = !notification.dismissed;
+
+  return (
+    <LineItemButton
+      icon={getNotificationIcon(notification.notif_type)}
+      title={notification.title}
+      description={notification.description ?? undefined}
+      selectVariant="select-heavy"
+      sizePreset="main-ui"
+      rounding="sm"
+      state={isNew ? "selected" : "empty"}
+      color={isNew ? "interactive" : "muted"}
+      onClick={onClick}
+      rightChildren={
+        <div className="flex flex-col items-end gap-1">
+          <Text font="secondary-body" color="text-02">
+            {formatRelativeDate(notification.first_shown)}
+          </Text>
+          {isNew && (
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgCheckAll}
+              onClick={(e) => onDismiss(notification.id, e)}
+              tooltip="Mark as read"
+            />
+          )}
+        </div>
+      }
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NotificationsPopover
+// ---------------------------------------------------------------------------
 
 interface NotificationsPopoverProps {
   onClose: () => void;
@@ -49,8 +125,7 @@ export default function NotificationsPopover({
     refresh: mutate,
   } = useNotifications();
 
-  const handleNotificationClick = (notification: Notification) => {
-    // Handle build_mode feature announcement specially - show intro animation
+  const handleNotificationClick = (notification: NotificationData) => {
     if (
       notification.notif_type === NotificationType.FEATURE_ANNOUNCEMENT &&
       notification.additional_data?.feature === "build_mode" &&
@@ -64,14 +139,12 @@ export default function NotificationsPopover({
     const link = notification.additional_data?.link;
     if (!link) return;
 
-    // Track release notes clicks
     if (notification.notif_type === NotificationType.RELEASE_NOTES) {
       track(AnalyticsEvent.RELEASE_NOTIFICATION_CLICKED, {
         version: notification.additional_data?.version,
       });
     }
 
-    // External links open in new tab
     if (link.startsWith("http://") || link.startsWith("https://")) {
       if (!notification.dismissed) {
         handleDismiss(notification.id);
@@ -80,7 +153,6 @@ export default function NotificationsPopover({
       return;
     }
 
-    // Relative links navigate internally
     onNavigate();
     router.push(link as Route);
   };
@@ -89,21 +161,22 @@ export default function NotificationsPopover({
     notificationId: number,
     e?: React.MouseEvent
   ) => {
-    e?.stopPropagation(); // Prevent triggering the LineItem onClick
+    e?.stopPropagation();
     try {
       const response = await fetch(
         `/api/notifications/${notificationId}/dismiss`,
-        {
-          method: "POST",
-        }
+        { method: "POST" }
       );
       if (response.ok) {
-        mutate(); // Refresh the notifications list
+        mutate();
       }
     } catch (error) {
       console.error("Error dismissing notification:", error);
     }
   };
+
+  const newNotifications = notifications?.filter((n) => !n.dismissed) ?? [];
+  const olderNotifications = notifications?.filter((n) => n.dismissed) ?? [];
 
   return (
     <Section gap={0}>
@@ -127,8 +200,6 @@ export default function NotificationsPopover({
         />
       </div>
 
-      <Divider paddingPerpendicular="fit" />
-
       {isLoading ? (
         <div className="h-[var(--notifications-popover)]">
           <Section>
@@ -145,36 +216,38 @@ export default function NotificationsPopover({
           </Section>
         </div>
       ) : (
-        <div className="max-h-[var(--notifications-popover)] overflow-y-auto pt-1 px-0 flex flex-col gap-1">
-          {/* TODO(@raunakab): make dismissed notifications have greyed out text */}
-          {notifications.map((notification) => (
-            <LineItemButton
-              key={notification.id}
-              icon={getNotificationIcon(notification.notif_type)}
-              title={markdown(
-                notification.dismissed
-                  ? `~~${notification.title}~~`
-                  : notification.title
-              )}
-              selectVariant="select-heavy"
-              sizePreset="main-ui"
-              rounding="sm"
-              state={notification.dismissed ? undefined : "selected"}
-              description={notification.description ?? undefined}
-              onClick={() => handleNotificationClick(notification)}
-              rightChildren={
-                !notification.dismissed ? (
-                  <Button
-                    prominence="tertiary"
-                    size="sm"
-                    icon={SvgX}
-                    onClick={(e) => handleDismiss(notification.id, e)}
-                    tooltip="Dismiss"
+        <div className="max-h-[var(--notifications-popover)] overflow-y-auto flex flex-col">
+          {newNotifications.length > 0 && (
+            <>
+              <Divider title="New" />
+              <div className="flex flex-col gap-1 px-1">
+                {newNotifications.map((notification) => (
+                  <NotificationItem
+                    key={notification.id}
+                    notification={notification}
+                    onClick={() => handleNotificationClick(notification)}
+                    onDismiss={handleDismiss}
                   />
-                ) : undefined
-              }
-            />
-          ))}
+                ))}
+              </div>
+            </>
+          )}
+
+          {olderNotifications.length > 0 && (
+            <>
+              <Divider title="Older" />
+              <div className="flex flex-col gap-1 px-1">
+                {olderNotifications.map((notification) => (
+                  <NotificationItem
+                    key={notification.id}
+                    notification={notification}
+                    onClick={() => handleNotificationClick(notification)}
+                    onDismiss={handleDismiss}
+                  />
+                ))}
+              </div>
+            </>
+          )}
         </div>
       )}
     </Section>

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -117,6 +117,28 @@ export default function NotificationsPopover({
     new Set()
   );
 
+  const handleDismiss = useCallback(
+    async (notificationId: number) => {
+      try {
+        const response = await fetch(
+          `/api/notifications/${notificationId}/dismiss`,
+          { method: "POST" }
+        );
+        if (response.ok) {
+          setSessionDismissedIds((prev) => {
+            const next = new Set(prev);
+            next.add(notificationId);
+            return next;
+          });
+          mutate();
+        }
+      } catch (error) {
+        console.error("Error dismissing notification:", error);
+      }
+    },
+    [mutate]
+  );
+
   const handleNotificationClick = useCallback(
     (notification: NotificationData) => {
       if (
@@ -149,25 +171,7 @@ export default function NotificationsPopover({
       onNavigate();
       router.push(link as Route);
     },
-    [onNavigate, onShowBuildIntro, router]
-  );
-
-  const handleDismiss = useCallback(
-    async (notificationId: number) => {
-      try {
-        const response = await fetch(
-          `/api/notifications/${notificationId}/dismiss`,
-          { method: "POST" }
-        );
-        if (response.ok) {
-          setSessionDismissedIds((prev) => new Set([...prev, notificationId]));
-          mutate();
-        }
-      } catch (error) {
-        console.error("Error dismissing notification:", error);
-      }
-    },
-    [mutate]
+    [handleDismiss, onNavigate, onShowBuildIntro, router]
   );
 
   const getState = useCallback(
@@ -180,11 +184,11 @@ export default function NotificationsPopover({
   );
 
   const newNotifications = useMemo(
-    () => notifications?.filter((n) => getState(n) === "new") ?? [],
+    () => notifications.filter((n) => getState(n) === "new"),
     [notifications, getState]
   );
   const olderNotifications = useMemo(
-    () => notifications?.filter((n) => getState(n) === "older") ?? [],
+    () => notifications.filter((n) => getState(n) === "older"),
     [notifications, getState]
   );
 

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -66,7 +66,7 @@ function formatRelativeDate(dateString: string): string {
 // NotificationItem
 // ---------------------------------------------------------------------------
 
-type NotificationState = "new" | "dismissed" | "older";
+type NotificationState = "new" | "older";
 
 interface NotificationItemProps {
   notification: NotificationData;
@@ -211,8 +211,8 @@ export default function NotificationsPopover({
 
   const getState = useCallback(
     (notification: NotificationData): NotificationState => {
-      if (sessionDismissedIds.has(notification.id)) return "dismissed";
-      if (notification.dismissed) return "older";
+      if (sessionDismissedIds.has(notification.id) || notification.dismissed)
+        return "older";
       return "new";
     },
     [sessionDismissedIds]
@@ -220,10 +220,6 @@ export default function NotificationsPopover({
 
   const newNotifications = useMemo(
     () => notifications?.filter((n) => getState(n) === "new") ?? [],
-    [notifications, getState]
-  );
-  const dismissedNotifications = useMemo(
-    () => notifications?.filter((n) => getState(n) === "dismissed") ?? [],
     [notifications, getState]
   );
   const olderNotifications = useMemo(
@@ -288,7 +284,7 @@ export default function NotificationsPopover({
           {newNotifications.length > 0 && (
             <>
               <Divider title="New" />
-              <div className="flex flex-col">
+              <div className="flex flex-col gap-1">
                 {newNotifications.map((notification) => (
                   <NotificationItem
                     key={notification.id}
@@ -302,27 +298,10 @@ export default function NotificationsPopover({
             </>
           )}
 
-          {dismissedNotifications.length > 0 && (
-            <>
-              <Divider title="Dismissed" />
-              <div className="flex flex-col">
-                {dismissedNotifications.map((notification) => (
-                  <NotificationItem
-                    key={notification.id}
-                    notification={notification}
-                    state="dismissed"
-                    onClick={() => handleNotificationClick(notification)}
-                    onDismiss={handleDismiss}
-                  />
-                ))}
-              </div>
-            </>
-          )}
-
           {olderNotifications.length > 0 && (
             <>
               <Divider title="Older" />
-              <div className="flex flex-col">
+              <div className="flex flex-col gap-1">
                 {olderNotifications.map((notification) => (
                   <NotificationItem
                     key={notification.id}

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -10,15 +10,15 @@ import { getNotificationIcon } from "@/lib/notifications";
 import { timeAgo } from "@/lib/time";
 import useNotifications from "@/hooks/useNotifications";
 import {
-  SvgX,
   SvgCheckAll,
   SvgNotificationBubble,
   SvgCheckSquare,
+  SvgChevronLeft,
 } from "@opal/icons";
 import { Button, Divider, LineItemButton, Text } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
-import { ContentAction, IllustrationContent } from "@opal/layouts";
+import { IllustrationContent } from "@opal/layouts";
 import { SvgEmpty } from "@opal/illustrations";
 import { Hoverable } from "@opal/core";
 import { noProp } from "@/lib/utils";
@@ -53,31 +53,35 @@ function NotificationItem({
         color={state === "new" ? undefined : "muted"}
         onClick={onClick}
         rightChildren={
-          <Section flexDirection="row" alignItems="start" gap={0.5} padding={0}>
-            <Text font="secondary-body" color="text-02">
-              {timeAgo(notification.first_shown) ?? ""}
-            </Text>
-            {state === "new" && (
-              <div className="w-4 flex flex-col items-center justify-center">
-                <Hoverable.Item
-                  group="notifications-popover/NotificationItem"
-                  variant="replace-on-hover"
-                  resting={
-                    <div className="w-full h-full p-1">
-                      <SvgNotificationBubble size={6} />
-                    </div>
-                  }
-                >
-                  <Button
-                    icon={SvgCheckSquare}
-                    size="2xs"
-                    prominence="tertiary"
-                    onClick={noProp(dismiss)}
-                    tooltip="Mark as read"
-                  />
-                </Hoverable.Item>
-              </div>
-            )}
+          <Section justifyContent="start">
+            <Section height="fit" gap={0.5} flexDirection="row">
+              <Text font="secondary-body" color="text-02">
+                {timeAgo(notification.first_shown) ?? ""}
+              </Text>
+              {state === "new" && (
+                <div className="w-4 flex flex-col items-center justify-center">
+                  <Hoverable.Item
+                    group="notifications-popover/NotificationItem"
+                    variant="replace-on-hover"
+                    resting={
+                      <div className="w-full h-full p-2">
+                        <div className="p-px">
+                          <SvgNotificationBubble size={6} />
+                        </div>
+                      </div>
+                    }
+                  >
+                    <Button
+                      icon={SvgCheckSquare}
+                      size="sm"
+                      prominence="tertiary"
+                      onClick={noProp(dismiss)}
+                      tooltip="Mark as read"
+                    />
+                  </Hoverable.Item>
+                </div>
+              )}
+            </Section>
           </Section>
         }
       />
@@ -191,35 +195,27 @@ export default function NotificationsPopover({
   }, [newNotifications, handleDismiss]);
 
   return (
-    <Section>
-      <ContentAction
-        title="Notifications"
-        sizePreset="main-content"
-        tag={{
-          title: `${undismissedCount} unread`,
-          color: "blue",
-        }}
-        rightChildren={
-          <div className="flex flex-row items-center gap-1">
-            {newNotifications.length > 0 && (
-              <Button
-                icon={SvgCheckAll}
-                onClick={handleDismissAll}
-                size="sm"
-                prominence="tertiary"
-                tooltip="Mark all as read"
-              />
-            )}
-            <Button
-              icon={SvgX}
-              onClick={onClose}
-              size="sm"
-              prominence="tertiary"
-            />
-          </div>
-        }
-        padding="fit"
-      />
+    <Section gap={0}>
+      <Section flexDirection="row" padding={0.325}>
+        <Section flexDirection="row" gap={0.25} justifyContent="start">
+          <Button
+            icon={SvgChevronLeft}
+            size="sm"
+            prominence="tertiary"
+            onClick={onClose}
+          />
+          <Text color="text-02">Notifications</Text>
+        </Section>
+
+        <Section flexDirection="row" gap={0.25} justifyContent="end">
+          <Button
+            icon={SvgCheckAll}
+            size="sm"
+            prominence="tertiary"
+            onClick={handleDismissAll}
+          />
+        </Section>
+      </Section>
 
       {isLoading ? (
         <div className="h-[var(--notifications-popover)]">

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -20,7 +20,7 @@ import {
   SvgNotificationBubble,
 } from "@opal/icons";
 import type { IconProps } from "@opal/types";
-import { Button, Divider, Text } from "@opal/components";
+import { Button, Divider, SelectCard, Text } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
@@ -85,57 +85,54 @@ function NotificationItem({
 
   return (
     <Hoverable.Root group={hoverGroup}>
-      <div
-        className="flex flex-row gap-1 items-start cursor-pointer"
-        onClick={onClick}
-        role="button"
-        tabIndex={0}
-      >
-        <div className="flex-1 min-w-0">
-          <ContentAction
-            icon={getNotificationIcon(notification.notif_type)}
-            title={notification.title}
-            description={notification.description ?? undefined}
-            sizePreset="main-ui"
-            variant="section"
-            color={state === "new" ? "default" : "muted"}
-            padding="fit"
-            rightChildren={
-              <Text font="secondary-body" color="text-02">
-                {formatRelativeDate(notification.first_shown)}
-              </Text>
-            }
-          />
-        </div>
+      <SelectCard onClick={onClick} padding="sm" rounding="sm">
+        <div className="flex flex-row gap-1 items-start">
+          <div className="flex-1 min-w-0">
+            <ContentAction
+              icon={getNotificationIcon(notification.notif_type)}
+              title={notification.title}
+              description={notification.description ?? undefined}
+              sizePreset="main-ui"
+              variant="section"
+              color={state === "new" ? "interactive" : "muted"}
+              padding="fit"
+              rightChildren={
+                <Text font="secondary-body" color="text-02">
+                  {formatRelativeDate(notification.first_shown)}
+                </Text>
+              }
+            />
+          </div>
 
-        <div className="flex items-center justify-center w-6 shrink-0">
-          {state === "new" ? (
-            <div className="relative flex items-center justify-center w-6 h-6">
-              {/* Dot: visible at rest, fades out on hover */}
-              <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-100 [div[data-hover-group]:hover_&]:opacity-0">
-                <SvgNotificationBubble size={6} />
+          <div className="flex items-center justify-center w-6 shrink-0">
+            {state === "new" ? (
+              <div className="relative flex items-center justify-center w-6 h-6">
+                {/* Dot: visible at rest, fades out on hover */}
+                <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-100 [div[data-hover-group]:hover_&]:opacity-0">
+                  <SvgNotificationBubble size={6} />
+                </div>
+                {/* Check: hidden at rest, fades in on hover */}
+                <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
+                  <Button
+                    icon={SvgCheckSquare}
+                    size="sm"
+                    prominence="tertiary"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDismiss(notification.id);
+                    }}
+                    tooltip="Mark as read"
+                  />
+                </Hoverable.Item>
               </div>
-              {/* Check: hidden at rest, fades in on hover */}
+            ) : (
               <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
-                <Button
-                  icon={SvgCheckSquare}
-                  size="sm"
-                  prominence="tertiary"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDismiss(notification.id);
-                  }}
-                  tooltip="Mark as read"
-                />
+                <Button icon={SvgSquare} size="sm" prominence="tertiary" />
               </Hoverable.Item>
-            </div>
-          ) : (
-            <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
-              <Button icon={SvgSquare} size="sm" prominence="tertiary" />
-            </Hoverable.Item>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      </SelectCard>
     </Hoverable.Root>
   );
 }

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -20,7 +20,7 @@ import {
   SvgNotificationBubble,
 } from "@opal/icons";
 import type { IconProps } from "@opal/types";
-import { Button, Divider, SelectCard, Text } from "@opal/components";
+import { Button, Divider, LineItemButton, Text } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
@@ -85,33 +85,24 @@ function NotificationItem({
 
   return (
     <Hoverable.Root group={hoverGroup}>
-      <SelectCard onClick={onClick} padding="sm" rounding="sm">
-        <div className="flex flex-row gap-1 items-start">
-          <div className="flex-1 min-w-0">
-            <ContentAction
-              icon={getNotificationIcon(notification.notif_type)}
-              title={notification.title}
-              description={notification.description ?? undefined}
-              sizePreset="main-ui"
-              variant="section"
-              color={state === "new" ? "interactive" : "muted"}
-              padding="fit"
-              rightChildren={
-                <Text font="secondary-body" color="text-02">
-                  {formatRelativeDate(notification.first_shown)}
-                </Text>
-              }
-            />
-          </div>
-
-          <div className="flex items-center justify-center w-6 shrink-0">
-            {state === "new" ? (
-              <div className="relative flex items-center justify-center w-6 h-6">
-                {/* Dot: visible at rest, fades out on hover */}
+      <LineItemButton
+        icon={getNotificationIcon(notification.notif_type)}
+        title={notification.title}
+        description={notification.description ?? undefined}
+        sizePreset="main-ui"
+        rounding="sm"
+        color={state === "new" ? undefined : "muted"}
+        onClick={onClick}
+        rightChildren={
+          <div className="flex flex-row items-start gap-1">
+            <Text font="secondary-body" color="text-02">
+              {formatRelativeDate(notification.first_shown)}
+            </Text>
+            {/*{state === "new" ? (
+              <>
                 <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-100 [div[data-hover-group]:hover_&]:opacity-0">
                   <SvgNotificationBubble size={6} />
                 </div>
-                {/* Check: hidden at rest, fades in on hover */}
                 <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
                   <Button
                     icon={SvgCheckSquare}
@@ -124,15 +115,15 @@ function NotificationItem({
                     tooltip="Mark as read"
                   />
                 </Hoverable.Item>
-              </div>
+              </>
             ) : (
               <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
                 <Button icon={SvgSquare} size="sm" prominence="tertiary" />
               </Hoverable.Item>
-            )}
+            )}*/}
           </div>
-        </div>
-      </SelectCard>
+        }
+      />
     </Hoverable.Root>
   );
 }
@@ -247,7 +238,7 @@ export default function NotificationsPopover({
   }, [newNotifications, handleDismiss]);
 
   return (
-    <div className="flex flex-col gap-1 p-1">
+    <div className="flex flex-col gap-1">
       <ContentAction
         title="Notifications"
         sizePreset="main-content"

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -76,7 +76,7 @@ function NotificationItem({
                       size="sm"
                       prominence="tertiary"
                       onClick={noProp(dismiss)}
-                      tooltip="Mark as read"
+                      tooltip="Mark as Read"
                     />
                   </Hoverable.Item>
                 </div>
@@ -208,11 +208,18 @@ export default function NotificationsPopover({
         </Section>
 
         <Section flexDirection="row" gap={0.25} justifyContent="end">
+          {undismissedCount !== 0 && (
+            <span className="text-action-link-05 font-secondary-body">
+              {`${undismissedCount} unread`}
+            </span>
+          )}
           <Button
             icon={SvgCheckAll}
             size="sm"
             prominence="tertiary"
             onClick={handleDismissAll}
+            tooltip="Mark All as Read"
+            disabled={undismissedCount === 0}
           />
         </Section>
       </Section>

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -4,59 +4,24 @@ import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
-import {
-  Notification as NotificationData,
-  NotificationType,
-} from "@/interfaces/settings";
+import type { Notification as NotificationData } from "@/lib/notifications/interfaces";
+import { NotificationType } from "@/lib/notifications/interfaces";
+import { getNotificationIcon } from "@/lib/notifications";
+import { timeAgo } from "@/lib/time";
 import useNotifications from "@/hooks/useNotifications";
 import {
-  SvgSparkle,
-  SvgRefreshCw,
   SvgX,
-  SvgBullhorn,
   SvgCheckAll,
+  SvgNotificationBubble,
+  SvgCheckSquare,
 } from "@opal/icons";
-import type { IconProps } from "@opal/types";
 import { Button, Divider, LineItemButton, Text } from "@opal/components";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction, IllustrationContent } from "@opal/layouts";
 import { SvgEmpty } from "@opal/illustrations";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function getNotificationIcon(
-  notifType: string
-): React.FunctionComponent<IconProps> {
-  switch (notifType) {
-    case NotificationType.REINDEX:
-      return SvgRefreshCw;
-    case NotificationType.RELEASE_NOTES:
-      return SvgBullhorn;
-    default:
-      return SvgSparkle;
-  }
-}
-
-function formatRelativeDate(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60_000);
-  const diffHours = Math.floor(diffMs / 3_600_000);
-  const diffDays = Math.floor(diffMs / 86_400_000);
-
-  if (diffMins < 1) return "just now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
+import { Hoverable } from "@opal/core";
+import { noProp } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // NotificationItem
@@ -68,28 +33,55 @@ interface NotificationItemProps {
   notification: NotificationData;
   state: NotificationState;
   onClick: () => void;
+  dismiss: () => void;
 }
 
 function NotificationItem({
   notification,
   state,
   onClick,
+  dismiss,
 }: NotificationItemProps) {
   return (
-    <LineItemButton
-      icon={getNotificationIcon(notification.notif_type)}
-      title={notification.title}
-      description={notification.description ?? undefined}
-      sizePreset="main-ui"
-      rounding="sm"
-      color={state === "new" ? undefined : "muted"}
-      onClick={onClick}
-      rightChildren={
-        <Text font="secondary-body" color="text-02">
-          {formatRelativeDate(notification.first_shown)}
-        </Text>
-      }
-    />
+    <Hoverable.Root group="notifications-popover/NotificationItem">
+      <LineItemButton
+        icon={getNotificationIcon(notification.notif_type)}
+        title={notification.title}
+        description={notification.description ?? undefined}
+        sizePreset="main-ui"
+        rounding="sm"
+        color={state === "new" ? undefined : "muted"}
+        onClick={onClick}
+        rightChildren={
+          <Section flexDirection="row" alignItems="start" gap={0.5} padding={0}>
+            <Text font="secondary-body" color="text-02">
+              {timeAgo(notification.first_shown) ?? ""}
+            </Text>
+            {state === "new" && (
+              <div className="w-4 flex flex-col items-center justify-center">
+                <Hoverable.Item
+                  group="notifications-popover/NotificationItem"
+                  variant="replace-on-hover"
+                  resting={
+                    <div className="w-full h-full p-1">
+                      <SvgNotificationBubble size={6} />
+                    </div>
+                  }
+                >
+                  <Button
+                    icon={SvgCheckSquare}
+                    size="2xs"
+                    prominence="tertiary"
+                    onClick={noProp(dismiss)}
+                    tooltip="Mark as read"
+                  />
+                </Hoverable.Item>
+              </div>
+            )}
+          </Section>
+        }
+      />
+    </Hoverable.Root>
   );
 }
 
@@ -199,7 +191,7 @@ export default function NotificationsPopover({
   }, [newNotifications, handleDismiss]);
 
   return (
-    <div className="flex flex-col gap-1">
+    <Section>
       <ContentAction
         title="Notifications"
         sizePreset="main-content"
@@ -256,6 +248,7 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="new"
                     onClick={() => handleNotificationClick(notification)}
+                    dismiss={() => handleDismiss(notification.id)}
                   />
                 ))}
               </div>
@@ -272,6 +265,7 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="older"
                     onClick={() => handleNotificationClick(notification)}
+                    dismiss={() => handleDismiss(notification.id)}
                   />
                 ))}
               </div>
@@ -279,6 +273,6 @@ export default function NotificationsPopover({
           )}
         </div>
       )}
-    </div>
+    </Section>
   );
 }

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -83,20 +83,9 @@ function NotificationItem({
       color={isNew ? "interactive" : "muted"}
       onClick={onClick}
       rightChildren={
-        <div className="flex flex-col items-end gap-1">
-          <Text font="secondary-body" color="text-02">
-            {formatRelativeDate(notification.first_shown)}
-          </Text>
-          {isNew && (
-            <Button
-              prominence="tertiary"
-              size="sm"
-              icon={SvgCheckAll}
-              onClick={(e) => onDismiss(notification.id, e)}
-              tooltip="Mark as read"
-            />
-          )}
-        </div>
+        <Text font="secondary-body" color="text-02">
+          {formatRelativeDate(notification.first_shown)}
+        </Text>
       }
     />
   );
@@ -178,27 +167,42 @@ export default function NotificationsPopover({
   const newNotifications = notifications?.filter((n) => !n.dismissed) ?? [];
   const olderNotifications = notifications?.filter((n) => n.dismissed) ?? [];
 
+  const handleDismissAll = async () => {
+    for (const n of newNotifications) {
+      await handleDismiss(n.id);
+    }
+  };
+
   return (
-    <Section gap={0}>
-      <div className="w-full p-2">
-        <ContentAction
-          title="Notifications"
-          sizePreset="main-content"
-          tag={{
-            title: `${undismissedCount} unread`,
-            color: "blue",
-          }}
-          rightChildren={
+    <div className="flex flex-col gap-1 p-1">
+      <ContentAction
+        title="Notifications"
+        sizePreset="main-content"
+        tag={{
+          title: `${undismissedCount} unread`,
+          color: "blue",
+        }}
+        rightChildren={
+          <div className="flex flex-row items-center gap-1">
+            {newNotifications.length > 0 && (
+              <Button
+                icon={SvgCheckAll}
+                onClick={handleDismissAll}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Mark all as read"
+              />
+            )}
             <Button
               icon={SvgX}
               onClick={onClose}
               size="sm"
               prominence="tertiary"
             />
-          }
-          padding="fit"
-        />
-      </div>
+          </div>
+        }
+        padding="fit"
+      />
 
       {isLoading ? (
         <div className="h-[var(--notifications-popover)]">
@@ -216,11 +220,11 @@ export default function NotificationsPopover({
           </Section>
         </div>
       ) : (
-        <div className="max-h-[var(--notifications-popover)] overflow-y-auto flex flex-col">
+        <div className="max-h-[var(--notifications-popover)] overflow-y-auto flex flex-col gap-1">
           {newNotifications.length > 0 && (
             <>
               <Divider title="New" />
-              <div className="flex flex-col gap-1 px-1">
+              <div className="flex flex-col">
                 {newNotifications.map((notification) => (
                   <NotificationItem
                     key={notification.id}
@@ -236,7 +240,7 @@ export default function NotificationsPopover({
           {olderNotifications.length > 0 && (
             <>
               <Divider title="Older" />
-              <div className="flex flex-col gap-1 px-1">
+              <div className="flex flex-col">
                 {olderNotifications.map((notification) => (
                   <NotificationItem
                     key={notification.id}
@@ -250,6 +254,6 @@ export default function NotificationsPopover({
           )}
         </div>
       )}
-    </Section>
+    </div>
   );
 }

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
@@ -14,9 +15,13 @@ import {
   SvgX,
   SvgBullhorn,
   SvgCheckAll,
+  SvgCheckSquare,
+  SvgSquare,
+  SvgNotificationBubble,
 } from "@opal/icons";
 import type { IconProps } from "@opal/types";
-import { Button, Divider, LineItemButton, Text } from "@opal/components";
+import { Button, Divider, Text } from "@opal/components";
+import { Hoverable } from "@opal/core";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction, IllustrationContent } from "@opal/layouts";
@@ -51,43 +56,87 @@ function formatRelativeDate(dateString: string): string {
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
 }
 
 // ---------------------------------------------------------------------------
 // NotificationItem
 // ---------------------------------------------------------------------------
 
+type NotificationState = "new" | "dismissed" | "older";
+
 interface NotificationItemProps {
   notification: NotificationData;
+  state: NotificationState;
   onClick: () => void;
-  onDismiss: (id: number, e?: React.MouseEvent) => void;
+  onDismiss: (id: number) => void;
 }
 
 function NotificationItem({
   notification,
+  state,
   onClick,
   onDismiss,
 }: NotificationItemProps) {
-  const isNew = !notification.dismissed;
+  const hoverGroup = `notif-${notification.id}`;
 
   return (
-    <LineItemButton
-      icon={getNotificationIcon(notification.notif_type)}
-      title={notification.title}
-      description={notification.description ?? undefined}
-      selectVariant="select-heavy"
-      sizePreset="main-ui"
-      rounding="sm"
-      state={isNew ? "selected" : "empty"}
-      color={isNew ? "interactive" : "muted"}
-      onClick={onClick}
-      rightChildren={
-        <Text font="secondary-body" color="text-02">
-          {formatRelativeDate(notification.first_shown)}
-        </Text>
-      }
-    />
+    <Hoverable.Root group={hoverGroup}>
+      <div
+        className="flex flex-row gap-1 items-start cursor-pointer"
+        onClick={onClick}
+        role="button"
+        tabIndex={0}
+      >
+        <div className="flex-1 min-w-0">
+          <ContentAction
+            icon={getNotificationIcon(notification.notif_type)}
+            title={notification.title}
+            description={notification.description ?? undefined}
+            sizePreset="main-ui"
+            variant="section"
+            color={state === "new" ? "default" : "muted"}
+            padding="fit"
+            rightChildren={
+              <Text font="secondary-body" color="text-02">
+                {formatRelativeDate(notification.first_shown)}
+              </Text>
+            }
+          />
+        </div>
+
+        <div className="flex items-center justify-center w-6 shrink-0">
+          {state === "new" ? (
+            <div className="relative flex items-center justify-center w-6 h-6">
+              {/* Dot: visible at rest, fades out on hover */}
+              <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-100 [div[data-hover-group]:hover_&]:opacity-0">
+                <SvgNotificationBubble size={6} />
+              </div>
+              {/* Check: hidden at rest, fades in on hover */}
+              <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
+                <Button
+                  icon={SvgCheckSquare}
+                  size="sm"
+                  prominence="tertiary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDismiss(notification.id);
+                  }}
+                  tooltip="Mark as read"
+                />
+              </Hoverable.Item>
+            </div>
+          ) : (
+            <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
+              <Button icon={SvgSquare} size="sm" prominence="tertiary" />
+            </Hoverable.Item>
+          )}
+        </div>
+      </div>
+    </Hoverable.Root>
   );
 }
 
@@ -114,64 +163,91 @@ export default function NotificationsPopover({
     refresh: mutate,
   } = useNotifications();
 
-  const handleNotificationClick = (notification: NotificationData) => {
-    if (
-      notification.notif_type === NotificationType.FEATURE_ANNOUNCEMENT &&
-      notification.additional_data?.feature === "build_mode" &&
-      onShowBuildIntro
-    ) {
+  // Track IDs dismissed during this session (before popover closes)
+  const [sessionDismissedIds, setSessionDismissedIds] = useState<Set<number>>(
+    new Set()
+  );
+
+  const handleNotificationClick = useCallback(
+    (notification: NotificationData) => {
+      if (
+        notification.notif_type === NotificationType.FEATURE_ANNOUNCEMENT &&
+        notification.additional_data?.feature === "build_mode" &&
+        onShowBuildIntro
+      ) {
+        onNavigate();
+        onShowBuildIntro();
+        return;
+      }
+
+      const link = notification.additional_data?.link;
+      if (!link) return;
+
+      if (notification.notif_type === NotificationType.RELEASE_NOTES) {
+        track(AnalyticsEvent.RELEASE_NOTIFICATION_CLICKED, {
+          version: notification.additional_data?.version,
+        });
+      }
+
+      if (link.startsWith("http://") || link.startsWith("https://")) {
+        if (!notification.dismissed) {
+          handleDismiss(notification.id);
+        }
+        window.open(link, "_blank", "noopener,noreferrer");
+        return;
+      }
+
       onNavigate();
-      onShowBuildIntro();
-      return;
-    }
+      router.push(link as Route);
+    },
+    [onNavigate, onShowBuildIntro, router]
+  );
 
-    const link = notification.additional_data?.link;
-    if (!link) return;
-
-    if (notification.notif_type === NotificationType.RELEASE_NOTES) {
-      track(AnalyticsEvent.RELEASE_NOTIFICATION_CLICKED, {
-        version: notification.additional_data?.version,
-      });
-    }
-
-    if (link.startsWith("http://") || link.startsWith("https://")) {
-      if (!notification.dismissed) {
-        handleDismiss(notification.id);
+  const handleDismiss = useCallback(
+    async (notificationId: number) => {
+      try {
+        const response = await fetch(
+          `/api/notifications/${notificationId}/dismiss`,
+          { method: "POST" }
+        );
+        if (response.ok) {
+          setSessionDismissedIds((prev) => new Set([...prev, notificationId]));
+          mutate();
+        }
+      } catch (error) {
+        console.error("Error dismissing notification:", error);
       }
-      window.open(link, "_blank", "noopener,noreferrer");
-      return;
-    }
+    },
+    [mutate]
+  );
 
-    onNavigate();
-    router.push(link as Route);
-  };
+  const getState = useCallback(
+    (notification: NotificationData): NotificationState => {
+      if (sessionDismissedIds.has(notification.id)) return "dismissed";
+      if (notification.dismissed) return "older";
+      return "new";
+    },
+    [sessionDismissedIds]
+  );
 
-  const handleDismiss = async (
-    notificationId: number,
-    e?: React.MouseEvent
-  ) => {
-    e?.stopPropagation();
-    try {
-      const response = await fetch(
-        `/api/notifications/${notificationId}/dismiss`,
-        { method: "POST" }
-      );
-      if (response.ok) {
-        mutate();
-      }
-    } catch (error) {
-      console.error("Error dismissing notification:", error);
-    }
-  };
+  const newNotifications = useMemo(
+    () => notifications?.filter((n) => getState(n) === "new") ?? [],
+    [notifications, getState]
+  );
+  const dismissedNotifications = useMemo(
+    () => notifications?.filter((n) => getState(n) === "dismissed") ?? [],
+    [notifications, getState]
+  );
+  const olderNotifications = useMemo(
+    () => notifications?.filter((n) => getState(n) === "older") ?? [],
+    [notifications, getState]
+  );
 
-  const newNotifications = notifications?.filter((n) => !n.dismissed) ?? [];
-  const olderNotifications = notifications?.filter((n) => n.dismissed) ?? [];
-
-  const handleDismissAll = async () => {
+  const handleDismissAll = useCallback(async () => {
     for (const n of newNotifications) {
       await handleDismiss(n.id);
     }
-  };
+  }, [newNotifications, handleDismiss]);
 
   return (
     <div className="flex flex-col gap-1 p-1">
@@ -229,6 +305,24 @@ export default function NotificationsPopover({
                   <NotificationItem
                     key={notification.id}
                     notification={notification}
+                    state="new"
+                    onClick={() => handleNotificationClick(notification)}
+                    onDismiss={handleDismiss}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+
+          {dismissedNotifications.length > 0 && (
+            <>
+              <Divider title="Dismissed" />
+              <div className="flex flex-col">
+                {dismissedNotifications.map((notification) => (
+                  <NotificationItem
+                    key={notification.id}
+                    notification={notification}
+                    state="dismissed"
                     onClick={() => handleNotificationClick(notification)}
                     onDismiss={handleDismiss}
                   />
@@ -245,6 +339,7 @@ export default function NotificationsPopover({
                   <NotificationItem
                     key={notification.id}
                     notification={notification}
+                    state="older"
                     onClick={() => handleNotificationClick(notification)}
                     onDismiss={handleDismiss}
                   />

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -64,7 +64,7 @@ function NotificationItem({
                     group="notifications-popover/NotificationItem"
                     variant="replace-on-hover"
                     resting={
-                      <div className="w-full h-full p-2">
+                      <div className="w-full h-full p-1.5">
                         <div className="p-px">
                           <SvgNotificationBubble size={6} />
                         </div>
@@ -73,7 +73,7 @@ function NotificationItem({
                   >
                     <Button
                       icon={SvgCheckSquare}
-                      size="sm"
+                      size="xs"
                       prominence="tertiary"
                       onClick={noProp(dismiss)}
                       tooltip="Mark as Read"

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -15,13 +15,9 @@ import {
   SvgX,
   SvgBullhorn,
   SvgCheckAll,
-  SvgCheckSquare,
-  SvgSquare,
-  SvgNotificationBubble,
 } from "@opal/icons";
 import type { IconProps } from "@opal/types";
 import { Button, Divider, LineItemButton, Text } from "@opal/components";
-import { Hoverable } from "@opal/core";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction, IllustrationContent } from "@opal/layouts";
@@ -72,59 +68,28 @@ interface NotificationItemProps {
   notification: NotificationData;
   state: NotificationState;
   onClick: () => void;
-  onDismiss: (id: number) => void;
 }
 
 function NotificationItem({
   notification,
   state,
   onClick,
-  onDismiss,
 }: NotificationItemProps) {
-  const hoverGroup = `notif-${notification.id}`;
-
   return (
-    <Hoverable.Root group={hoverGroup}>
-      <LineItemButton
-        icon={getNotificationIcon(notification.notif_type)}
-        title={notification.title}
-        description={notification.description ?? undefined}
-        sizePreset="main-ui"
-        rounding="sm"
-        color={state === "new" ? undefined : "muted"}
-        onClick={onClick}
-        rightChildren={
-          <div className="flex flex-row items-start gap-1">
-            <Text font="secondary-body" color="text-02">
-              {formatRelativeDate(notification.first_shown)}
-            </Text>
-            {/*{state === "new" ? (
-              <>
-                <div className="absolute inset-0 flex items-center justify-center transition-opacity opacity-100 [div[data-hover-group]:hover_&]:opacity-0">
-                  <SvgNotificationBubble size={6} />
-                </div>
-                <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
-                  <Button
-                    icon={SvgCheckSquare}
-                    size="sm"
-                    prominence="tertiary"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDismiss(notification.id);
-                    }}
-                    tooltip="Mark as read"
-                  />
-                </Hoverable.Item>
-              </>
-            ) : (
-              <Hoverable.Item group={hoverGroup} variant="opacity-on-hover">
-                <Button icon={SvgSquare} size="sm" prominence="tertiary" />
-              </Hoverable.Item>
-            )}*/}
-          </div>
-        }
-      />
-    </Hoverable.Root>
+    <LineItemButton
+      icon={getNotificationIcon(notification.notif_type)}
+      title={notification.title}
+      description={notification.description ?? undefined}
+      sizePreset="main-ui"
+      rounding="sm"
+      color={state === "new" ? undefined : "muted"}
+      onClick={onClick}
+      rightChildren={
+        <Text font="secondary-body" color="text-02">
+          {formatRelativeDate(notification.first_shown)}
+        </Text>
+      }
+    />
   );
 }
 
@@ -291,7 +256,6 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="new"
                     onClick={() => handleNotificationClick(notification)}
-                    onDismiss={handleDismiss}
                   />
                 ))}
               </div>
@@ -308,7 +272,6 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="older"
                     onClick={() => handleNotificationClick(notification)}
-                    onDismiss={handleDismiss}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Description

Revamps the notifications popover in the sidebar:

- **New/Older sections**: Notifications split into "New" (undismissed) and "Older" (dismissed) groups using titled `Divider` components
- **NotificationItem component**: Uses `LineItemButton` with `color="interactive"` for new notifications and `color="muted"` for older ones
- **Relative dates**: Shows "2h ago", "3d ago", "Apr 15" etc. in `rightChildren`
- **Mark as read**: Replaces the dismiss X with a `SvgCheckAll` button with "Mark as read" tooltip
- **New icons**: `SvgBullhorn` (used for release notes) and `SvgCheckAll` (mark as read), converted from SVG via the opal convert script

## Screenshots + Videos

https://github.com/user-attachments/assets/8e9a1ad4-7b3f-4ad8-87e3-aa54c5a957a9

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the sidebar notifications popover with New/Older sections, a compact header, and hover-to-mark-read for faster triage. Moves notification types and icon mapping to `@/lib/notifications`, switches to `timeAgo`, and expands the popover to `2xl`.

- **New Features**
  - New items show a dot and reveal “Mark as Read” on hover; older items are muted.
  - Header shows unread count and a “Mark All as Read” button (disabled when none).
  - Release-notes clicks are tracked; external links open a new tab; internal links navigate; build-mode announcement opens the intro.

- **Refactors**
  - Added `NotificationItem` using `LineItemButton` with `Hoverable` for hover actions.
  - Moved `NotificationType`/`Notification` to `@/lib/notifications/interfaces` and `getNotificationIcon` to `@/lib/notifications`; removed old types, updated imports, and addressed review feedback (fixed Set usage, removed optional chaining).

<sup>Written for commit 089fac9fbea632ebae044a94852170858c417a3f. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10651?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

