### PR TITLE
feat(openai): Add support for GPT Image 2

### DIFF
--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -71,13 +71,17 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
         reference_images: list[ReferenceImage] | None = None,
         **kwargs: Any,
     ) -> ImageGenerationResponse:
+        normalized_model = self._normalize_model_name(model)
+        # Explicitly prefix with `openai/` so LiteLLM routes correctly even
+        # for models not yet in its built-in registry (e.g. new gpt-image-* releases).
+        litellm_model = f"openai/{normalized_model}"
+
         if reference_images:
             if not self._model_supports_image_edits(model):
                 raise ValueError(
                     f"Model '{model}' does not support image edits with reference images."
                 )
 
-            normalized_model = self._normalize_model_name(model)
             if (
                 normalized_model == self._DALL_E_2_MODEL_NAME
                 and len(reference_images) > 1
@@ -91,7 +95,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
             return image_edit(
                 image=[image.data for image in reference_images],
                 prompt=prompt,
-                model=model,
+                model=litellm_model,
                 api_key=self._api_key,
                 api_base=self._api_base,
                 size=size,
@@ -104,7 +108,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
 
         return image_generation(
             prompt=prompt,
-            model=model,
+            model=litellm_model,
             api_key=self._api_key,
             api_base=self._api_base,
             size=size,

--- a/backend/onyx/server/manage/image_generation/api.py
+++ b/backend/onyx/server/manage/image_generation/api.py
@@ -39,13 +39,13 @@ admin_router = APIRouter(prefix="/admin/image-generation")
 def _get_test_quality_for_model(model_name: str) -> str | None:
     """Returns the fastest quality setting for credential testing.
 
-    - gpt-image-1: 'low' (fastest)
+    - gpt-image-*: 'low' (fastest)
     - dall-e-3: 'standard' (faster than 'hd')
     - Other models: None (use API default)
     """
     model_lower = model_name.lower()
 
-    if "gpt-image-1" in model_lower:
+    if "gpt-image-" in model_lower:
         return "low"
     elif "dall-e-3" in model_lower or "dalle-3" in model_lower:
         return "standard"

--- a/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
+++ b/backend/onyx/tools/tool_implementations/images/image_generation_tool.py
@@ -170,12 +170,12 @@ class ImageGenerationTool(Tool[None]):
         reference_images: list[ReferenceImage] | None = None,
     ) -> tuple[ImageGenerationResponse, Any]:
         if shape == ImageShape.LANDSCAPE:
-            if "gpt-image-1" in self.model:
+            if "gpt-image-" in self.model:
                 size = "1536x1024"
             else:
                 size = "1792x1024"
         elif shape == ImageShape.PORTRAIT:
-            if "gpt-image-1" in self.model:
+            if "gpt-image-" in self.model:
                 size = "1024x1536"
             else:
                 size = "1024x1792"
@@ -189,8 +189,8 @@ class ImageGenerationTool(Tool[None]):
                 size=size,
                 n=1,
                 reference_images=reference_images,
-                # response_format parameter is not supported for gpt-image-1
-                response_format=None if "gpt-image-1" in self.model else "b64_json",
+                # response_format parameter is not supported for gpt-image-* models
+                response_format=None if "gpt-image-" in self.model else "b64_json",
             )
 
             if not response.data or len(response.data) == 0:

--- a/web/src/refresh-pages/admin/ImageGenerationPage/constants.ts
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/constants.ts
@@ -16,12 +16,19 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
     name: "OpenAI",
     providers: [
       {
+        image_provider_id: "openai_gpt_image_2",
+        model_name: "gpt-image-2",
+        provider_name: "openai",
+        title: "GPT Image 2",
+        description:
+          "OpenAI's latest Image Generation model with the highest prompt fidelity.",
+      },
+      {
         image_provider_id: "openai_gpt_image_1_5",
         model_name: "gpt-image-1.5",
         provider_name: "openai",
         title: "GPT Image 1.5",
-        description:
-          "OpenAI's latest Image Generation model with the highest prompt fidelity.",
+        description: "OpenAI's previous flagship Image Generation model.",
       },
       {
         image_provider_id: "openai_gpt_image_1",
@@ -44,6 +51,14 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
   {
     name: "Azure OpenAI",
     providers: [
+      {
+        image_provider_id: "azure_gpt_image_2",
+        model_name: "", // Extracted from deployment in target URI
+        provider_name: "azure",
+        title: "Azure OpenAI GPT Image 2",
+        description:
+          "GPT Image 2 image generation model hosted on Microsoft Azure.",
+      },
       {
         image_provider_id: "azure_gpt_image_1_5",
         model_name: "", // Extracted from deployment in target URI


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding OpenAI GPT 2 Image support to our product

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Tested locally
<img width="900" height="1168" alt="Screenshot 2026-04-27 at 1 39 08 PM" src="https://github.com/user-attachments/assets/8fcaa457-fde5-4e9a-a081-14136ce7ae76" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full support for OpenAI `gpt-image-2` across backend and admin UI for both `openai` and Azure. Also generalizes handling for all `gpt-image-*` models and fixes routing via `openai/<model>` for `LiteLLM`.

- **New Features**
  - Support `gpt-image-2` for generation (and edits where allowed) via `openai`.
  - Add Azure option for `gpt-image-2` (model name from deployment).
  - Surface “GPT Image 2” in the admin providers list; update `GPT Image 1.5` description.

- **Bug Fixes**
  - Route OpenAI models as `openai/<normalized_model>` so `LiteLLM` recognizes new `gpt-image-*` releases.
  - Apply consistent behavior to all `gpt-image-*`:
    - Use `low` quality for test requests.
    - Use the smaller size presets for landscape/portrait.
    - Omit unsupported `response_format`.

<sup>Written for commit 2c3df55aeaf757435b419e61e565811f8c2039f8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10653?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

