### PR TITLE
fix(indexing): drop SectionType usage on release/v3.2

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -29,7 +29,6 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import IndexAttemptMetadata
 from onyx.connectors.models import IndexingDocument
 from onyx.connectors.models import Section
-from onyx.connectors.models import SectionType
 from onyx.connectors.models import TextSection
 from onyx.db.document import get_documents_by_ids
 from onyx.db.document import upsert_document_by_connector_credential_pair
@@ -524,10 +523,8 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         List of IndexingDocument objects with processed_sections as list[Section]
     """
     # Check if image extraction and analysis is enabled before trying to get a vision LLM.
-    # Use section.type rather than isinstance because sections can round-trip
-    # through pydantic as base Section instances (not the concrete subclass).
     has_image_section = any(
-        section.type == SectionType.IMAGE
+        isinstance(section, ImageSection)
         for document in documents
         for section in document.sections
     )


### PR DESCRIPTION
## Summary
- v3.2.12 fails at startup with `ImportError: cannot import name 'SectionType' from 'onyx.connectors.models'`. The cherry-pick of #10395 (#10655) imported `SectionType`, but `SectionType` was added in #10092 which was never cherry-picked into `release/v3.2`.
- Replace the `section.type == SectionType.IMAGE` check in `process_image_sections` with `isinstance(section, ImageSection)`, matching the existing `isinstance` pattern used elsewhere in the same function. Behavior-preserving on v3.2 since concrete subclass identity is retained on this branch (the round-trip-through-pydantic concern that motivated the enum check was introduced on a later branch).
- Drop the now-unused `SectionType` import.

The bad release tag (`v3.2.12`) and GitHub release have already been removed; we'll cut `v3.2.13` from `release/v3.2` once this lands.

## Test plan
- [ ] CI green on `release/v3.2` (mypy / backend / database tests — the same checks that were red on #10655)
- [ ] After tag cut, bump Mane to the new tag and confirm the api-server and indexing pods start without the ImportError

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash on `release/v3.2` by removing `SectionType` usage and switching to `isinstance(ImageSection)` in image section detection. Restores compatibility with this branch where `SectionType` is not available.

- **Bug Fixes**
  - Replaced `section.type == SectionType.IMAGE` with `isinstance(section, ImageSection)` in `process_image_sections`.
  - Dropped the unused `SectionType` import from `onyx.connectors.models` to prevent `ImportError` at startup.

<sup>Written for commit 420c489100736d17a281b3455a1d711cd8ee5c7e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10667?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

