### PR TITLE
fix: don't die mid docprocessing

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -226,7 +226,10 @@ def validate_active_indexing_attempts(
                 )
                 continue
 
-            if fresh_attempt.total_batches and fresh_attempt.completed_batches == 0:
+            if (
+                fresh_attempt.total_batches
+                and fresh_attempt.completed_batches < fresh_attempt.total_batches
+            ):
                 heartbeat_timeout_seconds = (
                     HEARTBEAT_TIMEOUT_SECONDS
                     * DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -130,7 +130,7 @@ from shared_configs.contextvars import INDEX_ATTEMPT_INFO_CONTEXTVAR
 logger = setup_logger()
 
 DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER = 4
-DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER = 24
+DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER = 48
 # Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead
 # This should be much longer than INDEXING_WORKER_HEARTBEAT_INTERVAL (30s)
 HEARTBEAT_TIMEOUT_SECONDS = 30 * 60  # 30 minutes


### PR DESCRIPTION
## Description

We were running into cases where 
a) docfetching finished
b) some docprocessing tasks for the index attempt finished
c) the remaining tasks were starved out as the docprocessing queue ballooned

In the past, we specifically accounted for the "docprocessing hasn't gotten the chance to start running" case with a timeout multiplier, but it's actually valid to let the tasks sit in queue to get a chance to run once docfetching has finished.

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent docprocessing attempts from being marked dead while there are still batches to run. Extends the heartbeat window to handle queue backlogs after docfetching.

- **Bug Fixes**
  - Apply the extended heartbeat when completed_batches < total_batches (not only when 0).
  - Increase `DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER` from 24 to 48 (24h at 30m base) to tolerate longer delays.

<sup>Written for commit da02427049d35d65d50223b71f14a0825c332bc8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10668?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

