### PR TITLE
chore(tests): fix `test_bedrock.py` unauthenticated text assertion

### DIFF
--- a/backend/tests/daily/llm/test_bedrock.py
+++ b/backend/tests/daily/llm/test_bedrock.py
@@ -65,6 +65,5 @@ def test_bedrock_llm_configuration_invalid_key(client: TestClient) -> None:
         response.status_code == 400
     ), f"Expected status code 400, but got {response.status_code}. Response: {response.text}"
     assert (
-        "Invalid credentials" in response.text
-        or "Invalid Authentication" in response.text
+        "Authentication failed" in response.text
     ), f"Expected error message about invalid credentials, but got: {response.text}"


### PR DESCRIPTION
## Description

* 6d88fbd07 - chore: llm error scrubbing (#10476) (5 days ago) <Evan Lohn>

Changed the wording on these errors slightly. Update the tests to reflect.

Closes https://onyx-company.slack.com/archives/C07K8KBMGKF/p1777047783585969

## How Has This Been Tested?

Confirmed culprit via bisection and confirmed test now passes locally

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `backend/tests/daily/llm/test_bedrock.py` to assert "Authentication failed" for unauthenticated Bedrock requests, matching the updated error-scrubbing message.
Fixes a failing test caused by the wording change.

<sup>Written for commit 1d55cc68d0a56f37711a1681d4268b0a60714b81. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10669?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

