### PR TITLE
refactor(opal): Hoverable variant rename + new variants

### DIFF
--- a/web/lib/opal/src/core/animations/Hoverable.stories.tsx
+++ b/web/lib/opal/src/core/animations/Hoverable.stories.tsx
@@ -35,7 +35,7 @@ export const GroupMode: StoryObj = {
         }}
       >
         <span style={{ color: "var(--text-01)" }}>Hover this card</span>
-        <Hoverable.Item group="demo" variant="opacity-on-hover">
+        <Hoverable.Item group="demo" variant="appear-on-hover">
           <span style={{ color: "var(--text-03)" }}>✓ Revealed</span>
         </Hoverable.Item>
       </div>
@@ -55,7 +55,7 @@ export const LocalMode: StoryObj = {
       }}
     >
       <span style={{ color: "var(--text-01)" }}>Hover the icon →</span>
-      <Hoverable.Item variant="opacity-on-hover">
+      <Hoverable.Item variant="appear-on-hover">
         <span style={{ fontSize: "1.25rem" }}>🗑</span>
       </Hoverable.Item>
     </div>
@@ -79,7 +79,7 @@ export const MultipleGroups: StoryObj = {
             }}
           >
             <span style={{ color: "var(--text-01)" }}>Group: {group}</span>
-            <Hoverable.Item group={group} variant="opacity-on-hover">
+            <Hoverable.Item group={group} variant="appear-on-hover">
               <span style={{ color: "var(--text-03)" }}>✓ Revealed</span>
             </Hoverable.Item>
           </div>
@@ -104,13 +104,13 @@ export const MultipleItems: StoryObj = {
         }}
       >
         <span style={{ color: "var(--text-01)" }}>Hover to reveal all</span>
-        <Hoverable.Item group="multi" variant="opacity-on-hover">
+        <Hoverable.Item group="multi" variant="appear-on-hover">
           <span>Edit</span>
         </Hoverable.Item>
-        <Hoverable.Item group="multi" variant="opacity-on-hover">
+        <Hoverable.Item group="multi" variant="appear-on-hover">
           <span>Delete</span>
         </Hoverable.Item>
-        <Hoverable.Item group="multi" variant="opacity-on-hover">
+        <Hoverable.Item group="multi" variant="appear-on-hover">
           <span>Share</span>
         </Hoverable.Item>
       </div>
@@ -134,7 +134,7 @@ export const NestedGroups: StoryObj = {
       >
         <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
           <span style={{ color: "var(--text-01)" }}>Outer card</span>
-          <Hoverable.Item group="outer" variant="opacity-on-hover">
+          <Hoverable.Item group="outer" variant="appear-on-hover">
             <span style={{ color: "var(--text-03)" }}>Outer action</span>
           </Hoverable.Item>
         </div>
@@ -151,7 +151,7 @@ export const NestedGroups: StoryObj = {
             }}
           >
             <span style={{ color: "var(--text-02)" }}>Inner card</span>
-            <Hoverable.Item group="inner" variant="opacity-on-hover">
+            <Hoverable.Item group="inner" variant="appear-on-hover">
               <span style={{ color: "var(--text-03)" }}>Inner action</span>
             </Hoverable.Item>
           </div>

--- a/web/lib/opal/src/core/animations/components.tsx
+++ b/web/lib/opal/src/core/animations/components.tsx
@@ -33,13 +33,22 @@ interface HoverableRootProps
   ref?: React.Ref<HTMLDivElement>;
 }
 
-type HoverableItemVariant = "opacity-on-hover";
+type HoverableItemVariant =
+  | "appear-on-hover"
+  | "appear-on-rest"
+  | "replace-on-hover";
 
 interface HoverableItemProps
   extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
   children: React.ReactNode;
   group?: string;
   variant?: HoverableItemVariant;
+  /**
+   * Content shown at rest when `variant="replace-on-hover"`.
+   * On hover, `resting` fades out and `children` fades in.
+   * Ignored for other variants.
+   */
+  resting?: React.ReactNode;
   /** Ref forwarded to the item `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 }
@@ -60,7 +69,7 @@ interface HoverableItemProps
  * ```tsx
  * <Hoverable.Root group="card">
  *   <Card>
- *     <Hoverable.Item group="card" variant="opacity-on-hover">
+ *     <Hoverable.Item group="card" variant="appear-on-hover">
  *       <TrashIcon />
  *     </Hoverable.Item>
  *   </Card>
@@ -104,13 +113,13 @@ function HoverableRoot({
  * @example
  * ```tsx
  * // Local mode — hover on the item itself
- * <Hoverable.Item variant="opacity-on-hover">
+ * <Hoverable.Item variant="appear-on-hover">
  *   <TrashIcon />
  * </Hoverable.Item>
  *
  * // Group mode — hover on the Root reveals the item
  * <Hoverable.Root group="card">
- *   <Hoverable.Item group="card" variant="opacity-on-hover">
+ *   <Hoverable.Item group="card" variant="appear-on-hover">
  *     <TrashIcon />
  *   </Hoverable.Item>
  * </Hoverable.Root>
@@ -118,12 +127,32 @@ function HoverableRoot({
  */
 function HoverableItem({
   group,
-  variant = "opacity-on-hover",
+  variant = "appear-on-hover",
+  resting,
   children,
   ref,
   ...props
 }: HoverableItemProps) {
   const isLocal = group === undefined;
+
+  if (variant === "replace-on-hover") {
+    return (
+      <div {...props} ref={ref} className="hoverable-replace">
+        <div
+          className="hoverable-replace-rest"
+          data-hoverable-local={isLocal ? "true" : undefined}
+        >
+          {resting}
+        </div>
+        <div
+          className="hoverable-replace-hover"
+          data-hoverable-local={isLocal ? "true" : undefined}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -164,14 +193,14 @@ function HoverableItem({
  * <Hoverable.Root group="card">
  *   <Card>
  *     <span>Card content</span>
- *     <Hoverable.Item group="card" variant="opacity-on-hover">
+ *     <Hoverable.Item group="card" variant="appear-on-hover">
  *       <TrashIcon />
  *     </Hoverable.Item>
  *   </Card>
  * </Hoverable.Root>
  *
  * // Local mode — hovering the item itself reveals it
- * <Hoverable.Item variant="opacity-on-hover">
+ * <Hoverable.Item variant="appear-on-hover">
  *   <TrashIcon />
  * </Hoverable.Item>
  * ```

--- a/web/lib/opal/src/core/animations/components.tsx
+++ b/web/lib/opal/src/core/animations/components.tsx
@@ -45,7 +45,7 @@ interface HoverableItemProps
   variant?: HoverableItemVariant;
   /**
    * Content shown at rest when `variant="replace-on-hover"`.
-   * On hover, `resting` fades out and `children` fades in.
+   * On hover, `resting` is removed and `children` is inserted (instant display swap, no transition).
    * Ignored for other variants.
    */
   resting?: React.ReactNode;

--- a/web/lib/opal/src/core/animations/styles.css
+++ b/web/lib/opal/src/core/animations/styles.css
@@ -139,6 +139,16 @@
   display: contents;
 }
 
+/* Local focus */
+.hoverable-replace:focus-within
+  > .hoverable-replace-rest[data-hoverable-local="true"] {
+  display: none;
+}
+.hoverable-replace:focus-within
+  > .hoverable-replace-hover[data-hoverable-local="true"] {
+  display: contents;
+}
+
 /* Focus ring on keyboard focus */
 .hoverable-item:focus-visible {
   outline: 2px solid var(--border-04);

--- a/web/lib/opal/src/core/animations/styles.css
+++ b/web/lib/opal/src/core/animations/styles.css
@@ -3,14 +3,18 @@
   transition: opacity 150ms ease-in-out;
 }
 
-.hoverable-item[data-hoverable-variant="opacity-on-hover"] {
+.hoverable-item[data-hoverable-variant="appear-on-hover"] {
   opacity: 0;
 }
+
+/* ---------------------------------------------------------------------------
+   appear-on-hover — hidden at rest, visible on hover
+   --------------------------------------------------------------------------- */
 
 /* Group mode — Root :hover controls descendant item visibility via CSS.
    Exclude local-mode items so they aren't revealed by an ancestor root. */
 [data-hover-group]:hover
-  .hoverable-item[data-hoverable-variant="opacity-on-hover"]:not(
+  .hoverable-item[data-hoverable-variant="appear-on-hover"]:not(
     [data-hoverable-local]
   ) {
   opacity: 1;
@@ -18,29 +22,121 @@
 
 /* Interaction override — force items visible via JS */
 [data-hover-group][data-interaction="hover"]
-  .hoverable-item[data-hoverable-variant="opacity-on-hover"]:not(
+  .hoverable-item[data-hoverable-variant="appear-on-hover"]:not(
     [data-hoverable-local]
   ) {
   opacity: 1;
 }
 
 /* Local mode — item handles its own :hover */
-.hoverable-item[data-hoverable-variant="opacity-on-hover"][data-hoverable-local="true"]:hover {
+.hoverable-item[data-hoverable-variant="appear-on-hover"][data-hoverable-local="true"]:hover {
   opacity: 1;
 }
 
 /* Group focus — any focusable descendant of the Root receives keyboard focus,
    revealing all group items (same behavior as hover). */
 [data-hover-group]:focus-within
-  .hoverable-item[data-hoverable-variant="opacity-on-hover"]:not(
+  .hoverable-item[data-hoverable-variant="appear-on-hover"]:not(
     [data-hoverable-local]
   ) {
   opacity: 1;
 }
 
 /* Local focus — item (or a focusable descendant) receives keyboard focus */
-.hoverable-item[data-hoverable-variant="opacity-on-hover"]:has(:focus-visible) {
+.hoverable-item[data-hoverable-variant="appear-on-hover"]:has(:focus-visible) {
   opacity: 1;
+}
+
+/* ---------------------------------------------------------------------------
+   appear-on-rest — visible at rest, hidden on hover (inverse of above)
+   --------------------------------------------------------------------------- */
+
+.hoverable-item[data-hoverable-variant="appear-on-rest"] {
+  opacity: 1;
+}
+
+/* Group mode */
+[data-hover-group]:hover
+  .hoverable-item[data-hoverable-variant="appear-on-rest"]:not(
+    [data-hoverable-local]
+  ) {
+  opacity: 0;
+}
+
+/* Interaction override */
+[data-hover-group][data-interaction="hover"]
+  .hoverable-item[data-hoverable-variant="appear-on-rest"]:not(
+    [data-hoverable-local]
+  ) {
+  opacity: 0;
+}
+
+/* Local mode */
+.hoverable-item[data-hoverable-variant="appear-on-rest"][data-hoverable-local="true"]:hover {
+  opacity: 0;
+}
+
+/* Group focus */
+[data-hover-group]:focus-within
+  .hoverable-item[data-hoverable-variant="appear-on-rest"]:not(
+    [data-hoverable-local]
+  ) {
+  opacity: 0;
+}
+
+/* Local focus */
+.hoverable-item[data-hoverable-variant="appear-on-rest"]:has(:focus-visible) {
+  opacity: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   replace-on-hover — swaps resting content for hover content via display toggle
+   --------------------------------------------------------------------------- */
+
+/* Rest: show resting, hide hover */
+.hoverable-replace-rest {
+  display: contents;
+}
+.hoverable-replace-hover {
+  display: none;
+}
+
+/* Group mode */
+[data-hover-group]:hover .hoverable-replace-rest:not([data-hoverable-local]) {
+  display: none;
+}
+[data-hover-group]:hover .hoverable-replace-hover:not([data-hoverable-local]) {
+  display: contents;
+}
+
+/* Interaction override */
+[data-hover-group][data-interaction="hover"]
+  .hoverable-replace-rest:not([data-hoverable-local]) {
+  display: none;
+}
+[data-hover-group][data-interaction="hover"]
+  .hoverable-replace-hover:not([data-hoverable-local]) {
+  display: contents;
+}
+
+/* Local mode */
+.hoverable-replace:hover
+  > .hoverable-replace-rest[data-hoverable-local="true"] {
+  display: none;
+}
+.hoverable-replace:hover
+  > .hoverable-replace-hover[data-hoverable-local="true"] {
+  display: contents;
+}
+
+/* Group focus */
+[data-hover-group]:focus-within
+  .hoverable-replace-rest:not([data-hoverable-local]) {
+  display: none;
+}
+[data-hover-group]:focus-within
+  .hoverable-replace-hover:not([data-hoverable-local]) {
+  display: contents;
 }
 
 /* Focus ring on keyboard focus */

--- a/web/src/app/admin/scim/ScimModal.tsx
+++ b/web/src/app/admin/scim/ScimModal.tsx
@@ -97,10 +97,7 @@ export default function ScimModal({
                     className="font-main-ui-mono break-all cursor-pointer [&_textarea]:cursor-pointer"
                     rightSection={
                       <div onClick={(e) => e.stopPropagation()}>
-                        <Hoverable.Item
-                          group="token"
-                          variant="opacity-on-hover"
-                        >
+                        <Hoverable.Item group="token" variant="appear-on-hover">
                           <CopyIconButton getCopyText={() => view.rawToken} />
                         </Hoverable.Item>
                       </div>

--- a/web/src/app/app/components/files/images/InMessageImage.tsx
+++ b/web/src/app/app/components/files/images/InMessageImage.tsx
@@ -103,7 +103,7 @@ export const InMessageImage = memo(function InMessageImage({
 
           {/* Download button - appears on hover */}
           <div className="absolute bottom-2 right-2 z-10">
-            <Hoverable.Item group="messageImage" variant="opacity-on-hover">
+            <Hoverable.Item group="messageImage" variant="appear-on-hover">
               <Button
                 icon={SvgDownload}
                 tooltip="Download"

--- a/web/src/app/app/components/projects/ProjectContextPanel.tsx
+++ b/web/src/app/app/components/projects/ProjectContextPanel.tsx
@@ -152,10 +152,7 @@ export default function ProjectContextPanel({
                     {projectName}
                   </Text>
                   {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-                  <Hoverable.Item
-                    group="projectName"
-                    variant="opacity-on-hover"
-                  >
+                  <Hoverable.Item group="projectName" variant="appear-on-hover">
                     <IconButton
                       icon={SvgEdit}
                       internal

--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -192,7 +192,7 @@ const HumanMessage = React.memo(function HumanMessage({
   );
 
   const copyEditButton = (
-    <Hoverable.Item group="humanMessage" variant="opacity-on-hover">
+    <Hoverable.Item group="humanMessage" variant="appear-on-hover">
       {copyEditButtonContent}
     </Hoverable.Item>
   );

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookLogsModal.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookLogsModal.tsx
@@ -66,7 +66,7 @@ function LogRow({ log, group }: { log: HookExecutionRecord; group: string }) {
         </span>
         {/* 3. Copy button */}
         <Section width="fit" height="fit" alignItems="center">
-          <Hoverable.Item group={group} variant="opacity-on-hover">
+          <Hoverable.Item group={group} variant="appear-on-hover">
             <CopyIconButton
               size="xs"
               getCopyText={() => log.error_message ?? ""}

--- a/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/HookStatusPopover.tsx
@@ -55,7 +55,7 @@ function ErrorLogRow({
               {formatDateTimeLog(log.created_at)}
             </Text>
           </span>
-          <Hoverable.Item group={group} variant="opacity-on-hover">
+          <Hoverable.Item group={group} variant="appear-on-hover">
             <CopyIconButton
               size="xs"
               getCopyText={() => log.error_message ?? ""}

--- a/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
@@ -392,7 +392,7 @@ function ConnectedHookCard({
                     <>
                       <Hoverable.Item
                         group="connected-hook-card"
-                        variant="opacity-on-hover"
+                        variant="appear-on-hover"
                       >
                         <Button
                           prominence="tertiary"

--- a/web/src/refresh-components/inputs/InputImage.tsx
+++ b/web/src/refresh-components/inputs/InputImage.tsx
@@ -225,7 +225,7 @@ export default function InputImage({
           {/* Edit overlay - shows on hover/focus when image is uploaded */}
           {showEditOverlay && isInteractive && hasImage && !isDragActive && (
             <div className="absolute bottom-0 left-0 right-0 pointer-events-none">
-              <Hoverable.Item group="inputImage" variant="opacity-on-hover">
+              <Hoverable.Item group="inputImage" variant="appear-on-hover">
                 <div
                   className={cn(
                     "flex items-center justify-center",
@@ -260,7 +260,7 @@ export default function InputImage({
         {/* Remove button - top left corner (only when image is uploaded) */}
         {isInteractive && hasImage && onRemove && (
           <div className="absolute top-1 left-1">
-            <Hoverable.Item group="inputImage" variant="opacity-on-hover">
+            <Hoverable.Item group="inputImage" variant="appear-on-hover">
               {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
               <IconButton
                 icon={SvgX}

--- a/web/src/refresh-components/tiles/FileTile.tsx
+++ b/web/src/refresh-components/tiles/FileTile.tsx
@@ -40,7 +40,7 @@ function RemoveButton({ onRemove }: RemoveButtonProps) {
         "pointer-events-none focus-within:pointer-events-auto"
       )}
     >
-      <Hoverable.Item group="fileTile" variant="opacity-on-hover">
+      <Hoverable.Item group="fileTile" variant="appear-on-hover">
         <button
           type="button"
           onClick={(e) => {

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -222,7 +222,7 @@ function AgentIconEditor({ existingAgent }: AgentIconEditorProps) {
               />
               {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
               <div className="absolute bottom-0 left-1/2 -translate-x-1/2 mb-2">
-                <Hoverable.Item group="inputAvatar" variant="opacity-on-hover">
+                <Hoverable.Item group="inputAvatar" variant="appear-on-hover">
                   <Button prominence="secondary" size="md">
                     Edit
                   </Button>

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -145,7 +145,7 @@ export default function AgentRowActions({
 
       <div className="flex items-center gap-0.5">
         {/* TODO(@raunakab): abstract a more standardized way of doing this
-            opacity-on-hover animation. Making Hoverable more extensible
+            appear-on-hover animation. Making Hoverable more extensible
             (e.g. supporting table row groups) would let us use it here
             instead of raw Tailwind group-hover. */}
         {!agent.builtin_persona && (

--- a/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
+++ b/web/src/refresh-pages/admin/ChatPreferencesPage.tsx
@@ -292,7 +292,7 @@ function NumericLimitField({
         variant={isOverMax ? "error" : undefined}
         rightSection={
           (value || "") !== defaultValue ? (
-            <Hoverable.Item group="numericLimit" variant="opacity-on-hover">
+            <Hoverable.Item group="numericLimit" variant="appear-on-hover">
               <IconButton
                 icon={SvgRefreshCw}
                 tooltip="Restore default"

--- a/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
+++ b/web/src/refresh-pages/admin/LLMConfigurationPage.tsx
@@ -152,7 +152,7 @@ function ExistingProviderCard({
               <div className="flex flex-row">
                 <Hoverable.Item
                   group="ExistingProviderCard"
-                  variant="opacity-on-hover"
+                  variant="appear-on-hover"
                 >
                   <Button
                     icon={SvgTrash}

--- a/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/GroupsCell.tsx
@@ -168,7 +168,7 @@ export default function GroupsCell({
             </Tooltip>
           )}
           {user.id && (
-            <Hoverable.Item group="tags" variant="opacity-on-hover">
+            <Hoverable.Item group="tags" variant="appear-on-hover">
               <Button
                 icon={SvgEdit}
                 prominence="tertiary"

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -38,7 +38,7 @@ function StatCell({ value, label, onFilter }: StatCellProps) {
         </Text>
         {onFilter && (
           <div className="absolute right-1 top-1">
-            <Hoverable.Item group="stat" variant="opacity-on-hover">
+            <Hoverable.Item group="stat" variant="appear-on-hover">
               <IconButton
                 tertiary
                 icon={SvgFilterPlus}

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -251,7 +251,7 @@ function FormContent({
                 <div className="absolute z-[100000] top-2 right-2 bg-background-tint-00">
                   <Hoverable.Item
                     group="definitionField"
-                    variant="opacity-on-hover"
+                    variant="appear-on-hover"
                   >
                     <div className="flex">
                       <CopyIconButton

--- a/web/src/sections/admin/ProviderCard.tsx
+++ b/web/src/sections/admin/ProviderCard.tsx
@@ -162,7 +162,7 @@ export default function ProviderCard({
                       {onDisconnect && (
                         <Hoverable.Item
                           group="ProviderCard"
-                          variant="opacity-on-hover"
+                          variant="appear-on-hover"
                         >
                           <Button
                             icon={SvgUnplug}

--- a/web/src/sections/cards/FileCard.tsx
+++ b/web/src/sections/cards/FileCard.tsx
@@ -30,7 +30,7 @@ function Removable({ onRemove, children }: RemovableProps) {
             "pointer-events-none focus-within:pointer-events-auto"
           )}
         >
-          <Hoverable.Item group="fileCard" variant="opacity-on-hover">
+          <Hoverable.Item group="fileCard" variant="appear-on-hover">
             <button
               type="button"
               onClick={(e) => {

--- a/web/src/sections/onboarding/components/NonAdminStep.tsx
+++ b/web/src/sections/onboarding/components/NonAdminStep.tsx
@@ -153,7 +153,7 @@ export default function NonAdminStep() {
             </div>
             <div className="p-1 flex items-center gap-1">
               {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-              <Hoverable.Item group="nonAdminName" variant="opacity-on-hover">
+              <Hoverable.Item group="nonAdminName" variant="appear-on-hover">
                 <IconButton internal icon={SvgEdit} tooltip="Edit" />
               </Hoverable.Item>
               <SvgCheckCircle className="w-4 h-4 stroke-status-success-05" />

--- a/web/src/sections/onboarding/steps/NameStep.tsx
+++ b/web/src/sections/onboarding/steps/NameStep.tsx
@@ -96,7 +96,7 @@ const NameStep = React.memo(
           </div>
           <div className="p-1 flex items-center gap-1">
             {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
-            <Hoverable.Item group="nameStep" variant="opacity-on-hover">
+            <Hoverable.Item group="nameStep" variant="appear-on-hover">
               <IconButton internal icon={SvgEdit} tooltip="Edit" />
             </Hoverable.Item>
             <SvgCheckCircle


### PR DESCRIPTION
## Description

Renames the Hoverable variant and adds two new variants to `@opal/core/animations`.

- **Rename**: `opacity-on-hover` → `appear-on-hover` across all 21 consumer files — the old name was confusing
- **New variant**: `appear-on-rest` — inverse of `appear-on-hover` (visible at rest, hidden on hover via opacity). Supports group mode, local mode, interaction override, and focus.
- **New variant**: `replace-on-hover` — instant content swap between `resting` (at rest) and `children` (on hover) using `display: none` / `display: contents`. No animation. Supports group mode, local mode, interaction override, and focus (including local focus).

Icons moved to a separate PR (#10676).

## How Has This Been Tested?

- `bun run types:check` passes
- Visual validation in browser

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check