### PR TITLE
fix(chat): allow Uploaded Files citations to open preview

### DIFF
--- a/web/src/lib/search/utils.test.ts
+++ b/web/src/lib/search/utils.test.ts
@@ -1,0 +1,101 @@
+import { ValidSources } from "../types";
+import { OnyxDocument } from "./interfaces";
+import { openDocument } from "./utils";
+
+function makeDocument(overrides: Partial<OnyxDocument>): OnyxDocument {
+  return {
+    document_id: "doc-1",
+    semantic_identifier: "doc.pdf",
+    link: "",
+    source_type: ValidSources.File,
+    blurb: "",
+    boost: 0,
+    hidden: false,
+    score: 0,
+    chunk_ind: 0,
+    match_highlights: [],
+    metadata: {},
+    updated_at: null,
+    is_internet: false,
+    ...overrides,
+  };
+}
+
+describe("openDocument", () => {
+  let windowOpen: jest.Mock;
+
+  beforeEach(() => {
+    windowOpen = jest.fn();
+    (global as unknown as { window: { open: jest.Mock } }).window = {
+      open: windowOpen,
+    };
+  });
+
+  it("opens the link in a new tab when one is present", () => {
+    const updatePresentingDocument = jest.fn();
+    const document = makeDocument({
+      link: "https://example.com/doc.pdf",
+      source_type: ValidSources.Web,
+    });
+
+    openDocument(document, updatePresentingDocument);
+
+    expect(windowOpen).toHaveBeenCalledWith(
+      "https://example.com/doc.pdf",
+      "_blank"
+    );
+    expect(updatePresentingDocument).not.toHaveBeenCalled();
+  });
+
+  it("opens the in-app preview for connector File documents without a link", () => {
+    const updatePresentingDocument = jest.fn();
+    const document = makeDocument({
+      link: "",
+      source_type: ValidSources.File,
+    });
+
+    openDocument(document, updatePresentingDocument);
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(updatePresentingDocument).toHaveBeenCalledWith(document);
+  });
+
+  it("opens the in-app preview for user-uploaded UserFile documents without a link", () => {
+    // Regression test: prior to the fix, "Uploaded Files" citations
+    // (source_type=user_file, link=null) silently no-op'd on click because
+    // openDocument only matched ValidSources.File.
+    const updatePresentingDocument = jest.fn();
+    const document = makeDocument({
+      link: "",
+      source_type: ValidSources.UserFile,
+    });
+
+    openDocument(document, updatePresentingDocument);
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(updatePresentingDocument).toHaveBeenCalledWith(document);
+  });
+
+  it("does nothing for non-file sources without a link", () => {
+    const updatePresentingDocument = jest.fn();
+    const document = makeDocument({
+      link: "",
+      source_type: ValidSources.Web,
+    });
+
+    openDocument(document, updatePresentingDocument);
+
+    expect(windowOpen).not.toHaveBeenCalled();
+    expect(updatePresentingDocument).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a missing updatePresentingDocument callback", () => {
+    const document = makeDocument({
+      link: "",
+      source_type: ValidSources.UserFile,
+    });
+
+    expect(() => openDocument(document)).not.toThrow();
+    expect(windowOpen).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/search/utils.ts
+++ b/web/src/lib/search/utils.ts
@@ -32,7 +32,10 @@ export const openDocument = (
 ) => {
   if (document.link) {
     window.open(document.link, "_blank");
-  } else if (document.source_type === ValidSources.File) {
+  } else if (
+    document.source_type === ValidSources.File ||
+    document.source_type === ValidSources.UserFile
+  ) {
     updatePresentingDocument?.(document);
   }
 };


### PR DESCRIPTION
## Description

When a citation in an assistant response points to a user-uploaded "user file" project file (the **Uploaded Files** pill in the chat UI), clicking the pill or the popover card silently does nothing. The user sees the small hover card with the filename but cannot open the underlying PDF/DOCX/etc.

**Root cause:** `openDocument()` in `web/src/lib/search/utils.ts` only routes to the in-app preview for documents whose `source_type === ValidSources.File`. User-uploaded project files have `source_type === ValidSources.UserFile` (set in `backend/onyx/background/celery/tasks/user_file_processing/tasks.py` when `LocalFileConnector` output is post-processed) and `link === null`, so neither branch of `openDocument` matched and the click became a no-op.

**Fix:** also route `ValidSources.UserFile` to the in-app preview. The `/api/chat/file/{file_id}` endpoint already accepts a `user_file_id` (it converts via `get_file_id_by_user_file_id` in `backend/onyx/server/query_and_chat/chat_backend.py`), so no backend change is needed — the preview modal works end-to-end once the click handler is wired up.

## How Has This Been Tested?

- New unit tests in `web/src/lib/search/utils.test.ts` cover all four branches of `openDocument`, including a regression test for the `UserFile`-without-link case.
- `npx jest src/lib/search/utils.test.ts` — 5/5 passing.
- `npx tsc --noEmit` clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat citations from Uploaded Files. Clicking a citation now opens the in-app preview instead of doing nothing.

- **Bug Fixes**
  - Updated `openDocument` to route `ValidSources.UserFile` (and `ValidSources.File`) without a link to the in-app preview; no backend change needed since `/api/chat/file/{file_id}` already supports `user_file_id`.
  - Added unit tests in `web/src/lib/search/utils.test.ts` covering all branches, including the UserFile-without-link regression.

<sup>Written for commit ff505803fa4ead1c2f0f49a0e95a833dc8628d79. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10675?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

