### PR TITLE
fix(Hubspot): use search API for incremental poll to avoid full scans - phase 2

### DIFF
--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -9,6 +9,9 @@ from typing import TypeVar
 
 import requests
 from hubspot import HubSpot
+from hubspot.crm.contacts.models import Filter
+from hubspot.crm.contacts.models import FilterGroup
+from hubspot.crm.contacts.models import PublicObjectSearchRequest
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
@@ -30,6 +33,8 @@ HUBSPOT_API_URL = "https://api.hubapi.com/integrations/v1/me"
 AVAILABLE_OBJECT_TYPES = {"tickets", "companies", "deals", "contacts"}
 
 HUBSPOT_PAGE_SIZE = 100
+# HubSpot Search API rejects cursors beyond this offset.
+HUBSPOT_SEARCH_LIMIT = 10_000
 
 T = TypeVar("T")
 
@@ -116,6 +121,118 @@ class HubSpotConnector(LoadConnector, PollConnector):
             after = getattr(next_page, "after", None)
             if after is None:
                 break
+
+    def _build_time_filter_group(
+        self,
+        start: datetime | None,
+        end: datetime | None,
+        property_name: str,
+    ) -> FilterGroup:
+        filters: list[Filter] = []
+        if start is not None:
+            filters.append(
+                Filter(
+                    property_name=property_name,
+                    operator="GTE",
+                    value=str(int(start.timestamp() * 1000)),
+                )
+            )
+        if end is not None:
+            filters.append(
+                Filter(
+                    property_name=property_name,
+                    operator="LTE",
+                    value=str(int(end.timestamp() * 1000)),
+                )
+            )
+        return FilterGroup(filters=filters)
+
+    def _search_paginated_results(
+        self,
+        search_fn: Callable[..., Any],
+        properties: list[str],
+        filter_group: FilterGroup,
+        sorts: list[str] | None = None,
+    ) -> Generator[Any, None, None]:
+        after: str | None = None
+        while True:
+            request = PublicObjectSearchRequest(
+                filter_groups=[filter_group],
+                limit=HUBSPOT_PAGE_SIZE,
+                properties=properties,
+                after=after,
+                sorts=sorts,
+            )
+            page = self._call_hubspot(search_fn, public_object_search_request=request)
+            results = getattr(page, "results", [])
+            for result in results:
+                yield result
+
+            paging = getattr(page, "paging", None)
+            next_page = getattr(paging, "next", None) if paging else None
+            if next_page is None:
+                break
+            after = getattr(next_page, "after", None)
+            if after is None:
+                break
+
+    def _search_time_range(
+        self,
+        search_fn: Callable[..., Any],
+        properties: list[str],
+        start: datetime,
+        end: datetime,
+        modified_date_prop: str,
+    ) -> Generator[Any, None, None]:
+        """Search [start, end] sorted by modified date ASC.
+
+        If results hit the 10,000-record hard cap, yield all fetched results
+        and continue from the last seen modified timestamp. Documents sharing
+        that exact timestamp may be yielded twice (acceptable — re-indexing is
+        idempotent).
+
+        Note: PublicObjectSearchRequest does not support an `associations`
+        parameter, so objects returned here will not have inline association
+        data. _extract_inline_association_ids will return None for each object,
+        falling back to a v4 associations API call per association type per
+        record (O(N×M) extra calls). This is acceptable for poll windows, which
+        are small by design (typically tens to low hundreds of changed objects
+        per 15-second window).
+        """
+        filter_group = self._build_time_filter_group(start, end, modified_date_prop)
+        results: list[Any] = []
+        for result in self._search_paginated_results(
+            search_fn, properties, filter_group, sorts=[modified_date_prop]
+        ):
+            results.append(result)
+            if len(results) >= HUBSPOT_SEARCH_LIMIT:
+                break
+
+        yield from results
+
+        if len(results) < HUBSPOT_SEARCH_LIMIT:
+            return
+
+        # Hit the cap — continue from the last seen modified timestamp.
+        last_ts_ms = (results[-1].properties or {}).get(modified_date_prop)
+        if last_ts_ms is None:
+            logger.error(
+                "HubSpot search limit reached but last modified timestamp is "
+                "unavailable; records after the 10,000th may be missing."
+            )
+            return
+
+        next_start = datetime.fromtimestamp(int(last_ts_ms) / 1000, tz=timezone.utc)
+        if next_start <= start:
+            logger.error(
+                "HubSpot search limit reached but timestamp did not advance; "
+                "records after the 10,000th may be missing."
+            )
+            return
+
+        yield from self._search_time_range(
+            search_fn, properties, next_start, end, modified_date_prop
+        )
 
     def _clean_html_content(self, html_content: str) -> str:
         """Clean HTML content and extract raw text"""
@@ -432,27 +549,32 @@ class HubSpotConnector(LoadConnector, PollConnector):
     ) -> GenerateDocumentsOutput:
         api_client = HubSpot(access_token=self.access_token)
 
-        tickets_iter = self._paginated_results(
-            api_client.crm.tickets.basic_api.get_page,
-            properties=[
-                "subject",
-                "content",
-                "hs_ticket_priority",
-                "createdate",
+        ticket_properties = [
+            "subject",
+            "content",
+            "hs_ticket_priority",
+            "createdate",
+            "hs_lastmodifieddate",
+        ]
+
+        if start is not None or end is not None:
+            tickets_iter = self._search_time_range(
+                api_client.crm.tickets.search_api.do_search,
+                ticket_properties,
+                start or datetime.min.replace(tzinfo=timezone.utc),
+                end or datetime.max.replace(tzinfo=timezone.utc),
                 "hs_lastmodifieddate",
-            ],
-            associations=["contacts", "companies", "deals"],
-        )
+            )
+        else:
+            tickets_iter = self._paginated_results(
+                api_client.crm.tickets.basic_api.get_page,
+                properties=ticket_properties,
+                associations=["contacts", "companies", "deals"],
+            )
 
         doc_batch: list[Document | HierarchyNode] = []
 
         for ticket in tickets_iter:
-            updated_at = ticket.updated_at.replace(tzinfo=None)
-            if start is not None and updated_at < start.replace(tzinfo=None):
-                continue
-            if end is not None and updated_at > end.replace(tzinfo=None):
-                continue
-
             title = ticket.properties.get("subject") or f"Ticket {ticket.id}"
             link = self._get_object_url("tickets", ticket.id)
             content_text = ticket.properties.get("content") or ""
@@ -560,30 +682,35 @@ class HubSpotConnector(LoadConnector, PollConnector):
     ) -> GenerateDocumentsOutput:
         api_client = HubSpot(access_token=self.access_token)
 
-        companies_iter = self._paginated_results(
-            api_client.crm.companies.basic_api.get_page,
-            properties=[
-                "name",
-                "domain",
-                "industry",
-                "city",
-                "state",
-                "description",
-                "createdate",
+        company_properties = [
+            "name",
+            "domain",
+            "industry",
+            "city",
+            "state",
+            "description",
+            "createdate",
+            "hs_lastmodifieddate",
+        ]
+
+        if start is not None or end is not None:
+            companies_iter = self._search_time_range(
+                api_client.crm.companies.search_api.do_search,
+                company_properties,
+                start or datetime.min.replace(tzinfo=timezone.utc),
+                end or datetime.max.replace(tzinfo=timezone.utc),
                 "hs_lastmodifieddate",
-            ],
-            associations=["contacts", "deals", "tickets"],
-        )
+            )
+        else:
+            companies_iter = self._paginated_results(
+                api_client.crm.companies.basic_api.get_page,
+                properties=company_properties,
+                associations=["contacts", "deals", "tickets"],
+            )
 
         doc_batch: list[Document | HierarchyNode] = []
 
         for company in companies_iter:
-            updated_at = company.updated_at.replace(tzinfo=None)
-            if start is not None and updated_at < start.replace(tzinfo=None):
-                continue
-            if end is not None and updated_at > end.replace(tzinfo=None):
-                continue
-
             title = company.properties.get("name") or f"Company {company.id}"
             link = self._get_object_url("companies", company.id)
 
@@ -710,30 +837,35 @@ class HubSpotConnector(LoadConnector, PollConnector):
     ) -> GenerateDocumentsOutput:
         api_client = HubSpot(access_token=self.access_token)
 
-        deals_iter = self._paginated_results(
-            api_client.crm.deals.basic_api.get_page,
-            properties=[
-                "dealname",
-                "amount",
-                "dealstage",
-                "closedate",
-                "pipeline",
-                "description",
-                "createdate",
+        deal_properties = [
+            "dealname",
+            "amount",
+            "dealstage",
+            "closedate",
+            "pipeline",
+            "description",
+            "createdate",
+            "hs_lastmodifieddate",
+        ]
+
+        if start is not None or end is not None:
+            deals_iter = self._search_time_range(
+                api_client.crm.deals.search_api.do_search,
+                deal_properties,
+                start or datetime.min.replace(tzinfo=timezone.utc),
+                end or datetime.max.replace(tzinfo=timezone.utc),
                 "hs_lastmodifieddate",
-            ],
-            associations=["contacts", "companies", "tickets"],
-        )
+            )
+        else:
+            deals_iter = self._paginated_results(
+                api_client.crm.deals.basic_api.get_page,
+                properties=deal_properties,
+                associations=["contacts", "companies", "tickets"],
+            )
 
         doc_batch: list[Document | HierarchyNode] = []
 
         for deal in deals_iter:
-            updated_at = deal.updated_at.replace(tzinfo=None)
-            if start is not None and updated_at < start.replace(tzinfo=None):
-                continue
-            if end is not None and updated_at > end.replace(tzinfo=None):
-                continue
-
             title = deal.properties.get("dealname") or f"Deal {deal.id}"
             link = self._get_object_url("deals", deal.id)
 
@@ -858,32 +990,37 @@ class HubSpotConnector(LoadConnector, PollConnector):
     ) -> GenerateDocumentsOutput:
         api_client = HubSpot(access_token=self.access_token)
 
-        contacts_iter = self._paginated_results(
-            api_client.crm.contacts.basic_api.get_page,
-            properties=[
-                "firstname",
-                "lastname",
-                "email",
-                "company",
-                "jobtitle",
-                "phone",
-                "city",
-                "state",
-                "createdate",
+        contact_properties = [
+            "firstname",
+            "lastname",
+            "email",
+            "company",
+            "jobtitle",
+            "phone",
+            "city",
+            "state",
+            "createdate",
+            "lastmodifieddate",
+        ]
+
+        if start is not None or end is not None:
+            contacts_iter = self._search_time_range(
+                api_client.crm.contacts.search_api.do_search,
+                contact_properties,
+                start or datetime.min.replace(tzinfo=timezone.utc),
+                end or datetime.max.replace(tzinfo=timezone.utc),
                 "lastmodifieddate",
-            ],
-            associations=["companies", "deals", "tickets"],
-        )
+            )
+        else:
+            contacts_iter = self._paginated_results(
+                api_client.crm.contacts.basic_api.get_page,
+                properties=contact_properties,
+                associations=["companies", "deals", "tickets"],
+            )
 
         doc_batch: list[Document | HierarchyNode] = []
 
         for contact in contacts_iter:
-            updated_at = contact.updated_at.replace(tzinfo=None)
-            if start is not None and updated_at < start.replace(tzinfo=None):
-                continue
-            if end is not None and updated_at > end.replace(tzinfo=None):
-                continue
-
             # Build contact name
             name_parts = []
             if contact.properties.get("firstname"):

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -1190,15 +1190,20 @@ class HubSpotConnector(LoadConnector, PollConnector):
         start_datetime = datetime.fromtimestamp(start, tz=timezone.utc)
         end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
 
-        # Process each object type with time filtering based on configuration
+        # Epoch 0 means no prior successful sync — full scan using get_page with
+        # inline associations (avoids O(N×M) v4 association calls on initial load).
+        is_full_scan = start == 0
+        effective_start = None if is_full_scan else start_datetime
+        effective_end = None if is_full_scan else end_datetime
+
         if "tickets" in self.object_types:
-            yield from self._process_tickets(start_datetime, end_datetime)
+            yield from self._process_tickets(effective_start, effective_end)
         if "companies" in self.object_types:
-            yield from self._process_companies(start_datetime, end_datetime)
+            yield from self._process_companies(effective_start, effective_end)
         if "deals" in self.object_types:
-            yield from self._process_deals(start_datetime, end_datetime)
+            yield from self._process_deals(effective_start, effective_end)
         if "contacts" in self.object_types:
-            yield from self._process_contacts(start_datetime, end_datetime)
+            yield from self._process_contacts(effective_start, effective_end)
 
 
 if __name__ == "__main__":

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -222,7 +222,21 @@ class HubSpotConnector(LoadConnector, PollConnector):
             )
             return
 
-        next_start = datetime.fromtimestamp(int(last_ts_ms) / 1000, tz=timezone.utc)
+        try:
+            # Search API returns ISO 8601 strings; filter values use ms epoch.
+            next_start = datetime.fromisoformat(last_ts_ms.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            try:
+                next_start = datetime.fromtimestamp(
+                    int(last_ts_ms) / 1000, tz=timezone.utc
+                )
+            except (ValueError, TypeError):
+                logger.error(
+                    f"HubSpot search limit reached but last modified timestamp "
+                    f"has unrecognized format ({last_ts_ms!r}); records after "
+                    "the 10,000th may be missing."
+                )
+                return
         if next_start <= start:
             logger.error(
                 "HubSpot search limit reached but timestamp did not advance; "

--- a/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
+++ b/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
@@ -268,9 +268,9 @@ class TestSearchPaginatedResults:
 
 
 class TestSearchWithTimeSplit:
-    def _make_result(self, ts_ms: int, prop: str = "hs_lastmodifieddate") -> MagicMock:
+    def _make_result(self, ts_iso: str, prop: str = "hs_lastmodifieddate") -> MagicMock:
         r = MagicMock()
-        r.properties = {prop: str(ts_ms)}
+        r.properties = {prop: ts_iso}
         return r
 
     def test_yields_all_when_under_limit(self) -> None:
@@ -279,7 +279,10 @@ class TestSearchWithTimeSplit:
         connector = _make_connector()
         start = datetime(2024, 1, 1, tzinfo=timezone.utc)
         end = datetime(2024, 2, 1, tzinfo=timezone.utc)
-        items = [self._make_result(i) for i in range(HUBSPOT_SEARCH_LIMIT - 1)]
+        items = [
+            self._make_result("2024-01-15T00:00:00.000Z")
+            for _ in range(HUBSPOT_SEARCH_LIMIT - 1)
+        ]
 
         with patch.object(
             connector, "_search_paginated_results", return_value=iter(items)
@@ -299,10 +302,11 @@ class TestSearchWithTimeSplit:
         start = datetime(2024, 1, 1, tzinfo=timezone.utc)
         end = datetime(2024, 2, 1, tzinfo=timezone.utc)
 
-        # Last item has a timestamp clearly after start
-        last_ts_ms = int(datetime(2024, 1, 15, tzinfo=timezone.utc).timestamp() * 1000)
-        first_batch = [self._make_result(last_ts_ms)] * HUBSPOT_SEARCH_LIMIT
-        continuation = [self._make_result(last_ts_ms + 1)]
+        # Last item has a timestamp clearly after start (ISO 8601 format, as HubSpot returns)
+        last_dt = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        last_ts_iso = last_dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        first_batch = [self._make_result(last_ts_iso)] * HUBSPOT_SEARCH_LIMIT
+        continuation = [self._make_result("2024-01-15T00:00:00.001Z")]
 
         search_calls: list[tuple[datetime, datetime]] = []
         original = connector._search_time_range
@@ -326,6 +330,4 @@ class TestSearchWithTimeSplit:
         assert results[-1] is continuation[0]
         # Second call starts from last_ts_ms
         assert len(search_calls) == 2
-        assert search_calls[1][0] == datetime.fromtimestamp(
-            last_ts_ms / 1000, tz=timezone.utc
-        )
+        assert search_calls[1][0] == last_dt

--- a/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
+++ b/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import datetime
+from datetime import timezone
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -120,3 +123,209 @@ class TestGetAssociatedObjectsSkipsV4Call:
             )
 
         mock_paginated.assert_called_once()
+
+
+class TestExtractInlineAssociationIdsDedup:
+    def test_deduplicates_ids_from_multiple_labels(self) -> None:
+        """HubSpot returns one entry per association label; duplicates must be collapsed."""
+        connector = _make_connector()
+        obj = MagicMock()
+        # Simulate HubSpot returning the same IDs twice (two labels each)
+        obj.associations = {
+            "contacts": _make_assoc_collection(["1", "2", "3", "1", "2", "3"])
+        }
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result == ["1", "2", "3"]
+
+    def test_preserves_order_after_dedup(self) -> None:
+        connector = _make_connector()
+        obj = MagicMock()
+        obj.associations = {
+            "contacts": _make_assoc_collection(["3", "1", "2", "3", "1", "2"])
+        }
+
+        result = connector._extract_inline_association_ids(obj, "contacts")
+
+        assert result == ["3", "1", "2"]
+
+
+class TestBuildTimeFilterGroup:
+    def test_both_start_and_end(self) -> None:
+        connector = _make_connector()
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+        group = connector._build_time_filter_group(start, end, "hs_lastmodifieddate")
+
+        assert len(group.filters) == 2
+        operators = {f.operator for f in group.filters}
+        assert operators == {"GTE", "LTE"}
+        values = {f.value for f in group.filters}
+        assert str(int(start.timestamp() * 1000)) in values
+        assert str(int(end.timestamp() * 1000)) in values
+
+    def test_start_only(self) -> None:
+        connector = _make_connector()
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+        group = connector._build_time_filter_group(start, None, "hs_lastmodifieddate")
+
+        assert len(group.filters) == 1
+        assert group.filters[0].operator == "GTE"
+        assert group.filters[0].value == str(int(start.timestamp() * 1000))
+
+    def test_end_only(self) -> None:
+        connector = _make_connector()
+        end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+        group = connector._build_time_filter_group(None, end, "lastmodifieddate")
+
+        assert len(group.filters) == 1
+        assert group.filters[0].operator == "LTE"
+        assert group.filters[0].property_name == "lastmodifieddate"
+
+    def test_property_name_is_passed_through(self) -> None:
+        connector = _make_connector()
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+        group = connector._build_time_filter_group(start, None, "lastmodifieddate")
+
+        assert group.filters[0].property_name == "lastmodifieddate"
+
+
+class TestSearchPaginatedResults:
+    def _make_page(self, ids: list[str], next_after: str | None) -> MagicMock:
+        page = MagicMock()
+        page.results = [MagicMock(id=i) for i in ids]
+        if next_after is not None:
+            page.paging = MagicMock()
+            page.paging.next = MagicMock()
+            page.paging.next.after = next_after
+        else:
+            page.paging = None
+        return page
+
+    def test_single_page(self) -> None:
+        connector = _make_connector()
+        search_fn = MagicMock(return_value=self._make_page(["1", "2"], None))
+        filter_group = MagicMock()
+
+        with patch.object(
+            connector, "_call_hubspot", side_effect=lambda fn, **kw: fn(**kw)
+        ):
+            results = list(
+                connector._search_paginated_results(search_fn, ["prop"], filter_group)
+            )
+
+        assert len(results) == 2
+        assert search_fn.call_count == 1
+
+    def test_large_single_page(self) -> None:
+        from onyx.connectors.hubspot.connector import HUBSPOT_SEARCH_LIMIT
+
+        connector = _make_connector()
+        # Return one giant page that exactly hits the limit
+        big_page = self._make_page(
+            [str(i) for i in range(HUBSPOT_SEARCH_LIMIT)], next_after=None
+        )
+        search_fn = MagicMock(return_value=big_page)
+        filter_group = MagicMock()
+
+        with patch.object(
+            connector, "_call_hubspot", side_effect=lambda fn, **kw: fn(**kw)
+        ):
+            results = list(
+                connector._search_paginated_results(search_fn, ["prop"], filter_group)
+            )
+
+        assert len(results) == HUBSPOT_SEARCH_LIMIT
+
+    def test_multiple_pages(self) -> None:
+        connector = _make_connector()
+        pages = [
+            self._make_page(["1", "2"], next_after="cursor1"),
+            self._make_page(["3", "4"], next_after=None),
+        ]
+        search_fn = MagicMock(side_effect=pages)
+        filter_group = MagicMock()
+
+        with patch.object(
+            connector, "_call_hubspot", side_effect=lambda fn, **kw: fn(**kw)
+        ):
+            results = list(
+                connector._search_paginated_results(search_fn, ["prop"], filter_group)
+            )
+
+        assert len(results) == 4
+        assert search_fn.call_count == 2
+        # Second call must pass the cursor from the first page
+        second_call_request = search_fn.call_args_list[1][1][
+            "public_object_search_request"
+        ]
+        assert second_call_request.after == "cursor1"
+
+
+class TestSearchWithTimeSplit:
+    def _make_result(self, ts_ms: int, prop: str = "hs_lastmodifieddate") -> MagicMock:
+        r = MagicMock()
+        r.properties = {prop: str(ts_ms)}
+        return r
+
+    def test_yields_all_when_under_limit(self) -> None:
+        from onyx.connectors.hubspot.connector import HUBSPOT_SEARCH_LIMIT
+
+        connector = _make_connector()
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 2, 1, tzinfo=timezone.utc)
+        items = [self._make_result(i) for i in range(HUBSPOT_SEARCH_LIMIT - 1)]
+
+        with patch.object(
+            connector, "_search_paginated_results", return_value=iter(items)
+        ):
+            results = list(
+                connector._search_time_range(
+                    MagicMock(), ["prop"], start, end, "hs_lastmodifieddate"
+                )
+            )
+
+        assert results == items
+
+    def test_yields_fetched_and_continues_from_last_timestamp(self) -> None:
+        from onyx.connectors.hubspot.connector import HUBSPOT_SEARCH_LIMIT
+
+        connector = _make_connector()
+        start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+        # Last item has a timestamp clearly after start
+        last_ts_ms = int(datetime(2024, 1, 15, tzinfo=timezone.utc).timestamp() * 1000)
+        first_batch = [self._make_result(last_ts_ms)] * HUBSPOT_SEARCH_LIMIT
+        continuation = [self._make_result(last_ts_ms + 1)]
+
+        search_calls: list[tuple[datetime, datetime]] = []
+        original = connector._search_time_range
+
+        def fake_split(fn: Any, props: Any, s: datetime, e: datetime, prop: Any) -> Any:
+            search_calls.append((s, e))
+            if s == start:
+                return original(fn, props, s, e, prop)
+            return iter(continuation)
+
+        with patch.object(
+            connector, "_search_paginated_results", return_value=iter(first_batch)
+        ):
+            with patch.object(connector, "_search_time_range", side_effect=fake_split):
+                results = list(
+                    fake_split(MagicMock(), ["prop"], start, end, "hs_lastmodifieddate")
+                )
+
+        # All 10k fetched results are yielded, then the continuation
+        assert len(results) == HUBSPOT_SEARCH_LIMIT + len(continuation)
+        assert results[-1] is continuation[0]
+        # Second call starts from last_ts_ms
+        assert len(search_calls) == 2
+        assert search_calls[1][0] == datetime.fromtimestamp(
+            last_ts_ms / 1000, tz=timezone.utc
+        )


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Summary:

  - Poll efficiency: poll_source now uses search_api.do_search with GTE/LTE time filters instead of fetching all objects and discarding non-matching ones in Python. Full sync (load_from_state) is unchanged — still uses get_page with inline associations.
  - 10k cap handling: Search results are fetched sorted by modified date ASC. If a window hits HubSpot's 10,000-record cursor limit, all fetched results are yielded and the next search continues from the last seen timestamp. Nothing is dropped; boundary-timestamp records may be re-indexed (idempotent).
  - Association fallback on poll path: PublicObjectSearchRequest has no associations field, so poll-path objects fall back to per-type v4 API calls. Acceptable — poll windows are small by design.
  - Dedup fix (prior commit): HubSpot returns one entry per association label, causing duplicate IDs. Both inline and v4 paths now deduplicate with  dict.fromkeys().

New helpers

  - _build_time_filter_group — GTE/LTE millisecond-epoch FilterGroup
  - _search_paginated_results — paginates search results via after cursor
  - _search_time_range — wraps search with 10k-cap continuation

https://linear.app/onyx-app/issue/ENG-4077/hubspot-connector-more-efficient-indexing

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Local tests
<img width="1016" height="216" alt="Screenshot 2026-04-28 at 6 17 52 PM" src="https://github.com/user-attachments/assets/65e7b9bb-8802-4c86-b1f5-567bdd68bbf1" />

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches incremental HubSpot polling to the Search API with last-modified filters to avoid full scans. Initial loads (start=0) keep `basic_api.get_page` with inline associations; continuation past the 10k cap now works with ISO 8601 or ms-epoch timestamps.

- **Bug Fixes**
  - Incremental polls use `crm.{type}.search_api.do_search` with GTE/LTE ms-epoch filters and ASC sort; full scans when `start==0` stay on `basic_api.get_page` with inline associations. Helpers: `_build_time_filter_group`, `_search_paginated_results`, `_search_time_range`.
  - Added modified-date properties (`hs_lastmodifieddate` for tickets/companies/deals, `lastmodifieddate` for contacts) and removed Python-side `updated_at` filtering.
  - 10k cap handling continues from the last timestamp and accepts ISO 8601 or ms-epoch formats, with safety logging on bad values.
  - Search results lack inline associations; fall back to v4 association lookups per record with ID de-dup that preserves order. Tests cover time-filter construction, pagination (single/limit-sized/multi-page), 10k continuation, and de-dup/order.

<sup>Written for commit aac06e912226929ce86cbc20be45ddd6fc80fa60. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10677?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





