### PR TITLE
fix(math): render LaTeX live during message streaming

### DIFF
--- a/web/src/app/app/message/codeUtils.test.ts
+++ b/web/src/app/app/message/codeUtils.test.ts
@@ -1,4 +1,4 @@
-import { preprocessLaTeX, stripIncompleteBlockMath } from "./codeUtils";
+import { preprocessLaTeX, escapeIncompleteBlockMath } from "./codeUtils";
 
 describe("preprocessLaTeX", () => {
   describe("currency formatting", () => {
@@ -132,52 +132,56 @@ describe("preprocessLaTeX", () => {
   });
 });
 
-describe("stripIncompleteBlockMath", () => {
+describe("escapeIncompleteBlockMath", () => {
   it("returns empty content unchanged", () => {
-    expect(stripIncompleteBlockMath("")).toBe("");
+    expect(escapeIncompleteBlockMath("")).toBe("");
   });
 
   it("returns content with no $$ unchanged", () => {
     const input = "Just some text with no math at all.";
-    expect(stripIncompleteBlockMath(input)).toBe(input);
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
   });
 
   it("returns a single balanced $$math$$ unchanged", () => {
     const input = "Before $$x = y$$ after.";
-    expect(stripIncompleteBlockMath(input)).toBe(input);
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
   });
 
   it("returns two balanced $$ blocks unchanged", () => {
     const input = "First $$a = b$$ then $$c = d$$ done.";
-    expect(stripIncompleteBlockMath(input)).toBe(input);
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
   });
 
-  it("strips a single trailing unmatched $$ block", () => {
+  it("escapes a single trailing unmatched $$ and preserves the tail", () => {
     const input = "Some prose then $$\\frac{a}{b";
-    expect(stripIncompleteBlockMath(input)).toBe("Some prose then ");
+    expect(escapeIncompleteBlockMath(input)).toBe(
+      "Some prose then \\$\\$\\frac{a}{b"
+    );
   });
 
-  it("strips a trailing unmatched $$ after a balanced pair", () => {
+  it("escapes a trailing unmatched $$ after a balanced pair", () => {
     const input = "Done: $$x = y$$ next: $$\\frac{c}{d";
-    expect(stripIncompleteBlockMath(input)).toBe("Done: $$x = y$$ next: ");
+    expect(escapeIncompleteBlockMath(input)).toBe(
+      "Done: $$x = y$$ next: \\$\\$\\frac{c}{d"
+    );
   });
 
   it("does not count $$ inside a closed fenced code block", () => {
     const input =
       "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n```\nDone.";
-    expect(stripIncompleteBlockMath(input)).toBe(input);
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
   });
 
-  it("strips trailing unmatched $$ outside a closed code block without truncating the code block", () => {
+  it("escapes trailing unmatched $$ outside a closed code block without modifying the code block", () => {
     const input =
       "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n``` then $$\\frac{c";
-    expect(stripIncompleteBlockMath(input)).toBe(
-      "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n``` then "
+    expect(escapeIncompleteBlockMath(input)).toBe(
+      "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n``` then \\$\\$\\frac{c"
     );
   });
 
   it("does not affect currency-only content", () => {
     const input = "I have $5 and you have $10.";
-    expect(stripIncompleteBlockMath(input)).toBe(input);
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
   });
 });

--- a/web/src/app/app/message/codeUtils.test.ts
+++ b/web/src/app/app/message/codeUtils.test.ts
@@ -1,4 +1,4 @@
-import { preprocessLaTeX } from "./codeUtils";
+import { preprocessLaTeX, stripIncompleteBlockMath } from "./codeUtils";
 
 describe("preprocessLaTeX", () => {
   describe("currency formatting", () => {
@@ -129,5 +129,55 @@ describe("preprocessLaTeX", () => {
       // LaTeX within code blocks should remain untouched
       expect(processed).toContain("```latex\nE = mc^2\n```");
     });
+  });
+});
+
+describe("stripIncompleteBlockMath", () => {
+  it("returns empty content unchanged", () => {
+    expect(stripIncompleteBlockMath("")).toBe("");
+  });
+
+  it("returns content with no $$ unchanged", () => {
+    const input = "Just some text with no math at all.";
+    expect(stripIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("returns a single balanced $$math$$ unchanged", () => {
+    const input = "Before $$x = y$$ after.";
+    expect(stripIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("returns two balanced $$ blocks unchanged", () => {
+    const input = "First $$a = b$$ then $$c = d$$ done.";
+    expect(stripIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("strips a single trailing unmatched $$ block", () => {
+    const input = "Some prose then $$\\frac{a}{b";
+    expect(stripIncompleteBlockMath(input)).toBe("Some prose then ");
+  });
+
+  it("strips a trailing unmatched $$ after a balanced pair", () => {
+    const input = "Done: $$x = y$$ next: $$\\frac{c}{d";
+    expect(stripIncompleteBlockMath(input)).toBe("Done: $$x = y$$ next: ");
+  });
+
+  it("does not count $$ inside a closed fenced code block", () => {
+    const input =
+      "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n```\nDone.";
+    expect(stripIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("strips trailing unmatched $$ outside a closed code block without truncating the code block", () => {
+    const input =
+      "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n``` then $$\\frac{c";
+    expect(stripIncompleteBlockMath(input)).toBe(
+      "Real math: $$x = y$$\n```latex\n$$\\frac{a}{b}$$\n``` then "
+    );
+  });
+
+  it("does not affect currency-only content", () => {
+    const input = "I have $5 and you have $10.";
+    expect(stripIncompleteBlockMath(input)).toBe(input);
   });
 });

--- a/web/src/app/app/message/codeUtils.test.ts
+++ b/web/src/app/app/message/codeUtils.test.ts
@@ -1,4 +1,8 @@
-import { preprocessLaTeX, escapeIncompleteBlockMath } from "./codeUtils";
+import {
+  preprocessLaTeX,
+  escapeIncompleteBlockMath,
+  escapeIncompleteInlineMath,
+} from "./codeUtils";
 
 describe("preprocessLaTeX", () => {
   describe("currency formatting", () => {
@@ -183,5 +187,72 @@ describe("escapeIncompleteBlockMath", () => {
   it("does not affect currency-only content", () => {
     const input = "I have $5 and you have $10.";
     expect(escapeIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("does not escape $$ inside an unclosed trailing fenced code block", () => {
+    const input = "Hello\n```\nfoo $$x = y$$ bar";
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("leaves balanced $$ untouched when an unclosed code block opens later", () => {
+    const input = "Done: $$x = y$$ then ```\nfoo";
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
+  });
+
+  it("preserves input that literally contains a fixed-shape placeholder token", () => {
+    // Input contains the OLD placeholder shape; the new nonce-based
+    // placeholder won't collide, so the sentinel must survive intact.
+    const input = "See ___MATHESC_CB_0___ and $$x = y$$ done.";
+    expect(escapeIncompleteBlockMath(input)).toBe(input);
+  });
+});
+
+describe("escapeIncompleteInlineMath", () => {
+  it("returns empty content unchanged", () => {
+    expect(escapeIncompleteInlineMath("")).toBe("");
+  });
+
+  it("returns content with no $ unchanged", () => {
+    const input = "Just some text with no math at all.";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("returns a balanced single-$ inline expression unchanged", () => {
+    const input = "Before $x = y$ after.";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("escapes a trailing unmatched single $", () => {
+    const input = "The cost is $\\frac{a}{";
+    expect(escapeIncompleteInlineMath(input)).toBe("The cost is \\$\\frac{a}{");
+  });
+
+  it("does not double-escape an already-escaped \\$", () => {
+    const input = "Maria has \\$5 and \\$10.";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("ignores $ inside a balanced $$...$$ block", () => {
+    // Stray `$` between the `$$` fences is part of block math and
+    // should not perturb inline parity.
+    const input = "Block: $$x$y$$ done.";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("ignores $ inside a closed fenced code block", () => {
+    const input = "```\nlet x = $5;\n``` done.";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("ignores $ inside an unclosed trailing fenced code block", () => {
+    const input = "Hello\n```\nlet x = $foo";
+    expect(escapeIncompleteInlineMath(input)).toBe(input);
+  });
+
+  it("escapes the trailing $ outside protected regions", () => {
+    const input = "Block: $$x = y$$ then $z";
+    expect(escapeIncompleteInlineMath(input)).toBe(
+      "Block: $$x = y$$ then \\$z"
+    );
   });
 });

--- a/web/src/app/app/message/codeUtils.ts
+++ b/web/src/app/app/message/codeUtils.ts
@@ -142,31 +142,101 @@ export const preprocessLaTeX = (content: string) => {
   return restoredCodeBlocks;
 };
 
-// Escape a trailing unclosed `$$` so remark-math skips it mid-stream while
-// the user still sees `$$` literally — the LaTeX source streams as plain
-// text, then swaps to a rendered formula the moment the closing `$$`
-// arrives. Closed fenced code blocks are protected so a literal `$$`
-// quoted inside ```...``` isn't counted as a math fence.
-export const escapeIncompleteBlockMath = (content: string): string => {
-  const codeBlocks: string[] = [];
-  const protectedContent = content.replace(/```[\s\S]*?```/g, (match) => {
-    codeBlocks.push(match);
-    return `___MATHESC_CB_${codeBlocks.length - 1}___`;
+// Hides code blocks behind temporary markers so the caller can count `$`
+// or `$$` without including ones that live inside code. Closed
+// ```...``` blocks become markers. A leftover ``` (mid-stream, no closer
+// yet) is sliced off as `tail` so the caller skips it entirely.
+// `restore` puts the original code blocks back.
+const protectCodeFences = (
+  content: string,
+  label: string
+): {
+  head: string;
+  tail: string;
+  restore: (s: string) => string;
+} => {
+  const nonce = Math.random().toString(36).slice(2);
+  const blocks: string[] = [];
+  const replaced = content.replace(/```[\s\S]*?```/g, (match) => {
+    blocks.push(match);
+    return `___${label}_${nonce}_CB_${blocks.length - 1}___`;
   });
 
-  // Even array length ⇔ odd `$$` count ⇔ trailing unmatched fence.
-  const parts = protectedContent.split("$$");
-  let result: string;
+  const lastOpen = replaced.lastIndexOf("```");
+  const head = lastOpen >= 0 ? replaced.slice(0, lastOpen) : replaced;
+  const tail = lastOpen >= 0 ? replaced.slice(lastOpen) : "";
+
+  return {
+    head,
+    tail,
+    restore: (s) =>
+      s.replace(
+        new RegExp(`___${label}_${nonce}_CB_(\\d+)___`, "g"),
+        (_, i) => blocks[Number(i)] ?? ""
+      ),
+  };
+};
+
+// Mid-stream the buffer can hold `$$x = y` with no closing `$$` yet.
+// Escape the lone `$$` to `\$\$` so the renderer shows it as literal
+// text instead of broken math. Once the closing `$$` arrives, the count
+// is balanced again and we leave it alone — the formula renders.
+export const escapeIncompleteBlockMath = (content: string): string => {
+  const { head, tail, restore } = protectCodeFences(content, "MATHESC");
+
+  // split on `$$`. Even number of pieces ⇒ odd number of `$$` ⇒ one is
+  // unmatched. Replace the last separator with an escaped `\$\$`.
+  const parts = head.split("$$");
+  let processedHead = head;
   if (parts.length % 2 === 0) {
-    const tail = parts[parts.length - 1] ?? "";
-    const head = parts.slice(0, -1).join("$$");
-    result = `${head}\\$\\$${tail}`;
-  } else {
-    result = parts.join("$$");
+    const last = parts[parts.length - 1] ?? "";
+    const before = parts.slice(0, -1).join("$$");
+    processedHead = `${before}\\$\\$${last}`;
   }
 
-  return result.replace(
-    /___MATHESC_CB_(\d+)___/g,
-    (_, i) => codeBlocks[Number(i)] ?? ""
+  return restore(processedHead + tail);
+};
+
+// Same idea as escapeIncompleteBlockMath, but for single `$` (inline
+// math). Mid-stream `The cost is $\frac{a}{` has one unmatched `$` —
+// escape it to `\$` so the renderer doesn't open a broken inline-math
+// span. Runs AFTER preprocessLaTeX so currency dollars are already
+// `\$5` (and won't be miscounted as inline-math openers).
+export const escapeIncompleteInlineMath = (content: string): string => {
+  const {
+    head: rawHead,
+    tail,
+    restore: restoreFences,
+  } = protectCodeFences(content, "INLMATH");
+
+  // Hide balanced `$$...$$` blocks too — their interior `$` is part of
+  // block math, not a separate inline delimiter.
+  const blockMath: string[] = [];
+  const blockNonce = Math.random().toString(36).slice(2);
+  let working = rawHead.replace(/\$\$[\s\S]*?\$\$/g, (match) => {
+    blockMath.push(match);
+    return `___INLMATH_${blockNonce}_BM_${blockMath.length - 1}___`;
+  });
+
+  // Walk the string; collect positions of `$` that aren't already
+  // escaped (i.e. preceding char isn't `\`). Odd count → escape the
+  // last one.
+  const indices: number[] = [];
+  for (let i = 0; i < working.length; i++) {
+    if (working[i] === "$" && (i === 0 || working[i - 1] !== "\\")) {
+      indices.push(i);
+    }
+  }
+  if (indices.length % 2 === 1) {
+    const last = indices[indices.length - 1] as number;
+    working = working.slice(0, last) + "\\$" + working.slice(last + 1);
+  }
+
+  // Restore in reverse order: block-math markers first (they may
+  // contain code-fence markers inside them), then code fences.
+  const restoredBlocks = working.replace(
+    new RegExp(`___INLMATH_${blockNonce}_BM_(\\d+)___`, "g"),
+    (_, i) => blockMath[Number(i)] ?? ""
   );
+  return restoreFences(restoredBlocks + tail);
 };

--- a/web/src/app/app/message/codeUtils.ts
+++ b/web/src/app/app/message/codeUtils.ts
@@ -141,3 +141,24 @@ export const preprocessLaTeX = (content: string) => {
 
   return restoredCodeBlocks;
 };
+
+// Drop a trailing unclosed `$$...` block so rehype-katex doesn't render
+// KaTeX error text mid-stream. Closed fenced code blocks are protected so
+// a literal `$$` quoted inside ```...``` isn't counted as a math fence.
+export const stripIncompleteBlockMath = (content: string): string => {
+  const codeBlocks: string[] = [];
+  const protectedContent = content.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `___MATHSTRIP_CB_${codeBlocks.length - 1}___`;
+  });
+
+  // Even array length ⇔ odd `$$` count ⇔ trailing unmatched fence.
+  const parts = protectedContent.split("$$");
+  if (parts.length % 2 === 0) parts.pop();
+  const stripped = parts.join("$$");
+
+  return stripped.replace(
+    /___MATHSTRIP_CB_(\d+)___/g,
+    (_, i) => codeBlocks[Number(i)] ?? ""
+  );
+};

--- a/web/src/app/app/message/codeUtils.ts
+++ b/web/src/app/app/message/codeUtils.ts
@@ -142,23 +142,31 @@ export const preprocessLaTeX = (content: string) => {
   return restoredCodeBlocks;
 };
 
-// Drop a trailing unclosed `$$...` block so rehype-katex doesn't render
-// KaTeX error text mid-stream. Closed fenced code blocks are protected so
-// a literal `$$` quoted inside ```...``` isn't counted as a math fence.
-export const stripIncompleteBlockMath = (content: string): string => {
+// Escape a trailing unclosed `$$` so remark-math skips it mid-stream while
+// the user still sees `$$` literally — the LaTeX source streams as plain
+// text, then swaps to a rendered formula the moment the closing `$$`
+// arrives. Closed fenced code blocks are protected so a literal `$$`
+// quoted inside ```...``` isn't counted as a math fence.
+export const escapeIncompleteBlockMath = (content: string): string => {
   const codeBlocks: string[] = [];
   const protectedContent = content.replace(/```[\s\S]*?```/g, (match) => {
     codeBlocks.push(match);
-    return `___MATHSTRIP_CB_${codeBlocks.length - 1}___`;
+    return `___MATHESC_CB_${codeBlocks.length - 1}___`;
   });
 
   // Even array length ⇔ odd `$$` count ⇔ trailing unmatched fence.
   const parts = protectedContent.split("$$");
-  if (parts.length % 2 === 0) parts.pop();
-  const stripped = parts.join("$$");
+  let result: string;
+  if (parts.length % 2 === 0) {
+    const tail = parts[parts.length - 1] ?? "";
+    const head = parts.slice(0, -1).join("$$");
+    result = `${head}\\$\\$${tail}`;
+  } else {
+    result = parts.join("$$");
+  }
 
-  return stripped.replace(
-    /___MATHSTRIP_CB_(\d+)___/g,
+  return result.replace(
+    /___MATHESC_CB_(\d+)___/g,
     (_, i) => codeBlocks[Number(i)] ?? ""
   );
 };

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -1,3 +1,28 @@
+/* Soft fade-in for KaTeX math elements during streaming. At the moment a
+   `$$...$$` block flips from streamed plain-text source to a rendered
+   formula the DOM swaps + the block's height changes — the fade smooths
+   what would otherwise read as a hard pop. Animation only fires on
+   element mount, so already-rendered formulas don't re-flicker on each
+   typewriter tick. */
+@keyframes onyx-math-appear {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.katex {
+  animation: onyx-math-appear 120ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .katex {
+    animation: none;
+  }
+}
+
 /* Map Tailwind Typography prose variables to the project's color tokens.
    These auto-switch for dark mode via colors.css — no dark: modifier needed.
    Note: text-05 = highest contrast, text-01 = lowest. */

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -1,9 +1,8 @@
-/* Soft fade-in for KaTeX math elements during streaming. At the moment a
-   `$$...$$` block flips from streamed plain-text source to a rendered
-   formula the DOM swaps + the block's height changes — the fade smooths
-   what would otherwise read as a hard pop. Animation only fires on
-   element mount, so already-rendered formulas don't re-flicker on each
-   typewriter tick. */
+/* Soft fade-in for KaTeX math elements that mount during streaming. The
+   `.streaming-katex` wrapper is only applied to the in-flight markdown
+   subtree, so the fade fires when a `$$...$$` flips from streamed
+   plain-text source to a rendered formula — and never on already-loaded
+   chats, search panels, or route navigations. */
 @keyframes onyx-math-appear {
   from {
     opacity: 0;
@@ -13,12 +12,12 @@
   }
 }
 
-.katex {
+.streaming-katex .katex {
   animation: onyx-math-appear 120ms ease-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .katex {
+  .streaming-katex .katex {
     animation: none;
   }
 }

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -14,7 +14,7 @@ import {
 import {
   extractCodeText,
   preprocessLaTeX,
-  stripIncompleteBlockMath,
+  escapeIncompleteBlockMath,
 } from "@/app/app/message/codeUtils";
 import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { transformLinkUri } from "@/lib/utils";
@@ -95,9 +95,10 @@ export const processContent = (content: string): string => {
   // Also strip a lone [[ or [[N] or [[N]] at the very end (before the URL part arrives)
   content = content.replace(/\[\[(?:\d+\]?\]?)?$/, "");
 
-  // Drop a trailing unclosed `$$...` so rehype-katex doesn't briefly
-  // render KaTeX error text mid-stream.
-  content = stripIncompleteBlockMath(content);
+  // Escape a trailing unclosed `$$` so remark-math skips it mid-stream and
+  // the user sees the LaTeX source streaming as plain text. The block swaps
+  // to a rendered formula the moment the closing `$$` arrives.
+  content = escapeIncompleteBlockMath(content);
 
   const codeBlockRegex = /```(\w*)\n[\s\S]*?```|```[\s\S]*?$/g;
   const matches = content.match(codeBlockRegex);

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -11,7 +11,11 @@ import {
   MemoizedAnchor,
   MemoizedParagraph,
 } from "@/app/app/message/MemoizedTextComponents";
-import { extractCodeText, preprocessLaTeX } from "@/app/app/message/codeUtils";
+import {
+  extractCodeText,
+  preprocessLaTeX,
+  stripIncompleteBlockMath,
+} from "@/app/app/message/codeUtils";
 import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { transformLinkUri } from "@/lib/utils";
 import { cn } from "@opal/utils";
@@ -90,6 +94,10 @@ export const processContent = (content: string): string => {
   content = content.replace(/\[\[\d+\]\]\([^)]*$/, "");
   // Also strip a lone [[ or [[N] or [[N]] at the very end (before the URL part arrives)
   content = content.replace(/\[\[(?:\d+\]?\]?)?$/, "");
+
+  // Drop a trailing unclosed `$$...` so rehype-katex doesn't briefly
+  // render KaTeX error text mid-stream.
+  content = stripIncompleteBlockMath(content);
 
   const codeBlockRegex = /```(\w*)\n[\s\S]*?```|```[\s\S]*?$/g;
   const matches = content.match(codeBlockRegex);

--- a/web/src/app/app/message/messageComponents/markdownUtils.tsx
+++ b/web/src/app/app/message/messageComponents/markdownUtils.tsx
@@ -15,6 +15,7 @@ import {
   extractCodeText,
   preprocessLaTeX,
   escapeIncompleteBlockMath,
+  escapeIncompleteInlineMath,
 } from "@/app/app/message/codeUtils";
 import { CodeBlock } from "@/app/app/message/CodeBlock";
 import { transformLinkUri } from "@/lib/utils";
@@ -113,12 +114,12 @@ export const processContent = (content: string): string => {
 
     const lastMatch = matches[matches.length - 1];
     if (lastMatch && !lastMatch.endsWith("```")) {
-      return preprocessLaTeX(content);
+      return escapeIncompleteInlineMath(preprocessLaTeX(content));
     }
   }
 
   const processed = preprocessLaTeX(content);
-  return processed;
+  return escapeIncompleteInlineMath(processed);
 };
 
 /**

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -73,14 +73,15 @@ function getRevealPosition(markdown: string, cleanChars: number): number {
   return mdIndex;
 }
 
-// Cheap streaming plugins (gfm only) → cheap per-frame parse. Full
-// pipeline flips in once, at the end, for syntax highlighting + math.
-const STREAMING_REMARK_PLUGINS: PluggableList = [remarkGfm];
-const STREAMING_REHYPE_PLUGINS: PluggableList = [];
-const FULL_REMARK_PLUGINS: PluggableList = [
+// Streaming pipeline runs gfm + math so LaTeX renders live.
+// Syntax highlighting is the heavier of the two and stays deferred —
+// rehype-highlight only flips in once the stream is fully displayed.
+const STREAMING_REMARK_PLUGINS: PluggableList = [
   remarkGfm,
   [remarkMath, { singleDollarTextMath: true }],
 ];
+const STREAMING_REHYPE_PLUGINS: PluggableList = [rehypeKatex];
+const FULL_REMARK_PLUGINS: PluggableList = STREAMING_REMARK_PLUGINS;
 const FULL_REHYPE_PLUGINS: PluggableList = [rehypeHighlight, rehypeKatex];
 
 export const MessageTextRenderer: MessageRenderer<

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -400,7 +400,10 @@ export const MessageTextRenderer: MessageRenderer<
             Thinking
           </Text>
         ) : displayedContent.length > 0 ? (
-          <div dir="auto">
+          <div
+            dir="auto"
+            className={cn(!streamFullyDisplayed && "streaming-katex")}
+          >
             <ReactMarkdown
               className="prose prose-onyx font-main-content-body max-w-full"
               components={markdownComponents}


### PR DESCRIPTION
## Description
- Render LaTeX live during message streaming — `remark-math` + `rehype-katex` now run in the streaming pipeline instead of only flipping in at the end.
 - Escape a trailing unclosed `$$` mid-stream so the user sees the LaTeX source as plain text while it streams, then swaps to the rendered formula the moment the closing `$$` arrives. Closed fenced code blocks are protected so a literal `$$` inside ```` ``` ```` isn't counted as a math fence.
 - Add a 120ms KaTeX fade-in to soften the source→formula swap (respects `prefers-reduced-motion`).
ticket - https://linear.app/onyx-app/issue/ENG-4082/some-renderings-like-latex-does-not-apply-until-streaming-is-done

## How Has This Been Tested?
Before:
https://github.com/user-attachments/assets/a6289ba3-3530-45df-8a01-f77a9910c05f

After:
https://github.com/user-attachments/assets/6f5e7ce7-68da-49ac-99d2-28cdfe151f9f

  - Added unit tests for `escapeIncompleteBlockMath` in `web/src/app/app/message/codeUtils.test.ts` covering balanced fences, trailing unmatched `$$`, fenced code-block protection, and currency-only content.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render LaTeX live during message streaming by running `remark-math` and `rehype-katex` in the streaming pipeline. Fixes Linear ENG-4082 so math appears as it streams instead of only at the end.

- **Bug Fixes**
  - Run `remark-math` (with `singleDollarTextMath: true`) + `rehype-katex` during streaming; keep `rehype-highlight` for the final pass.
  - Escape trailing unmatched `$$` and `$` mid-stream so math shows as plain text until closed; ignore delimiters inside `$$...$$` or fenced code blocks; avoid double-escaping currency.
  - Add a 120ms `.katex` fade-in to smooth the source→formula swap (respects `prefers-reduced-motion`).
  - Add unit tests for `escapeIncompleteBlockMath` and `escapeIncompleteInlineMath`.

<sup>Written for commit 89b364122e1056a215572095bf4cd4ff1bfb51a8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10681?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

