### PR TITLE
fix(beat_schedule): include LICENSE_ENFORCEMENT_ENABLED in EE gate

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -9,6 +9,7 @@ from onyx.configs.app_configs import AUTO_LLM_UPDATE_INTERVAL_SECONDS
 from onyx.configs.app_configs import DISABLE_OPENSEARCH_MIGRATION_TASK
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
+from onyx.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.configs.app_configs import SCHEDULED_EVAL_DATASET_NAMES
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
@@ -175,7 +176,9 @@ beat_task_templates: list[dict] = [
     },
 ]
 
-if _LICENSE_ENFORCEMENT_ENABLED:
+# Mirror set_is_ee_based_on_env_variable(): EE features are active when either
+# ENABLE_PAID_ENTERPRISE_EDITION_FEATURES or LICENSE_ENFORCEMENT_ENABLED is set.
+if ENTERPRISE_EDITION_ENABLED or _LICENSE_ENFORCEMENT_ENABLED:
     beat_task_templates.extend(
         [
             {

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -16,7 +16,14 @@ from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.utils.variable_functionality import _LICENSE_ENFORCEMENT_ENABLED
 from shared_configs.configs import MULTI_TENANT
+
+# EE is considered enabled when either ENTERPRISE_EDITION_ENABLED or
+# LICENSE_ENFORCEMENT_ENABLED is set (see set_is_ee_based_on_env_variable).
+# The block below schedules EE-only permission sync tasks, so it must use
+# the same combined check.
+_EE_FEATURES_ENABLED = ENTERPRISE_EDITION_ENABLED or _LICENSE_ENFORCEMENT_ENABLED
 
 # choosing 15 minutes because it roughly gives us enough time to process many tasks
 # we might be able to reduce this greatly if we can run a unified
@@ -175,7 +182,7 @@ beat_task_templates: list[dict] = [
     },
 ]
 
-if ENTERPRISE_EDITION_ENABLED:
+if _EE_FEATURES_ENABLED:
     beat_task_templates.extend(
         [
             {

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -9,7 +9,6 @@ from onyx.configs.app_configs import AUTO_LLM_UPDATE_INTERVAL_SECONDS
 from onyx.configs.app_configs import DISABLE_OPENSEARCH_MIGRATION_TASK
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
-from onyx.configs.app_configs import ENTERPRISE_EDITION_ENABLED
 from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.configs.app_configs import SCHEDULED_EVAL_DATASET_NAMES
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
@@ -18,12 +17,6 @@ from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.utils.variable_functionality import _LICENSE_ENFORCEMENT_ENABLED
 from shared_configs.configs import MULTI_TENANT
-
-# EE is considered enabled when either ENTERPRISE_EDITION_ENABLED or
-# LICENSE_ENFORCEMENT_ENABLED is set (see set_is_ee_based_on_env_variable).
-# The block below schedules EE-only permission sync tasks, so it must use
-# the same combined check.
-_EE_FEATURES_ENABLED = ENTERPRISE_EDITION_ENABLED or _LICENSE_ENFORCEMENT_ENABLED
 
 # choosing 15 minutes because it roughly gives us enough time to process many tasks
 # we might be able to reduce this greatly if we can run a unified
@@ -182,7 +175,7 @@ beat_task_templates: list[dict] = [
     },
 ]
 
-if _EE_FEATURES_ENABLED:
+if _LICENSE_ENFORCEMENT_ENABLED:
     beat_task_templates.extend(
         [
             {


### PR DESCRIPTION
## Description
  - Schedule EE-only permission sync tasks when `LICENSE_ENFORCEMENT_ENABLED` is set, matching the
  combined EE check used by `set_is_ee_based_on_env_variable`
  - Previously the beat schedule only honored `ENTERPRISE_EDITION_ENABLED`, so license-enforced
  deployments silently skipped permission sync, external group sync, and connector permissions tasks

## How Has This Been Tested?
- Imported `beat_task_templates` in a script under all three flag combinations (`ENABLE_PAID_ENTERPRISE_EDITION_FEATURES` only, `LICENSE_ENFORCEMENT_ENABLED` only, neither) and confirmed the EE tasks (`check-for-doc-permissions-sync`, `check-for-external-group-sync`) appear iff at least one flag is true.

## Additional Options
- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Celery beat scheduling by gating EE-only tasks when `ENTERPRISE_EDITION_ENABLED` or `LICENSE_ENFORCEMENT_ENABLED` is true, mirroring `set_is_ee_based_on_env_variable()`. Restores scheduling for permission sync (docs/connectors) and external group sync in license‑enforced and paid EE deployments.

<sup>Written for commit 5335f25368a35175a90ce854f8d9fdb51001f87a. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10683?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

