### PR TITLE
fix(monitoring): skip monitor_process_memory in kubernetes

### DIFF
--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -43,6 +43,7 @@ from onyx.db.search_settings import get_active_search_settings_list
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import redis_lock_dump
 from onyx.utils.platform import is_running_in_container
+from onyx.utils.platform import is_running_in_kubernetes
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
 from shared_configs.configs import MULTI_TENANT
@@ -1002,6 +1003,9 @@ def monitor_process_memory(self: Task, *, tenant_id: str) -> None:  # noqa: ARG0
 
     # Skip memory monitoring if not in container
     if not is_running_in_container():
+        return
+
+    if is_running_in_kubernetes():
         return
 
     try:

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -1005,6 +1005,8 @@ def monitor_process_memory(self: Task, *, tenant_id: str) -> None:  # noqa: ARG0
     if not is_running_in_container():
         return
 
+    # In k8s each worker runs in its own pod with an isolated pid namespace,
+    # so psutil.process_iter() only sees the local worker.
     if is_running_in_kubernetes():
         return
 

--- a/backend/onyx/utils/platform.py
+++ b/backend/onyx/utils/platform.py
@@ -24,7 +24,12 @@ def _resolve_container_flag() -> bool:
 
 
 _IS_RUNNING_IN_CONTAINER: bool = _resolve_container_flag()
+_IS_RUNNING_IN_KUBERNETES: bool = os.getenv("KUBERNETES_SERVICE_HOST") is not None
 
 
 def is_running_in_container() -> bool:
     return _IS_RUNNING_IN_CONTAINER
+
+
+def is_running_in_kubernetes() -> bool:
+    return _IS_RUNNING_IN_KUBERNETES


### PR DESCRIPTION
## Description

In k8s each celery worker runs in its own pod with isolated pid namespace, so `psutil.process_iter()` in the monitoring pod only sees its own celery worker. The supervisor-style process discovery in `monitor_process_memory` then emits spurious `Missing processes: {...}` errors for every other worker on every run, flooding Sentry (ONYX-BACKEND-H8VC, H8B6).

Adds `is_running_in_kubernetes()` helper (checks `KUBERNETES_SERVICE_HOST`) and short-circuits the task when set. Docker-compose / supervisor deploys are unaffected — they keep the existing per-process memory metrics path. K8s deploys already get memory metrics via Prometheus / kube-state-metrics, so nothing is lost.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check