### PR TITLE
fix(metrics): pass tenant_id explicitly to indexing-task connector resolver [ENG-4085]

### DIFF
--- a/backend/onyx/server/metrics/indexing_task_metrics.py
+++ b/backend/onyx/server/metrics/indexing_task_metrics.py
@@ -32,7 +32,6 @@ from prometheus_client import Histogram
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.server.metrics.celery_task_metrics import _MAX_START_TIME_AGE_SECONDS
 from onyx.utils.logger import setup_logger
-from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
@@ -113,20 +112,21 @@ def _evict_stale_start_times() -> None:
         _indexing_start_times.pop(tid, None)
 
 
-def _resolve_connector(cc_pair_id: int) -> ConnectorInfo:
+def _resolve_connector(cc_pair_id: int, tenant_id: str) -> ConnectorInfo:
     """Resolve cc_pair_id to ConnectorInfo, using cache when possible.
 
     On cache miss, does a single DB query with eager connector load.
     On any failure, returns _UNKNOWN_CONNECTOR without caching, so that
     subsequent calls can retry the lookup once the DB is available.
 
-    Note on tenant_id source: we read CURRENT_TENANT_ID_CONTEXTVAR for the
-    cache key. The Celery tenant-aware middleware sets this contextvar before
-    task execution, and it always matches kwargs["tenant_id"] (which is set
-    at task dispatch time). They are guaranteed to agree for a given task
-    execution context.
+    tenant_id must be passed in explicitly. The signal callbacks that call
+    this run outside the TenantAwareTask body (prerun fires before, postrun
+    fires after the contextvar is cleared), so CURRENT_TENANT_ID_CONTEXTVAR
+    is not reliably set at this point.
     """
-    tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get("") or ""
+    if not tenant_id or tenant_id == "unknown":
+        return _UNKNOWN_CONNECTOR
+
     cache_key = (tenant_id, cc_pair_id)
 
     with _connector_cache_lock:
@@ -138,9 +138,9 @@ def _resolve_connector(cc_pair_id: int) -> ConnectorInfo:
         from onyx.db.connector_credential_pair import (
             get_connector_credential_pair_from_id,
         )
-        from onyx.db.engine.sql_engine import get_session_with_current_tenant
+        from onyx.db.engine.sql_engine import get_session_with_tenant
 
-        with get_session_with_current_tenant() as db_session:
+        with get_session_with_tenant(tenant_id=tenant_id) as db_session:
             cc_pair = get_connector_credential_pair_from_id(
                 db_session,
                 cc_pair_id,
@@ -190,7 +190,7 @@ def on_indexing_task_prerun(
         if cc_pair_id is None:
             return
 
-        info = _resolve_connector(cc_pair_id)
+        info = _resolve_connector(cc_pair_id, tenant_id)
 
         INDEXING_TASK_STARTED.labels(
             task_name=task_name,
@@ -230,7 +230,7 @@ def on_indexing_task_postrun(
         if cc_pair_id is None:
             return
 
-        info = _resolve_connector(cc_pair_id)
+        info = _resolve_connector(cc_pair_id, tenant_id)
         outcome = "success" if state == "SUCCESS" else "failure"
 
         INDEXING_TASK_COMPLETED.labels(

--- a/backend/tests/unit/server/metrics/test_indexing_task_metrics.py
+++ b/backend/tests/unit/server/metrics/test_indexing_task_metrics.py
@@ -18,20 +18,12 @@ from onyx.server.metrics.indexing_task_metrics import on_indexing_task_prerun
 
 @pytest.fixture(autouse=True)
 def reset_state() -> Iterator[None]:
-    """Clear caches and state between tests.
-
-    Sets CURRENT_TENANT_ID_CONTEXTVAR to a realistic value so cache keys
-    are never keyed on an empty string.
-    """
-    from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
-
-    token = CURRENT_TENANT_ID_CONTEXTVAR.set("test_tenant")
+    """Clear caches and state between tests."""
     _connector_cache.clear()
     _indexing_start_times.clear()
     yield
     _connector_cache.clear()
     _indexing_start_times.clear()
-    CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 def _make_task(name: str) -> MagicMock:
@@ -48,7 +40,7 @@ def _mock_db_lookup(
     mock_cc_pair.name = name
     mock_cc_pair.connector.source.value = source
 
-    session_patch = patch("onyx.db.engine.sql_engine.get_session_with_current_tenant")
+    session_patch = patch("onyx.db.engine.sql_engine.get_session_with_tenant")
     cc_pair_patch = patch(
         "onyx.db.connector_credential_pair.get_connector_credential_pair_from_id",
         return_value=mock_cc_pair,
@@ -65,7 +57,7 @@ class TestIndexingTaskPrerun:
 
     def test_emits_started_for_docfetching(self) -> None:
         # Pre-populate cache to avoid DB lookup (tenant-scoped key)
-        _connector_cache[("test_tenant", 42)] = ConnectorInfo(
+        _connector_cache[("tenant-1", 42)] = ConnectorInfo(
             source="google_drive", name="My Google Drive"
         )
 
@@ -92,7 +84,7 @@ class TestIndexingTaskPrerun:
         assert "task-1" in _indexing_start_times
 
     def test_emits_started_for_docprocessing(self) -> None:
-        _connector_cache[("test_tenant", 10)] = ConnectorInfo(
+        _connector_cache[("public", 10)] = ConnectorInfo(
             source="slack", name="Slack Connector"
         )
 
@@ -103,7 +95,7 @@ class TestIndexingTaskPrerun:
         assert "task-2" in _indexing_start_times
 
     def test_cache_hit_avoids_db_call(self) -> None:
-        _connector_cache[("test_tenant", 42)] = ConnectorInfo(
+        _connector_cache[("public", 42)] = ConnectorInfo(
             source="confluence", name="Engineering Confluence"
         )
 
@@ -137,7 +129,7 @@ class TestIndexingTaskPrerun:
             kwargs = {"cc_pair_id": 77, "tenant_id": "public"}
 
             on_indexing_task_prerun("task-1", task, kwargs)
-            mock_resolve.assert_called_once_with(77)
+            mock_resolve.assert_called_once_with(77, "public")
 
     def test_missing_cc_pair_returns_unknown(self) -> None:
         """When _resolve_connector can't find the cc_pair, uses 'unknown'."""
@@ -177,7 +169,7 @@ class TestIndexingTaskPostrun:
         # Should not raise
 
     def test_emits_completed_and_duration(self) -> None:
-        _connector_cache[("test_tenant", 42)] = ConnectorInfo(
+        _connector_cache[("public", 42)] = ConnectorInfo(
             source="google_drive", name="Marketing Drive"
         )
 
@@ -221,9 +213,7 @@ class TestIndexingTaskPostrun:
         assert after_duration > before_duration
 
     def test_failure_outcome(self) -> None:
-        _connector_cache[("test_tenant", 42)] = ConnectorInfo(
-            source="slack", name="Slack"
-        )
+        _connector_cache[("public", 42)] = ConnectorInfo(source="slack", name="Slack")
 
         task = _make_task("connector_doc_fetching_task")
         kwargs = {"cc_pair_id": 42, "tenant_id": "public"}
@@ -252,9 +242,7 @@ class TestIndexingTaskPostrun:
 
     def test_handles_postrun_without_prerun(self) -> None:
         """Postrun for an indexing task without a matching prerun should not crash."""
-        _connector_cache[("test_tenant", 42)] = ConnectorInfo(
-            source="slack", name="Slack"
-        )
+        _connector_cache[("public", 42)] = ConnectorInfo(source="slack", name="Slack")
 
         task = _make_task("docprocessing_task")
         kwargs = {"cc_pair_id": 42, "tenant_id": "public"}
@@ -266,70 +254,66 @@ class TestIndexingTaskPostrun:
 class TestResolveConnector:
     def test_failed_lookup_not_cached(self) -> None:
         """When DB lookup returns None, result should NOT be cached."""
-        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+        with (
+            patch("onyx.db.engine.sql_engine.get_session_with_tenant"),
+            patch(
+                "onyx.db.connector_credential_pair"
+                ".get_connector_credential_pair_from_id",
+                return_value=None,
+            ),
+        ):
+            from onyx.server.metrics.indexing_task_metrics import _resolve_connector
 
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set("test-tenant")
-        try:
-            with (
-                patch("onyx.db.engine.sql_engine.get_session_with_current_tenant"),
-                patch(
-                    "onyx.db.connector_credential_pair"
-                    ".get_connector_credential_pair_from_id",
-                    return_value=None,
-                ),
-            ):
-                from onyx.server.metrics.indexing_task_metrics import _resolve_connector
-
-                result = _resolve_connector(999)
-                assert result.source == "unknown"
-                # Should NOT be cached so subsequent calls can retry
-                assert ("test-tenant", 999) not in _connector_cache
-        finally:
-            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+            result = _resolve_connector(999, "test-tenant")
+            assert result.source == "unknown"
+            # Should NOT be cached so subsequent calls can retry
+            assert ("test-tenant", 999) not in _connector_cache
 
     def test_exception_not_cached(self) -> None:
         """When DB lookup raises, result should NOT be cached."""
-        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+        with patch(
+            "onyx.db.engine.sql_engine.get_session_with_tenant",
+            side_effect=Exception("DB down"),
+        ):
+            from onyx.server.metrics.indexing_task_metrics import _resolve_connector
 
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set("test-tenant")
-        try:
-            with (
-                patch(
-                    "onyx.db.engine.sql_engine.get_session_with_current_tenant",
-                    side_effect=Exception("DB down"),
-                ),
-            ):
-                from onyx.server.metrics.indexing_task_metrics import _resolve_connector
-
-                result = _resolve_connector(888)
-                assert result.source == "unknown"
-                assert ("test-tenant", 888) not in _connector_cache
-        finally:
-            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+            result = _resolve_connector(888, "test-tenant")
+            assert result.source == "unknown"
+            assert ("test-tenant", 888) not in _connector_cache
 
     def test_successful_lookup_is_cached(self) -> None:
         """When DB lookup succeeds, result should be cached."""
-        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+        mock_cc_pair = MagicMock()
+        mock_cc_pair.name = "My Drive"
+        mock_cc_pair.connector.source.value = "google_drive"
 
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set("test-tenant")
-        try:
-            mock_cc_pair = MagicMock()
-            mock_cc_pair.name = "My Drive"
-            mock_cc_pair.connector.source.value = "google_drive"
+        with (
+            patch("onyx.db.engine.sql_engine.get_session_with_tenant"),
+            patch(
+                "onyx.db.connector_credential_pair"
+                ".get_connector_credential_pair_from_id",
+                return_value=mock_cc_pair,
+            ),
+        ):
+            from onyx.server.metrics.indexing_task_metrics import _resolve_connector
 
-            with (
-                patch("onyx.db.engine.sql_engine.get_session_with_current_tenant"),
-                patch(
-                    "onyx.db.connector_credential_pair"
-                    ".get_connector_credential_pair_from_id",
-                    return_value=mock_cc_pair,
-                ),
-            ):
-                from onyx.server.metrics.indexing_task_metrics import _resolve_connector
+            result = _resolve_connector(777, "test-tenant")
+            assert result.source == "google_drive"
+            assert result.name == "My Drive"
+            assert ("test-tenant", 777) in _connector_cache
 
-                result = _resolve_connector(777)
-                assert result.source == "google_drive"
-                assert result.name == "My Drive"
-                assert ("test-tenant", 777) in _connector_cache
-        finally:
-            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    def test_unknown_tenant_skips_db_lookup(self) -> None:
+        """When tenant_id is missing or 'unknown', return early without
+        hitting the DB. This is the regression path for the
+        UndefinedTable: public.connector_credential_pair errors that fired
+        when callbacks ran outside tenant context."""
+        with patch(
+            "onyx.db.engine.sql_engine.get_session_with_tenant",
+            side_effect=AssertionError("DB should not be touched"),
+        ):
+            from onyx.server.metrics.indexing_task_metrics import _resolve_connector
+
+            assert _resolve_connector(1, "unknown").source == "unknown"
+            assert _resolve_connector(2, "").source == "unknown"
+            assert (1, "unknown") not in _connector_cache
+            assert (2, "") not in _connector_cache


### PR DESCRIPTION
## Description

The indexing-task celery signal callbacks (`on_indexing_task_prerun`, `on_indexing_task_postrun`) fire **outside** the `TenantAwareTask.__call__` body — which is where `CURRENT_TENANT_ID_CONTEXTVAR` actually gets set:

```
task_prerun signal       <-- contextvar NOT set
TenantAwareTask.__call__ <-- contextvar set from kwargs["tenant_id"]
task body                <-- contextvar available
__call__ finally         <-- contextvar cleared
task_postrun signal      <-- contextvar NOT set
```

`_resolve_connector` was reading the contextvar (always empty in this context) and calling `get_session_with_current_tenant()`, which then fell back to the `public` schema. In multi-tenant deployments the `connector_credential_pair` table only exists in `tenant_*` schemas, so every indexing-task callback was logging:

```
psycopg2.errors.UndefinedTable: relation "public.connector_credential_pair" does not exist
```

Caught at `DEBUG` level so tasks didn't fail, but every connector reported as `source=unknown` in metrics — defeating the purpose of the new per-connector labels added in #10635. Observed firing ~30/min/pod in the managed_services cluster.

**Fix**: thread `tenant_id` from `kwargs` into `_resolve_connector` and use `get_session_with_tenant(tenant_id=...)` directly. Also bail out early when `tenant_id` is missing or `"unknown"` so we never touch the DB without an explicit tenant.

## How Has This Been Tested?

- Updated all existing unit tests to use the new `_resolve_connector(cc_pair_id, tenant_id)` signature
- Added a regression test (`test_unknown_tenant_skips_db_lookup`) that asserts no DB call is made when `tenant_id` is `""` or `"unknown"` (the exact path that was hitting `public.connector_credential_pair`)
- All 16 tests pass: `pytest -xv backend/tests/unit/server/metrics/test_indexing_task_metrics.py`
- Verified post-deploy: error log rate for `UndefinedTable: public.connector_credential_pair` should drop to 0 in the managed_services cluster

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-tenant connector resolution in indexing-task metrics by passing `tenant_id` explicitly, preventing public-schema lookups and restoring accurate per-connector labels. Reduces noisy `UndefinedTable` logs and improves monitoring accuracy for ENG-4085.

- **Bug Fixes**
  - Pass `tenant_id` into `_resolve_connector(cc_pair_id, tenant_id)` and read it from task kwargs.
  - Switch to `get_session_with_tenant(tenant_id=...)` (replaces `get_session_with_current_tenant()`).
  - Return early when `tenant_id` is missing or `"unknown"` to avoid DB access.
  - Updated tests to new signature; added `test_unknown_tenant_skips_db_lookup`.

<sup>Written for commit 8965995d7ed3b9213a9af818b83efce924d23bfb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10689?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

