### PR TITLE
chore(devtools): Delete "Profile celery beat" which uses "austin" from `.vscode/tasks.template.jsonc`

### DIFF
--- a/.vscode/tasks.template.jsonc
+++ b/.vscode/tasks.template.jsonc
@@ -2,25 +2,6 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "type": "austin",
-            "label": "Profile celery beat",
-            "envFile": "${workspaceFolder}/.env",
-            "options": {
-              "cwd": "${workspaceFolder}/backend"
-            },
-            "command": [
-                "sudo",
-                "-E"
-            ],
-            "args": [
-              "celery",
-              "-A",
-              "onyx.background.celery.versioned_apps.beat",
-              "beat",
-              "--loglevel=INFO"
-            ]
-        },
-        {
             "type": "shell",
             "label": "Generate Onyx OpenAPI Python client",
             "cwd": "${workspaceFolder}/backend",


### PR DESCRIPTION
## Description
Every time I started my IDE I would see "Error: there is no registered task type 'austin'. Did you miss installing an extension that provides a corresponding task provider?". Don't think we should have tasks committed in our repo that require certain non-standard extensions. Don't think any dev uses this profiling task anyway, the last time someone did python profiling was @Bo-Onyx for the API server and he used completely different tools.

## How Has This Been Tested?
Was not.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the "Profile celery beat" VS Code task that required the `austin` extension. This stops the missing task provider error on startup and removes a non-standard extension dependency.

<sup>Written for commit 9e107f7f076af0e68f8d4853d397ddef214e13fb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10690?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

