### PR TITLE
fix(external-group-sync): bridge fence validator transition gap

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -758,24 +758,20 @@ def validate_external_group_sync_fence(
     )
     if found:
         # the celery task exists in the redis queue
-        # redis_connector_index.set_active()
+        redis_connector.external_group_sync.set_active()
         return
 
     if payload.celery_task_id in reserved_tasks:
         # the celery task was prefetched and is reserved within the indexing worker
-        # redis_connector_index.set_active()
+        redis_connector.external_group_sync.set_active()
         return
-
-    # we may want to enable this check if using the active task list somehow isn't good enough
-    # if redis_connector_index.generator_locked():
-    #     logger.info(f"{payload.celery_task_id} is currently executing.")
 
     # if we get here, we didn't find any direct indication that the associated celery tasks exist,
     # but they still might be there due to gaps in our ability to check states during transitions
     # Checking the active signal safeguards us against these transition periods
     # (which has a duration that allows us to bridge those gaps)
-    # if redis_connector_index.active():
-    # return
+    if redis_connector.external_group_sync.active():
+        return
 
     # celery tasks don't exist and the active signal has expired, possibly due to a crash. Clean it up.
     emit_background_error(


### PR DESCRIPTION
## Description

`validate_external_group_sync_fence` had its active-signal scaffolding stubbed out. The `set_active()` calls in the find-task-in-queue and find-task-in-reserved branches were commented out, and the `active()` check before `reset()` was disabled.

When a celery task is mid-prefetch (out of the broker queue but not yet in any worker's `reserved_tasks` list), the validator races past the find checks, hits `reset()`, and deletes the fence. The worker then picks up the task, sees `fenced=False`, and raises `ValueError`.

This enables the same active-signal bridge that `validate_pruning_fence` already uses to handle this transition gap. Each successful sighting of the task refreshes the active TTL, and a fresh active signal blocks the reset path.

Silences ONYX-BACKEND-H6QX (1074 events).

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check