### PR TITLE
fix(connectors): add HTTP timeouts to prevent worker hangs

### DIFF
--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -14,6 +14,7 @@ from pyairtable.models.schema import TableSchema
 from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
@@ -258,7 +259,9 @@ class AirtableConnector(LoadConnector):
                 )
                 def get_attachment_with_retry(url: str, record_id: str) -> bytes | None:
                     try:
-                        attachment_response = requests.get(url)
+                        attachment_response = requests.get(
+                            url, timeout=REQUEST_TIMEOUT_SECONDS
+                        )
                         attachment_response.raise_for_status()
                         return attachment_response.content
                     except requests.exceptions.HTTPError as e:
@@ -274,7 +277,9 @@ class AirtableConnector(LoadConnector):
                                 if refreshed_attachment.get("filename") == filename:
                                     new_url = refreshed_attachment.get("url")
                                     if new_url:
-                                        attachment_response = requests.get(new_url)
+                                        attachment_response = requests.get(
+                                            new_url, timeout=REQUEST_TIMEOUT_SECONDS
+                                        )
                                         attachment_response.raise_for_status()
                                         return attachment_response.content
 

--- a/backend/onyx/connectors/axero/connector.py
+++ b/backend/onyx/connectors/axero/connector.py
@@ -7,6 +7,7 @@ import requests
 from pydantic import BaseModel
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import process_in_batches
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
@@ -37,7 +38,9 @@ def _rate_limited_request(
     endpoint: str, headers: dict, params: dict | None = None
 ) -> Any:
     # https://my.axerosolutions.com/spaces/5/communifire-documentation/wiki/view/370/rest-api
-    return requests.get(endpoint, headers=headers, params=params)
+    return requests.get(
+        endpoint, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
+    )
 
 
 # https://my.axerosolutions.com/spaces/5/communifire-documentation/wiki/view/595/rest-api-get-content-list

--- a/backend/onyx/connectors/bookstack/client.py
+++ b/backend/onyx/connectors/bookstack/client.py
@@ -2,6 +2,8 @@ from typing import Any
 
 import requests
 
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
+
 
 class BookStackClientRequestFailedError(ConnectionError):
     def __init__(self, status: int, error: str) -> None:
@@ -28,7 +30,9 @@ class BookStackApiClient:
     def get(self, endpoint: str, params: dict[str, str]) -> dict[str, Any]:
         url: str = self._build_url(endpoint)
         headers = self._build_headers()
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(
+            url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
+        )
 
         try:
             json = response.json()

--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -6,6 +6,7 @@ from typing import Optional
 import requests
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rate_limit_builder
 from onyx.connectors.interfaces import GenerateDocumentsOutput
@@ -53,7 +54,10 @@ class ClickupConnector(LoadConnector, PollConnector):
         headers = {"Authorization": self.api_token}
 
         response = requests.get(
-            f"{CLICKUP_API_BASE_URL}/{endpoint}", headers=headers, params=params
+            f"{CLICKUP_API_BASE_URL}/{endpoint}",
+            headers=headers,
+            params=params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
         response.raise_for_status()

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -22,6 +22,7 @@ from onyx.configs.app_configs import (
     CONFLUENCE_CONNECTOR_ATTACHMENT_CHAR_COUNT_THRESHOLD,
 )
 from onyx.configs.app_configs import CONFLUENCE_CONNECTOR_ATTACHMENT_SIZE_THRESHOLD
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import FileOrigin
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
@@ -318,6 +319,7 @@ def confluence_refresh_tokens(
             "client_secret": client_secret,
             "refresh_token": refresh_token,
         },
+        timeout=REQUEST_TIMEOUT_SECONDS,
     )
 
     try:

--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from requests import Response
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rate_limit_builder
@@ -40,7 +41,9 @@ def discourse_request(
 ) -> Response:
     headers = {"Api-Key": perms.api_key, "Api-Username": perms.api_username}
 
-    response = requests.get(endpoint, headers=headers, params=params)
+    response = requests.get(
+        endpoint, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
+    )
     response.raise_for_status()
 
     return response

--- a/backend/onyx/connectors/document360/connector.py
+++ b/backend/onyx/connectors/document360/connector.py
@@ -7,6 +7,7 @@ from typing import Optional
 import requests
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rate_limit_builder
 from onyx.connectors.document360.utils import flatten_child_categories
@@ -63,7 +64,10 @@ class Document360Connector(LoadConnector, PollConnector):
         headers = {"accept": "application/json", "api_token": self.api_token}
 
         response = requests.get(
-            f"{DOCUMENT360_API_BASE_URL}/{endpoint}", headers=headers, params=params
+            f"{DOCUMENT360_API_BASE_URL}/{endpoint}",
+            headers=headers,
+            params=params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         response.raise_for_status()
 

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -8,6 +8,7 @@ from typing import List
 import requests
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
@@ -184,6 +185,7 @@ class FirefliesConnector(PollConnector, LoadConnector):
                         "query": _FIREFLIES_API_QUERY,
                         "variables": variables,
                     },
+                    timeout=REQUEST_TIMEOUT_SECONDS,
                 )
                 if response.status_code < 500 or attempt == _FIREFLIES_MAX_RETRIES - 1:
                     break

--- a/backend/onyx/connectors/gitbook/connector.py
+++ b/backend/onyx/connectors/gitbook/connector.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 import requests
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
@@ -33,7 +34,9 @@ class GitbookApiClient:
         }
 
         url = urljoin(GITBOOK_API_BASE, endpoint.lstrip("/"))
-        response = requests.get(url, headers=headers, params=params)
+        response = requests.get(
+            url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
+        )
         response.raise_for_status()
         return response.json()
 

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -11,6 +11,7 @@ import requests
 from hubspot import HubSpot
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.hubspot.rate_limit import HubSpotRateLimiter
 from onyx.connectors.interfaces import GenerateDocumentsOutput
@@ -144,7 +145,9 @@ class HubSpotConnector(LoadConnector, PollConnector):
             "Content-Type": "application/json",
         }
 
-        response = requests.get(HUBSPOT_API_URL, headers=headers)
+        response = requests.get(
+            HUBSPOT_API_URL, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+        )
         if response.status_code != 200:
             raise Exception("Error fetching portal ID")
 

--- a/backend/onyx/connectors/productboard/connector.py
+++ b/backend/onyx/connectors/productboard/connector.py
@@ -9,6 +9,7 @@ from dateutil import parser
 from retry import retry
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.interfaces import GenerateDocumentsOutput
@@ -68,7 +69,9 @@ class ProductboardConnector(PollConnector):
 
         @retry(tries=3, delay=1, backoff=2)
         def fetch(link: str) -> dict[str, Any]:
-            response = requests.get(link, headers=headers)
+            response = requests.get(
+                link, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+            )
             if not response.ok:
                 # rate-limiting is at 50 requests per second.
                 # The delay in this retry should handle this while this is

--- a/backend/onyx/connectors/testrail/connector.py
+++ b/backend/onyx/connectors/testrail/connector.py
@@ -11,6 +11,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
@@ -154,6 +155,7 @@ class TestRailConnector(LoadConnector, PollConnector):
                 url,
                 auth=(self.username, self.api_key),
                 params=params,
+                timeout=REQUEST_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -23,6 +23,7 @@ from typing_extensions import override
 from urllib3.exceptions import MaxRetryError
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_ID
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_TOKEN_URL
@@ -346,7 +347,9 @@ def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:
     # a regression as someone says "Ah, looks like this brotli package isn't used anywhere, let's remove it"
     # import brotli
     try:
-        response = requests.get(sitemap_url, headers=DEFAULT_HEADERS)
+        response = requests.get(
+            sitemap_url, headers=DEFAULT_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS
+        )
         response.raise_for_status()
         soup = BeautifulSoup(response.content, "html.parser")
         urls = [
@@ -519,7 +522,10 @@ class WebConnector(LoadConnector, SlimConnector):
 
         # First do a HEAD request to check content type without downloading the entire content
         head_response = requests.head(
-            initial_url, headers=DEFAULT_HEADERS, allow_redirects=True
+            initial_url,
+            headers=DEFAULT_HEADERS,
+            allow_redirects=True,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
         content_type = head_response.headers.get("content-type")
         is_pdf = is_pdf_resource(initial_url, content_type)
@@ -535,7 +541,9 @@ class WebConnector(LoadConnector, SlimConnector):
                 )
                 return result
 
-            response = requests.get(initial_url, headers=DEFAULT_HEADERS)
+            response = requests.get(
+                initial_url, headers=DEFAULT_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS
+            )
             page_text, metadata = extract_pdf_text(response.content)
             last_modified = response.headers.get("Last-Modified")
 

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from requests.exceptions import HTTPError
 from typing_extensions import override
 
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.app_configs import ZENDESK_CONNECTOR_SKIP_ARTICLE_LABELS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
@@ -70,7 +71,10 @@ def request_with_rate_limit(
     )
     def make_request(endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
         response = requests.get(
-            f"{client.base_url}/{endpoint}", auth=client.auth, params=params
+            f"{client.base_url}/{endpoint}",
+            auth=client.auth,
+            params=params,
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
         if response.status_code == 429:

--- a/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_rate_limit.py
+++ b/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_rate_limit.py
@@ -60,6 +60,7 @@ def test_zendesk_client_per_minute_rate_limiting(
         url: str,
         auth: Any,  # noqa: ARG001
         params: Dict[str, Any],  # noqa: ARG001
+        **kwargs: Any,  # noqa: ARG001
     ) -> _FakeResponse:
         calls.append(url)
         # minimal Zendesk list response (articles path)


### PR DESCRIPTION
## Description

Multiple connectors call `requests.get` / `requests.post` / `requests.head` without a `timeout=` argument. A stalled TCP connection or a hung server response blocks the worker thread indefinitely, the heartbeat counter stops advancing, and the indexing watchdog eventually marks the attempt failed (30 min heartbeat timeout, or 12-24 h overall stall).

Production data from the last two days:

| Source | 30 min heartbeat | Multi-hour stall | Total stuck |
|---|---|---|---|
| AIRTABLE | 31 | 10 | 41 |
| WEB | 15 | 17 | 32 |
| GOOGLE_DRIVE | 5 | 11 | 16 |
| SLACK | 6 | 2 | 8 |
| Others | 3 | 5 | 8 |

This sweep applies the existing `REQUEST_TIMEOUT_SECONDS` constant (default 60 s, env-overridable) to every untimed `requests.*` call across the connector tree, mirroring the pattern already in use by sharepoint, outline, and bitbucket. Files touched: airtable, web, axero, bookstack, clickup, confluence/utils, discourse, document360, fireflies, gitbook, hubspot, productboard, testrail, zendesk.

`requests`' read timeout is the per-chunk silence threshold, not a total request budget, so legitimate large downloads still complete as long as bytes keep flowing; only genuinely hung connections are aborted.

Silences ONYX-BACKEND-H7PW and ONYX-BACKEND-H876.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check