### PR TITLE
fix(slack): treat account_inactive as expired credential

### DIFF
--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1243,6 +1243,10 @@ class SlackConnector(
                 raise CredentialExpiredError(
                     f"Invalid or expired Slack bot token ({slack_error})."
                 )
+            elif slack_error == "account_inactive":
+                raise CredentialExpiredError(
+                    f"Slack workspace or bot user is deactivated ({slack_error})."
+                )
             raise UnexpectedValidationError(
                 f"Unexpected Slack error '{slack_error}' during settings validation."
             )

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1191,6 +1191,14 @@ class SlackConnector(
                     raise CredentialExpiredError(
                         f"Invalid or expired Slack bot token ({error_msg})."
                     )
+                elif error_msg == "account_inactive":
+                    raise CredentialExpiredError(
+                        f"Slack workspace or bot user is deactivated ({error_msg})."
+                    )
+                elif error_msg == "token_revoked":
+                    raise CredentialExpiredError(
+                        f"Slack bot token has been revoked ({error_msg})."
+                    )
                 raise UnexpectedValidationError(
                     f"Slack API returned a failure: {error_msg}"
                 )
@@ -1243,9 +1251,13 @@ class SlackConnector(
                 raise CredentialExpiredError(
                     f"Invalid or expired Slack bot token ({slack_error})."
                 )
-            elif slack_error in ("account_inactive", "token_revoked"):
+            elif slack_error == "account_inactive":
                 raise CredentialExpiredError(
-                    f"Slack workspace or bot user is deactivated or token was revoked ({slack_error})."
+                    f"Slack workspace or bot user is deactivated ({slack_error})."
+                )
+            elif slack_error == "token_revoked":
+                raise CredentialExpiredError(
+                    f"Slack bot token has been revoked ({slack_error})."
                 )
             raise UnexpectedValidationError(
                 f"Unexpected Slack error '{slack_error}' during settings validation."

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1191,14 +1191,6 @@ class SlackConnector(
                     raise CredentialExpiredError(
                         f"Invalid or expired Slack bot token ({error_msg})."
                     )
-                elif error_msg == "account_inactive":
-                    raise CredentialExpiredError(
-                        f"Slack workspace or bot user is deactivated ({error_msg})."
-                    )
-                elif error_msg == "token_revoked":
-                    raise CredentialExpiredError(
-                        f"Slack bot token has been revoked ({error_msg})."
-                    )
                 raise UnexpectedValidationError(
                     f"Slack API returned a failure: {error_msg}"
                 )

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1243,9 +1243,9 @@ class SlackConnector(
                 raise CredentialExpiredError(
                     f"Invalid or expired Slack bot token ({slack_error})."
                 )
-            elif slack_error == "account_inactive":
+            elif slack_error in ("account_inactive", "token_revoked"):
                 raise CredentialExpiredError(
-                    f"Slack workspace or bot user is deactivated ({slack_error})."
+                    f"Slack workspace or bot user is deactivated or token was revoked ({slack_error})."
                 )
             raise UnexpectedValidationError(
                 f"Unexpected Slack error '{slack_error}' during settings validation."


### PR DESCRIPTION
## Description

When a Slack workspace or bot user is deactivated, the API returns the error code `account_inactive`. `validate_connector_settings` only handled `ratelimited`, `missing_scope`, `invalid_auth`, and `not_authed`, so `account_inactive` fell through to the catch-all `UnexpectedValidationError`. The docfetching subprocess crashed (`exit_code=255`), the connector was never marked credential-expired, and Beat kept re-attempting it every scheduling cycle.

Effect: 33 dead attempts in 2 days for one tenant on prod, all with `total_docs_indexed=0` / `completed_batches=0`. Beat retry storm filling Sentry.

Route `account_inactive` to `CredentialExpiredError` alongside `invalid_auth` / `not_authed` so the connector is marked as needing fresh credentials and stops getting retried until the user reconnects.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check