### PR TITLE
chore(tests): unit tests for llm utils

### DIFF
--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -839,12 +839,11 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
         )
         if model_obj and "supports_reasoning" in model_obj:
             reasoning = model_obj["supports_reasoning"]
-            if reasoning is None:
-                logger.error(
-                    f"Cannot find reasoning for name={model_name} and provider={model_provider}"
-                )
-                reasoning = False
-            return reasoning
+            if reasoning is not None:
+                return reasoning
+            logger.error(
+                f"Cannot find reasoning for name={model_name} and provider={model_provider}"
+            )
 
         # Fallback: try using litellm.supports_reasoning() for newer models
         try:

--- a/backend/tests/unit/onyx/llm/test_model_map.py
+++ b/backend/tests/unit/onyx/llm/test_model_map.py
@@ -6,6 +6,7 @@ from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.utils import find_model_obj
 from onyx.llm.utils import get_model_map
+from onyx.llm.utils import model_is_reasoning_model
 
 
 def test_partial_match_in_model_map() -> None:
@@ -81,6 +82,39 @@ def test_no_overwrite_in_model_map() -> None:
         assert result["is_correct"] is True
 
     get_model_map.cache_clear()
+
+
+def test_model_is_reasoning_model_handles_none_in_model_map() -> None:
+    """Regression: litellm may set supports_reasoning=None for some models.
+    model_is_reasoning_model must always return a bool, never None."""
+    mock_model_cost = {
+        "openai/gpt-4o": {
+            "supports_reasoning": None,
+        },
+        "openai/o3": {
+            "supports_reasoning": True,
+        },
+        "openai/gpt-4o-mini": {
+            # key missing entirely
+        },
+    }
+
+    with patch.object(litellm, "model_cost", mock_model_cost):
+        get_model_map.cache_clear()
+        try:
+            # None in map — should fall through to litellm.supports_reasoning
+            result = model_is_reasoning_model("gpt-4o", "openai")
+            assert result is False or result is True  # must be a bool, not None
+
+            # True in map — should return True
+            result = model_is_reasoning_model("o3", "openai")
+            assert result is True
+
+            # Missing key — should fall through to litellm.supports_reasoning
+            result = model_is_reasoning_model("gpt-4o-mini", "openai")
+            assert result is False or result is True
+        finally:
+            get_model_map.cache_clear()
 
 
 def test_twelvelabs_pegasus_override_present() -> None:

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -1,0 +1,214 @@
+"""Tests for the token-limit lookup helpers in `onyx.llm.utils`:
+`llm_max_input_tokens`, `get_llm_max_output_tokens`, and `get_max_input_tokens`."""
+
+from unittest.mock import patch
+
+from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+from onyx.llm.utils import get_llm_max_output_tokens
+from onyx.llm.utils import get_max_input_tokens
+from onyx.llm.utils import llm_max_input_tokens
+
+
+class TestLlmMaxInputTokens:
+    def test_prefers_max_input_tokens(self) -> None:
+        model_map = {"openai/gpt-4o": {"max_input_tokens": 128000, "max_tokens": 4096}}
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == 128000
+        )
+
+    def test_falls_back_to_max_tokens(self) -> None:
+        model_map = {"openai/gpt-4o": {"max_tokens": 4096}}
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == 4096
+        )
+
+    def test_model_not_found_returns_fallback(self) -> None:
+        assert (
+            llm_max_input_tokens(
+                model_map={},
+                model_name="nonexistent",
+                model_provider="openai",
+            )
+            == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        )
+
+    def test_model_has_no_token_keys_returns_fallback(self) -> None:
+        model_map = {"openai/gpt-4o": {"input_cost_per_token": 0.0001}}
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        )
+
+    def test_none_max_input_tokens_falls_through(self) -> None:
+        # Regression: litellm 1.83.0 ships entries like ollama_chat/gpt-oss:20b-cloud
+        # with `max_input_tokens: None` — previously returned None and crashed callers.
+        model_map = {
+            "ollama_chat/gpt-oss:20b-cloud": {
+                "max_input_tokens": None,
+                "max_tokens": 131072,
+            }
+        }
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-oss:20b-cloud",
+                model_provider="ollama_chat",
+            )
+            == 131072
+        )
+
+    def test_all_none_falls_back_to_default(self) -> None:
+        model_map = {
+            "ollama_chat/gpt-oss:20b-cloud": {
+                "max_input_tokens": None,
+                "max_tokens": None,
+            }
+        }
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-oss:20b-cloud",
+                model_provider="ollama_chat",
+            )
+            == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        )
+
+    def test_override_env_var_wins(self) -> None:
+        model_map = {"openai/gpt-4o": {"max_input_tokens": 128000}}
+        with patch("onyx.llm.utils.GEN_AI_MAX_TOKENS", 5000):
+            assert (
+                llm_max_input_tokens(
+                    model_map=model_map,
+                    model_name="gpt-4o",
+                    model_provider="openai",
+                )
+                == 5000
+            )
+
+
+class TestGetLlmMaxOutputTokens:
+    def test_prefers_max_output_tokens(self) -> None:
+        model_map = {
+            "openai/gpt-4o": {"max_output_tokens": 16384, "max_tokens": 128000}
+        }
+        assert (
+            get_llm_max_output_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == 16384
+        )
+
+    def test_falls_back_to_ten_percent_of_max_tokens(self) -> None:
+        model_map = {"openai/gpt-4o": {"max_tokens": 100000}}
+        assert (
+            get_llm_max_output_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == 10000
+        )
+
+    def test_lookup_without_provider_prefix(self) -> None:
+        model_map = {"gpt-4o": {"max_output_tokens": 4096}}
+        assert (
+            get_llm_max_output_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+            )
+            == 4096
+        )
+
+    def test_model_not_found_returns_fallback(self) -> None:
+        assert get_llm_max_output_tokens(
+            model_map={},
+            model_name="nonexistent",
+            model_provider="openai",
+        ) == int(GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
+
+    def test_none_max_output_tokens_falls_through(self) -> None:
+        # Regression — same None-in-model_cost shape as litellm 1.83.0 produces.
+        model_map = {
+            "ollama_chat/gpt-oss:20b-cloud": {
+                "max_output_tokens": None,
+                "max_tokens": 131072,
+            }
+        }
+        assert get_llm_max_output_tokens(
+            model_map=model_map,
+            model_name="gpt-oss:20b-cloud",
+            model_provider="ollama_chat",
+        ) == int(131072 * 0.1)
+
+    def test_all_none_falls_back_to_default(self) -> None:
+        model_map = {
+            "ollama_chat/gpt-oss:20b-cloud": {
+                "max_output_tokens": None,
+                "max_tokens": None,
+            }
+        }
+        assert get_llm_max_output_tokens(
+            model_map=model_map,
+            model_name="gpt-oss:20b-cloud",
+            model_provider="ollama_chat",
+        ) == int(GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
+
+
+class TestGetMaxInputTokens:
+    def test_subtracts_reserved_output_tokens(self) -> None:
+        model_map = {"openai/gpt-4o": {"max_input_tokens": 128000}}
+        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+            assert (
+                get_max_input_tokens(
+                    model_name="gpt-4o",
+                    model_provider="openai",
+                    output_tokens=1024,
+                )
+                == 128000 - 1024
+            )
+
+    def test_non_positive_budget_falls_back(self) -> None:
+        model_map = {"tiny/model": {"max_input_tokens": 100}}
+        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+            assert (
+                get_max_input_tokens(
+                    model_name="model",
+                    model_provider="tiny",
+                    output_tokens=100,
+                )
+                == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+            )
+
+    def test_does_not_raise_when_litellm_returns_none_values(self) -> None:
+        # This is the exact path that 500'd the nightly provider chat test
+        # for ollama_chat/gpt-oss:20b-cloud on litellm 1.83.0.
+        model_map = {
+            "ollama_chat/gpt-oss:20b-cloud": {
+                "max_input_tokens": None,
+                "max_tokens": None,
+            }
+        }
+        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+            result = get_max_input_tokens(
+                model_name="gpt-oss:20b-cloud",
+                model_provider="ollama_chat",
+            )
+        assert isinstance(result, int)
+        assert result > 0


### PR DESCRIPTION
## Description

These are effectively regression tests for these two commits: 3e75994be & 2fb086052

Note, there is a small, functional change to `backend/onyx/llm/utils.py`

## How Has This Been Tested?

`uv run pytest backend/tests/unit/onyx/llm/test_model_map.py backend/tests/unit/onyx/llm/test_token_limit_lookups.py`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression unit tests for `onyx.llm.utils` covering `llm_max_input_tokens`, `get_llm_max_output_tokens`, `get_max_input_tokens`, and `model_is_reasoning_model`; also update `model_is_reasoning_model` to fall back to `litellm.supports_reasoning` when `supports_reasoning` is `None`.

Tests verify fallbacks (`GEN_AI_MAX_TOKENS`, `GEN_AI_MODEL_FALLBACK_MAX_TOKENS`, 10% of `max_tokens`, minus reserved output tokens), provider-less lookups, and that `None` from `litellm` never crashes and always yields ints/bools.

<sup>Written for commit 64b5aa5a33e116048518255f377e469594b978e1. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

