### PR TITLE
fix(embedding): Change vertex embedding to global

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -368,7 +368,7 @@ class CloudEmbedding:
         location = (
             service_account_info.get("location")
             or os.environ.get("GOOGLE_CLOUD_LOCATION")
-            or "us-central1"
+            or "global"
         )
 
         client = genai.Client(


### PR DESCRIPTION
## Description
Changes the default location of the vertex embedding model from us-central1 to global.

## How Has This Been Tested?


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default Vertex AI embedding location to global instead of us-central1 to use the worldwide endpoint and avoid region mismatches. When no service account location or `GOOGLE_CLOUD_LOCATION` is provided, the client now falls back to global.

<sup>Written for commit cff49fd255bc9219722edbcc3cf6f59cc5ed15b9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

