### PR TITLE
chore(llms): update recommended models

### DIFF
--- a/backend/onyx/llm/model_metadata_enrichments.json
+++ b/backend/onyx/llm/model_metadata_enrichments.json
@@ -1920,6 +1920,11 @@
     "model_vendor": "google",
     "model_version": "preview"
   },
+  "gemini-3.1-pro-preview": {
+    "display_name": "Gemini 3.1 Pro Preview",
+    "model_vendor": "google",
+    "model_version": "preview"
+  },
   "gemini-3-flash-preview": {
     "display_name": "Gemini 3 Flash Preview",
     "model_vendor": "google",
@@ -2527,6 +2532,10 @@
     "display_name": "GPT-5 Pro",
     "model_vendor": "openai",
     "model_version": "2025-10-06"
+  },
+  "gpt-5.5": {
+    "display_name": "GPT-5.5",
+    "model_vendor": "openai"
   },
   "gpt-5.4": {
     "display_name": "GPT-5.4",

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,10 +1,11 @@
 {
-  "version": "1.2",
-  "updated_at": "2026-04-16T00:00:00Z",
+  "version": "1.3",
+  "updated_at": "2026-04-28T00:00:00Z",
   "providers": {
     "openai": {
-      "default_model": { "name": "gpt-5.4" },
+      "default_model": "gpt-5.5",
       "additional_visible_models": [
+        { "name": "gpt-5.5" },
         { "name": "gpt-5.4" },
         { "name": "gpt-5.2" }
       ]
@@ -25,21 +26,17 @@
           "display_name": "Claude Sonnet 4.6"
         },
         {
-          "name": "claude-opus-4-5",
-          "display_name": "Claude Opus 4.5"
-        },
-        {
-          "name": "claude-sonnet-4-5",
-          "display_name": "Claude Sonnet 4.5"
+          "name": "claude-haiku-4-5",
+          "display_name": "Claude Haiku 4.5"
         }
       ]
     },
     "vertex_ai": {
-      "default_model": "gemini-3-pro-preview",
+      "default_model": "gemini-3.1-pro-preview",
       "additional_visible_models": [
         {
-          "name": "gemini-3-pro-preview",
-          "display_name": "Gemini 3 Pro"
+          "name": "gemini-3.1-pro-preview",
+          "display_name": "Gemini 3.1 Pro"
         },
         {
           "name": "gemini-3-flash-preview",
@@ -48,23 +45,23 @@
       ]
     },
     "openrouter": {
-      "default_model": "z-ai/glm-4.7",
+      "default_model": "z-ai/glm-5.1",
       "additional_visible_models": [
         {
-          "name": "z-ai/glm-4.7",
-          "display_name": "GLM 4.7"
+          "name": "z-ai/glm-5.1",
+          "display_name": "GLM 5.1"
         },
         {
-          "name": "deepseek/deepseek-v3.2",
-          "display_name": "DeepSeek V3.2"
+          "name": "deepseek/deepseek-v4-pro",
+          "display_name": "DeepSeek V4 Pro"
         },
         {
-          "name": "qwen/qwen3-235b-a22b-2507",
-          "display_name": "Qwen3 235B A22B Instruct 2507"
+          "name": "qwen/qwen3.6-plus",
+          "display_name": "Qwen3.6 Plus"
         },
         {
-          "name": "moonshotai/kimi-k2-0905",
-          "display_name": "Kimi K2 0905"
+          "name": "moonshotai/kimi-k2.6",
+          "display_name": "Kimi K2.6"
         }
       ]
     }


### PR DESCRIPTION
## Description

The recommended models are about a generation behind

## How Has This Been Tested?

TODO

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the recommended LLM models to the latest stable options and aligns names across providers. Updates defaults and visible lists for `openai`, `anthropic`, `vertex_ai`, and `openrouter`.

- **Refactors**
  - Bump spec to `1.3`; update `updated_at`; add metadata for `gpt-5.5` and `gemini-3.1-pro-preview`.
  - `openai`: default `gpt-5.5`; add `gpt-5.5`; default field is now a string.
  - `anthropic`: keep `claude-sonnet-4.6`; replace 4.5 entries with `claude-haiku-4-5`.
  - `vertex_ai`: default `gemini-3.1-pro-preview`; display “Gemini 3.1 Pro”.
  - `openrouter`: default `z-ai/glm-5.1`; visible list: `z-ai/glm-5.1`, `deepseek/deepseek-v4-pro`, `qwen/qwen3.6-plus`, `moonshotai/kimi-k2.6`.

<sup>Written for commit d8b9e0457282ca06b91b2589778126496204f302. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10700?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

