### PR TITLE
fix(fe): add padding to welcome header

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -783,7 +783,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center">
+                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-4">
                   {/* ChatUI */}
                   <Fade
                     show={


### PR DESCRIPTION
## Description

Ensures the welcome header does not touch the edge of the viewport on small screens

## How Has This Been Tested?

Captured by playwright

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add horizontal padding to the welcome header so it doesn’t touch the viewport edge on small screens. Applies px-4 to the top row container in AppPage.tsx.

<sup>Written for commit 9a952f11533ed60ed7fec4c281f512c4d4cc8be9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10707?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

