### PR TITLE
feat(craft): add docker-compose sandbox backend

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -6,17 +6,23 @@ from pathlib import Path
 class SandboxBackend(str, Enum):
     """Backend mode for sandbox operations.
 
-    LOCAL: Development mode - no snapshots, no automatic cleanup
-    KUBERNETES: Production mode - full snapshots and cleanup
+    LOCAL: Development mode only - no container isolation, no snapshots, no cleanup.
+    DOCKER: Self-hosted production mode - one container per user via the Docker
+        Engine API, snapshots through FileStore, idle cleanup enabled.
+    KUBERNETES: Cloud production mode - one pod per user, S3-based snapshots via
+        s5cmd sidecar, idle cleanup enabled.
     """
 
     LOCAL = "local"
+    DOCKER = "docker"
     KUBERNETES = "kubernetes"
 
 
-# Sandbox backend mode (controls snapshot and cleanup behavior)
-# "local" = no snapshots, no cleanup (for development)
-# "kubernetes" = full snapshots and cleanup (for production)
+# Sandbox backend selection. Defaults to "local" (no isolation) so that running
+# the api_server outside any container keeps working unchanged. Deployment defaults:
+# - docker compose deployments set SANDBOX_BACKEND=docker explicitly
+# - the helm chart sets SANDBOX_BACKEND=kubernetes
+# - dev / ad-hoc invocations stay on "local"
 SANDBOX_BACKEND = SandboxBackend(os.environ.get("SANDBOX_BACKEND", "local"))
 
 # Base directory path for persistent document storage (local filesystem)
@@ -106,6 +112,28 @@ SANDBOX_SERVICE_ACCOUNT_NAME = os.environ.get(
 SANDBOX_FILE_SYNC_SERVICE_ACCOUNT = os.environ.get(
     "SANDBOX_FILE_SYNC_SERVICE_ACCOUNT", "sandbox-file-sync"
 )
+
+# ============================================================================
+# Docker Sandbox Configuration
+# Only used when SANDBOX_BACKEND = "docker"
+# ============================================================================
+
+# Docker daemon URL. None / empty means use docker.from_env() (the default
+# /var/run/docker.sock or DOCKER_HOST env var). Set to e.g. "tcp://docker:2375"
+# to talk to a remote daemon.
+SANDBOX_DOCKER_HOST = os.environ.get("SANDBOX_DOCKER_HOST", "") or None
+
+# Docker bridge network the api_server and all sandbox containers join. The
+# api_server reaches sandbox containers by hostname over this network, mirroring
+# Kubernetes ClusterIP service discovery.
+SANDBOX_DOCKER_NETWORK = os.environ.get("SANDBOX_DOCKER_NETWORK", "onyx_craft_sandbox")
+
+# Resource limits for each sandbox container. Mirror the Kubernetes pod limits
+# in `kubernetes_sandbox_manager.py` so behavior matches across deployments.
+# Memory accepts docker-style suffixes (e.g. "10g", "512m"). CPU is fractional
+# cores; nano_cpus = SANDBOX_DOCKER_CPU_LIMIT * 1e9.
+SANDBOX_DOCKER_CPU_LIMIT = float(os.environ.get("SANDBOX_DOCKER_CPU_LIMIT", "2.0"))
+SANDBOX_DOCKER_MEMORY_LIMIT = os.environ.get("SANDBOX_DOCKER_MEMORY_LIMIT", "10g")
 
 ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -15,16 +15,41 @@ The sandbox system provides isolated execution environments where OpenCode agent
 
 ### Deployment Modes
 
-1. **Local Mode** (`SANDBOX_BACKEND=local`)
-   - Sandboxes run as directories on the local filesystem
-   - No automatic cleanup or snapshots
-   - Suitable for development and testing
+| Backend | Isolation | Snapshots | Idle cleanup | Use case |
+|---|---|---|---|---|
+| `local` | None — runs in the api_server process | No | No | Dev-only |
+| `docker` | One container per user via Docker Engine | Yes (via FileStore) | Yes | Self-hosted production |
+| `kubernetes` | One pod per user, RBAC-controlled | Yes (S3 via s5cmd sidecar) | Yes | Cloud production |
 
-2. **Kubernetes Mode** (`SANDBOX_BACKEND=kubernetes`)
-   - Sandboxes run as Kubernetes pods
-   - Automatic snapshots to S3
-   - Auto-cleanup of idle sandboxes
-   - Production-ready with resource isolation
+1. **Local Mode** (`SANDBOX_BACKEND=local`)
+   - Sandboxes run as directories on the local filesystem in the api_server process
+   - **No container isolation.** The agent's bash, write, and edit tools execute on
+     the host as the api_server user. **Use only for dev.**
+   - No automatic cleanup or snapshots.
+
+2. **Docker Mode** (`SANDBOX_BACKEND=docker`)
+   - Sandboxes run as Docker containers, one per user, on the same host or
+     Docker daemon as the api_server. Driven directly via the Docker Engine API
+     (no separate runner microservice).
+   - Reuses the same `SANDBOX_CONTAINER_IMAGE` as Kubernetes — bug fixes to
+     skills, templates, OpenCode, LibreOffice, etc. land in both backends at once.
+   - Snapshots stream `tar -czf -` from inside the container through the docker
+     socket and are persisted via the existing `FileStore` abstraction. Works
+     against MinIO, S3, GCS, or local-disk file stores with no extra config.
+   - Idle cleanup is enabled — `cleanup_idle_sandboxes_task` snapshots and tears
+     down idle containers.
+   - **Trust boundary:** the api_server needs access to the Docker daemon
+     (typically by mounting `/var/run/docker.sock`). That is equivalent to root
+     on the host; same model as Kubernetes' RBAC for sandbox pods. If you do
+     not want to grant Docker access to the api_server, set
+     `SANDBOX_BACKEND=local` and accept the loss of isolation.
+   - **The supported self-hosted production path.**
+
+3. **Kubernetes Mode** (`SANDBOX_BACKEND=kubernetes`)
+   - Sandboxes run as Kubernetes pods.
+   - Automatic snapshots to S3 via an s5cmd sidecar container with IRSA.
+   - Auto-cleanup of idle sandboxes.
+   - Cloud-native production.
 
 ### Directory Structure
 
@@ -145,8 +170,16 @@ Configuration is generated dynamically in `templates/opencode_config.py`.
 ### Managers
 
 - **`base.py`** - Abstract base class defining the sandbox interface
-- **`local/manager.py`** - Filesystem-based sandbox manager for local development
-- **`kubernetes/manager.py`** - Kubernetes-based sandbox manager for production
+- **`local/local_sandbox_manager.py`** - Filesystem-based sandbox manager for local
+  development (no isolation)
+- **`docker/docker_sandbox_manager.py`** - Docker-Engine-backed sandbox manager
+  for self-hosted production. Drives the Docker SDK directly. The path
+  `kubernetes/docker/Dockerfile` is the image source and is shared with the
+  Kubernetes backend; it does not mean the docker backend is "Kubernetes-only."
+  (The path name is awkward — see the V1 plan note about not renaming `build/`
+  modules.)
+- **`kubernetes/kubernetes_sandbox_manager.py`** - Kubernetes-based sandbox
+  manager for cloud production
 
 ### Managers (Shared)
 
@@ -174,7 +207,9 @@ Configuration is generated dynamically in `templates/opencode_config.py`.
 
 ```bash
 # Sandbox backend mode
-SANDBOX_BACKEND=local|kubernetes           # Default: local
+SANDBOX_BACKEND=local|docker|kubernetes    # Default: local
+                                           # docker-compose deployments default to docker
+                                           # helm chart defaults to kubernetes
 
 # Template paths (local mode)
 OUTPUTS_TEMPLATE_PATH=/templates/outputs   # Default: /templates/outputs
@@ -186,6 +221,30 @@ SANDBOX_BASE_PATH=/tmp/onyx-sandboxes     # Default: /tmp/onyx-sandboxes
 # OpenCode configuration
 OPENCODE_DISABLED_TOOLS=question          # Comma-separated list, default: question
 ```
+
+### Docker Settings
+
+```bash
+# Container image — same image family as Kubernetes
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.5
+
+# Bridge network shared between the api_server and sandbox containers.
+# Auto-created if missing.
+SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
+
+# Optional: talk to a remote Docker daemon. Empty = use docker.from_env()
+# (i.e. /var/run/docker.sock or the DOCKER_HOST env var).
+SANDBOX_DOCKER_HOST=
+
+# Per-container resource limits — mirror the K8s pod limits.
+SANDBOX_DOCKER_CPU_LIMIT=2.0              # in fractional cores
+SANDBOX_DOCKER_MEMORY_LIMIT=10g           # docker memory string
+```
+
+The docker-compose deployment mounts `/var/run/docker.sock` into the
+`api_server` and `background` containers when `SANDBOX_BACKEND=docker`. This
+grants those containers root-level access to the host. If you don't want to
+grant that, set `SANDBOX_BACKEND=local`.
 
 ### Kubernetes Settings
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -491,6 +491,31 @@ class SandboxManager(ABC):
             nextjs_port: The port the Next.js server should be listening on
         """
 
+    def supports_idle_cleanup(self) -> bool:
+        """Whether this backend participates in idle-sandbox cleanup.
+
+        Local sandboxes persist on disk and are not torn down on idle.
+        Container-backed sandboxes (docker, kubernetes) are idled to free
+        compute and resumed from snapshots on the next message.
+        """
+        return False
+
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:  # noqa: ARG002
+        """List session workspace UUIDs that exist inside the sandbox.
+
+        Used by the idle-cleanup task to enumerate sessions to snapshot.
+        Default: backends that don't support idle cleanup return [].
+        Container-backed managers override this to exec a directory listing
+        inside the container/pod.
+
+        Args:
+            sandbox_id: The sandbox ID
+
+        Returns:
+            List of session UUIDs found under sessions/ inside the sandbox.
+        """
+        return []
+
 
 # Singleton instance cache for the factory
 _sandbox_manager_instance: SandboxManager | None = None
@@ -502,8 +527,9 @@ def get_sandbox_manager() -> SandboxManager:
 
     Returns:
         SandboxManager instance:
-        - LocalSandboxManager for local backend (development)
-        - KubernetesSandboxManager for kubernetes backend (production)
+        - LocalSandboxManager for local backend (development only)
+        - DockerSandboxManager for docker backend (self-hosted)
+        - KubernetesSandboxManager for kubernetes backend (cloud)
     """
     global _sandbox_manager_instance
 
@@ -516,6 +542,13 @@ def get_sandbox_manager() -> SandboxManager:
                     )
 
                     _sandbox_manager_instance = LocalSandboxManager()
+                elif SANDBOX_BACKEND == SandboxBackend.DOCKER:
+                    from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+                        DockerSandboxManager,
+                    )
+
+                    _sandbox_manager_instance = DockerSandboxManager()
+                    logger.info("Using DockerSandboxManager for sandbox operations")
                 elif SANDBOX_BACKEND == SandboxBackend.KUBERNETES:
                     from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
                         KubernetesSandboxManager,

--- a/backend/onyx/server/features/build/sandbox/docker/__init__.py
+++ b/backend/onyx/server/features/build/sandbox/docker/__init__.py
@@ -1,0 +1,12 @@
+"""Docker-Compose sandbox backend.
+
+Drives the Docker Engine API directly from the api_server to run one
+container per user. Mirrors the Kubernetes manager's shape (one pod per
+user, sessions as subdirectories) but talks to ``/var/run/docker.sock``
+instead of the Kubernetes API.
+
+This module assumes ``SANDBOX_BACKEND=docker``. Importing it is safe even
+when the backend isn't selected, but resolving the docker SDK happens
+lazily inside the manager so deployments that pin to ``local`` or
+``kubernetes`` don't pay for the import.
+"""

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1,0 +1,1212 @@
+"""Docker-Engine-backed sandbox manager for self-hosted Onyx deployments.
+
+Symmetric with ``KubernetesSandboxManager``: one container per user, sessions
+are subdirectories under ``/workspace/sessions/`` inside the container, and
+every operation goes through ``docker exec`` (the Docker analog of
+``kubectl exec``). Snapshots tar the session directory inside the container,
+stream the bytes back through the SDK socket, and hand them to the existing
+``FileStore`` abstraction — no s5cmd sidecar, no IRSA, no init container.
+
+Runtime deps:
+- ``SANDBOX_BACKEND=docker`` selected in ``configs.py``
+- The api_server has access to the Docker daemon (typically by mounting
+  ``/var/run/docker.sock``; see ``deployment/docker_compose/docker-compose.yml``).
+- The api_server and sandbox containers share a Docker bridge network
+  (``SANDBOX_DOCKER_NETWORK``) so the api_server can reach NextJS dev
+  servers by container hostname.
+
+Trust boundary: mounting the docker socket is equivalent to root on the host.
+This is documented in ``sandbox/README.md`` and is the same trust model the
+helm chart inherits via the ``sandbox-runner`` ServiceAccount.
+"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+import re
+import shlex
+import tarfile
+import threading
+from collections.abc import Generator
+from io import BytesIO
+from pathlib import Path
+from uuid import UUID
+
+import docker  # type: ignore[import-untyped]
+from docker.errors import APIError  # type: ignore[import-untyped]
+from docker.errors import ImageNotFound  # type: ignore[import-untyped]
+from docker.errors import NotFound  # type: ignore[import-untyped]
+from docker.models.containers import Container  # type: ignore[import-untyped]
+
+from onyx.db.enums import SandboxStatus
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
+from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
+from onyx.server.features.build.configs import SANDBOX_DOCKER_CPU_LIMIT
+from onyx.server.features.build.configs import SANDBOX_DOCKER_HOST
+from onyx.server.features.build.configs import SANDBOX_DOCKER_MEMORY_LIMIT
+from onyx.server.features.build.configs import SANDBOX_DOCKER_NETWORK
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.docker.internal.acp_exec_client import ACPEvent
+from onyx.server.features.build.sandbox.docker.internal.acp_exec_client import (
+    ACPExecClient,
+)
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
+    DockerExecError,
+)
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import exec_shell
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
+    exec_stream_stdout,
+)
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
+    exec_write_stdin,
+)
+from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    ATTACHMENTS_SECTION_CONTENT,
+)
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    generate_agent_instructions,
+)
+from onyx.server.features.build.sandbox.util.opencode_config import (
+    build_opencode_config,
+)
+from onyx.server.features.build.sandbox.util.persona_mapping import (
+    generate_user_identity_content,
+)
+from onyx.server.features.build.sandbox.util.persona_mapping import get_persona_info
+from onyx.server.features.build.sandbox.util.persona_mapping import ORG_INFO_AGENTS_MD
+from onyx.server.features.build.sandbox.util.persona_mapping import (
+    ORGANIZATION_STRUCTURE,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Same convention as the K8s manager: container/pod name = "sandbox-{first 8 chars of UUID}".
+# Keeping the shape parallel makes log greps work across deployments.
+_CONTAINER_NAME_PREFIX = "sandbox-"
+
+# Default user inside the sandbox image (matches the Dockerfile's UID/GID).
+_SANDBOX_USER = "1000:1000"
+
+# Resource defaults for the volume — the container holds /workspace/sessions/
+# on this volume. Image-baked content (templates, skills, venv) lives inside
+# the image itself so we don't need to bind-mount anything from the host.
+_VOLUME_NAME_PREFIX = "onyx_sandbox_"
+
+
+def _container_name(sandbox_id: UUID | str) -> str:
+    return f"{_CONTAINER_NAME_PREFIX}{str(sandbox_id)[:8]}"
+
+
+def _volume_name(sandbox_id: UUID | str) -> str:
+    return f"{_VOLUME_NAME_PREFIX}{str(sandbox_id)[:8]}"
+
+
+def _build_nextjs_start_script(
+    session_path: str,
+    nextjs_port: int,
+    check_node_modules: bool = False,
+) -> str:
+    """Same shape as the K8s helper — kept duplicated rather than imported to
+    avoid a fragile cross-package dependency on a shell-script string. If the
+    two ever diverge, divergence is the bug to fix, not the duplication."""
+    npm_install_check = ""
+    if check_node_modules:
+        npm_install_check = """
+# Check if npm dependencies are installed
+if [ ! -d "node_modules" ]; then
+    echo "Installing npm dependencies..."
+    npm install
+fi
+"""
+    return f"""
+set -e
+cd {session_path}/outputs/web
+{npm_install_check}
+echo "Starting Next.js dev server on port {nextjs_port}..."
+nohup npm run dev -- -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
+NEXTJS_PID=$!
+echo "Next.js server started with PID $NEXTJS_PID"
+echo $NEXTJS_PID > {session_path}/nextjs.pid
+"""
+
+
+class DockerSandboxManager(SandboxManager):
+    """Docker-Engine-backed sandbox manager (self-hosted production).
+
+    Singleton. Mirrors ``KubernetesSandboxManager`` in shape and orchestration
+    so callers can treat the two interchangeably; only the transport changes.
+    """
+
+    _instance: "DockerSandboxManager | None" = None
+    _lock = threading.Lock()
+
+    def __new__(cls) -> "DockerSandboxManager":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._initialize()
+        return cls._instance
+
+    def _initialize(self) -> None:
+        if SANDBOX_DOCKER_HOST:
+            self._client = docker.DockerClient(base_url=SANDBOX_DOCKER_HOST)
+        else:
+            self._client = docker.from_env()
+        self._image = SANDBOX_CONTAINER_IMAGE
+        self._network = SANDBOX_DOCKER_NETWORK
+        self._cpu_limit = SANDBOX_DOCKER_CPU_LIMIT
+        self._memory_limit = SANDBOX_DOCKER_MEMORY_LIMIT
+
+        build_dir = Path(__file__).parent.parent.parent  # /onyx/server/features/build/
+        self._agent_instructions_template_path = build_dir / "AGENTS.template.md"
+        self._skills_path = build_dir / "sandbox" / "kubernetes" / "docker" / "skills"
+
+        self._snapshot_manager = SnapshotManager(get_default_file_store())
+
+        self._ensure_network()
+
+        logger.info(
+            f"DockerSandboxManager initialized: image={self._image} network={self._network} "
+            f"cpu={self._cpu_limit} memory={self._memory_limit}"
+        )
+
+    def supports_idle_cleanup(self) -> bool:
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_network(self) -> None:
+        """Create the shared bridge network if it doesn't already exist.
+
+        Idempotent: 409 / "already exists" means another api_server replica
+        beat us to it, which is fine.
+        """
+        try:
+            self._client.networks.get(self._network)
+            return
+        except NotFound:
+            pass
+
+        try:
+            self._client.networks.create(self._network, driver="bridge")
+            logger.info(f"Created docker bridge network {self._network}")
+        except APIError as e:
+            if "already exists" in str(e).lower():
+                return
+            raise
+
+    def _get_container(self, sandbox_id: UUID) -> Container:
+        try:
+            return self._client.containers.get(_container_name(sandbox_id))
+        except NotFound as e:
+            raise RuntimeError(f"Sandbox container for {sandbox_id} not found") from e
+
+    def _container_or_none(self, sandbox_id: UUID) -> Container | None:
+        try:
+            return self._client.containers.get(_container_name(sandbox_id))
+        except NotFound:
+            return None
+
+    def _container_is_healthy(self, container: Container) -> bool:
+        container.reload()
+        # "running" is good. "created" / "restarting" are transient — wait elsewhere.
+        if container.status == "running":
+            return True
+        return False
+
+    def _ensure_volume(self, sandbox_id: UUID) -> str:
+        name = _volume_name(sandbox_id)
+        try:
+            self._client.volumes.get(name)
+        except NotFound:
+            self._client.volumes.create(name=name, driver="local")
+            logger.debug(f"Created docker volume {name}")
+        return name
+
+    def _load_agent_instructions(
+        self,
+        provider: str | None = None,
+        model_name: str | None = None,
+        nextjs_port: int | None = None,
+        disabled_tools: list[str] | None = None,
+        user_name: str | None = None,
+        user_role: str | None = None,
+        use_demo_data: bool = False,
+        include_org_info: bool = False,
+    ) -> str:
+        return generate_agent_instructions(
+            template_path=self._agent_instructions_template_path,
+            skills_path=self._skills_path,
+            files_path=None,  # generated inside container at runtime
+            provider=provider,
+            model_name=model_name,
+            nextjs_port=nextjs_port,
+            disabled_tools=disabled_tools,
+            user_name=user_name,
+            user_role=user_role,
+            use_demo_data=use_demo_data,
+            include_org_info=include_org_info,
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def provision(
+        self,
+        sandbox_id: UUID,
+        user_id: UUID,
+        tenant_id: str,
+        llm_config: LLMProviderConfig,  # noqa: ARG002
+    ) -> SandboxInfo:
+        """Provision the user's sandbox container.
+
+        Idempotent: if a healthy container with the expected name already
+        exists, reuse it. If a stopped one exists, start it. If a wedged
+        one exists, recreate it.
+        """
+        logger.info(
+            f"Starting Docker sandbox provisioning for sandbox {sandbox_id}, user {user_id}, tenant {tenant_id}"
+        )
+
+        name = _container_name(sandbox_id)
+        existing = self._container_or_none(sandbox_id)
+        if existing is not None:
+            existing.reload()
+            if existing.status == "running":
+                logger.info(f"Container {name} already running, reusing")
+                return SandboxInfo(
+                    sandbox_id=sandbox_id,
+                    directory_path=f"docker://{name}",
+                    status=SandboxStatus.RUNNING,
+                    last_heartbeat=None,
+                )
+            if existing.status in {"exited", "created"}:
+                try:
+                    existing.start()
+                    existing.reload()
+                    if existing.status == "running":
+                        logger.info(f"Started existing container {name}")
+                        return SandboxInfo(
+                            sandbox_id=sandbox_id,
+                            directory_path=f"docker://{name}",
+                            status=SandboxStatus.RUNNING,
+                            last_heartbeat=None,
+                        )
+                except APIError as e:
+                    logger.warning(
+                        f"Failed to start existing container {name}: {e}, will recreate"
+                    )
+            # Wedged — recreate
+            logger.warning(
+                f"Container {name} in unexpected state {existing.status}, recreating"
+            )
+            try:
+                existing.remove(force=True)
+            except APIError as e:
+                logger.warning(f"Failed to remove wedged container {name}: {e}")
+
+        volume_name = self._ensure_volume(sandbox_id)
+
+        try:
+            container = self._client.containers.run(
+                image=self._image,
+                name=name,
+                detach=True,
+                # Keep the main process alive so we can exec into it. The image
+                # has its own entrypoint that already serves this purpose, but
+                # we override with a sleep loop in case the image entrypoint
+                # exits prematurely or assumes K8s-only init.
+                command=["/bin/sh", "-c", "while sleep 86400; do :; done"],
+                user=_SANDBOX_USER,
+                network=self._network,
+                hostname=name,
+                cap_drop=["ALL"],
+                security_opt=["no-new-privileges:true"],
+                read_only=False,
+                # Image-baked content (templates, skills, venv) is in the image.
+                # Sessions live on a docker volume so we control lifecycle.
+                volumes={
+                    volume_name: {"bind": "/workspace/sessions", "mode": "rw"},
+                },
+                mem_limit=self._memory_limit,
+                nano_cpus=int(self._cpu_limit * 1_000_000_000),
+                labels={
+                    "app.kubernetes.io/component": "sandbox",
+                    "app.kubernetes.io/managed-by": "onyx",
+                    "onyx.app/sandbox-id": str(sandbox_id),
+                    "onyx.app/tenant-id": tenant_id,
+                    "onyx.app/user-id": str(user_id),
+                },
+                restart_policy={"Name": "no"},
+            )
+        except ImageNotFound as e:
+            raise RuntimeError(
+                f"Sandbox image not available locally: {self._image}. "
+                "Pull it on the host or set SANDBOX_CONTAINER_IMAGE."
+            ) from e
+        except APIError as e:
+            if "Conflict" in str(e) or "already in use" in str(e).lower():
+                logger.warning(
+                    f"Concurrent provisioning detected for {name}, fetching existing container"
+                )
+                container = self._get_container(sandbox_id)
+            else:
+                raise RuntimeError(
+                    f"Failed to provision Docker sandbox {sandbox_id}: {e}"
+                ) from e
+
+        # Make sure /workspace/sessions exists with the right perms.
+        try:
+            exec_shell(
+                container,
+                "mkdir -p /workspace/sessions && chmod 0775 /workspace/sessions",
+                user="root",
+            )
+        except DockerExecError as e:
+            logger.warning(f"Failed to prepare /workspace/sessions in {name}: {e}")
+
+        logger.info(f"Provisioned Docker sandbox {sandbox_id} as container {name}")
+
+        return SandboxInfo(
+            sandbox_id=sandbox_id,
+            directory_path=f"docker://{name}",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+
+    def terminate(self, sandbox_id: UUID) -> None:
+        name = _container_name(sandbox_id)
+        container = self._container_or_none(sandbox_id)
+        if container is not None:
+            try:
+                container.remove(force=True)
+                logger.info(f"Removed sandbox container {name}")
+            except APIError as e:
+                logger.error(f"Failed to remove container {name}: {e}")
+
+        volume_name = _volume_name(sandbox_id)
+        try:
+            volume = self._client.volumes.get(volume_name)
+            volume.remove(force=True)
+            logger.debug(f"Removed sandbox volume {volume_name}")
+        except NotFound:
+            pass
+        except APIError as e:
+            logger.warning(f"Failed to remove volume {volume_name}: {e}")
+
+    def health_check(
+        self, sandbox_id: UUID, timeout: float = 60.0  # noqa: ARG002
+    ) -> bool:
+        container = self._container_or_none(sandbox_id)
+        if container is None:
+            return False
+        return self._container_is_healthy(container)
+
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        container = self._container_or_none(sandbox_id)
+        if container is None:
+            return []
+        try:
+            output = exec_shell(
+                container,
+                "ls -1 /workspace/sessions/ 2>/dev/null || echo ''",
+            )
+        except DockerExecError as e:
+            logger.warning(
+                f"Failed to list session workspaces in {container.name}: {e}"
+            )
+            return []
+        sessions: list[UUID] = []
+        for line in output.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                sessions.append(UUID(line))
+            except ValueError:
+                continue
+        return sessions
+
+    # ------------------------------------------------------------------
+    # Session workspace setup
+    # ------------------------------------------------------------------
+    def setup_session_workspace(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        llm_config: LLMProviderConfig,
+        nextjs_port: int,
+        file_system_path: str | None = None,
+        snapshot_path: str | None = None,
+        user_name: str | None = None,
+        user_role: str | None = None,
+        user_work_area: str | None = None,
+        user_level: str | None = None,
+        use_demo_data: bool = False,
+        excluded_user_library_paths: list[str] | None = None,
+    ) -> None:
+        # file_system_path / excluded_user_library_paths intentionally unused —
+        # the V1 plan moves knowledge retrieval to the HTTP search tool (project #1)
+        # rather than syncing the corpus into the sandbox.
+        del file_system_path, excluded_user_library_paths
+
+        if snapshot_path:
+            logger.warning(
+                f"Snapshot restoration requested via setup_session_workspace; "
+                f"use restore_snapshot() instead. Path={snapshot_path} ignored."
+            )
+
+        container = self._get_container(sandbox_id)
+        session_path = f"/workspace/sessions/{session_id}"
+
+        agent_instructions = self._load_agent_instructions(
+            provider=llm_config.provider,
+            model_name=llm_config.model_name,
+            nextjs_port=nextjs_port,
+            disabled_tools=OPENCODE_DISABLED_TOOLS,
+            user_name=user_name,
+            user_role=user_role,
+            use_demo_data=use_demo_data,
+            include_org_info=use_demo_data,
+        )
+
+        opencode_config = build_opencode_config(
+            provider=llm_config.provider,
+            model_name=llm_config.model_name,
+            api_key=llm_config.api_key if llm_config.api_key else None,
+            api_base=llm_config.api_base,
+            disabled_tools=OPENCODE_DISABLED_TOOLS,
+        )
+        opencode_json = json.dumps(opencode_config)
+        opencode_json_escaped = opencode_json.replace("'", "'\\''")
+        agent_instructions_escaped = agent_instructions.replace("'", "'\\''")
+
+        org_info_setup = ""
+        if user_work_area:
+            persona = get_persona_info(user_work_area, user_level)
+            if persona:
+                agents_md_escaped = ORG_INFO_AGENTS_MD.replace("'", "'\\''")
+                identity_escaped = generate_user_identity_content(persona).replace(
+                    "'", "'\\''"
+                )
+                org_structure_escaped = json.dumps(
+                    ORGANIZATION_STRUCTURE, indent=2
+                ).replace("'", "'\\''")
+                org_info_setup = f"""
+mkdir -p {session_path}/org_info
+printf '%s' '{agents_md_escaped}' > {session_path}/org_info/AGENTS.md
+printf '%s' '{identity_escaped}' > {session_path}/org_info/user_identity_profile.txt
+printf '%s' '{org_structure_escaped}' > {session_path}/org_info/organization_structure.json
+"""
+
+        # files/ behavior: The K8s backend symlinks to either /workspace/files
+        # (S3-synced) or /workspace/demo_data. Per the V1 plan, /workspace/files
+        # is empty in docker mode (search becomes an HTTP tool). We still create
+        # an empty files/ directory so AGENTS.md tooling that references it
+        # doesn't break.
+        if use_demo_data:
+            files_setup = (
+                f"# Demo data symlink (image-baked)\n"
+                f"ln -sf /workspace/demo_data {session_path}/files\n"
+            )
+        else:
+            files_setup = (
+                f"# files/ is empty in docker mode (search is provided via the HTTP tool, project #1)\n"
+                f"mkdir -p {session_path}/files\n"
+            )
+
+        outputs_setup = f"""
+# Copy outputs template baked into the image and install npm deps.
+echo "Copying outputs template"
+if [ -d /workspace/templates/outputs ]; then
+    cp -r /workspace/templates/outputs/* {session_path}/outputs/
+    cd {session_path}/outputs/web && npm install
+else
+    echo "Warning: outputs template not found at /workspace/templates/outputs"
+    mkdir -p {session_path}/outputs/web
+fi
+"""
+
+        nextjs_start_script = _build_nextjs_start_script(
+            session_path, nextjs_port, check_node_modules=False
+        )
+
+        setup_script = f"""
+set -e
+
+echo "Creating session directory: {session_path}"
+mkdir -p {session_path}/outputs
+mkdir -p {session_path}/attachments
+
+{files_setup}
+
+{outputs_setup}
+
+# Symlink skills (baked into image at /workspace/skills/)
+if [ -d /workspace/skills ]; then
+    mkdir -p {session_path}/.opencode
+    ln -sf /workspace/skills {session_path}/.opencode/skills
+fi
+
+echo "Writing AGENTS.md"
+printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
+
+# Best-effort knowledge-source rendering. Continues if the script is missing.
+python3 /usr/local/bin/generate_agents_md.py {session_path}/AGENTS.md {session_path}/files || true
+
+echo "Writing opencode.json"
+printf '%s' '{opencode_json_escaped}' > {session_path}/opencode.json
+
+{org_info_setup}
+
+# Start Next.js dev server
+{nextjs_start_script}
+
+echo "Session workspace setup complete"
+"""
+
+        logger.info(
+            f"Setting up session workspace {session_id} in sandbox {sandbox_id}"
+        )
+
+        try:
+            exec_shell(container, setup_script)
+        except DockerExecError as e:
+            logger.error(
+                f"Failed to setup session workspace {session_id} in sandbox {sandbox_id}: {e}"
+            )
+            raise RuntimeError(
+                f"Failed to setup session workspace {session_id}: {e}"
+            ) from e
+
+    def cleanup_session_workspace(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        nextjs_port: int | None = None,  # noqa: ARG002
+    ) -> None:
+        container = self._container_or_none(sandbox_id)
+        if container is None:
+            logger.debug(
+                f"Container for sandbox {sandbox_id} gone, skipping session cleanup"
+            )
+            return
+        session_path = f"/workspace/sessions/{session_id}"
+        cleanup_script = f"""
+set -e
+if [ -f {session_path}/nextjs.pid ]; then
+    NEXTJS_PID=$(cat {session_path}/nextjs.pid)
+    kill $NEXTJS_PID 2>/dev/null || true
+fi
+rm -rf {session_path}
+echo "Session cleanup complete"
+"""
+        try:
+            exec_shell(container, cleanup_script)
+        except DockerExecError as e:
+            logger.warning(f"Error cleaning up session workspace {session_id}: {e}")
+
+    # ------------------------------------------------------------------
+    # Snapshots
+    # ------------------------------------------------------------------
+    def session_workspace_exists(self, sandbox_id: UUID, session_id: UUID) -> bool:
+        container = self._container_or_none(sandbox_id)
+        if container is None:
+            return False
+        path = f"/workspace/sessions/{session_id}/outputs"
+        try:
+            exec_shell(container, f"[ -d {shlex.quote(path)} ]")
+            return True
+        except DockerExecError:
+            return False
+
+    def create_snapshot(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        tenant_id: str,
+    ) -> SnapshotResult | None:
+        container = self._get_container(sandbox_id)
+        session_path = f"/workspace/sessions/{session_id}"
+        safe_session_path = shlex.quote(session_path)
+
+        # Discover what's actually present so tar doesn't error on missing dirs.
+        try:
+            check = exec_shell(
+                container,
+                f"""
+set -e
+cd {safe_session_path} 2>/dev/null || {{ echo "EMPTY_SNAPSHOT"; exit 0; }}
+[ -d outputs ] || {{ echo "EMPTY_SNAPSHOT"; exit 0; }}
+parts="outputs"
+[ -d attachments ] && [ -n "$(ls -A attachments 2>/dev/null)" ] && parts="$parts attachments"
+[ -d .opencode-data ] && [ -n "$(ls -A .opencode-data 2>/dev/null)" ] && parts="$parts .opencode-data"
+echo "READY:$parts"
+""",
+            )
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to inspect session for snapshot: {e}") from e
+
+        if "EMPTY_SNAPSHOT" in check:
+            logger.info(
+                f"No outputs to snapshot for session {session_id} in sandbox {sandbox_id}"
+            )
+            return None
+
+        # Last "READY:..." line tells us what tar should include.
+        ready_line = next(
+            (line for line in check.strip().splitlines() if line.startswith("READY:")),
+            "",
+        )
+        components = ready_line.removeprefix("READY:").strip()
+        if not components:
+            logger.info(f"No components to snapshot for session {session_id}")
+            return None
+
+        cmd = [
+            "/bin/sh",
+            "-c",
+            f"cd {safe_session_path} && tar -czf - {components}",
+        ]
+
+        # Stream tar bytes into the file store. We pipe through a BytesIO so
+        # SnapshotManager (which expects a seekable BinaryIO) can checksum and
+        # upload. For multi-GB snapshots this would want a chunked uploader,
+        # but V1 keeps things simple.
+        buf = BytesIO()
+        try:
+            for chunk in exec_stream_stdout(self._client, container, cmd):
+                buf.write(chunk)
+        except DockerExecError as e:
+            raise RuntimeError(f"tar failed during snapshot: {e}") from e
+        buf.seek(0)
+
+        try:
+            snapshot_id, storage_path, size_bytes = (
+                self._snapshot_manager.create_snapshot_from_stream(
+                    stream=buf,
+                    sandbox_id=str(sandbox_id),
+                    tenant_id=tenant_id,
+                )
+            )
+        finally:
+            buf.close()
+
+        logger.info(
+            f"Snapshot {snapshot_id} created for session {session_id} (size={size_bytes})"
+        )
+        return SnapshotResult(storage_path=storage_path, size_bytes=size_bytes)
+
+    def restore_snapshot(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        snapshot_storage_path: str,
+        tenant_id: str,  # noqa: ARG002
+        nextjs_port: int,
+        llm_config: LLMProviderConfig,
+        use_demo_data: bool = False,
+    ) -> None:
+        container = self._get_container(sandbox_id)
+        session_path = f"/workspace/sessions/{session_id}"
+        safe_session_path = shlex.quote(session_path)
+
+        # Pull bytes from the file store into memory, then push through the
+        # exec stdin into ``tar -xzf -`` inside the container.
+        stream = self._snapshot_manager.restore_snapshot_to_stream(
+            snapshot_storage_path
+        )
+        try:
+            payload = stream.read()
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+        cmd = [
+            "/bin/sh",
+            "-c",
+            f"mkdir -p {safe_session_path} && tar -xzf - -C {safe_session_path}",
+        ]
+        try:
+            exec_write_stdin(self._client, container, cmd, payload)
+        except DockerExecError as e:
+            raise RuntimeError(f"tar -xzf failed during restore: {e}") from e
+
+        # Regenerate per-deployment configuration that's not in the snapshot.
+        self._regenerate_session_config(
+            container=container,
+            session_path=session_path,
+            llm_config=llm_config,
+            nextjs_port=nextjs_port,
+            use_demo_data=use_demo_data,
+        )
+
+        # Start Next.js (npm install in case node_modules is missing or stale).
+        try:
+            exec_shell(
+                container,
+                _build_nextjs_start_script(
+                    session_path, nextjs_port, check_node_modules=True
+                ),
+            )
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to start Next.js after restore: {e}") from e
+
+    def _regenerate_session_config(
+        self,
+        container: Container,
+        session_path: str,
+        llm_config: LLMProviderConfig,
+        nextjs_port: int,
+        use_demo_data: bool,
+    ) -> None:
+        agent_instructions = self._load_agent_instructions(
+            provider=llm_config.provider,
+            model_name=llm_config.model_name,
+            nextjs_port=nextjs_port,
+            disabled_tools=OPENCODE_DISABLED_TOOLS,
+            user_name=None,
+            user_role=None,
+            use_demo_data=use_demo_data,
+            include_org_info=False,
+        )
+        opencode_config = build_opencode_config(
+            provider=llm_config.provider,
+            model_name=llm_config.model_name,
+            api_key=llm_config.api_key if llm_config.api_key else None,
+            api_base=llm_config.api_base,
+            disabled_tools=OPENCODE_DISABLED_TOOLS,
+        )
+        opencode_json = json.dumps(opencode_config)
+        opencode_json_escaped = opencode_json.replace("'", "'\\''")
+        agent_instructions_escaped = agent_instructions.replace("'", "'\\''")
+
+        if use_demo_data:
+            files_setup = f"ln -sf /workspace/demo_data {session_path}/files\n"
+        else:
+            files_setup = f"mkdir -p {session_path}/files\n"
+
+        config_script = f"""
+set -e
+{files_setup}
+printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
+python3 /usr/local/bin/generate_agents_md.py {session_path}/AGENTS.md {session_path}/files || true
+printf '%s' '{opencode_json_escaped}' > {session_path}/opencode.json
+"""
+        try:
+            exec_shell(container, config_script)
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to regenerate session config: {e}") from e
+
+    # ------------------------------------------------------------------
+    # ACP messaging
+    # ------------------------------------------------------------------
+    def send_message(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        message: str,
+    ) -> Generator[ACPEvent, None, None]:
+        packet_logger = get_packet_logger()
+        session_path = f"/workspace/sessions/{session_id}"
+        container = self._get_container(sandbox_id)
+
+        acp_client = ACPExecClient(
+            container_name=container.name,
+            docker_client=self._client,
+        )
+        acp_client.start(cwd=session_path)
+
+        try:
+            acp_session_id = acp_client.resume_or_create_session(cwd=session_path)
+            packet_logger.log_session_start(session_id, sandbox_id, message)
+
+            events_count = 0
+            try:
+                for event in acp_client.send_message(
+                    message, session_id=acp_session_id
+                ):
+                    events_count += 1
+                    yield event
+                packet_logger.log_session_end(
+                    session_id, success=True, events_count=events_count
+                )
+            except GeneratorExit:
+                try:
+                    acp_client.cancel(session_id=acp_session_id)
+                except Exception as cancel_err:
+                    logger.warning(
+                        f"[SANDBOX-ACP-DOCKER] session/cancel failed on GeneratorExit: {cancel_err}"
+                    )
+                packet_logger.log_session_end(
+                    session_id,
+                    success=False,
+                    error="GeneratorExit",
+                    events_count=events_count,
+                )
+                raise
+            except Exception as e:
+                try:
+                    acp_client.cancel(session_id=acp_session_id)
+                except Exception as cancel_err:
+                    logger.warning(
+                        f"[SANDBOX-ACP-DOCKER] session/cancel failed on Exception: {cancel_err}"
+                    )
+                packet_logger.log_session_end(
+                    session_id,
+                    success=False,
+                    error=f"Exception: {e}",
+                    events_count=events_count,
+                )
+                raise
+        finally:
+            try:
+                acp_client.stop()
+            except Exception as e:
+                logger.warning(
+                    f"[SANDBOX-ACP-DOCKER] Failed to stop ACP client: session={session_id} error={e}"
+                )
+
+    # ------------------------------------------------------------------
+    # Filesystem operations
+    # ------------------------------------------------------------------
+    def list_directory(
+        self, sandbox_id: UUID, session_id: UUID, path: str
+    ) -> list[FilesystemEntry]:
+        container = self._get_container(sandbox_id)
+        path_obj = Path(path.lstrip("/"))
+        clean_parts = [p for p in path_obj.parts if p != ".."]
+        clean_path = str(Path(*clean_parts)) if clean_parts else "."
+        target_path = f"/workspace/sessions/{session_id}/{clean_path}"
+        quoted = shlex.quote(target_path)
+        try:
+            output = exec_shell(
+                container,
+                f"ls -laL --time-style=+%s {quoted} 2>/dev/null || echo 'ERROR_NOT_FOUND'",
+            )
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to list directory: {e}") from e
+
+        if "ERROR_NOT_FOUND" in output:
+            raise ValueError(f"Path not found or not a directory: {path}")
+
+        entries = self._parse_ls_output(output, clean_path)
+        return sorted(entries, key=lambda e: (not e.is_directory, e.name.lower()))
+
+    def _parse_ls_output(self, ls_output: str, base_path: str) -> list[FilesystemEntry]:
+        entries: list[FilesystemEntry] = []
+        for line in ls_output.strip().split("\n"):
+            if line.startswith("total") or not line:
+                continue
+            parts = line.split()
+            if len(parts) < 7:
+                continue
+
+            is_symlink = line.startswith("l")
+            if is_symlink and " -> " in line:
+                name_and_target = " ".join(parts[6:])
+                name = (
+                    name_and_target.split(" -> ")[0]
+                    if " -> " in name_and_target
+                    else parts[-1]
+                )
+            else:
+                name = " ".join(parts[6:])
+
+            if name in (".", ".."):
+                continue
+
+            is_directory = line.startswith("d") or is_symlink
+            size_str = parts[4]
+            try:
+                size = int(size_str) if not is_directory else None
+            except ValueError:
+                size = None
+            mime_type = mimetypes.guess_type(name)[0] if not is_directory else None
+            entry_path = f"{base_path}/{name}".lstrip("/")
+            entries.append(
+                FilesystemEntry(
+                    name=name,
+                    path=entry_path,
+                    is_directory=is_directory,
+                    size=size,
+                    mime_type=mime_type,
+                )
+            )
+        return entries
+
+    def read_file(self, sandbox_id: UUID, session_id: UUID, path: str) -> bytes:
+        container = self._get_container(sandbox_id)
+        path_obj = Path(path.lstrip("/"))
+        clean_parts = [p for p in path_obj.parts if p != ".."]
+        clean_path = str(Path(*clean_parts)) if clean_parts else "."
+        target_path = f"/workspace/sessions/{session_id}/{clean_path}"
+
+        # Use docker's get_archive to pull the file as a tar. Avoids base64
+        # encoding overhead and handles binary data cleanly.
+        try:
+            stream, _ = container.get_archive(target_path)
+        except NotFound as e:
+            raise ValueError(f"File not found: {path}") from e
+        except APIError as e:
+            raise RuntimeError(f"Failed to read file: {e}") from e
+
+        buf = BytesIO()
+        for chunk in stream:
+            buf.write(chunk)
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r:*") as tar:
+            members = [m for m in tar.getmembers() if m.isfile()]
+            if not members:
+                raise ValueError(f"Not a file: {path}")
+            extracted = tar.extractfile(members[0])
+            if extracted is None:
+                raise ValueError(f"Could not extract: {path}")
+            return extracted.read()
+
+    def upload_file(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        filename: str,
+        content: bytes,
+    ) -> str:
+        container = self._get_container(sandbox_id)
+        target_dir = f"/workspace/sessions/{session_id}/attachments"
+
+        # Build a tar in memory containing just this file.
+        buf = BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            info = tarfile.TarInfo(name=filename)
+            info.size = len(content)
+            info.mode = 0o644
+            tar.addfile(info, BytesIO(content))
+        tar_bytes = buf.getvalue()
+
+        # Ensure target directory exists.
+        try:
+            exec_shell(container, f"mkdir -p {shlex.quote(target_dir)}")
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to prepare attachments dir: {e}") from e
+
+        # Resolve filename collisions: pick a non-existing name before extracting.
+        final_name = self._pick_unique_attachment_name(container, target_dir, filename)
+        if final_name != filename:
+            buf2 = BytesIO()
+            with tarfile.open(fileobj=buf2, mode="w") as tar:
+                info = tarfile.TarInfo(name=final_name)
+                info.size = len(content)
+                info.mode = 0o644
+                tar.addfile(info, BytesIO(content))
+            tar_bytes = buf2.getvalue()
+
+        try:
+            ok = container.put_archive(path=target_dir, data=tar_bytes)
+            if not ok:
+                raise RuntimeError("put_archive returned False")
+        except APIError as e:
+            raise RuntimeError(f"Failed to upload file: {e}") from e
+
+        # Best-effort: ensure AGENTS.md surfaces the attachments section.
+        self._ensure_agents_md_attachments_section(container, session_id)
+        logger.info(
+            f"Uploaded file to session {session_id}: attachments/{final_name} ({len(content)} bytes)"
+        )
+        return f"attachments/{final_name}"
+
+    def _pick_unique_attachment_name(
+        self, container: Container, target_dir: str, filename: str
+    ) -> str:
+        """Return ``filename`` if free, otherwise ``stem_N.ext``."""
+        try:
+            existing = exec_shell(
+                container,
+                f"ls -1 {shlex.quote(target_dir)} 2>/dev/null || true",
+            )
+        except DockerExecError:
+            existing = ""
+        existing_set = {line.strip() for line in existing.split("\n") if line.strip()}
+        if filename not in existing_set:
+            return filename
+        stem, dot, ext = filename.rpartition(".")
+        if not dot:
+            stem, ext = filename, ""
+        else:
+            ext = "." + ext
+        i = 1
+        while f"{stem}_{i}{ext}" in existing_set:
+            i += 1
+        return f"{stem}_{i}{ext}"
+
+    def _ensure_agents_md_attachments_section(
+        self, container: Container, session_id: UUID
+    ) -> None:
+        agents_md_path = f"/workspace/sessions/{session_id}/AGENTS.md"
+        # Use base64 to safely embed multi-line content in shell.
+        import base64
+
+        attachments_b64 = base64.b64encode(
+            ATTACHMENTS_SECTION_CONTENT.encode()
+        ).decode()
+        script = f"""
+if [ -f "{agents_md_path}" ]; then
+    if ! grep -q "## Attachments (PRIORITY)" "{agents_md_path}" 2>/dev/null; then
+        if grep -q "## Skills" "{agents_md_path}" 2>/dev/null; then
+            awk -v content="$(echo "{attachments_b64}" | base64 -d)" '
+                /^## Skills/ {{ print content; print ""; }}
+                {{ print }}
+            ' "{agents_md_path}" > "{agents_md_path}.tmp" && mv "{agents_md_path}.tmp" "{agents_md_path}"
+        else
+            echo "" >> "{agents_md_path}"
+            echo "" >> "{agents_md_path}"
+            echo "{attachments_b64}" | base64 -d >> "{agents_md_path}"
+        fi
+    fi
+fi
+"""
+        try:
+            exec_shell(container, script)
+        except DockerExecError as e:
+            logger.warning(f"Failed to ensure AGENTS.md attachments section: {e}")
+
+    def delete_file(self, sandbox_id: UUID, session_id: UUID, path: str) -> bool:
+        container = self._get_container(sandbox_id)
+        # Same path-validation rules as the K8s implementation.
+        if re.search(r"\.\.", path) or "%" in path or "\x00" in path:
+            raise ValueError("Invalid path: potential path traversal detected")
+        if re.search(r'[;&|`$(){}[\]<>\'"\n\r\\]', path):
+            raise ValueError("Invalid path: contains disallowed characters")
+        clean_path = path.lstrip("/")
+        if not re.match(r"^[a-zA-Z0-9_\-./]+$", clean_path):
+            raise ValueError("Invalid path: contains disallowed characters")
+        target = f"/workspace/sessions/{session_id}/{clean_path}"
+        try:
+            output = exec_shell(
+                container,
+                f'[ -f "{target}" ] && rm "{target}" && echo "DELETED" || echo "NOT_FOUND"',
+            )
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to delete file: {e}") from e
+        return "DELETED" in output
+
+    def get_upload_stats(self, sandbox_id: UUID, session_id: UUID) -> tuple[int, int]:
+        container = self._container_or_none(sandbox_id)
+        if container is None:
+            return 0, 0
+        target_dir = f"/workspace/sessions/{session_id}/attachments"
+        try:
+            output = exec_shell(
+                container,
+                f"""
+if [ -d "{target_dir}" ]; then
+    count=$(find "{target_dir}" -maxdepth 1 -type f 2>/dev/null | wc -l)
+    size=$(du -sb "{target_dir}" 2>/dev/null | cut -f1)
+    echo "$count $size"
+else
+    echo "0 0"
+fi
+""",
+            )
+        except DockerExecError as e:
+            logger.warning(f"Failed to get upload stats: {e}")
+            return 0, 0
+        parts = output.strip().split()
+        if len(parts) >= 2:
+            try:
+                return int(parts[0]), int(parts[1])
+            except ValueError:
+                logger.warning(f"Failed to parse upload stats: {output}")
+        return 0, 0
+
+    def get_webapp_url(self, sandbox_id: UUID, port: int) -> str:
+        # Reachable from the api_server over the shared bridge network.
+        return f"http://{_container_name(sandbox_id)}:{port}"
+
+    def generate_pptx_preview(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        pptx_path: str,
+        cache_dir: str,
+    ) -> tuple[list[str], bool]:
+        container = self._get_container(sandbox_id)
+
+        pptx_path_obj = Path(pptx_path.lstrip("/"))
+        pptx_clean_parts = [p for p in pptx_path_obj.parts if p != ".."]
+        clean_pptx = str(Path(*pptx_clean_parts)) if pptx_clean_parts else "."
+
+        cache_path_obj = Path(cache_dir.lstrip("/"))
+        cache_clean_parts = [p for p in cache_path_obj.parts if p != ".."]
+        clean_cache = str(Path(*cache_clean_parts)) if cache_clean_parts else "."
+
+        session_root = f"/workspace/sessions/{session_id}"
+        pptx_abs = f"{session_root}/{clean_pptx}"
+        cache_abs = f"{session_root}/{clean_cache}"
+
+        try:
+            output = exec_shell(
+                container,
+                shlex.join(
+                    [
+                        "python",
+                        "/workspace/skills/pptx/scripts/preview.py",
+                        pptx_abs,
+                        cache_abs,
+                    ]
+                ),
+            )
+        except DockerExecError as e:
+            raise RuntimeError(f"Failed to generate PPTX preview: {e}") from e
+
+        lines = [line.strip() for line in output.strip().split("\n") if line.strip()]
+        if not lines:
+            raise ValueError("Empty response from PPTX conversion")
+        if lines[0] == "ERROR_NOT_FOUND":
+            raise ValueError(f"File not found: {pptx_path}")
+        if lines[0] == "ERROR_NO_PDF":
+            raise ValueError("soffice did not produce a PDF file")
+
+        cached = lines[0] == "CACHED"
+        abs_paths = lines[1:] if lines[0] in ("CACHED", "GENERATED") else lines
+        prefix = f"{session_root}/"
+        rel: list[str] = []
+        for p in abs_paths:
+            if p.startswith(prefix):
+                rel.append(p[len(prefix) :])
+            elif p.endswith(".jpg"):
+                rel.append(p)
+        return rel, cached
+
+    def sync_files(
+        self,
+        sandbox_id: UUID,
+        user_id: UUID,  # noqa: ARG002
+        tenant_id: str,  # noqa: ARG002
+        source: str | None = None,  # noqa: ARG002
+    ) -> bool:
+        """No-op for docker mode.
+
+        Per the V1 plan, knowledge retrieval moves to the HTTP search tool
+        (project #1) rather than syncing the corpus into the sandbox. We keep
+        this method as a no-op so callers (e.g. the indexing post-write hook)
+        don't need to special-case backends.
+        """
+        logger.debug(f"sync_files called for docker sandbox {sandbox_id} - no-op")
+        return True
+
+
+# Re-exported so kubernetes-equivalent imports still resolve from a clean path.
+__all__ = ["DockerSandboxManager"]

--- a/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
@@ -1,0 +1,664 @@
+"""ACP client that communicates via ``docker exec`` into the sandbox container.
+
+Mirrors ``backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py``
+in shape: starts ``opencode acp`` in the container, speaks JSON-RPC over
+stdin/stdout, runs a reader thread that drains the stream, and exposes the
+same ``start`` / ``resume_or_create_session`` / ``send_message`` / ``stop`` /
+``cancel`` / ``health_check`` surface used by the Docker manager.
+
+The transport is the only difference. Where K8s uses
+``kubernetes.stream.stream(... connect_get_namespaced_pod_exec ...)`` and
+treats the resulting WebSocket as a JSON-RPC pipe, here we use
+``client.api.exec_create(...)`` + ``client.api.exec_start(socket=True)`` to
+obtain a duplex socket. Frames on that socket are stream-multiplexed (when
+the exec is created with ``tty=False``), so we strip the 8-byte framing
+header before passing payload bytes to the JSON-RPC parser.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import socket as socketlib
+import threading
+import time
+from collections.abc import Generator
+from dataclasses import dataclass
+from dataclasses import field
+from queue import Empty
+from queue import Queue
+from typing import Any
+from typing import cast
+
+import docker  # type: ignore[import-untyped]
+from acp.schema import AgentMessageChunk
+from acp.schema import AgentPlanUpdate
+from acp.schema import AgentThoughtChunk
+from acp.schema import CurrentModeUpdate
+from acp.schema import Error
+from acp.schema import PromptResponse
+from acp.schema import ToolCallProgress
+from acp.schema import ToolCallStart
+from docker.errors import NotFound  # type: ignore[import-untyped]
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import ACP_MESSAGE_TIMEOUT
+from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+ACP_PROTOCOL_VERSION = 1
+
+DEFAULT_CLIENT_INFO = {
+    "name": "onyx-sandbox-docker-exec",
+    "title": "Onyx Sandbox Agent Client (Docker Exec)",
+    "version": "1.0.0",
+}
+
+
+@dataclass
+class SSEKeepalive:
+    """Marker yielded when the prompt has been idle too long for SSE.
+
+    Same shape as the K8s client's marker so the upstream consumer doesn't
+    need to know which backend produced the stream.
+    """
+
+
+ACPEvent = (
+    AgentMessageChunk
+    | AgentThoughtChunk
+    | ToolCallStart
+    | ToolCallProgress
+    | AgentPlanUpdate
+    | CurrentModeUpdate
+    | PromptResponse
+    | Error
+    | SSEKeepalive
+)
+
+
+@dataclass
+class ACPSession:
+    session_id: str
+    cwd: str
+
+
+@dataclass
+class ACPClientState:
+    initialized: bool = False
+    sessions: dict[str, ACPSession] = field(default_factory=dict)
+    next_request_id: int = 0
+    agent_capabilities: dict[str, Any] = field(default_factory=dict)
+    agent_info: dict[str, Any] = field(default_factory=dict)
+
+
+class _DemuxBuffer:
+    """Stateful demuxer for the Docker stream-multiplexing framing.
+
+    Feed raw bytes via ``feed()``; iterate ``drain_stdout()`` / ``drain_stderr()``
+    to consume the demultiplexed payloads. The buffer keeps any trailing bytes
+    that don't yet form a complete frame.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self._stdout = bytearray()
+        self._stderr = bytearray()
+
+    def feed(self, data: bytes) -> None:
+        self._buf.extend(data)
+        self._parse()
+
+    def _parse(self) -> None:
+        i = 0
+        n = len(self._buf)
+        while i + 8 <= n:
+            header = self._buf[i : i + 8]
+            stream_type = header[0]
+            size = int.from_bytes(bytes(header[4:8]), "big")
+            if i + 8 + size > n:
+                break
+            payload = self._buf[i + 8 : i + 8 + size]
+            if stream_type == 1:
+                self._stdout.extend(payload)
+            elif stream_type == 2:
+                self._stderr.extend(payload)
+            else:
+                # unknown stream id, treat as stdout to avoid losing data
+                self._stdout.extend(payload)
+            i += 8 + size
+        if i > 0:
+            del self._buf[:i]
+
+    def drain_stdout(self) -> bytes:
+        out = bytes(self._stdout)
+        self._stdout.clear()
+        return out
+
+    def drain_stderr(self) -> bytes:
+        out = bytes(self._stderr)
+        self._stderr.clear()
+        return out
+
+
+class ACPExecClient:
+    """ACP client that talks to ``opencode acp`` over a docker exec socket.
+
+    Public surface mirrors ``kubernetes/internal/acp_exec_client.ACPExecClient``
+    so the Docker manager can swap the import without touching call sites.
+    """
+
+    def __init__(
+        self,
+        container_name: str,
+        docker_client: docker.DockerClient,
+        client_info: dict[str, Any] | None = None,
+        client_capabilities: dict[str, Any] | None = None,
+    ) -> None:
+        self._container_name = container_name
+        self._docker = docker_client
+        self._client_info = client_info or DEFAULT_CLIENT_INFO
+        self._client_capabilities = client_capabilities or {
+            "fs": {"readTextFile": True, "writeTextFile": True},
+            "terminal": True,
+        }
+        self._state = ACPClientState()
+        self._exec_id: str | None = None
+        self._socket: Any | None = None  # the SDK's socket wrapper
+        self._raw_sock: socketlib.socket | None = None
+        self._response_queue: Queue[dict[str, Any]] = Queue()
+        self._reader_thread: threading.Thread | None = None
+        self._stop_reader = threading.Event()
+        self._send_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def start(self, cwd: str = "/workspace", timeout: float = 30.0) -> None:
+        if self._exec_id is not None:
+            raise RuntimeError("Client already started. Call stop() first.")
+
+        try:
+            container = self._docker.containers.get(self._container_name)
+        except NotFound as e:
+            raise RuntimeError(
+                f"Sandbox container {self._container_name} not found"
+            ) from e
+
+        data_dir = shlex.quote(f"{cwd}/.opencode-data")
+        safe_cwd = shlex.quote(cwd)
+        cmd = [
+            "/bin/sh",
+            "-c",
+            f"XDG_DATA_HOME={data_dir} exec opencode acp --cwd {safe_cwd}",
+        ]
+
+        logger.info(
+            f"[ACP-DOCKER] Starting client: container={self._container_name} cwd={cwd}"
+        )
+
+        try:
+            create = self._docker.api.exec_create(
+                container.id,
+                cmd=cmd,
+                stdin=True,
+                stdout=True,
+                stderr=True,
+                tty=False,
+                workdir=cwd,
+            )
+            self._exec_id = create["Id"]
+
+            sock = self._docker.api.exec_start(
+                self._exec_id,
+                detach=False,
+                tty=False,
+                stream=False,
+                socket=True,
+                demux=False,
+            )
+            self._socket = sock
+            self._raw_sock = sock._sock if hasattr(sock, "_sock") else sock
+            assert self._raw_sock is not None
+            self._raw_sock.settimeout(0.1)
+
+            self._stop_reader.clear()
+            self._reader_thread = threading.Thread(
+                target=self._read_responses, daemon=True
+            )
+            self._reader_thread.start()
+
+            time.sleep(0.5)
+
+            self._initialize(timeout=timeout)
+            logger.info(
+                f"[ACP-DOCKER] Client started: container={self._container_name}"
+            )
+        except Exception as e:
+            logger.error(
+                f"[ACP-DOCKER] Client start failed: container={self._container_name} error={e}"
+            )
+            self.stop()
+            raise RuntimeError(f"Failed to start ACP exec client: {e}") from e
+
+    def stop(self) -> None:
+        session_ids = list(self._state.sessions.keys())
+        logger.info(
+            f"[ACP-DOCKER] Stopping client: container={self._container_name} sessions={session_ids}"
+        )
+        self._stop_reader.set()
+
+        if self._raw_sock is not None:
+            try:
+                self._raw_sock.shutdown(socketlib.SHUT_RDWR)
+            except Exception:
+                pass
+            try:
+                self._raw_sock.close()
+            except Exception:
+                pass
+        self._raw_sock = None
+        self._socket = None
+        self._exec_id = None
+
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=2.0)
+            self._reader_thread = None
+
+        self._state = ACPClientState()
+
+    # ------------------------------------------------------------------
+    # JSON-RPC plumbing
+    # ------------------------------------------------------------------
+    def _read_responses(self) -> None:
+        demux = _DemuxBuffer()
+        text_buffer = ""
+        packet_logger = get_packet_logger()
+
+        while not self._stop_reader.is_set():
+            sock = self._raw_sock
+            if sock is None:
+                break
+            try:
+                data = sock.recv(65536)
+            except socketlib.timeout:
+                continue
+            except OSError as e:
+                if not self._stop_reader.is_set():
+                    logger.warning(
+                        f"[ACP-DOCKER] Reader socket error: {e}, container={self._container_name}"
+                    )
+                break
+
+            if not data:
+                logger.warning(
+                    f"[ACP-DOCKER] Reader EOF: container={self._container_name}"
+                )
+                break
+
+            demux.feed(data)
+            err = demux.drain_stderr()
+            if err:
+                logger.warning(
+                    f"[ACP-DOCKER] stderr container={self._container_name}: "
+                    f"{err.decode('utf-8', errors='replace').strip()[:500]}"
+                )
+            stdout = demux.drain_stdout()
+            if stdout:
+                text_buffer += stdout.decode("utf-8", errors="replace")
+                while "\n" in text_buffer:
+                    line, text_buffer = text_buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        message = json.loads(line)
+                        packet_logger.log_jsonrpc_raw_message(
+                            "IN", message, context="docker"
+                        )
+                        self._response_queue.put(message)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            f"[ACP-DOCKER] Invalid JSON from agent: {line[:100]}"
+                        )
+
+    def _send_raw(self, payload: dict[str, Any]) -> None:
+        if self._raw_sock is None:
+            raise RuntimeError("Exec session not open")
+        message = (json.dumps(payload) + "\n").encode("utf-8")
+        with self._send_lock:
+            view = memoryview(message)
+            offset = 0
+            while offset < len(view):
+                sent = self._raw_sock.send(view[offset:])
+                if sent == 0:
+                    raise RuntimeError("Exec socket closed")
+                offset += sent
+
+    def _get_next_id(self) -> int:
+        request_id = self._state.next_request_id
+        self._state.next_request_id += 1
+        return request_id
+
+    def _send_request(self, method: str, params: dict[str, Any] | None = None) -> int:
+        request_id = self._get_next_id()
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+
+        get_packet_logger().log_jsonrpc_request(
+            method, request_id, params, context="docker"
+        )
+        self._send_raw(payload)
+        return request_id
+
+    def _send_notification(
+        self, method: str, params: dict[str, Any] | None = None
+    ) -> None:
+        if self._raw_sock is None:
+            return
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        get_packet_logger().log_jsonrpc_request(method, None, params, context="docker")
+        try:
+            self._send_raw(payload)
+        except Exception as e:
+            logger.warning(f"[ACP-DOCKER] Failed to send notification: {e}")
+
+    def _wait_for_response(
+        self, request_id: int, timeout: float = 30.0
+    ) -> dict[str, Any]:
+        start = time.time()
+        while True:
+            remaining = timeout - (time.time() - start)
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"Timeout waiting for response to request {request_id}"
+                )
+            try:
+                message = self._response_queue.get(timeout=min(remaining, 1.0))
+                if message.get("id") == request_id:
+                    if "error" in message:
+                        error = message["error"]
+                        raise RuntimeError(
+                            f"ACP error {error.get('code')}: {error.get('message')}"
+                        )
+                    return message.get("result", {})
+                # Not for us; put back for other consumers
+                self._response_queue.put(message)
+            except Empty:
+                continue
+
+    def _initialize(self, timeout: float = 30.0) -> dict[str, Any]:
+        params = {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": self._client_capabilities,
+            "clientInfo": self._client_info,
+        }
+        request_id = self._send_request("initialize", params)
+        result = self._wait_for_response(request_id, timeout)
+        self._state.initialized = True
+        self._state.agent_capabilities = result.get("agentCapabilities", {})
+        self._state.agent_info = result.get("agentInfo", {})
+        return result
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+    def _create_session(self, cwd: str, timeout: float = 30.0) -> str:
+        params = {"cwd": cwd, "mcpServers": []}
+        request_id = self._send_request("session/new", params)
+        result = self._wait_for_response(request_id, timeout)
+        session_id = result.get("sessionId")
+        if not session_id:
+            raise RuntimeError("No session ID returned from session/new")
+        self._state.sessions[session_id] = ACPSession(session_id=session_id, cwd=cwd)
+        logger.info(f"[ACP-DOCKER] Created session: acp_session={session_id} cwd={cwd}")
+        return session_id
+
+    def _list_sessions(self, cwd: str, timeout: float = 10.0) -> list[dict[str, Any]]:
+        try:
+            request_id = self._send_request("session/list", {"cwd": cwd})
+            result = self._wait_for_response(request_id, timeout)
+            return result.get("sessions", [])
+        except Exception as e:
+            logger.info(f"[ACP-DOCKER] session/list unavailable: {e}")
+            return []
+
+    def _resume_session(self, session_id: str, cwd: str, timeout: float = 30.0) -> str:
+        params = {"sessionId": session_id, "cwd": cwd, "mcpServers": []}
+        request_id = self._send_request("session/resume", params)
+        result = self._wait_for_response(request_id, timeout)
+        resumed_id = result.get("sessionId", session_id)
+        self._state.sessions[resumed_id] = ACPSession(session_id=resumed_id, cwd=cwd)
+        return resumed_id
+
+    def _try_resume_existing_session(self, cwd: str, timeout: float) -> str | None:
+        sessions = self._list_sessions(cwd, timeout=min(timeout, 10.0))
+        if not sessions:
+            return None
+        target = sessions[0]
+        target_id = target.get("sessionId")
+        if not target_id:
+            return None
+        try:
+            return self._resume_session(target_id, cwd, timeout)
+        except Exception as e:
+            logger.warning(
+                f"[ACP-DOCKER] session/resume failed for {target_id}: {e}, falling back to session/new"
+            )
+            return None
+
+    def resume_or_create_session(self, cwd: str, timeout: float = 30.0) -> str:
+        if not self._state.initialized:
+            raise RuntimeError("Client not initialized. Call start() first.")
+        resumed = self._try_resume_existing_session(cwd, timeout)
+        if resumed:
+            return resumed
+        return self._create_session(cwd=cwd, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Prompt streaming
+    # ------------------------------------------------------------------
+    def send_message(
+        self,
+        message: str,
+        session_id: str,
+        timeout: float = ACP_MESSAGE_TIMEOUT,
+    ) -> Generator[ACPEvent, None, None]:
+        if session_id not in self._state.sessions:
+            raise RuntimeError(
+                f"Unknown session {session_id}. Known sessions: {list(self._state.sessions.keys())}"
+            )
+
+        packet_logger = get_packet_logger()
+        prompt_content = [{"type": "text", "text": message}]
+        params = {"sessionId": session_id, "prompt": prompt_content}
+
+        request_id = self._send_request("session/prompt", params)
+        start_time = time.time()
+        last_event_time = time.time()
+        events_yielded = 0
+        completion_reason = "unknown"
+
+        while True:
+            remaining = timeout - (time.time() - start_time)
+            if remaining <= 0:
+                completion_reason = "timeout"
+                logger.warning(
+                    f"[ACP-DOCKER] Prompt timeout: acp_session={session_id} events={events_yielded}, sending session/cancel"
+                )
+                try:
+                    self.cancel(session_id=session_id)
+                except Exception as cancel_err:
+                    logger.warning(
+                        f"[ACP-DOCKER] session/cancel failed on timeout: {cancel_err}"
+                    )
+                yield Error(code=-1, message="Timeout waiting for response")
+                break
+
+            try:
+                message_data = self._response_queue.get(timeout=min(remaining, 1.0))
+                last_event_time = time.time()
+            except Empty:
+                idle_time = time.time() - last_event_time
+                if idle_time >= SSE_KEEPALIVE_INTERVAL:
+                    yield SSEKeepalive()
+                    last_event_time = time.time()
+                continue
+
+            msg_id = message_data.get("id")
+            is_response = "method" not in message_data and (
+                msg_id == request_id
+                or (msg_id is not None and str(msg_id) == str(request_id))
+            )
+            if is_response:
+                completion_reason = "jsonrpc_response"
+                if "error" in message_data:
+                    error_data = message_data["error"]
+                    completion_reason = "jsonrpc_error"
+                    packet_logger.log_jsonrpc_response(
+                        request_id, error=error_data, context="docker"
+                    )
+                    yield Error(
+                        code=error_data.get("code", -1),
+                        message=error_data.get("message", "Unknown error"),
+                    )
+                else:
+                    result = message_data.get("result", {})
+                    packet_logger.log_jsonrpc_response(
+                        request_id, result=result, context="docker"
+                    )
+                    try:
+                        prompt_response = PromptResponse.model_validate(result)
+                        events_yielded += 1
+                        yield prompt_response
+                    except ValidationError as e:
+                        logger.error(
+                            f"[ACP-DOCKER] PromptResponse validation failed: {e}"
+                        )
+
+                elapsed_ms = (time.time() - start_time) * 1000
+                logger.info(
+                    f"[ACP-DOCKER] Prompt complete: reason={completion_reason} "
+                    f"acp_session={session_id} events={events_yielded} elapsed={elapsed_ms:.0f}ms"
+                )
+                break
+
+            if message_data.get("method") == "session/update":
+                params_data = message_data.get("params", {})
+                update = params_data.get("update", {})
+                prompt_complete = False
+                for event in self._process_session_update(update):
+                    events_yielded += 1
+                    yield event
+                    if isinstance(event, PromptResponse):
+                        prompt_complete = True
+                        break
+                if prompt_complete:
+                    completion_reason = "prompt_response_via_notification"
+                    elapsed_ms = (time.time() - start_time) * 1000
+                    logger.info(
+                        f"[ACP-DOCKER] Prompt complete: reason={completion_reason} "
+                        f"acp_session={session_id} events={events_yielded} elapsed={elapsed_ms:.0f}ms"
+                    )
+                    break
+
+            elif "method" in message_data and "id" in message_data:
+                self._send_error_response(
+                    message_data["id"],
+                    -32601,
+                    f"Method not supported: {message_data['method']}",
+                )
+
+            else:
+                logger.warning(
+                    f"[ACP-DOCKER] Unhandled message: id={message_data.get('id')} "
+                    f"method={message_data.get('method')} keys={list(message_data.keys())}"
+                )
+
+    def _process_session_update(
+        self, update: dict[str, Any]
+    ) -> Generator[ACPEvent, None, None]:
+        update_type = update.get("sessionUpdate")
+        if not isinstance(update_type, str):
+            return
+        type_map: dict[str, type[BaseModel]] = {
+            "agent_message_chunk": AgentMessageChunk,
+            "agent_thought_chunk": AgentThoughtChunk,
+            "tool_call": ToolCallStart,
+            "tool_call_update": ToolCallProgress,
+            "plan": AgentPlanUpdate,
+            "current_mode_update": CurrentModeUpdate,
+            "prompt_response": PromptResponse,
+        }
+        model_class = type_map.get(update_type)
+        if model_class is not None:
+            try:
+                yield cast(ACPEvent, model_class.model_validate(update))
+            except ValidationError as e:
+                logger.warning(f"[ACP-DOCKER] Validation error for {update_type}: {e}")
+
+    def _send_error_response(self, request_id: int, code: int, message: str) -> None:
+        if self._raw_sock is None:
+            return
+        try:
+            self._send_raw(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": code, "message": message},
+                }
+            )
+        except Exception:
+            pass
+
+    def cancel(self, session_id: str | None = None) -> None:
+        if session_id:
+            if session_id in self._state.sessions:
+                self._send_notification("session/cancel", {"sessionId": session_id})
+        else:
+            for sid in self._state.sessions:
+                self._send_notification("session/cancel", {"sessionId": sid})
+
+    def health_check(self, timeout: float = 5.0) -> bool:  # noqa: ARG002
+        """Check if we can exec into the container.
+
+        Lightweight: runs ``echo ok`` in the container and returns True if
+        we got "ok" back. Does not require the ACP process to be running.
+        """
+        try:
+            container = self._docker.containers.get(self._container_name)
+        except NotFound:
+            return False
+        try:
+            exit_code, output = container.exec_run(
+                cmd=["echo", "ok"], stdout=True, stderr=False, tty=False
+            )
+            text = (
+                output.decode("utf-8", errors="replace")
+                if isinstance(output, bytes)
+                else str(output)
+            )
+            return exit_code == 0 and "ok" in text
+        except Exception:
+            return False
+
+    @property
+    def is_running(self) -> bool:
+        return self._raw_sock is not None and not self._stop_reader.is_set()
+
+    def __enter__(self) -> "ACPExecClient":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.stop()

--- a/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py
@@ -1,0 +1,222 @@
+"""Helpers for executing commands inside Docker sandbox containers.
+
+Mirrors the ergonomics of the Kubernetes ``k8s_stream(... command=[...] ...)``
+calls used throughout ``KubernetesSandboxManager`` so that the docker manager
+reads naturally next to its k8s sibling: a single helper that runs a shell
+script inside the container and returns combined stdout/stderr as a string.
+
+Streaming variants are provided for snapshot tar pipelines where the response
+can be many MB and we don't want it in memory all at once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import docker  # type: ignore[import-untyped]
+from docker.errors import APIError  # type: ignore[import-untyped]
+from docker.errors import NotFound  # type: ignore[import-untyped]
+from docker.models.containers import Container  # type: ignore[import-untyped]
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class DockerExecError(RuntimeError):
+    """Raised when an exec inside a sandbox container exits non-zero."""
+
+    def __init__(self, exit_code: int, output: str) -> None:
+        super().__init__(
+            f"docker exec failed with exit code {exit_code}: {output[:1000]}"
+        )
+        self.exit_code = exit_code
+        self.output = output
+
+
+def exec_shell(
+    container: Container,
+    script: str,
+    *,
+    user: str | None = None,
+    workdir: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,  # noqa: ARG001 - reserved for future use
+) -> str:
+    """Run a shell script inside the container and return combined output.
+
+    Equivalent shape to ``k8s_stream(... command=["/bin/sh", "-c", script])``.
+    Raises ``DockerExecError`` on non-zero exit so callers can surface failures
+    like the K8s code surfaces ``ApiException``.
+    """
+    try:
+        exit_code, output = container.exec_run(
+            cmd=["/bin/sh", "-c", script],
+            user=user or "",
+            workdir=workdir,
+            environment=env,
+            stdout=True,
+            stderr=True,
+            tty=False,
+            demux=False,
+        )
+    except (APIError, NotFound) as e:
+        raise RuntimeError(
+            f"docker exec failed for container {container.name}: {e}"
+        ) from e
+
+    text = (
+        output.decode("utf-8", errors="replace")
+        if isinstance(output, bytes)
+        else str(output)
+    )
+    if exit_code != 0:
+        raise DockerExecError(exit_code, text)
+    return text
+
+
+def exec_stream_stdout(
+    client: docker.DockerClient,
+    container: Container,
+    cmd: list[str],
+    *,
+    workdir: str | None = None,
+) -> Iterator[bytes]:
+    """Run a command and yield stdout chunks as raw bytes.
+
+    Used for streaming a ``tar -czf -`` snapshot back through the docker socket
+    without buffering the whole archive in memory. We deliberately drop stderr
+    here — the underlying ``client.api.exec_create`` does not split streams when
+    ``tty=False`` and ``demux=False``, but for tar producers that is fine
+    because tar writes to stdout only and reports failures via exit code.
+    """
+    create = client.api.exec_create(
+        container.id,
+        cmd=cmd,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        workdir=workdir,
+    )
+    exec_id = create["Id"]
+
+    sock_or_stream: Any = client.api.exec_start(
+        exec_id,
+        detach=False,
+        tty=False,
+        stream=True,
+        demux=False,
+    )
+
+    try:
+        for chunk in sock_or_stream:
+            if chunk:
+                yield chunk
+    finally:
+        # Always inspect for exit code so callers can detect tar failures.
+        result = client.api.exec_inspect(exec_id)
+        exit_code = result.get("ExitCode")
+        if exit_code not in (0, None):
+            raise DockerExecError(int(exit_code), f"exec {cmd} exited {exit_code}")
+
+
+def exec_write_stdin(
+    client: docker.DockerClient,
+    container: Container,
+    cmd: list[str],
+    payload: bytes,
+    *,
+    workdir: str | None = None,
+) -> str:
+    """Run a command, write ``payload`` to its stdin, return combined output.
+
+    The Docker SDK does not expose a clean "send stdin then close" via the
+    high-level ``exec_run``. We use the lower-level ``exec_create`` /
+    ``exec_start(socket=True)`` to get a duplex socket, write the payload,
+    half-close stdin, and drain stdout/stderr.
+    """
+    create = client.api.exec_create(
+        container.id,
+        cmd=cmd,
+        stdin=True,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        workdir=workdir,
+    )
+    exec_id = create["Id"]
+
+    sock = client.api.exec_start(
+        exec_id,
+        detach=False,
+        tty=False,
+        stream=False,
+        socket=True,
+        demux=False,
+    )
+
+    # The SDK wraps the raw socket; the underlying socket is at ._sock.
+    raw = sock._sock if hasattr(sock, "_sock") else sock
+
+    try:
+        view = memoryview(payload)
+        offset = 0
+        while offset < len(view):
+            sent = raw.send(view[offset:])
+            if sent == 0:
+                break
+            offset += sent
+        try:
+            raw.shutdown(1)  # half-close write side so reader sees EOF
+        except OSError:
+            pass
+
+        # Drain stdout. Output is multiplexed (8-byte header + payload) when
+        # tty=False; we strip headers here.
+        chunks: list[bytes] = []
+        while True:
+            try:
+                buf = raw.recv(65536)
+            except OSError:
+                break
+            if not buf:
+                break
+            chunks.append(buf)
+        raw_output = b"".join(chunks)
+    finally:
+        try:
+            raw.close()
+        except Exception:
+            pass
+
+    text = _strip_demux_headers(raw_output).decode("utf-8", errors="replace")
+
+    result = client.api.exec_inspect(exec_id)
+    exit_code = result.get("ExitCode")
+    if exit_code not in (0, None):
+        raise DockerExecError(int(exit_code), text)
+    return text
+
+
+def _strip_demux_headers(data: bytes) -> bytes:
+    """Strip the 8-byte stream-multiplexing headers Docker prepends per chunk.
+
+    Format: ``[stream_type(1)][padding(3)][size(4 BE)][payload(size)]``.
+    Used when the exec was started without a TTY and stdout/stderr are
+    interleaved on the same socket.
+    """
+    out = bytearray()
+    i = 0
+    n = len(data)
+    while i + 8 <= n:
+        header = data[i : i + 8]
+        size = int.from_bytes(header[4:8], "big")
+        i += 8
+        end = min(i + size, n)
+        out.extend(data[i:end])
+        i = end
+    if i < n:
+        # Trailing partial frame (shouldn't normally happen) — append raw
+        out.extend(data[i:])
+    return bytes(out)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1797,6 +1797,46 @@ echo "Session config regeneration complete"
         )
         logger.info("Session configuration files regenerated")
 
+    def supports_idle_cleanup(self) -> bool:
+        return True
+
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List UUID-shaped session directories under /workspace/sessions/."""
+        pod_name = self._get_pod_name(str(sandbox_id))
+
+        exec_command = [
+            "/bin/sh",
+            "-c",
+            'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
+        ]
+
+        try:
+            resp = k8s_stream(
+                self._stream_core_api.connect_get_namespaced_pod_exec,
+                name=pod_name,
+                namespace=self._namespace,
+                container="sandbox",
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
+        except ApiException as e:
+            logger.warning(f"Failed to list session workspaces in {pod_name}: {e}")
+            return []
+
+        session_ids: list[UUID] = []
+        for line in resp.strip().split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                session_ids.append(UUID(line))
+            except ValueError:
+                continue
+        return session_ids
+
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
         """Check if the sandbox pod is healthy (can exec into it).
 

--- a/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
@@ -1,8 +1,11 @@
 """Snapshot management for sandbox state persistence."""
 
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import BinaryIO
+from typing import IO
 from uuid import uuid4
 
 from onyx.configs.constants import FileOrigin
@@ -25,6 +28,17 @@ class SnapshotManager:
     - Creating snapshots of outputs directories
     - Restoring snapshots to target directories
     - Deleting snapshots from storage
+
+    Two flavors of API:
+
+    - Path-based: ``create_snapshot(sandbox_path, ...)`` and
+      ``restore_snapshot(storage_path, target_path)``. Used by the local
+      backend, which has direct filesystem access.
+    - Stream-based: ``create_snapshot_from_stream(...)`` and
+      ``restore_snapshot_to_stream(...)``. Used by container-backed
+      backends (Docker, future Firecracker, etc.) where the bytes come
+      from a `docker exec` socket. The path-based methods are thin
+      wrappers around these.
     """
 
     def __init__(self, file_store: FileStore) -> None:
@@ -34,6 +48,123 @@ class SnapshotManager:
             file_store: The file store to use for snapshot storage
         """
         self._file_store = file_store
+
+    @staticmethod
+    def _build_storage_path(tenant_id: str, sandbox_id: str, snapshot_id: str) -> str:
+        """Storage path for a snapshot tarball within the file store.
+
+        Format: ``sandbox-snapshots/{tenant_id}/{sandbox_id}/{snapshot_id}.tar.gz``
+        """
+        return f"sandbox-snapshots/{tenant_id}/{sandbox_id}/{snapshot_id}.tar.gz"
+
+    def _save_stream_to_file_store(
+        self,
+        stream: BinaryIO,
+        sandbox_id: str,
+        tenant_id: str,
+        snapshot_id: str,
+    ) -> tuple[str, int]:
+        """Persist tarball bytes to the file store and return (storage_path, size).
+
+        Streams the bytes through a temp file so we can both upload via the
+        FileStore API (which wants a seekable IO) and report a size.
+        """
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".tar.gz", delete=False
+            ) as tmp_file:
+                tmp_path = tmp_file.name
+                # Use shutil.copyfileobj so memory stays bounded for big snapshots
+                shutil.copyfileobj(stream, tmp_file)
+
+            size_bytes = Path(tmp_path).stat().st_size
+            storage_path = self._build_storage_path(tenant_id, sandbox_id, snapshot_id)
+            display_name = f"sandbox-snapshot-{sandbox_id}-{snapshot_id}.tar.gz"
+
+            with open(tmp_path, "rb") as f:
+                self._file_store.save_file(
+                    content=f,
+                    display_name=display_name,
+                    file_origin=FileOrigin.SANDBOX_SNAPSHOT,
+                    file_type=SNAPSHOT_FILE_TYPE,
+                    file_id=storage_path,
+                    file_metadata={
+                        "sandbox_id": sandbox_id,
+                        "tenant_id": tenant_id,
+                        "snapshot_id": snapshot_id,
+                    },
+                )
+
+            return storage_path, size_bytes
+        finally:
+            if tmp_path:
+                try:
+                    Path(tmp_path).unlink(missing_ok=True)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Failed to cleanup temp file {tmp_path}: {cleanup_error}"
+                    )
+
+    def create_snapshot_from_stream(
+        self,
+        stream: BinaryIO,
+        sandbox_id: str,
+        tenant_id: str,
+    ) -> tuple[str, str, int]:
+        """Persist an already-tarred snapshot stream to the file store.
+
+        Used by container-backed backends that produce a tar archive via
+        ``tar -czf -`` inside the container and stream the bytes back through
+        the exec socket.
+
+        Args:
+            stream: Binary stream yielding the tar.gz bytes (will be read to EOF)
+            sandbox_id: Sandbox identifier
+            tenant_id: Tenant identifier for multi-tenant isolation
+
+        Returns:
+            Tuple of (snapshot_id, storage_path, size_bytes)
+
+        Raises:
+            RuntimeError: If snapshot upload fails
+        """
+        snapshot_id = str(uuid4())
+        try:
+            storage_path, size_bytes = self._save_stream_to_file_store(
+                stream=stream,
+                sandbox_id=sandbox_id,
+                tenant_id=tenant_id,
+                snapshot_id=snapshot_id,
+            )
+            logger.info(
+                f"Created snapshot {snapshot_id} for sandbox {sandbox_id}, size: {size_bytes} bytes"
+            )
+            return snapshot_id, storage_path, size_bytes
+        except Exception as e:
+            logger.error(f"Failed to create snapshot for sandbox {sandbox_id}: {e}")
+            raise RuntimeError(f"Failed to create snapshot: {e}") from e
+
+    def restore_snapshot_to_stream(self, storage_path: str) -> IO[bytes]:
+        """Open a snapshot from the file store as a binary stream.
+
+        The caller is responsible for closing the returned stream and for
+        consuming it (e.g. piping into ``tar -xzf -`` inside a container).
+
+        Args:
+            storage_path: The file store path of the snapshot
+
+        Returns:
+            A binary stream containing the tar.gz bytes
+
+        Raises:
+            RuntimeError: If the snapshot can't be opened
+        """
+        try:
+            return self._file_store.read_file(storage_path, use_tempfile=True)
+        except Exception as e:
+            logger.error(f"Failed to open snapshot {storage_path}: {e}")
+            raise RuntimeError(f"Failed to open snapshot: {e}") from e
 
     def create_snapshot(
         self,
@@ -58,13 +189,12 @@ class SnapshotManager:
             FileNotFoundError: If outputs directory doesn't exist
             RuntimeError: If snapshot creation fails
         """
-        snapshot_id = str(uuid4())
         outputs_path = sandbox_path / "outputs"
 
         if not outputs_path.exists():
             raise FileNotFoundError(f"Outputs directory not found: {outputs_path}")
 
-        # Create tar.gz in temp location
+        # Create tar.gz in temp location, then hand to the stream-based path
         tmp_path: str | None = None
         try:
             with tempfile.NamedTemporaryFile(
@@ -72,46 +202,16 @@ class SnapshotManager:
             ) as tmp_file:
                 tmp_path = tmp_file.name
 
-            # Create the tar archive
             with tarfile.open(tmp_path, "w:gz") as tar:
                 tar.add(outputs_path, arcname="outputs")
 
-            # Get size
-            size_bytes = Path(tmp_path).stat().st_size
-
-            # Generate storage path for file store
-            # Format: sandbox-snapshots/{tenant_id}/{sandbox_id}/{snapshot_id}.tar.gz
-            storage_path = (
-                f"sandbox-snapshots/{tenant_id}/{sandbox_id}/{snapshot_id}.tar.gz"
-            )
-            display_name = f"sandbox-snapshot-{sandbox_id}-{snapshot_id}.tar.gz"
-
-            # Upload to file store
             with open(tmp_path, "rb") as f:
-                self._file_store.save_file(
-                    content=f,
-                    display_name=display_name,
-                    file_origin=FileOrigin.SANDBOX_SNAPSHOT,
-                    file_type=SNAPSHOT_FILE_TYPE,
-                    file_id=storage_path,
-                    file_metadata={
-                        "sandbox_id": sandbox_id,
-                        "tenant_id": tenant_id,
-                        "snapshot_id": snapshot_id,
-                    },
+                return self.create_snapshot_from_stream(
+                    stream=f,
+                    sandbox_id=sandbox_id,
+                    tenant_id=tenant_id,
                 )
-
-            logger.info(
-                f"Created snapshot {snapshot_id} for sandbox {sandbox_id}, size: {size_bytes} bytes"
-            )
-
-            return snapshot_id, storage_path, size_bytes
-
-        except Exception as e:
-            logger.error(f"Failed to create snapshot for sandbox {sandbox_id}: {e}")
-            raise RuntimeError(f"Failed to create snapshot: {e}") from e
         finally:
-            # Cleanup temp file
             if tmp_path:
                 try:
                     Path(tmp_path).unlink(missing_ok=True)
@@ -141,22 +241,16 @@ class SnapshotManager:
         tmp_path: str | None = None
         file_io = None
         try:
-            # Download from file store
-            file_io = self._file_store.read_file(storage_path, use_tempfile=True)
+            file_io = self.restore_snapshot_to_stream(storage_path)
 
-            # Write to temp file for tarfile extraction
             with tempfile.NamedTemporaryFile(
                 suffix=".tar.gz", delete=False
             ) as tmp_file:
                 tmp_path = tmp_file.name
-                # Read from the IO object and write to temp file
-                content = file_io.read()
-                tmp_file.write(content)
+                shutil.copyfileobj(file_io, tmp_file)
 
-            # Ensure target path exists
             target_path.mkdir(parents=True, exist_ok=True)
 
-            # Extract with security filter
             with tarfile.open(tmp_path, "r:gz") as tar:
                 # Use data filter for safe extraction (prevents path traversal)
                 # Available in Python 3.11.4+
@@ -164,9 +258,7 @@ class SnapshotManager:
                     tar.extractall(target_path, filter="data")
                 except TypeError:
                     # Fallback for older Python versions without filter support
-                    # Manually validate paths for security
                     for member in tar.getmembers():
-                        # Check for path traversal attempts
                         member_path = Path(target_path) / member.name
                         try:
                             member_path.resolve().relative_to(target_path.resolve())
@@ -182,7 +274,6 @@ class SnapshotManager:
             logger.error(f"Failed to restore snapshot {storage_path}: {e}")
             raise RuntimeError(f"Failed to restore snapshot: {e}") from e
         finally:
-            # Cleanup temp file
             if tmp_path:
                 try:
                     Path(tmp_path).unlink(missing_ok=True)
@@ -190,7 +281,6 @@ class SnapshotManager:
                     logger.warning(
                         f"Failed to cleanup temp file {tmp_path}: {cleanup_error}"
                     )
-            # Close the file IO if it's still open
             try:
                 if file_io:
                     file_io.close()

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -20,9 +20,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SandboxStatus
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
-from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
-from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.configs import USER_LIBRARY_SOURCE_DIR
 from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
 from onyx.server.features.build.db.build_session import (
@@ -30,9 +28,6 @@ from onyx.server.features.build.db.build_session import (
 )
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    KubernetesSandboxManager,
-)
 
 # Snapshot retention period in days
 SNAPSHOT_RETENTION_DAYS = 30
@@ -63,10 +58,10 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     Args:
         tenant_id: The tenant ID for multi-tenant isolation
     """
-    # Skip cleanup for local backend - sandboxes persist until manual termination
-    if SANDBOX_BACKEND == SandboxBackend.LOCAL:
+    sandbox_manager = get_sandbox_manager()
+    if not sandbox_manager.supports_idle_cleanup():
         task_logger.debug(
-            "cleanup_idle_sandboxes_task skipped (local backend - cleanup disabled)"
+            "cleanup_idle_sandboxes_task skipped (backend does not support idle cleanup)"
         )
         return
 
@@ -92,15 +87,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
             update_sandbox_status__no_commit,
         )
 
-        sandbox_manager = get_sandbox_manager()
-
-        # Type guard for kubernetes-specific methods
-        if not isinstance(sandbox_manager, KubernetesSandboxManager):
-            task_logger.debug(
-                "cleanup_idle_sandboxes_task skipped (not kubernetes backend)"
-            )
-            return
-
         with get_session_with_current_tenant() as db_session:
             idle_sandboxes = get_idle_sandboxes(
                 db_session, SANDBOX_IDLE_TIMEOUT_SECONDS
@@ -124,16 +110,16 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 task_logger.info(f"Putting sandbox {sandbox_id_str} to sleep")
 
                 try:
-                    # List session directories in the pod
-                    session_ids = _list_session_directories(sandbox_manager, sandbox_id)
+                    # List session directories inside the sandbox (backend-specific)
+                    session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
                     task_logger.info(
                         f"Found {len(session_ids)} sessions in sandbox {sandbox_id_str}"
                     )
 
                     # Snapshot each session
-                    for session_id_str in session_ids:
+                    for session_id in session_ids:
+                        session_id_str = str(session_id)
                         try:
-                            session_id = UUID(session_id_str)
                             task_logger.debug(
                                 f"Creating snapshot for session {session_id_str}"
                             )
@@ -196,64 +182,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
             lock.release()
 
     task_logger.info("cleanup_idle_sandboxes_task completed")
-
-
-def _list_session_directories(
-    sandbox_manager: KubernetesSandboxManager,
-    sandbox_id: UUID,
-) -> list[str]:
-    """List session directory names in the pod's /workspace/sessions/.
-
-    Args:
-        sandbox_manager: The kubernetes sandbox manager
-        sandbox_id: The sandbox ID
-
-    Returns:
-        List of session ID strings (directory names)
-    """
-    from kubernetes.client.rest import ApiException
-    from kubernetes.stream import stream as k8s_stream
-
-    pod_name = sandbox_manager._get_pod_name(str(sandbox_id))
-
-    # List directories in /workspace/sessions/
-    exec_command = [
-        "/bin/sh",
-        "-c",
-        'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
-    ]
-
-    try:
-        resp = k8s_stream(
-            sandbox_manager._core_api.connect_get_namespaced_pod_exec,
-            name=pod_name,
-            namespace=sandbox_manager._namespace,
-            container="sandbox",
-            command=exec_command,
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
-        )
-
-        # Parse output - one directory name per line
-        session_ids = []
-        for line in resp.strip().split("\n"):
-            line = line.strip()
-            if line:
-                # Validate it looks like a UUID
-                try:
-                    UUID(line)
-                    session_ids.append(line)
-                except ValueError:
-                    # Not a valid UUID, skip
-                    pass
-
-        return session_ids
-
-    except ApiException as e:
-        task_logger.warning(f"Failed to list session directories: {e}")
-        return []
 
 
 @contextmanager

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -210,6 +210,8 @@ distro==1.9.0
     #   zulip
 dnspython==2.8.0
     # via email-validator
+docker==7.1.0
+    # via onyx
 docstring-parser==0.17.0
     # via
     #   cyclopts
@@ -794,6 +796,7 @@ pytz==2025.2
 pywikibot==9.0.0
 pywin32==311 ; sys_platform == 'win32'
     # via
+    #   docker
     #   mcp
     #   pympler
 pywin32-ctypes==0.2.3 ; sys_platform == 'win32'
@@ -826,6 +829,7 @@ requests==2.33.0
     #   atlassian-python-api
     #   braintrust
     #   cohere
+    #   docker
     #   dropbox
     #   exa-py
     #   google-api-core
@@ -1061,6 +1065,7 @@ urllib3==2.6.3
     #   botocore
     #   courlan
     #   distributed
+    #   docker
     #   htmldate
     #   hubspot-api-client
     #   kubernetes

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -114,6 +114,8 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via openai
+docker==7.1.0
+    # via onyx
 docstring-parser==0.17.0
     # via google-cloud-aiplatform
 durationpy==0.10
@@ -448,7 +450,9 @@ python-multipart==0.0.26
 pytokens==0.4.1
     # via black
 pywin32==311 ; sys_platform == 'win32'
-    # via mcp
+    # via
+    #   docker
+    #   mcp
 pyyaml==6.0.3
     # via
     #   huggingface-hub
@@ -469,6 +473,7 @@ reorder-python-imports-black==3.14.0
 requests==2.33.0
     # via
     #   cohere
+    #   docker
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
@@ -598,6 +603,7 @@ tzdata==2025.2 ; sys_platform == 'win32'
 urllib3==2.6.3
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   requests
     #   sentry-sdk

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -87,6 +87,8 @@ discord-py==2.4.0
     # via onyx
 distro==1.9.0
     # via openai
+docker==7.1.0
+    # via onyx
 docstring-parser==0.17.0
     # via google-cloud-aiplatform
 durationpy==0.10
@@ -312,7 +314,9 @@ python-dotenv==1.2.2
 python-multipart==0.0.26
     # via mcp
 pywin32==311 ; sys_platform == 'win32'
-    # via mcp
+    # via
+    #   docker
+    #   mcp
 pyyaml==6.0.3
     # via
     #   huggingface-hub
@@ -326,6 +330,7 @@ regex==2025.11.3
 requests==2.33.0
     # via
     #   cohere
+    #   docker
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
@@ -414,6 +419,7 @@ typing-inspection==0.4.2
 urllib3==2.6.3
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   requests
     #   sentry-sdk

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -102,6 +102,8 @@ discord-py==2.4.0
     # via onyx
 distro==1.9.0
     # via openai
+docker==7.1.0
+    # via onyx
 docstring-parser==0.17.0
     # via google-cloud-aiplatform
 durationpy==0.10
@@ -397,7 +399,9 @@ python-dotenv==1.2.2
 python-multipart==0.0.26
     # via mcp
 pywin32==311 ; sys_platform == 'win32'
-    # via mcp
+    # via
+    #   docker
+    #   mcp
 pyyaml==6.0.3
     # via
     #   accelerate
@@ -415,6 +419,7 @@ regex==2025.11.3
 requests==2.33.0
     # via
     #   cohere
+    #   docker
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
@@ -536,6 +541,7 @@ tzdata==2025.2
 urllib3==2.6.3
     # via
     #   botocore
+    #   docker
     #   kubernetes
     #   requests
     #   sentry-sdk

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -95,6 +95,14 @@ services:
       - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
       - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
       - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+      # Sandbox backend selection. With ENABLE_CRAFT=true the supported default
+      # for docker-compose deployments is "docker" — uses the Docker Engine
+      # (via the mounted socket below) to run one container per user, with the
+      # same image family as the Kubernetes path. "local" is dev-only and
+      # provides NO container isolation. See sandbox/README.md.
+      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.5}
+      - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
     # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
     # volumes:
     #   - ./bundle.pem:/app/bundle.pem:ro
@@ -117,11 +125,24 @@ services:
       timeout: 20s
       retries: 3
       start_period: 25s
+    networks:
+      - default
+      # Shared bridge network with sandbox containers. The api_server reaches
+      # NextJS dev servers running inside sandbox containers by hostname over
+      # this network, mirroring how it reaches them via ClusterIP DNS in K8s.
+      - craft_sandbox
     # Optional, only for debugging purposes
     volumes:
       - api_server_logs:/var/log/onyx
       # Shared volume for persistent document storage (Craft file-system mode)
       - file-system:/app/file-system
+      # WARNING: Mounting the Docker socket grants the api_server root-level
+      # access to the host. Required when SANDBOX_BACKEND=docker (the supported
+      # default for self-hosted Craft). To avoid the socket mount, set
+      # SANDBOX_BACKEND=local — but note that "local" provides NO container
+      # isolation and is intended for dev only. See sandbox/README.md for
+      # the full trust-boundary discussion.
+      - /var/run/docker.sock:/var/run/docker.sock
 
   background:
     image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
@@ -181,16 +202,30 @@ services:
       - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
       - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
       - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+      # Mirror the api_server's sandbox backend so the idle-cleanup beat task
+      # picks the same code path. The background container does not strictly
+      # need the docker socket (cleanup happens via the api_server-side manager
+      # that already has the socket), but it does need the env var for branch
+      # selection inside the manager factory.
+      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.5}
+      - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
     # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
     # volumes:
     #   - ./bundle.pem:/app/bundle.pem:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - craft_sandbox
     # Optional, only for debugging purposes
     volumes:
       - background_logs:/var/log/onyx
       # Shared volume for persistent document storage (Craft file-system mode)
       - file-system:/app/file-system
+      # See note on the api_server socket mount. Beat uses the manager factory
+      # for idle cleanup (snapshot + terminate), so it needs Docker access too.
+      - /var/run/docker.sock:/var/run/docker.sock
     logging:
       driver: json-file
       options:
@@ -594,3 +629,16 @@ volumes:
   file-system:
   # Persistent data for OpenSearch.
   opensearch-data:
+
+networks:
+  # Default network used by the rest of the deployment.
+  default:
+  # Bridge network shared between the api_server, background workers, and
+  # sandbox containers when SANDBOX_BACKEND=docker. Sandbox containers are not
+  # published on the host — the api_server reaches their NextJS dev servers
+  # by container hostname over this network. Backed by the docker default
+  # bridge driver; idempotently created in DockerSandboxManager._ensure_network
+  # if not already present.
+  craft_sandbox:
+    name: ${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
+    driver: bridge

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -18,6 +18,21 @@ IMAGE_TAG=latest
 # ENABLE_CRAFT=true
 # IMAGE_TAG=craft-latest
 
+## Sandbox backend selection.
+## - "docker" (default for compose deployments): one container per user via the
+##   Docker Engine API. Requires the api_server to have access to the Docker
+##   socket — that's already mounted in docker-compose.yml. Mounting the socket
+##   is equivalent to root on the host; same trust model that K8s' RBAC for
+##   sandbox pods provides. This is the supported self-hosted production path.
+## - "local": NO container isolation, runs the agent in the api_server process.
+##   Dev-only.
+# SANDBOX_BACKEND=docker
+## Sandbox container image. Pinned default tracks the helm chart's image.
+# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.5
+## Bridge network the api_server and sandbox containers join. The default name
+## is what docker-compose.yml creates; only change if you have a collision.
+# SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
+
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
 AUTH_TYPE=basic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.19",
     "agent-client-protocol>=0.7.1",
     "discord-py==2.4.0",
+    "docker>=7.0.0,<8",
     "kubernetes>=31.0.0",
 ]
 
@@ -63,6 +64,7 @@ backend = [
     "inflection==0.5.1",
     "jira==3.10.5",
     "jsonref==1.1.0",
+    "docker==7.1.0",
     "kubernetes==31.0.0",
     "trafilatura==1.12.2",
     "langchain-core==1.2.28",

--- a/uv.lock
+++ b/uv.lock
@@ -1498,6 +1498,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4350,6 +4364,7 @@ dependencies = [
     { name = "claude-agent-sdk" },
     { name = "cohere" },
     { name = "discord-py" },
+    { name = "docker" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "kubernetes" },
@@ -4382,6 +4397,7 @@ backend = [
     { name = "dask" },
     { name = "discord-py" },
     { name = "distributed" },
+    { name = "docker" },
     { name = "dropbox" },
     { name = "exa-py" },
     { name = "fastapi-limiter" },
@@ -4522,6 +4538,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = ">=0.1.19" },
     { name = "cohere", specifier = "==5.6.1" },
     { name = "discord-py", specifier = "==2.4.0" },
+    { name = "docker", specifier = ">=7.0.0,<8" },
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
@@ -4554,6 +4571,7 @@ backend = [
     { name = "dask", specifier = "==2026.1.1" },
     { name = "discord-py", specifier = "==2.4.0" },
     { name = "distributed", specifier = "==2026.1.1" },
+    { name = "docker", specifier = "==7.1.0" },
     { name = "dropbox", specifier = "==12.0.2" },
     { name = "exa-py", specifier = "==1.15.4" },
     { name = "fastapi-limiter", specifier = "==0.1.6" },


### PR DESCRIPTION
## Description

Implements project #2 from `plans/craft/sandbox-backends.md` — a `docker` `SandboxManager` backend that drives the Docker Engine API directly from the api_server. This gives self-hosted Onyx deployments real container isolation for Craft without requiring Kubernetes; `local` becomes explicitly dev-only and `kubernetes` stays the cloud path.

**What's added**

- `DockerSandboxManager` (`backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py`) — symmetric with `KubernetesSandboxManager`: one container per user, sessions as subdirectories, every operation goes through `docker exec` (the analog of `kubectl exec`). Idempotent provisioning, idle cleanup, and snapshot/restore are supported.
- Docker ACP exec client (`docker/internal/acp_exec_client.py`) — mirrors the K8s client's public surface (`start`, `resume_or_create_session`, `send_message`, `stop`, `cancel`, `health_check`). Uses `exec_create` + `exec_start(socket=True)` for a duplex JSON-RPC pipe and demultiplexes the 8-byte stream-framing headers Docker emits in non-TTY mode.
- Exec helpers (`docker/internal/exec_helpers.py`) — `exec_shell`, `exec_stream_stdout` (tar pipe), `exec_write_stdin` (restore), with a typed `DockerExecError`.
- New `SandboxBackend.DOCKER` enum + Docker-specific config knobs (`SANDBOX_DOCKER_HOST`, `SANDBOX_DOCKER_NETWORK`, `SANDBOX_DOCKER_CPU_LIMIT`, `SANDBOX_DOCKER_MEMORY_LIMIT`).

**What's refactored**

- `SandboxManager` ABC gains `supports_idle_cleanup()` and `list_session_workspaces()` so `cleanup_idle_sandboxes_task` no longer needs `isinstance(KubernetesSandboxManager)`. The free-function `_list_session_directories` helper in `tasks.py` is removed; both K8s and Docker managers implement the new method.
- `SnapshotManager` grows `create_snapshot_from_stream` / `restore_snapshot_to_stream`. The path-based methods become thin wrappers, so the docker backend can hand it raw bytes from a `docker exec` socket and reuse the same `FileStore` plumbing — works against MinIO, S3, GCS, or local-disk file stores with zero extra config (no s5cmd, no IRSA, no init container).
- K8s manager now also implements `list_session_workspaces()` / `supports_idle_cleanup()`.

**Deployment**

- `deployment/docker_compose/docker-compose.yml`: api_server + background mount `/var/run/docker.sock`, join a new `craft_sandbox` bridge network, and default to `SANDBOX_BACKEND=docker`. The compose file declares the network at the top level (also created idempotently by the manager on startup).
- `env.template`: documents `SANDBOX_BACKEND`, `SANDBOX_CONTAINER_IMAGE`, `SANDBOX_DOCKER_NETWORK`, and the trust-boundary note about mounting the Docker socket.
- `pyproject.toml` + `backend/requirements/*.txt` + `uv.lock`: add `docker>=7.0,<8` (resolved to 7.1.0).
- `sandbox/README.md`: deployment-mode comparison table, Docker config reference, updated managers list.

**Trust boundary**

Mounting `/var/run/docker.sock` into the api_server is equivalent to root on the host. This is the same trust delta the helm chart accepts via the `sandbox-runner` ServiceAccount. Self-hosted admins who don't want to mount the socket are explicitly told to set `SANDBOX_BACKEND=local` and accept the loss of isolation. Documented in `sandbox/README.md` and `env.template`.

**Out of scope (per the plan)**

- Tests — explicitly skipped for this PR per request.
- Renaming the `kubernetes/docker/` subtree (the awkward path is documented in the README and is per the V1 plan).
- Migration of existing Craft sessions — V1 has no migration story; existing sandboxes will be wiped on upgrade.

## How Has This Been Tested?

Static checks only (no runtime/integration tests yet):

- `ruff check` — clean across all modified/new files.
- `uv run --active ty check` — clean across all modified/new files.
- `python -c \"...DockerSandboxManager...\"` — confirms `__abstractmethods__` is empty (all SandboxManager methods implemented).
- `docker compose -f deployment/docker_compose/docker-compose.yml config` — validates compose syntax and that the new `craft_sandbox` network + socket mount + env vars resolve.
- Pre-commit hooks (uv-lock, uv-export, lazy-imports, ty, black, ruff, ripsecrets) all pass.

End-to-end manual smoke testing called out in the plan (provision a sandbox via `docker compose up`, run a Craft session, verify idle cleanup snapshots and restores) **has not been done in this PR** and should be a follow-up before merge.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `docker` sandbox backend that runs one container per user via the Docker Engine to give self-hosted deployments real isolation without Kubernetes. Docker Compose now defaults to this backend and wires the socket and network.

- New Features
  - `DockerSandboxManager`: one container per user, sessions as subdirectories, all ops via `docker exec`; supports snapshots and idle cleanup.
  - Docker ACP exec client using `exec_create`/`exec_start(socket=True)` with stream demux; mirrors the K8s client surface.
  - `SnapshotManager` stream APIs (`create_snapshot_from_stream` / `restore_snapshot_to_stream`); path methods wrap these; reuse existing `FileStore`.
  - Config and compose defaults: new `SandboxBackend.DOCKER`, `SANDBOX_DOCKER_*` knobs; compose mounts `/var/run/docker.sock`, creates `craft_sandbox` network, and sets `SANDBOX_BACKEND=docker`; adds `docker` dependency.
  - Idle cleanup API generalized: `supports_idle_cleanup()` and `list_session_workspaces()` added to the ABC; K8s implements them; tasks simplified. Docs updated with mode comparison and socket trust boundary.

- Migration
  - Use `deployment/docker_compose/docker-compose.yml`; default backend is `docker`.
  - Ensure `/var/run/docker.sock` is mounted and the bridge network (`SANDBOX_DOCKER_NETWORK`) exists.
  - Set `SANDBOX_CONTAINER_IMAGE` if you need a specific sandbox image.
  - Note the trust boundary: mounting the Docker socket is root-equivalent; `local` remains dev-only.

<sup>Written for commit 7db3495ed76b79976447e6b4a361d580c879035e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

