### PR TITLE
chore(playwright): remove timestamp from persona chat screenshot

### DIFF
--- a/web/tests/e2e/agents/persona_chat.spec.ts
+++ b/web/tests/e2e/agents/persona_chat.spec.ts
@@ -16,7 +16,7 @@ test.describe("Chatting with a custom persona", () => {
   test.describe.configure({ mode: "serial" });
 
   let agentId: number | null = null;
-  const agentName = `E2E Persona Chat ${Date.now()}`;
+  const agentName = `E2E Persona Chat`;
 
   test.beforeAll(async ({ browser }: { browser: Browser }) => {
     const context = await browser.newContext({


### PR DESCRIPTION
## Summary
- Drop the `Date.now()` suffix from the persona name in the persona chat E2E test so the agent name is stable across runs (better for screenshot diffing / determinism).

## Test plan
- [ ] `npx playwright test persona_chat`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `Date.now()` suffix from the persona name in the persona chat Playwright E2E test so the agent name is stable across runs. This makes screenshots deterministic and prevents noisy diffs.

<sup>Written for commit 3afc682cf7fa3c66ab185a309495882dfabb22f0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10713?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

