### PR TITLE
fix(pruning): Explicitly stamp enqueued_at header on pruning generator tasks

### DIFF
--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -425,6 +425,7 @@ def try_creating_prune_generator_task(
             queue=OnyxCeleryQueues.CONNECTOR_PRUNING,
             task_id=custom_task_id,
             priority=OnyxCeleryPriority.LOW,
+            headers={"enqueued_at": time.time()},
         )
 
         # fill in the celery task id


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
The onyx_celery_task_queue_wait_seconds metric for queue="connector_pruning" stopped showing data around April 24. Investigation confirmed on_celery_task_prerun is running (TASK_STARTED has data), but task.request.headers["enqueued_at"] is absent when it executes, so the queue wait observation is skipped.
<img width="800" height="304" alt="Screenshot 2026-04-29 at 1 40 35 PM" src="https://github.com/user-attachments/assets/f8502b0c-0a6d-49da-9b5e-4be9ec99fca9" />

The global before_task_publish signal in app_base.py is responsible for stamping enqueued_at on all tasks, but it is not reliably firing for connector_pruning_generator_task (likely a signal receiver capture timing issue on the heavy worker). Adding headers={"enqueued_at": time.time()} directly to the send_task() call bypasses the signal entirely and unconditionally stamps the header at the call site.
https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
## How Has This Been Tested?
n/a
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly stamps the `enqueued_at` header when enqueuing pruning generator tasks so `onyx_celery_task_queue_wait_seconds` for the `connector_pruning` queue records again. Addresses ENG-3954 (pruning correctness).

- **Bug Fixes**
  - Add `headers={"enqueued_at": time.time()}` to the pruning generator `send_task(...)`, bypassing the flaky `before_task_publish` signal.

<sup>Written for commit 6cda19da9758292c97dd02972b11ef9aa9eea7a6. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10714?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

