### PR TITLE
fix(hubspot): N+1 HubSpot association fetches using batch_read API

### DIFF
--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -1,4 +1,5 @@
 import re
+import time
 from collections.abc import Callable
 from collections.abc import Generator
 from datetime import datetime
@@ -57,11 +58,16 @@ HUBSPOT_PAGE_SIZE = 100
 # HubSpot Search API rejects cursors beyond this offset.
 HUBSPOT_SEARCH_LIMIT = 10_000
 
-CONTACT_PROPERTIES = ["firstname", "lastname", "email", "company", "jobtitle"]
-COMPANY_PROPERTIES = ["name", "domain", "industry", "city", "state"]
-DEAL_PROPERTIES = ["dealname", "amount", "dealstage", "closedate", "pipeline"]
-TICKET_PROPERTIES = ["subject", "content", "hs_ticket_priority"]
-NOTE_PROPERTIES = ["hs_note_body", "hs_timestamp", "hs_created_by", "hubspot_owner_id"]
+ASSOC_CONTACT_PROPERTIES = ["firstname", "lastname", "email", "company", "jobtitle"]
+ASSOC_COMPANY_PROPERTIES = ["name", "domain", "industry", "city", "state"]
+ASSOC_DEAL_PROPERTIES = ["dealname", "amount", "dealstage", "closedate", "pipeline"]
+ASSOC_TICKET_PROPERTIES = ["subject", "content", "hs_ticket_priority"]
+ASSOC_NOTE_PROPERTIES = [
+    "hs_note_body",
+    "hs_timestamp",
+    "hs_created_by",
+    "hubspot_owner_id",
+]
 
 
 _T = TypeVar("_T")
@@ -149,6 +155,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     logger.warning(
                         f"Batch fetch of {len(chunk)} {object_type} failed, retrying: {e}"
                     )
+                    time.sleep(1)
         logger.warning(
             f"Failed to batch-fetch {len(chunk)} {object_type} {chunk} after retry: {last_exc}"
         )
@@ -429,7 +436,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                         self._batch_read(
                             api_client.crm.contacts.batch_api.read,
                             ContactsBatchReadInput(
-                                properties=CONTACT_PROPERTIES,
+                                properties=ASSOC_CONTACT_PROPERTIES,
                                 inputs=[ContactObjectId(id=i) for i in chunk],
                             ),
                             "contacts",
@@ -443,7 +450,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                         self._batch_read(
                             api_client.crm.companies.batch_api.read,
                             CompaniesBatchReadInput(
-                                properties=COMPANY_PROPERTIES,
+                                properties=ASSOC_COMPANY_PROPERTIES,
                                 inputs=[CompanyObjectId(id=i) for i in chunk],
                             ),
                             "companies",
@@ -457,7 +464,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                         self._batch_read(
                             api_client.crm.deals.batch_api.read,
                             DealsBatchReadInput(
-                                properties=DEAL_PROPERTIES,
+                                properties=ASSOC_DEAL_PROPERTIES,
                                 inputs=[DealObjectId(id=i) for i in chunk],
                             ),
                             "deals",
@@ -471,7 +478,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                         self._batch_read(
                             api_client.crm.tickets.batch_api.read,
                             TicketsBatchReadInput(
-                                properties=TICKET_PROPERTIES,
+                                properties=ASSOC_TICKET_PROPERTIES,
                                 inputs=[TicketObjectId(id=i) for i in chunk],
                             ),
                             "tickets",
@@ -511,7 +518,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     self._batch_read(
                         api_client.crm.objects.notes.batch_api.read,
                         NotesBatchReadInput(
-                            properties=NOTE_PROPERTIES,
+                            properties=ASSOC_NOTE_PROPERTIES,
                             inputs=[NoteObjectId(id=str(nid)) for nid in chunk],
                         ),
                         "notes",

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -9,9 +9,29 @@ from typing import TypeVar
 
 import requests
 from hubspot import HubSpot
+from hubspot.crm.companies.models import (
+    BatchReadInputSimplePublicObjectId as CompaniesBatchReadInput,
+)
+from hubspot.crm.companies.models import SimplePublicObjectId as CompanyObjectId
+from hubspot.crm.contacts.models import (
+    BatchReadInputSimplePublicObjectId as ContactsBatchReadInput,
+)
 from hubspot.crm.contacts.models import Filter
 from hubspot.crm.contacts.models import FilterGroup
 from hubspot.crm.contacts.models import PublicObjectSearchRequest
+from hubspot.crm.contacts.models import SimplePublicObjectId as ContactObjectId
+from hubspot.crm.deals.models import (
+    BatchReadInputSimplePublicObjectId as DealsBatchReadInput,
+)
+from hubspot.crm.deals.models import SimplePublicObjectId as DealObjectId
+from hubspot.crm.objects.notes.models import (
+    BatchReadInputSimplePublicObjectId as NotesBatchReadInput,
+)
+from hubspot.crm.objects.notes.models import SimplePublicObjectId as NoteObjectId
+from hubspot.crm.tickets.models import (
+    BatchReadInputSimplePublicObjectId as TicketsBatchReadInput,
+)
+from hubspot.crm.tickets.models import SimplePublicObjectId as TicketObjectId
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -36,6 +56,12 @@ AVAILABLE_OBJECT_TYPES = {"tickets", "companies", "deals", "contacts"}
 HUBSPOT_PAGE_SIZE = 100
 # HubSpot Search API rejects cursors beyond this offset.
 HUBSPOT_SEARCH_LIMIT = 10_000
+
+
+def _chunked(items: list[Any], size: int) -> Generator[list[Any], None, None]:
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
 
 T = TypeVar("T")
 
@@ -365,70 +391,78 @@ class HubSpotConnector(LoadConnector, PollConnector):
             associated_objects: list[dict[str, Any]] = []
 
             if to_object_type == "contacts":
-                for obj_id in object_ids:
+                properties = ["firstname", "lastname", "email", "company", "jobtitle"]
+                for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
                     try:
-                        obj = self._call_hubspot(
-                            api_client.crm.contacts.basic_api.get_by_id,
-                            contact_id=obj_id,
-                            properties=[
-                                "firstname",
-                                "lastname",
-                                "email",
-                                "company",
-                                "jobtitle",
-                            ],
+                        resp = self._call_hubspot(
+                            api_client.crm.contacts.batch_api.read,
+                            ContactsBatchReadInput(
+                                properties=properties,
+                                inputs=[ContactObjectId(id=i) for i in chunk],
+                            ),
                         )
-                        associated_objects.append(obj.to_dict())
+                        associated_objects.extend(
+                            obj.to_dict() for obj in (resp.results or [])
+                        )
                     except Exception as e:
-                        logger.warning(f"Failed to fetch contact {obj_id}: {e}")
+                        logger.warning(f"Failed to batch-fetch contacts {chunk}: {e}")
 
             elif to_object_type == "companies":
-                for obj_id in object_ids:
+                properties = ["name", "domain", "industry", "city", "state"]
+                for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
                     try:
-                        obj = self._call_hubspot(
-                            api_client.crm.companies.basic_api.get_by_id,
-                            company_id=obj_id,
-                            properties=[
-                                "name",
-                                "domain",
-                                "industry",
-                                "city",
-                                "state",
-                            ],
+                        resp = self._call_hubspot(
+                            api_client.crm.companies.batch_api.read,
+                            CompaniesBatchReadInput(
+                                properties=properties,
+                                inputs=[CompanyObjectId(id=i) for i in chunk],
+                            ),
                         )
-                        associated_objects.append(obj.to_dict())
+                        associated_objects.extend(
+                            obj.to_dict() for obj in (resp.results or [])
+                        )
                     except Exception as e:
-                        logger.warning(f"Failed to fetch company {obj_id}: {e}")
+                        logger.warning(f"Failed to batch-fetch companies {chunk}: {e}")
 
             elif to_object_type == "deals":
-                for obj_id in object_ids:
+                properties = [
+                    "dealname",
+                    "amount",
+                    "dealstage",
+                    "closedate",
+                    "pipeline",
+                ]
+                for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
                     try:
-                        obj = self._call_hubspot(
-                            api_client.crm.deals.basic_api.get_by_id,
-                            deal_id=obj_id,
-                            properties=[
-                                "dealname",
-                                "amount",
-                                "dealstage",
-                                "closedate",
-                                "pipeline",
-                            ],
+                        resp = self._call_hubspot(
+                            api_client.crm.deals.batch_api.read,
+                            DealsBatchReadInput(
+                                properties=properties,
+                                inputs=[DealObjectId(id=i) for i in chunk],
+                            ),
                         )
-                        associated_objects.append(obj.to_dict())
+                        associated_objects.extend(
+                            obj.to_dict() for obj in (resp.results or [])
+                        )
                     except Exception as e:
-                        logger.warning(f"Failed to fetch deal {obj_id}: {e}")
+                        logger.warning(f"Failed to batch-fetch deals {chunk}: {e}")
 
             elif to_object_type == "tickets":
-                for obj_id in object_ids:
+                properties = ["subject", "content", "hs_ticket_priority"]
+                for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
                     try:
-                        obj = self._call_hubspot(
-                            api_client.crm.tickets.basic_api.get_by_id,
-                            ticket_id=obj_id,
-                            properties=["subject", "content", "hs_ticket_priority"],
+                        resp = self._call_hubspot(
+                            api_client.crm.tickets.batch_api.read,
+                            TicketsBatchReadInput(
+                                properties=properties,
+                                inputs=[TicketObjectId(id=i) for i in chunk],
+                            ),
                         )
-                        associated_objects.append(obj.to_dict())
+                        associated_objects.extend(
+                            obj.to_dict() for obj in (resp.results or [])
+                        )
                     except Exception as e:
-                        logger.warning(f"Failed to fetch ticket {obj_id}: {e}")
+                        logger.warning(f"Failed to batch-fetch tickets {chunk}: {e}")
 
             return associated_objects
 
@@ -455,24 +489,28 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
             note_ids = [assoc.to_object_id for assoc in associations_iter]
 
-            associated_notes = []
+            associated_notes: list[dict[str, Any]] = []
+            note_properties = [
+                "hs_note_body",
+                "hs_timestamp",
+                "hs_created_by",
+                "hubspot_owner_id",
+            ]
 
-            for note_id in note_ids:
+            for chunk in _chunked(note_ids, HUBSPOT_PAGE_SIZE):
                 try:
-                    # Notes are engagements in HubSpot, use the engagements API
-                    note = self._call_hubspot(
-                        api_client.crm.objects.notes.basic_api.get_by_id,
-                        note_id=note_id,
-                        properties=[
-                            "hs_note_body",
-                            "hs_timestamp",
-                            "hs_created_by",
-                            "hubspot_owner_id",
-                        ],
+                    resp = self._call_hubspot(
+                        api_client.crm.objects.notes.batch_api.read,
+                        NotesBatchReadInput(
+                            properties=note_properties,
+                            inputs=[NoteObjectId(id=str(nid)) for nid in chunk],
+                        ),
                     )
-                    associated_notes.append(note.to_dict())
+                    associated_notes.extend(
+                        note.to_dict() for note in (resp.results or [])
+                    )
                 except Exception as e:
-                    logger.warning(f"Failed to fetch note {note_id}: {e}")
+                    logger.warning(f"Failed to batch-fetch notes {chunk}: {e}")
 
             return associated_notes
 

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -57,8 +57,17 @@ HUBSPOT_PAGE_SIZE = 100
 # HubSpot Search API rejects cursors beyond this offset.
 HUBSPOT_SEARCH_LIMIT = 10_000
 
+CONTACT_PROPERTIES = ["firstname", "lastname", "email", "company", "jobtitle"]
+COMPANY_PROPERTIES = ["name", "domain", "industry", "city", "state"]
+DEAL_PROPERTIES = ["dealname", "amount", "dealstage", "closedate", "pipeline"]
+TICKET_PROPERTIES = ["subject", "content", "hs_ticket_priority"]
+NOTE_PROPERTIES = ["hs_note_body", "hs_timestamp", "hs_created_by", "hubspot_owner_id"]
 
-def _chunked(items: list[Any], size: int) -> Generator[list[Any], None, None]:
+
+_T = TypeVar("_T")
+
+
+def _chunked(items: list[_T], size: int) -> Generator[list[_T], None, None]:
     for i in range(0, len(items), size):
         yield items[i : i + size]
 
@@ -120,6 +129,30 @@ class HubSpotConnector(LoadConnector, PollConnector):
 
     def _call_hubspot(self, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         return self._rate_limiter.call(func, *args, **kwargs)
+
+    def _batch_read(
+        self,
+        batch_fn: Callable[..., Any],
+        batch_input: Any,
+        object_type: str,
+        chunk: list[Any],
+    ) -> list[dict[str, Any]]:
+        """Call batch_fn with one retry; logs dropped IDs if both attempts fail."""
+        last_exc: Exception | None = None
+        for attempt in range(2):
+            try:
+                resp = self._call_hubspot(batch_fn, batch_input)
+                return [obj.to_dict() for obj in (resp.results or [])]
+            except Exception as e:
+                last_exc = e
+                if attempt == 0:
+                    logger.warning(
+                        f"Batch fetch of {len(chunk)} {object_type} failed, retrying: {e}"
+                    )
+        logger.warning(
+            f"Failed to batch-fetch {len(chunk)} {object_type} {chunk} after retry: {last_exc}"
+        )
+        return []
 
     def _paginated_results(
         self,
@@ -391,78 +424,60 @@ class HubSpotConnector(LoadConnector, PollConnector):
             associated_objects: list[dict[str, Any]] = []
 
             if to_object_type == "contacts":
-                properties = ["firstname", "lastname", "email", "company", "jobtitle"]
                 for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
-                    try:
-                        resp = self._call_hubspot(
+                    associated_objects.extend(
+                        self._batch_read(
                             api_client.crm.contacts.batch_api.read,
                             ContactsBatchReadInput(
-                                properties=properties,
+                                properties=CONTACT_PROPERTIES,
                                 inputs=[ContactObjectId(id=i) for i in chunk],
                             ),
+                            "contacts",
+                            chunk,
                         )
-                        associated_objects.extend(
-                            obj.to_dict() for obj in (resp.results or [])
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to batch-fetch contacts {chunk}: {e}")
+                    )
 
             elif to_object_type == "companies":
-                properties = ["name", "domain", "industry", "city", "state"]
                 for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
-                    try:
-                        resp = self._call_hubspot(
+                    associated_objects.extend(
+                        self._batch_read(
                             api_client.crm.companies.batch_api.read,
                             CompaniesBatchReadInput(
-                                properties=properties,
+                                properties=COMPANY_PROPERTIES,
                                 inputs=[CompanyObjectId(id=i) for i in chunk],
                             ),
+                            "companies",
+                            chunk,
                         )
-                        associated_objects.extend(
-                            obj.to_dict() for obj in (resp.results or [])
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to batch-fetch companies {chunk}: {e}")
+                    )
 
             elif to_object_type == "deals":
-                properties = [
-                    "dealname",
-                    "amount",
-                    "dealstage",
-                    "closedate",
-                    "pipeline",
-                ]
                 for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
-                    try:
-                        resp = self._call_hubspot(
+                    associated_objects.extend(
+                        self._batch_read(
                             api_client.crm.deals.batch_api.read,
                             DealsBatchReadInput(
-                                properties=properties,
+                                properties=DEAL_PROPERTIES,
                                 inputs=[DealObjectId(id=i) for i in chunk],
                             ),
+                            "deals",
+                            chunk,
                         )
-                        associated_objects.extend(
-                            obj.to_dict() for obj in (resp.results or [])
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to batch-fetch deals {chunk}: {e}")
+                    )
 
             elif to_object_type == "tickets":
-                properties = ["subject", "content", "hs_ticket_priority"]
                 for chunk in _chunked(object_ids, HUBSPOT_PAGE_SIZE):
-                    try:
-                        resp = self._call_hubspot(
+                    associated_objects.extend(
+                        self._batch_read(
                             api_client.crm.tickets.batch_api.read,
                             TicketsBatchReadInput(
-                                properties=properties,
+                                properties=TICKET_PROPERTIES,
                                 inputs=[TicketObjectId(id=i) for i in chunk],
                             ),
+                            "tickets",
+                            chunk,
                         )
-                        associated_objects.extend(
-                            obj.to_dict() for obj in (resp.results or [])
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to batch-fetch tickets {chunk}: {e}")
+                    )
 
             return associated_objects
 
@@ -490,27 +505,19 @@ class HubSpotConnector(LoadConnector, PollConnector):
             note_ids = [assoc.to_object_id for assoc in associations_iter]
 
             associated_notes: list[dict[str, Any]] = []
-            note_properties = [
-                "hs_note_body",
-                "hs_timestamp",
-                "hs_created_by",
-                "hubspot_owner_id",
-            ]
 
             for chunk in _chunked(note_ids, HUBSPOT_PAGE_SIZE):
-                try:
-                    resp = self._call_hubspot(
+                associated_notes.extend(
+                    self._batch_read(
                         api_client.crm.objects.notes.batch_api.read,
                         NotesBatchReadInput(
-                            properties=note_properties,
+                            properties=NOTE_PROPERTIES,
                             inputs=[NoteObjectId(id=str(nid)) for nid in chunk],
                         ),
+                        "notes",
+                        chunk,
                     )
-                    associated_notes.extend(
-                        note.to_dict() for note in (resp.results or [])
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to batch-fetch notes {chunk}: {e}")
+                )
 
             return associated_notes
 

--- a/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
+++ b/backend/tests/unit/onyx/connectors/hubspot/test_hubspot_inline_associations.py
@@ -88,10 +88,9 @@ class TestGetAssociatedObjectsSkipsV4Call:
             m.to_dict.return_value = {"id": id_, "properties": {"firstname": "A"}}
             return m
 
-        mock_client.crm.contacts.basic_api.get_by_id.side_effect = [
-            make_contact("11"),
-            make_contact("22"),
-        ]
+        batch_response = MagicMock()
+        batch_response.results = [make_contact("11"), make_contact("22")]
+        mock_client.crm.contacts.batch_api.read.return_value = batch_response
 
         with patch.object(connector, "_paginated_results") as mock_paginated:
             result = connector._get_associated_objects(
@@ -103,7 +102,7 @@ class TestGetAssociatedObjectsSkipsV4Call:
             )
 
         mock_paginated.assert_not_called()
-        assert mock_client.crm.contacts.basic_api.get_by_id.call_count == 2
+        assert mock_client.crm.contacts.batch_api.read.call_count == 1
         assert [r["id"] for r in result] == ["11", "22"]
 
     def test_v4_api_called_when_inline_ids_is_none(self) -> None:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fix N+1 HubSpot association fetches using batch_read API

Replace per-ID get_by_id calls in _get_associated_objects and _get_associated_notes with chunked batch_api.read calls (up to 100 IDs per request). For a ticket with 50 associated contacts, this drops 50 API calls to 1. No behavior change — results are identical, error handling is preserved per-chunk.

Files changed:

- connector.py — imports 6 new SDK batch models, adds _chunked helper, rewrites both fetch loops
- test_hubspot_inline_associations.py — updates one test to mock batch_api.read instead of basic_api.get_by_id

https://linear.app/onyx-app/issue/ENG-4077/hubspot-connector-more-efficient-indexing

## How Has This Been Tested?
All unit tests passed 

Local tested

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes N+1 HubSpot association fetches by switching to `batch_api.read`, cutting dozens of requests down to one per chunk and speeding up indexing. Behavior is unchanged and aligns with Linear ENG-4077 (more efficient indexing).

- **Refactors**
  - Replace `basic_api.get_by_id` with `batch_api.read` for contacts, companies, deals, tickets, and notes (chunked by `HUBSPOT_PAGE_SIZE`, up to 100 IDs per request).
  - Add `_chunked` and `_batch_read` (one retry with 1s backoff and per-chunk logging); define shared `ASSOC_*_PROPERTIES` lists for consistent fields.
  - Update unit test to mock `crm.contacts.batch_api.read` and assert a single batch call.

<sup>Written for commit b7a613d60b7f7f1b27fb187a9359c7f07bf902a1. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10715?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

