### PR TITLE
chore(tests): use `allow_module_level=True` as needed

### DIFF
--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -95,7 +95,8 @@ def _get_all_backend_configs() -> List[BackendConfig]:
 
     if not configs:
         pytest.skip(
-            "No backend configurations available - set MinIO or AWS S3 credentials"
+            "No backend configurations available - set MinIO or AWS S3 credentials",
+            allow_module_level=True,
         )
 
     return configs


### PR DESCRIPTION
## Description

The nightly external dependency tests added in 
* 3746a59dd - chore(tests): LLM provider tests for openai and ollama (#10462) (21 hours ago) <Jamison Lahman>

skip many tests.

pytest is complaining because `backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py` is being skipped and has a global `pytest.skip()` which pytest requires an explicit `allow_module_level=True,` to allow.

Closes https://onyx-company.slack.com/archives/C07K8KBMGKF/p1777461372317869

## How Has This Been Tested?

https://github.com/onyx-dot-app/onyx/actions/runs/25135408149

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `allow_module_level=True` to the module-level `pytest.skip()` in the file-store external dependency test. This removes the `pytest` complaint and cleanly skips the test when MinIO or AWS S3 credentials are not set.

<sup>Written for commit 68000edaee483fcdeb906173c24f6803b06af868. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10717?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

