### PR TITLE
fix(openrouter): enable auto-update mode

### DIFF
--- a/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
+++ b/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
@@ -85,7 +85,7 @@ function OpenRouterModalInternals({
 
       <InputDivider />
       <ModelSelectionField
-        shouldShowAutoUpdateToggle={false}
+        shouldShowAutoUpdateToggle={true}
         onRefetch={isFetchDisabled ? undefined : handleFetchModels}
       />
 


### PR DESCRIPTION
## Description

OpenRouter is in the recommended-models.json, so should have the toggle for auto-mode.

## How Has This Been Tested?

<img width="1587" height="2085" alt="20260429_15h22m51s_grim" src="https://github.com/user-attachments/assets/d435b1c2-87d1-4f20-a8b0-a7cd95302c92" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable auto-update mode for OpenRouter by showing the auto-update toggle in the model selector. This aligns with `recommended-models.json` and lets OpenRouter models update automatically.

<sup>Written for commit 518b217b50f55c7a63550f1223066767476dfcb9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10718?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

