### PR TITLE
fix(fe): model selector check icon is center aligned

### DIFF
--- a/web/src/refresh-components/popovers/ModelListContent.tsx
+++ b/web/src/refresh-components/popovers/ModelListContent.tsx
@@ -126,7 +126,9 @@ export default function ModelListContent({
         onClick={() => onSelect(option)}
         rightChildren={
           selected ? (
-            <SvgCheck className="text-action-link-05" size={16} />
+            <div className="flex h-5 items-center">
+              <SvgCheck className="text-action-link-05" size={16} />
+            </div>
           ) : null
         }
         sizePreset="main-ui"


### PR DESCRIPTION
## Description

Wraps the icon with a `1.25rem` div and center aligns the icon within. This ensures the icon is always inline with the first line of text.

## How Has This Been Tested?

**before**
<img width="1587" height="2085" alt="20260429_15h36m43s_grim" src="https://github.com/user-attachments/assets/cf7b41f4-48a6-499c-a2ea-96c49d534bcc" />

**after**
<img width="1587" height="2085" alt="20260429_15h37m16s_grim" src="https://github.com/user-attachments/assets/22818303-bf33-4ddb-8fe7-0987c681ada4" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers the selected check icon in the model selector so it aligns with the first line of the option label. Wraps `SvgCheck` in a `div` with `flex h-5 items-center` to keep vertical alignment consistent, including when text wraps.

<sup>Written for commit 4f5592dfce85a8d3720e21976cdc6daedb47b272. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10719?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

