### PR TITLE
feat(retry): schema for targeted document re-indexing

### DIFF
--- a/backend/alembic/versions/eeda3dae20c0_retry_job_table_and_index_attempt_type.py
+++ b/backend/alembic/versions/eeda3dae20c0_retry_job_table_and_index_attempt_type.py
@@ -10,34 +10,15 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
+from onyx.db.enums import IndexAttemptType
+from onyx.db.enums import IndexingStatus
+
 
 # revision identifiers, used by Alembic.
 revision = "eeda3dae20c0"
 down_revision = "14162713706c"
 branch_labels = None
 depends_on = None
-
-
-INDEX_ATTEMPT_TYPE_ENUM = sa.Enum(
-    "FULL_RUN",
-    "TARGETED_RETRY",
-    name="indexattempttype",
-    native_enum=False,
-)
-# `retry_job.status` reuses the existing `IndexingStatus` enum
-# (NOT_STARTED → IN_PROGRESS → {SUCCESS,COMPLETED_WITH_ERRORS,FAILED,CANCELED}).
-# Since IndexingStatus is `native_enum=False` everywhere, the column is a
-# plain VARCHAR with a CHECK constraint — no shared Postgres TYPE to manage.
-INDEXING_STATUS_ENUM = sa.Enum(
-    "NOT_STARTED",
-    "IN_PROGRESS",
-    "SUCCESS",
-    "CANCELED",
-    "FAILED",
-    "COMPLETED_WITH_ERRORS",
-    name="indexingstatus",
-    native_enum=False,
-)
 
 
 def upgrade() -> None:
@@ -59,7 +40,7 @@ def upgrade() -> None:
         ),
         sa.Column(
             "status",
-            INDEXING_STATUS_ENUM,
+            sa.Enum(IndexingStatus, native_enum=False),
             server_default="NOT_STARTED",
             nullable=False,
         ),
@@ -108,7 +89,7 @@ def upgrade() -> None:
         "index_attempt",
         sa.Column(
             "attempt_type",
-            INDEX_ATTEMPT_TYPE_ENUM,
+            sa.Enum(IndexAttemptType, native_enum=False),
             server_default="FULL_RUN",
             nullable=False,
         ),

--- a/backend/alembic/versions/eeda3dae20c0_retry_job_table_and_index_attempt_type.py
+++ b/backend/alembic/versions/eeda3dae20c0_retry_job_table_and_index_attempt_type.py
@@ -1,0 +1,237 @@
+"""retry_job table + index_attempt.attempt_type discriminator + index_attempt_errors retry audit columns
+
+Revision ID: eeda3dae20c0
+Revises: 14162713706c
+Create Date: 2026-04-29 15:35:23.923345
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "eeda3dae20c0"
+down_revision = "14162713706c"
+branch_labels = None
+depends_on = None
+
+
+INDEX_ATTEMPT_TYPE_ENUM = sa.Enum(
+    "FULL_RUN",
+    "TARGETED_RETRY",
+    name="indexattempttype",
+    native_enum=False,
+)
+# `retry_job.status` reuses the existing `IndexingStatus` enum
+# (NOT_STARTED → IN_PROGRESS → {SUCCESS,COMPLETED_WITH_ERRORS,FAILED,CANCELED}).
+# Since IndexingStatus is `native_enum=False` everywhere, the column is a
+# plain VARCHAR with a CHECK constraint — no shared Postgres TYPE to manage.
+INDEXING_STATUS_ENUM = sa.Enum(
+    "NOT_STARTED",
+    "IN_PROGRESS",
+    "SUCCESS",
+    "CANCELED",
+    "FAILED",
+    "COMPLETED_WITH_ERRORS",
+    name="indexingstatus",
+    native_enum=False,
+)
+
+
+def upgrade() -> None:
+    # 1. Create retry_job table.
+    op.create_table(
+        "retry_job",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "requested_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            INDEXING_STATUS_ENUM,
+            server_default="NOT_STARTED",
+            nullable=False,
+        ),
+        sa.Column(
+            "error_ids",
+            postgresql.ARRAY(sa.Integer()),
+            server_default="{}",
+            nullable=False,
+        ),
+        sa.Column("resolved_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "still_failing_count", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column("skipped_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "resolved_summary",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_retry_job_status",
+        "retry_job",
+        ["status"],
+    )
+    op.create_index(
+        "ix_retry_job_requested_by_user_id",
+        "retry_job",
+        ["requested_by_user_id"],
+    )
+    op.create_index(
+        "ix_retry_job_requested_at",
+        "retry_job",
+        ["requested_at"],
+    )
+
+    # 2. Add attempt_type discriminator + retry_job_id FK on index_attempt.
+    #    `attempt_type` defaults to FULL_RUN so existing rows backfill safely.
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "attempt_type",
+            INDEX_ATTEMPT_TYPE_ENUM,
+            server_default="FULL_RUN",
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_attempt_type",
+        "index_attempt",
+        ["attempt_type"],
+    )
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "retry_job_id",
+            sa.Integer(),
+            sa.ForeignKey("retry_job.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_retry_job_id",
+        "index_attempt",
+        ["retry_job_id"],
+    )
+
+    # 3. Additive retry-audit columns on index_attempt_errors. All nullable
+    #    or default-backed; existing rows stay untouched.
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "retry_count",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "last_retry_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "last_retry_job_id",
+            sa.Integer(),
+            sa.ForeignKey("retry_job.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_errors_last_retry_job_id",
+        "index_attempt_errors",
+        ["last_retry_job_id"],
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "resolved_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "resolved_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_errors_resolved_by_user_id",
+        "index_attempt_errors",
+        ["resolved_by_user_id"],
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "retry_history",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "connector_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Reverse order of upgrade: drop columns from index_attempt_errors,
+    # then index_attempt, then drop retry_job.
+    op.drop_column("index_attempt_errors", "connector_metadata")
+    op.drop_column("index_attempt_errors", "retry_history")
+    op.drop_index(
+        "ix_index_attempt_errors_resolved_by_user_id",
+        table_name="index_attempt_errors",
+    )
+    op.drop_column("index_attempt_errors", "resolved_by_user_id")
+    op.drop_column("index_attempt_errors", "resolved_at")
+    op.drop_index(
+        "ix_index_attempt_errors_last_retry_job_id",
+        table_name="index_attempt_errors",
+    )
+    op.drop_column("index_attempt_errors", "last_retry_job_id")
+    op.drop_column("index_attempt_errors", "last_retry_at")
+    op.drop_column("index_attempt_errors", "retry_count")
+
+    op.drop_index("ix_index_attempt_retry_job_id", table_name="index_attempt")
+    op.drop_column("index_attempt", "retry_job_id")
+    op.drop_index("ix_index_attempt_attempt_type", table_name="index_attempt")
+    op.drop_column("index_attempt", "attempt_type")
+
+    op.drop_index("ix_retry_job_requested_at", table_name="retry_job")
+    op.drop_index("ix_retry_job_requested_by_user_id", table_name="retry_job")
+    op.drop_index("ix_retry_job_status", table_name="retry_job")
+    op.drop_table("retry_job")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -90,6 +90,17 @@ class IndexingMode(str, PyEnum):
     REINDEX = "reindex"
 
 
+class IndexAttemptType(str, PyEnum):
+    """Discriminator on `index_attempt`. `FULL_RUN` rows are real indexing
+    attempts spawned by the scheduler or `run-once`. `TARGETED_RETRY` rows
+    are synthetic attempts created when an admin retries specific failed
+    documents — they reuse the indexing pipeline but are excluded from
+    freshness, scheduling, and swap-gating queries."""
+
+    FULL_RUN = "full_run"
+    TARGETED_RETRY = "targeted_retry"
+
+
 class ProcessingMode(str, PyEnum):
     """Determines how documents are processed after fetching."""
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -97,8 +97,8 @@ class IndexAttemptType(str, PyEnum):
     documents — they reuse the indexing pipeline but are excluded from
     freshness, scheduling, and swap-gating queries."""
 
-    FULL_RUN = "full_run"
-    TARGETED_RETRY = "targeted_retry"
+    FULL_RUN = "FULL_RUN"
+    TARGETED_RETRY = "TARGETED_RETRY"
 
 
 class ProcessingMode(str, PyEnum):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -68,6 +68,7 @@ from onyx.db.enums import GrantSource
 from onyx.db.enums import HierarchyNodeType
 from onyx.db.enums import HookFailStrategy
 from onyx.db.enums import HookPoint
+from onyx.db.enums import IndexAttemptType
 from onyx.db.enums import IndexingMode
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
@@ -2183,6 +2184,66 @@ class SearchSettings(Base):
         )
 
 
+class RetryJob(Base):
+    """
+    Lifecycle row for a single user-initiated targeted-retry request.
+
+    A request can span multiple `(cc_pair, search_settings)` tuples; one
+    synthetic `IndexAttempt` is created per tuple and links back via
+    `IndexAttempt.retry_job_id`. The FE polls this row for aggregate
+    status. Per-cc_pair execution state lives on the linked attempts.
+    """
+
+    __tablename__ = "retry_job"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    requested_by_user_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    requested_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        index=True,
+        nullable=False,
+    )
+    status: Mapped[IndexingStatus] = mapped_column(
+        Enum(IndexingStatus, native_enum=False),
+        nullable=False,
+        server_default=IndexingStatus.NOT_STARTED.name,
+        index=True,
+    )
+
+    # Snapshot of the IndexAttemptError ids the request targeted. Used for
+    # idempotency on Celery redelivery and for the resolved_summary join
+    # at completion.
+    error_ids: Mapped[list[int]] = mapped_column(
+        postgresql.ARRAY(Integer), nullable=False, server_default="{}"
+    )
+
+    resolved_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    still_failing_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    skipped_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Snapshot of resolved error rows captured at completion. Survives
+    # later cleanup of the underlying `index_attempt_errors` rows.
+    resolved_summary: Mapped[list[dict[str, Any]]] = mapped_column(
+        PGJSONB, nullable=False, server_default="[]"
+    )
+
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    index_attempts: Mapped[list["IndexAttempt"]] = relationship(
+        "IndexAttempt",
+        back_populates="retry_job",
+        primaryjoin="RetryJob.id == IndexAttempt.retry_job_id",
+    )
+
+
 class IndexAttempt(Base):
     """
     Represents an attempt to index a group of 0 or more documents from a
@@ -2204,6 +2265,23 @@ class IndexAttempt(Base):
     # This is only for attempts that are explicitly marked as from the start via
     # the run once API
     from_beginning: Mapped[bool] = mapped_column(Boolean)
+    # Discriminator separating real indexing runs from synthetic
+    # `targeted_retry` attempts created by the per-document retry path.
+    # Existing rows backfill to FULL_RUN; freshness, scheduling, and
+    # swap-gating queries filter on this column.
+    attempt_type: Mapped[IndexAttemptType] = mapped_column(
+        Enum(IndexAttemptType, native_enum=False),
+        nullable=False,
+        server_default=IndexAttemptType.FULL_RUN.name,
+        index=True,
+    )
+    # Set on synthetic retry attempts; links back to the `retry_job` row
+    # the FE polls for aggregate status.
+    retry_job_id: Mapped[int | None] = mapped_column(
+        ForeignKey("retry_job.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     status: Mapped[IndexingStatus] = mapped_column(
         Enum(IndexingStatus, native_enum=False, index=True)
     )
@@ -2282,6 +2360,10 @@ class IndexAttempt(Base):
 
     search_settings: Mapped[SearchSettings | None] = relationship(
         "SearchSettings", back_populates="index_attempts"
+    )
+
+    retry_job: Mapped["RetryJob | None"] = relationship(
+        "RetryJob", back_populates="index_attempts"
     )
 
     error_rows = relationship(
@@ -2434,6 +2516,41 @@ class IndexAttemptError(Base):
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+    )
+
+    # Targeted-retry audit columns. All nullable / additive; existing rows
+    # leave them null. Original `failure_message` and `error_type` are
+    # preserved across retries — per-attempt outcomes are appended to
+    # `retry_history` instead.
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_retry_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_retry_job_id: Mapped[int | None] = mapped_column(
+        ForeignKey("retry_job.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    resolved_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    resolved_by_user_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # JSON array; each retry appends an entry shaped like
+    # {retry_job_id, retried_at, new_error_type, new_failure_message, succeeded}.
+    # Caller responsibility to bound length (most-recent-N).
+    retry_history: Mapped[list[dict[str, Any]]] = mapped_column(
+        PGJSONB, nullable=False, server_default="[]"
+    )
+    # Connector-specific keys required for a retry round-trip (e.g.
+    # Sharepoint stores `{site_id, drive_id}` because Graph API needs both
+    # to refetch by `driveItemId`). Other connectors leave it null.
+    connector_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        PGJSONB, nullable=True
     )
 
     # This is the reverse side of the relationship

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2212,7 +2212,8 @@ class RetryJob(Base):
     status: Mapped[IndexingStatus] = mapped_column(
         Enum(IndexingStatus, native_enum=False),
         nullable=False,
-        server_default=IndexingStatus.NOT_STARTED.name,
+        default=IndexingStatus.NOT_STARTED,
+        server_default="NOT_STARTED",
         index=True,
     )
 
@@ -2272,7 +2273,8 @@ class IndexAttempt(Base):
     attempt_type: Mapped[IndexAttemptType] = mapped_column(
         Enum(IndexAttemptType, native_enum=False),
         nullable=False,
-        server_default=IndexAttemptType.FULL_RUN.name,
+        default=IndexAttemptType.FULL_RUN,
+        server_default="FULL_RUN",
         index=True,
     )
     # Set on synthetic retry attempts; links back to the `retry_job` row

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2243,6 +2243,11 @@ class RetryJob(Base):
         back_populates="retry_job",
         primaryjoin="RetryJob.id == IndexAttempt.retry_job_id",
     )
+    errors: Mapped[list["IndexAttemptError"]] = relationship(
+        "IndexAttemptError",
+        back_populates="last_retry_job",
+        primaryjoin="RetryJob.id == IndexAttemptError.last_retry_job_id",
+    )
 
 
 class IndexAttempt(Base):
@@ -2532,6 +2537,11 @@ class IndexAttemptError(Base):
         ForeignKey("retry_job.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
+    )
+    last_retry_job: Mapped["RetryJob | None"] = relationship(
+        "RetryJob",
+        back_populates="errors",
+        primaryjoin="RetryJob.id == IndexAttemptError.last_retry_job_id",
     )
     resolved_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True


### PR DESCRIPTION
## Description

Adds the schema layer for the per-document retry feature.

- New `retry_job` table tracks the lifecycle of a single user-initiated retry request. The FE polls this row for aggregate status; per-cc_pair execution lives on linked synthetic `IndexAttempt` rows (added in a later PR).
- New `attempt_type` discriminator on `index_attempt` (`FULL_RUN` | `TARGETED_RETRY`) plus a nullable `retry_job_id` FK. Default is `FULL_RUN` so existing rows backfill safely. Consumer query sites (`should_index`, `get_latest_*`, swap gating, monitoring) get the `attempt_type=FULL_RUN` filter in the next PR.
- Audit columns on `index_attempt_errors`: `retry_count`, `last_retry_at`, `last_retry_job_id`, `resolved_at`, `resolved_by_user_id`, `retry_history` (JSONB), `connector_metadata` (JSONB). All additive and nullable or default-backed; existing rows untouched.

`retry_job.status` reuses the existing `IndexingStatus` enum (`NOT_STARTED` / `IN_PROGRESS` / `SUCCESS` / `COMPLETED_WITH_ERRORS` / `FAILED` / `CANCELED`) instead of introducing a parallel taxonomy.

Indexes added on `retry_job.requested_by_user_id`, `retry_job.requested_at`, and `index_attempt_errors.resolved_by_user_id` to support admin-page lookups.

No behavior change in this PR — nothing reads or writes the new columns yet.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check