### PR TITLE
fix(deploy): add opensearch to depends_on so init-letsencrypt brings it up

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -13,6 +13,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - inference_model_server
       - minio
@@ -50,6 +51,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - inference_model_server
       - indexing_model_server

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -13,6 +13,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - inference_model_server
       - minio
@@ -64,6 +65,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - inference_model_server
       - indexing_model_server

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -14,6 +14,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - minio
       - inference_model_server
@@ -69,6 +70,7 @@ services:
     depends_on:
       - relational_db
       - index
+      - opensearch
       - cache
       - inference_model_server
       - indexing_model_server


### PR DESCRIPTION
## Description

`init-letsencrypt.sh` runs `docker compose -f docker-compose.prod.yml up --force-recreate -d nginx`. Compose only starts the transitive deps of `nginx` → `api_server`, but `opensearch` was not listed in any `depends_on`, so the container was never created. `api_server` then died after 10 retries with "temporary failure in name resolution" on the `opensearch` host, and `init-letsencrypt.sh` looped on `Nginx is not ready yet` forever.

Adds `opensearch` to `api_server` and `background` `depends_on` in all three prod compose files so the bootstrap path pulls the service in. `install.sh` already worked because it runs `up -d` (everything).

Repro + diagnosis from the reporter: #10641.

## How Has This Been Tested?

- `docker compose -f docker-compose.prod.yml config` parses cleanly.
- Inspected the resolved config — `api_server.depends_on` and `background.depends_on` now include `opensearch` (alongside the existing `relational_db`, `index`, `cache`, etc.).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Closes #10641