### PR TITLE
fix(google drive): Download google slides w/ images

### DIFF
--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -385,10 +385,7 @@ def _download_and_extract_sections_basic(
                 content_type=export_mime_type,
             )
 
-        if (
-            export_mime_type
-            == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        ):
+        if export_mime_type == PRESENTATION_MIME_TYPE:
             pptx_sections: list[TextSection | ImageSection | TabularSection] = []
             text, _ = read_pptx_file(
                 io.BytesIO(response),
@@ -439,10 +436,7 @@ def _download_and_extract_sections_basic(
             response_call(), name=tabular_file_name, content_type=mime_type
         )
 
-    elif (
-        mime_type
-        == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-    ):
+    elif mime_type == PRESENTATION_MIME_TYPE:
         pptx_sections_native: list[TextSection | ImageSection | TabularSection] = []
         text, _ = read_pptx_file(
             io.BytesIO(response_call()),

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -39,12 +39,14 @@ from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.extract_file_text import get_file_ext
-from onyx.file_processing.extract_file_text import pptx_to_text
 from onyx.file_processing.extract_file_text import read_docx_file
 from onyx.file_processing.extract_file_text import read_pdf_file
+from onyx.file_processing.extract_file_text import read_pptx_file
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.file_types import OnyxMimeTypes
+from onyx.file_processing.file_types import PRESENTATION_MIME_TYPE
 from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPE
+from onyx.file_processing.image_utils import make_image_callback
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
@@ -215,14 +217,7 @@ CHUNK_SIZE_BUFFER = 64  # extra bytes past the limit to read
 GOOGLE_MIME_TYPES_TO_EXPORT = {
     GDriveMimeType.DOC.value: "text/plain",
     GDriveMimeType.SPREADSHEET.value: "text/csv",
-    GDriveMimeType.PPT.value: "text/plain",
-}
-
-# Define Google MIME types mapping
-GOOGLE_MIME_TYPES = {
-    GDriveMimeType.DOC.value: "text/plain",
-    GDriveMimeType.SPREADSHEET.value: "text/csv",
-    GDriveMimeType.PPT.value: "text/plain",
+    GDriveMimeType.PPT.value: PRESENTATION_MIME_TYPE,
 }
 
 
@@ -390,6 +385,23 @@ def _download_and_extract_sections_basic(
                 content_type=export_mime_type,
             )
 
+        if (
+            export_mime_type
+            == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        ):
+            pptx_sections: list[TextSection | ImageSection | TabularSection] = []
+            text, _ = read_pptx_file(
+                io.BytesIO(response),
+                file_name=file_name,
+                extract_images=allow_images,
+                image_callback=make_image_callback(
+                    pptx_sections, file_id, file_name, link
+                ),
+            )
+            if text:
+                pptx_sections.insert(0, TextSection(link=link, text=text))
+            return FileExtractionResult(sections=pptx_sections)
+
         text = response.decode("utf-8")
         return FileExtractionResult(sections=[TextSection(link=link, text=text)])
 
@@ -431,10 +443,18 @@ def _download_and_extract_sections_basic(
         mime_type
         == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     ):
-        text = pptx_to_text(io.BytesIO(response_call()), file_name=file_name)
-        return FileExtractionResult(
-            sections=[TextSection(link=link, text=text)] if text else []
+        pptx_sections_native: list[TextSection | ImageSection | TabularSection] = []
+        text, _ = read_pptx_file(
+            io.BytesIO(response_call()),
+            file_name=file_name,
+            extract_images=allow_images,
+            image_callback=make_image_callback(
+                pptx_sections_native, file_id, file_name, link
+            ),
         )
+        if text:
+            pptx_sections_native.insert(0, TextSection(link=link, text=text))
+        return FileExtractionResult(sections=pptx_sections_native)
 
     elif mime_type == "application/pdf":
         text, _pdf_meta, images = read_pdf_file(io.BytesIO(response_call()))

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -75,9 +75,9 @@ from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.file_types import OnyxMimeTypes
+from onyx.file_processing.image_utils import make_image_callback
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.staging import RawFileCallback
-from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import SSRFException
 from onyx.utils.url import validate_outbound_http_url
@@ -645,38 +645,12 @@ def _convert_driveitem_to_document_with_permissions(
                 f"Failed to extract tabular sections for '{driveitem.name}': {e}"
             )
     else:
-
-        def _store_embedded_image(img_data: bytes, img_name: str) -> None:
-            try:
-                img_mime = get_image_type_from_bytes(img_data)
-            except ValueError:
-                logger.debug(
-                    "Skipping embedded image with unknown format for %s",
-                    driveitem.name,
-                )
-                return
-
-            if img_mime in OnyxMimeTypes.EXCLUDED_IMAGE_TYPES:
-                logger.debug(
-                    "Skipping embedded image of excluded type %s for %s",
-                    img_mime,
-                    driveitem.name,
-                )
-                return
-
-            image_section, _ = store_image_and_create_section(
-                image_data=img_data,
-                file_id=f"{driveitem.id}_img_{len(sections)}",
-                display_name=img_name or f"{driveitem.name} - image {len(sections)}",
-                file_origin=FileOrigin.CONNECTOR,
-            )
-            image_section.link = driveitem.web_url
-            sections.append(image_section)
-
         extraction_result = extract_text_and_images(
             file=io.BytesIO(content_bytes),
             file_name=driveitem.name,
-            image_callback=_store_embedded_image,
+            image_callback=make_image_callback(
+                sections, driveitem.id, driveitem.name, driveitem.web_url
+            ),
         )
         if extraction_result.text_content:
             sections.append(

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -471,6 +471,20 @@ def read_docx_file(
     return doc.markdown, []
 
 
+def extract_pptx_images(pptx_bytes: IO[Any]) -> Iterator[tuple[bytes, str]]:
+    """
+    Given the bytes of a pptx file, extract all the images.
+    Returns an iterator of tuples (image_bytes, image_name).
+    """
+    try:
+        with zipfile.ZipFile(pptx_bytes) as z:
+            for name in z.namelist():
+                if name.startswith("ppt/media/"):
+                    yield (z.read(name), name.split("/")[-1])
+    except Exception:
+        logger.exception("Failed to extract all pptx images")
+
+
 def pptx_to_text(file: IO[Any], file_name: str = "") -> str:
     md = get_markitdown_converter()
     from markitdown import FileConversionException
@@ -492,6 +506,31 @@ def pptx_to_text(file: IO[Any], file_name: str = "") -> str:
         logger.warning(error_str)
         return ""
     return presentation.markdown
+
+
+def read_pptx_file(
+    file: IO[Any],
+    file_name: str = "",
+    extract_images: bool = False,
+    image_callback: Callable[[bytes, str], None] | None = None,
+) -> tuple[str, Sequence[tuple[bytes, str]]]:
+    """
+    Extract text and optionally images from a pptx.
+    Return (text_content, list_of_images).
+    """
+    text = pptx_to_text(file, file_name=file_name)
+
+    file.seek(0)
+
+    if extract_images:
+        if image_callback is None:
+            return text, list(extract_pptx_images(to_bytesio(file)))
+        try:
+            for img_file_bytes, img_file_name in extract_pptx_images(to_bytesio(file)):
+                image_callback(img_file_bytes, img_file_name)
+        except Exception:
+            logger.exception("Failed to stream pptx images")
+    return text, []
 
 
 def _columns_to_keep(col_has_data: bytearray, max_empty: int) -> list[int]:
@@ -833,13 +872,12 @@ def _extract_text_and_images(
                 text_content=text_content, embedded_images=images, metadata=pdf_metadata
             )
 
-        # For PPTX, XLSX, EML, etc., we do not show embedded image logic here.
-        # You can do something similar to docx if needed.
         if extension == ".pptx":
+            text_content, images = read_pptx_file(
+                file, file_name, extract_images=True, image_callback=image_callback
+            )
             return ExtractionResult(
-                text_content=pptx_to_text(file, file_name=file_name),
-                embedded_images=[],
-                metadata={},
+                text_content=text_content, embedded_images=images, metadata={}
             )
 
         if extension == ".xlsx":

--- a/backend/onyx/file_processing/image_utils.py
+++ b/backend/onyx/file_processing/image_utils.py
@@ -1,12 +1,59 @@
+from collections.abc import Callable
 from io import BytesIO
 from typing import Tuple
 
 from onyx.configs.constants import FileOrigin
 from onyx.connectors.models import ImageSection
+from onyx.connectors.models import TabularSection
+from onyx.connectors.models import TextSection
+from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_store.file_store import get_default_file_store
+from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def make_image_callback(
+    sections: list[TextSection | ImageSection | TabularSection],
+    file_id: str,
+    file_name: str,
+    link: str | None = None,
+) -> Callable[[bytes, str], None]:
+    """Create a callback that validates, stores, and appends embedded images.
+
+    This is the shared pattern used by connectors (SharePoint, Google Drive, etc.)
+    to handle embedded images extracted from documents like PPTX, DOCX, and PDF.
+    """
+
+    def _store_embedded_image(img_data: bytes, img_name: str) -> None:
+        try:
+            img_mime = get_image_type_from_bytes(img_data)
+        except ValueError:
+            logger.debug(
+                "Skipping embedded image with unknown format for %s",
+                file_name,
+            )
+            return
+
+        if img_mime in OnyxMimeTypes.EXCLUDED_IMAGE_TYPES:
+            logger.debug(
+                "Skipping embedded image of excluded type %s for %s",
+                img_mime,
+                file_name,
+            )
+            return
+
+        image_section, _ = store_image_and_create_section(
+            image_data=img_data,
+            file_id=f"{file_id}_img_{len(sections)}",
+            display_name=img_name or f"{file_name} - image {len(sections)}",
+            file_origin=FileOrigin.CONNECTOR,
+        )
+        image_section.link = link
+        sections.append(image_section)
+
+    return _store_embedded_image
 
 
 def store_image_and_create_section(

--- a/backend/tests/unit/onyx/file_processing/test_image_utils.py
+++ b/backend/tests/unit/onyx/file_processing/test_image_utils.py
@@ -1,0 +1,120 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.models import ImageSection
+from onyx.connectors.models import TabularSection
+from onyx.connectors.models import TextSection
+from onyx.file_processing.image_utils import make_image_callback
+
+# Minimal valid file headers for testing magic-byte detection
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+_JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 50
+_GIF_BYTES = b"GIF89a" + b"\x00" * 50  # recognized but excluded
+_UNKNOWN_BYTES = b"\x00\x00\x00\x00" + b"\x00" * 50
+
+
+class TestMakeImageCallback:
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_valid_png_appends_section(self, mock_store: MagicMock) -> None:
+        mock_store.return_value = (
+            ImageSection(image_file_id="stored_id"),
+            "stored_id",
+        )
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(
+            sections,
+            file_id="doc1",
+            file_name="slides.pptx",
+            link="https://example.com",
+        )
+
+        callback(_PNG_BYTES, "image1.png")
+
+        assert len(sections) == 1
+        assert isinstance(sections[0], ImageSection)
+        assert sections[0].image_file_id == "stored_id"
+        assert sections[0].link == "https://example.com"
+        mock_store.assert_called_once()
+        call_kwargs = mock_store.call_args
+        assert call_kwargs.kwargs["file_id"] == "doc1_img_0"
+        assert call_kwargs.kwargs["display_name"] == "image1.png"
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_valid_jpeg_appends_section(self, mock_store: MagicMock) -> None:
+        mock_store.return_value = (
+            ImageSection(image_file_id="stored_id"),
+            "stored_id",
+        )
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_JPEG_BYTES, "photo.jpg")
+
+        assert len(sections) == 1
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_unknown_format_skipped(self, mock_store: MagicMock) -> None:
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_UNKNOWN_BYTES, "mystery.bin")
+
+        assert len(sections) == 0
+        mock_store.assert_not_called()
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_excluded_type_skipped(self, mock_store: MagicMock) -> None:
+        """GIF is recognized by magic bytes but is in EXCLUDED_IMAGE_TYPES."""
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_GIF_BYTES, "animation.gif")
+
+        assert len(sections) == 0
+        mock_store.assert_not_called()
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_file_id_increments_with_section_count(self, mock_store: MagicMock) -> None:
+        mock_store.return_value = (
+            ImageSection(image_file_id="stored_id"),
+            "stored_id",
+        )
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_PNG_BYTES, "img1.png")
+        callback(_PNG_BYTES, "img2.png")
+
+        assert len(sections) == 2
+        calls = mock_store.call_args_list
+        assert calls[0].kwargs["file_id"] == "doc1_img_0"
+        assert calls[1].kwargs["file_id"] == "doc1_img_1"
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_fallback_display_name_when_img_name_empty(
+        self, mock_store: MagicMock
+    ) -> None:
+        mock_store.return_value = (
+            ImageSection(image_file_id="stored_id"),
+            "stored_id",
+        )
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_PNG_BYTES, "")
+
+        call_kwargs = mock_store.call_args
+        assert call_kwargs.kwargs["display_name"] == "slides.pptx - image 0"
+
+    @patch("onyx.file_processing.image_utils.store_image_and_create_section")
+    def test_link_is_none_when_not_provided(self, mock_store: MagicMock) -> None:
+        mock_store.return_value = (
+            ImageSection(image_file_id="stored_id"),
+            "stored_id",
+        )
+        sections: list[TextSection | ImageSection | TabularSection] = []
+        callback = make_image_callback(sections, "doc1", "slides.pptx")
+
+        callback(_PNG_BYTES, "img.png")
+
+        assert sections[0].link is None

--- a/backend/tests/unit/onyx/file_processing/test_pptx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_pptx_to_text.py
@@ -5,7 +5,49 @@ from pptx.chart.data import CategoryChartData
 from pptx.enum.chart import XL_CHART_TYPE
 from pptx.util import Inches
 
+from onyx.file_processing.extract_file_text import extract_pptx_images
 from onyx.file_processing.extract_file_text import pptx_to_text
+from onyx.file_processing.extract_file_text import read_pptx_file
+
+
+def _make_1x1_png() -> bytes:
+    """Minimal valid 1x1 white PNG (67 bytes)."""
+    import struct
+    import zlib
+
+    signature = b"\x89PNG\r\n\x1a\n"
+
+    def _chunk(ctype: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(ctype + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + ctype + data + struct.pack(">I", crc)
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    raw_row = b"\x00\xff\xff\xff"
+    idat = zlib.compress(raw_row)
+    return (
+        signature + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+    )
+
+
+def _make_pptx_with_image() -> io.BytesIO:
+    """Create an in-memory pptx with a text slide and an embedded PNG image."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])  # Blank layout
+
+    # Add a title via a textbox
+    txBox = slide.shapes.add_textbox(Inches(1), Inches(0.5), Inches(6), Inches(1))
+    txBox.text_frame.text = "Slide with image"
+
+    # Embed a real PNG image
+    png_bytes = _make_1x1_png()
+    slide.shapes.add_picture(
+        io.BytesIO(png_bytes), Inches(1), Inches(2), Inches(2), Inches(2)
+    )
+
+    buf = io.BytesIO()
+    prs.save(buf)
+    buf.seek(0)
+    return buf
 
 
 def _make_pptx_with_chart() -> io.BytesIO:
@@ -77,3 +119,73 @@ class TestPptxToText:
         assert "Hello World" in result
         assert "Some content" in result
         assert "[chart omitted]" not in result
+
+
+class TestExtractPptxImages:
+    def test_extracts_embedded_image(self) -> None:
+        pptx_file = _make_pptx_with_image()
+
+        images = list(extract_pptx_images(pptx_file))
+
+        assert len(images) == 1
+        img_bytes, img_name = images[0]
+        assert len(img_bytes) > 0
+        assert img_bytes[:4] == b"\x89PNG"
+        assert img_name  # non-empty name
+
+    def test_no_images_in_text_only_pptx(self) -> None:
+        pptx_file = _make_pptx_without_chart()
+
+        images = list(extract_pptx_images(pptx_file))
+
+        assert images == []
+
+    def test_invalid_file_yields_nothing(self) -> None:
+        bad_file = io.BytesIO(b"not a zip file")
+
+        images = list(extract_pptx_images(bad_file))
+
+        assert images == []
+
+
+class TestReadPptxFile:
+    def test_returns_text_without_images_by_default(self) -> None:
+        pptx_file = _make_pptx_with_image()
+
+        text, images = read_pptx_file(pptx_file, file_name="test.pptx")
+
+        assert "Slide with image" in text
+        assert images == []
+
+    def test_extract_images_returns_list(self) -> None:
+        pptx_file = _make_pptx_with_image()
+
+        text, images = read_pptx_file(
+            pptx_file, file_name="test.pptx", extract_images=True
+        )
+
+        assert "Slide with image" in text
+        assert len(images) == 1
+        img_bytes, img_name = images[0]
+        assert img_bytes[:4] == b"\x89PNG"
+        assert img_name
+
+    def test_callback_streams_instead_of_collecting(self) -> None:
+        pptx_file = _make_pptx_with_image()
+        collected: list[tuple[bytes, str]] = []
+
+        def callback(data: bytes, name: str) -> None:
+            collected.append((data, name))
+
+        text, images = read_pptx_file(
+            pptx_file,
+            file_name="test.pptx",
+            extract_images=True,
+            image_callback=callback,
+        )
+
+        assert "Slide with image" in text
+        assert len(collected) == 1
+        assert collected[0][0][:4] == b"\x89PNG"
+        # Returned list is empty when callback is used
+        assert images == []


### PR DESCRIPTION
## Description
Currently we download google slides as plain text. This changes that to download google slides as powerpoints. We can then extract the images from the downloaded pptx files.

## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Download Google Slides as PPTX and extract embedded images instead of plain text. Fixes missing images and improves content extraction for Google Drive and SharePoint PPTX files.

- **Bug Fixes**
  - Export Google Slides as PPTX (`PRESENTATION_MIME_TYPE`) and parse with `read_pptx_file`; include embedded images via `make_image_callback`.
  - Apply the same logic for native PPTX in Google Drive; return a text section plus image sections.
  - Core `.pptx` extraction in `extract_file_text` now emits embedded images (streamed via callback).

- **Refactors**
  - Added `extract_pptx_images` and `read_pptx_file`; introduced shared `make_image_callback` in `image_utils`.
  - Updated SharePoint connector to use the shared image callback, removing duplicated image code.
  - Added unit tests for PPTX image extraction and callback streaming.

<sup>Written for commit 04cfc8fedfd6d68e89a4481363ba9c355ffc8d80. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10723?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

