### PR TITLE
fix(doc-processing): Cap num threads for contextual rag

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -801,7 +801,8 @@ def add_chunk_summaries(
             chunk.chunk_context = ""
 
     run_functions_tuples_in_parallel(
-        [(assign_context, (chunk,)) for chunk in chunks_by_doc]
+        functions_with_args=[(assign_context, (chunk,)) for chunk in chunks_by_doc],
+        max_workers=128,
     )
 
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -86,6 +86,8 @@ from onyx.utils.timing import log_function_time
 
 logger = setup_logger()
 
+MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
+
 
 class DocumentBatchPrepareContext(BaseModel):
     updatable_docs: list[Document]
@@ -802,7 +804,7 @@ def add_chunk_summaries(
 
     run_functions_tuples_in_parallel(
         functions_with_args=[(assign_context, (chunk,)) for chunk in chunks_by_doc],
-        max_workers=128,
+        max_workers=MAX_CONTEXTUAL_RAG_WORKERS,
     )
 
 


### PR DESCRIPTION
## Description
In the contextual rag part of the doc processing pipeline, we run assign_context on each chunk. assign_context is an I/O bound task hence we we want the threads. A thread in python I believe is allocated ~8mb of memory. This means that documents w/ large number of chunks can take up massive amounts of memory (2000 chunks = ~16gb).

This change caps the number of threads so that we don't reach our memory limits and OOM

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
