### PR TITLE
fix(google-connector): catch impersonation failures across all Google Drive API calls

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -60,6 +60,8 @@ from onyx.connectors.google_utils.google_utils import GoogleFields
 from onyx.connectors.google_utils.resources import get_admin_service
 from onyx.connectors.google_utils.resources import get_drive_service
 from onyx.connectors.google_utils.resources import GoogleDriveService
+from onyx.connectors.google_utils.resources import ImpersonationError
+from onyx.connectors.google_utils.resources import make_user_removal_checker
 from onyx.connectors.google_utils.shared_constants import (
     DB_CREDENTIALS_PRIMARY_ADMIN_KEY,
 )
@@ -823,74 +825,29 @@ class GoogleDriveConnector(
 
         return get_available_drive_id
 
-    def _impersonate_user_for_retrieval(
+    def _make_fresh_emails_callback(
+        self, checkpoint: GoogleDriveCheckpoint
+    ) -> Callable[[], list[str]]:
+        def _callback() -> list[str]:
+            fresh_emails = self._get_all_user_emails()
+            checkpoint.user_emails = fresh_emails
+            return fresh_emails
+
+        return _callback
+
+    def _post_validation_retrieval(
         self,
+        curr_stage: StageCompletion,
+        drive_service: GoogleDriveService,
         user_email: str,
         field_type: DriveFileFieldType,
         checkpoint: GoogleDriveCheckpoint,
         get_new_drive_id: Callable[[str], str | None],
         sorted_filtered_folder_ids: list[str],
-        start: SecondsSinceUnixEpoch | None = None,
-        end: SecondsSinceUnixEpoch | None = None,
+        resuming: bool,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
     ) -> Iterator[RetrievedDriveFile]:
-        logger.info(f"Impersonating user {user_email}")
-        curr_stage = checkpoint.completion_map[user_email]
-        resuming = True
-        if curr_stage.stage == DriveRetrievalStage.START:
-            logger.info(f"Setting stage to {DriveRetrievalStage.MY_DRIVE_FILES.value}")
-            curr_stage.stage = DriveRetrievalStage.MY_DRIVE_FILES
-            resuming = False
-        drive_service = get_drive_service(self.creds, user_email)
-
-        # validate that the user has access to the drive APIs by performing a simple
-        # request and checking for a 401
-        try:
-            logger.debug(f"Getting root folder id for user {user_email}")
-            # default is ~17mins of retries, don't do that here for cases so we don't
-            # waste 17mins everytime we run into a user without access to drive APIs
-            retry_builder(tries=3, delay=1)(get_root_folder_id)(drive_service)
-        except HttpError as e:
-            if e.status_code == 401:
-                # fail gracefully, let the other impersonations continue
-                # one user without access shouldn't block the entire connector
-                logger.warning(
-                    f"User '{user_email}' does not have access to the drive APIs."
-                )
-                # mark this user as done so we don't try to retrieve anything for them
-                # again
-                curr_stage.stage = DriveRetrievalStage.DONE
-                return
-            raise
-        except RefreshError as e:
-            logger.warning(
-                f"User '{user_email}' token refresh failed, re-fetching user list "
-                f"to check if they were removed. Error: {e}"
-            )
-            try:
-                fresh_emails = self._get_all_user_emails()
-                checkpoint.user_emails = fresh_emails
-            except Exception as fetch_err:
-                logger.warning(
-                    f"Could not re-fetch user list to verify '{user_email}' removal "
-                    f"(error: {fetch_err}); surfacing original RefreshError as failure."
-                )
-                fresh_emails = [user_email]  # treat as if user still exists
-            if user_email not in fresh_emails:
-                # User was removed from the workspace — skip silently
-                logger.warning(
-                    f"User '{user_email}' confirmed removed from workspace, skipping."
-                )
-                curr_stage.stage = DriveRetrievalStage.DONE
-                return
-            # User still exists — this is a real token problem, surface as a failure
-            yield RetrievedDriveFile(
-                completion_stage=DriveRetrievalStage.DONE,
-                drive_file={},
-                user_email=user_email,
-                error=e,
-            )
-            curr_stage.stage = DriveRetrievalStage.DONE
-            return
         # if we are including my drives, try to get the current user's my
         # drive if any of the following are true:
         # - include_my_drives is true
@@ -956,17 +913,17 @@ class GoogleDriveConnector(
                 )
 
             # resume from a checkpoint
-            if resuming and (drive_id := curr_stage.current_folder_or_drive_id):
-                resume_start = curr_stage.completed_until
-                for file_or_token in _yield_from_drive(
-                    drive_id, resume_start  # ty: ignore[possibly-unresolved-reference]
-                ):
-                    if isinstance(file_or_token, str):
-                        checkpoint.completion_map[user_email].next_page_token = (
-                            file_or_token
-                        )
-                        return  # done with the max num pages, return checkpoint
-                    yield file_or_token
+            if resuming:
+                drive_id = curr_stage.current_folder_or_drive_id
+                if drive_id:
+                    resume_start = curr_stage.completed_until
+                    for file_or_token in _yield_from_drive(drive_id, resume_start):
+                        if isinstance(file_or_token, str):
+                            checkpoint.completion_map[user_email].next_page_token = (
+                                file_or_token
+                            )
+                            return  # done with the max num pages, return checkpoint
+                        yield file_or_token
 
             drive_id = get_new_drive_id(user_email)
             if drive_id:
@@ -1001,7 +958,7 @@ class GoogleDriveConnector(
             def _yield_from_folder_crawl(
                 folder_id: str, folder_start: SecondsSinceUnixEpoch | None
             ) -> Iterator[RetrievedDriveFile]:
-                for retrieved_file in crawl_folders_for_files(
+                yield from crawl_folders_for_files(
                     service=drive_service,
                     parent_id=folder_id,
                     field_type=field_type,
@@ -1010,8 +967,7 @@ class GoogleDriveConnector(
                     update_traversed_ids_func=self._update_traversed_parent_ids,
                     start=folder_start,
                     end=end,
-                ):
-                    yield retrieved_file
+                )
 
             # resume from a checkpoint
             last_processed_folder = None
@@ -1052,6 +1008,97 @@ class GoogleDriveConnector(
                 num_completed_folders += 1
 
         curr_stage.stage = DriveRetrievalStage.DONE
+
+    def _impersonate_user_for_retrieval(
+        self,
+        user_email: str,
+        field_type: DriveFileFieldType,
+        checkpoint: GoogleDriveCheckpoint,
+        get_new_drive_id: Callable[[str], str | None],
+        sorted_filtered_folder_ids: list[str],
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> Iterator[RetrievedDriveFile]:
+        logger.info(f"Impersonating user {user_email}")
+        curr_stage = checkpoint.completion_map[user_email]
+        resuming = True
+        if curr_stage.stage == DriveRetrievalStage.START:
+            logger.info(f"Setting stage to {DriveRetrievalStage.MY_DRIVE_FILES.value}")
+            curr_stage.stage = DriveRetrievalStage.MY_DRIVE_FILES
+            resuming = False
+        drive_service = get_drive_service(self.creds, user_email)
+        is_user_removed = make_user_removal_checker(
+            user_email, self._make_fresh_emails_callback(checkpoint)
+        )
+
+        # validate that the user has access to the drive APIs by performing a simple
+        # request and checking for a 401
+        try:
+            logger.debug(f"Getting root folder id for user {user_email}")
+            # default is ~17mins of retries, don't do that here for cases so we don't
+            # waste 17mins everytime we run into a user without access to drive APIs
+            retry_builder(tries=3, delay=1)(get_root_folder_id)(drive_service)
+        except HttpError as e:
+            if e.status_code == 401:
+                # fail gracefully, let the other impersonations continue
+                # one user without access shouldn't block the entire connector
+                logger.warning(
+                    f"User '{user_email}' does not have access to the drive APIs."
+                )
+                # mark this user as done so we don't try to retrieve anything for them
+                # again
+                curr_stage.stage = DriveRetrievalStage.DONE
+                return
+            raise
+        except RefreshError as e:
+            if is_user_removed():
+                logger.warning(
+                    f"User '{user_email}' confirmed removed from workspace, skipping."
+                )
+                curr_stage.stage = DriveRetrievalStage.DONE
+                return
+            logger.warning(
+                f"User '{user_email}' impersonation failed at validation gate. Error: {e}"
+            )
+            curr_stage.stage = DriveRetrievalStage.DONE
+            yield RetrievedDriveFile(
+                completion_stage=DriveRetrievalStage.DONE,
+                drive_file={},
+                user_email=user_email,
+                error=ImpersonationError(user_email, e),
+            )
+            return
+
+        try:
+            yield from self._post_validation_retrieval(
+                curr_stage=curr_stage,
+                drive_service=drive_service,
+                user_email=user_email,
+                field_type=field_type,
+                checkpoint=checkpoint,
+                get_new_drive_id=get_new_drive_id,
+                sorted_filtered_folder_ids=sorted_filtered_folder_ids,
+                resuming=resuming,
+                start=start,
+                end=end,
+            )
+        except RefreshError as e:
+            if is_user_removed():
+                logger.warning(
+                    f"User '{user_email}' removed mid-run, skipping remaining files."
+                )
+                curr_stage.stage = DriveRetrievalStage.DONE
+            else:
+                logger.warning(
+                    f"User '{user_email}' impersonation failed mid-run. Error: {e}"
+                )
+                curr_stage.stage = DriveRetrievalStage.DONE
+                yield RetrievedDriveFile(
+                    completion_stage=DriveRetrievalStage.DONE,
+                    drive_file={},
+                    user_email=user_email,
+                    error=ImpersonationError(user_email, e),
+                )
 
     def _manage_service_account_retrieval(
         self,

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -7,6 +7,7 @@ from typing import cast
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
+from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
 from googleapiclient.http import BatchHttpRequest
@@ -148,6 +149,8 @@ def get_folder_metadata(
             logger.debug(f"Cannot access folder {folder_id}: {e}")
         else:
             raise e
+    except RefreshError:
+        logger.debug(f"Cannot access folder {folder_id}: impersonation failed")
     return None
 
 
@@ -179,6 +182,8 @@ def get_shared_drive_name(
             logger.debug(f"Cannot access drive {drive_id}: {e}")
         else:
             raise
+    except RefreshError:
+        logger.debug(f"Cannot access drive {drive_id}: impersonation failed")
     return None
 
 

--- a/backend/onyx/connectors/google_utils/resources.py
+++ b/backend/onyx/connectors/google_utils/resources.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from typing import Any
 
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials as OAuthCredentials
@@ -28,54 +27,43 @@ class GmailService(Resource):
     pass
 
 
-class RefreshableDriveObject:
+class ImpersonationError(Exception):
+    """Raised when the service account cannot impersonate a user."""
+
+    def __init__(self, user_email: str, original: RefreshError) -> None:
+        super().__init__(f"Cannot impersonate '{user_email}'")
+        self.user_email = user_email
+        self.original = original
+
+
+class UserRemovedError(ImpersonationError):
+    """Raised when the impersonation failure is confirmed to be a deleted/suspended user."""
+
+
+def make_user_removal_checker(
+    user_email: str,
+    get_fresh_emails: Callable[[], list[str]] | None = None,
+) -> Callable[[], bool]:
+    """Return a callable that checks whether user_email was removed from the workspace.
+
+    The Admin SDK callback is fired at most once regardless of how many times
+    the returned callable is invoked.
     """
-    Running Google drive service retrieval functions
-    involves accessing methods of the service object (ie. files().list())
-    which can raise a RefreshError if the access token is expired.
-    This class is a wrapper that propagates the ability to refresh the access token
-    and retry the final retrieval function until execute() is called.
-    """
+    checked = False
+    user_removed = False
 
-    def __init__(
-        self,
-        call_stack: Callable[[ServiceAccountCredentials | OAuthCredentials], Any],
-        creds: ServiceAccountCredentials | OAuthCredentials,
-        creds_getter: Callable[..., ServiceAccountCredentials | OAuthCredentials],
-    ):
-        self.call_stack = call_stack
-        self.creds = creds
-        self.creds_getter = creds_getter
+    def is_user_removed() -> bool:
+        nonlocal checked, user_removed
+        if not checked:
+            checked = True
+            if get_fresh_emails is not None:
+                try:
+                    user_removed = user_email not in get_fresh_emails()
+                except Exception:
+                    pass
+        return user_removed
 
-    def __getattr__(self, name: str) -> Any:
-        if name == "execute":
-            return self.make_refreshable_execute()
-        return RefreshableDriveObject(
-            lambda creds: getattr(self.call_stack(creds), name),
-            self.creds,
-            self.creds_getter,
-        )
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        return RefreshableDriveObject(
-            lambda creds: self.call_stack(creds)(*args, **kwargs),
-            self.creds,
-            self.creds_getter,
-        )
-
-    def make_refreshable_execute(self) -> Callable:
-        def execute(*args: Any, **kwargs: Any) -> Any:
-            try:
-                return self.call_stack(self.creds).execute(*args, **kwargs)
-            except RefreshError as e:
-                logger.warning(
-                    f"RefreshError, going to attempt a creds refresh and retry: {e}"
-                )
-                # Refresh the access token
-                self.creds = self.creds_getter()
-                return self.call_stack(self.creds).execute(*args, **kwargs)
-
-        return execute
+    return is_user_removed
 
 
 def _get_google_service(

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -18,6 +18,7 @@ from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.models import DriveRetrievalStage
 from onyx.connectors.google_drive.models import GoogleDriveCheckpoint
 from onyx.connectors.google_drive.models import StageCompletion
+from onyx.connectors.google_utils.resources import ImpersonationError
 from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import SlimDocument
@@ -449,15 +450,11 @@ def _make_checkpoint_with_user(user_email: str) -> GoogleDriveCheckpoint:
 
 
 class TestImpersonateUserRefreshError:
-    def test_refresh_error_user_removed_skips_silently(self) -> None:
-        """When RefreshError occurs and the user is absent from the re-fetched
-        user list, the connector should skip them silently (no error yielded),
-        mark them DONE in completion_map, and update checkpoint.user_emails."""
+    def test_user_removed_error_skips_silently(self) -> None:
+        """RefreshError + user absent from workspace: silent skip, no error yielded, stage DONE."""
         user_email = "wilbur.suero@savvywealth.com"
         connector = _make_connector()
         checkpoint = _make_checkpoint_with_user(user_email)
-
-        refresh_error = RefreshError("invalid_grant: Invalid email or User ID")
 
         with (
             patch(
@@ -466,7 +463,7 @@ class TestImpersonateUserRefreshError:
             ),
             patch(
                 "onyx.connectors.google_drive.connector.get_root_folder_id",
-                side_effect=refresh_error,
+                side_effect=RefreshError("invalid_grant: Invalid email or User ID"),
             ),
             patch(
                 "onyx.connectors.google_drive.connector.retry_builder",
@@ -490,94 +487,59 @@ class TestImpersonateUserRefreshError:
 
         assert results == []
         assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
+
+    def test_impersonation_error_yields_error(self) -> None:
+        """RefreshError + user still present: error record yielded, stage DONE."""
+        user_email = "wilbur.suero@savvywealth.com"
+        connector = _make_connector()
+        checkpoint = _make_checkpoint_with_user(user_email)
+
+        with (
+            patch(
+                "onyx.connectors.google_drive.connector.get_drive_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.get_root_folder_id",
+                side_effect=RefreshError("token_refresh_failed"),
+            ),
+            patch(
+                "onyx.connectors.google_drive.connector.retry_builder",
+                return_value=lambda f: f,
+            ),
+            patch.object(
+                connector,
+                "_get_all_user_emails",
+                return_value=[user_email, "admin@example.com"],  # user present
+            ),
+        ):
+            results = list(
+                connector._impersonate_user_for_retrieval(
+                    user_email=user_email,
+                    field_type=DriveFileFieldType.SLIM,
+                    checkpoint=checkpoint,
+                    get_new_drive_id=lambda _: None,
+                    sorted_filtered_folder_ids=[],
+                )
+            )
+
+        assert len(results) == 1
+        assert isinstance(results[0].error, ImpersonationError)
+        assert results[0].error.user_email == user_email
+        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
+
+    def test_fresh_emails_callback_updates_checkpoint(self) -> None:
+        """_make_fresh_emails_callback returns a closure that calls _get_all_user_emails
+        and updates checkpoint.user_emails as a side effect."""
+        user_email = "wilbur.suero@savvywealth.com"
+        connector = _make_connector()
+        checkpoint = _make_checkpoint_with_user(user_email)
+        fresh_emails = ["admin@example.com"]  # user absent from fresh list
+
+        with patch.object(connector, "_get_all_user_emails", return_value=fresh_emails):
+            callback = connector._make_fresh_emails_callback(checkpoint)
+            result = callback()
+
+        assert result == fresh_emails
+        assert checkpoint.user_emails == fresh_emails
         assert user_email not in (checkpoint.user_emails or [])
-
-    def test_refresh_error_user_still_exists_yields_error(self) -> None:
-        """When RefreshError occurs but the user is still present in the
-        re-fetched user list, the error should be yielded as a real failure."""
-        user_email = "wilbur.suero@savvywealth.com"
-        connector = _make_connector()
-        checkpoint = _make_checkpoint_with_user(user_email)
-
-        refresh_error = RefreshError("token_refresh_failed")
-
-        with (
-            patch(
-                "onyx.connectors.google_drive.connector.get_drive_service",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "onyx.connectors.google_drive.connector.get_root_folder_id",
-                side_effect=refresh_error,
-            ),
-            patch(
-                "onyx.connectors.google_drive.connector.retry_builder",
-                return_value=lambda f: f,
-            ),
-            patch.object(
-                connector,
-                "_get_all_user_emails",
-                return_value=[user_email, "admin@example.com"],  # user still present
-            ),
-        ):
-            results = list(
-                connector._impersonate_user_for_retrieval(
-                    user_email=user_email,
-                    field_type=DriveFileFieldType.SLIM,
-                    checkpoint=checkpoint,
-                    get_new_drive_id=lambda _: None,
-                    sorted_filtered_folder_ids=[],
-                )
-            )
-
-        assert len(results) == 1
-        assert results[0].error is refresh_error
-        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
-        assert checkpoint.user_emails == [user_email, "admin@example.com"]
-
-    def test_refresh_error_refetch_fails_yields_error_and_preserves_checkpoint(
-        self,
-    ) -> None:
-        """When the re-fetch of user emails itself fails, the original RefreshError
-        should be surfaced as a failure and checkpoint.user_emails must not be
-        overwritten with a partial/incorrect list."""
-        user_email = "wilbur.suero@savvywealth.com"
-        connector = _make_connector()
-        checkpoint = _make_checkpoint_with_user(user_email)
-        original_user_emails = list(checkpoint.user_emails or [])
-
-        refresh_error = RefreshError("invalid_grant: Invalid email or User ID")
-
-        with (
-            patch(
-                "onyx.connectors.google_drive.connector.get_drive_service",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "onyx.connectors.google_drive.connector.get_root_folder_id",
-                side_effect=refresh_error,
-            ),
-            patch(
-                "onyx.connectors.google_drive.connector.retry_builder",
-                return_value=lambda f: f,
-            ),
-            patch.object(
-                connector,
-                "_get_all_user_emails",
-                side_effect=Exception("Admin SDK unavailable"),
-            ),
-        ):
-            results = list(
-                connector._impersonate_user_for_retrieval(
-                    user_email=user_email,
-                    field_type=DriveFileFieldType.SLIM,
-                    checkpoint=checkpoint,
-                    get_new_drive_id=lambda _: None,
-                    sorted_filtered_folder_ids=[],
-                )
-            )
-
-        assert len(results) == 1
-        assert results[0].error is refresh_error
-        assert checkpoint.completion_map[user_email].stage == DriveRetrievalStage.DONE
-        assert checkpoint.user_emails == original_user_emails

--- a/backend/tests/unit/onyx/connectors/google_utils/test_impersonation_guard.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_impersonation_guard.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+from google.auth.exceptions import RefreshError
+
+from onyx.connectors.google_utils.resources import ImpersonationError
+from onyx.connectors.google_utils.resources import make_user_removal_checker
+from onyx.connectors.google_utils.resources import UserRemovedError
+from onyx.connectors.google_utils.shared_constants import MISSING_SCOPES_ERROR_STR
+
+
+def _make_checker(
+    get_fresh_emails: Callable[[], list[str]] | None = None,
+    user_email: str = "user@example.com",
+) -> Callable[[], bool]:
+    return make_user_removal_checker(
+        user_email=user_email, get_fresh_emails=get_fresh_emails
+    )
+
+
+class TestUserRemovalChecker:
+    def test_returns_false_without_callback(self) -> None:
+        is_removed = _make_checker(get_fresh_emails=None)
+        assert is_removed() is False
+
+    def test_returns_true_when_email_absent(self) -> None:
+        callback = MagicMock(return_value=["other@example.com"])
+        is_removed = _make_checker(
+            get_fresh_emails=callback, user_email="gone@example.com"
+        )
+        assert is_removed() is True
+        callback.assert_called_once()
+
+    def test_returns_false_when_email_present(self) -> None:
+        callback = MagicMock(return_value=["user@example.com", "other@example.com"])
+        is_removed = _make_checker(
+            get_fresh_emails=callback, user_email="user@example.com"
+        )
+        assert is_removed() is False
+        callback.assert_called_once()
+
+    def test_returns_false_when_callback_fails(self) -> None:
+        callback = MagicMock(side_effect=Exception("admin sdk down"))
+        is_removed = _make_checker(
+            get_fresh_emails=callback, user_email="user@example.com"
+        )
+        assert is_removed() is False
+
+    def test_callback_called_at_most_once(self) -> None:
+        callback = MagicMock(return_value=["user@example.com"])
+        is_removed = _make_checker(
+            get_fresh_emails=callback, user_email="user@example.com"
+        )
+        is_removed()
+        is_removed()
+        is_removed()
+        callback.assert_called_once()
+
+    def test_cached_result_used_on_repeated_calls(self) -> None:
+        callback = MagicMock(return_value=["other@example.com"])
+        is_removed = _make_checker(
+            get_fresh_emails=callback, user_email="gone@example.com"
+        )
+        assert is_removed() is True
+        assert is_removed() is True
+        callback.assert_called_once()
+
+
+class TestImpersonationErrorClasses:
+    def test_message_does_not_contain_missing_scopes_string(self) -> None:
+        original = RefreshError(MISSING_SCOPES_ERROR_STR)
+        err = ImpersonationError("u@example.com", original)
+        assert MISSING_SCOPES_ERROR_STR not in str(err)
+
+    def test_original_error_preserved(self) -> None:
+        original = RefreshError("some message")
+        err = ImpersonationError("u@example.com", original)
+        assert err.original is original
+
+    def test_user_removed_is_subclass_of_impersonation(self) -> None:
+        original = RefreshError("x")
+        err = UserRemovedError("u@example.com", original)
+        assert isinstance(err, ImpersonationError)


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Translates RefreshError from impersonated Google Drive API calls into two typed outcomes: silent skip (user confirmed deleted/suspended) or ImpersonationError (impersonation misconfiguration). The original proxy-based approach was replaced with a simpler guard after it caused silent data loss and confusing crashes at call sites that consume API objects as values rather than chaining to .execute().

Key changes
resources.py: Removes RefreshableDriveObject proxy and _ImpersonationState. Adds ImpersonationGuard — a simple stateful object that fires an Admin SDK callback at most once to check if a user was removed. get_drive_service returns a plain service object with no wrapping.
connector.py: Creates an ImpersonationGuard per user in _impersonate_user_for_retrieval, catches RefreshError directly at the validation gate and mid-run, and calls guard.is_user_removed() to determine which path to take.
file_retrieval.py / doc_conversion.py: Reverts the _unwrap() escape hatches that were needed to work around proxy limitations in BatchHttpRequest and MediaIoBaseDownload call sites — no longer needed.
Tests: test_refreshable_drive_object.py replaced by test_impersonation_guard.py; test_slim_retrieval.py updated to mock RefreshError + _get_all_user_emails directly.

https://linear.app/onyx-app/issue/ENG-4091/improving-google-connector-to-handle-user-removal-during-task-refresh

## How Has This Been Tested?
Updated unit tests
local test
<img width="986" height="178" alt="Screenshot 2026-04-30 at 11 26 57 AM" src="https://github.com/user-attachments/assets/f3af35f2-97c3-4782-906c-262487f7dd44" />


<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
