### PR TITLE
chore(metrics): Add metrics for image processing

### DIFF
--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -15,6 +15,7 @@ from onyx.llm.models import TextContentPart
 from onyx.llm.models import UserMessage
 from onyx.llm.utils import llm_response_to_string
 from onyx.tracing.flows import LLMFlow
+from onyx.server.metrics.image_processing import track_image_summarization
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.b64 import get_image_type_from_bytes
@@ -38,6 +39,7 @@ def prepare_image_bytes(image_data: bytes) -> str:
     return encoded_image
 
 
+@track_image_summarization
 def summarize_image_pipeline(
     llm: LLM,
     image_data: bytes,

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -14,8 +14,8 @@ from onyx.llm.models import SystemMessage
 from onyx.llm.models import TextContentPart
 from onyx.llm.models import UserMessage
 from onyx.llm.utils import llm_response_to_string
-from onyx.tracing.flows import LLMFlow
 from onyx.server.metrics.image_processing import track_image_summarization
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.b64 import get_image_type_from_bytes

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,4 +1,3 @@
-import time
 from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Generator
@@ -683,19 +682,13 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                             file_id=section.image_file_id
                         )
                         image_data = image_data_io.read()
-                        onyx_image_size_bytes.observe(len(image_data))
-
-                        start = time.monotonic()
                         summary = summarize_image_with_error_handling(
                             llm=llm,
                             image_data=image_data,
                             context_name=file_record.display_name or "Image",
                         )
-                        elapsed = time.monotonic() - start
 
                         if summary:
-                            onyx_image_summarization_duration_seconds.observe(elapsed)
-                            onyx_image_summarization_total.inc()
                             processed_section.text = summary
                         else:
                             processed_section.text = "[Image could not be summarized]"

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1,3 +1,4 @@
+import time
 from collections import defaultdict
 from collections.abc import Callable
 from collections.abc import Generator

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -683,13 +683,19 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                             file_id=section.image_file_id
                         )
                         image_data = image_data_io.read()
+                        onyx_image_size_bytes.observe(len(image_data))
+
+                        start = time.monotonic()
                         summary = summarize_image_with_error_handling(
                             llm=llm,
                             image_data=image_data,
                             context_name=file_record.display_name or "Image",
                         )
+                        elapsed = time.monotonic() - start
 
                         if summary:
+                            onyx_image_summarization_duration_seconds.observe(elapsed)
+                            onyx_image_summarization_total.inc()
                             processed_section.text = summary
                         else:
                             processed_section.text = "[Image could not be summarized]"

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -1,11 +1,18 @@
-"""Prometheus metrics for image processing during document indexing.
+import functools
+import inspect
+import io
+import logging
+import time
+from collections.abc import Callable
+from typing import ParamSpec
+from typing import TypeVar
 
-Tracks the size of images being processed and the latency of LLM
-summarization calls in ``process_image_sections``.
-"""
-
-from prometheus_client import Counter
 from prometheus_client import Histogram
+
+logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 _IMAGE_SIZE_BUCKETS = (
     1_000,
@@ -18,6 +25,18 @@ _IMAGE_SIZE_BUCKETS = (
     10_000_000,
 )
 
+_IMAGE_DIMENSION_BUCKETS = (
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2048,
+    4096,
+    8192,
+)
+
 _LLM_LATENCY_BUCKETS = (
     0.5,
     1.0,
@@ -28,19 +47,72 @@ _LLM_LATENCY_BUCKETS = (
     60.0,
 )
 
-onyx_image_size_bytes = Histogram(
+_image_size_bytes = Histogram(
     "onyx_image_size_bytes",
     "Size of images processed during indexing, in bytes.",
     buckets=_IMAGE_SIZE_BUCKETS,
 )
 
-onyx_image_summarization_duration_seconds = Histogram(
+_image_width_pixels = Histogram(
+    "onyx_image_width_pixels",
+    "Width of images processed during indexing, in pixels.",
+    buckets=_IMAGE_DIMENSION_BUCKETS,
+)
+
+_image_height_pixels = Histogram(
+    "onyx_image_height_pixels",
+    "Height of images processed during indexing, in pixels.",
+    buckets=_IMAGE_DIMENSION_BUCKETS,
+)
+
+_image_summarization_duration_seconds = Histogram(
     "onyx_image_summarization_duration_seconds",
     "Latency of LLM image summarization calls, in seconds.",
     buckets=_LLM_LATENCY_BUCKETS,
 )
 
-onyx_image_summarization_total = Counter(
-    "onyx_image_summarization_total",
-    "Total successful image summarizations.",
-)
+
+def track_image_summarization(
+    fn: Callable[P, R],
+) -> Callable[P, R]:
+    """Decorator that records image metrics around an image summarization function.
+
+    Looks for an ``image_data`` parameter (positional or keyword) containing
+    the raw image bytes. If found, records size and dimensions. Always records
+    the wall-clock duration of the wrapped call.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound = inspect.signature(fn).bind(*args, **kwargs)
+        bound.apply_defaults()
+        image_data: bytes | None = bound.arguments.get("image_data")  # type: ignore[assignment]
+
+        if image_data is not None:
+            try:
+                from PIL import Image
+
+                _image_size_bytes.observe(len(image_data))
+                img = Image.open(io.BytesIO(image_data))
+                w, h = img.size
+                _image_width_pixels.observe(w)
+                _image_height_pixels.observe(h)
+            except Exception:
+                logger.warning(
+                    "Failed to record image processing metrics.", exc_info=True
+                )
+
+        start = time.monotonic()
+        result = fn(*args, **kwargs)
+        elapsed = time.monotonic() - start
+
+        try:
+            _image_summarization_duration_seconds.observe(elapsed)
+        except Exception:
+            logger.warning(
+                "Failed to record image summarization metrics.", exc_info=True
+            )
+
+        return result
+
+    return wrapper

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -92,13 +92,19 @@ def track_image_summarization(
                     "Failed to record image processing metrics.", exc_info=True
                 )
 
+        try:
+            _image_summarization_total.labels(**labels).inc()
+        except Exception:
+            logger.warning(
+                "Failed to record image summarization metrics.", exc_info=True
+            )
+
         start = time.monotonic()
         result = fn(*args, **kwargs)
         elapsed = time.monotonic() - start
 
         try:
             _image_summarization_duration_seconds.labels(**labels).observe(elapsed)
-            _image_summarization_total.labels(**labels).inc()
         except Exception:
             logger.warning(
                 "Failed to record image summarization metrics.", exc_info=True

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -93,6 +93,8 @@ def track_image_summarization(
                 )
 
         try:
+            # Metrics for all images that attempt to get processed
+            # We want to know the size distribution
             _image_summarization_total.labels(**labels).inc()
         except Exception:
             logger.warning(
@@ -104,6 +106,7 @@ def track_image_summarization(
         elapsed = time.monotonic() - start
 
         try:
+            # Metrics for how long image X took to upload plus the details about it
             _image_summarization_duration_seconds.labels(**labels).observe(elapsed)
         except Exception:
             logger.warning(

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -83,8 +83,8 @@ def track_image_summarization(
                 from PIL import Image
 
                 labels["size_bucket"] = _size_tier(len(image_data))
-                img = Image.open(io.BytesIO(image_data))
-                w, h = img.size
+                with Image.open(io.BytesIO(image_data)) as img:
+                    w, h = img.size
                 labels["width_bucket"] = _dim_tier(w)
                 labels["height_bucket"] = _dim_tier(h)
             except Exception:

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -1,3 +1,4 @@
+import bisect
 import functools
 import inspect
 import io
@@ -7,6 +8,7 @@ from collections.abc import Callable
 from typing import ParamSpec
 from typing import TypeVar
 
+from prometheus_client import Counter
 from prometheus_client import Histogram
 
 logger = logging.getLogger(__name__)
@@ -14,28 +16,11 @@ logger = logging.getLogger(__name__)
 P = ParamSpec("P")
 R = TypeVar("R")
 
-_IMAGE_SIZE_BUCKETS = (
-    1_000,
-    10_000,
-    50_000,
-    100_000,
-    500_000,
-    1_000_000,
-    5_000_000,
-    10_000_000,
-)
+_SIZE_TIERS = (10_000, 100_000, 1_000_000, 5_000_000)
+_SIZE_TIER_LABELS = ("< 10KB", "10KB-100KB", "100KB-1MB", "1MB-5MB", ">= 5MB")
 
-_IMAGE_DIMENSION_BUCKETS = (
-    32,
-    64,
-    128,
-    256,
-    512,
-    1024,
-    2048,
-    4096,
-    8192,
-)
+_DIM_TIERS = (128, 512, 1024, 2048, 4096)
+_DIM_TIER_LABELS = ("< 128", "128-512", "512-1024", "1024-2048", "2048-4096", ">= 4096")
 
 _LLM_LATENCY_BUCKETS = (
     0.5,
@@ -47,28 +32,28 @@ _LLM_LATENCY_BUCKETS = (
     60.0,
 )
 
-_image_size_bytes = Histogram(
-    "onyx_image_size_bytes",
-    "Size of images processed during indexing, in bytes.",
-    buckets=_IMAGE_SIZE_BUCKETS,
-)
+_LABEL_NAMES = ["size_bucket", "width_bucket", "height_bucket"]
 
-_image_width_pixels = Histogram(
-    "onyx_image_width_pixels",
-    "Width of images processed during indexing, in pixels.",
-    buckets=_IMAGE_DIMENSION_BUCKETS,
-)
 
-_image_height_pixels = Histogram(
-    "onyx_image_height_pixels",
-    "Height of images processed during indexing, in pixels.",
-    buckets=_IMAGE_DIMENSION_BUCKETS,
-)
+def _size_tier(size_bytes: int) -> str:
+    return _SIZE_TIER_LABELS[bisect.bisect_right(_SIZE_TIERS, size_bytes)]
+
+
+def _dim_tier(pixels: int) -> str:
+    return _DIM_TIER_LABELS[bisect.bisect_right(_DIM_TIERS, pixels)]
+
 
 _image_summarization_duration_seconds = Histogram(
     "onyx_image_summarization_duration_seconds",
     "Latency of LLM image summarization calls, in seconds.",
+    _LABEL_NAMES,
     buckets=_LLM_LATENCY_BUCKETS,
+)
+
+_image_summarization_total = Counter(
+    "onyx_image_summarization_total",
+    "Total image summarizations processed.",
+    _LABEL_NAMES,
 )
 
 
@@ -78,8 +63,8 @@ def track_image_summarization(
     """Decorator that records image metrics around an image summarization function.
 
     Looks for an ``image_data`` parameter (positional or keyword) containing
-    the raw image bytes. If found, records size and dimensions. Always records
-    the wall-clock duration of the wrapped call.
+    the raw image bytes. If found, records size and dimension labels. Always
+    records the wall-clock duration of the wrapped call.
     """
 
     @functools.wraps(fn)
@@ -88,15 +73,20 @@ def track_image_summarization(
         bound.apply_defaults()
         image_data: bytes | None = bound.arguments.get("image_data")  # type: ignore[assignment]
 
+        labels: dict[str, str] = {
+            "size_bucket": "unknown",
+            "width_bucket": "unknown",
+            "height_bucket": "unknown",
+        }
         if image_data is not None:
             try:
                 from PIL import Image
 
-                _image_size_bytes.observe(len(image_data))
+                labels["size_bucket"] = _size_tier(len(image_data))
                 img = Image.open(io.BytesIO(image_data))
                 w, h = img.size
-                _image_width_pixels.observe(w)
-                _image_height_pixels.observe(h)
+                labels["width_bucket"] = _dim_tier(w)
+                labels["height_bucket"] = _dim_tier(h)
             except Exception:
                 logger.warning(
                     "Failed to record image processing metrics.", exc_info=True
@@ -107,7 +97,8 @@ def track_image_summarization(
         elapsed = time.monotonic() - start
 
         try:
-            _image_summarization_duration_seconds.observe(elapsed)
+            _image_summarization_duration_seconds.labels(**labels).observe(elapsed)
+            _image_summarization_total.labels(**labels).inc()
         except Exception:
             logger.warning(
                 "Failed to record image summarization metrics.", exc_info=True

--- a/backend/onyx/server/metrics/image_processing.py
+++ b/backend/onyx/server/metrics/image_processing.py
@@ -1,0 +1,46 @@
+"""Prometheus metrics for image processing during document indexing.
+
+Tracks the size of images being processed and the latency of LLM
+summarization calls in ``process_image_sections``.
+"""
+
+from prometheus_client import Counter
+from prometheus_client import Histogram
+
+_IMAGE_SIZE_BUCKETS = (
+    1_000,
+    10_000,
+    50_000,
+    100_000,
+    500_000,
+    1_000_000,
+    5_000_000,
+    10_000_000,
+)
+
+_LLM_LATENCY_BUCKETS = (
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    25.0,
+    60.0,
+)
+
+onyx_image_size_bytes = Histogram(
+    "onyx_image_size_bytes",
+    "Size of images processed during indexing, in bytes.",
+    buckets=_IMAGE_SIZE_BUCKETS,
+)
+
+onyx_image_summarization_duration_seconds = Histogram(
+    "onyx_image_summarization_duration_seconds",
+    "Latency of LLM image summarization calls, in seconds.",
+    buckets=_LLM_LATENCY_BUCKETS,
+)
+
+onyx_image_summarization_total = Counter(
+    "onyx_image_summarization_total",
+    "Total successful image summarizations.",
+)


### PR DESCRIPTION
## Description
We want more insights into the type of images that are being uploaded to see if these are a bottleneck.
Let's track the size, dimensions and latency of images being processed by the doc processing workers.

This will help us know if certain optimisations should be done.

Views that I want:
 - How long it is taking for images to be summarised (view by size, and dimensions)
 - What images are being processed (view by size and dimension)

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
