### PR TITLE
feat(billing): allow trialing tenants to upgrade on demand

### DIFF
--- a/backend/ee/onyx/server/billing/api.py
+++ b/backend/ee/onyx/server/billing/api.py
@@ -214,6 +214,7 @@ async def create_customer_portal_session(
         license_data=license_data,
         return_url=return_url,
         tenant_id=tenant_id,
+        flow_type=request.flow_type if request else None,
     )
 
 

--- a/backend/ee/onyx/server/billing/api.py
+++ b/backend/ee/onyx/server/billing/api.py
@@ -36,6 +36,7 @@ from ee.onyx.server.billing.models import CreateCheckoutSessionRequest
 from ee.onyx.server.billing.models import CreateCheckoutSessionResponse
 from ee.onyx.server.billing.models import CreateCustomerPortalSessionRequest
 from ee.onyx.server.billing.models import CreateCustomerPortalSessionResponse
+from ee.onyx.server.billing.models import EndTrialResponse
 from ee.onyx.server.billing.models import SeatUpdateRequest
 from ee.onyx.server.billing.models import SeatUpdateResponse
 from ee.onyx.server.billing.models import StripePublishableKeyResponse
@@ -46,6 +47,7 @@ from ee.onyx.server.billing.service import (
 from ee.onyx.server.billing.service import (
     create_customer_portal_session as create_portal_service,
 )
+from ee.onyx.server.billing.service import end_trial as end_trial_service
 from ee.onyx.server.billing.service import (
     get_billing_information as get_billing_service,
 )
@@ -292,6 +294,29 @@ async def update_seats(
         license_data=license_data,
         tenant_id=tenant_id,
     )
+
+
+@router.post("/end-trial")
+async def end_trial(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> EndTrialResponse:
+    """End the current trial immediately and charge the customer's card.
+
+    Cloud-only. The control plane sets `trial_end="now"` on the Stripe
+    subscription; Stripe attempts to charge the attached payment method, and
+    the resulting webhook transitions the subscription to active.
+
+    Returns 402 (forwarded from the control plane) when no payment method is
+    attached. The frontend handles that by routing to the customer portal.
+    """
+    if not MULTI_TENANT:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "End-trial is only available for cloud deployments",
+        )
+
+    tenant_id = _get_tenant_id()
+    return await end_trial_service(tenant_id=tenant_id)
 
 
 @router.get("/stripe-publishable-key")

--- a/backend/ee/onyx/server/billing/models.py
+++ b/backend/ee/onyx/server/billing/models.py
@@ -24,6 +24,7 @@ class CreateCustomerPortalSessionRequest(BaseModel):
     """Request to create a Stripe customer portal session."""
 
     return_url: str | None = None
+    flow_type: Literal["payment_method_update"] | None = None
 
 
 class CreateCustomerPortalSessionResponse(BaseModel):

--- a/backend/ee/onyx/server/billing/models.py
+++ b/backend/ee/onyx/server/billing/models.py
@@ -1,9 +1,19 @@
 """Pydantic models for the billing API."""
 
 from datetime import datetime
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel
+
+
+class StripePortalFlowType(str, Enum):
+    """Stripe billing portal `flow_data.type` values supported by the API.
+
+    Mirrors `shared.enums.StripePortalFlowType` on the control plane.
+    """
+
+    PAYMENT_METHOD_UPDATE = "payment_method_update"
 
 
 class CreateCheckoutSessionRequest(BaseModel):
@@ -24,7 +34,7 @@ class CreateCustomerPortalSessionRequest(BaseModel):
     """Request to create a Stripe customer portal session."""
 
     return_url: str | None = None
-    flow_type: Literal["payment_method_update"] | None = None
+    flow_type: StripePortalFlowType | None = None
 
 
 class CreateCustomerPortalSessionResponse(BaseModel):

--- a/backend/ee/onyx/server/billing/models.py
+++ b/backend/ee/onyx/server/billing/models.py
@@ -75,3 +75,11 @@ class StripePublishableKeyResponse(BaseModel):
     """Response containing the Stripe publishable key."""
 
     publishable_key: str
+
+
+class EndTrialResponse(BaseModel):
+    """Response from ending a trial early."""
+
+    success: bool
+    stripe_subscription_id: str
+    status: str

--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -18,6 +18,7 @@ from ee.onyx.configs.app_configs import CLOUD_DATA_PLANE_URL
 from ee.onyx.server.billing.models import BillingInformationResponse
 from ee.onyx.server.billing.models import CreateCheckoutSessionResponse
 from ee.onyx.server.billing.models import CreateCustomerPortalSessionResponse
+from ee.onyx.server.billing.models import EndTrialResponse
 from ee.onyx.server.billing.models import SeatUpdateResponse
 from ee.onyx.server.billing.models import SubscriptionStatusResponse
 from ee.onyx.server.tenants.access import generate_data_plane_token
@@ -271,4 +272,32 @@ async def update_seat_count(
         used_seats=data.get("used_seats", 0),
         message=data.get("message"),
         license=data.get("license"),
+    )
+
+
+async def end_trial(tenant_id: str | None) -> EndTrialResponse:
+    """End the trial for the current subscription immediately.
+
+    Calls the control plane, which sets `trial_end="now"` on the Stripe
+    subscription so the customer is charged right away. The Stripe webhook
+    transitions the local subscription trialing -> active.
+
+    Cloud-only: requires a tenant_id. Self-hosted callers should use the
+    standard checkout flow instead.
+    """
+    body: dict = {}
+    if tenant_id and MULTI_TENANT:
+        body["tenant_id"] = tenant_id
+
+    data = await _make_billing_request(
+        method="POST",
+        path="/end-trial",
+        license_data=None,
+        body=body,
+        error_message="Failed to end trial",
+    )
+    return EndTrialResponse(
+        success=data.get("success", False),
+        stripe_subscription_id=data.get("stripe_subscription_id", ""),
+        status=data.get("status", ""),
     )

--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -180,6 +180,7 @@ async def create_customer_portal_session(
     license_data: str | None = None,
     return_url: str | None = None,
     tenant_id: str | None = None,
+    flow_type: Literal["payment_method_update"] | None = None,
 ) -> CreateCustomerPortalSessionResponse:
     """Create a Stripe customer portal session.
 
@@ -187,6 +188,8 @@ async def create_customer_portal_session(
         license_data: License blob for authentication (self-hosted)
         return_url: URL to return to after portal session
         tenant_id: Tenant ID (cloud only)
+        flow_type: When "payment_method_update", deep-links the user to the
+            add-payment-method screen instead of the portal home.
 
     Returns:
         CreateCustomerPortalSessionResponse with portal URL
@@ -196,6 +199,8 @@ async def create_customer_portal_session(
         body["return_url"] = return_url
     if tenant_id and MULTI_TENANT:
         body["tenant_id"] = tenant_id
+    if flow_type:
+        body["flow_type"] = flow_type
 
     data = await _make_billing_request(
         method="POST",

--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -20,6 +20,7 @@ from ee.onyx.server.billing.models import CreateCheckoutSessionResponse
 from ee.onyx.server.billing.models import CreateCustomerPortalSessionResponse
 from ee.onyx.server.billing.models import EndTrialResponse
 from ee.onyx.server.billing.models import SeatUpdateResponse
+from ee.onyx.server.billing.models import StripePortalFlowType
 from ee.onyx.server.billing.models import SubscriptionStatusResponse
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
@@ -180,7 +181,7 @@ async def create_customer_portal_session(
     license_data: str | None = None,
     return_url: str | None = None,
     tenant_id: str | None = None,
-    flow_type: Literal["payment_method_update"] | None = None,
+    flow_type: StripePortalFlowType | None = None,
 ) -> CreateCustomerPortalSessionResponse:
     """Create a Stripe customer portal session.
 
@@ -200,7 +201,7 @@ async def create_customer_portal_session(
     if tenant_id and MULTI_TENANT:
         body["tenant_id"] = tenant_id
     if flow_type:
-        body["flow_type"] = flow_type
+        body["flow_type"] = flow_type.value
 
     data = await _make_billing_request(
         method="POST",

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -223,10 +223,13 @@ function SubscriptionCard({
       await onRefresh?.();
     } catch (error) {
       if (error instanceof PaymentMethodRequiredError) {
-        // Route to Stripe customer portal to add a card, then return here.
+        // Deep-link the user to the Stripe add-payment-method screen, then
+        // return to /admin/billing with a marker that auto-retries the
+        // upgrade so they don't have to click the button again.
         try {
           const response = await createCustomerPortalSession({
-            return_url: `${window.location.origin}/admin/billing?portal_return=true`,
+            return_url: `${window.location.origin}/admin/billing?portal_return=true&retry_upgrade=1`,
+            flow_type: "payment_method_update",
           });
           if (response.stripe_customer_portal_url) {
             window.location.href = response.stripe_customer_portal_url;

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -248,7 +248,8 @@ function SubscriptionCard({
     }
   };
 
-  const isTrialing = billing?.status === "trialing";
+  const isTrialing =
+    NEXT_PUBLIC_CLOUD_ENABLED && billing?.status === "trialing";
 
   return (
     <Card>
@@ -297,7 +298,7 @@ function SubscriptionCard({
             </OpalButton>
           ) : (
             <Section
-              flexDirection="column"
+              flexDirection="row"
               gap={0.5}
               alignItems="end"
               height="auto"

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -19,9 +19,14 @@ import {
   SvgFileText,
   SvgOrganization,
 } from "@opal/icons";
-import { BillingInformation, LicenseStatus } from "@/lib/billing/interfaces";
+import {
+  BillingInformation,
+  LicenseStatus,
+  PaymentMethodRequiredError,
+} from "@/lib/billing/interfaces";
 import {
   createCustomerPortalSession,
+  endTrial,
   resetStripeConnection,
   updateSeatCount,
   claimLicense,
@@ -146,6 +151,7 @@ function SubscriptionCard({
   disabled,
   isManualLicenseOnly,
   onReconnect,
+  onRefresh,
 }: {
   billing?: BillingInformation;
   license?: LicenseStatus;
@@ -153,8 +159,11 @@ function SubscriptionCard({
   disabled?: boolean;
   isManualLicenseOnly?: boolean;
   onReconnect?: () => Promise<void>;
+  onRefresh?: () => Promise<void>;
 }) {
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [isEndingTrial, setIsEndingTrial] = useState(false);
+  const [endTrialError, setEndTrialError] = useState<string | null>(null);
 
   const planName = isManualLicenseOnly ? "Enterprise Plan" : "Business Plan";
   const PlanIcon = isManualLicenseOnly ? SvgOrganization : SvgUsers;
@@ -206,6 +215,41 @@ function SubscriptionCard({
     }
   };
 
+  const handleEndTrial = async () => {
+    setIsEndingTrial(true);
+    setEndTrialError(null);
+    try {
+      await endTrial();
+      await onRefresh?.();
+    } catch (error) {
+      if (error instanceof PaymentMethodRequiredError) {
+        // Route to Stripe customer portal to add a card, then return here.
+        try {
+          const response = await createCustomerPortalSession({
+            return_url: `${window.location.origin}/admin/billing?portal_return=true`,
+          });
+          if (response.stripe_customer_portal_url) {
+            window.location.href = response.stripe_customer_portal_url;
+            return;
+          }
+        } catch (portalError) {
+          console.error("Failed to open customer portal:", portalError);
+          setEndTrialError(
+            "Add a payment method first, then try upgrading again."
+          );
+        }
+      } else {
+        setEndTrialError(
+          error instanceof Error ? error.message : "Failed to end trial"
+        );
+      }
+    } finally {
+      setIsEndingTrial(false);
+    }
+  };
+
+  const isTrialing = billing?.status === "trialing";
+
   return (
     <Card>
       <Section
@@ -252,9 +296,35 @@ function SubscriptionCard({
               {isReconnecting ? "Connecting..." : "Connect to Stripe"}
             </OpalButton>
           ) : (
-            <OpalButton onClick={handleManagePlan} rightIcon={SvgExternalLink}>
-              Manage Plan
-            </OpalButton>
+            <Section
+              flexDirection="column"
+              gap={0.5}
+              alignItems="end"
+              height="auto"
+              width="auto"
+            >
+              {isTrialing && (
+                <OpalButton
+                  disabled={isEndingTrial}
+                  onClick={handleEndTrial}
+                  rightIcon={SvgArrowRight}
+                >
+                  {isEndingTrial ? "Upgrading..." : "Upgrade now"}
+                </OpalButton>
+              )}
+              <OpalButton
+                prominence={isTrialing ? "secondary" : "primary"}
+                onClick={handleManagePlan}
+                rightIcon={SvgExternalLink}
+              >
+                Manage Plan
+              </OpalButton>
+            </Section>
+          )}
+          {endTrialError && (
+            <Text secondaryBody className="text-status-error-04">
+              {endTrialError}
+            </Text>
           )}
           {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
           <Button tertiary onClick={onViewPlans} className="billing-text-link">
@@ -682,6 +752,7 @@ export default function BillingDetailsView({
           disabled={disableBillingActions}
           isManualLicenseOnly={isManualLicenseOnly}
           onReconnect={onRefresh}
+          onRefresh={onRefresh}
         />
       )}
 

--- a/web/src/app/admin/billing/BillingDetailsView.tsx
+++ b/web/src/app/admin/billing/BillingDetailsView.tsx
@@ -21,8 +21,10 @@ import {
 } from "@opal/icons";
 import {
   BillingInformation,
+  BillingStatus,
   LicenseStatus,
   PaymentMethodRequiredError,
+  StripePortalFlowType,
 } from "@/lib/billing/interfaces";
 import {
   createCustomerPortalSession,
@@ -229,7 +231,7 @@ function SubscriptionCard({
         try {
           const response = await createCustomerPortalSession({
             return_url: `${window.location.origin}/admin/billing?portal_return=true&retry_upgrade=1`,
-            flow_type: "payment_method_update",
+            flow_type: StripePortalFlowType.PAYMENT_METHOD_UPDATE,
           });
           if (response.stripe_customer_portal_url) {
             window.location.href = response.stripe_customer_portal_url;
@@ -252,7 +254,7 @@ function SubscriptionCard({
   };
 
   const isTrialing =
-    NEXT_PUBLIC_CLOUD_ENABLED && billing?.status === "trialing";
+    NEXT_PUBLIC_CLOUD_ENABLED && billing?.status === BillingStatus.TRIALING;
 
   return (
     <Card>

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -14,6 +14,9 @@ import {
   BillingInformation,
   hasActiveSubscription,
   claimLicense,
+  endTrial,
+  PaymentMethodRequiredError,
+  createCustomerPortalSession,
 } from "@/lib/billing";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -169,6 +172,7 @@ export default function BillingPage() {
   useEffect(() => {
     const sessionId = searchParams.get("session_id");
     const portalReturn = searchParams.get("portal_return");
+    const retryUpgrade = searchParams.get("retry_upgrade") === "1";
 
     if (!sessionId && !portalReturn) return;
 
@@ -220,6 +224,39 @@ export default function BillingPage() {
         }
       }
       if (!cancelled) refreshBilling();
+
+      // Auto-retry the trial upgrade if the user just came back from the
+      // add-payment-method portal flow. This avoids making them click
+      // "Upgrade now" a second time once their card is on file.
+      if (!cancelled && retryUpgrade && NEXT_PUBLIC_CLOUD_ENABLED) {
+        try {
+          await endTrial();
+          if (!cancelled) {
+            refreshBilling();
+            router.refresh();
+            mutate(SWR_KEYS.settings);
+            mutate(SWR_KEYS.enterpriseSettings);
+          }
+        } catch (err) {
+          if (err instanceof PaymentMethodRequiredError) {
+            // Card add was abandoned or failed verification — bounce them
+            // back to the same flow so they can complete it.
+            try {
+              const response = await createCustomerPortalSession({
+                return_url: `${window.location.origin}/admin/billing?portal_return=true&retry_upgrade=1`,
+                flow_type: "payment_method_update",
+              });
+              if (response.stripe_customer_portal_url) {
+                window.location.href = response.stripe_customer_portal_url;
+              }
+            } catch (portalErr) {
+              console.error("Failed to reopen portal after retry:", portalErr);
+            }
+          } else {
+            console.error("Auto-retry of trial upgrade failed:", err);
+          }
+        }
+      }
     };
     handleBillingReturn();
 

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -17,6 +17,7 @@ import {
   endTrial,
   PaymentMethodRequiredError,
   createCustomerPortalSession,
+  StripePortalFlowType,
 } from "@/lib/billing";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -244,7 +245,7 @@ export default function BillingPage() {
             try {
               const response = await createCustomerPortalSession({
                 return_url: `${window.location.origin}/admin/billing?portal_return=true&retry_upgrade=1`,
-                flow_type: "payment_method_update",
+                flow_type: StripePortalFlowType.PAYMENT_METHOD_UPDATE,
               });
               if (response.stripe_customer_portal_url) {
                 window.location.href = response.stripe_customer_portal_url;

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -117,6 +117,23 @@ export interface SeatUpdateResponse {
 }
 
 // ----------------------------------------------------------------------------
+// Trial Management Types
+// ----------------------------------------------------------------------------
+
+export interface EndTrialResponse {
+  success: boolean;
+  stripe_subscription_id: string;
+  status: string;
+}
+
+export class PaymentMethodRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PaymentMethodRequiredError";
+  }
+}
+
+// ----------------------------------------------------------------------------
 // Type Guards
 // ----------------------------------------------------------------------------
 

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -95,6 +95,7 @@ export interface CreateCheckoutSessionResponse {
 
 export interface CreateCustomerPortalSessionRequest {
   return_url?: string;
+  flow_type?: "payment_method_update";
 }
 
 export interface CreateCustomerPortalSessionResponse {

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -93,9 +93,17 @@ export interface CreateCheckoutSessionResponse {
   stripe_checkout_url: string;
 }
 
+/**
+ * Stripe billing portal `flow_data.type` values supported by the API.
+ * Mirrors `shared.enums.StripePortalFlowType` on the control plane.
+ */
+export enum StripePortalFlowType {
+  PAYMENT_METHOD_UPDATE = "payment_method_update",
+}
+
 export interface CreateCustomerPortalSessionRequest {
   return_url?: string;
-  flow_type?: "payment_method_update";
+  flow_type?: StripePortalFlowType;
 }
 
 export interface CreateCustomerPortalSessionResponse {

--- a/web/src/lib/billing/svc.ts
+++ b/web/src/lib/billing/svc.ts
@@ -20,6 +20,8 @@ import {
   CreateCheckoutSessionResponse,
   CreateCustomerPortalSessionRequest,
   CreateCustomerPortalSessionResponse,
+  EndTrialResponse,
+  PaymentMethodRequiredError,
   SeatUpdateRequest,
   SeatUpdateResponse,
 } from "@/lib/billing/interfaces";
@@ -59,6 +61,35 @@ export const createCustomerPortalSession = (
 
 export const updateSeatCount = (request: SeatUpdateRequest) =>
   billingPost<SeatUpdateResponse>("/seats/update", request);
+
+/**
+ * End the current trial immediately and charge the customer's card.
+ *
+ * Cloud-only. Always hits the unified /admin/billing route since this is a
+ * brand-new endpoint without a legacy /tenants alias.
+ *
+ * Throws `PaymentMethodRequiredError` when the tenant has no card on file
+ * (HTTP 402). The caller should route the user to the customer portal to
+ * add a payment method, then retry.
+ */
+export async function endTrial(): Promise<EndTrialResponse> {
+  const response = await fetch("/api/admin/billing/end-trial", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    const detail = error.detail || "Failed to end trial";
+    if (response.status === 402) {
+      throw new PaymentMethodRequiredError(detail);
+    }
+    throw new Error(detail);
+  }
+
+  return response.json();
+}
 
 /**
  * Reset the Stripe connection circuit breaker (self-hosted only).


### PR DESCRIPTION
## Description

Adds an "Upgrade now" button on `/admin/billing` for tenants whose subscription is `trialing`. Clicking it ends the trial immediately so the tenant is charged and gains paid access without waiting for the trial to expire.

- New backend route `POST /admin/billing/end-trial` (cloud-only) that proxies to the control plane's new `/end-trial` endpoint (see paired control-plane PR)
- New `endTrial()` and `PaymentMethodRequiredError` in `web/src/lib/billing`
- `BillingDetailsView` renders the "Upgrade now" button when `billing.status === "trialing"`; on 402 (no card on file) it routes the user to the Stripe customer portal to add a payment method, then they retry

The Stripe customer portal does not expose an "End trial" action, which is why we are surfacing it natively in our UI.

## How Has This Been Tested?

- [x] Existing `web/src/app/admin/billing/page.test.tsx` still passes (11/11)
- [x] `mypy`, `black`, `ruff`, `prettier`, and `tsc --noEmit` all clean
- [ ] Manual: trigger button against a staging tenant in trialing state with and without a card attached

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check