### PR TITLE
feat(tracing): LLMFlow registry, wrap every LLM call site

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -39,6 +39,10 @@ Routes not starting with `/api` are not caught by the existing `^/(api|openapi\.
 
 Code changes must consider both regular Onyx deployments and Onyx lite deployments. Lite deployments disable the vector DB, Redis, model servers, and background workers by default, use PostgreSQL-backed cache/auth/file storage, and rely on the API server to handle background work. Do not assume those services are available unless the code path is explicitly limited to full deployments.
 
+## LLM Call Tagging — Always Use LLMFlow Registry
+
+Every LLM, embedding, rerank, image-generation, voice (STT/TTS), and intent-classification call must open a generation span tagged with a value from the `LLMFlow` registry in `backend/onyx/tracing/flows.py`. Use `llm_generation_span(llm=..., flow=LLMFlow.X, ...)` for calls going through an `LLM` subclass, or `traced_llm_call(flow=LLMFlow.X, model=..., provider=..., ...)` for direct provider SDK / `litellm` / model_server HTTP calls that bypass the `LLM` abstraction. Never pass raw strings to `flow=` — add a new `LLMFlow` enum value first. Flow tags name the operation (e.g. `IMAGE_EDIT`, `RERANK`), not the provider; provider goes in `model_config["model_provider"]`. The auto-wrap fallback emits `LLMFlow.UNTAGGED_INVOKE` / `UNTAGGED_STREAM` for missing instrumentation — those sentinels are a signal to fix the call site, not a substitute for explicit tagging.
+
 ## SWR Cache Keys — Always Use SWR_KEYS Registry
 
 All `useSWR()` calls and `mutate()` calls in the frontend must reference the centralized `SWR_KEYS` registry in `web/src/lib/swr-keys.ts` instead of inline endpoint strings or local string constants. Never write `useSWR("/api/some/endpoint", ...)` or `mutate("/api/some/endpoint")` — always use the corresponding `SWR_KEYS.someEndpoint` constant. If the endpoint does not yet exist in the registry, add it there first. This applies to all variants of an endpoint (e.g. query-string variants like `?get_editable=true` must also be registered as their own key).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,18 +27,21 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
 #### Worker Types
 
 1. **Primary Worker** (`celery_app.py`)
+
    - Coordinates core background tasks and system-wide operations
    - Handles connector management, document sync, pruning, and periodic checks
    - Runs with 4 threads concurrency
    - Tasks: connector deletion, vespa sync, pruning, LLM model updates, user file sync
 
 2. **Docfetching Worker** (`docfetching`)
+
    - Fetches documents from external data sources (connectors)
    - Spawns docprocessing tasks for each document batch
    - Implements watchdog monitoring for stuck connectors
    - Configurable concurrency (default from env)
 
 3. **Docprocessing Worker** (`docprocessing`)
+
    - Processes fetched documents through the indexing pipeline:
      - Upserts documents to PostgreSQL
      - Chunks documents and adds contextual information
@@ -48,28 +51,33 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
    - Configurable concurrency (default from env)
 
 4. **Light Worker** (`light`)
+
    - Handles lightweight, fast operations
    - Tasks: vespa metadata sync, connector deletion, doc permissions upsert, checkpoint cleanup, index attempt cleanup
    - Higher concurrency for quick tasks
 
 5. **Heavy Worker** (`heavy`)
+
    - Handles resource-intensive operations
    - Tasks: connector pruning, document permissions sync, external group sync, CSV generation
    - Runs with 4 threads concurrency
 
 6. **KG Processing Worker** (`kg_processing`)
+
    - Handles Knowledge Graph processing and clustering
    - Builds relationships between documents
    - Runs clustering algorithms
    - Configurable concurrency
 
 7. **Monitoring Worker** (`monitoring`)
+
    - System health monitoring and metrics collection
    - Monitors Celery queues, process memory, and system status
    - Single thread (monitoring doesn't need parallelism)
    - Cloud-specific monitoring tasks
 
 8. **User File Processing Worker** (`user_file_processing`)
+
    - Processes user-uploaded files
    - Handles user file indexing and project synchronization
    - Configurable concurrency
@@ -118,7 +126,7 @@ If you make any updates to a celery worker and you want to test these changes, y
 to ask me to restart the celery worker. There is no auto-restart on code-change mechanism.
 
 **Task Time Limits**:
-Since all tasks are executed in thread pools, the time limit features of Celery are silently 
+Since all tasks are executed in thread pools, the time limit features of Celery are silently
 disabled and won't work. Timeout logic must be implemented within the task itself.
 
 ### Code Quality
@@ -290,6 +298,19 @@ will be tailing their logs to this file.
 - Streaming support for real-time responses
 - Token management and rate limiting
 - Custom prompts and agent actions
+
+### Tracing — every LLM invocation must be tagged
+
+Every LLM, embedding, rerank, image-generation, voice (STT/TTS), and intent-classification call must open a generation span tagged with a value from the `LLMFlow` registry in `backend/onyx/tracing/flows.py`. Use one of:
+
+- `llm_generation_span(llm=..., flow=LLMFlow.X, input_messages=...)` for calls going through an `LLM` subclass.
+- `traced_llm_call(flow=LLMFlow.X, model=..., provider=..., input_messages=...)` for direct provider SDK / `litellm` / model_server HTTP calls that bypass the `LLM` abstraction.
+
+Rules:
+
+1. Add a new `LLMFlow` enum value before instrumenting a new operation. Don't pass raw strings.
+2. Flow tags name the **operation** (e.g. `IMAGE_EDIT`, `RERANK`) — not the provider. Provider lives in `model_config["model_provider"]`.
+3. The auto-wrap fallback in `onyx/llm/tracing_wrap.py` emits `LLMFlow.UNTAGGED_INVOKE` / `UNTAGGED_STREAM` for calls that reach `LLM.invoke` / `LLM.stream` without an explicit span. These sentinels are visible in dashboards and indicate missing instrumentation — fix the call site, don't rely on the fallback.
 
 ## Creating a Plan
 

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -27,6 +27,7 @@ from onyx.prompts.compression_prompts import PROGRESSIVE_USER_REMINDER
 from onyx.prompts.compression_prompts import SUMMARIZATION_CUTOFF_MARKER
 from onyx.prompts.compression_prompts import SUMMARIZATION_PROMPT
 from onyx.prompts.compression_prompts import USER_REMINDER
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
@@ -314,7 +315,7 @@ def generate_summary(
 
     with llm_generation_span(
         llm=llm,
-        flow="chat_history_summarization",
+        flow=LLMFlow.CHAT_HISTORY_SUMMARIZATION,
         input_messages=input_messages,
     ) as span_generation:
         response = llm.invoke(input_messages)

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -53,6 +53,7 @@ from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDone
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
 from onyx.tools.models import ToolCallKickoff
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span
 from onyx.utils.b64 import get_image_type_from_bytes
 from onyx.utils.jsonriver import Parser
@@ -1032,6 +1033,7 @@ def run_llm_step_pkt_generator(
         model_config={
             "base_url": str(llm.config.api_base or ""),
             "model_impl": "litellm",
+            "flow": LLMFlow.CHAT_RESPONSE.value,
         },
     ) as span_generation:
         span_generation.span_data.input = cast(

--- a/backend/onyx/context/search/federated/slack_search_utils.py
+++ b/backend/onyx/context/search/federated/slack_search_utils.py
@@ -20,6 +20,7 @@ from onyx.natural_language_processing.english_stopwords import ENGLISH_STOPWORDS
 from onyx.onyxbot.slack.models import ChannelType
 from onyx.prompts.federated_search import SLACK_DATE_EXTRACTION_PROMPT
 from onyx.prompts.federated_search import SLACK_QUERY_EXPANSION_PROMPT
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -199,7 +200,9 @@ def extract_date_range_from_query(
 
         # Call LLM with Braintrust tracing
         with llm_generation_span(
-            llm=llm, flow="slack_date_extraction", input_messages=[prompt_msg]
+            llm=llm,
+            flow=LLMFlow.SLACK_DATE_EXTRACTION,
+            input_messages=[prompt_msg],
         ) as span_generation:
             llm_response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, llm_response)
@@ -603,7 +606,7 @@ def expand_query_with_llm(query_text: str, llm: LLM) -> list[str]:
     try:
         # Call LLM with Braintrust tracing
         with llm_generation_span(
-            llm=llm, flow="slack_query_expansion", input_messages=[prompt]
+            llm=llm, flow=LLMFlow.SLACK_QUERY_EXPANSION, input_messages=[prompt]
         ) as span_generation:
             llm_response = llm.invoke(prompt)
             record_llm_response(span_generation, llm_response)

--- a/backend/onyx/file_processing/image_summarization.py
+++ b/backend/onyx/file_processing/image_summarization.py
@@ -14,6 +14,7 @@ from onyx.llm.models import SystemMessage
 from onyx.llm.models import TextContentPart
 from onyx.llm.models import UserMessage
 from onyx.llm.utils import llm_response_to_string
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.b64 import get_image_type_from_bytes
@@ -127,7 +128,7 @@ def _summarize_image(
         # Call LLM with Braintrust tracing
         with llm_generation_span(
             llm=llm,
-            flow="image_summarization",
+            flow=LLMFlow.IMAGE_SUMMARIZATION,
             input_messages=[{"type": "image_summarization_request"}],
         ) as span_generation:
             # Note: We don't include the actual image in the span input to avoid bloating traces

--- a/backend/onyx/image_gen/providers/azure_img_gen.py
+++ b/backend/onyx/image_gen/providers/azure_img_gen.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from onyx.image_gen.interfaces import ImageGenerationProvider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.image_gen.interfaces import ReferenceImage
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 
 if TYPE_CHECKING:
     from onyx.image_gen.interfaces import ImageGenerationResponse
@@ -105,8 +107,34 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
 
             from litellm import image_edit
 
-            return image_edit(
-                image=[image.data for image in reference_images],
+            with traced_llm_call(
+                flow=LLMFlow.IMAGE_EDIT,
+                model=deployment,
+                provider="azure",
+                input_messages=[{"prompt": prompt, "n": n, "size": size}],
+            ):
+                return image_edit(
+                    image=[image.data for image in reference_images],
+                    prompt=prompt,
+                    model=model_name,
+                    api_key=self._api_key,
+                    api_base=self._api_base,
+                    api_version=self._api_version,
+                    size=size,
+                    n=n,
+                    quality=quality,
+                    **kwargs,
+                )
+
+        from litellm import image_generation
+
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_GENERATION,
+            model=deployment,
+            provider="azure",
+            input_messages=[{"prompt": prompt, "n": n, "size": size}],
+        ):
+            return image_generation(
                 prompt=prompt,
                 model=model_name,
                 api_key=self._api_key,
@@ -117,17 +145,3 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
                 quality=quality,
                 **kwargs,
             )
-
-        from litellm import image_generation
-
-        return image_generation(
-            prompt=prompt,
-            model=model_name,
-            api_key=self._api_key,
-            api_base=self._api_base,
-            api_version=self._api_version,
-            size=size,
-            n=n,
-            quality=quality,
-            **kwargs,
-        )

--- a/backend/onyx/image_gen/providers/azure_img_gen.py
+++ b/backend/onyx/image_gen/providers/azure_img_gen.py
@@ -111,7 +111,6 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
                 flow=LLMFlow.IMAGE_EDIT,
                 model=deployment,
                 provider="azure",
-                input_messages=[{"prompt": prompt, "n": n, "size": size}],
             ):
                 return image_edit(
                     image=[image.data for image in reference_images],
@@ -132,7 +131,6 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=deployment,
             provider="azure",
-            input_messages=[{"prompt": prompt, "n": n, "size": size}],
         ):
             return image_generation(
                 prompt=prompt,

--- a/backend/onyx/image_gen/providers/azure_img_gen.py
+++ b/backend/onyx/image_gen/providers/azure_img_gen.py
@@ -111,6 +111,7 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
                 flow=LLMFlow.IMAGE_EDIT,
                 model=deployment,
                 provider="azure",
+                input_messages=[{"role": "user", "content": prompt}],
             ):
                 return image_edit(
                     image=[image.data for image in reference_images],
@@ -131,6 +132,7 @@ class AzureImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=deployment,
             provider="azure",
+            input_messages=[{"role": "user", "content": prompt}],
         ):
             return image_generation(
                 prompt=prompt,

--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -98,7 +98,6 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
                 flow=LLMFlow.IMAGE_EDIT,
                 model=normalized_model,
                 provider="openai",
-                input_messages=[{"prompt": prompt, "n": n, "size": size}],
             ):
                 return image_edit(
                     image=[image.data for image in reference_images],
@@ -118,7 +117,6 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=normalized_model,
             provider="openai",
-            input_messages=[{"prompt": prompt, "n": n, "size": size}],
         ):
             return image_generation(
                 prompt=prompt,

--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from onyx.image_gen.interfaces import ImageGenerationProvider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.image_gen.interfaces import ReferenceImage
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 
 if TYPE_CHECKING:
     from onyx.image_gen.interfaces import ImageGenerationResponse
@@ -92,8 +94,33 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
 
             from litellm import image_edit
 
-            return image_edit(
-                image=[image.data for image in reference_images],
+            with traced_llm_call(
+                flow=LLMFlow.IMAGE_EDIT,
+                model=normalized_model,
+                provider="openai",
+                input_messages=[{"prompt": prompt, "n": n, "size": size}],
+            ):
+                return image_edit(
+                    image=[image.data for image in reference_images],
+                    prompt=prompt,
+                    model=litellm_model,
+                    api_key=self._api_key,
+                    api_base=self._api_base,
+                    size=size,
+                    n=n,
+                    quality=quality,
+                    **kwargs,
+                )
+
+        from litellm import image_generation
+
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_GENERATION,
+            model=normalized_model,
+            provider="openai",
+            input_messages=[{"prompt": prompt, "n": n, "size": size}],
+        ):
+            return image_generation(
                 prompt=prompt,
                 model=litellm_model,
                 api_key=self._api_key,
@@ -103,16 +130,3 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
                 quality=quality,
                 **kwargs,
             )
-
-        from litellm import image_generation
-
-        return image_generation(
-            prompt=prompt,
-            model=litellm_model,
-            api_key=self._api_key,
-            api_base=self._api_base,
-            size=size,
-            n=n,
-            quality=quality,
-            **kwargs,
-        )

--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -98,6 +98,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
                 flow=LLMFlow.IMAGE_EDIT,
                 model=normalized_model,
                 provider="openai",
+                input_messages=[{"role": "user", "content": prompt}],
             ):
                 return image_edit(
                     image=[image.data for image in reference_images],
@@ -117,6 +118,7 @@ class OpenAIImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=normalized_model,
             provider="openai",
+            input_messages=[{"role": "user", "content": prompt}],
         ):
             return image_generation(
                 prompt=prompt,

--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -90,7 +90,6 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=model,
             provider="vertex_ai",
-            input_messages=[{"prompt": prompt, "n": n, "size": size}],
         ):
             return image_generation(
                 prompt=prompt,
@@ -149,13 +148,6 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_EDIT,
             model=model_name,
             provider="vertex_ai",
-            input_messages=[
-                {
-                    "prompt": prompt,
-                    "n": n,
-                    "reference_image_count": len(reference_images),
-                }
-            ],
         ):
             response = client.models.generate_content(
                 model=model_name,

--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -90,6 +90,7 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_GENERATION,
             model=model,
             provider="vertex_ai",
+            input_messages=[{"role": "user", "content": prompt}],
         ):
             return image_generation(
                 prompt=prompt,
@@ -148,6 +149,7 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
             flow=LLMFlow.IMAGE_EDIT,
             model=model_name,
             provider="vertex_ai",
+            input_messages=[{"role": "user", "content": prompt}],
         ):
             response = client.models.generate_content(
                 model=model_name,

--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -12,6 +12,8 @@ from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.interfaces import ImageGenerationProvider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.image_gen.interfaces import ReferenceImage
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 
 if TYPE_CHECKING:
     from onyx.image_gen.interfaces import ImageGenerationResponse
@@ -84,17 +86,23 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
 
         from litellm import image_generation
 
-        return image_generation(
-            prompt=prompt,
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_GENERATION,
             model=model,
-            size=size,
-            n=n,
-            quality=quality,
-            vertex_location=self._vertex_location,
-            vertex_credentials=self._vertex_credentials,
-            vertex_project=self._vertex_project,
-            **kwargs,
-        )
+            provider="vertex_ai",
+            input_messages=[{"prompt": prompt, "n": n, "size": size}],
+        ):
+            return image_generation(
+                prompt=prompt,
+                model=model,
+                size=size,
+                n=n,
+                quality=quality,
+                vertex_location=self._vertex_location,
+                vertex_credentials=self._vertex_credentials,
+                vertex_project=self._vertex_project,
+                **kwargs,
+            )
 
     def _generate_image_with_reference_images(
         self,
@@ -137,14 +145,26 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
             ),
         )
         model_name = model.replace("vertex_ai/", "")
-        response = client.models.generate_content(
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_EDIT,
             model=model_name,
-            contents=genai_types.Content(
-                role="user",
-                parts=parts,
-            ),
-            config=config,
-        )
+            provider="vertex_ai",
+            input_messages=[
+                {
+                    "prompt": prompt,
+                    "n": n,
+                    "reference_image_count": len(reference_images),
+                }
+            ],
+        ):
+            response = client.models.generate_content(
+                model=model_name,
+                contents=genai_types.Content(
+                    role="user",
+                    parts=parts,
+                ),
+                config=config,
+            )
 
         generated_data: list[ImageObject] = []
         for candidate in response.candidates or []:

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -82,6 +82,9 @@ from onyx.natural_language_processing.utils import tokenizer_trim_middle
 from onyx.prompts.contextual_retrieval import CONTEXTUAL_RAG_PROMPT1
 from onyx.prompts.contextual_retrieval import CONTEXTUAL_RAG_PROMPT2
 from onyx.prompts.contextual_retrieval import DOCUMENT_SUMMARY_PROMPT
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import llm_generation_span
+from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
 from onyx.utils.postgres_sanitization import sanitize_documents_for_postgres
@@ -742,7 +745,13 @@ def add_document_summaries(
     summary_prompt = DOCUMENT_SUMMARY_PROMPT.format(document=doc_content)
     prompt_msg = UserMessage(content=summary_prompt)
 
-    response = llm.invoke(prompt_msg, max_tokens=MAX_CONTEXT_TOKENS)
+    with llm_generation_span(
+        llm=llm,
+        flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
+        input_messages=[prompt_msg],
+    ) as span_generation:
+        response = llm.invoke(prompt_msg, max_tokens=MAX_CONTEXT_TOKENS)
+        record_llm_response(span_generation, response)
     doc_summary = llm_response_to_string(response)
 
     for chunk in chunks_by_doc:
@@ -785,7 +794,13 @@ def add_chunk_summaries(
         fallback_prompt = UserMessage(
             content=DOCUMENT_SUMMARY_PROMPT.format(document=doc_content)
         )
-        response = llm.invoke(fallback_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+        with llm_generation_span(
+            llm=llm,
+            flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
+            input_messages=[fallback_prompt],
+        ) as span_generation:
+            response = llm.invoke(fallback_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+            record_llm_response(span_generation, response)
         doc_info = llm_response_to_string(response)
 
     from onyx.llm.prompt_cache.processor import process_with_prompt_cache
@@ -804,7 +819,13 @@ def add_chunk_summaries(
                 continuation=True,  # Append chunk to the document context
             )
 
-            response = llm.invoke(processed_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+            with llm_generation_span(
+                llm=llm,
+                flow=LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
+                input_messages=[processed_prompt],
+            ) as span_generation:
+                response = llm.invoke(processed_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+                record_llm_response(span_generation, response)
             chunk.chunk_context = llm_response_to_string(response)
 
         except LLMRateLimitError as e:
@@ -1177,12 +1198,13 @@ def index_doc_batch(
                         yield enricher.enrich_chunk(chunk, 1.0)
 
                 vector_db_write_start = time.monotonic()
-                insertion_records, write_failures = (
-                    write_chunks_to_vector_db_with_backoff(
-                        document_index=document_index,
-                        make_chunks=_enriched_stream,
-                        index_batch_params=index_batch_params,
-                    )
+                (
+                    insertion_records,
+                    write_failures,
+                ) = write_chunks_to_vector_db_with_backoff(
+                    document_index=document_index,
+                    make_chunks=_enriched_stream,
+                    index_batch_params=index_batch_params,
                 )
                 vector_db_write_ms += max(
                     0, int((time.monotonic() - vector_db_write_start) * 1000)

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1198,13 +1198,12 @@ def index_doc_batch(
                         yield enricher.enrich_chunk(chunk, 1.0)
 
                 vector_db_write_start = time.monotonic()
-                (
-                    insertion_records,
-                    write_failures,
-                ) = write_chunks_to_vector_db_with_backoff(
-                    document_index=document_index,
-                    make_chunks=_enriched_stream,
-                    index_batch_params=index_batch_params,
+                insertion_records, write_failures = (
+                    write_chunks_to_vector_db_with_backoff(
+                        document_index=document_index,
+                        make_chunks=_enriched_stream,
+                        index_batch_params=index_batch_params,
+                    )
                 )
                 vector_db_write_ms += max(
                     0, int((time.monotonic() - vector_db_write_start) * 1000)

--- a/backend/onyx/kg/utils/extraction_utils.py
+++ b/backend/onyx/kg/utils/extraction_utils.py
@@ -35,6 +35,7 @@ from onyx.prompts.kg_prompts import CALL_CHUNK_PREPROCESSING_PROMPT
 from onyx.prompts.kg_prompts import CALL_DOCUMENT_CLASSIFICATION_PROMPT
 from onyx.prompts.kg_prompts import GENERAL_CHUNK_PREPROCESSING_PROMPT
 from onyx.prompts.kg_prompts import MASTER_EXTRACTION_PROMPT
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -422,7 +423,9 @@ def kg_classify_document(
     try:
         prompt_msg = UserMessage(content=prompt)
         with llm_generation_span(
-            llm=llm, flow="kg_document_classification", input_messages=[prompt_msg]
+            llm=llm,
+            flow=LLMFlow.KG_DOCUMENT_CLASSIFICATION,
+            input_messages=[prompt_msg],
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)
@@ -493,7 +496,7 @@ def kg_deep_extract_chunks(
     try:
         prompt_msg = UserMessage(content=prompt)
         with llm_generation_span(
-            llm=llm, flow="kg_deep_extraction", input_messages=[prompt_msg]
+            llm=llm, flow=LLMFlow.KG_DEEP_EXTRACTION, input_messages=[prompt_msg]
         ) as span_generation:
             response = llm.invoke(prompt_msg)
             record_llm_response(span_generation, response)

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -136,12 +136,13 @@ def wrap_invoke(
         if _outer_generation_span_active():
             return invoke_fn(self, *args, **kwargs)
 
+        from onyx.tracing.flows import LLMFlow
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_response
 
         prompt = _extract_prompt(sig, self, args, kwargs)
         with llm_generation_span(
-            self, flow="llm_invoke_fallback", input_messages=prompt
+            self, flow=LLMFlow.UNTAGGED_INVOKE, input_messages=prompt
         ) as span:
             try:
                 response = invoke_fn(self, *args, **kwargs)
@@ -192,12 +193,13 @@ def wrap_stream(
             yield from stream_fn(self, *args, **kwargs)
             return
 
+        from onyx.tracing.flows import LLMFlow
         from onyx.tracing.llm_utils import llm_generation_span
         from onyx.tracing.llm_utils import record_llm_span_output
 
         prompt = _extract_prompt(sig, self, args, kwargs)
         with llm_generation_span(
-            self, flow="llm_stream_fallback", input_messages=prompt
+            self, flow=LLMFlow.UNTAGGED_STREAM, input_messages=prompt
         ) as span:
             accumulated_content: list[str] = []
             final_usage: Usage | None = None

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -899,7 +899,7 @@ class EmbeddingModel:
                         flow=embed_flow,
                         model=self.model_name or "",
                         provider=(
-                            str(self.provider_type)
+                            self.provider_type.value
                             if self.provider_type
                             else "model_server"
                         ),
@@ -1159,7 +1159,9 @@ class RerankingModel:
         with traced_llm_call(
             flow=LLMFlow.RERANK,
             model=self.model_name,
-            provider=str(self.provider_type) if self.provider_type else "model_server",
+            provider=(
+                self.provider_type.value if self.provider_type else "model_server"
+            ),
             extra_config={"num_passages": str(len(passages))},
         ):
             # Route between direct API calls and model server calls

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -44,6 +44,8 @@ from onyx.natural_language_processing.utils import get_tokenizer
 from onyx.natural_language_processing.utils import tokenizer_trim_content
 from onyx.server.metrics.embedding import observe_embedding_client
 from onyx.server.metrics.embedding import track_embedding_in_progress
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 from onyx.utils.logger import setup_logger
 from onyx.utils.search_nlp_models_utils import pass_aws_key
 from onyx.utils.text_processing import remove_invalid_unicode_chars
@@ -886,8 +888,28 @@ class EmbeddingModel:
             start_time = time.monotonic()
             response: EmbedResponse
             success = False
+            embed_flow = (
+                LLMFlow.EMBED_PASSAGE
+                if text_type == EmbedTextType.PASSAGE
+                else LLMFlow.EMBED_QUERY
+            )
             try:
-                with track_embedding_in_progress(self.provider_type, text_type):
+                with (
+                    traced_llm_call(
+                        flow=embed_flow,
+                        model=self.model_name or "",
+                        provider=(
+                            str(self.provider_type)
+                            if self.provider_type
+                            else "model_server"
+                        ),
+                        extra_config={
+                            "num_texts": str(num_texts),
+                            "num_chars": str(num_chars),
+                        },
+                    ),
+                    track_embedding_in_progress(self.provider_type, text_type),
+                ):
                     # Route between direct API calls and model server calls.
                     if self.provider_type is not None:
                         # For API providers, make direct API call.
@@ -1134,39 +1156,45 @@ class RerankingModel:
             raise ValueError(f"Unsupported reranking provider: {self.provider_type}")
 
     def predict(self, query: str, passages: list[str]) -> list[float]:
-        # Route between direct API calls and model server calls
-        if self.provider_type is not None:
-            # For API providers, make direct API call
-            loop = asyncio.new_event_loop()
-            try:
-                asyncio.set_event_loop(loop)
-                return loop.run_until_complete(
-                    self._make_direct_rerank_call(query, passages)
+        with traced_llm_call(
+            flow=LLMFlow.RERANK,
+            model=self.model_name,
+            provider=str(self.provider_type) if self.provider_type else "model_server",
+            extra_config={"num_passages": str(len(passages))},
+        ):
+            # Route between direct API calls and model server calls
+            if self.provider_type is not None:
+                # For API providers, make direct API call
+                loop = asyncio.new_event_loop()
+                try:
+                    asyncio.set_event_loop(loop)
+                    return loop.run_until_complete(
+                        self._make_direct_rerank_call(query, passages)
+                    )
+                finally:
+                    loop.close()
+            else:
+                # For local models, use model server
+                if self.rerank_server_endpoint is None:
+                    raise ValueError(
+                        "Rerank server endpoint is not configured for local models"
+                    )
+
+                rerank_request = RerankRequest(
+                    query=query,
+                    documents=passages,
+                    model_name=self.model_name,
+                    provider_type=self.provider_type,
+                    api_key=self.api_key,
+                    api_url=self.api_url,
                 )
-            finally:
-                loop.close()
-        else:
-            # For local models, use model server
-            if self.rerank_server_endpoint is None:
-                raise ValueError(
-                    "Rerank server endpoint is not configured for local models"
+
+                response = requests.post(
+                    self.rerank_server_endpoint, json=rerank_request.model_dump()
                 )
+                response.raise_for_status()
 
-            rerank_request = RerankRequest(
-                query=query,
-                documents=passages,
-                model_name=self.model_name,
-                provider_type=self.provider_type,
-                api_key=self.api_key,
-                api_url=self.api_url,
-            )
-
-            response = requests.post(
-                self.rerank_server_endpoint, json=rerank_request.model_dump()
-            )
-            response.raise_for_status()
-
-            return RerankResponse(**response.json()).scores
+                return RerankResponse(**response.json()).scores
 
 
 class QueryAnalysisModel:
@@ -1194,12 +1222,17 @@ class QueryAnalysisModel:
             semantic_percent_threshold=self.semantic_percent_threshold,
         )
 
-        response = requests.post(
-            self.intent_server_endpoint, json=intent_request.model_dump()
-        )
-        response.raise_for_status()
+        with traced_llm_call(
+            flow=LLMFlow.INTENT_CLASSIFICATION,
+            model="query-analysis",
+            provider="model_server",
+        ):
+            response = requests.post(
+                self.intent_server_endpoint, json=intent_request.model_dump()
+            )
+            response.raise_for_status()
 
-        response_model = IntentResponse(**response.json())
+            response_model = IntentResponse(**response.json())
 
         return response_model.is_keyword, response_model.keywords
 

--- a/backend/onyx/secondary_llm_flows/chat_session_naming.py
+++ b/backend/onyx/secondary_llm_flows/chat_session_naming.py
@@ -6,6 +6,7 @@ from onyx.llm.models import ReasoningEffort
 from onyx.llm.utils import llm_response_to_string
 from onyx.prompts.chat_prompts import CHAT_NAMING_REMINDER
 from onyx.prompts.chat_prompts import CHAT_NAMING_SYSTEM_PROMPT
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -37,7 +38,9 @@ def generate_chat_session_name(
 
     # Call LLM with Braintrust tracing
     with llm_generation_span(
-        llm=llm, flow="chat_session_naming", input_messages=llm_facing_history
+        llm=llm,
+        flow=LLMFlow.CHAT_SESSION_NAMING,
+        input_messages=llm_facing_history,
     ) as span_generation:
         response = llm.invoke(llm_facing_history, reasoning_effort=ReasoningEffort.OFF)
         record_llm_response(span_generation, response)

--- a/backend/onyx/secondary_llm_flows/document_filter.py
+++ b/backend/onyx/secondary_llm_flows/document_filter.py
@@ -11,6 +11,7 @@ from onyx.prompts.search_prompts import DOCUMENT_CONTEXT_SELECTION_PROMPT
 from onyx.prompts.search_prompts import DOCUMENT_SELECTION_PROMPT
 from onyx.prompts.search_prompts import TRY_TO_FILL_TO_MAX_INSTRUCTIONS
 from onyx.tools.tool_implementations.search.constants import MAX_CHUNKS_FOR_RELEVANCE
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -125,7 +126,9 @@ def classify_section_relevance(
     try:
         prompt_msg = UserMessage(content=prompt_text)
         with llm_generation_span(
-            llm=llm, flow="classify_section_relevance", input_messages=[prompt_msg]
+            llm=llm,
+            flow=LLMFlow.CLASSIFY_SECTION_RELEVANCE,
+            input_messages=[prompt_msg],
         ) as span_generation:
             response = llm.invoke(
                 prompt=prompt_msg,
@@ -274,7 +277,9 @@ def select_sections_for_expansion(
     # Call LLM for selection with Braintrust tracing
     try:
         with llm_generation_span(
-            llm=llm, flow="select_sections_for_expansion", input_messages=[prompt_text]
+            llm=llm,
+            flow=LLMFlow.SELECT_SECTIONS_FOR_EXPANSION,
+            input_messages=[prompt_text],
         ) as span_generation:
             response = llm.invoke(
                 prompt=[prompt_text], reasoning_effort=ReasoningEffort.OFF

--- a/backend/onyx/secondary_llm_flows/memory_update.py
+++ b/backend/onyx/secondary_llm_flows/memory_update.py
@@ -4,6 +4,7 @@ from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import UserMessage
 from onyx.prompts.basic_memory import FULL_MEMORY_UPDATE_PROMPT
 from onyx.tools.models import ChatMinimalTextMessage
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -118,7 +119,7 @@ def process_memory_update(
     try:
         prompt_msg = UserMessage(content=prompt)
         with llm_generation_span(
-            llm=llm, flow="memory_update", input_messages=[prompt_msg]
+            llm=llm, flow=LLMFlow.MEMORY_UPDATE, input_messages=[prompt_msg]
         ) as span_generation:
             response = llm.invoke(
                 prompt=prompt_msg, reasoning_effort=ReasoningEffort.OFF

--- a/backend/onyx/secondary_llm_flows/query_expansion.py
+++ b/backend/onyx/secondary_llm_flows/query_expansion.py
@@ -12,6 +12,7 @@ from onyx.prompts.search_prompts import REPHRASE_CONTEXT_PROMPT
 from onyx.prompts.search_prompts import SEMANTIC_QUERY_REPHRASE_SYSTEM_PROMPT
 from onyx.prompts.search_prompts import SEMANTIC_QUERY_REPHRASE_USER_PROMPT
 from onyx.tools.models import ChatMinimalTextMessage
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
 from onyx.utils.logger import setup_logger
@@ -132,7 +133,7 @@ def semantic_query_rephrase(
 
     # Call LLM and return result with Braintrust tracing
     with llm_generation_span(
-        llm=llm, flow="semantic_query_rephrase", input_messages=messages
+        llm=llm, flow=LLMFlow.SEMANTIC_QUERY_REPHRASE, input_messages=messages
     ) as span_generation:
         response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
         record_llm_response(span_generation, response)
@@ -212,7 +213,7 @@ def keyword_query_expansion(
 
     # Call LLM and return result with Braintrust tracing
     with llm_generation_span(
-        llm=llm, flow="keyword_query_expansion", input_messages=messages
+        llm=llm, flow=LLMFlow.KEYWORD_QUERY_EXPANSION, input_messages=messages
     ) as span_generation:
         response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
         record_llm_response(span_generation, response)

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -85,6 +85,7 @@ from onyx.server.features.build.session.prompts import (
     FOLLOWUP_SUGGESTIONS_SYSTEM_PROMPT,
 )
 from onyx.server.features.build.session.prompts import FOLLOWUP_SUGGESTIONS_USER_PROMPT
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.llm_utils import llm_generation_span
 from onyx.tracing.llm_utils import record_llm_response
@@ -858,7 +859,7 @@ class SessionManager:
             ):
                 with llm_generation_span(
                     llm=llm,
-                    flow="build_session_naming",
+                    flow=LLMFlow.BUILD_SESSION_NAMING,
                     input_messages=prompt_messages,
                 ) as span_generation:
                     response = llm.invoke(
@@ -914,7 +915,7 @@ class SessionManager:
             with ensure_trace("build_followup_suggestions"):
                 with llm_generation_span(
                     llm=llm,
-                    flow="build_followup_suggestions",
+                    flow=LLMFlow.BUILD_FOLLOWUP_SUGGESTIONS,
                     input_messages=prompt_messages,
                 ) as span_generation:
                     response = llm.invoke(

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -10,8 +10,6 @@ and makes it possible to enforce instrumentation coverage by searching for
 ``LLMFlow.UNTAGGED_*`` (the sentinel used by the auto-wrap fallback).
 """
 
-from __future__ import annotations
-
 from enum import StrEnum
 
 

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -1,0 +1,69 @@
+"""Registry of flow tags applied to LLM-related generation spans.
+
+Each value identifies the *operation* a span represents — e.g.
+``contextual_rag_chunk_context`` or ``image_generation``. The provider, model,
+and deployment are captured separately on the span's ``model_config``, so the
+flow tag should describe **what the call does**, not **who serves it**.
+
+A single source of truth here lets dashboards group/filter without typo drift,
+and makes it possible to enforce instrumentation coverage by searching for
+``LLMFlow.UNTAGGED_*`` (the sentinel used by the auto-wrap fallback).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class LLMFlow(StrEnum):
+    # Chat / agent
+    CHAT_RESPONSE = "chat_response"
+    CHAT_HISTORY_SUMMARIZATION = "chat_history_summarization"
+
+    # Secondary LLM flows
+    SEMANTIC_QUERY_REPHRASE = "semantic_query_rephrase"
+    KEYWORD_QUERY_EXPANSION = "keyword_query_expansion"
+    CLASSIFY_SECTION_RELEVANCE = "classify_section_relevance"
+    SELECT_SECTIONS_FOR_EXPANSION = "select_sections_for_expansion"
+    CHAT_SESSION_NAMING = "chat_session_naming"
+    MEMORY_UPDATE = "memory_update"
+
+    # Build session (assistants)
+    BUILD_SESSION_NAMING = "build_session_naming"
+    BUILD_FOLLOWUP_SUGGESTIONS = "build_followup_suggestions"
+
+    # Federated search helpers
+    SLACK_DATE_EXTRACTION = "slack_date_extraction"
+    SLACK_QUERY_EXPANSION = "slack_query_expansion"
+
+    # Indexing (docprocessing pod)
+    CONTEXTUAL_RAG_DOC_SUMMARY = "contextual_rag_doc_summary"
+    CONTEXTUAL_RAG_CHUNK_CONTEXT = "contextual_rag_chunk_context"
+    IMAGE_SUMMARIZATION = "image_summarization"
+
+    # Knowledge graph
+    KG_DOCUMENT_CLASSIFICATION = "kg_document_classification"
+    KG_DEEP_EXTRACTION = "kg_deep_extraction"
+
+    # Image generation
+    IMAGE_GENERATION = "image_generation"
+    IMAGE_EDIT = "image_edit"
+
+    # Voice
+    STT = "stt"
+    TTS = "tts"
+
+    # Embeddings / rerank / intent (cross-process to model_server)
+    EMBED_QUERY = "embed_query"
+    EMBED_PASSAGE = "embed_passage"
+    RERANK = "rerank"
+    INTENT_CLASSIFICATION = "intent_classification"
+
+    # Tools
+    CUSTOM_TOOL_LLM = "custom_tool_llm"
+
+    # Sentinels — emitted by the LLM auto-wrap fallback when a caller did not
+    # tag the call. Showing up in dashboards is a signal to add an explicit
+    # ``llm_generation_span`` at the call site with the right tag.
+    UNTAGGED_INVOKE = "untagged_invoke"
+    UNTAGGED_STREAM = "untagged_stream"

--- a/backend/onyx/tracing/flows.py
+++ b/backend/onyx/tracing/flows.py
@@ -59,9 +59,6 @@ class LLMFlow(StrEnum):
     RERANK = "rerank"
     INTENT_CLASSIFICATION = "intent_classification"
 
-    # Tools
-    CUSTOM_TOOL_LLM = "custom_tool_llm"
-
     # Sentinels — emitted by the LLM auto-wrap fallback when a caller did not
     # tag the call. Showing up in dashboards is a signal to add an explicit
     # ``llm_generation_span`` at the call site with the right tag.

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -21,7 +21,7 @@ def build_llm_model_config(llm: LLM, flow: LLMFlow | None = None) -> dict[str, s
         "base_url": str(llm.config.api_base or ""),
         "model_provider": llm.config.model_provider,
     }
-    if flow is not None:
+    if flow:
         model_config["flow"] = flow.value
     return model_config
 

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -10,31 +10,73 @@ from typing import cast
 from onyx.llm.interfaces import LLM
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.models import ToolCall
+from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
 
 
-def build_llm_model_config(llm: LLM, flow: str | None = None) -> dict[str, str]:
+def build_llm_model_config(llm: LLM, flow: LLMFlow | None = None) -> dict[str, str]:
     model_config: dict[str, str] = {
         "base_url": str(llm.config.api_base or ""),
         "model_provider": llm.config.model_provider,
     }
-    if flow:
-        model_config["flow"] = flow
+    if flow is not None:
+        model_config["flow"] = flow.value
     return model_config
 
 
 @contextmanager
 def llm_generation_span(
     llm: LLM,
-    flow: str | None,
+    flow: LLMFlow | None,
     input_messages: Sequence[Any] | Any | None = None,
     parent: Any | None = None,
 ) -> Iterator[Span[GenerationSpanData]]:
     with generation_span(
         model=llm.config.model_name,
         model_config=build_llm_model_config(llm, flow),
+        parent=parent,
+    ) as span:
+        if input_messages is not None:
+            if isinstance(input_messages, Sequence) and not isinstance(
+                input_messages, (str, bytes)
+            ):
+                normalized_messages = input_messages
+            else:
+                normalized_messages = [input_messages]
+            span.span_data.input = cast(
+                Sequence[Mapping[str, Any]], normalized_messages
+            )
+        yield span
+
+
+@contextmanager
+def traced_llm_call(
+    flow: LLMFlow,
+    model: str,
+    provider: str,
+    extra_config: Mapping[str, str] | None = None,
+    input_messages: Sequence[Any] | Any | None = None,
+    parent: Any | None = None,
+) -> Iterator[Span[GenerationSpanData]]:
+    """Open a generation span for call sites that don't go through ``LLM``.
+
+    Use this for image generation, voice (TTS/STT), embeddings/rerank crossing
+    the model_server boundary, and any direct provider-SDK call. For calls
+    that already go through an ``LLM`` subclass, use
+    :func:`llm_generation_span` instead — it pulls model and provider straight
+    off the ``LLM`` config.
+    """
+    model_config: dict[str, str] = {
+        "model_provider": provider,
+        "flow": flow.value,
+    }
+    if extra_config:
+        model_config.update(extra_config)
+    with generation_span(
+        model=model,
+        model_config=model_config,
         parent=parent,
     ) as span:
         if input_messages is not None:

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -68,12 +68,11 @@ def traced_llm_call(
     :func:`llm_generation_span` instead — it pulls model and provider straight
     off the ``LLM`` config.
     """
-    model_config: dict[str, str] = {
-        "model_provider": provider,
-        "flow": flow.value,
-    }
-    if extra_config:
-        model_config.update(extra_config)
+    # Build extra_config first, then overlay authoritative keys so callers
+    # cannot accidentally override ``flow`` / ``model_provider``.
+    model_config: dict[str, str] = dict(extra_config) if extra_config else {}
+    model_config["model_provider"] = provider
+    model_config["flow"] = flow.value
     with generation_span(
         model=model,
         model_config=model_config,

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -534,6 +534,7 @@ class AzureVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model or "azure-speech-tts",
             provider="azure",
+            input_messages=[{"role": "user", "content": text}],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, headers=headers, data=ssml) as response:

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -467,9 +467,6 @@ class AzureVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.STT,
             model=self.stt_model or "azure-speech-stt",
             provider="azure",
-            input_messages=[
-                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
-            ],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(
@@ -537,7 +534,6 @@ class AzureVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model or "azure-speech-tts",
             provider="azure",
-            input_messages=[{"text_chars": len(text), "voice": voice_name}],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, headers=headers, data=ssml) as response:

--- a/backend/onyx/voice/providers/azure.py
+++ b/backend/onyx/voice/providers/azure.py
@@ -34,6 +34,8 @@ from xml.sax.saxutils import quoteattr
 
 import aiohttp
 
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 from onyx.utils.logger import setup_logger
 from onyx.voice.interface import StreamingSynthesizerProtocol
 from onyx.voice.interface import StreamingTranscriberProtocol
@@ -461,14 +463,22 @@ class AzureVoiceProvider(VoiceProviderInterface):
             "Accept": "application/json",
         }
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url, params=params, headers=headers, data=payload
-            ) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    raise RuntimeError(f"Azure STT failed: {error_text}")
-                result = await response.json()
+        with traced_llm_call(
+            flow=LLMFlow.STT,
+            model=self.stt_model or "azure-speech-stt",
+            provider="azure",
+            input_messages=[
+                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
+            ],
+        ):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url, params=params, headers=headers, data=payload
+                ) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        raise RuntimeError(f"Azure STT failed: {error_text}")
+                    result = await response.json()
 
         if result.get("RecognitionStatus") != "Success":
             return ""
@@ -523,16 +533,22 @@ class AzureVoiceProvider(VoiceProviderInterface):
             "User-Agent": "Onyx",
         }
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, data=ssml) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    raise RuntimeError(f"Azure TTS failed: {error_text}")
+        with traced_llm_call(
+            flow=LLMFlow.TTS,
+            model=self.tts_model or "azure-speech-tts",
+            provider="azure",
+            input_messages=[{"text_chars": len(text), "voice": voice_name}],
+        ):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, data=ssml) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        raise RuntimeError(f"Azure TTS failed: {error_text}")
 
-                # Use 8192 byte chunks for smoother streaming
-                async for chunk in response.content.iter_chunked(8192):
-                    if chunk:
-                        yield chunk
+                    # Use 8192 byte chunks for smoother streaming
+                    async for chunk in response.content.iter_chunked(8192):
+                        if chunk:
+                            yield chunk
 
     async def validate_credentials(self) -> None:
         """Validate Azure credentials by listing available voices."""

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -20,6 +20,8 @@ from typing import Any
 
 import aiohttp
 
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 from onyx.voice.interface import StreamingSynthesizerProtocol
 from onyx.voice.interface import StreamingTranscriberProtocol
 from onyx.voice.interface import TranscriptResult
@@ -692,17 +694,29 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
             f"ElevenLabs transcribe: sending {len(audio_data)} bytes, format={audio_format}"
         )
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, data=form_data) as response:
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"ElevenLabs transcribe failed: {error_text}")
-                    raise RuntimeError(f"ElevenLabs transcription failed: {error_text}")
+        with traced_llm_call(
+            flow=LLMFlow.STT,
+            model=batch_model,
+            provider="elevenlabs",
+            input_messages=[
+                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
+            ],
+        ):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url, headers=headers, data=form_data
+                ) as response:
+                    if response.status != 200:
+                        error_text = await response.text()
+                        logger.error(f"ElevenLabs transcribe failed: {error_text}")
+                        raise RuntimeError(
+                            f"ElevenLabs transcription failed: {error_text}"
+                        )
 
-                result = await response.json()
-                text = result.get("text", "")
-                logger.info(f"ElevenLabs transcribe: got result: {text[:50]}...")
-                return text
+                    result = await response.json()
+                    text = result.get("text", "")
+                    logger.info(f"ElevenLabs transcribe: got result: {text[:50]}...")
+                    return text
 
     async def synthesize_stream(
         self, text: str, voice: str | None = None, speed: float = 1.0
@@ -749,27 +763,33 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
             },
         }
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json=payload) as response:
-                logger.info(
-                    f"ElevenLabs TTS: got response status={response.status}, content-type={response.headers.get('content-type')}"
-                )
-                if response.status != 200:
-                    error_text = await response.text()
-                    logger.error(f"ElevenLabs TTS failed: {error_text}")
-                    raise RuntimeError(f"ElevenLabs TTS failed: {error_text}")
+        with traced_llm_call(
+            flow=LLMFlow.TTS,
+            model=self.tts_model,
+            provider="elevenlabs",
+            input_messages=[{"text_chars": len(text), "voice": voice_id}],
+        ):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(url, headers=headers, json=payload) as response:
+                    logger.info(
+                        f"ElevenLabs TTS: got response status={response.status}, content-type={response.headers.get('content-type')}"
+                    )
+                    if response.status != 200:
+                        error_text = await response.text()
+                        logger.error(f"ElevenLabs TTS failed: {error_text}")
+                        raise RuntimeError(f"ElevenLabs TTS failed: {error_text}")
 
-                # Use 8192 byte chunks for smoother streaming
-                chunk_count = 0
-                total_bytes = 0
-                async for chunk in response.content.iter_chunked(8192):
-                    if chunk:
-                        chunk_count += 1
-                        total_bytes += len(chunk)
-                        yield chunk
-                logger.info(
-                    f"ElevenLabs TTS: streaming complete, {chunk_count} chunks, {total_bytes} total bytes"
-                )
+                    # Use 8192 byte chunks for smoother streaming
+                    chunk_count = 0
+                    total_bytes = 0
+                    async for chunk in response.content.iter_chunked(8192):
+                        if chunk:
+                            chunk_count += 1
+                            total_bytes += len(chunk)
+                            yield chunk
+                    logger.info(
+                        f"ElevenLabs TTS: streaming complete, {chunk_count} chunks, {total_bytes} total bytes"
+                    )
 
     async def validate_credentials(self) -> None:
         """Validate ElevenLabs API key.

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -698,9 +698,6 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.STT,
             model=batch_model,
             provider="elevenlabs",
-            input_messages=[
-                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
-            ],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(
@@ -767,7 +764,6 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model,
             provider="elevenlabs",
-            input_messages=[{"text_chars": len(text), "voice": voice_id}],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, headers=headers, json=payload) as response:

--- a/backend/onyx/voice/providers/elevenlabs.py
+++ b/backend/onyx/voice/providers/elevenlabs.py
@@ -764,6 +764,7 @@ class ElevenLabsVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model,
             provider="elevenlabs",
+            input_messages=[{"role": "user", "content": text}],
         ):
             async with aiohttp.ClientSession() as session:
                 async with session.post(url, headers=headers, json=payload) as response:

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -537,9 +537,6 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.STT,
             model=self.stt_model,
             provider="openai",
-            input_messages=[
-                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
-            ],
         ):
             response = await client.audio.transcriptions.create(
                 model=self.stt_model,
@@ -574,9 +571,6 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model,
             provider="openai",
-            input_messages=[
-                {"text_chars": len(text), "voice": voice or self.default_voice}
-            ],
         ):
             async with client.audio.speech.with_streaming_response.create(
                 model=self.tts_model,

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -571,6 +571,7 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
             flow=LLMFlow.TTS,
             model=self.tts_model,
             provider="openai",
+            input_messages=[{"role": "user", "content": text}],
         ):
             async with client.audio.speech.with_streaming_response.create(
                 model=self.tts_model,

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -21,6 +21,8 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.llm_utils import traced_llm_call
 from onyx.voice.interface import StreamingSynthesizerProtocol
 from onyx.voice.interface import StreamingTranscriberProtocol
 from onyx.voice.interface import TranscriptResult
@@ -531,10 +533,18 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         audio_file = io.BytesIO(audio_data)
         audio_file.name = f"audio.{audio_format}"
 
-        response = await client.audio.transcriptions.create(
+        with traced_llm_call(
+            flow=LLMFlow.STT,
             model=self.stt_model,
-            file=audio_file,
-        )
+            provider="openai",
+            input_messages=[
+                {"audio_format": audio_format, "audio_bytes": len(audio_data)}
+            ],
+        ):
+            response = await client.audio.transcriptions.create(
+                model=self.stt_model,
+                file=audio_file,
+            )
 
         return response.text
 
@@ -560,15 +570,23 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         # Use with_streaming_response for proper async streaming
         # Using 8192 byte chunks for better streaming performance
         # (larger chunks = fewer round-trips, more complete MP3 frames)
-        async with client.audio.speech.with_streaming_response.create(
+        with traced_llm_call(
+            flow=LLMFlow.TTS,
             model=self.tts_model,
-            voice=voice or self.default_voice,
-            input=text,
-            speed=speed,
-            response_format="mp3",
-        ) as response:
-            async for chunk in response.iter_bytes(chunk_size=8192):
-                yield chunk
+            provider="openai",
+            input_messages=[
+                {"text_chars": len(text), "voice": voice or self.default_voice}
+            ],
+        ):
+            async with client.audio.speech.with_streaming_response.create(
+                model=self.tts_model,
+                voice=voice or self.default_voice,
+                input=text,
+                speed=speed,
+                response_format="mp3",
+            ) as response:
+                async for chunk in response.iter_bytes(chunk_size=8192):
+                    yield chunk
 
     async def validate_credentials(self) -> None:
         """Validate OpenAI API key by listing models."""

--- a/backend/tests/unit/onyx/tracing/test_flows_registry.py
+++ b/backend/tests/unit/onyx/tracing/test_flows_registry.py
@@ -1,0 +1,51 @@
+"""Unit tests for ``onyx.tracing.flows`` and ``traced_llm_call``."""
+
+from onyx.tracing.flows import LLMFlow
+from onyx.tracing.framework.create import trace
+from onyx.tracing.llm_utils import traced_llm_call
+
+
+def test_llmflow_values_are_lower_snake_case() -> None:
+    for member in LLMFlow:
+        assert member.value == member.value.lower()
+        assert " " not in member.value
+        assert "-" not in member.value
+
+
+def test_llmflow_values_are_unique() -> None:
+    values = [m.value for m in LLMFlow]
+    assert len(values) == len(set(values))
+
+
+def test_untagged_sentinels_present() -> None:
+    """Sentinels are how the LLM auto-wrap fallback identifies untagged sites."""
+    assert LLMFlow.UNTAGGED_INVOKE.value == "untagged_invoke"
+    assert LLMFlow.UNTAGGED_STREAM.value == "untagged_stream"
+
+
+def test_traced_llm_call_records_flow_and_provider_on_span() -> None:
+    with trace("test_traced_llm_call"):
+        with traced_llm_call(
+            flow=LLMFlow.IMAGE_GENERATION,
+            model="gpt-image-1",
+            provider="openai",
+            extra_config={"size": "1024x1024"},
+        ) as span:
+            assert span.span_data.model == "gpt-image-1"
+            assert span.span_data.model_config is not None
+            assert span.span_data.model_config["flow"] == "image_generation"
+            assert span.span_data.model_config["model_provider"] == "openai"
+            assert span.span_data.model_config["size"] == "1024x1024"
+
+
+def test_traced_llm_call_records_input_messages() -> None:
+    with trace("test_traced_llm_input_messages"):
+        with traced_llm_call(
+            flow=LLMFlow.STT,
+            model="whisper-1",
+            provider="openai",
+            input_messages=[{"audio_format": "webm", "audio_bytes": 1234}],
+        ) as span:
+            assert span.span_data.input == [
+                {"audio_format": "webm", "audio_bytes": 1234}
+            ]


### PR DESCRIPTION
## Description

Adds `onyx.tracing.flows.LLMFlow` — a single `StrEnum` registry of every operation that opens a generation span — and a `traced_llm_call` helper for sites that don't go through the `LLM` abstraction. All existing magic-string flows now use enum values, and every previously-untraced LLM/AI call has an explicit span.

New coverage:
- Indexing contextual-RAG (doc summary + chunk context)
- Image generation/edit across OpenAI, Azure, and Vertex providers
- Voice STT/TTS across OpenAI, Azure, and ElevenLabs providers
- Embedding (query + passage), reranking, and intent classification at the model_server boundary

The auto-wrap fallback in `tracing_wrap.py` now emits `LLMFlow.UNTAGGED_INVOKE` / `UNTAGGED_STREAM`, so any future untagged site is discoverable in dashboards instead of hiding under a generic label.

Provider tag is read from `EmbeddingProvider.value` / `RerankerProvider.value` (those enums are `(str, Enum)` not `StrEnum`, so `str(member)` would have rendered as `"EmbeddingProvider.OPENAI"`).

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check