### PR TITLE
fix(opensearch): For MT cloud only verify each index once per process

### DIFF
--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -84,6 +84,15 @@ VERIFY_INDEX_LOCK_TTL_S = 60
 VERIFY_INDEX_LOCK_BLOCKING_TIMEOUT_S = 60
 
 
+# Per-process cache of indices we've already verified/created/applied the
+# mapping for. Used for the multi-tenant cloud codepath, which attempts to
+# verify or create an index on DocumentIndex init since that deployment mode
+# does not run setup on application start. This attempt can be expensive, and it
+# only needs to happen at most once per process lifetime, since any changes to
+# an index should always be correlated with a redeploy.
+_verified_index_names_for_current_process: set[str] = set()
+
+
 class ChunkCountNotFoundError(ValueError):
     """Raised when a document has no chunk count."""
 
@@ -600,10 +609,15 @@ class OpenSearchDocumentIndex(DocumentIndex):
         self._tenant_state: TenantState = tenant_state
         self._client = OpenSearchIndexClient(index_name=self._index_name)
 
-        if self._tenant_state.multitenant and VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT:
+        if (
+            self._tenant_state.multitenant
+            and VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT
+            and index_name not in _verified_index_names_for_current_process
+        ):
             self.verify_and_create_index_if_necessary(
                 embedding_dim=embedding_dim, embedding_precision=embedding_precision
             )
+            _verified_index_names_for_current_process.add(index_name)
 
     def verify_and_create_index_if_necessary(
         self,

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from collections.abc import Generator
 from collections.abc import Iterator
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -224,3 +225,39 @@ class TestDocumentIndexNew:
             assert len(results) == 1
             assert results[0].document_id == doc_id
             assert results[0].already_existed is False
+
+    def test_mt_cloud_opensearch_index_verification_only_happens_once(
+        self,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """
+        Tests that for multiple instantiations of OpenSearchDocumentIndex,
+        verify_and_create_index_if_necessary is only called once given the same
+        index name on multi-tenant cloud.
+        """
+        # Precondition.
+        with patch.object(
+            OpenSearchDocumentIndex, "verify_and_create_index_if_necessary"
+        ) as mock_verify_and_create_index_if_necessary:
+            assert mock_verify_and_create_index_if_necessary.call_count == 0
+
+            test_index_name = "test_index_name_for_mt_cloud_index_verification"
+            tenant_state = TenantState(tenant_id=TEST_TENANT_ID, multitenant=True)
+            _ = OpenSearchDocumentIndex(
+                tenant_state=tenant_state,
+                index_name=test_index_name,
+                embedding_dim=EMBEDDING_DIM,
+                embedding_precision=EmbeddingPrecision.FLOAT,
+            )
+            assert mock_verify_and_create_index_if_necessary.call_count == 1
+
+            # Under test.
+            _ = OpenSearchDocumentIndex(
+                tenant_state=tenant_state,
+                index_name=test_index_name,
+                embedding_dim=EMBEDDING_DIM,
+                embedding_precision=EmbeddingPrecision.FLOAT,
+            )
+
+            # Postcondition.
+            assert mock_verify_and_create_index_if_necessary.call_count == 1


### PR DESCRIPTION
## Description
Paraphrased from @evan-onyx: We were seeing some contention for the lock which was being acquired on every DocumentIndex init, so to resolve that and save round trips to the index we can cache whether it looked fine when the process started. This is only relevant to MT cloud, on all other deployment types we only verify existing indices once on product start.

We do not need to CP this because it is only relevant to MT cloud.

## How Has This Been Tested?
Added a unit test.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
