### PR TITLE
chore(ci): enable license enforcement in test infra via dev license

### DIFF
--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -60,7 +60,6 @@ runs:
         cat <<EOF2 > deployment/docker_compose/.env
         COMPOSE_PROFILES=s3-filestore
         ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
-        LICENSE_ENFORCEMENT_ENABLED=false
         AUTH_TYPE=basic
         POSTGRES_POOL_PRE_PING=true
         POSTGRES_USE_NULL_POOL=true
@@ -72,6 +71,11 @@ runs:
         ONYX_BACKEND_IMAGE=${ECR_CACHE}:nightly-llm-it-backend-${RUN_ID}
         ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:nightly-llm-it-model-server-${RUN_ID}
         EOF2
+        # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
+        # license enforcement so the stack still boots.
+        if [ -z "$ONYX_DEV_LICENSE" ]; then
+          echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
+        fi
 
     - name: Start Docker containers
       shell: bash
@@ -84,6 +88,12 @@ runs:
           minio \
           api_server \
           inference_model_server
+
+    - name: Seed dev license
+      shell: bash
+      run: |
+        docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+          python -m scripts.seed_dev_license
 
     - name: Run nightly provider integration test
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # ratchet:nick-fields/retry@v3

--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -71,11 +71,6 @@ runs:
         ONYX_BACKEND_IMAGE=${ECR_CACHE}:nightly-llm-it-backend-${RUN_ID}
         ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:nightly-llm-it-model-server-${RUN_ID}
         EOF2
-        # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
-        # license enforcement so the stack still boots.
-        if [ -z "$ONYX_DEV_LICENSE" ]; then
-          echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
-        fi
 
     - name: Start Docker containers
       shell: bash

--- a/.github/actions/setup-test-license/action.yml
+++ b/.github/actions/setup-test-license/action.yml
@@ -1,0 +1,21 @@
+name: "Setup Test License"
+description: "Pulls the dev license from AWS Secrets Manager and exposes it as the ONYX_DEV_LICENSE env var for subsequent steps."
+inputs:
+  aws-oidc-role-arn:
+    description: "AWS OIDC role ARN used to authenticate to AWS Secrets Manager"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # ratchet:aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-oidc-role-arn }}
+        aws-region: us-east-2
+
+    - name: Get dev license from AWS Secrets Manager
+      uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # ratchet:aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        parse-json-secrets: false
+        secret-ids: |
+          ONYX_DEV_LICENSE, test/onyx-dev-license

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -40,6 +40,10 @@ jobs:
 
       - name: Generate OpenAPI schema and Python client
         shell: bash
+        # OpenAPI client codegen does not handle some EE-only schema shapes;
+        # disable enforcement so the MIT route set is exported.
+        env:
+          LICENSE_ENFORCEMENT_ENABLED: "false"
         run: |
           ods openapi all
 

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -40,9 +40,6 @@ jobs:
 
       - name: Generate OpenAPI schema and Python client
         shell: bash
-        # TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-        env:
-          LICENSE_ENFORCEMENT_ENABLED: "false"
         run: |
           ods openapi all
 

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -659,6 +659,7 @@ jobs:
         run: |
           cd deployment/docker_compose
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
+          LICENSE_ENFORCEMENT_ENABLED=false \
           MULTI_TENANT=true \
           AUTH_TYPE=cloud \
           REQUIRE_EMAIL_VERIFICATION=false \

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -630,9 +630,6 @@ jobs:
   multitenant-tests:
     needs:
       [build-backend-image, build-model-server-image, build-integration-image]
-    permissions:
-      id-token: write # Required for OIDC-based AWS credential exchange
-      contents: read
     runs-on:
       [
         runs-on,
@@ -648,11 +645,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-
-      - name: Setup test license
-        uses: ./.github/actions/setup-test-license
-        with:
-          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
@@ -713,11 +705,6 @@ jobs:
             sleep 5
           done
           echo "Finished waiting for service."
-
-      - name: Seed dev license
-        run: |
-          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
-            python -m scripts.seed_dev_license
 
       - name: Run Multi-Tenant Integration Tests
         env:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -287,8 +287,6 @@ jobs:
       - extras=ecr-cache
     timeout-minutes: 45
 
-    environment: ci-protected
-
     strategy:
       fail-fast: false
       matrix:
@@ -504,7 +502,6 @@ jobs:
         "extras=ecr-cache",
       ]
     timeout-minutes: 45
-    environment: ci-protected
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
@@ -644,7 +641,6 @@ jobs:
         "extras=ecr-cache",
       ]
     timeout-minutes: 45
-    environment: ci-protected
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -14,7 +14,6 @@ on:
       - "v*.*.*"
 
 permissions:
-  id-token: write # Required for OIDC-based AWS credential exchange
   contents: read
 
 env:
@@ -278,6 +277,9 @@ jobs:
         build-model-server-image,
         build-integration-image,
       ]
+    permissions:
+      id-token: write # Required for OIDC-based AWS credential exchange
+      contents: read
     runs-on:
       - runs-on
       - runner=4cpu-linux-arm64
@@ -344,11 +346,6 @@ jobs:
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
           CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS=0.001
           EOF
-            # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
-            # license enforcement so the stack still boots.
-            if [ -z "$ONYX_DEV_LICENSE" ]; then
-              echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
-            fi
           fi
 
       - name: Start Docker containers
@@ -496,6 +493,9 @@ jobs:
 
   onyx-lite-tests:
     needs: [build-backend-image, build-integration-image]
+    permissions:
+      id-token: write # Required for OIDC-based AWS credential exchange
+      contents: read
     runs-on:
       [
         runs-on,
@@ -539,11 +539,6 @@ jobs:
           ONYX_BACKEND_IMAGE=${ECR_CACHE}:integration-test-backend-test-${RUN_ID}
           INTEGRATION_TESTS_MODE=true
           EOF
-          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
-          # license enforcement so the stack still boots.
-          if [ -z "$ONYX_DEV_LICENSE" ]; then
-            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
-          fi
 
       # Start only the services needed for Onyx Lite (Postgres + API server)
       - name: Start Docker containers (onyx-lite)
@@ -638,6 +633,9 @@ jobs:
   multitenant-tests:
     needs:
       [build-backend-image, build-model-server-image, build-integration-image]
+    permissions:
+      id-token: write # Required for OIDC-based AWS credential exchange
+      contents: read
     runs-on:
       [
         runs-on,
@@ -646,6 +644,7 @@ jobs:
         "extras=ecr-cache",
       ]
     timeout-minutes: 45
+    environment: ci-protected
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
@@ -653,6 +652,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Setup test license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
@@ -713,6 +717,11 @@ jobs:
             sleep 5
           done
           echo "Finished waiting for service."
+
+      - name: Seed dev license
+        run: |
+          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Run Multi-Tenant Integration Tests
         env:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -14,6 +14,7 @@ on:
       - "v*.*.*"
 
 permissions:
+  id-token: write # Required for OIDC-based AWS credential exchange
   contents: read
 
 env:
@@ -284,6 +285,8 @@ jobs:
       - extras=ecr-cache
     timeout-minutes: 45
 
+    environment: ci-protected
+
     strategy:
       fail-fast: false
       matrix:
@@ -296,6 +299,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Setup test license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       # needed for pulling Vespa, Redis, Postgres, and Minio images
       # otherwise, we hit the "Unauthenticated users" limit
@@ -334,10 +342,13 @@ jobs:
           if [ "$EDITION" = "ee" ]; then
             cat <<EOF >> deployment/docker_compose/.env
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
-          # TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-          LICENSE_ENFORCEMENT_ENABLED=false
           CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS=0.001
           EOF
+            # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
+            # license enforcement so the stack still boots.
+            if [ -z "$ONYX_DEV_LICENSE" ]; then
+              echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
+            fi
           fi
 
       - name: Start Docker containers
@@ -394,6 +405,12 @@ jobs:
 
           wait_for_service "http://localhost:8080/health" "API server"
           echo "Finished waiting for services."
+
+      - name: Seed dev license
+        if: matrix.edition == 'ee'
+        run: |
+          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Start Mock Services
         run: |
@@ -487,6 +504,7 @@ jobs:
         "extras=ecr-cache",
       ]
     timeout-minutes: 45
+    environment: ci-protected
 
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
@@ -494,6 +512,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Setup test license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
@@ -508,7 +531,6 @@ jobs:
         run: |
           cat <<EOF > deployment/docker_compose/.env
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
-          LICENSE_ENFORCEMENT_ENABLED=false
           AUTH_TYPE=basic
           POSTGRES_POOL_PRE_PING=true
           POSTGRES_USE_NULL_POOL=true
@@ -517,6 +539,11 @@ jobs:
           ONYX_BACKEND_IMAGE=${ECR_CACHE}:integration-test-backend-test-${RUN_ID}
           INTEGRATION_TESTS_MODE=true
           EOF
+          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
+          # license enforcement so the stack still boots.
+          if [ -z "$ONYX_DEV_LICENSE" ]; then
+            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
+          fi
 
       # Start only the services needed for Onyx Lite (Postgres + API server)
       - name: Start Docker containers (onyx-lite)
@@ -551,6 +578,11 @@ jobs:
             fi
             sleep 5
           done
+
+      - name: Seed dev license
+        run: |
+          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Run Onyx Lite Integration Tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # ratchet:nick-fields/retry@v3
@@ -635,7 +667,6 @@ jobs:
         run: |
           cd deployment/docker_compose
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
-          LICENSE_ENFORCEMENT_ENABLED=false \
           MULTI_TENANT=true \
           AUTH_TYPE=cloud \
           REQUIRE_EMAIL_VERIFICATION=false \

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -401,12 +401,6 @@ jobs:
           wait_for_service "http://localhost:8080/health" "API server"
           echo "Finished waiting for services."
 
-      - name: Seed dev license
-        if: matrix.edition == 'ee'
-        run: |
-          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
-            python -m scripts.seed_dev_license
-
       - name: Start Mock Services
         run: |
           cd backend/tests/integration/mock_services
@@ -464,6 +458,7 @@ jobs:
               -e MOCK_CONNECTOR_SERVER_HOST=mock_connector_server \
               -e MOCK_CONNECTOR_SERVER_PORT=8001 \
               -e ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=${{ matrix.edition == 'ee' && 'true' || 'false' }} \
+              -e ONYX_DEV_LICENSE \
               ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-${{ github.run_id }} \
               /app/tests/integration/${{ matrix.test-dir.path }}
 
@@ -571,11 +566,6 @@ jobs:
             sleep 5
           done
 
-      - name: Seed dev license
-        run: |
-          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
-            python -m scripts.seed_dev_license
-
       - name: Run Onyx Lite Integration Tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # ratchet:nick-fields/retry@v3
         with:
@@ -597,6 +587,7 @@ jobs:
               -e API_SERVER_HOST=api_server \
               -e OPENAI_API_KEY=${OPENAI_API_KEY} \
               -e TEST_WEB_HOSTNAME=test-runner \
+              -e ONYX_DEV_LICENSE \
               ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-${{ github.run_id }} \
               /app/tests/integration/tests/no_vectordb
 

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -682,26 +682,8 @@ jobs:
       - name: Start Docker containers (lite)
         run: |
           cd deployment/docker_compose
-          docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml up -d
+          docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml up -d --wait
         id: start_docker
-
-      - name: Wait for API server to be ready
-        run: |
-          start_time=$(date +%s)
-          timeout=300
-          while true; do
-            elapsed=$(( $(date +%s) - start_time ))
-            if [ $elapsed -ge $timeout ]; then
-              echo "Timeout reached. API server did not become ready in $timeout seconds."
-              exit 1
-            fi
-            response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "curl_error")
-            if [ "$response" = "200" ]; then
-              echo "API server is ready."
-              break
-            fi
-            sleep 5
-          done
 
       - name: Seed dev license
         run: |

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -258,7 +258,6 @@ jobs:
       - "extras=ecr-cache"
       - volume=50gb
     timeout-minutes: 45
-    environment: ci-protected
     strategy:
       fail-fast: false
       matrix:
@@ -616,7 +615,6 @@ jobs:
       - "run-id=${{ github.run_id }}-playwright-tests-lite"
       - "extras=ecr-cache"
     timeout-minutes: 30
-    environment: ci-protected
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -17,7 +17,6 @@ on:
       - "release/**"
 
 permissions:
-  id-token: write # Required for OIDC-based AWS credential exchange
   contents: read
 
 env:
@@ -322,11 +321,6 @@ jobs:
           ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:playwright-test-model-server-${RUN_ID}
           ONYX_WEB_SERVER_IMAGE=${ECR_CACHE}:playwright-test-web-${RUN_ID}
           EOF
-          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
-          # license enforcement so the stack still boots.
-          if [ -z "$ONYX_DEV_LICENSE" ]; then
-            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
-          fi
 
       # needed for pulling Vespa, Redis, Postgres, and Minio images
       # otherwise, we hit the "Unauthenticated users" limit
@@ -613,6 +607,9 @@ jobs:
   playwright-tests-lite:
     needs: [build-web-image, build-backend-image]
     name: Playwright Tests (lite)
+    permissions:
+      id-token: write # Required for OIDC-based AWS credential exchange
+      contents: read
     runs-on:
       - runs-on
       - runner=4cpu-linux-arm64
@@ -675,11 +672,6 @@ jobs:
           ONYX_BACKEND_IMAGE=${ECR_CACHE}:playwright-test-backend-${RUN_ID}
           ONYX_WEB_SERVER_IMAGE=${ECR_CACHE}:playwright-test-web-${RUN_ID}
           EOF
-          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
-          # license enforcement so the stack still boots.
-          if [ -z "$ONYX_DEV_LICENSE" ]; then
-            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
-          fi
 
       # needed for pulling external images otherwise, we hit the "Unauthenticated users" limit
       # https://docs.docker.com/docker-hub/usage/

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -17,6 +17,7 @@ on:
       - "release/**"
 
 permissions:
+  id-token: write # Required for OIDC-based AWS credential exchange
   contents: read
 
 env:
@@ -258,6 +259,7 @@ jobs:
       - "extras=ecr-cache"
       - volume=50gb
     timeout-minutes: 45
+    environment: ci-protected
     strategy:
       fail-fast: false
       matrix:
@@ -295,6 +297,11 @@ jobs:
         working-directory: ./web
         run: npx playwright install --with-deps
 
+      - name: Setup test license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Create .env file for Docker Compose
         env:
           OPENAI_API_KEY_VALUE: ${{ env.OPENAI_API_KEY }}
@@ -305,8 +312,6 @@ jobs:
           cat <<EOF > deployment/docker_compose/.env
           COMPOSE_PROFILES=s3-filestore
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
-          # TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-          LICENSE_ENFORCEMENT_ENABLED=false
           AUTH_TYPE=basic
           INTEGRATION_TESTS_MODE=true
           GEN_AI_API_KEY=${OPENAI_API_KEY_VALUE}
@@ -317,6 +322,11 @@ jobs:
           ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:playwright-test-model-server-${RUN_ID}
           ONYX_WEB_SERVER_IMAGE=${ECR_CACHE}:playwright-test-web-${RUN_ID}
           EOF
+          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
+          # license enforcement so the stack still boots.
+          if [ -z "$ONYX_DEV_LICENSE" ]; then
+            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
+          fi
 
       # needed for pulling Vespa, Redis, Postgres, and Minio images
       # otherwise, we hit the "Unauthenticated users" limit
@@ -437,6 +447,11 @@ jobs:
             echo "Web server not ready yet. Retrying in 3 seconds..."
             sleep 3
           done
+
+      - name: Seed dev license
+        run: |
+          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Run Playwright tests
         working-directory: ./web
@@ -604,6 +619,7 @@ jobs:
       - "run-id=${{ github.run_id }}-playwright-tests-lite"
       - "extras=ecr-cache"
     timeout-minutes: 30
+    environment: ci-protected
     steps:
       - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2
 
@@ -637,6 +653,11 @@ jobs:
         working-directory: ./web
         run: npx playwright install --with-deps
 
+      - name: Setup test license
+        uses: ./.github/actions/setup-test-license
+        with:
+          aws-oidc-role-arn: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+
       - name: Create .env file for Docker Compose
         env:
           OPENAI_API_KEY_VALUE: ${{ env.OPENAI_API_KEY }}
@@ -645,7 +666,6 @@ jobs:
         run: |
           cat <<EOF > deployment/docker_compose/.env
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
-          LICENSE_ENFORCEMENT_ENABLED=false
           AUTH_TYPE=basic
           INTEGRATION_TESTS_MODE=true
           GEN_AI_API_KEY=${OPENAI_API_KEY_VALUE}
@@ -655,6 +675,11 @@ jobs:
           ONYX_BACKEND_IMAGE=${ECR_CACHE}:playwright-test-backend-${RUN_ID}
           ONYX_WEB_SERVER_IMAGE=${ECR_CACHE}:playwright-test-web-${RUN_ID}
           EOF
+          # Fork PRs do not have access to ONYX_DEV_LICENSE; fall back to disabling
+          # license enforcement so the stack still boots.
+          if [ -z "$ONYX_DEV_LICENSE" ]; then
+            echo "LICENSE_ENFORCEMENT_ENABLED=false" >> deployment/docker_compose/.env
+          fi
 
       # needed for pulling external images otherwise, we hit the "Unauthenticated users" limit
       # https://docs.docker.com/docker-hub/usage/
@@ -669,6 +694,29 @@ jobs:
           cd deployment/docker_compose
           docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml up -d
         id: start_docker
+
+      - name: Wait for API server to be ready
+        run: |
+          start_time=$(date +%s)
+          timeout=300
+          while true; do
+            elapsed=$(( $(date +%s) - start_time ))
+            if [ $elapsed -ge $timeout ]; then
+              echo "Timeout reached. API server did not become ready in $timeout seconds."
+              exit 1
+            fi
+            response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health || echo "curl_error")
+            if [ "$response" = "200" ]; then
+              echo "API server is ready."
+              break
+            fi
+            sleep 5
+          done
+
+      - name: Seed dev license
+        run: |
+          docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+            python -m scripts.seed_dev_license
 
       - name: Run Playwright tests (lite)
         working-directory: ./web

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -27,6 +27,9 @@ jobs:
       PYTHONPATH: ./backend
       REDIS_CLOUD_PYTEST_PASSWORD: ${{ secrets.REDIS_CLOUD_PYTEST_PASSWORD }}
       DISABLE_TELEMETRY: "true"
+      # Unit tests run without a live backend; EE code paths that depend on
+      # Redis/Vespa/etc are not available, so disable enforcement here.
+      LICENSE_ENFORCEMENT_ENABLED: "false"
 
     steps:
     - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -27,8 +27,6 @@ jobs:
       PYTHONPATH: ./backend
       REDIS_CLOUD_PYTEST_PASSWORD: ${{ secrets.REDIS_CLOUD_PYTEST_PASSWORD }}
       DISABLE_TELEMETRY: "true"
-      # TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-      LICENSE_ENFORCEMENT_ENABLED: "false"
 
     steps:
     - uses: runs-on/action@cd2b598b0515d39d78c38a02d529db87d2196d1e # ratchet:runs-on/action@v2

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -288,6 +288,7 @@ jobs:
             AZURE_API_KEY, test/azure-api-key
             OLLAMA_API_KEY, test/ollama-api-key
             OPENROUTER_API_KEY, test/openrouter-api-key
+            ONYX_DEV_LICENSE, test/onyx-dev-license
 
       - name: Run nightly provider chat test
         uses: ./.github/actions/run-nightly-provider-chat-test

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -147,6 +147,7 @@ COPY --chown=onyx:onyx ./scripts/supervisord_entrypoint.sh /app/scripts/supervis
 COPY --chown=onyx:onyx ./scripts/setup_craft_templates.sh /app/scripts/setup_craft_templates.sh
 COPY --chown=onyx:onyx ./scripts/reencrypt_secrets.py /app/scripts/reencrypt_secrets.py
 COPY --chown=onyx:onyx ./scripts/rotate_llm_provider_keys.py /app/scripts/rotate_llm_provider_keys.py
+COPY --chown=onyx:onyx ./scripts/seed_dev_license.py /app/scripts/seed_dev_license.py
 RUN chmod +x /app/scripts/supervisord_entrypoint.sh /app/scripts/setup_craft_templates.sh
 
 # Run Craft template setup at build time when ENABLE_CRAFT=true

--- a/backend/scripts/seed_dev_license.py
+++ b/backend/scripts/seed_dev_license.py
@@ -13,14 +13,6 @@ signature before persisting.
 import os
 import sys
 
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(parent_dir)
-
-from ee.onyx.db.license import upsert_license  # noqa: E402
-from ee.onyx.utils.license import verify_license_signature  # noqa: E402
-from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
-from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
-
 _PEM_BEGIN = "-----BEGIN ONYX LICENSE-----"
 _PEM_END = "-----END ONYX LICENSE-----"
 
@@ -39,10 +31,18 @@ def main() -> None:
         print("ONYX_DEV_LICENSE empty: skipping license seed", file=sys.stderr)
         return
 
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path.append(parent_dir)
+
+    from ee.onyx.db.license import upsert_license
+    from ee.onyx.utils.license import verify_license_signature
+    from onyx.db.engine.sql_engine import get_session_with_current_tenant
+    from onyx.db.engine.sql_engine import SqlEngine
+
     license_data = _strip_pem_delimiters(blob).strip()
 
     try:
-        _payload = verify_license_signature(license_data)
+        verify_license_signature(license_data)
     except ValueError as e:
         print(f"License signature verification failed: {e}", file=sys.stderr)
         sys.exit(1)

--- a/backend/scripts/seed_dev_license.py
+++ b/backend/scripts/seed_dev_license.py
@@ -1,16 +1,25 @@
 """Seed a dev license blob into the DB for CI test environments.
 
-Usage:
-    ONYX_DEV_LICENSE="$(cat license.lic)" python -m scripts.seed_dev_license
+Usage (docker):
+    docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
+        python -m scripts.seed_dev_license
 
 Reads ONYX_DEV_LICENSE from the environment. Empty values no-op so the
 script can be invoked unconditionally (e.g. local dev runs without a
-license to hand). Accepts both PEM-armored and raw base64 license blobs.
-Verifies the RSA-4096 signature before persisting.
+license to hand). Accepts both PEM-armored and raw base64 license blobs;
+verifies the RSA-4096 signature before persisting.
 """
 
 import os
 import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+from ee.onyx.db.license import upsert_license  # noqa: E402
+from ee.onyx.utils.license import verify_license_signature  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
+from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
 
 _PEM_BEGIN = "-----BEGIN ONYX LICENSE-----"
 _PEM_END = "-----END ONYX LICENSE-----"
@@ -19,38 +28,24 @@ _PEM_END = "-----END ONYX LICENSE-----"
 def _strip_pem_delimiters(content: str) -> str:
     content = content.strip()
     if content.startswith(_PEM_BEGIN) and content.endswith(_PEM_END):
-        lines = content.split("\n")
-        return "\n".join(lines[1:-1]).strip()
+        return "\n".join(content.split("\n")[1:-1]).strip()
     return content
 
 
 def main() -> None:
     blob = os.environ.get("ONYX_DEV_LICENSE", "").strip()
     if not blob:
-        print("ONYX_DEV_LICENSE empty: skipping license seed", file=sys.stderr)
+        print("ONYX_DEV_LICENSE empty: skipping license seed")
         return
 
-    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    sys.path.append(parent_dir)
-
-    from ee.onyx.db.license import upsert_license
-    from ee.onyx.utils.license import verify_license_signature
-    from onyx.db.engine.sql_engine import get_session_with_current_tenant
-    from onyx.db.engine.sql_engine import SqlEngine
-
-    license_data = _strip_pem_delimiters(blob).strip()
-
-    try:
-        verify_license_signature(license_data)
-    except ValueError as e:
-        print(f"License signature verification failed: {e}", file=sys.stderr)
-        sys.exit(1)
+    license_data = _strip_pem_delimiters(blob)
+    verify_license_signature(license_data)
 
     SqlEngine.init_engine(pool_size=1, max_overflow=0)
-    with get_session_with_current_tenant() as db:
-        upsert_license(db, license_data)
+    with get_session_with_current_tenant() as db_session:
+        upsert_license(db_session, license_data)
 
-    print("Dev license seeded", file=sys.stderr)
+    print("Dev license seeded")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/seed_dev_license.py
+++ b/backend/scripts/seed_dev_license.py
@@ -3,11 +3,10 @@
 Usage:
     ONYX_DEV_LICENSE="$(cat license.lic)" python -m scripts.seed_dev_license
 
-Reads ONYX_DEV_LICENSE from the environment. If empty, no-ops so fork PRs
-that don't have access to the secret can still boot the stack.
-
-Accepts both PEM-armored and raw base64 license blobs. Verifies the RSA-4096
-signature before persisting.
+Reads ONYX_DEV_LICENSE from the environment. Empty values no-op so the
+script can be invoked unconditionally (e.g. local dev runs without a
+license to hand). Accepts both PEM-armored and raw base64 license blobs.
+Verifies the RSA-4096 signature before persisting.
 """
 
 import os

--- a/backend/scripts/seed_dev_license.py
+++ b/backend/scripts/seed_dev_license.py
@@ -1,0 +1,58 @@
+"""Seed a dev license blob into the DB for CI test environments.
+
+Usage:
+    ONYX_DEV_LICENSE="$(cat license.lic)" python -m scripts.seed_dev_license
+
+Reads ONYX_DEV_LICENSE from the environment. If empty, no-ops so fork PRs
+that don't have access to the secret can still boot the stack.
+
+Accepts both PEM-armored and raw base64 license blobs. Verifies the RSA-4096
+signature before persisting.
+"""
+
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+from ee.onyx.db.license import upsert_license  # noqa: E402
+from ee.onyx.utils.license import verify_license_signature  # noqa: E402
+from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
+from onyx.db.engine.sql_engine import SqlEngine  # noqa: E402
+
+_PEM_BEGIN = "-----BEGIN ONYX LICENSE-----"
+_PEM_END = "-----END ONYX LICENSE-----"
+
+
+def _strip_pem_delimiters(content: str) -> str:
+    content = content.strip()
+    if content.startswith(_PEM_BEGIN) and content.endswith(_PEM_END):
+        lines = content.split("\n")
+        return "\n".join(lines[1:-1]).strip()
+    return content
+
+
+def main() -> None:
+    blob = os.environ.get("ONYX_DEV_LICENSE", "").strip()
+    if not blob:
+        print("ONYX_DEV_LICENSE empty: skipping license seed", file=sys.stderr)
+        return
+
+    license_data = _strip_pem_delimiters(blob).strip()
+
+    try:
+        _payload = verify_license_signature(license_data)
+    except ValueError as e:
+        print(f"License signature verification failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    SqlEngine.init_engine(pool_size=1, max_overflow=0)
+    with get_session_with_current_tenant() as db:
+        upsert_license(db, license_data)
+
+    print("Dev license seeded", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -1,27 +1,36 @@
-from collections.abc import AsyncGenerator
-from collections.abc import Generator
-from contextlib import asynccontextmanager
-from unittest.mock import MagicMock
-from unittest.mock import patch
+import os
 
-import pytest
-from dotenv import load_dotenv
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+# Daily tests run without a live backend; EE code paths that depend on
+# Redis/Vespa/etc are not available, so disable enforcement before any
+# module-level imports below pull in EE versioned implementations.
+os.environ["LICENSE_ENFORCEMENT_ENABLED"] = "false"
 
-from onyx.auth.users import current_user
-from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import Permission
-from onyx.db.models import UserRole
-from onyx.main import get_application
-from onyx.utils.logger import setup_logger
+from collections.abc import AsyncGenerator  # noqa: E402
+from collections.abc import Generator  # noqa: E402
+from contextlib import asynccontextmanager  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+import pytest  # noqa: E402
+from dotenv import load_dotenv  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from onyx.auth.users import current_user  # noqa: E402
+from onyx.db.engine.sql_engine import get_session  # noqa: E402
+from onyx.db.enums import Permission  # noqa: E402
+from onyx.db.models import UserRole  # noqa: E402
+from onyx.main import get_application  # noqa: E402
+from onyx.utils.logger import setup_logger  # noqa: E402
 
 # Opt into the shared @pytest.mark.secrets / test_secrets infrastructure.
-from tests.utils.pytest_secrets import (
+from tests.utils.pytest_secrets import (  # noqa: E402
     pytest_collection_modifyitems as pytest_collection_modifyitems,
 )
-from tests.utils.pytest_secrets import pytest_configure as pytest_configure
-from tests.utils.pytest_secrets import test_secrets as test_secrets
+from tests.utils.pytest_secrets import (
+    pytest_configure as pytest_configure,  # noqa: E402
+)
+from tests.utils.pytest_secrets import test_secrets as test_secrets  # noqa: E402
 
 logger = setup_logger()
 

--- a/backend/tests/daily/conftest.py
+++ b/backend/tests/daily/conftest.py
@@ -1,10 +1,3 @@
-import os
-
-# Set environment variables BEFORE any other imports to ensure they're picked up
-# by module-level code that reads env vars at import time
-# TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-os.environ["LICENSE_ENFORCEMENT_ENABLED"] = "false"
-
 from collections.abc import AsyncGenerator
 from collections.abc import Generator
 from contextlib import asynccontextmanager

--- a/backend/tests/integration/Dockerfile
+++ b/backend/tests/integration/Dockerfile
@@ -18,8 +18,7 @@ COPY ./tests/utils/* /app/tests/utils/
 
 FROM base AS openapi-schema
 COPY ./scripts/onyx_openapi_schema.py /app/scripts/onyx_openapi_schema.py
-# TODO(Nik): https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license
-RUN LICENSE_ENFORCEMENT_ENABLED=false python scripts/onyx_openapi_schema.py --filename openapi.json
+RUN python scripts/onyx_openapi_schema.py --filename openapi.json
 
 FROM openapitools/openapi-generator-cli:latest AS openapi-client
 WORKDIR /local

--- a/backend/tests/integration/Dockerfile
+++ b/backend/tests/integration/Dockerfile
@@ -18,7 +18,9 @@ COPY ./tests/utils/* /app/tests/utils/
 
 FROM base AS openapi-schema
 COPY ./scripts/onyx_openapi_schema.py /app/scripts/onyx_openapi_schema.py
-RUN python scripts/onyx_openapi_schema.py --filename openapi.json
+# OpenAPI client codegen cannot handle some EE-only schema shapes; export
+# the MIT route set with enforcement disabled.
+RUN LICENSE_ENFORCEMENT_ENABLED=false python scripts/onyx_openapi_schema.py --filename openapi.json
 
 FROM openapitools/openapi-generator-cli:latest AS openapi-client
 WORKDIR /local

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -7,6 +7,7 @@ import psycopg2
 import requests
 from alembic import command
 from alembic.config import Config
+from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PASSWORD
@@ -289,6 +290,33 @@ def reset_postgres(
         logger.info("Setting up Postgres...")
         with get_session_with_current_tenant() as db_session:
             setup_postgres(db_session)
+            _seed_dev_license_if_set(db_session)
+
+
+_PEM_BEGIN = "-----BEGIN ONYX LICENSE-----"
+_PEM_END = "-----END ONYX LICENSE-----"
+
+
+def _seed_dev_license_if_set(db_session: Session) -> None:
+    """Seed the ONYX_DEV_LICENSE blob into the License table.
+
+    Called after every Postgres reset so EE-gated routes don't return 402
+    after the License row is wiped by alembic downgrade. No-ops when the
+    env var is unset.
+    """
+    blob = os.environ.get("ONYX_DEV_LICENSE", "").strip()
+    if not blob:
+        return
+
+    if blob.startswith(_PEM_BEGIN) and blob.endswith(_PEM_END):
+        blob = "\n".join(blob.split("\n")[1:-1]).strip()
+
+    from ee.onyx.db.license import upsert_license
+    from ee.onyx.utils.license import verify_license_signature
+
+    verify_license_signature(blob)
+    upsert_license(db_session, blob)
+    logger.info("Dev license seeded after Postgres reset")
 
 
 def reset_vespa() -> None:

--- a/backend/tests/utils/secret_names.py
+++ b/backend/tests/utils/secret_names.py
@@ -28,6 +28,7 @@ class TestSecret(StrEnum):
     LITELLM_API_URL = "LITELLM_API_URL"
     OLLAMA_API_KEY = "OLLAMA_API_KEY"
     BEDROCK_API_KEY = "bedrock-api-key"
+    ONYX_DEV_LICENSE = "onyx-dev-license"
 
     # Connector test secrets. Member names match the CI env var; values match
     # the AWS Secrets Manager key (the suffix after the ``test/`` prefix).


### PR DESCRIPTION
## Description

Replaces every `LICENSE_ENFORCEMENT_ENABLED=false` bypass on full-stack CI workflows with the new default (`true`). For workflows that boot the real backend (integration, playwright, nightly LLM provider chat), pulls a signed dev license from AWS Secrets Manager (`test/onyx-dev-license`) and seeds it into the DB before tests run via a new `scripts/seed_dev_license.py`. AWS auth + secret pull live in a new `./.github/actions/setup-test-license` composite action used by all five call sites.

Pure-pytest contexts (`pr-python-tests`, `pr-database-tests` OpenAPI step, `tests/integration/Dockerfile` OpenAPI step, `daily/conftest.py`) keep `LICENSE_ENFORCEMENT_ENABLED=false`. With enforcement on, `is_ee_version=True` activates EE versioned implementations that depend on Redis/Vespa, which unit tests don't run; `openapi-generator-cli` also rejects some EE-only schema shapes. Full-stack jobs are where the coverage gain matters.

Fork PR behavior: `pull_request` from forks does not propagate secrets, so `aws-actions/configure-aws-credentials` fails fast at OIDC. There is no silent enforcement bypass — that would let EE-validating tests pass without actually exercising enforcement.

Closes ENG-1: https://linear.app/onyx-app/issue/ENG-1/update-test-infra-to-use-test-license

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check