### PR TITLE
chore(codeowners): drop required reviewer for AGENTS.md and CLAUDE.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,5 @@
 # Web standards updates
 /web/STANDARDS.md @raunakab @Weves
 
-# Agent context files
-/CLAUDE.md @Weves
-/AGENTS.md @Weves
-
 # Beta cherry-pick workflow owners
 /.github/workflows/post-merge-beta-cherry-pick.yml @justin-tahara @jmelahman


### PR DESCRIPTION
## Summary
- Removes `/AGENTS.md @Weves` and `/CLAUDE.md @Weves` from `.github/CODEOWNERS`
- Reduces review friction on agent context files; the catch-all `@onyx-dot-app/onyx-core-team` rule still ensures review coverage

## Test plan
- [ ] Confirm a PR touching only `AGENTS.md` or `CLAUDE.md` no longer auto-requests @Weves

🤖 Generated with [Claude Code](https://claude.com/claude-code)