### PR TITLE
feat(tenants): disable default LLM provider for multi-tenant cloud

### DIFF
--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -22,6 +22,7 @@ from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from ee.onyx.server.tenants.user_mapping import user_owns_a_tenant
 from onyx.auth.users import exceptions
 from onyx.configs.app_configs import ANTHROPIC_DEFAULT_API_KEY
+from onyx.configs.app_configs import AUTO_PROVISION_DEFAULT_LLM_PROVIDERS
 from onyx.configs.app_configs import COHERE_DEFAULT_API_KEY
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.configs.app_configs import DEV_MODE
@@ -350,7 +351,7 @@ def configure_default_api_keys(db_session: Session) -> None:
             logger.error("Failed to configure %s provider: %s", request.provider, e)
 
     # Configure OpenAI provider
-    if OPENAI_DEFAULT_API_KEY:
+    if OPENAI_DEFAULT_API_KEY and AUTO_PROVISION_DEFAULT_LLM_PROVIDERS:
         default_model = recommendations.get_default_model(OPENAI_PROVIDER_NAME)
         if default_model is None:
             logger.error(
@@ -379,11 +380,12 @@ def configure_default_api_keys(db_session: Session) -> None:
             logger.error("Failed to create default image gen config: %s", e)
     else:
         logger.info(
-            "OPENAI_DEFAULT_API_KEY not set, skipping OpenAI provider configuration"
+            "Skipping OpenAI default provider configuration "
+            "(OPENAI_DEFAULT_API_KEY unset or AUTO_PROVISION_DEFAULT_LLM_PROVIDERS=false)"
         )
 
     # Configure Anthropic provider
-    if ANTHROPIC_DEFAULT_API_KEY:
+    if ANTHROPIC_DEFAULT_API_KEY and AUTO_PROVISION_DEFAULT_LLM_PROVIDERS:
         default_model = recommendations.get_default_model(ANTHROPIC_PROVIDER_NAME)
         if default_model is None:
             logger.error(
@@ -407,7 +409,8 @@ def configure_default_api_keys(db_session: Session) -> None:
         _upsert(anthropic_provider, default_model_name)
     else:
         logger.info(
-            "ANTHROPIC_DEFAULT_API_KEY not set, skipping Anthropic provider configuration"
+            "Skipping Anthropic default provider configuration "
+            "(ANTHROPIC_DEFAULT_API_KEY unset or AUTO_PROVISION_DEFAULT_LLM_PROVIDERS=false)"
         )
 
     # Configure Vertex AI provider
@@ -443,7 +446,7 @@ def configure_default_api_keys(db_session: Session) -> None:
         )
 
     # Configure OpenRouter provider
-    if OPENROUTER_DEFAULT_API_KEY:
+    if OPENROUTER_DEFAULT_API_KEY and AUTO_PROVISION_DEFAULT_LLM_PROVIDERS:
         default_model = recommendations.get_default_model(OPENROUTER_PROVIDER_NAME)
         if default_model is None:
             logger.error(
@@ -476,7 +479,8 @@ def configure_default_api_keys(db_session: Session) -> None:
         _upsert(openrouter_provider, default_model_name)
     else:
         logger.info(
-            "OPENROUTER_DEFAULT_API_KEY not set, skipping OpenRouter provider configuration"
+            "Skipping OpenRouter default provider configuration "
+            "(OPENROUTER_DEFAULT_API_KEY unset or AUTO_PROVISION_DEFAULT_LLM_PROVIDERS=false)"
         )
 
     # Configure Cohere embedding provider

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1330,9 +1330,9 @@ VERTEXAI_DEFAULT_CREDENTIALS = os.environ.get("VERTEXAI_DEFAULT_CREDENTIALS")
 VERTEXAI_DEFAULT_LOCATION = os.environ.get("VERTEXAI_DEFAULT_LOCATION", "global")
 OPENROUTER_DEFAULT_API_KEY = os.environ.get("OPENROUTER_DEFAULT_API_KEY")
 # Whether tenant provisioning auto-creates LLMProvider rows seeded with the
-# *_DEFAULT_API_KEY env vars above. Defaults to True for self-hosted and
-# legacy cloud deployments; cloud sets this to False to require new tenants
-# to bring their own LLM keys.
+# *_DEFAULT_API_KEY env vars above. Defaults to True so self-hosted
+# deployments keep the existing behavior. Cloud sets this to False to
+# require new tenants to bring their own LLM keys.
 AUTO_PROVISION_DEFAULT_LLM_PROVIDERS = (
     os.environ.get("AUTO_PROVISION_DEFAULT_LLM_PROVIDERS", "true").lower() == "true"
 )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1329,6 +1329,13 @@ COHERE_DEFAULT_API_KEY = os.environ.get("COHERE_DEFAULT_API_KEY")
 VERTEXAI_DEFAULT_CREDENTIALS = os.environ.get("VERTEXAI_DEFAULT_CREDENTIALS")
 VERTEXAI_DEFAULT_LOCATION = os.environ.get("VERTEXAI_DEFAULT_LOCATION", "global")
 OPENROUTER_DEFAULT_API_KEY = os.environ.get("OPENROUTER_DEFAULT_API_KEY")
+# Whether tenant provisioning auto-creates LLMProvider rows seeded with the
+# *_DEFAULT_API_KEY env vars above. Defaults to True for self-hosted and
+# legacy cloud deployments; cloud sets this to False to require new tenants
+# to bring their own LLM keys.
+AUTO_PROVISION_DEFAULT_LLM_PROVIDERS = (
+    os.environ.get("AUTO_PROVISION_DEFAULT_LLM_PROVIDERS", "true").lower() == "true"
+)
 
 INSTANCE_TYPE = (
     "managed"

--- a/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
@@ -1,0 +1,76 @@
+"""Tests for tenant provisioning helpers."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+_PROVISIONING_MODULE = "ee.onyx.server.tenants.provisioning"
+
+
+def _patch_recommendations() -> MagicMock:
+    """Build a MagicMock that imitates `LLMProviderRecommendations`.
+
+    `configure_default_api_keys` calls `get_default_model(provider)` and
+    `get_visible_models(provider)` on the recommendations object — return
+    plausible stubs so the function reaches the env-var gating logic.
+    """
+    rec = MagicMock()
+    default_model = MagicMock()
+    default_model.name = "test-model"
+    rec.get_default_model.return_value = default_model
+    rec.get_visible_models.return_value = []
+    return rec
+
+
+def _run_configure(
+    *,
+    enabled: bool,
+) -> tuple[MagicMock, MagicMock]:
+    """Execute `configure_default_api_keys` with all four cloud key env vars
+    set to non-empty placeholders and the auto-provision flag toggled.
+
+    Returns the (upsert_llm_provider, create_default_image_gen_config_from_api_key)
+    mocks so callers can assert call counts.
+    """
+    with (
+        patch(f"{_PROVISIONING_MODULE}.AUTO_PROVISION_DEFAULT_LLM_PROVIDERS", enabled),
+        patch(f"{_PROVISIONING_MODULE}.OPENAI_DEFAULT_API_KEY", "openai-key"),
+        patch(f"{_PROVISIONING_MODULE}.ANTHROPIC_DEFAULT_API_KEY", "anthropic-key"),
+        patch(f"{_PROVISIONING_MODULE}.OPENROUTER_DEFAULT_API_KEY", "openrouter-key"),
+        patch(f"{_PROVISIONING_MODULE}.COHERE_DEFAULT_API_KEY", None),
+        patch(f"{_PROVISIONING_MODULE}.VERTEXAI_DEFAULT_CREDENTIALS", None),
+        patch(
+            f"{_PROVISIONING_MODULE}.get_recommendations",
+            return_value=_patch_recommendations(),
+        ),
+        patch(f"{_PROVISIONING_MODULE}.fetch_existing_llm_provider", return_value=None),
+        patch(f"{_PROVISIONING_MODULE}.upsert_llm_provider") as upsert_mock,
+        patch(f"{_PROVISIONING_MODULE}.update_default_provider"),
+        patch(
+            f"{_PROVISIONING_MODULE}.create_default_image_gen_config_from_api_key"
+        ) as image_gen_mock,
+        patch(
+            f"{_PROVISIONING_MODULE}._build_model_configuration_upsert_requests",
+            return_value=[],
+        ),
+    ):
+        upsert_mock.return_value = MagicMock(id=1)
+        from ee.onyx.server.tenants.provisioning import configure_default_api_keys
+
+        configure_default_api_keys(MagicMock())
+        return upsert_mock, image_gen_mock
+
+
+def test_auto_provision_enabled_creates_default_providers() -> None:
+    upsert_mock, image_gen_mock = _run_configure(enabled=True)
+    # OpenAI + Anthropic + OpenRouter all auto-provisioned.
+    assert upsert_mock.call_count == 3
+    # Image generation default config is seeded from the OpenAI key.
+    assert image_gen_mock.call_count == 1
+
+
+def test_auto_provision_disabled_skips_default_providers() -> None:
+    upsert_mock, image_gen_mock = _run_configure(enabled=False)
+    # Cloud opt-out: no LLMProvider rows created and no default image-gen
+    # config seeded with the cloud OpenAI key.
+    assert upsert_mock.call_count == 0
+    assert image_gen_mock.call_count == 0

--- a/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_provisioning.py
@@ -42,7 +42,14 @@ def _run_configure(
             f"{_PROVISIONING_MODULE}.get_recommendations",
             return_value=_patch_recommendations(),
         ),
-        patch(f"{_PROVISIONING_MODULE}.fetch_existing_llm_provider", return_value=None),
+        patch(
+            f"{_PROVISIONING_MODULE}.fetch_existing_llm_provider_by_name_and_type",
+            return_value=None,
+        ),
+        patch(
+            f"{_PROVISIONING_MODULE}.fetch_existing_llm_provider_by_type_nameless",
+            return_value=None,
+        ),
         patch(f"{_PROVISIONING_MODULE}.upsert_llm_provider") as upsert_mock,
         patch(f"{_PROVISIONING_MODULE}.update_default_provider"),
         patch(


### PR DESCRIPTION
## Description

Tenant provisioning seeds every new tenant with `LLMProvider` rows wired to the cloud `*_DEFAULT_API_KEY` env vars (OpenAI / Anthropic / OpenRouter) and a default image-generation config. That free-LLM-on-signup behavior is the engine of the recent abuse-bot economics — bots create gmail accounts, get an instant cloud-funded LLM, and burn until throttled.

Add `AUTO_PROVISION_DEFAULT_LLM_PROVIDERS` (default `true`) so cloud can opt out without disturbing self-hosted deployments. When `false`:
- No OpenAI / Anthropic / OpenRouter `LLMProvider` rows are created for new tenants
- No default image-generation config is seeded with the cloud OpenAI key
- New tenants must bring their own keys before accessing LLM features (existing `hasLlmProvider` UI gates already handle this)
- Existing tenants are unaffected — their already-persisted `LLMProvider` rows continue to work

Vertex AI and Cohere blocks are intentionally untouched: Vertex uses customer-supplied creds, Cohere is for embeddings (search), neither participates in the bot-spend vector.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check