### PR TITLE
chore(CI): Revert: Temporarily disable 2 tests which depend on Anthro…

### DIFF
--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from uuid import uuid4
 
-import pytest
 from sqlalchemy.orm import Session
 
 from onyx.chat.models import AnswerStreamPart
@@ -26,10 +25,6 @@ from onyx.server.query_and_chat.streaming_models import Packet
 from tests.external_dependency_unit.conftest import create_test_user
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause a CI run to fail if this test passes, acting as a reminder to re-enable this test.",
-)
 def test_answer_with_only_anthropic_provider(
     db_session: Session,
     full_deployment_setup: None,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
+++ b/backend/tests/external_dependency_unit/llm/test_prompt_caching.py
@@ -269,14 +269,10 @@ def test_openai_prompt_caching_reduces_costs(
     ), f"Expected at least one success. 0 of {attempts} attempts used prompt caching."
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Temporarily disabled due to Anthropic key issues. When those issues are resolved, `strict=True` will cause a CI run to fail if this test passes, acting as a reminder to re-enable this test.",
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="Anthropic API key not available",
 )
-# @pytest.mark.skipif(
-#     not os.environ.get("ANTHROPIC_API_KEY"),
-#     reason="Anthropic API key not available",
-# )
 def test_anthropic_prompt_caching_reduces_costs(
     db_session: Session,  # noqa: ARG001
 ) -> None:


### PR DESCRIPTION
## Description

These are passing again, so re-enable.

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
