### PR TITLE
fix(doc processing): Apply multiple threads for image processing

### DIFF
--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -94,7 +94,7 @@ from onyx.utils.timing import log_function_time
 logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
-MAX_IMAGE_WORKERS = 20
+MAX_IMAGE_WORKERS = 16
 
 
 class _PendingImageSummarization(BaseModel):

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Protocol
 
 import sentry_sdk
@@ -650,26 +651,36 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             for document in documents
         ]
 
+    # Collect all image summarization work items across all documents,
+    # then run them in parallel threads and slot results back in.
+    _MAX_IMAGE_WORKERS = 20
+
+    # First pass: build processed_sections for each document, leaving
+    # image sections as placeholders, and collect work items.
+    @dataclass
+    class _ImageWorkItem:
+        image_data: bytes
+        context_name: str
+        # Location to write the result back into
+        section: Section
+
     indexed_documents: list[IndexingDocument] = []
+    work_items: list[_ImageWorkItem] = []
 
     for document in documents:
         processed_sections: list[Section] = []
 
         for section in document.sections:
-            # For ImageSection, process and create base Section with both text and image_file_id
             if isinstance(section, ImageSection):
-                # Default section with image path preserved - ensure text is always a string
                 processed_section = Section(
                     type=section.type,
                     link=section.link,
                     image_file_id=section.image_file_id,
-                    text="",  # Initialize with empty string
+                    text="",
                 )
 
-                # Try to get image summary
                 try:
                     file_store = get_default_file_store()
-
                     file_record = file_store.read_file_record(
                         file_id=section.image_file_id
                     )
@@ -677,45 +688,57 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                         logger.warning(
                             f"Image file {section.image_file_id} not found in FileStore"
                         )
-
                         processed_section.text = "[Image could not be processed]"
                     else:
-                        # Get the image data
                         image_data_io = file_store.read_file(
                             file_id=section.image_file_id
                         )
                         image_data = image_data_io.read()
-                        summary = summarize_image_with_error_handling(
-                            llm=llm,
-                            image_data=image_data,
-                            context_name=file_record.display_name or "Image",
+                        work_items.append(
+                            _ImageWorkItem(
+                                image_data=image_data,
+                                context_name=file_record.display_name or "Image",
+                                section=processed_section,
+                            )
                         )
-
-                        if summary:
-                            processed_section.text = summary
-                        else:
-                            processed_section.text = "[Image could not be summarized]"
                 except Exception as e:
-                    logger.error(f"Error processing image section: {e}")
+                    logger.error(f"Error reading image section: {e}")
                     processed_section.text = "[Error processing image]"
 
                 processed_sections.append(processed_section)
-
-            # For TextSection, create a base Section with text and link
             else:
                 processed_section = Section(
                     type=section.type,
-                    text=section.text or "",  # Ensure text is always a string, not None
+                    text=section.text or "",
                     link=section.link,
                     image_file_id=None,
                 )
                 processed_sections.append(processed_section)
 
-        # Create IndexingDocument with original sections and processed_sections
         indexed_document = IndexingDocument(
             **document.model_dump(), processed_sections=processed_sections
         )
         indexed_documents.append(indexed_document)
+
+    # Second pass: run all image summarizations in parallel
+    if work_items:
+
+        def _summarize(item: _ImageWorkItem) -> str:
+            summary = summarize_image_with_error_handling(
+                llm=llm,
+                image_data=item.image_data,
+                context_name=item.context_name,
+            )
+            return summary or "[Image could not be summarized]"
+
+        results = run_functions_tuples_in_parallel(
+            [(_summarize, (item,)) for item in work_items],
+            allow_failures=True,
+            max_workers=_MAX_IMAGE_WORKERS,
+        )
+
+        for item, result in zip(work_items, results):
+            item.section.text = result or "[Error processing image]"
 
     return indexed_documents
 

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from typing import Protocol
 
 import sentry_sdk
@@ -95,6 +94,17 @@ from onyx.utils.timing import log_function_time
 logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
+MAX_IMAGE_WORKERS = 20
+
+
+class _PendingImageSummarization(BaseModel):
+    """An image section awaiting LLM summarization."""
+
+    section: Section
+    image_data: bytes
+    context_name: str
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class DocumentBatchPrepareContext(BaseModel):
@@ -651,94 +661,82 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
             for document in documents
         ]
 
-    # Collect all image summarization work items across all documents,
-    # then run them in parallel threads and slot results back in.
-    _MAX_IMAGE_WORKERS = 20
-
-    # First pass: build processed_sections for each document, leaving
-    # image sections as placeholders, and collect work items.
-    @dataclass
-    class _ImageWorkItem:
-        image_data: bytes
-        context_name: str
-        # Location to write the result back into
-        section: Section
-
     indexed_documents: list[IndexingDocument] = []
-    work_items: list[_ImageWorkItem] = []
+    # Sections that need LLM summarization, paired with their image data.
+    # Each Section is already placed in its document's processed_sections
+    # list — we just fill in .text after the parallel run.
+    pending: list[_PendingImageSummarization] = []
+    file_store = get_default_file_store()
 
     for document in documents:
         processed_sections: list[Section] = []
 
         for section in document.sections:
-            if isinstance(section, ImageSection):
-                processed_section = Section(
-                    type=section.type,
-                    link=section.link,
-                    image_file_id=section.image_file_id,
-                    text="",
-                )
-
-                try:
-                    file_store = get_default_file_store()
-                    file_record = file_store.read_file_record(
-                        file_id=section.image_file_id
+            if not isinstance(section, ImageSection):
+                processed_sections.append(
+                    Section(
+                        type=section.type,
+                        text=section.text or "",
+                        link=section.link,
+                        image_file_id=None,
                     )
-                    if not file_record:
-                        logger.warning(
-                            f"Image file {section.image_file_id} not found in FileStore"
-                        )
-                        processed_section.text = "[Image could not be processed]"
-                    else:
-                        image_data_io = file_store.read_file(
-                            file_id=section.image_file_id
-                        )
-                        image_data = image_data_io.read()
-                        work_items.append(
-                            _ImageWorkItem(
-                                image_data=image_data,
-                                context_name=file_record.display_name or "Image",
-                                section=processed_section,
-                            )
-                        )
-                except Exception as e:
-                    logger.error(f"Error reading image section: {e}")
-                    processed_section.text = "[Error processing image]"
-
-                processed_sections.append(processed_section)
-            else:
-                processed_section = Section(
-                    type=section.type,
-                    text=section.text or "",
-                    link=section.link,
-                    image_file_id=None,
                 )
-                processed_sections.append(processed_section)
+                continue
 
-        indexed_document = IndexingDocument(
-            **document.model_dump(), processed_sections=processed_sections
-        )
-        indexed_documents.append(indexed_document)
-
-    # Second pass: run all image summarizations in parallel
-    if work_items:
-
-        def _summarize(item: _ImageWorkItem) -> str:
-            summary = summarize_image_with_error_handling(
-                llm=llm,
-                image_data=item.image_data,
-                context_name=item.context_name,
+            processed_section = Section(
+                type=section.type,
+                link=section.link,
+                image_file_id=section.image_file_id,
+                text="",
             )
-            return summary or "[Image could not be summarized]"
+            processed_sections.append(processed_section)
+
+            try:
+                file_record = file_store.read_file_record(file_id=section.image_file_id)
+                if not file_record:
+                    logger.warning(
+                        f"Image file {section.image_file_id} not found in FileStore"
+                    )
+                    processed_section.text = "[Image could not be processed]"
+                    continue
+
+                image_data = file_store.read_file(file_id=section.image_file_id).read()
+                pending.append(
+                    _PendingImageSummarization(
+                        section=processed_section,
+                        image_data=image_data,
+                        context_name=file_record.display_name or "Image",
+                    )
+                )
+            except Exception as e:
+                logger.error(f"Error reading image section: {e}")
+                processed_section.text = "[Error processing image]"
+
+        indexed_documents.append(
+            IndexingDocument(
+                **document.model_dump(), processed_sections=processed_sections
+            )
+        )
+
+    # Summarize all images in parallel
+    if pending:
+
+        def _summarize(image_data: bytes, context_name: str) -> str:
+            return (
+                summarize_image_with_error_handling(
+                    llm=llm, image_data=image_data, context_name=context_name
+                )
+                or "[Image could not be summarized]"
+            )
 
         results = run_functions_tuples_in_parallel(
-            [(_summarize, (item,)) for item in work_items],
+            [(_summarize, (p.image_data, p.context_name)) for p in pending],
             allow_failures=True,
-            max_workers=_MAX_IMAGE_WORKERS,
+            max_workers=MAX_IMAGE_WORKERS,
         )
 
-        for item, result in zip(work_items, results):
-            item.section.text = result or "[Error processing image]"
+        for p, result in zip(pending, results):
+            p.section.text = result or "[Error processing image]"
 
     return indexed_documents
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -1,4 +1,6 @@
+import random
 import threading
+import time
 from typing import Any
 from typing import cast
 from typing import List
@@ -371,3 +373,228 @@ def test_document_ingestion_hook_mixed_batch() -> None:
     rewritten = next(d for d in result if d.id == "rewrite")
     assert isinstance(rewritten.sections[0], TextSection)
     assert rewritten.sections[0].text == "new text"
+
+
+# ---------------------------------------------------------------------------
+# process_image_sections
+# ---------------------------------------------------------------------------
+
+_PATCH_PREFIX = "onyx.indexing.indexing_pipeline"
+
+
+def _mock_file_store(image_map: dict[str, bytes]) -> MagicMock:
+    """Build a fake file store that serves images from a dict."""
+    store = MagicMock()
+
+    def _read_file_record(file_id: str) -> MagicMock | None:
+        if file_id not in image_map:
+            return None
+        record = MagicMock()
+        record.display_name = file_id
+        return record
+
+    def _read_file(file_id: str) -> MagicMock:
+        data = MagicMock()
+        data.read.return_value = image_map[file_id]
+        return data
+
+    store.read_file_record = _read_file_record
+    store.read_file = _read_file
+    return store
+
+
+def _make_image_doc(
+    doc_id: str,
+    sections: list[TextSection | ImageSection],
+) -> Document:
+    return Document(
+        id=doc_id,
+        title=f"Doc {doc_id}",
+        semantic_identifier=doc_id,
+        sections=sections,
+        source=DocumentSource.FILE,
+        metadata={},
+    )
+
+
+class TestProcessImageSections:
+    """Validate that parallel image summarization places results in the
+    correct section positions — especially under concurrent execution."""
+
+    def _run(
+        self,
+        documents: list[Document],
+        image_map: dict[str, bytes],
+        summarize_side_effect: Any = None,
+    ) -> list[Any]:
+        """Helper that patches all external deps and calls process_image_sections."""
+        if summarize_side_effect is None:
+
+            def summarize_side_effect(
+                **kwargs: Any,
+            ) -> str:
+                return f"summary-of-{kwargs['context_name']}"
+
+        with (
+            patch(
+                f"{_PATCH_PREFIX}.get_image_extraction_and_analysis_enabled",
+                return_value=True,
+            ),
+            patch(
+                f"{_PATCH_PREFIX}.get_default_llm_with_vision",
+                return_value=MagicMock(),
+            ),
+            patch(
+                f"{_PATCH_PREFIX}.get_default_file_store",
+                return_value=_mock_file_store(image_map),
+            ),
+            patch(
+                f"{_PATCH_PREFIX}.summarize_image_with_error_handling",
+                side_effect=summarize_side_effect,
+            ),
+        ):
+            return process_image_sections(documents)
+
+    def test_interleaved_sections_preserve_order(self) -> None:
+        """Text and image sections must stay in their original positions."""
+        doc = _make_image_doc(
+            "doc1",
+            [
+                TextSection(text="text-0", link="link-0"),
+                ImageSection(image_file_id="img-A"),
+                TextSection(text="text-2", link="link-2"),
+                ImageSection(image_file_id="img-B"),
+                TextSection(text="text-4", link="link-4"),
+            ],
+        )
+        image_map = {"img-A": b"aa", "img-B": b"bb"}
+        result = self._run([doc], image_map)
+
+        sections = result[0].processed_sections
+        assert len(sections) == 5
+        assert sections[0].text == "text-0"
+        assert sections[1].text == "summary-of-img-A"
+        assert sections[1].image_file_id == "img-A"
+        assert sections[2].text == "text-2"
+        assert sections[3].text == "summary-of-img-B"
+        assert sections[3].image_file_id == "img-B"
+        assert sections[4].text == "text-4"
+
+    def test_multiple_documents_preserve_order(self) -> None:
+        """Each document's sections must be independent and correctly ordered."""
+        doc1 = _make_image_doc(
+            "doc1",
+            [
+                ImageSection(image_file_id="img-1"),
+                TextSection(text="middle", link=None),
+                ImageSection(image_file_id="img-2"),
+            ],
+        )
+        doc2 = _make_image_doc(
+            "doc2",
+            [
+                TextSection(text="start", link=None),
+                ImageSection(image_file_id="img-3"),
+            ],
+        )
+        image_map = {"img-1": b"a", "img-2": b"b", "img-3": b"c"}
+        result = self._run([doc1, doc2], image_map)
+
+        s1 = result[0].processed_sections
+        assert len(s1) == 3
+        assert s1[0].text == "summary-of-img-1"
+        assert s1[1].text == "middle"
+        assert s1[2].text == "summary-of-img-2"
+
+        s2 = result[1].processed_sections
+        assert len(s2) == 2
+        assert s2[0].text == "start"
+        assert s2[1].text == "summary-of-img-3"
+
+    def test_ordering_under_varied_latency(self) -> None:
+        """Simulate threads finishing in random order — results must still
+        land in the correct section positions."""
+        num_images = 10
+        sections: list[TextSection | ImageSection] = []
+        image_map: dict[str, bytes] = {}
+        for i in range(num_images):
+            fid = f"img-{i}"
+            sections.append(TextSection(text=f"text-{i}", link=None))
+            sections.append(ImageSection(image_file_id=fid))
+            image_map[fid] = f"data-{i}".encode()
+
+        doc = _make_image_doc("doc1", sections)
+
+        def _slow_summarize(**kwargs: Any) -> str:
+            time.sleep(random.uniform(0.001, 0.02))
+            return f"summary-of-{kwargs['context_name']}"
+
+        result = self._run([doc], image_map, summarize_side_effect=_slow_summarize)
+
+        ps = result[0].processed_sections
+        assert len(ps) == num_images * 2
+        for i in range(num_images):
+            assert ps[i * 2].text == f"text-{i}"
+            assert ps[i * 2 + 1].text == f"summary-of-img-{i}"
+            assert ps[i * 2 + 1].image_file_id == f"img-{i}"
+
+    def test_text_only_document_unchanged(self) -> None:
+        doc = _make_image_doc(
+            "doc1",
+            [
+                TextSection(text="hello", link="a"),
+                TextSection(text="world", link="b"),
+            ],
+        )
+        result = self._run([doc], {})
+
+        sections = result[0].processed_sections
+        assert len(sections) == 2
+        assert sections[0].text == "hello"
+        assert sections[1].text == "world"
+
+    def test_missing_file_record_does_not_corrupt_order(self) -> None:
+        """An image whose file record is missing should get a placeholder
+        without shifting other sections."""
+        doc = _make_image_doc(
+            "doc1",
+            [
+                ImageSection(image_file_id="exists"),
+                ImageSection(image_file_id="missing"),
+                TextSection(text="after", link=None),
+            ],
+        )
+        image_map = {"exists": b"data"}
+        result = self._run([doc], image_map)
+
+        sections = result[0].processed_sections
+        assert len(sections) == 3
+        assert sections[0].text == "summary-of-exists"
+        assert sections[1].text == "[Image could not be processed]"
+        assert sections[2].text == "after"
+
+    def test_summarization_failure_does_not_corrupt_order(self) -> None:
+        """If one summarization fails, other sections must be unaffected."""
+        doc = _make_image_doc(
+            "doc1",
+            [
+                ImageSection(image_file_id="ok"),
+                ImageSection(image_file_id="fail"),
+                ImageSection(image_file_id="ok2"),
+            ],
+        )
+        image_map = {"ok": b"a", "fail": b"b", "ok2": b"c"}
+
+        def _sometimes_fail(**kwargs: Any) -> str | None:
+            if kwargs["context_name"] == "fail":
+                raise ValueError("boom")
+            return f"summary-of-{kwargs['context_name']}"
+
+        result = self._run([doc], image_map, summarize_side_effect=_sometimes_fail)
+
+        sections = result[0].processed_sections
+        assert len(sections) == 3
+        assert sections[0].text == "summary-of-ok"
+        # allow_failures=True → None result → fallback text
+        assert sections[1].text == "[Error processing image]"
+        assert sections[2].text == "summary-of-ok2"


### PR DESCRIPTION
## Description
Currently  image processing is done by sending the image to a vision model and waiting for a reply. This is done sequentially.

This PR introduces a multi-threaded approach.
On an example powerpoint, we went from doc-processing taking ~114s to ~19.56s by putting multiple worker threads on this IO bound task

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
