### PR TITLE
fix(chat): resolve send parent via immutable tree, not mainline pointer

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -64,6 +64,7 @@ from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import SearchDoc
+from onyx.db.chat import build_chat_history_to_message
 from onyx.db.chat import create_new_chat_message
 from onyx.db.chat import get_chat_session_by_id
 from onyx.db.chat import get_or_create_root_message
@@ -721,40 +722,36 @@ def build_chat_turn(
         project_id=chat_session.project_id,
     )
 
-    # Re-create linear history of messages
-    chat_history = create_chat_history_chain(
-        chat_session_id=chat_session.id, db_session=db_session
-    )
-
     # Determine the parent message based on the request:
-    # - AUTO_PLACE_AFTER_LATEST_MESSAGE (-1): auto-place after latest message in chain
+    # - AUTO_PLACE_AFTER_LATEST_MESSAGE (-1): auto-place after latest message in current mainline
     # - None or root ID: regeneration from root (first message)
-    # - positive int: place after that specific parent message
+    # - positive int: place after that specific parent message (any branch)
     root_message = get_or_create_root_message(
         chat_session_id=chat_session.id, db_session=db_session
     )
 
+    parent_message: ChatMessage
+    chat_history: list[ChatMessage]
     if new_msg_req.parent_message_id == AUTO_PLACE_AFTER_LATEST_MESSAGE:
+        chat_history = create_chat_history_chain(
+            chat_session_id=chat_session.id, db_session=db_session
+        )
         parent_message = chat_history[-1] if chat_history else root_message
     elif (
         new_msg_req.parent_message_id is None
         or new_msg_req.parent_message_id == root_message.id
     ):
-        # Regeneration from root — clear history so we start fresh
         parent_message = root_message
         chat_history = []
     else:
-        parent_message = None
-        for i in range(len(chat_history) - 1, -1, -1):
-            if chat_history[i].id == new_msg_req.parent_message_id:
-                parent_message = chat_history[i]
-                # Truncate to only messages up to and including the parent
-                chat_history = chat_history[: i + 1]
-                break
-
-    if parent_message is None:
-        raise ValueError(
-            "The new message sent is not on the latest mainline of messages"
+        # Resolve via the immutable parent chain so the next send is
+        # independent of the client's pending set-message-as-latest PUT —
+        # avoids races on branch switch, message edit, regenerate
+        # mid-stream, and agent/persona switch.
+        parent_message, chat_history = build_chat_history_to_message(
+            chat_session_id=chat_session.id,
+            target_message_id=new_msg_req.parent_message_id,
+            db_session=db_session,
         )
 
     # ── Query Processing hook + user message ─────────────────────────────────

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -796,6 +796,76 @@ def set_as_latest_chat_message(
     db_session.commit()
 
 
+def build_chat_history_to_message(
+    chat_session_id: UUID,
+    target_message_id: int,
+    db_session: Session,
+) -> tuple[ChatMessage, list[ChatMessage]]:
+    """Walk UP from ``target_message_id`` via the immutable ``parent_message_id``
+    pointer to reconstruct the chain leading to it, regardless of the current
+    mainline (``latest_child_message_id``) state.
+
+    Returns ``(target_message, chain_excluding_root_root_to_leaf)`` matching
+    the shape of :func:`create_chat_history_chain` so callers can use the
+    chain interchangeably.
+
+    Side effect: rewrites ``latest_child_message_id`` on each ancestor so the
+    mainline pointer chain matches the path we just used. This makes the
+    backend authoritative about which branch the next send addresses, so a
+    racing client-side ``set-message-as-latest`` PUT is no longer required for
+    correctness.
+    """
+    all_messages = get_chat_messages_by_session(
+        chat_session_id=chat_session_id,
+        user_id=None,
+        db_session=db_session,
+        skip_permission_check=True,
+        prefetch_top_two_level_tool_calls=True,
+    )
+    by_id: dict[int, ChatMessage] = {m.id: m for m in all_messages}
+
+    target = by_id.get(target_message_id)
+    if target is None:
+        raise ValueError(
+            f"parent_message_id {target_message_id} not found in chat session"
+        )
+
+    chain_leaf_to_root: list[ChatMessage] = []
+    visited: set[int] = set()
+    cur: ChatMessage | None = target
+    while cur is not None and cur.parent_message_id is not None:
+        if cur.id in visited:
+            raise RuntimeError(
+                f"Cycle detected in chat message parent chain at id={cur.id}"
+            )
+        visited.add(cur.id)
+        chain_leaf_to_root.append(cur)
+        next_id = cur.parent_message_id
+        cur = by_id.get(next_id)
+        if cur is None:
+            raise RuntimeError(
+                f"Broken parent chain: message {next_id} missing from session"
+            )
+
+    root_message = cur
+    if root_message is None:
+        raise RuntimeError("Could not resolve root message while walking parent chain")
+
+    chain = list(reversed(chain_leaf_to_root))
+
+    prev: ChatMessage = root_message
+    changed = False
+    for msg in chain:
+        if prev.latest_child_message_id != msg.id:
+            prev.latest_child_message_id = msg.id
+            changed = True
+        prev = msg
+    if changed:
+        db_session.commit()
+
+    return target, chain
+
+
 def create_db_search_doc(
     server_search_doc: ServerSearchDoc,
     db_session: Session,

--- a/backend/tests/external_dependency_unit/db/test_build_chat_history_to_message.py
+++ b/backend/tests/external_dependency_unit/db/test_build_chat_history_to_message.py
@@ -1,0 +1,124 @@
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import MessageType
+from onyx.db.chat import build_chat_history_to_message
+from onyx.db.chat import create_chat_session
+from onyx.db.chat import create_new_chat_message
+from onyx.db.chat import get_or_create_root_message
+from onyx.db.models import ChatMessage
+from onyx.db.models import Persona
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _add_message(
+    db_session: Session,
+    chat_session_id: "ChatMessage.chat_session_id.type",
+    parent: ChatMessage,
+    text: str,
+    message_type: MessageType,
+) -> ChatMessage:
+    msg = create_new_chat_message(
+        chat_session_id=chat_session_id,
+        parent_message=parent,
+        message=text,
+        token_count=0,
+        message_type=message_type,
+        db_session=db_session,
+        commit=True,
+    )
+    parent.latest_child_message_id = msg.id
+    db_session.commit()
+    return msg
+
+
+def test_build_chat_history_to_message_off_mainline(db_session: Session) -> None:
+    """A non-mainline parent should resolve via the immutable parent chain
+    and rewrite ``latest_child_message_id`` so the mainline matches the path
+    we just used.
+
+    Tree (root excluded from chain):
+        root → U1 → A1 → U2 → A2 (mainline)
+                       └─ A1' (sibling assistant response, off mainline)
+    Calling with target=A1' should return chain [U1, A1'] and update
+    root.latest_child_message_id = U1, U1.latest_child_message_id = A1'.
+    """
+    user = create_test_user(db_session, "build-chain")
+    persona = Persona(name="build-chain-test", description="test")
+    db_session.add(persona)
+    db_session.flush()
+
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="test",
+        user_id=user.id,
+        persona_id=persona.id,
+    )
+    root = get_or_create_root_message(
+        chat_session_id=chat_session.id, db_session=db_session
+    )
+
+    u1 = _add_message(db_session, chat_session.id, root, "u1", MessageType.USER)
+    a1 = _add_message(db_session, chat_session.id, u1, "a1", MessageType.ASSISTANT)
+    u2 = _add_message(db_session, chat_session.id, a1, "u2", MessageType.USER)
+    _a2 = _add_message(db_session, chat_session.id, u2, "a2", MessageType.ASSISTANT)
+
+    # Branch: alternate assistant response to u1. ``create_new_chat_message``
+    # updates ``u1.latest_child_message_id`` to point at the new child, so we
+    # manually reset it to ``a1`` to simulate the exact race we're fixing:
+    # the client has locally flipped to ``a1_prime`` but its
+    # ``set-message-as-latest`` PUT has not yet rewritten the mainline pointer.
+    a1_prime = create_new_chat_message(
+        chat_session_id=chat_session.id,
+        parent_message=u1,
+        message="a1_prime",
+        token_count=0,
+        message_type=MessageType.ASSISTANT,
+        db_session=db_session,
+        commit=True,
+    )
+    u1.latest_child_message_id = a1.id
+    db_session.commit()
+
+    db_session.refresh(u1)
+    assert u1.latest_child_message_id == a1.id  # mainline still on a1
+
+    target, chain = build_chat_history_to_message(
+        chat_session_id=chat_session.id,
+        target_message_id=a1_prime.id,
+        db_session=db_session,
+    )
+
+    assert target.id == a1_prime.id
+    assert [m.id for m in chain] == [u1.id, a1_prime.id]
+
+    # Mainline should have been rewritten along the path we just used.
+    db_session.refresh(root)
+    db_session.refresh(u1)
+    assert root.latest_child_message_id == u1.id
+    assert u1.latest_child_message_id == a1_prime.id
+
+
+def test_build_chat_history_to_message_invalid_id(db_session: Session) -> None:
+    """A parent_message_id that does not belong to the session must raise."""
+    user = create_test_user(db_session, "build-chain-invalid")
+    persona = Persona(name="build-chain-invalid", description="test")
+    db_session.add(persona)
+    db_session.flush()
+
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="test",
+        user_id=user.id,
+        persona_id=persona.id,
+    )
+
+    try:
+        build_chat_history_to_message(
+            chat_session_id=chat_session.id,
+            target_message_id=-99999,
+            db_session=db_session,
+        )
+    except ValueError as e:
+        assert "not found in chat session" in str(e)
+    else:
+        raise AssertionError("Expected ValueError for missing message id")


### PR DESCRIPTION
## Description

Customers continue to hit `"The new message sent is not on the latest mainline of messages"` (500) on v3.2.11+ even though #10075/#10078 was supposed to fix it. The earlier fix only patched the multi-model preferred-response path. The same race exists on every other place the client mutates its local message tree before its `set-message-as-latest` PUT lands:

- branch-switcher arrows on a prior assistant response
- editing a prior user message
- regenerating mid-stream and sending a follow-up
- agent / persona switch on an existing session
- multi-tab / refresh after a local flip

Backend currently rejects the send when the supplied `parent_message_id` isn't on the mainline chain (built from mutable `latest_child_message_id` pointers). Resolve the parent via the immutable `parent_message_id` chain instead. The send endpoint now walks UP from the supplied `parent_message_id` to root, builds `chat_history` from that walk, and rewrites `latest_child_message_id` along the path so the mainline matches the branch the client just used. Whatever branch the user picked locally, the backend reconstructs the correct ancestry — the client-side PUT becomes redundant for correctness.

Adds `build_chat_history_to_message` in `onyx/db/chat.py` and an external-dependency-unit test exercising the off-mainline path.

## How Has This Been Tested?

<!-- Filled in by reviewer -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check