### PR TITLE
feat: crawler playwright retry +improved error msg

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -636,6 +636,14 @@ WEB_CONNECTOR_OAUTH_CLIENT_SECRET = os.environ.get("WEB_CONNECTOR_OAUTH_CLIENT_S
 WEB_CONNECTOR_OAUTH_TOKEN_URL = os.environ.get("WEB_CONNECTOR_OAUTH_TOKEN_URL")
 WEB_CONNECTOR_VALIDATE_URLS = os.environ.get("WEB_CONNECTOR_VALIDATE_URLS")
 
+# When the OnyxWebCrawler (open_url tool) hits a 403 / Cloudflare challenge,
+# fall back to a one-shot Playwright (Chromium) render to bypass JS-based
+# bot detection. Disable to skip the fallback (e.g. on hosts that don't have
+# the Chromium binary installed).
+OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED = (
+    os.environ.get("OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED", "true").lower() == "true"
+)
+
 HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY = os.environ.get(
     "HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY",
     HtmlBasedConnectorTransformLinksStrategy.STRIP,

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -7,26 +7,19 @@ from datetime import timezone
 from enum import Enum
 from typing import Any
 from typing import cast
-from typing import Tuple
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
 import requests
 from bs4 import BeautifulSoup
-from oauthlib.oauth2 import BackendApplicationClient
 from playwright.sync_api import BrowserContext
 from playwright.sync_api import Playwright
-from playwright.sync_api import sync_playwright
 from playwright.sync_api import TimeoutError
-from requests_oauthlib import OAuth2Session
 from typing_extensions import override
 from urllib3.exceptions import MaxRetryError
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
-from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_ID
-from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_SECRET
-from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_TOKEN_URL
 from onyx.configs.app_configs import WEB_CONNECTOR_VALIDATE_URLS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.exceptions import ConnectorValidationError
@@ -45,6 +38,12 @@ from onyx.connectors.models import TextSection
 from onyx.file_processing.html_utils import web_html_cleanup
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
+
+# Re-exported for backwards compatibility with existing tests/callers that
+# patch these names on `onyx.connectors.web.connector`.
+from onyx.utils.playwright_fetch import DEFAULT_HEADERS
+from onyx.utils.playwright_fetch import DEFAULT_USER_AGENT  # noqa: F401
+from onyx.utils.playwright_fetch import start_playwright
 from onyx.utils.sitemap import list_pages_for_site
 from onyx.utils.web_content import extract_pdf_text
 from onyx.utils.web_content import is_pdf_resource
@@ -96,29 +95,6 @@ JAVASCRIPT_DISABLED_MESSAGE = "You have JavaScript disabled in your browser"
 # Grace period after page navigation to allow bot-detection challenges
 # and SPA content rendering to complete
 PAGE_RENDER_TIMEOUT_MS = 5000
-
-# Define common headers that mimic a real browser
-DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
-DEFAULT_HEADERS = {
-    "User-Agent": DEFAULT_USER_AGENT,
-    "Accept": (
-        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,"
-        "image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
-    ),
-    "Accept-Language": "en-US,en;q=0.9",
-    # Brotli decoding has been flaky in brotlicffi/httpx for certain chunked responses;
-    # stick to gzip/deflate to keep connectivity checks stable.
-    "Accept-Encoding": "gzip, deflate",
-    "Connection": "keep-alive",
-    "Upgrade-Insecure-Requests": "1",
-    "Sec-Fetch-Dest": "document",
-    "Sec-Fetch-Mode": "navigate",
-    "Sec-Fetch-Site": "none",
-    "Sec-Fetch-User": "?1",
-    "Sec-CH-UA": '"Google Chrome";v="123", "Not:A-Brand";v="8"',
-    "Sec-CH-UA-Mobile": "?0",
-    "Sec-CH-UA-Platform": '"macOS"',
-}
 
 
 class WEB_CONNECTOR_VALID_SETTINGS(str, Enum):
@@ -260,85 +236,6 @@ def get_internal_links(
         if _same_site(base_url, href):
             internal_links.add(href)
     return internal_links
-
-
-def start_playwright() -> Tuple[Playwright, BrowserContext]:
-    playwright = sync_playwright().start()
-
-    # Launch browser with more realistic settings
-    browser = playwright.chromium.launch(
-        headless=True,
-        args=[
-            "--disable-blink-features=AutomationControlled",
-            "--disable-features=IsolateOrigins,site-per-process",
-            "--disable-site-isolation-trials",
-        ],
-    )
-
-    # Create a context with realistic browser properties
-    context = browser.new_context(
-        user_agent=DEFAULT_USER_AGENT,
-        viewport={"width": 1440, "height": 900},
-        device_scale_factor=2.0,
-        locale="en-US",
-        timezone_id="America/Los_Angeles",
-        has_touch=False,
-        java_script_enabled=True,
-        color_scheme="light",
-        # Add more realistic browser properties
-        bypass_csp=True,
-        ignore_https_errors=True,
-    )
-
-    # Set additional headers to mimic a real browser
-    context.set_extra_http_headers(
-        {
-            "Accept": DEFAULT_HEADERS["Accept"],
-            "Accept-Language": DEFAULT_HEADERS["Accept-Language"],
-            "Sec-Fetch-Dest": DEFAULT_HEADERS["Sec-Fetch-Dest"],
-            "Sec-Fetch-Mode": DEFAULT_HEADERS["Sec-Fetch-Mode"],
-            "Sec-Fetch-Site": DEFAULT_HEADERS["Sec-Fetch-Site"],
-            "Sec-Fetch-User": DEFAULT_HEADERS["Sec-Fetch-User"],
-            "Sec-CH-UA": DEFAULT_HEADERS["Sec-CH-UA"],
-            "Sec-CH-UA-Mobile": DEFAULT_HEADERS["Sec-CH-UA-Mobile"],
-            "Sec-CH-UA-Platform": DEFAULT_HEADERS["Sec-CH-UA-Platform"],
-            "Cache-Control": "max-age=0",
-            "DNT": "1",
-        }
-    )
-
-    # Add a script to modify navigator properties to avoid detection
-    context.add_init_script(
-        """
-        Object.defineProperty(navigator, 'webdriver', {
-            get: () => undefined
-        });
-        Object.defineProperty(navigator, 'plugins', {
-            get: () => [1, 2, 3, 4, 5]
-        });
-        Object.defineProperty(navigator, 'languages', {
-            get: () => ['en-US', 'en']
-        });
-    """
-    )
-
-    if (
-        WEB_CONNECTOR_OAUTH_CLIENT_ID
-        and WEB_CONNECTOR_OAUTH_CLIENT_SECRET
-        and WEB_CONNECTOR_OAUTH_TOKEN_URL
-    ):
-        client = BackendApplicationClient(client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID)
-        oauth = OAuth2Session(client=client)
-        token = oauth.fetch_token(
-            token_url=WEB_CONNECTOR_OAUTH_TOKEN_URL,
-            client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID,
-            client_secret=WEB_CONNECTOR_OAUTH_CLIENT_SECRET,
-        )
-        context.set_extra_http_headers(
-            {"Authorization": "Bearer {}".format(token["access_token"])}
-        )
-
-    return playwright, context
 
 
 def extract_urls_from_sitemap(sitemap_url: str) -> list[str]:

--- a/backend/onyx/tools/tool_implementations/open_url/models.py
+++ b/backend/onyx/tools/tool_implementations/open_url/models.py
@@ -15,11 +15,23 @@ class WebContent(BaseModel):
     full_content: str
     published_date: datetime | None = None
     scrape_successful: bool = True
+    # Short, LLM-/admin-facing explanation of why a fetch failed (set when
+    # `scrape_successful=False`). Examples: "blocked by a Cloudflare bot
+    # challenge — try a different URL or configure Firecrawl as the web
+    # content provider", "request timed out", "404 not found".
+    failure_reason: str | None = None
 
     @field_validator("link")
     @classmethod
     def normalize_link(cls, v: str) -> str:
         return normalize_url(v)
+
+
+class FailedFetch(BaseModel):
+    """A URL that the open_url tool could not retrieve, with the reason."""
+
+    url: str
+    failure_reason: str | None = None
 
 
 class WebContentProvider(ABC):

--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -46,6 +46,13 @@ class FailureReason:
         "cannot solve — try a different URL or configure Firecrawl as the "
         "web content provider"
     )
+    # Generic 403 with no Cloudflare evidence. Kept distinct from
+    # CLOUDFLARE_CHALLENGE so we don't tell the LLM to "configure Firecrawl"
+    # for what's actually an auth wall, expired presigned URL, private repo, etc.
+    HTTP_403_BLOCKED = (
+        "upstream returned HTTP 403 — the URL likely requires authentication "
+        "or is otherwise restricted from the built-in crawler"
+    )
     SSRF_BLOCKED = "blocked by SSRF protection (URL resolves to an internal address)"
     NETWORK_ERROR = "network error while fetching the URL"
     OVERSIZED_HTML = "HTML response exceeded the configured maximum size"
@@ -69,20 +76,47 @@ def _failed_result(url: str, failure_reason: str | None = None) -> WebContent:
     )
 
 
-def _looks_like_bot_challenge_response(response: requests.Response) -> bool:
-    """True if a non-2xx response looks like a Cloudflare/bot-management challenge.
+def _has_cloudflare_signals(response: requests.Response) -> bool:
+    """True iff the response carries actual Cloudflare-specific markers.
 
-    Conservative on purpose: we want to spend Chromium time (and emit
-    "Cloudflare blocked us" failure reasons) only on responses that actually
-    look like CF challenges, not on real 401/404/410/etc. errors.
+    Strict on purpose — only used to choose between the CF-specific failure
+    reason (which tells admins to configure Firecrawl) vs. the generic 403
+    failure reason (which points at auth / access). A bare 403 with no
+    `cf-ray` / `cf-mitigated` / `Server: cloudflare` headers is treated
+    as "not Cloudflare" here.
     """
-    if response.status_code == 403:
-        return True
     headers = response.headers
     if any(name in headers for name in _CLOUDFLARE_HEADER_NAMES):
         return True
     server = headers.get("Server", "").lower()
     return server.startswith("cloudflare")
+
+
+def _should_try_playwright_fallback(response: requests.Response) -> bool:
+    """True if a Playwright render is plausibly worth attempting.
+
+    Broader than `_has_cloudflare_signals` — any 403 is cheap insurance to
+    retry through a real browser (some sites serve JS-protected interstitials
+    without CF headers). Real 401/404/410/5xx errors fall through unchanged.
+    """
+    return response.status_code == 403 or _has_cloudflare_signals(response)
+
+
+def _failure_reason_for_status(
+    response: requests.Response, has_cf_signals: bool
+) -> str:
+    """Pick the LLM-facing failure reason for a 4xx/5xx upstream response.
+
+    Only labels failures as Cloudflare when the response actually carries
+    CF-specific headers — bare 403s without those headers are far more
+    often auth walls or access-restricted resources, and labelling them
+    "Cloudflare" sends the LLM and the admin chasing the wrong fix.
+    """
+    if has_cf_signals:
+        return FailureReason.CLOUDFLARE_CHALLENGE
+    if response.status_code == 403:
+        return FailureReason.HTTP_403_BLOCKED
+    return FailureReason.http_status(response.status_code)
 
 
 def _parse_html_to_web_content(url: str, html: str) -> WebContent:
@@ -188,33 +222,40 @@ class OnyxWebCrawler(WebContentProvider):
             return _failed_result(url, FailureReason.NETWORK_ERROR)
 
         if response.status_code >= 400:
-            cf_challenge_suspected = _looks_like_bot_challenge_response(response)
-            if cf_challenge_suspected and self._playwright_fallback_enabled:
+            # Decide separately:
+            #   - whether to attempt the Playwright fallback (broad, any 403
+            #     is cheap insurance — some sites serve JS interstitials
+            #     without CF-specific headers)
+            #   - what failure reason to surface when nothing works (strict;
+            #     only claim "Cloudflare" when we have actual CF evidence,
+            #     either headers or a CF body returned by the render. A bare
+            #     403 from e.g. a private GitHub repo or expired presigned
+            #     S3 URL gets the generic-403 reason instead).
+            has_cf_signals = _has_cloudflare_signals(response)
+            try_fallback = (
+                self._playwright_fallback_enabled
+                and _should_try_playwright_fallback(response)
+            )
+
+            if try_fallback:
                 logger.info(
-                    "Onyx crawler got %s for %s with bot-challenge signals; "
-                    "retrying via Playwright",
+                    "Onyx crawler got %s for %s; retrying via Playwright "
+                    "(cf_signals=%s)",
                     response.status_code,
                     url,
+                    has_cf_signals,
                 )
                 fallback = self._fetch_via_playwright(url)
                 if fallback is not None:
+                    # Either a successful render OR a definitive CF-challenge
+                    # signal from the rendered body itself. Either way the
+                    # fallback's own result is the truth.
                     return fallback
-                # Playwright path either failed to render or came back with the
-                # challenge body itself — surface a CF-specific failure reason
-                # so the LLM stops retrying and the admin knows what to fix.
-                logger.warning(
-                    "Onyx crawler could not bypass Cloudflare challenge for %s",
-                    url,
-                )
-                return _failed_result(url, FailureReason.CLOUDFLARE_CHALLENGE)
 
             logger.warning("Onyx crawler received %s for %s", response.status_code, url)
-            reason = (
-                FailureReason.CLOUDFLARE_CHALLENGE
-                if cf_challenge_suspected
-                else FailureReason.http_status(response.status_code)
+            return _failed_result(
+                url, _failure_reason_for_status(response, has_cf_signals)
             )
-            return _failed_result(url, reason)
 
         content_type = response.headers.get("Content-Type", "")
         content = response.content
@@ -277,10 +318,15 @@ class OnyxWebCrawler(WebContentProvider):
         """Try a one-shot headless render.
 
         Returns:
-            WebContent on success.
-            None when the fallback didn't help (browser failed to launch,
-            CF challenge page came back, or content was empty/oversized).
-            The caller decides what failure_reason to surface in that case.
+            - Successful `WebContent` on success.
+            - Failed `WebContent` with `failure_reason=CLOUDFLARE_CHALLENGE`
+              when the render came back as the CF challenge interstitial
+              itself (a definitive signal we can pass up regardless of what
+              headers the original response carried).
+            - `None` when the fallback gave us no new information (Chromium
+              failed to launch, navigation hard-errored, content oversized,
+              or rendered HTML didn't parse to anything). Caller should fall
+              back to its own status-based failure reason.
         """
         rendered: RenderedPage | None = fetch_rendered_html(url)
         if rendered is None:
@@ -298,17 +344,17 @@ class OnyxWebCrawler(WebContentProvider):
             )
             return None
 
-        # If the render came back as a CF challenge interstitial itself,
-        # don't return it — it parses to "Just a moment..." or similar
-        # garbage that would mislead the LLM into thinking it had real
-        # content. Caller will surface the CLOUDFLARE_CHALLENGE reason.
+        # If the render came back as a CF challenge interstitial, surface
+        # that as a definitive CF failure (parsing it would just leak
+        # "Just a moment..." text to the LLM). This is the one case where
+        # Playwright actually adds information vs. the original 4xx.
         if looks_like_cloudflare_challenge(rendered.html):
             logger.info(
                 "Playwright fallback rendered the Cloudflare challenge page "
-                "itself for %s; treating as failure",
+                "itself for %s; treating as Cloudflare failure",
                 url,
             )
-            return None
+            return _failed_result(url, FailureReason.CLOUDFLARE_CHALLENGE)
 
         result = _parse_html_to_web_content(url, rendered.html)
         if not result.scrape_successful:

--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -99,7 +99,9 @@ def _should_try_playwright_fallback(response: requests.Response) -> bool:
     retry through a real browser (some sites serve JS-protected interstitials
     without CF headers). Real 401/404/410/5xx errors fall through unchanged.
     """
-    return response.status_code == 403 or _has_cloudflare_signals(response)
+    return response.status_code >= 300 and (
+        response.status_code == 403 or _has_cloudflare_signals(response)
+    )
 
 
 def _failure_reason_for_status(

--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 
+import requests
+
+from onyx.configs.app_configs import OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED
 from onyx.file_processing.html_utils import ParsedHTML
 from onyx.file_processing.html_utils import web_html_cleanup
 from onyx.tools.tool_implementations.open_url.models import WebContent
 from onyx.tools.tool_implementations.open_url.models import WebContentProvider
 from onyx.utils.logger import setup_logger
+from onyx.utils.playwright_fetch import fetch_rendered_html
+from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+from onyx.utils.playwright_fetch import RenderedPage
 from onyx.utils.url import ssrf_safe_get
 from onyx.utils.url import SSRFException
 from onyx.utils.web_content import decode_html_bytes
@@ -25,14 +31,85 @@ DEFAULT_MAX_PDF_SIZE_BYTES = 50 * 1024 * 1024  # 50 MB
 DEFAULT_MAX_HTML_SIZE_BYTES = 20 * 1024 * 1024  # 20 MB
 DEFAULT_MAX_WORKERS = 5
 
+# Headers that, when present on a 4xx response, signal that the upstream
+# is a Cloudflare-style bot challenge (vs. a real auth/not-found error)
+# and that retrying via a headless browser is likely to succeed.
+_CLOUDFLARE_HEADER_NAMES = ("cf-ray", "cf-mitigated")
 
-def _failed_result(url: str) -> WebContent:
+
+# Failure-reason strings surfaced to the LLM. Centralized so we don't drift
+# wording across call sites and so the LLM sees consistent text to reason
+# over (e.g. "don't bother retrying this URL").
+class FailureReason:
+    CLOUDFLARE_CHALLENGE = (
+        "blocked by a Cloudflare bot challenge that the built-in crawler "
+        "cannot solve — try a different URL or configure Firecrawl as the "
+        "web content provider"
+    )
+    SSRF_BLOCKED = "blocked by SSRF protection (URL resolves to an internal address)"
+    NETWORK_ERROR = "network error while fetching the URL"
+    OVERSIZED_HTML = "HTML response exceeded the configured maximum size"
+    OVERSIZED_PDF = "PDF response exceeded the configured maximum size"
+    DECODE_ERROR = "could not decode the response body"
+    EMPTY_OR_UNPARSEABLE = "response could not be parsed into readable text"
+
+    @staticmethod
+    def http_status(status_code: int) -> str:
+        return f"upstream returned HTTP {status_code}"
+
+
+def _failed_result(url: str, failure_reason: str | None = None) -> WebContent:
     return WebContent(
         title="",
         link=url,
         full_content="",
         published_date=None,
         scrape_successful=False,
+        failure_reason=failure_reason,
+    )
+
+
+def _looks_like_bot_challenge_response(response: requests.Response) -> bool:
+    """True if a non-2xx response looks like a Cloudflare/bot-management challenge.
+
+    Conservative on purpose: we want to spend Chromium time (and emit
+    "Cloudflare blocked us" failure reasons) only on responses that actually
+    look like CF challenges, not on real 401/404/410/etc. errors.
+    """
+    if response.status_code == 403:
+        return True
+    headers = response.headers
+    if any(name in headers for name in _CLOUDFLARE_HEADER_NAMES):
+        return True
+    server = headers.get("Server", "").lower()
+    return server.startswith("cloudflare")
+
+
+def _parse_html_to_web_content(url: str, html: str) -> WebContent:
+    """Run cleanup on raw HTML and shape the result into a WebContent.
+
+    Used by both the fast `requests` path and the Playwright fallback, so
+    they emit identical-shape results.
+    """
+    try:
+        parsed: ParsedHTML = web_html_cleanup(html)
+        text_content = parsed.cleaned_text or ""
+        title = parsed.title or ""
+    except Exception as exc:
+        logger.warning(
+            "Onyx crawler failed to parse %s (%s)", url, exc.__class__.__name__
+        )
+        return _failed_result(url, FailureReason.EMPTY_OR_UNPARSEABLE)
+
+    if not text_content.strip():
+        return _failed_result(url, FailureReason.EMPTY_OR_UNPARSEABLE)
+
+    return WebContent(
+        title=title,
+        link=url,
+        full_content=text_content,
+        published_date=None,
+        scrape_successful=True,
     )
 
 
@@ -41,6 +118,11 @@ class OnyxWebCrawler(WebContentProvider):
     Lightweight built-in crawler that fetches HTML directly and extracts readable text.
     Acts as the default content provider when no external crawler (e.g. Firecrawl) is
     configured.
+
+    On a Cloudflare/bot-challenge response (canonical entry point: HTTP 403,
+    or any response carrying a `cf-ray` / `cf-mitigated` header), falls back
+    to a one-shot headless-browser fetch via `playwright_fetch`. Controlled
+    by the `OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED` flag.
     """
 
     def __init__(
@@ -51,11 +133,13 @@ class OnyxWebCrawler(WebContentProvider):
         user_agent: str = DEFAULT_USER_AGENT,
         max_pdf_size_bytes: int | None = None,
         max_html_size_bytes: int | None = None,
+        playwright_fallback_enabled: bool = OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED,
     ) -> None:
         self._read_timeout_seconds = timeout_seconds
         self._connect_timeout_seconds = connect_timeout_seconds
         self._max_pdf_size_bytes = max_pdf_size_bytes
         self._max_html_size_bytes = max_html_size_bytes
+        self._playwright_fallback_enabled = playwright_fallback_enabled
         self._headers = {
             "User-Agent": user_agent,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -79,7 +163,7 @@ class OnyxWebCrawler(WebContentProvider):
                 url,
                 exc.__class__.__name__,
             )
-            return _failed_result(url)
+            return _failed_result(url, FailureReason.NETWORK_ERROR)
 
     def _fetch_url(self, url: str) -> WebContent:
         try:
@@ -94,44 +178,50 @@ class OnyxWebCrawler(WebContentProvider):
                 url,
                 exc.__class__.__name__,
             )
-            return _failed_result(url)
+            return _failed_result(url, FailureReason.SSRF_BLOCKED)
         except Exception as exc:
             logger.warning(
                 "Onyx crawler failed to fetch %s (%s)",
                 url,
                 exc.__class__.__name__,
             )
-            return _failed_result(url)
+            return _failed_result(url, FailureReason.NETWORK_ERROR)
 
         if response.status_code >= 400:
+            cf_challenge_suspected = _looks_like_bot_challenge_response(response)
+            if cf_challenge_suspected and self._playwright_fallback_enabled:
+                logger.info(
+                    "Onyx crawler got %s for %s with bot-challenge signals; "
+                    "retrying via Playwright",
+                    response.status_code,
+                    url,
+                )
+                fallback = self._fetch_via_playwright(url)
+                if fallback is not None:
+                    return fallback
+                # Playwright path either failed to render or came back with the
+                # challenge body itself — surface a CF-specific failure reason
+                # so the LLM stops retrying and the admin knows what to fix.
+                logger.warning(
+                    "Onyx crawler could not bypass Cloudflare challenge for %s",
+                    url,
+                )
+                return _failed_result(url, FailureReason.CLOUDFLARE_CHALLENGE)
+
             logger.warning("Onyx crawler received %s for %s", response.status_code, url)
-            return _failed_result(url)
+            reason = (
+                FailureReason.CLOUDFLARE_CHALLENGE
+                if cf_challenge_suspected
+                else FailureReason.http_status(response.status_code)
+            )
+            return _failed_result(url, reason)
 
         content_type = response.headers.get("Content-Type", "")
         content = response.content
 
         content_sniff = content[:1024] if content else None
         if is_pdf_resource(url, content_type, content_sniff):
-            if (
-                self._max_pdf_size_bytes is not None
-                and len(content) > self._max_pdf_size_bytes
-            ):
-                logger.warning(
-                    "PDF content too large (%d bytes) for %s, max is %d",
-                    len(content),
-                    url,
-                    self._max_pdf_size_bytes,
-                )
-                return _failed_result(url)
-            text_content, metadata = extract_pdf_text(content)
-            title = title_from_pdf_metadata(metadata) or title_from_url(url)
-            return WebContent(
-                title=title,
-                link=url,
-                full_content=text_content,
-                published_date=None,
-                scrape_successful=bool(text_content.strip()),
-            )
+            return self._handle_pdf_response(url, content)
 
         if (
             self._max_html_size_bytes is not None
@@ -143,7 +233,7 @@ class OnyxWebCrawler(WebContentProvider):
                 url,
                 self._max_html_size_bytes,
             )
-            return _failed_result(url)
+            return _failed_result(url, FailureReason.OVERSIZED_HTML)
 
         try:
             decoded_html = decode_html_bytes(
@@ -151,20 +241,77 @@ class OnyxWebCrawler(WebContentProvider):
                 content_type=content_type,
                 fallback_encoding=response.apparent_encoding or response.encoding,
             )
-            parsed: ParsedHTML = web_html_cleanup(decoded_html)
-            text_content = parsed.cleaned_text or ""
-            title = parsed.title or ""
         except Exception as exc:
             logger.warning(
-                "Onyx crawler failed to parse %s (%s)", url, exc.__class__.__name__
+                "Onyx crawler failed to decode %s (%s)", url, exc.__class__.__name__
             )
-            text_content = ""
-            title = ""
+            return _failed_result(url, FailureReason.DECODE_ERROR)
 
+        return _parse_html_to_web_content(url, decoded_html)
+
+    def _handle_pdf_response(self, url: str, content: bytes) -> WebContent:
+        if (
+            self._max_pdf_size_bytes is not None
+            and len(content) > self._max_pdf_size_bytes
+        ):
+            logger.warning(
+                "PDF content too large (%d bytes) for %s, max is %d",
+                len(content),
+                url,
+                self._max_pdf_size_bytes,
+            )
+            return _failed_result(url, FailureReason.OVERSIZED_PDF)
+        text_content, metadata = extract_pdf_text(content)
+        title = title_from_pdf_metadata(metadata) or title_from_url(url)
+        if not text_content.strip():
+            return _failed_result(url, FailureReason.EMPTY_OR_UNPARSEABLE)
         return WebContent(
             title=title,
             link=url,
             full_content=text_content,
             published_date=None,
-            scrape_successful=bool(text_content.strip()),
+            scrape_successful=True,
         )
+
+    def _fetch_via_playwright(self, url: str) -> WebContent | None:
+        """Try a one-shot headless render.
+
+        Returns:
+            WebContent on success.
+            None when the fallback didn't help (browser failed to launch,
+            CF challenge page came back, or content was empty/oversized).
+            The caller decides what failure_reason to surface in that case.
+        """
+        rendered: RenderedPage | None = fetch_rendered_html(url)
+        if rendered is None:
+            return None
+
+        if (
+            self._max_html_size_bytes is not None
+            and len(rendered.html) > self._max_html_size_bytes
+        ):
+            logger.warning(
+                "Rendered HTML too large (%d chars) for %s, max is %d",
+                len(rendered.html),
+                url,
+                self._max_html_size_bytes,
+            )
+            return None
+
+        # If the render came back as a CF challenge interstitial itself,
+        # don't return it — it parses to "Just a moment..." or similar
+        # garbage that would mislead the LLM into thinking it had real
+        # content. Caller will surface the CLOUDFLARE_CHALLENGE reason.
+        if looks_like_cloudflare_challenge(rendered.html):
+            logger.info(
+                "Playwright fallback rendered the Cloudflare challenge page "
+                "itself for %s; treating as failure",
+                url,
+            )
+            return None
+
+        result = _parse_html_to_web_content(url, rendered.html)
+        if not result.scrape_successful:
+            return None
+        logger.info("Playwright fallback succeeded for %s", url)
+        return result

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -30,6 +30,7 @@ from onyx.tools.interface import Tool
 from onyx.tools.models import OpenURLToolOverrideKwargs
 from onyx.tools.models import ToolCallException
 from onyx.tools.models import ToolResponse
+from onyx.tools.tool_implementations.open_url.models import FailedFetch
 from onyx.tools.tool_implementations.open_url.models import WebContentProvider
 from onyx.tools.tool_implementations.open_url.url_normalization import (
     _default_url_normalizer,
@@ -77,6 +78,46 @@ class IndexedDocumentRequest(BaseModel):
 class IndexedRetrievalResult(BaseModel):
     sections: list[InferenceSection]
     missing_document_ids: list[str]
+
+
+def _format_failed_url(failure: FailedFetch) -> str:
+    """Format one failed URL for the LLM-facing failure message.
+
+    With a reason: "https://x.com (blocked by a Cloudflare bot challenge ...)"
+    Without:        "https://x.com"
+    """
+    if failure.failure_reason:
+        return f"{failure.url} ({failure.failure_reason})"
+    return failure.url
+
+
+def _build_failure_message(
+    *,
+    missing_document_ids: list[str],
+    failed_web_fetches: list[FailedFetch],
+) -> str:
+    """Construct the human-/LLM-readable failure message.
+
+    Includes per-URL `failure_reason` strings so the LLM knows e.g. that a
+    URL is bot-protected and shouldn't be re-tried verbatim.
+    """
+    parts: list[str] = []
+    if missing_document_ids:
+        parts.append("documents " + ", ".join(sorted(set(missing_document_ids))))
+
+    cleaned_failures = [f for f in failed_web_fetches if f.url]
+    if cleaned_failures:
+        # Dedup by URL, prefer the first FailedFetch we see for each (which
+        # already has the most-informative reason from `_mark_failed`).
+        deduped: dict[str, FailedFetch] = {}
+        for f in cleaned_failures:
+            deduped.setdefault(f.url, f)
+        ordered = sorted(deduped.values(), key=lambda f: f.url)
+        parts.append("URLs " + ", ".join(_format_failed_url(f) for f in ordered))
+
+    if not parts:
+        return "Failed to fetch content from the requested resources."
+    return "Failed to fetch content from " + " and ".join(parts)
 
 
 def _dedupe_preserve_order(values: list[str]) -> list[str]:
@@ -558,7 +599,7 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
             indexed_result = indexed_result or IndexedRetrievalResult(
                 sections=[], missing_document_ids=[]
             )
-            crawled_sections, failed_web_urls = crawled_result or ([], [])
+            crawled_sections, failed_web_fetches = crawled_result or ([], [])
 
             # If timeout occurred and we have no successful results from either path,
             # return a timeout-specific error message
@@ -574,9 +615,9 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
 
             # Last-resort: attempt link-based lookup for URLs that failed both
             # document-ID resolution and crawling.
-            failed_web_urls = self._fallback_link_lookup(
+            failed_web_fetches = self._fallback_link_lookup(
                 unresolved_urls=unresolved_urls,
-                failed_web_urls=failed_web_urls,
+                failed_web_fetches=failed_web_fetches,
                 db_session=db_session,
                 indexed_result=indexed_result,
                 url_to_doc_id=url_to_doc_id,
@@ -589,24 +630,13 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                 crawled_sections,
                 url_to_doc_id,
                 urls,
-                failed_web_urls,
+                failed_web_fetches,
             )
 
         if not inference_sections:
-            failure_descriptions = []
-            if indexed_result.missing_document_ids:
-                failure_descriptions.append(
-                    "documents "
-                    + ", ".join(sorted(set(indexed_result.missing_document_ids)))
-                )
-            if failed_web_urls:
-                cleaned_failures = sorted({url for url in failed_web_urls if url})
-                if cleaned_failures:
-                    failure_descriptions.append("URLs " + ", ".join(cleaned_failures))
-            failure_msg = (
-                "Failed to fetch content from " + " and ".join(failure_descriptions)
-                if failure_descriptions
-                else "Failed to fetch content from the requested resources."
+            failure_msg = _build_failure_message(
+                missing_document_ids=indexed_result.missing_document_ids,
+                failed_web_fetches=failed_web_fetches,
             )
             logger.warning(f"OpenURL tool failed: {failure_msg}")
             return ToolResponse(rich_response=None, llm_facing_response=failure_msg)
@@ -648,38 +678,38 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
     def _fallback_link_lookup(
         self,
         unresolved_urls: list[str],
-        failed_web_urls: list[str],
+        failed_web_fetches: list[FailedFetch],
         db_session: Session,
         indexed_result: IndexedRetrievalResult,
         url_to_doc_id: dict[str, str],
         filters: IndexFilters,
-    ) -> list[str]:
+    ) -> list[FailedFetch]:
         """Attempt link-based lookup for URLs that failed both document-ID resolution and crawling.
 
         Args:
             unresolved_urls: URLs that couldn't be resolved to document IDs
-            failed_web_urls: URLs that failed crawling
+            failed_web_fetches: URLs that failed crawling, with per-URL reasons
             db_session: Database session
             indexed_result: Result object to update with found sections
             url_to_doc_id: Mapping to update with resolved URLs
             filters: Pre-built index filters for document retrieval
 
         Returns:
-            Updated list of failed_web_urls (with resolved URLs removed)
+            Updated list of failed fetches (with resolved URLs removed)
         """
-        if not unresolved_urls or not failed_web_urls:
-            return failed_web_urls
+        if not unresolved_urls or not failed_web_fetches:
+            return failed_web_fetches
 
-        failed_set = {url for url in failed_web_urls if url}
+        failed_set = {f.url for f in failed_web_fetches if f.url}
         fallback_urls = sorted(set(unresolved_urls).intersection(failed_set))
 
         if not fallback_urls:
-            return failed_web_urls
+            return failed_web_fetches
 
         fallback_requests = _lookup_document_ids_by_link(fallback_urls, db_session)
 
         if not fallback_requests:
-            return failed_web_urls
+            return failed_web_fetches
 
         deduped_fallback_requests = _dedupe_document_requests(fallback_requests)
         fallback_result = self._retrieve_indexed_documents_with_filters(
@@ -698,7 +728,7 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
             )
 
         resolved_links = {request.original_url for request in deduped_fallback_requests}
-        return [url for url in failed_web_urls if url not in resolved_links]
+        return [f for f in failed_web_fetches if f.url not in resolved_links]
 
     def _retrieve_indexed_documents_with_filters(
         self,
@@ -773,14 +803,14 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         crawled_sections: list[InferenceSection],
         url_to_doc_id: dict[str, str],
         all_urls: list[str],
-        failed_web_urls: list[str],  # noqa: ARG002
+        failed_web_fetches: list[FailedFetch],  # noqa: ARG002
     ) -> list[InferenceSection]:
         """Merge indexed and crawled results, preferring indexed when available.
 
         For each URL:
         - If indexed result exists and has content, use it (better/cleaner representation)
         - Otherwise, use crawled result if available
-        - If both fail, the URL will be in failed_web_urls for error reporting
+        - If both fail, the URL will be in failed_web_fetches for error reporting
         """
         # Map indexed sections by document_id
         indexed_by_doc_id: dict[str, InferenceSection] = {}
@@ -827,18 +857,29 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
 
     def _fetch_web_content(
         self, urls: list[str], url_snippet_map: dict[str, str]
-    ) -> tuple[list[InferenceSection], list[str]]:
+    ) -> tuple[list[InferenceSection], list[FailedFetch]]:
         if not urls:
             return [], []
 
         raw_web_contents = self._provider.contents(urls)
+        # Track per-URL failure reasons (preferred) but de-dupe by URL since the
+        # same URL can show up in both the "empty" and "scrape unsuccessful"
+        # branches below.
+        failed_by_url: dict[str, FailedFetch] = {}
+
+        def _mark_failed(url: str, reason: str | None) -> None:
+            existing = failed_by_url.get(url)
+            # Prefer a non-None reason if we have one, otherwise keep the
+            # earlier entry (which itself may already have a reason).
+            if existing is None or (reason and not existing.failure_reason):
+                failed_by_url[url] = FailedFetch(url=url, failure_reason=reason)
+
         # Treat "no title and no content" as a failure for that URL, but don't
         # include the empty entry in downstream prompting/sections.
-        failed_urls: list[str] = [
-            content.link
-            for content in raw_web_contents
-            if not content.title.strip() and not content.full_content.strip()
-        ]
+        for content in raw_web_contents:
+            if not content.title.strip() and not content.full_content.strip():
+                _mark_failed(content.link, content.failure_reason)
+
         web_contents = filter_web_contents_with_no_title_or_content(raw_web_contents)
         sections: list[InferenceSection] = []
 
@@ -863,9 +904,6 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                     )
                 )
             else:
-                # TODO: Slight improvement - if failed URL reasons are passed back to the LLM
-                # for example, if it tries to crawl Reddit and fails, it should know (probably) that this error would
-                # happen again if it tried to crawl Reddit again.
-                failed_urls.append(content.link or "")
+                _mark_failed(content.link or "", content.failure_reason)
 
-        return sections, failed_urls
+        return sections, list(failed_by_url.values())

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -1,0 +1,308 @@
+"""Shared Playwright-based fetching helpers.
+
+Centralizes the browser-launch tuning and bot-detection-aware navigation
+logic that was originally embedded in `onyx.connectors.web.connector`.
+
+Two consumers:
+- `WebConnector` (long-lived `BrowserContext` reused across many pages
+  in a single crawl) uses `start_playwright()` directly.
+- `OnyxWebCrawler` (lazy fallback when its `requests`-based fetch hits
+  a Cloudflare/bot challenge) uses `fetch_rendered_html()` to do a
+  one-shot navigation per URL.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from playwright.sync_api import BrowserContext
+from playwright.sync_api import Playwright
+from playwright.sync_api import sync_playwright
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from pydantic import BaseModel
+
+from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_ID
+from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_CLIENT_SECRET
+from onyx.configs.app_configs import WEB_CONNECTOR_OAUTH_TOKEN_URL
+from onyx.utils.logger import setup_logger
+from onyx.utils.url import SSRFException
+from onyx.utils.url import validate_outbound_http_url
+
+logger = setup_logger()
+
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+)
+
+DEFAULT_HEADERS: dict[str, str] = {
+    "User-Agent": DEFAULT_USER_AGENT,
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,"
+        "image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    # Brotli decoding has been flaky in brotlicffi/httpx for certain chunked responses;
+    # stick to gzip/deflate to keep connectivity checks stable.
+    "Accept-Encoding": "gzip, deflate",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Sec-CH-UA": '"Google Chrome";v="123", "Not:A-Brand";v="8"',
+    "Sec-CH-UA-Mobile": "?0",
+    "Sec-CH-UA-Platform": '"macOS"',
+}
+
+# Grace period after page navigation to allow bot-detection challenges
+# (Cloudflare / Imperva / etc.) and SPA content rendering to complete.
+DEFAULT_BOT_CHALLENGE_GRACE_MS = 5000
+
+# Total per-navigation budget for Playwright `goto` / wait_for_load_state.
+# Generous because we *want* to absorb a Cloudflare interstitial.
+DEFAULT_NAVIGATION_TIMEOUT_MS = 30000
+
+
+class RenderedPage(BaseModel):
+    """Result of a successful Playwright navigation."""
+
+    html: str
+    final_url: str
+    last_modified: str | None = None
+    status: int | None = None
+
+
+def start_playwright() -> Tuple[Playwright, BrowserContext]:
+    """Launch a Playwright Chromium context tuned to look like a real browser.
+
+    Used by both the long-lived web-connector crawl and the one-shot
+    OnyxWebCrawler fallback. Caller owns lifecycle and must call
+    `context.close()` + `playwright.stop()` when done.
+    """
+    playwright = sync_playwright().start()
+
+    browser = playwright.chromium.launch(
+        headless=True,
+        args=[
+            "--disable-blink-features=AutomationControlled",
+            "--disable-features=IsolateOrigins,site-per-process",
+            "--disable-site-isolation-trials",
+        ],
+    )
+
+    context = browser.new_context(
+        user_agent=DEFAULT_USER_AGENT,
+        viewport={"width": 1440, "height": 900},
+        device_scale_factor=2.0,
+        locale="en-US",
+        timezone_id="America/Los_Angeles",
+        has_touch=False,
+        java_script_enabled=True,
+        color_scheme="light",
+        bypass_csp=True,
+        ignore_https_errors=True,
+    )
+
+    context.set_extra_http_headers(
+        {
+            "Accept": DEFAULT_HEADERS["Accept"],
+            "Accept-Language": DEFAULT_HEADERS["Accept-Language"],
+            "Sec-Fetch-Dest": DEFAULT_HEADERS["Sec-Fetch-Dest"],
+            "Sec-Fetch-Mode": DEFAULT_HEADERS["Sec-Fetch-Mode"],
+            "Sec-Fetch-Site": DEFAULT_HEADERS["Sec-Fetch-Site"],
+            "Sec-Fetch-User": DEFAULT_HEADERS["Sec-Fetch-User"],
+            "Sec-CH-UA": DEFAULT_HEADERS["Sec-CH-UA"],
+            "Sec-CH-UA-Mobile": DEFAULT_HEADERS["Sec-CH-UA-Mobile"],
+            "Sec-CH-UA-Platform": DEFAULT_HEADERS["Sec-CH-UA-Platform"],
+            "Cache-Control": "max-age=0",
+            "DNT": "1",
+        }
+    )
+
+    # Hide common automation tells used by bot-detection scripts.
+    context.add_init_script(
+        """
+        Object.defineProperty(navigator, 'webdriver', {
+            get: () => undefined
+        });
+        Object.defineProperty(navigator, 'plugins', {
+            get: () => [1, 2, 3, 4, 5]
+        });
+        Object.defineProperty(navigator, 'languages', {
+            get: () => ['en-US', 'en']
+        });
+    """
+    )
+
+    if (
+        WEB_CONNECTOR_OAUTH_CLIENT_ID
+        and WEB_CONNECTOR_OAUTH_CLIENT_SECRET
+        and WEB_CONNECTOR_OAUTH_TOKEN_URL
+    ):
+        # Imported lazily so the OAuth deps don't get pulled in unless configured.
+        from oauthlib.oauth2 import BackendApplicationClient
+        from requests_oauthlib import OAuth2Session
+
+        client = BackendApplicationClient(client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID)
+        oauth = OAuth2Session(client=client)
+        token = oauth.fetch_token(
+            token_url=WEB_CONNECTOR_OAUTH_TOKEN_URL,
+            client_id=WEB_CONNECTOR_OAUTH_CLIENT_ID,
+            client_secret=WEB_CONNECTOR_OAUTH_CLIENT_SECRET,
+        )
+        context.set_extra_http_headers(
+            {"Authorization": "Bearer {}".format(token["access_token"])}
+        )
+
+    return playwright, context
+
+
+def _looks_like_bot_challenge(status: int, cf_ray_header: str | None) -> bool:
+    """Heuristic: did this response look like a Cloudflare/Imperva challenge?
+
+    We trigger the post-navigation grace period when *either* signal is
+    present so JS challenges have time to resolve before we read the DOM.
+    """
+    return cf_ray_header is not None or status == 403
+
+
+# Strings that appear in Cloudflare challenge HTML bodies (Managed Challenge,
+# Turnstile interstitial, "I'm Under Attack" mode, etc.). If a rendered page
+# still contains any of these after our grace period, the JS challenge did
+# not resolve (or we were actively rejected) and the body is the challenge
+# page itself rather than the real content.
+#
+# Why these specifically:
+# - `challenges.cloudflare.com` — script src on every CF challenge page
+# - `/cdn-cgi/challenge-platform/` — CF's challenge JS path
+# - `cf-chl-bypass` — class on CF challenge container divs
+# - `cf-mitigated` — appears in some challenge bodies as well as headers
+# - `Just a moment...` — title on the legacy IUAM challenge page
+# - `Verifying you are human` — Managed Challenge / Turnstile UI string
+_CLOUDFLARE_CHALLENGE_BODY_MARKERS = (
+    "challenges.cloudflare.com",
+    "/cdn-cgi/challenge-platform/",
+    "cf-chl-bypass",
+    "cf-mitigated",
+    "Just a moment...",
+    "Verifying you are human",
+)
+
+
+def looks_like_cloudflare_challenge(html: str) -> bool:
+    """Did this rendered HTML come back as a Cloudflare challenge page?
+
+    Used by callers (e.g. `OnyxWebCrawler`) to distinguish "we got real
+    content" from "Chromium rendered the challenge interstitial itself
+    because CF didn't let us through". The latter must NOT be returned
+    to the LLM as if it were the page.
+    """
+    if not html:
+        return False
+    return any(marker in html for marker in _CLOUDFLARE_CHALLENGE_BODY_MARKERS)
+
+
+def fetch_rendered_html(
+    url: str,
+    *,
+    navigation_timeout_ms: int = DEFAULT_NAVIGATION_TIMEOUT_MS,
+    bot_challenge_grace_ms: int = DEFAULT_BOT_CHALLENGE_GRACE_MS,
+) -> RenderedPage | None:
+    """Render a single URL via headless Chromium and return the final HTML.
+
+    Owns its own short-lived Playwright lifecycle (one context per call),
+    so it's safe to invoke from arbitrary worker threads. Suitable for
+    one-shot fetches where bot-detection mitigation is needed; not the
+    right tool for high-volume crawling (use a long-lived `BrowserContext`
+    via `start_playwright()` instead).
+
+    Returns:
+        RenderedPage on success, or None if navigation failed entirely
+        (including SSRF rejection of the URL). A non-None return with a
+        4xx/5xx `status` is still possible — the caller can decide whether
+        to use the rendered HTML (challenge pages often render real content
+        after JS executes despite the original 4xx status code).
+    """
+    # Playwright bypasses our `requests`-level SSRF protection, so revalidate
+    # the URL here before letting Chromium navigate to it. Note: there is a
+    # small TOCTOU window between validation and the actual navigation, the
+    # same window that ssrf_safe_get accepts for HTTPS URLs.
+    try:
+        validate_outbound_http_url(url)
+    except (SSRFException, ValueError) as exc:
+        logger.warning(
+            "Refusing Playwright fallback for %s (%s)", url, exc.__class__.__name__
+        )
+        return None
+
+    playwright: Playwright | None = None
+    context: BrowserContext | None = None
+    try:
+        playwright, context = start_playwright()
+        page = context.new_page()
+        try:
+            # Use "commit" instead of "domcontentloaded" to avoid hanging
+            # on bot-detection pages that may never fire domcontentloaded.
+            response = page.goto(
+                url,
+                timeout=navigation_timeout_ms,
+                wait_until="commit",
+            )
+
+            cf_ray = response.header_value("cf-ray") if response else None
+            status = response.status if response else None
+
+            if status is not None and _looks_like_bot_challenge(status, cf_ray):
+                page.wait_for_timeout(bot_challenge_grace_ms)
+
+            # Best-effort wait for network to settle (SPA / CF challenge JS).
+            try:
+                page.wait_for_load_state("networkidle", timeout=bot_challenge_grace_ms)
+            except PlaywrightTimeoutError:
+                pass
+
+            html = page.content()
+            final_url = page.url
+            last_modified = response.header_value("Last-Modified") if response else None
+            return RenderedPage(
+                html=html,
+                final_url=final_url,
+                last_modified=last_modified,
+                status=status,
+            )
+        finally:
+            page.close()
+    except Exception as exc:
+        msg = str(exc)
+        if "Executable doesn't exist" in msg:
+            # Friendlier message for the common "venv has Playwright but
+            # Chromium binary not installed" footgun. Production Docker
+            # images install it during build (see backend/Dockerfile),
+            # but local dev `pip install`s won't.
+            logger.warning(
+                "Playwright fallback unavailable for %s: Chromium binary not "
+                "installed. Run `playwright install chromium` in your venv.",
+                url,
+            )
+        else:
+            logger.warning(
+                "Playwright fallback failed to render %s (%s: %s)",
+                url,
+                exc.__class__.__name__,
+                msg.splitlines()[0] if msg else "",
+            )
+        return None
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:
+                logger.debug("Failed to close Playwright context", exc_info=True)
+        if playwright is not None:
+            try:
+                playwright.stop()
+            except Exception:
+                logger.debug("Failed to stop Playwright", exc_info=True)

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -11,10 +11,6 @@ Two consumers:
   one-shot navigation per URL.
 """
 
-from __future__ import annotations
-
-from typing import Tuple
-
 from playwright.sync_api import BrowserContext
 from playwright.sync_api import Playwright
 from playwright.sync_api import sync_playwright
@@ -75,7 +71,7 @@ class RenderedPage(BaseModel):
     status: int | None = None
 
 
-def start_playwright() -> Tuple[Playwright, BrowserContext]:
+def start_playwright() -> tuple[Playwright, BrowserContext]:
     """Launch a Playwright Chromium context tuned to look like a real browser.
 
     Used by both the long-lived web-connector crawl and the one-shot

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -229,9 +229,9 @@ def looks_like_cloudflare_challenge(html: str) -> bool:
     because CF didn't let us through". The latter must NOT be returned
     to the LLM as if it were the page.
     """
-    if not html:
-        return False
-    return any(marker in html for marker in _CLOUDFLARE_CHALLENGE_BODY_MARKERS)
+    return bool(html) and any(
+        marker in html for marker in _CLOUDFLARE_CHALLENGE_BODY_MARKERS
+    )
 
 
 def fetch_rendered_html(

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -11,6 +11,9 @@ Two consumers:
   one-shot navigation per URL.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from playwright.sync_api import BrowserContext
 from playwright.sync_api import Playwright
 from playwright.sync_api import sync_playwright
@@ -156,6 +159,36 @@ def start_playwright() -> tuple[Playwright, BrowserContext]:
     return playwright, context
 
 
+@contextmanager
+def playwright_session() -> Iterator[BrowserContext]:
+    """Context-manager wrapper around `start_playwright()` for one-shot use.
+
+    Yields a `BrowserContext` and guarantees both the context and the
+    underlying `Playwright` instance are torn down when the `with` block
+    exits, including when setup itself raises (e.g. missing Chromium binary).
+    Use this for short-lived fetches that own their Playwright lifecycle
+    end-to-end. Long-lived crawls that need to detach setup from teardown
+    across method boundaries (see `WebConnector`) should keep using
+    `start_playwright()` directly.
+    """
+    playwright: Playwright | None = None
+    context: BrowserContext | None = None
+    try:
+        playwright, context = start_playwright()
+        yield context
+    finally:
+        if context is not None:
+            try:
+                context.close()
+            except Exception:
+                logger.debug("Failed to close Playwright context", exc_info=True)
+        if playwright is not None:
+            try:
+                playwright.stop()
+            except Exception:
+                logger.debug("Failed to stop Playwright", exc_info=True)
+
+
 def _looks_like_bot_challenge(status: int, cf_ray_header: str | None) -> bool:
     """Heuristic: did this response look like a Cloudflare/Imperva challenge?
 
@@ -234,43 +267,45 @@ def fetch_rendered_html(
         )
         return None
 
-    playwright: Playwright | None = None
-    context: BrowserContext | None = None
     try:
-        playwright, context = start_playwright()
-        page = context.new_page()
-        try:
-            # Use "commit" instead of "domcontentloaded" to avoid hanging
-            # on bot-detection pages that may never fire domcontentloaded.
-            response = page.goto(
-                url,
-                timeout=navigation_timeout_ms,
-                wait_until="commit",
-            )
-
-            cf_ray = response.header_value("cf-ray") if response else None
-            status = response.status if response else None
-
-            if status is not None and _looks_like_bot_challenge(status, cf_ray):
-                page.wait_for_timeout(bot_challenge_grace_ms)
-
-            # Best-effort wait for network to settle (SPA / CF challenge JS).
+        with playwright_session() as context:
+            page = context.new_page()
             try:
-                page.wait_for_load_state("networkidle", timeout=bot_challenge_grace_ms)
-            except PlaywrightTimeoutError:
-                pass
+                # Use "commit" instead of "domcontentloaded" to avoid hanging
+                # on bot-detection pages that may never fire domcontentloaded.
+                response = page.goto(
+                    url,
+                    timeout=navigation_timeout_ms,
+                    wait_until="commit",
+                )
 
-            html = page.content()
-            final_url = page.url
-            last_modified = response.header_value("Last-Modified") if response else None
-            return RenderedPage(
-                html=html,
-                final_url=final_url,
-                last_modified=last_modified,
-                status=status,
-            )
-        finally:
-            page.close()
+                cf_ray = response.header_value("cf-ray") if response else None
+                status = response.status if response else None
+
+                if status is not None and _looks_like_bot_challenge(status, cf_ray):
+                    page.wait_for_timeout(bot_challenge_grace_ms)
+
+                # Best-effort wait for network to settle (SPA / CF challenge JS).
+                try:
+                    page.wait_for_load_state(
+                        "networkidle", timeout=bot_challenge_grace_ms
+                    )
+                except PlaywrightTimeoutError:
+                    pass
+
+                html = page.content()
+                final_url = page.url
+                last_modified = (
+                    response.header_value("Last-Modified") if response else None
+                )
+                return RenderedPage(
+                    html=html,
+                    final_url=final_url,
+                    last_modified=last_modified,
+                    status=status,
+                )
+            finally:
+                page.close()
     except Exception as exc:
         msg = str(exc)
         if "Executable doesn't exist" in msg:
@@ -291,14 +326,3 @@ def fetch_rendered_html(
                 msg.splitlines()[0] if msg else "",
             )
         return None
-    finally:
-        if context is not None:
-            try:
-                context.close()
-            except Exception:
-                logger.debug("Failed to close Playwright context", exc_info=True)
-        if playwright is not None:
-            try:
-                playwright.stop()
-            except Exception:
-                logger.debug("Failed to stop Playwright", exc_info=True)

--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -79,19 +79,28 @@ class TestOnyxWebCrawler:
         assert data["results"] == []
 
     def test_handles_404_page(self, admin_user: DATestUser) -> None:
-        """Test that the crawler handles 404 responses gracefully."""
+        """Test that the crawler surfaces a 404 page's body to the LLM.
+
+        Some "soft 404" pages (like example.com's, which returns HTTP 404 but
+        still serves the standard Example Domain HTML body) carry useful
+        signal. We deliberately surface the parsed content so the LLM can see
+        what the URL actually returned, rather than silently dropping it.
+        """
+        url = "https://example.com/this-page-does-not-exist-12345"
         response = requests.post(
             f"{API_SERVER_URL}/web-search/open-urls",
-            json={"urls": ["https://example.com/this-page-does-not-exist-12345"]},
+            json={"urls": [url]},
             headers=admin_user.headers,
         )
         assert response.status_code == 200, response.text
         data = response.json()
 
         assert data["provider_type"] == WebContentProviderType.ONYX_WEB_CRAWLER.value
+        assert len(data["results"]) == 1
 
-        # Non-200 responses are treated as non-content and filtered out
-        assert data["results"] == []
+        result = data["results"][0]
+        assert result["unique_identifier_to_strip_away"] == url
+        assert result["content"].strip(), "Expected non-empty content for soft-404 page"
 
     def test_https_url_with_path(self, admin_user: DATestUser) -> None:
         """Test that the crawler handles HTTPS URLs with paths correctly."""

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
@@ -281,16 +281,35 @@ def test_rendered_cloudflare_challenge_body_yields_failure_with_reason(
 def test_render_failure_with_cf_signals_yields_cloudflare_reason(
     mock_get: MagicMock, mock_render: MagicMock
 ) -> None:
-    """When the original 403 had CF signals AND Playwright failed to render
-    at all (None), the surfaced reason should still call out Cloudflare —
-    not a generic 'upstream returned 403'."""
-    mock_get.return_value = _mock_response(status_code=403)
+    """When the original 403 had actual CF headers AND Playwright failed to
+    render, the surfaced reason should call out Cloudflare specifically."""
+    mock_get.return_value = _mock_response(
+        status_code=403, headers={"cf-mitigated": "challenge"}
+    )
     mock_render.return_value = None
 
     result = OnyxWebCrawler()._fetch_url("https://example.com/")
 
     assert not result.scrape_successful
     assert result.failure_reason == FailureReason.CLOUDFLARE_CHALLENGE
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_bare_403_without_cf_signals_yields_generic_403_reason(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    """A 403 with no Cloudflare evidence shouldn't be labelled as Cloudflare —
+    it's far more likely to be an auth wall or restricted resource. Playwright
+    is still tried as cheap insurance, but the reason is honest."""
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = None
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()  # fallback still tried
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.HTTP_403_BLOCKED
 
 
 # ---------------------------------------------------------------------------
@@ -332,19 +351,35 @@ def test_network_error_failure_reason(mock_get: MagicMock) -> None:
 
 
 @patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
-def test_403_with_fallback_disabled_yields_cloudflare_reason(
+def test_403_with_cf_signals_and_fallback_disabled_yields_cloudflare_reason(
     mock_get: MagicMock,
 ) -> None:
-    """Even without invoking Playwright, a 403 with CF signals should still
-    label the failure as a CF challenge — admins shouldn't have to enable
+    """A 403 with actual CF headers should still label as a CF challenge
+    even without invoking Playwright — admins shouldn't have to enable
     the fallback to find out why their URL is failing."""
-    mock_get.return_value = _mock_response(status_code=403)
+    mock_get.return_value = _mock_response(
+        status_code=403, headers={"cf-ray": "9f4994882a46eb36-SJC"}
+    )
 
     crawler = OnyxWebCrawler(playwright_fallback_enabled=False)
     result = crawler._fetch_url("https://example.com/")
 
     assert not result.scrape_successful
     assert result.failure_reason == FailureReason.CLOUDFLARE_CHALLENGE
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_bare_403_with_fallback_disabled_yields_generic_403_reason(
+    mock_get: MagicMock,
+) -> None:
+    """No CF headers + fallback disabled: don't pretend it's Cloudflare."""
+    mock_get.return_value = _mock_response(status_code=403)
+
+    crawler = OnyxWebCrawler(playwright_fallback_enabled=False)
+    result = crawler._fetch_url("https://example.com/")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.HTTP_403_BLOCKED
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
@@ -1,0 +1,360 @@
+"""Tests for OnyxWebCrawler's Playwright fallback on Cloudflare/bot challenges.
+
+The fallback is triggered when the fast `requests` path returns a response
+that looks like a Cloudflare challenge (HTTP 403, or any 4xx with `cf-ray`
+/ `cf-mitigated` headers, or `Server: cloudflare`). On hit, we try a
+one-shot headless render and re-parse.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import onyx.tools.tool_implementations.open_url.onyx_web_crawler as crawler_module
+from onyx.tools.tool_implementations.open_url.onyx_web_crawler import FailureReason
+from onyx.tools.tool_implementations.open_url.onyx_web_crawler import OnyxWebCrawler
+from onyx.utils.playwright_fetch import RenderedPage
+
+SUCCESS_HTML = "<html><head><title>Real Page</title></head><body><p>Hello world, this is real content from the page after rendering.</p></body></html>"
+# Empty rendered page — what we'd get if Playwright navigation produced nothing
+# parseable (e.g. CF challenge hung past our grace period and was never replaced).
+EMPTY_HTML = "<html><body></body></html>"
+# Realistic-ish CF challenge interstitial. The marker that triggers detection
+# is the script src referencing `challenges.cloudflare.com`.
+CF_CHALLENGE_HTML = """<html>
+<head><title>Just a moment...</title></head>
+<body>
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+<p>Verifying you are human. This may take a few seconds.</p>
+</body></html>"""
+
+
+def _mock_response(
+    *,
+    status_code: int,
+    headers: dict[str, str] | None = None,
+    content: bytes = b"",
+    content_type: str = "text/html",
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    merged_headers = {"Content-Type": content_type, **(headers or {})}
+    resp.headers = merged_headers
+    resp.content = content
+    resp.apparent_encoding = None
+    resp.encoding = None
+    return resp
+
+
+def _ok_rendered() -> RenderedPage:
+    return RenderedPage(
+        html=SUCCESS_HTML,
+        final_url="https://example.com/",
+        last_modified=None,
+        status=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback-trigger tests: which responses cause us to invoke Playwright?
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_403_triggers_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = _ok_rendered()
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once_with("https://example.com/")
+    assert result.scrape_successful
+    assert "Hello world" in result.full_content
+    assert result.title == "Real Page"
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_4xx_with_cf_ray_triggers_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(
+        status_code=429, headers={"cf-ray": "9f4994882a46eb36-SJC"}
+    )
+    mock_render.return_value = _ok_rendered()
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+    assert result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_4xx_with_cf_mitigated_triggers_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(
+        status_code=503, headers={"cf-mitigated": "challenge"}
+    )
+    mock_render.return_value = _ok_rendered()
+
+    OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_4xx_with_server_cloudflare_triggers_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(
+        status_code=503, headers={"Server": "cloudflare"}
+    )
+    mock_render.return_value = _ok_rendered()
+
+    OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Conservatism: don't fire Playwright when there's no reason to.
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_2xx_skips_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(
+        status_code=200, content=SUCCESS_HTML.encode()
+    )
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_not_called()
+    assert result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_404_without_cloudflare_signals_skips_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=404)
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/missing")
+
+    mock_render.assert_not_called()
+    assert not result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_401_without_cloudflare_signals_skips_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=401)
+
+    OnyxWebCrawler()._fetch_url("https://example.com/private")
+
+    mock_render.assert_not_called()
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_500_without_cloudflare_signals_skips_playwright_fallback(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=500)
+
+    OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Feature flag and fallback failure behavior.
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_fallback_disabled_skips_playwright(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=403)
+
+    crawler = OnyxWebCrawler(playwright_fallback_enabled=False)
+    result = crawler._fetch_url("https://example.com/")
+
+    mock_render.assert_not_called()
+    assert not result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_fallback_render_returns_none_yields_failure(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    """If Playwright itself fails (e.g. Chromium not installed), we surface failure."""
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = None
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+    assert not result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_fallback_returns_empty_page_yields_failure(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    """A render that comes back empty (e.g. CF challenge never resolved) is a failure."""
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = RenderedPage(
+        html=EMPTY_HTML, final_url="https://example.com/", status=403
+    )
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+    assert not result.scrape_successful
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_fallback_respects_max_html_size(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    mock_get.return_value = _mock_response(status_code=403)
+    huge_html = "<html><body>" + "x" * 5000 + "</body></html>"
+    mock_render.return_value = RenderedPage(
+        html=huge_html, final_url="https://example.com/", status=200
+    )
+
+    crawler = OnyxWebCrawler(max_html_size_bytes=100)
+    result = crawler._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+    assert not result.scrape_successful
+
+
+# ---------------------------------------------------------------------------
+# Cloudflare challenge body detection: when Playwright DOES render but the
+# rendered HTML is still the CF challenge interstitial, we must NOT pass
+# garbage like "Just a moment..." back to the LLM as if it were the page.
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_rendered_cloudflare_challenge_body_yields_failure_with_reason(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    """If Playwright rendered the CF challenge page itself, surface a clear
+    Cloudflare-specific failure reason instead of silently returning the
+    challenge HTML's text content."""
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = RenderedPage(
+        html=CF_CHALLENGE_HTML, final_url="https://example.com/", status=403
+    )
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    mock_render.assert_called_once()
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.CLOUDFLARE_CHALLENGE
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.fetch_rendered_html")
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_render_failure_with_cf_signals_yields_cloudflare_reason(
+    mock_get: MagicMock, mock_render: MagicMock
+) -> None:
+    """When the original 403 had CF signals AND Playwright failed to render
+    at all (None), the surfaced reason should still call out Cloudflare —
+    not a generic 'upstream returned 403'."""
+    mock_get.return_value = _mock_response(status_code=403)
+    mock_render.return_value = None
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.CLOUDFLARE_CHALLENGE
+
+
+# ---------------------------------------------------------------------------
+# Failure-reason coverage on non-CF paths: every failure path should set
+# `failure_reason` so the open_url tool can pass it to the LLM.
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_404_failure_reason_includes_status(mock_get: MagicMock) -> None:
+    mock_get.return_value = _mock_response(status_code=404)
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/missing")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.http_status(404)
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_ssrf_failure_reason(mock_get: MagicMock) -> None:
+    from onyx.utils.url import SSRFException
+
+    mock_get.side_effect = SSRFException("internal IP")
+
+    result = OnyxWebCrawler()._fetch_url("http://internal.local/")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.SSRF_BLOCKED
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_network_error_failure_reason(mock_get: MagicMock) -> None:
+    mock_get.side_effect = RuntimeError("connection reset")
+
+    result = OnyxWebCrawler()._fetch_url("https://example.com/")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.NETWORK_ERROR
+
+
+@patch("onyx.tools.tool_implementations.open_url.onyx_web_crawler.ssrf_safe_get")
+def test_403_with_fallback_disabled_yields_cloudflare_reason(
+    mock_get: MagicMock,
+) -> None:
+    """Even without invoking Playwright, a 403 with CF signals should still
+    label the failure as a CF challenge — admins shouldn't have to enable
+    the fallback to find out why their URL is failing."""
+    mock_get.return_value = _mock_response(status_code=403)
+
+    crawler = OnyxWebCrawler(playwright_fallback_enabled=False)
+    result = crawler._fetch_url("https://example.com/")
+
+    assert not result.scrape_successful
+    assert result.failure_reason == FailureReason.CLOUDFLARE_CHALLENGE
+
+
+# ---------------------------------------------------------------------------
+# The fallback path routes through the helper module so existing tests that
+# patch `ssrf_safe_get` directly continue to work; this test exists to lock
+# in the import name we expose for monkey-patching.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_rendered_html_is_importable_from_crawler_module() -> None:
+    assert hasattr(crawler_module, "fetch_rendered_html")
+    assert hasattr(crawler_module, "RenderedPage")
+    assert hasattr(crawler_module, "looks_like_cloudflare_challenge")

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_open_url_failure_messages.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_open_url_failure_messages.py
@@ -1,0 +1,132 @@
+"""Tests for the failure-message construction in `open_url_tool`.
+
+When a URL can't be fetched, the LLM-facing message should include each
+URL's `failure_reason` so the model knows why and won't retry verbatim.
+"""
+
+from __future__ import annotations
+
+from onyx.tools.tool_implementations.open_url.models import FailedFetch
+from onyx.tools.tool_implementations.open_url.onyx_web_crawler import FailureReason
+from onyx.tools.tool_implementations.open_url.open_url_tool import (
+    _build_failure_message,
+)
+from onyx.tools.tool_implementations.open_url.open_url_tool import _format_failed_url
+
+
+def test_format_failed_url_with_reason() -> None:
+    failure = FailedFetch(url="https://x.com/", failure_reason="404 not found")
+    assert _format_failed_url(failure) == "https://x.com/ (404 not found)"
+
+
+def test_format_failed_url_without_reason() -> None:
+    failure = FailedFetch(url="https://x.com/", failure_reason=None)
+    assert _format_failed_url(failure) == "https://x.com/"
+
+
+def test_failure_message_with_no_inputs_is_generic() -> None:
+    msg = _build_failure_message(missing_document_ids=[], failed_web_fetches=[])
+    assert msg == "Failed to fetch content from the requested resources."
+
+
+def test_failure_message_includes_cloudflare_reason() -> None:
+    """The whole point of #1: the LLM sees that this URL is bot-protected."""
+    failure = FailedFetch(
+        url="https://integrations.mindbodyonline.com/",
+        failure_reason=FailureReason.CLOUDFLARE_CHALLENGE,
+    )
+    msg = _build_failure_message(missing_document_ids=[], failed_web_fetches=[failure])
+    assert "https://integrations.mindbodyonline.com/" in msg
+    assert "Cloudflare bot challenge" in msg
+    assert "Firecrawl" in msg
+
+
+def test_failure_message_dedupes_same_url() -> None:
+    failures = [
+        FailedFetch(url="https://x.com/", failure_reason="reason A"),
+        FailedFetch(url="https://x.com/", failure_reason="reason B"),
+    ]
+    msg = _build_failure_message(missing_document_ids=[], failed_web_fetches=failures)
+    # Should mention the URL once, with the first-seen reason.
+    assert msg.count("https://x.com/") == 1
+    assert "(reason A)" in msg
+
+
+def test_failure_message_combines_documents_and_urls() -> None:
+    failure = FailedFetch(
+        url="https://x.com/", failure_reason="upstream returned HTTP 500"
+    )
+    msg = _build_failure_message(
+        missing_document_ids=["doc-1", "doc-2"],
+        failed_web_fetches=[failure],
+    )
+    # Sorted: doc-1, doc-2 / single URL.
+    assert "documents doc-1, doc-2" in msg
+    assert "URLs https://x.com/ (upstream returned HTTP 500)" in msg
+    assert " and " in msg
+
+
+def test_failure_message_skips_urls_with_blank_url_field() -> None:
+    failures = [
+        FailedFetch(url="", failure_reason="reason"),
+        FailedFetch(url="https://real.com/", failure_reason="reason"),
+    ]
+    msg = _build_failure_message(missing_document_ids=[], failed_web_fetches=failures)
+    assert "https://real.com/" in msg
+    # Empty URL should not show up as ", ()" or similar oddity.
+    assert msg.count("(reason)") == 1
+
+
+def test_failure_message_url_without_reason_omits_parens() -> None:
+    failure = FailedFetch(url="https://x.com/", failure_reason=None)
+    msg = _build_failure_message(missing_document_ids=[], failed_web_fetches=[failure])
+    assert "https://x.com/" in msg
+    assert "(" not in msg
+
+
+# ---------------------------------------------------------------------------
+# CF challenge body detector — used by the OnyxWebCrawler fallback to decide
+# whether a successful Playwright render actually contains the real page or
+# just the CF interstitial.
+# ---------------------------------------------------------------------------
+
+
+def test_looks_like_cloudflare_challenge_detects_script_src() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    html = '<html><body><script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script></body></html>'
+    assert looks_like_cloudflare_challenge(html)
+
+
+def test_looks_like_cloudflare_challenge_detects_jschallenge_path() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    html = '<html><body><script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script></body></html>'
+    assert looks_like_cloudflare_challenge(html)
+
+
+def test_looks_like_cloudflare_challenge_detects_just_a_moment() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    html = "<html><head><title>Just a moment...</title></head></html>"
+    assert looks_like_cloudflare_challenge(html)
+
+
+def test_looks_like_cloudflare_challenge_detects_verifying_human_text() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    html = "<html><body>Verifying you are human. Please wait.</body></html>"
+    assert looks_like_cloudflare_challenge(html)
+
+
+def test_looks_like_cloudflare_challenge_is_false_for_real_page() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    html = "<html><head><title>Welcome</title></head><body><p>Real content here.</p></body></html>"
+    assert not looks_like_cloudflare_challenge(html)
+
+
+def test_looks_like_cloudflare_challenge_handles_empty_string() -> None:
+    from onyx.utils.playwright_fetch import looks_like_cloudflare_challenge
+
+    assert not looks_like_cloudflare_challenge("")


### PR DESCRIPTION
## Description

While the web connector used a playwright fallback, we didn't previously have it hooked up to the Onyx web crawler (now we do). there are many cases where it just isn't feasible to get past cloudflare bot protection even with this, but in those cases we want the user to know that Onyx couldn't retrieve the info and why (which this PR does)

## How Has This Been Tested?

added tests for the discrete new stuff and checked E2E behavior in UI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
