### PR TITLE
feat(targeted-reindex): schema for targeted document reindexing

### DIFF
--- a/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
+++ b/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
@@ -1,5 +1,5 @@
 """targeted reindex schema: targeted_reindex_job, targeted_reindex_job_target,
-targeted_reindex_job_id on index_attempt, connector_metadata on index_attempt_errors
+targeted_reindex_job_id on index_attempt
 
 Revision ID: 31bd8c17325e
 Revises: 14162713706c
@@ -135,22 +135,8 @@ def upgrade() -> None:
         ["targeted_reindex_job_id"],
     )
 
-    # 4. Connector-specific hints on errors, captured at error-creation time
-    #    and consumed by the retry path. Other retry-related state is derived
-    #    via joins through targeted_reindex_job_target.
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "connector_metadata",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=True,
-        ),
-    )
-
 
 def downgrade() -> None:
-    op.drop_column("index_attempt_errors", "connector_metadata")
-
     op.drop_index(
         "ix_index_attempt_targeted_reindex_job_id",
         table_name="index_attempt",

--- a/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
+++ b/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
@@ -1,5 +1,5 @@
 """targeted reindex schema: targeted_reindex_job, targeted_reindex_job_target,
-attempt_type discriminator on index_attempt, audit columns on index_attempt_errors
+targeted_reindex_job_id on index_attempt, connector_metadata on index_attempt_errors
 
 Revision ID: 31bd8c17325e
 Revises: 14162713706c
@@ -10,8 +10,6 @@ Create Date: 2026-04-30 15:35:00.000000
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-
-from onyx.db.enums import IndexAttemptType
 
 
 # revision identifiers, used by Alembic.
@@ -87,7 +85,7 @@ def upgrade() -> None:
         ["status"],
     )
 
-    # 2. Target rows.
+    # 2. Per-doc target rows.
     op.create_table(
         "targeted_reindex_job_target",
         sa.Column(
@@ -121,22 +119,8 @@ def upgrade() -> None:
         ["cc_pair_id", "document_id"],
     )
 
-    # 3. Discriminator + retry job FK on index_attempt. Default FULL_RUN
-    #    so existing rows backfill safely.
-    op.add_column(
-        "index_attempt",
-        sa.Column(
-            "attempt_type",
-            sa.Enum(IndexAttemptType, native_enum=False),
-            server_default="FULL_RUN",
-            nullable=False,
-        ),
-    )
-    op.create_index(
-        "ix_index_attempt_attempt_type",
-        "index_attempt",
-        ["attempt_type"],
-    )
+    # 3. FK on index_attempt linking synthetic targeted-reindex attempts
+    #    back to their job. NULL on full-run attempts.
     op.add_column(
         "index_attempt",
         sa.Column(
@@ -152,69 +136,9 @@ def upgrade() -> None:
         ["targeted_reindex_job_id"],
     )
 
-    # 4. Audit columns on index_attempt_errors. All nullable or default-backed.
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "targeted_reindex_count",
-            sa.Integer(),
-            server_default="0",
-            nullable=False,
-        ),
-    )
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "last_targeted_reindex_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "last_targeted_reindex_job_id",
-            sa.Integer(),
-            sa.ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-    )
-    op.create_index(
-        "ix_index_attempt_errors_last_targeted_reindex_job_id",
-        "index_attempt_errors",
-        ["last_targeted_reindex_job_id"],
-    )
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "resolved_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "resolved_by_user_id",
-            postgresql.UUID(as_uuid=True),
-            sa.ForeignKey("user.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
-    )
-    op.create_index(
-        "ix_index_attempt_errors_resolved_by_user_id",
-        "index_attempt_errors",
-        ["resolved_by_user_id"],
-    )
-    op.add_column(
-        "index_attempt_errors",
-        sa.Column(
-            "targeted_reindex_history",
-            postgresql.JSONB(astext_type=sa.Text()),
-            server_default="[]",
-            nullable=False,
-        ),
-    )
+    # 4. Connector-specific hints on errors, captured at error-creation time
+    #    and consumed by the retry path. Other retry-related state is derived
+    #    via joins through targeted_reindex_job_target.
     op.add_column(
         "index_attempt_errors",
         sa.Column(
@@ -227,28 +151,12 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_column("index_attempt_errors", "connector_metadata")
-    op.drop_column("index_attempt_errors", "targeted_reindex_history")
-    op.drop_index(
-        "ix_index_attempt_errors_resolved_by_user_id",
-        table_name="index_attempt_errors",
-    )
-    op.drop_column("index_attempt_errors", "resolved_by_user_id")
-    op.drop_column("index_attempt_errors", "resolved_at")
-    op.drop_index(
-        "ix_index_attempt_errors_last_targeted_reindex_job_id",
-        table_name="index_attempt_errors",
-    )
-    op.drop_column("index_attempt_errors", "last_targeted_reindex_job_id")
-    op.drop_column("index_attempt_errors", "last_targeted_reindex_at")
-    op.drop_column("index_attempt_errors", "targeted_reindex_count")
 
     op.drop_index(
         "ix_index_attempt_targeted_reindex_job_id",
         table_name="index_attempt",
     )
     op.drop_column("index_attempt", "targeted_reindex_job_id")
-    op.drop_index("ix_index_attempt_attempt_type", table_name="index_attempt")
-    op.drop_column("index_attempt", "attempt_type")
 
     op.drop_index(
         "ix_targeted_reindex_job_target_cc_pair_doc",

--- a/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
+++ b/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
@@ -1,0 +1,271 @@
+"""targeted reindex schema: targeted_reindex_job, targeted_reindex_job_target,
+attempt_type discriminator on index_attempt, audit columns on index_attempt_errors
+
+Revision ID: 31bd8c17325e
+Revises: 14162713706c
+Create Date: 2026-04-30 15:35:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from onyx.db.enums import IndexAttemptType
+
+
+# revision identifiers, used by Alembic.
+revision = "31bd8c17325e"
+down_revision = "14162713706c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Lifecycle table.
+    op.create_table(
+        "targeted_reindex_job",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "requested_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "NOT_STARTED",
+                "IN_PROGRESS",
+                "SUCCESS",
+                "CANCELED",
+                "FAILED",
+                "COMPLETED_WITH_ERRORS",
+                name="indexingstatus",
+                native_enum=False,
+            ),
+            server_default="NOT_STARTED",
+            nullable=False,
+        ),
+        sa.Column("celery_task_id", sa.Text(), nullable=True),
+        sa.Column("resolved_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "still_failing_count", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column("skipped_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column(
+            "resolved_summary",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_targeted_reindex_job_requested_by_user_id",
+        "targeted_reindex_job",
+        ["requested_by_user_id"],
+    )
+    op.create_index(
+        "ix_targeted_reindex_job_requested_at",
+        "targeted_reindex_job",
+        ["requested_at"],
+    )
+    op.create_index(
+        "ix_targeted_reindex_job_status",
+        "targeted_reindex_job",
+        ["status"],
+    )
+
+    # 2. Target rows.
+    op.create_table(
+        "targeted_reindex_job_target",
+        sa.Column(
+            "targeted_reindex_job_id",
+            sa.Integer(),
+            sa.ForeignKey("targeted_reindex_job.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "cc_pair_id",
+            sa.Integer(),
+            sa.ForeignKey("connector_credential_pair.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("document_id", sa.Text(), primary_key=True),
+        sa.Column(
+            "source_error_id",
+            sa.Integer(),
+            sa.ForeignKey("index_attempt_errors.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_targeted_reindex_job_target_source_error_id",
+        "targeted_reindex_job_target",
+        ["source_error_id"],
+    )
+    op.create_index(
+        "ix_targeted_reindex_job_target_cc_pair_doc",
+        "targeted_reindex_job_target",
+        ["cc_pair_id", "document_id"],
+    )
+
+    # 3. Discriminator + retry job FK on index_attempt. Default FULL_RUN
+    #    so existing rows backfill safely.
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "attempt_type",
+            sa.Enum(IndexAttemptType, native_enum=False),
+            server_default="FULL_RUN",
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_attempt_type",
+        "index_attempt",
+        ["attempt_type"],
+    )
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "targeted_reindex_job_id",
+            sa.Integer(),
+            sa.ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_targeted_reindex_job_id",
+        "index_attempt",
+        ["targeted_reindex_job_id"],
+    )
+
+    # 4. Audit columns on index_attempt_errors. All nullable or default-backed.
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "targeted_reindex_count",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "last_targeted_reindex_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "last_targeted_reindex_job_id",
+            sa.Integer(),
+            sa.ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_errors_last_targeted_reindex_job_id",
+        "index_attempt_errors",
+        ["last_targeted_reindex_job_id"],
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "resolved_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "resolved_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_index_attempt_errors_resolved_by_user_id",
+        "index_attempt_errors",
+        ["resolved_by_user_id"],
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "targeted_reindex_history",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default="[]",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "index_attempt_errors",
+        sa.Column(
+            "connector_metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("index_attempt_errors", "connector_metadata")
+    op.drop_column("index_attempt_errors", "targeted_reindex_history")
+    op.drop_index(
+        "ix_index_attempt_errors_resolved_by_user_id",
+        table_name="index_attempt_errors",
+    )
+    op.drop_column("index_attempt_errors", "resolved_by_user_id")
+    op.drop_column("index_attempt_errors", "resolved_at")
+    op.drop_index(
+        "ix_index_attempt_errors_last_targeted_reindex_job_id",
+        table_name="index_attempt_errors",
+    )
+    op.drop_column("index_attempt_errors", "last_targeted_reindex_job_id")
+    op.drop_column("index_attempt_errors", "last_targeted_reindex_at")
+    op.drop_column("index_attempt_errors", "targeted_reindex_count")
+
+    op.drop_index(
+        "ix_index_attempt_targeted_reindex_job_id",
+        table_name="index_attempt",
+    )
+    op.drop_column("index_attempt", "targeted_reindex_job_id")
+    op.drop_index("ix_index_attempt_attempt_type", table_name="index_attempt")
+    op.drop_column("index_attempt", "attempt_type")
+
+    op.drop_index(
+        "ix_targeted_reindex_job_target_cc_pair_doc",
+        table_name="targeted_reindex_job_target",
+    )
+    op.drop_index(
+        "ix_targeted_reindex_job_target_source_error_id",
+        table_name="targeted_reindex_job_target",
+    )
+    op.drop_table("targeted_reindex_job_target")
+
+    op.drop_index("ix_targeted_reindex_job_status", table_name="targeted_reindex_job")
+    op.drop_index(
+        "ix_targeted_reindex_job_requested_at", table_name="targeted_reindex_job"
+    )
+    op.drop_index(
+        "ix_targeted_reindex_job_requested_by_user_id",
+        table_name="targeted_reindex_job",
+    )
+    op.drop_table("targeted_reindex_job")

--- a/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
+++ b/backend/alembic/versions/31bd8c17325e_targeted_reindex_schema.py
@@ -48,7 +48,6 @@ def upgrade() -> None:
                 name="indexingstatus",
                 native_enum=False,
             ),
-            server_default="NOT_STARTED",
             nullable=False,
         ),
         sa.Column("celery_task_id", sa.Text(), nullable=True),

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -90,17 +90,6 @@ class IndexingMode(str, PyEnum):
     REINDEX = "reindex"
 
 
-class IndexAttemptType(str, PyEnum):
-    """Discriminator on `index_attempt`. `FULL_RUN` rows are real indexing
-    attempts spawned by the scheduler or `run-once`. `TARGETED_REINDEX` rows
-    are synthetic attempts created when an admin reindexes specific documents
-    (failed or otherwise). They reuse the indexing pipeline but are excluded
-    from freshness, scheduling, and swap-gating queries."""
-
-    FULL_RUN = "FULL_RUN"
-    TARGETED_REINDEX = "TARGETED_REINDEX"
-
-
 class ProcessingMode(str, PyEnum):
     """Determines how documents are processed after fetching."""
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -90,6 +90,17 @@ class IndexingMode(str, PyEnum):
     REINDEX = "reindex"
 
 
+class IndexAttemptType(str, PyEnum):
+    """Discriminator on `index_attempt`. `FULL_RUN` rows are real indexing
+    attempts spawned by the scheduler or `run-once`. `TARGETED_REINDEX` rows
+    are synthetic attempts created when an admin reindexes specific documents
+    (failed or otherwise). They reuse the indexing pipeline but are excluded
+    from freshness, scheduling, and swap-gating queries."""
+
+    FULL_RUN = "FULL_RUN"
+    TARGETED_REINDEX = "TARGETED_REINDEX"
+
+
 class ProcessingMode(str, PyEnum):
     """Determines how documents are processed after fetching."""
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2230,7 +2230,7 @@ class TargetedReindexJob(Base):
     # Snapshot of resolved error rows captured at completion. Outlives later
     # cleanup of the underlying `index_attempt_errors` rows.
     resolved_summary: Mapped[list[dict[str, Any]]] = mapped_column(
-        PGJSONB, nullable=False, server_default="[]"
+        PGJSONB, nullable=False, default=list, server_default="[]"
     )
 
     completed_at: Mapped[datetime.datetime | None] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -68,7 +68,6 @@ from onyx.db.enums import GrantSource
 from onyx.db.enums import HierarchyNodeType
 from onyx.db.enums import HookFailStrategy
 from onyx.db.enums import HookPoint
-from onyx.db.enums import IndexAttemptType
 from onyx.db.enums import IndexingMode
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
@@ -2249,11 +2248,6 @@ class TargetedReindexJob(Base):
         back_populates="targeted_reindex_job",
         primaryjoin="TargetedReindexJob.id == IndexAttempt.targeted_reindex_job_id",
     )
-    errors: Mapped[list["IndexAttemptError"]] = relationship(
-        "IndexAttemptError",
-        back_populates="last_targeted_reindex_job",
-        primaryjoin="TargetedReindexJob.id == IndexAttemptError.last_targeted_reindex_job_id",
-    )
 
 
 class TargetedReindexJobTarget(Base):
@@ -2319,19 +2313,10 @@ class IndexAttempt(Base):
     # This is only for attempts that are explicitly marked as from the start via
     # the run once API
     from_beginning: Mapped[bool] = mapped_column(Boolean)
-    # Discriminator separating real indexing runs from synthetic targeted
-    # reindex attempts. Existing rows backfill to FULL_RUN. Consumer query
-    # sites filter on this column so retry attempts don't bleed into
-    # freshness, scheduling, or swap-gating decisions.
-    attempt_type: Mapped[IndexAttemptType] = mapped_column(
-        Enum(IndexAttemptType, native_enum=False),
-        nullable=False,
-        default=IndexAttemptType.FULL_RUN,
-        server_default="FULL_RUN",
-        index=True,
-    )
-    # Set on synthetic targeted reindex attempts. Links back to the
-    # `targeted_reindex_job` row the FE polls for aggregate status.
+    # NULL on full-run attempts. Set on synthetic attempts spawned by a
+    # targeted reindex; links back to the `targeted_reindex_job` row.
+    # Consumer query sites that only care about full runs filter
+    # `WHERE targeted_reindex_job_id IS NULL`.
     targeted_reindex_job_id: Mapped[int | None] = mapped_column(
         ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
         nullable=True,
@@ -2574,41 +2559,10 @@ class IndexAttemptError(Base):
         server_default=func.now(),
     )
 
-    # Targeted reindex audit. These fill on failure-driven retries (where the
-    # target row has source_error_id pointing at this error). Arbitrary doc
-    # reindexes don't touch this table.
-    targeted_reindex_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default="0"
-    )
-    last_targeted_reindex_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    last_targeted_reindex_job_id: Mapped[int | None] = mapped_column(
-        ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
-    )
-    last_targeted_reindex_job: Mapped["TargetedReindexJob | None"] = relationship(
-        "TargetedReindexJob",
-        back_populates="errors",
-        primaryjoin="IndexAttemptError.last_targeted_reindex_job_id == TargetedReindexJob.id",
-    )
-    resolved_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-    resolved_by_user_id: Mapped[UUID | None] = mapped_column(
-        PGUUID(as_uuid=True),
-        ForeignKey("user.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
-    )
-    # JSON array; each retry appends an entry. Bounded to last 20 entries
-    # at the application layer.
-    targeted_reindex_history: Mapped[list[dict[str, Any]]] = mapped_column(
-        PGJSONB, nullable=False, server_default="[]"
-    )
-    # Connector-specific hints needed to retry. Sharepoint stores
-    # {site_id, drive_id} here; most others leave it null.
+    # Connector-specific hints captured at error-creation time, used by the
+    # retry path. Sharepoint stores `{site_id, drive_id}` here; most others
+    # leave it null. All other retry-related state (count, timestamps, who
+    # resolved it) is derived via JOINs through `targeted_reindex_job_target`.
     connector_metadata: Mapped[dict[str, Any] | None] = mapped_column(
         PGJSONB, nullable=True
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2221,9 +2221,15 @@ class TargetedReindexJob(Base):
     # cancellation has a handle to revoke.
     celery_task_id: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    resolved_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    still_failing_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    skipped_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    resolved_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    still_failing_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    skipped_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
 
     # Snapshot of resolved error rows captured at completion. Outlives later
     # cleanup of the underlying `index_attempt_errors` rows.
@@ -2576,7 +2582,7 @@ class IndexAttemptError(Base):
     # target row has source_error_id pointing at this error). Arbitrary doc
     # reindexes don't touch this table.
     targeted_reindex_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0
+        Integer, nullable=False, default=0, server_default="0"
     )
     last_targeted_reindex_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2210,7 +2210,6 @@ class TargetedReindexJob(Base):
         Enum(IndexingStatus, native_enum=False),
         nullable=False,
         default=IndexingStatus.NOT_STARTED,
-        server_default="NOT_STARTED",
         index=True,
     )
     # Pre-allocated celery task UUID. Written before `apply_async` so the

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2186,12 +2186,10 @@ class SearchSettings(Base):
 
 class TargetedReindexJob(Base):
     """
-    Lifecycle row for a single user-initiated targeted reindex request.
-
-    A request can span multiple `(cc_pair, search_settings)` tuples. One
-    synthetic `IndexAttempt` is created per tuple and links back via
-    `IndexAttempt.targeted_reindex_job_id`. The FE polls this row for
-    aggregate status. The actual targets live in `targeted_reindex_job_target`.
+    One row per user-initiated reindex request. Gives the FE a stable handle
+    to poll for aggregate status across a request that may span multiple
+    `(cc_pair, search_settings)` tuples. The per-doc work list lives in
+    `targeted_reindex_job_target`.
     """
 
     __tablename__ = "targeted_reindex_job"
@@ -2260,12 +2258,10 @@ class TargetedReindexJob(Base):
 
 class TargetedReindexJobTarget(Base):
     """
-    One row per `(cc_pair_id, document_id)` targeted by a reindex job.
-
-    `source_error_id` is set when the target was derived from a failed
-    `IndexAttemptError`. NULL means an arbitrary doc reindex with no failure
-    context. Resolution tracking at completion only fires for rows where
-    `source_error_id IS NOT NULL`.
+    One row per doc a reindex job will touch. Separate table (not JSONB on
+    the job) so each row can FK to its source `IndexAttemptError` for clean
+    resolution tracking and FK to its `cc_pair` for cascade cleanup. NULL
+    `source_error_id` means an arbitrary reindex with no failure context.
     """
 
     __tablename__ = "targeted_reindex_job_target"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -68,6 +68,7 @@ from onyx.db.enums import GrantSource
 from onyx.db.enums import HierarchyNodeType
 from onyx.db.enums import HookFailStrategy
 from onyx.db.enums import HookPoint
+from onyx.db.enums import IndexAttemptType
 from onyx.db.enums import IndexingMode
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
@@ -2183,6 +2184,118 @@ class SearchSettings(Base):
         )
 
 
+class TargetedReindexJob(Base):
+    """
+    Lifecycle row for a single user-initiated targeted reindex request.
+
+    A request can span multiple `(cc_pair, search_settings)` tuples. One
+    synthetic `IndexAttempt` is created per tuple and links back via
+    `IndexAttempt.targeted_reindex_job_id`. The FE polls this row for
+    aggregate status. The actual targets live in `targeted_reindex_job_target`.
+    """
+
+    __tablename__ = "targeted_reindex_job"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    requested_by_user_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    requested_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[IndexingStatus] = mapped_column(
+        Enum(IndexingStatus, native_enum=False),
+        nullable=False,
+        default=IndexingStatus.NOT_STARTED,
+        server_default="NOT_STARTED",
+        index=True,
+    )
+    # Pre-allocated celery task UUID. Written before `apply_async` so the
+    # orphan-detector can clean up if enqueue fails after INSERT, and so
+    # cancellation has a handle to revoke.
+    celery_task_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    resolved_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    still_failing_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    skipped_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Snapshot of resolved error rows captured at completion. Outlives later
+    # cleanup of the underlying `index_attempt_errors` rows.
+    resolved_summary: Mapped[list[dict[str, Any]]] = mapped_column(
+        PGJSONB, nullable=False, server_default="[]"
+    )
+
+    completed_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    targets: Mapped[list["TargetedReindexJobTarget"]] = relationship(
+        "TargetedReindexJobTarget",
+        back_populates="job",
+        cascade="all, delete-orphan",
+    )
+    index_attempts: Mapped[list["IndexAttempt"]] = relationship(
+        "IndexAttempt",
+        back_populates="targeted_reindex_job",
+        primaryjoin="TargetedReindexJob.id == IndexAttempt.targeted_reindex_job_id",
+    )
+    errors: Mapped[list["IndexAttemptError"]] = relationship(
+        "IndexAttemptError",
+        back_populates="last_targeted_reindex_job",
+        primaryjoin="TargetedReindexJob.id == IndexAttemptError.last_targeted_reindex_job_id",
+    )
+
+
+class TargetedReindexJobTarget(Base):
+    """
+    One row per `(cc_pair_id, document_id)` targeted by a reindex job.
+
+    `source_error_id` is set when the target was derived from a failed
+    `IndexAttemptError`. NULL means an arbitrary doc reindex with no failure
+    context. Resolution tracking at completion only fires for rows where
+    `source_error_id IS NOT NULL`.
+    """
+
+    __tablename__ = "targeted_reindex_job_target"
+
+    targeted_reindex_job_id: Mapped[int] = mapped_column(
+        ForeignKey("targeted_reindex_job.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    cc_pair_id: Mapped[int] = mapped_column(
+        ForeignKey("connector_credential_pair.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    document_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    source_error_id: Mapped[int | None] = mapped_column(
+        ForeignKey("index_attempt_errors.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_targeted_reindex_job_target_cc_pair_doc",
+            "cc_pair_id",
+            "document_id",
+        ),
+    )
+
+    job: Mapped["TargetedReindexJob"] = relationship(
+        "TargetedReindexJob", back_populates="targets"
+    )
+    source_error: Mapped["IndexAttemptError | None"] = relationship(
+        "IndexAttemptError",
+        primaryjoin="TargetedReindexJobTarget.source_error_id == IndexAttemptError.id",
+    )
+
+
 class IndexAttempt(Base):
     """
     Represents an attempt to index a group of 0 or more documents from a
@@ -2204,6 +2317,29 @@ class IndexAttempt(Base):
     # This is only for attempts that are explicitly marked as from the start via
     # the run once API
     from_beginning: Mapped[bool] = mapped_column(Boolean)
+    # Discriminator separating real indexing runs from synthetic targeted
+    # reindex attempts. Existing rows backfill to FULL_RUN. Consumer query
+    # sites filter on this column so retry attempts don't bleed into
+    # freshness, scheduling, or swap-gating decisions.
+    attempt_type: Mapped[IndexAttemptType] = mapped_column(
+        Enum(IndexAttemptType, native_enum=False),
+        nullable=False,
+        default=IndexAttemptType.FULL_RUN,
+        server_default="FULL_RUN",
+        index=True,
+    )
+    # Set on synthetic targeted reindex attempts. Links back to the
+    # `targeted_reindex_job` row the FE polls for aggregate status.
+    targeted_reindex_job_id: Mapped[int | None] = mapped_column(
+        ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    targeted_reindex_job: Mapped["TargetedReindexJob | None"] = relationship(
+        "TargetedReindexJob",
+        back_populates="index_attempts",
+        primaryjoin="IndexAttempt.targeted_reindex_job_id == TargetedReindexJob.id",
+    )
     status: Mapped[IndexingStatus] = mapped_column(
         Enum(IndexingStatus, native_enum=False, index=True)
     )
@@ -2434,6 +2570,45 @@ class IndexAttemptError(Base):
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
+    )
+
+    # Targeted reindex audit. These fill on failure-driven retries (where the
+    # target row has source_error_id pointing at this error). Arbitrary doc
+    # reindexes don't touch this table.
+    targeted_reindex_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0
+    )
+    last_targeted_reindex_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_targeted_reindex_job_id: Mapped[int | None] = mapped_column(
+        ForeignKey("targeted_reindex_job.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    last_targeted_reindex_job: Mapped["TargetedReindexJob | None"] = relationship(
+        "TargetedReindexJob",
+        back_populates="errors",
+        primaryjoin="IndexAttemptError.last_targeted_reindex_job_id == TargetedReindexJob.id",
+    )
+    resolved_at: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    resolved_by_user_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # JSON array; each retry appends an entry. Bounded to last 20 entries
+    # at the application layer.
+    targeted_reindex_history: Mapped[list[dict[str, Any]]] = mapped_column(
+        PGJSONB, nullable=False, server_default="[]"
+    )
+    # Connector-specific hints needed to retry. Sharepoint stores
+    # {site_id, drive_id} here; most others leave it null.
+    connector_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        PGJSONB, nullable=True
     )
 
     # This is the reverse side of the relationship

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2558,14 +2558,6 @@ class IndexAttemptError(Base):
         server_default=func.now(),
     )
 
-    # Connector-specific hints captured at error-creation time, used by the
-    # retry path. Sharepoint stores `{site_id, drive_id}` here; most others
-    # leave it null. All other retry-related state (count, timestamps, who
-    # resolved it) is derived via JOINs through `targeted_reindex_job_target`.
-    connector_metadata: Mapped[dict[str, Any] | None] = mapped_column(
-        PGJSONB, nullable=True
-    )
-
     # This is the reverse side of the relationship
     index_attempt = relationship("IndexAttempt", back_populates="error_rows")
 


### PR DESCRIPTION
## Description

Adds the schema for per-document reindexing. Covers both failed-doc retry and arbitrary-doc reindex flows in a single shape. Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

- New `targeted_reindex_job` table tracks each request's lifecycle. The FE polls it for aggregate status. `celery_task_id` is pre-allocated so the orphan-detector can clean up if `apply_async` fails after INSERT, and so cancellation has a handle to revoke.
- New `targeted_reindex_job_target` table holds one row per target doc. Carries `(cc_pair_id, document_id)` plus an optional `source_error_id` linking back to a failed `IndexAttemptError`. NULL means arbitrary reindex with no failure context. Composite PK enforces "one target per doc per job."
- `index_attempt` gets a nullable `targeted_reindex_job_id` FK. NULL on full-run rows. Consumer query sites that only care about full runs filter `WHERE targeted_reindex_job_id IS NULL`.

`IndexingStatus` is reused for `targeted_reindex_job.status` with no `server_default` (matches the existing `IndexAttempt.status` pattern). Indexes added on `requested_by_user_id`, `requested_at`, `status` on the job table; on `(cc_pair_id, document_id)` and `source_error_id` on the target table; on `targeted_reindex_job_id` on `index_attempt`.

No behavior change in this PR. Nothing reads or writes the new columns yet. Follow-ups: PR 2 tightens consumer query sites with the `targeted_reindex_job_id IS NULL` filter, PR 3 adds API + retry task + `Resolver.reindex`, PR 4 ships the failed-docs admin UI.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check