### PR TITLE
fix: paginate role assignments

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -43,6 +43,16 @@ LIMITED_ACCESS_ROLE_NAMES = ["Limited Access", "Web-Only Limited Access"]
 
 AD_GROUP_ENUMERATION_THRESHOLD = 100_000
 
+# Page size for SharePoint REST RoleAssignments queries with
+# $expand=Member,RoleDefinitionBindings. Without an explicit $top, SharePoint
+# can stream the entire collection in one chunked response which has been
+# observed to be terminated mid-stream by upstream gateways
+# (ChunkedEncodingError: Response ended prematurely) on items with many
+# assignments. 100 matches Microsoft Graph / SharePoint UI defaults for
+# paged collections and keeps each page well under typical proxy buffer
+# limits while not making the round-trip count overwhelming.
+ROLE_ASSIGNMENTS_PAGE_SIZE = 100
+
 
 def _graph_api_get(
     url: str,
@@ -616,6 +626,7 @@ def get_external_access_from_sharepoint(
 
         sleep_and_retry(
             item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
+                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
                 page_loaded=add_user_and_group_to_sets,
             ),
             "get_external_access_from_sharepoint",
@@ -635,6 +646,7 @@ def get_external_access_from_sharepoint(
 
         sleep_and_retry(
             item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
+                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
                 page_loaded=add_user_and_group_to_sets,
             ),
             "get_external_access_from_sharepoint",
@@ -781,7 +793,7 @@ def get_sharepoint_external_groups(
     sleep_and_retry(
         client_context.web.role_assignments.expand(
             ["Member", "RoleDefinitionBindings"]
-        ).get_all(page_loaded=add_group_to_sets),
+        ).get_all(page_size=ROLE_ASSIGNMENTS_PAGE_SIZE, page_loaded=add_group_to_sets),
         "get_sharepoint_external_groups",
     )
     groups_and_members: GroupsResult = _get_groups_and_members_recursively(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -325,7 +325,7 @@ def sleep_and_retry(
             # into ClientRequestException with response=None (e.g.
             # ChunkedEncodingError).
             wrapped_transport_error = e.response is None and isinstance(
-                e.__cause__, TRANSIENT_TRANSPORT_EXCEPTIONS
+                e.__cause__ or e.__context__, TRANSIENT_TRANSPORT_EXCEPTIONS
             )
 
             is_retryable = status in RETRYABLE_HTTP_STATUSES or wrapped_transport_error


### PR DESCRIPTION
## Description

add pagination to role assignments in the sharepoint connector. We were seeing some failures that might just have been due to making too large of a request.

## How Has This Been Tested?

tested in UI

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
