### PR TITLE
fix(sharepoint): add slim connector so it does not need to fetch permission during pruning

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -35,6 +35,7 @@ from office365.sharepoint.client_context import ClientContext
 from pydantic import BaseModel
 from pydantic import Field
 from requests.exceptions import HTTPError
+from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -54,6 +55,7 @@ from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import IndexingHeartbeatInterface
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.microsoft_graph_env import resolve_microsoft_environment
 from onyx.connectors.models import BasicExpertInfo
@@ -897,7 +899,8 @@ def _convert_sitepage_to_slim_document(
     treat_sharing_link_as_public: bool = False,
 ) -> SlimDocument:
     """Convert a SharePoint site page to a SlimDocument object."""
-    if site_page.get("id") is None:
+    page_id = site_page.get("id")
+    if page_id is None:
         raise ValueError("Site page ID is required")
 
     external_access = get_sharepoint_external_access(
@@ -906,17 +909,16 @@ def _convert_sitepage_to_slim_document(
         site_page=site_page,
         treat_sharing_link_as_public=treat_sharing_link_as_public,
     )
-    id = site_page.get("id")
-    if id is None:
-        raise ValueError("Site page ID is required")
+
     return SlimDocument(
-        id=id,
+        id=page_id,
         external_access=external_access,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
     )
 
 
 class SharepointConnector(
+    SlimConnector,
     SlimConnectorWithPermSync,
     CheckpointedConnectorWithPermSync[SharepointConnectorCheckpoint],
 ):
@@ -1827,6 +1829,7 @@ class SharepointConnector(
         self,
         start: datetime | None = None,
         end: datetime | None = None,
+        include_permissions: bool = True,
     ) -> GenerateSlimDocumentOutput:
         site_descriptors = self._filter_excluded_sites(
             self.site_descriptors or self.fetch_sites()
@@ -1885,17 +1888,28 @@ class SharepointConnector(
 
                     try:
                         logger.debug(f"Processing: {driveitem.web_url}")
-                        ctx = self._create_rest_client_context(site_descriptor.url)
-                        doc_batch.append(
-                            _convert_driveitem_to_slim_document(
-                                driveitem,
-                                drive_name,
-                                ctx,
-                                self.graph_client,
-                                parent_hierarchy_raw_node_id=parent_hierarchy_url,
-                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        if include_permissions:
+                            ctx = self._create_rest_client_context(site_descriptor.url)
+                            doc_batch.append(
+                                _convert_driveitem_to_slim_document(
+                                    driveitem,
+                                    drive_name,
+                                    ctx,
+                                    self.graph_client,
+                                    parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                                )
                             )
-                        )
+                        else:
+                            if driveitem.id is None:
+                                raise ValueError("DriveItem ID is required")
+                            doc_batch.append(
+                                SlimDocument(
+                                    id=driveitem.id,
+                                    external_access=ExternalAccess.empty(),
+                                    parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                                )
+                            )
                     except Exception as e:
                         logger.warning(f"Failed to process driveitem: {str(e)}")
 
@@ -1913,16 +1927,28 @@ class SharepointConnector(
                         f"Processing site page: {site_page.get('webUrl', site_page.get('name', 'Unknown'))}"
                     )
                     try:
-                        ctx = self._create_rest_client_context(site_descriptor.url)
-                        doc_batch.append(
-                            _convert_sitepage_to_slim_document(
-                                site_page,
-                                ctx,
-                                self.graph_client,
-                                parent_hierarchy_raw_node_id=site_descriptor.url,
-                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        if include_permissions:
+                            ctx = self._create_rest_client_context(site_descriptor.url)
+                            doc_batch.append(
+                                _convert_sitepage_to_slim_document(
+                                    site_page,
+                                    ctx,
+                                    self.graph_client,
+                                    parent_hierarchy_raw_node_id=site_descriptor.url,
+                                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                                )
                             )
-                        )
+                        else:
+                            page_id = site_page.get("id")
+                            if page_id is None:
+                                raise ValueError("Site page ID is required")
+                            doc_batch.append(
+                                SlimDocument(
+                                    id=page_id,
+                                    external_access=ExternalAccess.empty(),
+                                    parent_hierarchy_raw_node_id=site_descriptor.url,
+                                )
+                            )
                     except Exception as e:
                         logger.warning(
                             f"Failed to process site page "
@@ -2635,6 +2661,28 @@ class SharepointConnector(
     ) -> SharepointConnectorCheckpoint:
         return SharepointConnectorCheckpoint.model_validate_json(checkpoint_json)
 
+    @override
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
+    ) -> GenerateSlimDocumentOutput:
+        start_dt = (
+            datetime.fromtimestamp(start, tz=timezone.utc)
+            if start is not None
+            else None
+        )
+        end_dt = (
+            datetime.fromtimestamp(end, tz=timezone.utc) if end is not None else None
+        )
+        yield from self._fetch_slim_documents_from_sharepoint(
+            start=start_dt,
+            end=end_dt,
+            include_permissions=False,
+        )
+
+    @override
     def retrieve_all_slim_docs_perm_sync(
         self,
         start: SecondsSinceUnixEpoch | None = None,
@@ -2652,6 +2700,7 @@ class SharepointConnector(
         yield from self._fetch_slim_documents_from_sharepoint(
             start=start_dt,
             end=end_dt,
+            include_permissions=True,
         )
 
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -125,6 +125,65 @@ def test_all_site_pages_fail_does_not_crash(
 
 
 # ---------------------------------------------------------------------------
+# retrieve_all_slim_docs — pruning path skips permission fetching
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._create_rest_client_context"
+)
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_site_pages")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_driveitems")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector.fetch_sites")
+def test_retrieve_all_slim_docs_does_not_fetch_permissions(
+    mock_fetch_sites: MagicMock,
+    mock_fetch_driveitems: MagicMock,
+    mock_fetch_site_pages: MagicMock,
+    mock_create_ctx: MagicMock,
+) -> None:
+    """retrieve_all_slim_docs (pruning path) never calls _create_rest_client_context
+    and returns SlimDocuments with empty ExternalAccess."""
+    from onyx.connectors.models import ExternalAccess
+    from onyx.connectors.models import SlimDocument
+    from onyx.connectors.sharepoint.connector import DriveItemData
+
+    connector = _make_connector()
+    connector.include_site_documents = True
+    connector.include_site_pages = True
+
+    site = MagicMock()
+    site.url = SITE_URL
+    mock_fetch_sites.return_value = [site]
+
+    driveitem = MagicMock(spec=DriveItemData)
+    driveitem.id = "item-1"
+    driveitem.web_url = SITE_URL + "/doc.docx"
+    driveitem.parent_reference_path = None
+    mock_fetch_driveitems.return_value = [
+        (driveitem, "Documents", None),
+    ]
+
+    mock_fetch_site_pages.return_value = [
+        {"id": "page-1", "webUrl": SITE_URL + "/SitePages/Home.aspx"},
+    ]
+
+    results = [
+        doc
+        for batch in connector.retrieve_all_slim_docs()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    ]
+
+    # Permissions were never fetched — no REST client context created.
+    mock_create_ctx.assert_not_called()
+
+    assert any(d.id == "item-1" for d in results)
+    assert any(d.id == "page-1" for d in results)
+    for doc in results:
+        assert doc.external_access == ExternalAccess.empty()
+
+
+# ---------------------------------------------------------------------------
 # validate_connector_settings — RoleAssignments permission probe
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

During pruning, `SharepointConnector` was routing through `SlimConnectorWithPermSync.retrieve_all_slim_docs_perm_sync`, which called the SharePoint role assignments API for every document. This caused unnecessary 403 errors (surfaced in Sentry) and wasted API calls, since pruning only needs document IDs — not permissions.

This adds `SlimConnector` to `SharepointConnector` with a `retrieve_all_slim_docs` implementation that calls the existing `_fetch_slim_documents_from_sharepoint(include_permissions=False)` path. `extract_ids_from_runnable_connector` checks `SlimConnector` first, so pruning now takes the cheap no-permission path automatically. `retrieve_all_slim_docs_perm_sync` (used by permission sync) is unchanged and will still surface 403s as real failures.

https://linear.app/onyx-app/issue/ENG-3954/pruning-correctness
https://docs.google.com/document/d/1bY0UEzO3E2M5y_DjPswSu14zz2hUdMzpDNymd4X7W7M/edit?tab=t.f1a2kq3e2ry3

## How Has This Been Tested?

Added a unit test (`test_retrieve_all_slim_docs_does_not_fetch_permissions`) that asserts `_create_rest_client_context` is never called during `retrieve_all_slim_docs`, and that all returned `SlimDocument`s have `ExternalAccess.empty()`. All 8 unit tests pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check