### PR TITLE
fix(chat): defer mainline-pointer PUTs until session is idle

### DIFF
--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -238,8 +238,12 @@ export default function MultiModelResponseView({
       // frontend chain walk disagrees, the next follow-up fails with
       // "not on the latest mainline".
       if (parentMessage?.messageId && response.messageId && currentSessionId) {
-        setPreferredResponse(parentMessage.messageId, response.messageId).catch(
-          (err) => console.error("Failed to persist preferred response:", err)
+        setPreferredResponse(
+          parentMessage.messageId,
+          response.messageId,
+          currentSessionId
+        ).catch((err) =>
+          console.error("Failed to persist preferred response:", err)
         );
 
         const tree = useChatSessionStore

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -27,17 +27,19 @@ import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { Packet } from "./streamingModels";
 import { awaitChatStateInput } from "@/app/app/stores/useChatSessionStore";
 
-// Tracks the latest in-flight PUT that mutates the backend's
+// Per-session tracker for the latest in-flight PUT that mutates the backend's
 // `latest_child_message_id` mainline pointer (set-message-as-latest,
-// set-preferred-response). The next send must wait for it so the backend's
-// mainline-walk lookup can find the supplied parent_message_id and avoid the
-// 500 "The new message sent is not on the latest mainline of messages".
+// set-preferred-response). The next send for that session must wait for it
+// so the backend's mainline-walk lookup can find the supplied
+// parent_message_id and avoid the 500 "The new message sent is not on the
+// latest mainline of messages".
 //
-// PUTs are deferred until the session's stream has fully finished —
+// Keyed by chatSessionId so a stream in one session doesn't block sends in
+// another. PUTs are deferred until that session's stream has finished —
 // otherwise the streaming save-completion writes
 // `parent.latest_child_message_id = streaming_msg.id` AFTER our PUT and
 // clobbers it.
-let pendingMainlineSync: Promise<unknown> | null = null;
+const pendingMainlineSync = new Map<string, Promise<unknown>>();
 
 export async function updateLlmOverrideForChatSession(
   chatSessionId: string,
@@ -199,13 +201,14 @@ export async function* sendMessage({
 
   const body = JSON.stringify(payload);
 
-  // Wait for any in-flight mainline-pointer PUT to land so the backend's
-  // chat_history walk can locate parentMessageId.
-  if (pendingMainlineSync) {
-    const promise = pendingMainlineSync;
-    await promise.catch(() => undefined);
-    if (pendingMainlineSync === promise) {
-      pendingMainlineSync = null;
+  // Wait for any in-flight mainline-pointer PUT for THIS session to land so
+  // the backend's chat_history walk can locate parentMessageId. Other
+  // sessions' PUTs are not awaited.
+  const pending = pendingMainlineSync.get(chatSessionId);
+  if (pending) {
+    await pending.catch(() => undefined);
+    if (pendingMainlineSync.get(chatSessionId) === pending) {
+      pendingMainlineSync.delete(chatSessionId);
     }
   }
 
@@ -240,12 +243,12 @@ export async function setPreferredResponse(
         preferred_response_id: preferredResponseId,
       }),
     });
-  const previous = pendingMainlineSync ?? Promise.resolve();
+  const previous = pendingMainlineSync.get(chatSessionId) ?? Promise.resolve();
   const chained = previous
     .catch(() => undefined)
     .then(() => awaitChatStateInput(chatSessionId))
     .then(() => work());
-  pendingMainlineSync = chained;
+  pendingMainlineSync.set(chatSessionId, chained);
   return chained;
 }
 
@@ -273,12 +276,12 @@ export async function patchMessageToBeLatest(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message_id: messageId }),
     });
-  const previous = pendingMainlineSync ?? Promise.resolve();
+  const previous = pendingMainlineSync.get(chatSessionId) ?? Promise.resolve();
   const chained = previous
     .catch(() => undefined)
     .then(() => awaitChatStateInput(chatSessionId))
     .then(() => work());
-  pendingMainlineSync = chained;
+  pendingMainlineSync.set(chatSessionId, chained);
   return chained;
 }
 

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -26,6 +26,13 @@ import { WEB_SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { Packet } from "./streamingModels";
 
+// Tracks the latest in-flight PUT that mutates the backend's
+// `latest_child_message_id` mainline pointer (set-message-as-latest,
+// set-preferred-response). The next send must wait for it so the backend's
+// mainline-walk lookup can find the supplied parent_message_id and avoid the
+// 500 "The new message sent is not on the latest mainline of messages".
+let pendingMainlineSync: Promise<unknown> | null = null;
+
 export async function updateLlmOverrideForChatSession(
   chatSessionId: string,
   newAlternateModel: string
@@ -186,6 +193,12 @@ export async function* sendMessage({
 
   const body = JSON.stringify(payload);
 
+  // Wait for any in-flight mainline-pointer PUT to land so the backend's
+  // chat_history walk can locate parentMessageId.
+  if (pendingMainlineSync) {
+    await pendingMainlineSync.catch(() => undefined);
+  }
+
   const response = await fetch(`/api/chat/send-chat-message`, {
     method: "POST",
     headers: {
@@ -207,7 +220,7 @@ export async function setPreferredResponse(
   userMessageId: number,
   preferredResponseId: number
 ): Promise<Response> {
-  return fetch("/api/chat/set-preferred-response", {
+  const request = fetch("/api/chat/set-preferred-response", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -215,6 +228,8 @@ export async function setPreferredResponse(
       preferred_response_id: preferredResponseId,
     }),
   });
+  pendingMainlineSync = request;
+  return request;
 }
 
 export async function nameChatSession(chatSessionId: string) {
@@ -232,7 +247,7 @@ export async function nameChatSession(chatSessionId: string) {
 }
 
 export async function patchMessageToBeLatest(messageId: number) {
-  const response = await fetch("/api/chat/set-message-as-latest", {
+  const request = fetch("/api/chat/set-message-as-latest", {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -241,7 +256,8 @@ export async function patchMessageToBeLatest(messageId: number) {
       message_id: messageId,
     }),
   });
-  return response;
+  pendingMainlineSync = request;
+  return request;
 }
 
 export async function handleChatFeedback(

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -25,12 +25,18 @@ import { SEARCH_PARAM_NAMES } from "./searchParams";
 import { WEB_SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { Packet } from "./streamingModels";
+import { awaitChatStateInput } from "@/app/app/stores/useChatSessionStore";
 
 // Tracks the latest in-flight PUT that mutates the backend's
 // `latest_child_message_id` mainline pointer (set-message-as-latest,
 // set-preferred-response). The next send must wait for it so the backend's
 // mainline-walk lookup can find the supplied parent_message_id and avoid the
 // 500 "The new message sent is not on the latest mainline of messages".
+//
+// PUTs are deferred until the session's stream has fully finished —
+// otherwise the streaming save-completion writes
+// `parent.latest_child_message_id = streaming_msg.id` AFTER our PUT and
+// clobbers it.
 let pendingMainlineSync: Promise<unknown> | null = null;
 
 export async function updateLlmOverrideForChatSession(
@@ -222,21 +228,25 @@ export async function* sendMessage({
 
 export async function setPreferredResponse(
   userMessageId: number,
-  preferredResponseId: number
+  preferredResponseId: number,
+  chatSessionId: string
 ): Promise<Response> {
-  const request = fetch("/api/chat/set-preferred-response", {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      user_message_id: userMessageId,
-      preferred_response_id: preferredResponseId,
-    }),
-  });
-  pendingMainlineSync = (pendingMainlineSync ?? Promise.resolve()).then(
-    () => request,
-    () => request
-  );
-  return request;
+  const work = (): Promise<Response> =>
+    fetch("/api/chat/set-preferred-response", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_message_id: userMessageId,
+        preferred_response_id: preferredResponseId,
+      }),
+    });
+  const previous = pendingMainlineSync ?? Promise.resolve();
+  const chained = previous
+    .catch(() => undefined)
+    .then(() => awaitChatStateInput(chatSessionId))
+    .then(() => work());
+  pendingMainlineSync = chained;
+  return chained;
 }
 
 export async function nameChatSession(chatSessionId: string) {
@@ -253,21 +263,23 @@ export async function nameChatSession(chatSessionId: string) {
   return response;
 }
 
-export async function patchMessageToBeLatest(messageId: number) {
-  const request = fetch("/api/chat/set-message-as-latest", {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      message_id: messageId,
-    }),
-  });
-  pendingMainlineSync = (pendingMainlineSync ?? Promise.resolve()).then(
-    () => request,
-    () => request
-  );
-  return request;
+export async function patchMessageToBeLatest(
+  messageId: number,
+  chatSessionId: string
+): Promise<Response> {
+  const work = (): Promise<Response> =>
+    fetch("/api/chat/set-message-as-latest", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message_id: messageId }),
+    });
+  const previous = pendingMainlineSync ?? Promise.resolve();
+  const chained = previous
+    .catch(() => undefined)
+    .then(() => awaitChatStateInput(chatSessionId))
+    .then(() => work());
+  pendingMainlineSync = chained;
+  return chained;
 }
 
 export async function handleChatFeedback(

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -196,7 +196,11 @@ export async function* sendMessage({
   // Wait for any in-flight mainline-pointer PUT to land so the backend's
   // chat_history walk can locate parentMessageId.
   if (pendingMainlineSync) {
-    await pendingMainlineSync.catch(() => undefined);
+    const promise = pendingMainlineSync;
+    await promise.catch(() => undefined);
+    if (pendingMainlineSync === promise) {
+      pendingMainlineSync = null;
+    }
   }
 
   const response = await fetch(`/api/chat/send-chat-message`, {
@@ -228,7 +232,10 @@ export async function setPreferredResponse(
       preferred_response_id: preferredResponseId,
     }),
   });
-  pendingMainlineSync = request;
+  pendingMainlineSync = (pendingMainlineSync ?? Promise.resolve()).then(
+    () => request,
+    () => request
+  );
   return request;
 }
 
@@ -256,7 +263,10 @@ export async function patchMessageToBeLatest(messageId: number) {
       message_id: messageId,
     }),
   });
-  pendingMainlineSync = request;
+  pendingMainlineSync = (pendingMainlineSync ?? Promise.resolve()).then(
+    () => request,
+    () => request
+  );
   return request;
 }
 

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -717,3 +717,30 @@ export const useCurrentQueuedMessages = () =>
       : null;
     return currentSession?.queuedMessages ?? EMPTY_QUEUED_MESSAGES;
   });
+
+// Resolves when the session's chatState becomes "input" (no stream in
+// progress). If already idle, resolves immediately. Used by mainline-pointer
+// PUTs that must land AFTER the streaming save-completion writeback —
+// otherwise the stream's `parent.latest_child_message_id` write clobbers
+// ours and the next send is rejected as not-on-mainline.
+export function awaitChatStateInput(sessionId: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const idle = (): boolean => {
+      const session = useChatSessionStore.getState().sessions.get(sessionId);
+      return !session || session.chatState === "input";
+    };
+
+    if (idle()) {
+      resolve();
+      return;
+    }
+
+    const unsubscribe = useChatSessionStore.subscribe((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session || session.chatState === "input") {
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}

--- a/web/src/hooks/useChatSessionController.ts
+++ b/web/src/hooks/useChatSessionController.ts
@@ -382,11 +382,11 @@ export default function useChatSessionController({
 
         const message = currentMessageTree.get(nodeId);
 
-        if (message?.messageId) {
+        if (message?.messageId && currentSessionId) {
           // Makes actual API call to set message as latest in the DB so we can
           // edit this message and so it sticks around on page reload
-          patchMessageToBeLatest(message.messageId);
-        } else {
+          patchMessageToBeLatest(message.messageId, currentSessionId);
+        } else if (!message?.messageId) {
           console.error("Message has no messageId", nodeId);
         }
       }


### PR DESCRIPTION
## Description

Customers continue to hit `"The new message sent is not on the latest mainline of messages"` (500) on v3.2.11+. #10075/#10078 patched only the multi-model preferred-response path. Same race fires on every other place the client mutates the local message tree before its backend mainline pointer (`latest_child_message_id`) lands:

- branch-switcher arrows on a prior assistant response
- editing a prior user message
- regenerating mid-stream and sending a follow-up
- agent / persona switch on an existing session
- multi-model preferred-response selection

The repro that broke earlier attempts: while an agent stream is in flight, click a branch arrow on a parent message, then send a new message → 500.

The deepest cause: backend `create_new_chat_message` and the stream-completion writeback both unconditionally set `parent.latest_child_message_id = streaming_msg.id`. A user PUT issued while a stream is in flight gets clobbered by the stream's own commits, so a simple "wait for the PUT before sending" gate on the FE isn't enough.

This PR:

1. Defers `set-message-as-latest` and `set-preferred-response` PUTs until the session's `chatState` transitions to `"input"` (all streams finished saving). PUT then lands AFTER the streaming writeback and is not overwritten.
2. Tracks the deferred PUT in a module-level `pendingMainlineSync` promise; `sendMessage` awaits it before issuing the POST. A queued send (auto-flushed by `AppInputBar` when the stream ends) blocks on the PUT before posting.
3. If `chatState` is already `"input"`, `awaitChatStateInput` resolves immediately — common path adds no latency.

## How Has This Been Tested?

<!-- Filled in by reviewer -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check