### PR TITLE
test(notion): accept new app.notion.com page URL format

### DIFF
--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -143,7 +143,11 @@ class NotionConnector(LoadConnector, PollConnector):
         parsed = urlparse(url)
         netloc = parsed.netloc.lower()
 
-        if not ("notion.so" in netloc or "notion.site" in netloc):
+        if not (
+            "notion.so" in netloc
+            or "notion.site" in netloc
+            or "app.notion.com" in netloc
+        ):
             return NormalizationResult(normalized_url=None, use_default=False)
 
         # Extract page ID from path (format: "Title-PageID")

--- a/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
+++ b/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
@@ -72,11 +72,7 @@ def _detect_source_type(url: str) -> DocumentSource | None:
 
     if "docs.google.com" in netloc or "drive.google.com" in netloc:
         return DocumentSource.GOOGLE_DRIVE
-    if (
-        "notion.so" in netloc
-        or "notion.site" in netloc
-        or "app.notion.com" in netloc
-    ):
+    if "notion.so" in netloc or "notion.site" in netloc or "app.notion.com" in netloc:
         return DocumentSource.NOTION
     if "atlassian.net" in netloc:
         # Check path for Jira indicators (more specific than netloc)

--- a/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
+++ b/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
@@ -72,7 +72,11 @@ def _detect_source_type(url: str) -> DocumentSource | None:
 
     if "docs.google.com" in netloc or "drive.google.com" in netloc:
         return DocumentSource.GOOGLE_DRIVE
-    if "notion.so" in netloc or "notion.site" in netloc:
+    if (
+        "notion.so" in netloc
+        or "notion.site" in netloc
+        or "app.notion.com" in netloc
+    ):
         return DocumentSource.NOTION
     if "atlassian.net" in netloc:
         # Check path for Jira indicators (more specific than netloc)

--- a/backend/tests/daily/connectors/notion/test_notion_connector.py
+++ b/backend/tests/daily/connectors/notion/test_notion_connector.py
@@ -11,6 +11,9 @@ from tests.utils.secret_names import TestSecret
 pytestmark = pytest.mark.secrets(TestSecret.NOTION_INTEGRATION_TOKEN)
 
 
+VALID_NOTION_URL_PREFIXES = ("https://www.notion.so/", "https://app.notion.com/p/")
+
+
 def compare_hierarchy_nodes(
     yielded_nodes: list[HierarchyNode],
     expected_nodes: list[HierarchyNode],
@@ -115,7 +118,7 @@ def test_notion_connector_basic(notion_connector: NotionConnector) -> None:
     # Content specific checks for root
     assert root_section.text == "\nroot"
     assert root_section.link is not None
-    assert root_section.link.startswith("https://www.notion.so/")
+    assert root_section.link.startswith(VALID_NOTION_URL_PREFIXES)
 
     # Verify child1 document structure
     assert child1_doc.id is not None
@@ -128,7 +131,7 @@ def test_notion_connector_basic(notion_connector: NotionConnector) -> None:
     # Content specific checks for child1
     assert child1_section.text == "\nchild1"
     assert child1_section.link is not None
-    assert child1_section.link.startswith("https://www.notion.so/")
+    assert child1_section.link.startswith(VALID_NOTION_URL_PREFIXES)
 
     # Verify child2 document structure (includes database)
     assert child2_doc.id is not None
@@ -142,13 +145,13 @@ def test_notion_connector_basic(notion_connector: NotionConnector) -> None:
     # Content specific checks for child2
     assert child2_section.text == "\nchild2"
     assert child2_section.link is not None
-    assert child2_section.link.startswith("https://www.notion.so/")
+    assert child2_section.link.startswith(VALID_NOTION_URL_PREFIXES)
 
     # Database section checks for child2
     assert child2_db_section.text is not None
     assert child2_db_section.text.strip() != ""  # Should contain some database content
     assert child2_db_section.link is not None
-    assert child2_db_section.link.startswith("https://www.notion.so/")
+    assert child2_db_section.link.startswith(VALID_NOTION_URL_PREFIXES)
 
     # Verify table entry document structure
     assert table_entry_doc.id is not None
@@ -161,7 +164,7 @@ def test_notion_connector_basic(notion_connector: NotionConnector) -> None:
     # Content specific checks for table entry
     assert table_entry_section.text == "\ntable-entry01"
     assert table_entry_section.link is not None
-    assert table_entry_section.link.startswith("https://www.notion.so/")
+    assert table_entry_section.link.startswith(VALID_NOTION_URL_PREFIXES)
 
     # Verify table entry child document structure
     assert table_entry_child_doc.id is not None
@@ -174,4 +177,4 @@ def test_notion_connector_basic(notion_connector: NotionConnector) -> None:
     # Content specific checks for table entry child
     assert table_entry_child_section.text == "\nchild-table-entry01"
     assert table_entry_child_section.link is not None
-    assert table_entry_child_section.link.startswith("https://www.notion.so/")
+    assert table_entry_child_section.link.startswith(VALID_NOTION_URL_PREFIXES)

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
@@ -55,6 +55,14 @@ def test_google_drive_normalization(url: str, expected: str) -> None:
             "https://notion.so/page?p=1234567890abcdef1234567890abcdef",
             "12345678-90ab-cdef-1234-567890abcdef",
         ),
+        (
+            "https://app.notion.com/p/Page-1234567890abcdef1234567890abcdef",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
+        (
+            "https://app.notion.com/p/Page-1234567890abcdef1234567890abcdef#fedcba0987654321fedcba0987654321",
+            "12345678-90ab-cdef-1234-567890abcdef",
+        ),
         # Edge case: URL with title prefix but valid UUID
         (
             "https://www.notion.so/My-Page-abc123def456ghi789jkl012mno345pq",
@@ -178,6 +186,10 @@ def test_sharepoint_normalization(url: str, expected: str) -> None:
         ("https://drive.google.com/file/d/123", DocumentSource.GOOGLE_DRIVE),
         ("https://www.notion.so/Page-abc123def456", DocumentSource.NOTION),
         ("https://notion.site/page", DocumentSource.NOTION),
+        (
+            "https://app.notion.com/p/Page-1234567890abcdef1234567890abcdef",
+            DocumentSource.NOTION,
+        ),
         (
             "https://example.atlassian.net/wiki/spaces/SPACE/pages/123",
             DocumentSource.CONFLUENCE,


### PR DESCRIPTION
## Summary
- Notion now returns canonical page URLs as `https://app.notion.com/p/...` instead of `https://www.notion.so/...`, breaking the daily Notion connector test
- Updated `test_notion_connector_basic` to accept either prefix via a shared `VALID_NOTION_URL_PREFIXES` tuple

## Test plan
- [x] `uv run --active pytest backend/tests/daily/connectors/notion/test_notion_connector.py` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Notion’s new canonical page URLs (`https://app.notion.com/p/...`) in the Notion connector and open URL detection/normalization so Notion links are recognized and normalized for index lookups. Updated the daily Notion connector test to allow both `https://app.notion.com/p/...` and `https://www.notion.so/...`, and expanded unit tests for `app.notion.com` parsing to cover normalization and source detection, fixing the failing daily test.

<sup>Written for commit 93b7509021ed3ec3c6821edc6a79228a58670be9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

