### PR TITLE
feat(license): tiered expiry warnings + 14d grace period

### DIFF
--- a/backend/ee/onyx/background/celery/apps/primary.py
+++ b/backend/ee/onyx/background/celery/apps/primary.py
@@ -10,6 +10,7 @@ celery_app.autodiscover_tasks(
             "ee.onyx.background.celery.tasks.cloud",
             "ee.onyx.background.celery.tasks.ttl_management",
             "ee.onyx.background.celery.tasks.usage_reporting",
+            "ee.onyx.background.celery.tasks.license_notifications",
         ]
     )
 )

--- a/backend/ee/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/ee/onyx/background/celery/tasks/beat_schedule.py
@@ -65,6 +65,15 @@ if not MULTI_TENANT:
             },
         },
         {
+            "name": "check-license-expiry-notifications",
+            "task": OnyxCeleryTask.CHECK_LICENSE_EXPIRY_NOTIFICATIONS,
+            "schedule": timedelta(hours=1),
+            "options": {
+                "priority": OnyxCeleryPriority.MEDIUM,
+                "expires": BEAT_EXPIRES_DEFAULT,
+            },
+        },
+        {
             "name": "autogenerate-usage-report",
             "task": OnyxCeleryTask.GENERATE_USAGE_REPORT_TASK,
             "schedule": timedelta(days=30),  # TODO: change this to config flag

--- a/backend/ee/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/ee/onyx/background/celery/tasks/beat_schedule.py
@@ -67,7 +67,7 @@ if not MULTI_TENANT:
         {
             "name": "check-license-expiry-notifications",
             "task": OnyxCeleryTask.CHECK_LICENSE_EXPIRY_NOTIFICATIONS,
-            "schedule": timedelta(hours=1),
+            "schedule": timedelta(days=1),
             "options": {
                 "priority": OnyxCeleryPriority.MEDIUM,
                 "expires": BEAT_EXPIRES_DEFAULT,

--- a/backend/ee/onyx/background/celery/tasks/license_notifications/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/license_notifications/tasks.py
@@ -1,0 +1,47 @@
+from celery import shared_task
+
+from ee.onyx.db.license import get_license
+from ee.onyx.utils.license import verify_license_signature
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
+from ee.onyx.utils.license_expiry import get_expiry_warning_stage
+from ee.onyx.utils.license_notifications import notify_admins_for_stage
+from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+
+@shared_task(
+    name=OnyxCeleryTask.CHECK_LICENSE_EXPIRY_NOTIFICATIONS,
+    ignore_result=True,
+    soft_time_limit=JOB_TIMEOUT,
+)
+def check_license_expiry_notifications_task(*, tenant_id: str) -> None:  # noqa: ARG001
+    if MULTI_TENANT:
+        return
+
+    with get_session_with_current_tenant() as db_session:
+        license_record = get_license(db_session)
+        if not license_record:
+            return
+
+        try:
+            payload = verify_license_signature(license_record.license_data)
+        except ValueError:
+            logger.exception(
+                "Failed to verify license during expiry-notification check"
+            )
+            return
+
+        stage = get_expiry_warning_stage(payload.expires_at)
+        if stage == ExpiryWarningStage.NONE:
+            return
+
+        notify_admins_for_stage(
+            db_session=db_session,
+            stage=stage,
+            expires_at=payload.expires_at,
+        )

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -209,12 +209,17 @@ def update_license_cache(
     from ee.onyx.utils.license import get_license_status
     from ee.onyx.utils.license_expiry import get_expiry_warning_stage
     from ee.onyx.utils.license_expiry import get_grace_days_remaining
+    from ee.onyx.utils.license_expiry import get_grace_period_end
 
     tenant = tenant_id or get_current_tenant_id()
     cache = get_cache_backend(tenant_id=tenant_id)
 
     used_seats = get_used_seats(tenant)
-    status = get_license_status(payload, grace_period_end)
+    # Default the grace window to 14 days past expires_at so the license-
+    # enforcement middleware returns GRACE_PERIOD (not GATED_ACCESS) during
+    # that window — matching the banner copy and daily admin emails.
+    effective_grace_end = grace_period_end or get_grace_period_end(payload.expires_at)
+    status = get_license_status(payload, effective_grace_end)
     warning_stage = get_expiry_warning_stage(payload.expires_at)
     grace_days = get_grace_days_remaining(payload.expires_at)
 
@@ -226,7 +231,7 @@ def update_license_cache(
         plan_type=payload.plan_type,
         issued_at=payload.issued_at,
         expires_at=payload.expires_at,
-        grace_period_end=grace_period_end,
+        grace_period_end=effective_grace_end,
         status=status,
         expiry_warning_stage=warning_stage,
         grace_days_remaining=grace_days,

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -207,12 +207,16 @@ def update_license_cache(
         The cached LicenseMetadata
     """
     from ee.onyx.utils.license import get_license_status
+    from ee.onyx.utils.license_expiry import get_expiry_warning_stage
+    from ee.onyx.utils.license_expiry import get_grace_days_remaining
 
     tenant = tenant_id or get_current_tenant_id()
     cache = get_cache_backend(tenant_id=tenant_id)
 
     used_seats = get_used_seats(tenant)
     status = get_license_status(payload, grace_period_end)
+    warning_stage = get_expiry_warning_stage(payload.expires_at)
+    grace_days = get_grace_days_remaining(payload.expires_at)
 
     metadata = LicenseMetadata(
         tenant_id=payload.tenant_id,
@@ -224,6 +228,8 @@ def update_license_cache(
         expires_at=payload.expires_at,
         grace_period_end=grace_period_end,
         status=status,
+        expiry_warning_stage=warning_stage,
+        grace_days_remaining=grace_days,
         source=source,
         stripe_subscription_id=payload.stripe_subscription_id,
     )

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -208,7 +208,6 @@ def update_license_cache(
     """
     from ee.onyx.utils.license import get_license_status
     from ee.onyx.utils.license_expiry import get_expiry_warning_stage
-    from ee.onyx.utils.license_expiry import get_grace_days_remaining
     from ee.onyx.utils.license_expiry import get_grace_period_end
 
     tenant = tenant_id or get_current_tenant_id()
@@ -221,7 +220,6 @@ def update_license_cache(
     effective_grace_end = grace_period_end or get_grace_period_end(payload.expires_at)
     status = get_license_status(payload, effective_grace_end)
     warning_stage = get_expiry_warning_stage(payload.expires_at)
-    grace_days = get_grace_days_remaining(payload.expires_at)
 
     metadata = LicenseMetadata(
         tenant_id=payload.tenant_id,
@@ -234,7 +232,6 @@ def update_license_cache(
         grace_period_end=effective_grace_end,
         status=status,
         expiry_warning_stage=warning_stage,
-        grace_days_remaining=grace_days,
         source=source,
         stripe_subscription_id=payload.stripe_subscription_id,
     )

--- a/backend/ee/onyx/server/license/api.py
+++ b/backend/ee/onyx/server/license/api.py
@@ -79,6 +79,8 @@ async def get_license_status(
         expires_at=metadata.expires_at,
         grace_period_end=metadata.grace_period_end,
         status=metadata.status,
+        expiry_warning_stage=metadata.expiry_warning_stage,
+        grace_days_remaining=metadata.grace_days_remaining,
         source=metadata.source,
     )
 
@@ -287,6 +289,8 @@ async def refresh_license_cache_endpoint(
         expires_at=metadata.expires_at,
         grace_period_end=metadata.grace_period_end,
         status=metadata.status,
+        expiry_warning_stage=metadata.expiry_warning_stage,
+        grace_days_remaining=metadata.grace_days_remaining,
         source=metadata.source,
     )
 

--- a/backend/ee/onyx/server/license/api.py
+++ b/backend/ee/onyx/server/license/api.py
@@ -80,7 +80,6 @@ async def get_license_status(
         grace_period_end=metadata.grace_period_end,
         status=metadata.status,
         expiry_warning_stage=metadata.expiry_warning_stage,
-        grace_days_remaining=metadata.grace_days_remaining,
         source=metadata.source,
     )
 
@@ -290,7 +289,6 @@ async def refresh_license_cache_endpoint(
         grace_period_end=metadata.grace_period_end,
         status=metadata.status,
         expiry_warning_stage=metadata.expiry_warning_stage,
-        grace_days_remaining=metadata.grace_days_remaining,
         source=metadata.source,
     )
 

--- a/backend/ee/onyx/server/license/models.py
+++ b/backend/ee/onyx/server/license/models.py
@@ -53,7 +53,6 @@ class LicenseMetadata(BaseModel):
     grace_period_end: datetime | None = None
     status: ApplicationStatus
     expiry_warning_stage: ExpiryWarningStage = ExpiryWarningStage.NONE
-    grace_days_remaining: int = 0
     source: LicenseSource | None = None
     stripe_subscription_id: str | None = None
 
@@ -70,7 +69,6 @@ class LicenseStatusResponse(BaseModel):
     grace_period_end: datetime | None = None
     status: ApplicationStatus | None = None
     expiry_warning_stage: ExpiryWarningStage = ExpiryWarningStage.NONE
-    grace_days_remaining: int = 0
     source: LicenseSource | None = None
 
 

--- a/backend/ee/onyx/server/license/models.py
+++ b/backend/ee/onyx/server/license/models.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 from pydantic import BaseModel
 
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
 from onyx.server.settings.models import ApplicationStatus
 
 
@@ -51,6 +52,8 @@ class LicenseMetadata(BaseModel):
     expires_at: datetime
     grace_period_end: datetime | None = None
     status: ApplicationStatus
+    expiry_warning_stage: ExpiryWarningStage = ExpiryWarningStage.NONE
+    grace_days_remaining: int = 0
     source: LicenseSource | None = None
     stripe_subscription_id: str | None = None
 
@@ -66,6 +69,8 @@ class LicenseStatusResponse(BaseModel):
     expires_at: datetime | None = None
     grace_period_end: datetime | None = None
     status: ApplicationStatus | None = None
+    expiry_warning_stage: ExpiryWarningStage = ExpiryWarningStage.NONE
+    grace_days_remaining: int = 0
     source: LicenseSource | None = None
 
 

--- a/backend/ee/onyx/utils/license_expiry.py
+++ b/backend/ee/onyx/utils/license_expiry.py
@@ -49,8 +49,6 @@ def get_grace_period_end(expires_at: datetime) -> datetime:
 
 
 def get_grace_days_remaining(expires_at: datetime) -> int:
-    grace_end = get_grace_period_end(expires_at)
-    seconds_left = (grace_end - datetime.now(timezone.utc)).total_seconds()
-    if seconds_left <= 0:
-        return 0
-    return max(1, int(seconds_left // 86400) + (1 if seconds_left % 86400 > 0 else 0))
+    grace_end_date = get_grace_period_end(expires_at).date()
+    today = datetime.now(timezone.utc).date()
+    return max(0, (grace_end_date - today).days)

--- a/backend/ee/onyx/utils/license_expiry.py
+++ b/backend/ee/onyx/utils/license_expiry.py
@@ -27,14 +27,8 @@ class ExpiryWarningStage(str, Enum):
     GRACE = "grace"
 
 
-def get_expiry_warning_stage(
-    expires_at: datetime,
-    now: datetime | None = None,
-) -> ExpiryWarningStage:
-    if now is None:
-        now = datetime.now(timezone.utc)
-
-    seconds_remaining = (expires_at - now).total_seconds()
+def get_expiry_warning_stage(expires_at: datetime) -> ExpiryWarningStage:
+    seconds_remaining = (expires_at - datetime.now(timezone.utc)).total_seconds()
     days_remaining = seconds_remaining / 86400.0
 
     if days_remaining > 30:
@@ -54,11 +48,9 @@ def get_grace_period_end(expires_at: datetime) -> datetime:
     return expires_at + timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
 
 
-def get_grace_days_remaining(expires_at: datetime, now: datetime | None = None) -> int:
-    if now is None:
-        now = datetime.now(timezone.utc)
+def get_grace_days_remaining(expires_at: datetime) -> int:
     grace_end = get_grace_period_end(expires_at)
-    seconds_left = (grace_end - now).total_seconds()
+    seconds_left = (grace_end - datetime.now(timezone.utc)).total_seconds()
     if seconds_left <= 0:
         return 0
     return max(1, int(seconds_left // 86400) + (1 if seconds_left % 86400 > 0 else 0))

--- a/backend/ee/onyx/utils/license_expiry.py
+++ b/backend/ee/onyx/utils/license_expiry.py
@@ -12,6 +12,7 @@ Stages:
 """
 
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from enum import Enum
 
@@ -44,14 +45,12 @@ def get_expiry_warning_stage(
         return ExpiryWarningStage.T_14D
     if days_remaining > 0:
         return ExpiryWarningStage.T_1D
-    if days_remaining >= -LICENSE_GRACE_PERIOD_DAYS:
+    if days_remaining > -LICENSE_GRACE_PERIOD_DAYS:
         return ExpiryWarningStage.GRACE
     return ExpiryWarningStage.NONE
 
 
 def get_grace_period_end(expires_at: datetime) -> datetime:
-    from datetime import timedelta
-
     return expires_at + timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
 
 

--- a/backend/ee/onyx/utils/license_expiry.py
+++ b/backend/ee/onyx/utils/license_expiry.py
@@ -1,0 +1,65 @@
+"""Tiered license-expiry warning stage derivation.
+
+Pure logic — no DB, no I/O. Given an `expires_at` and current time, returns the
+warning stage that should drive banner copy + notification + email triggers.
+
+Stages:
+    NONE  — more than 30 days remain, or grace period already exhausted
+    T_30D — 14 < days_remaining <= 30
+    T_14D —  1 < days_remaining <= 14
+    T_1D  —  0 < days_remaining <=  1
+    GRACE — license already expired, within 14-day grace window
+"""
+
+from datetime import datetime
+from datetime import timezone
+from enum import Enum
+
+LICENSE_GRACE_PERIOD_DAYS = 14
+
+
+class ExpiryWarningStage(str, Enum):
+    NONE = "none"
+    T_30D = "t_30d"
+    T_14D = "t_14d"
+    T_1D = "t_1d"
+    GRACE = "grace"
+
+
+def get_expiry_warning_stage(
+    expires_at: datetime,
+    now: datetime | None = None,
+) -> ExpiryWarningStage:
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    seconds_remaining = (expires_at - now).total_seconds()
+    days_remaining = seconds_remaining / 86400.0
+
+    if days_remaining > 30:
+        return ExpiryWarningStage.NONE
+    if days_remaining > 14:
+        return ExpiryWarningStage.T_30D
+    if days_remaining > 1:
+        return ExpiryWarningStage.T_14D
+    if days_remaining > 0:
+        return ExpiryWarningStage.T_1D
+    if days_remaining >= -LICENSE_GRACE_PERIOD_DAYS:
+        return ExpiryWarningStage.GRACE
+    return ExpiryWarningStage.NONE
+
+
+def get_grace_period_end(expires_at: datetime) -> datetime:
+    from datetime import timedelta
+
+    return expires_at + timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
+
+
+def get_grace_days_remaining(expires_at: datetime, now: datetime | None = None) -> int:
+    if now is None:
+        now = datetime.now(timezone.utc)
+    grace_end = get_grace_period_end(expires_at)
+    seconds_left = (grace_end - now).total_seconds()
+    if seconds_left <= 0:
+        return 0
+    return max(1, int(seconds_left // 86400) + (1 if seconds_left % 86400 > 0 else 0))

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -143,7 +143,7 @@ def _create_stage_notifications(
             [
                 {
                     "user_id": admin_id,
-                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING.name,
+                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING,
                     "title": title,
                     "description": description,
                     "dismissed": False,

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -11,42 +11,21 @@ from datetime import date
 from datetime import datetime
 from datetime import timezone
 from typing import Any
-from uuid import UUID
 
-from sqlalchemy import cast
-from sqlalchemy import select
-from sqlalchemy.dialects import postgresql
-from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import func
 
 from ee.onyx.utils.license_expiry import ExpiryWarningStage
 from ee.onyx.utils.license_expiry import get_grace_days_remaining
 from onyx.auth.email_utils import build_html_email
 from onyx.auth.email_utils import send_email
-from onyx.auth.schemas import UserRole
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.constants import NotificationType
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
-from onyx.db.models import Notification
-from onyx.db.models import User
+from onyx.db.notification import batch_create_notifications
+from onyx.db.users import get_active_admin_users
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-
-def _get_admin_users(db_session: Session) -> list[User]:
-    return list(
-        db_session.execute(
-            select(User).where(
-                User.is_active,  # ty: ignore[invalid-argument-type]
-                User.role == UserRole.ADMIN,
-            )
-        )
-        .unique()
-        .scalars()
-        .all()
-    )
 
 
 def _build_copy(
@@ -124,98 +103,37 @@ def _build_additional_data(
     return data
 
 
-def _create_stage_notifications(
-    *,
-    db_session: Session,
-    admin_ids: list[UUID],
-    title: str,
-    description: str,
-    additional_data: dict[str, Any],
-) -> set[UUID]:
-    if not admin_ids:
-        return set()
-
-    now = datetime.now(timezone.utc)
-
-    stmt = (
-        insert(Notification)
-        .values(
-            [
-                {
-                    "user_id": admin_id,
-                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING,
-                    "title": title,
-                    "description": description,
-                    "dismissed": False,
-                    "last_shown": now,
-                    "first_shown": now,
-                    "additional_data": additional_data,
-                }
-                for admin_id in admin_ids
-            ]
-        )
-        .on_conflict_do_nothing()
-        .returning(Notification.user_id)
-    )
-    result = db_session.execute(stmt)
-    inserted_ids = set(result.scalars())
-    db_session.commit()
-    return inserted_ids
-
-
 def notify_admins_for_stage(
     db_session: Session,
     stage: ExpiryWarningStage,
     expires_at: datetime,
-    today: date | None = None,
-) -> int:
-    """Create in-app notifications + send emails for admins not already notified.
-
-    Returns count of admins newly notified.
-    """
+) -> None:
+    """Create in-app notifications + send emails for admins not already notified."""
     if stage == ExpiryWarningStage.NONE:
-        return 0
+        return
 
-    if today is None:
-        today = datetime.now(timezone.utc).date()
-
-    admins = _get_admin_users(db_session)
+    today = datetime.now(timezone.utc).date()
+    admins = get_active_admin_users(db_session)
     if not admins:
         logger.warning("No active admins found to notify for license stage %s", stage)
-        return 0
+        return
 
     additional_data = _build_additional_data(stage, expires_at, today)
-
-    already_notified_ids = set(
-        db_session.execute(
-            select(Notification.user_id).where(
-                Notification.notif_type == NotificationType.LICENSE_EXPIRY_WARNING,
-                func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
-                == additional_data,
-            )
-        ).scalars()
-    )
-
-    new_admins = [a for a in admins if a.id not in already_notified_ids]
-    if not new_admins:
-        return 0
-
     grace_days = get_grace_days_remaining(expires_at)
     title, description, email_subject = _build_copy(stage, expires_at, grace_days)
 
-    admin_ids = [a.id for a in new_admins]
-    inserted_admin_ids = _create_stage_notifications(
+    inserted_admin_ids = batch_create_notifications(
+        user_ids=[a.id for a in admins],
+        notif_type=NotificationType.LICENSE_EXPIRY_WARNING,
         db_session=db_session,
-        admin_ids=admin_ids,
         title=title,
         description=description,
         additional_data=additional_data,
     )
     if not inserted_admin_ids:
-        return 0
+        return
 
-    admin_by_id = {admin.id: admin for admin in new_admins}
-
+    admin_by_id = {admin.id: admin for admin in admins}
     for admin_id in inserted_admin_ids:
         admin = admin_by_id.get(admin_id)
         if admin is not None and admin.email:
@@ -232,4 +150,3 @@ def notify_admins_for_stage(
         len(inserted_admin_ids),
         today.isoformat(),
     )
-    return len(inserted_admin_ids)

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -42,6 +42,7 @@ def _get_admin_users(db_session: Session) -> list[User]:
                 User.role == UserRole.ADMIN,
             )
         )
+        .unique()
         .scalars()
         .all()
     )
@@ -142,7 +143,7 @@ def _create_stage_notifications(
             [
                 {
                     "user_id": admin_id,
-                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING.value,
+                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING.name,
                     "title": title,
                     "description": description,
                     "dismissed": False,

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -1,0 +1,234 @@
+"""License-expiry tiered notification orchestration.
+
+Drives email + in-app notification side effects. Idempotency is enforced
+through the existing `notification` unique index
+`(user_id, notif_type, COALESCE(additional_data, '{}'::jsonb))`. Pre-existing
+admins for a given (stage, expires_at[, sent_date]) tuple are skipped — only
+freshly-notified admins receive an email.
+"""
+
+from datetime import date
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from sqlalchemy import cast
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
+
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
+from ee.onyx.utils.license_expiry import get_grace_days_remaining
+from onyx.auth.email_utils import build_html_email
+from onyx.auth.email_utils import send_email
+from onyx.auth.schemas import UserRole
+from onyx.configs.app_configs import EMAIL_CONFIGURED
+from onyx.configs.constants import NotificationType
+from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
+from onyx.db.models import Notification
+from onyx.db.models import User
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def _get_admin_users(db_session: Session) -> list[User]:
+    return list(
+        db_session.execute(
+            select(User).where(
+                User.is_active,  # ty: ignore[invalid-argument-type]
+                User.role == UserRole.ADMIN,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def _build_copy(
+    stage: ExpiryWarningStage,
+    expires_at: datetime,
+    grace_days_remaining: int,
+) -> tuple[str, str, str]:
+    """Returns (banner_title, banner_description, email_subject)."""
+    expires_str = expires_at.strftime("%Y-%m-%d")
+    if stage == ExpiryWarningStage.T_30D:
+        return (
+            f"Onyx license expires {expires_str}",
+            "Your license will expire in approximately 30 days. Contact your "
+            "Onyx representative to renew.",
+            "Action required: Onyx license expires in ~30 days",
+        )
+    if stage == ExpiryWarningStage.T_14D:
+        return (
+            f"Onyx license expires {expires_str}",
+            "Your license will expire in approximately 2 weeks. Renewal must "
+            "be completed soon to avoid service interruption.",
+            "Action required: Onyx license expires in ~2 weeks",
+        )
+    if stage == ExpiryWarningStage.T_1D:
+        return (
+            f"Onyx license expires tomorrow ({expires_str})",
+            "Your license expires within 24 hours. Renew immediately to avoid "
+            "service interruption.",
+            "URGENT: Onyx license expires within 24 hours",
+        )
+    if stage == ExpiryWarningStage.GRACE:
+        return (
+            f"Onyx license expired — {grace_days_remaining} grace days remaining",
+            f"Your license expired on {expires_str}. You have "
+            f"{grace_days_remaining} day(s) of grace access remaining before "
+            "the instance is gated. Renew now.",
+            f"Onyx license expired — {grace_days_remaining} grace days remaining",
+        )
+    raise ValueError(f"Unsupported stage for notification copy: {stage}")
+
+
+def _send_email_for_stage(
+    user_email: str, subject: str, heading: str, message: str
+) -> None:
+    if not EMAIL_CONFIGURED:
+        logger.warning(
+            "Email not configured — skipping license expiry email to %s", user_email
+        )
+        return
+    html_body = build_html_email(
+        application_name=ONYX_DEFAULT_APPLICATION_NAME,
+        heading=heading,
+        message=message,
+    )
+    text_body = f"{heading}\n\n{message}"
+    try:
+        send_email(user_email, subject, html_body, text_body)
+    except Exception:
+        logger.exception("Failed to send license expiry email to %s", user_email)
+
+
+def _build_additional_data(
+    stage: ExpiryWarningStage,
+    expires_at: datetime,
+    today: date,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "stage": stage.value,
+        "expires_at": expires_at.isoformat(),
+    }
+    if stage == ExpiryWarningStage.GRACE:
+        # Grace period sends one notification per UTC date so admins are
+        # reminded daily until they renew.
+        data["sent_date"] = today.isoformat()
+    return data
+
+
+def _create_stage_notifications(
+    *,
+    db_session: Session,
+    admin_ids: list,
+    title: str,
+    description: str,
+    additional_data: dict[str, Any],
+) -> set:
+    if not admin_ids:
+        return set()
+
+    now = datetime.now(timezone.utc)
+    normalized_data = additional_data if additional_data is not None else {}
+
+    stmt = (
+        insert(Notification)
+        .values(
+            [
+                {
+                    "user_id": admin_id,
+                    "notif_type": NotificationType.LICENSE_EXPIRY_WARNING.value,
+                    "title": title,
+                    "description": description,
+                    "dismissed": False,
+                    "last_shown": now,
+                    "first_shown": now,
+                    "additional_data": normalized_data,
+                }
+                for admin_id in admin_ids
+            ]
+        )
+        .on_conflict_do_nothing()
+        .returning(Notification.user_id)
+    )
+    result = db_session.execute(stmt)
+    inserted_ids = set(result.scalars())
+    db_session.commit()
+    return inserted_ids
+
+
+def notify_admins_for_stage(
+    db_session: Session,
+    stage: ExpiryWarningStage,
+    expires_at: datetime,
+    today: date | None = None,
+) -> int:
+    """Create in-app notifications + send emails for admins not already notified.
+
+    Returns count of admins newly notified.
+    """
+    if stage == ExpiryWarningStage.NONE:
+        return 0
+
+    if today is None:
+        today = datetime.now(timezone.utc).date()
+
+    admins = _get_admin_users(db_session)
+    if not admins:
+        logger.warning("No active admins found to notify for license stage %s", stage)
+        return 0
+
+    additional_data = _build_additional_data(stage, expires_at, today)
+
+    already_notified_ids = set(
+        db_session.execute(
+            select(Notification.user_id).where(
+                Notification.notif_type == NotificationType.LICENSE_EXPIRY_WARNING,
+                func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
+                == additional_data,
+            )
+        ).scalars()
+    )
+
+    new_admins = [a for a in admins if a.id not in already_notified_ids]
+    if not new_admins:
+        return 0
+
+    grace_days = get_grace_days_remaining(expires_at)
+    title, description, email_subject = _build_copy(stage, expires_at, grace_days)
+
+    admin_ids = [a.id for a in new_admins]
+    inserted_admin_ids = _create_stage_notifications(
+        db_session=db_session,
+        admin_ids=admin_ids,
+        title=title,
+        description=description,
+        additional_data=additional_data,
+    )
+    if not inserted_admin_ids:
+        return 0
+
+    admin_by_id = {admin.id: admin for admin in new_admins}
+
+    for admin_id in inserted_admin_ids:
+        admin = admin_by_id.get(admin_id)
+        if admin is not None and admin.email:
+            _send_email_for_stage(
+                user_email=admin.email,
+                subject=email_subject,
+                heading=title,
+                message=description,
+            )
+
+    logger.info(
+        "License expiry notifications sent: stage=%s admins=%d date=%s",
+        stage.value,
+        len(inserted_admin_ids),
+        today.isoformat(),
+    )
+    return len(inserted_admin_ids)

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -11,6 +11,7 @@ from datetime import date
 from datetime import datetime
 from datetime import timezone
 from typing import Any
+from uuid import UUID
 
 from sqlalchemy import cast
 from sqlalchemy import select
@@ -126,16 +127,15 @@ def _build_additional_data(
 def _create_stage_notifications(
     *,
     db_session: Session,
-    admin_ids: list,
+    admin_ids: list[UUID],
     title: str,
     description: str,
     additional_data: dict[str, Any],
-) -> set:
+) -> set[UUID]:
     if not admin_ids:
         return set()
 
     now = datetime.now(timezone.utc)
-    normalized_data = additional_data if additional_data is not None else {}
 
     stmt = (
         insert(Notification)
@@ -149,7 +149,7 @@ def _create_stage_notifications(
                     "dismissed": False,
                     "last_shown": now,
                     "first_shown": now,
-                    "additional_data": normalized_data,
+                    "additional_data": additional_data,
                 }
                 for admin_id in admin_ids
             ]

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -288,6 +288,7 @@ class NotificationType(str, Enum):
     ASSISTANT_FILES_READY = "assistant_files_ready"
     FEATURE_ANNOUNCEMENT = "feature_announcement"
     CONNECTOR_REPEATED_ERRORS = "connector_repeated_errors"
+    LICENSE_EXPIRY_WARNING = "license_expiry_warning"
 
 
 class BlobType(str, Enum):
@@ -619,6 +620,9 @@ class OnyxCeleryTask:
 
     # Hook execution log retention
     HOOK_EXECUTION_LOG_CLEANUP_TASK = "hook_execution_log_cleanup_task"
+
+    # License expiry tiered warnings
+    CHECK_LICENSE_EXPIRY_NOTIFICATIONS = "check_license_expiry_notifications"
 
     # Sandbox cleanup
     CLEANUP_IDLE_SANDBOXES = "cleanup_idle_sandboxes"

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -136,28 +136,29 @@ def batch_create_notifications(
     title: str,
     description: str | None = None,
     additional_data: dict | None = None,
-) -> int:
+) -> set[UUID]:
     """
     Create notifications for multiple users in a single batch operation.
     Uses ON CONFLICT DO NOTHING for atomic idempotent inserts - if a user already
     has a notification with the same (user_id, notif_type, additional_data), the
     insert is silently skipped.
 
-    Returns the number of notifications created.
+    Returns the set of user_ids whose row was newly inserted (excludes conflicts).
+    Callers that need to fire side effects only on fresh inserts (emails, webhooks)
+    can iterate the returned set without re-triggering on idempotent retries.
 
     Relies on unique index on (user_id, notif_type, COALESCE(additional_data, '{}'))
     """
     if not user_ids:
-        return 0
+        return set()
 
     now = datetime.now(timezone.utc)
-    # Use empty dict instead of None to match COALESCE behavior in the unique index
     additional_data_normalized = additional_data if additional_data is not None else {}
 
     values = [
         {
             "user_id": uid,
-            "notif_type": notif_type.value,
+            "notif_type": notif_type,
             "title": title,
             "description": description,
             "dismissed": False,
@@ -168,17 +169,16 @@ def batch_create_notifications(
         for uid in user_ids
     ]
 
-    stmt = insert(Notification).values(values).on_conflict_do_nothing()
-    result = db_session.execute(stmt)
-    db_session.commit()
-
-    # rowcount returns number of rows inserted (excludes conflicts)
-    # CursorResult has rowcount but session.execute type hints are too broad
-    return (
-        result.rowcount  # ty: ignore[unresolved-attribute]
-        if result.rowcount >= 0  # ty: ignore[unresolved-attribute]
-        else 0
+    stmt = (
+        insert(Notification)
+        .values(values)
+        .on_conflict_do_nothing()
+        .returning(Notification.user_id)
     )
+    result = db_session.execute(stmt)
+    inserted_ids = set(result.scalars())
+    db_session.commit()
+    return inserted_ids
 
 
 def update_notification_last_shown(

--- a/backend/onyx/db/release_notes.py
+++ b/backend/onyx/db/release_notes.py
@@ -80,7 +80,7 @@ def create_release_notifications_for_versions(
             "link": link,
         }
 
-        created_count = batch_create_notifications(
+        inserted_ids = batch_create_notifications(
             user_ids,
             NotificationType.RELEASE_NOTES,
             db_session,
@@ -88,6 +88,7 @@ def create_release_notifications_for_versions(
             description=f"Check out what's new in {entry.version}",
             additional_data=additional_data,
         )
+        created_count = len(inserted_ids)
         total_created += created_count
 
         logger.debug(

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -566,25 +566,20 @@ def batch_get_user_groups(
 def get_active_admin_users(db_session: Session) -> list[User]:
     """Active human admins, excluding API-key dummy users and system placeholders.
 
-    Mirrors the filter set used by `_add_live_user_count_where_clause(only_admin_users=True)`
-    so callers that want to email or surface UI to admins can reuse it.
+    Mirrors `_add_live_user_count_where_clause(only_admin_users=True)` in
+    `onyx/db/auth.py` so callers that email or surface UI to admins reuse
+    the same filter set.
     """
     from onyx.db.api_key import get_api_key_email_pattern
 
-    return list(
-        db_session.execute(
-            select(User).where(
-                User.is_active,  # ty: ignore[invalid-argument-type]
-                User.role == UserRole.ADMIN,
-                ~User.email.endswith(  # ty: ignore[invalid-argument-type]
-                    get_api_key_email_pattern()
-                ),
-                User.email != ANONYMOUS_USER_EMAIL,  # ty: ignore[invalid-argument-type]
-                User.email
-                != NO_AUTH_PLACEHOLDER_USER_EMAIL,  # ty: ignore[invalid-argument-type]
-            )
-        )
-        .unique()
-        .scalars()
-        .all()
+    email_col: KeyedColumnElement[Any] = User.__table__.c.email
+    is_active_col: KeyedColumnElement[Any] = User.__table__.c.is_active
+
+    stmt = select(User).where(
+        is_active_col.is_(True),
+        User.role == UserRole.ADMIN,
+        expression.not_(email_col.endswith(get_api_key_email_pattern())),
+        email_col != ANONYMOUS_USER_EMAIL,
+        email_col != NO_AUTH_PLACEHOLDER_USER_EMAIL,
     )
+    return list(db_session.execute(stmt).unique().scalars().all())

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -561,3 +561,30 @@ def batch_get_user_groups(
     for user_id, group_id, group_name in rows:
         result[user_id].append((group_id, group_name))
     return result
+
+
+def get_active_admin_users(db_session: Session) -> list[User]:
+    """Active human admins, excluding API-key dummy users and system placeholders.
+
+    Mirrors the filter set used by `_add_live_user_count_where_clause(only_admin_users=True)`
+    so callers that want to email or surface UI to admins can reuse it.
+    """
+    from onyx.db.api_key import get_api_key_email_pattern
+
+    return list(
+        db_session.execute(
+            select(User).where(
+                User.is_active,  # ty: ignore[invalid-argument-type]
+                User.role == UserRole.ADMIN,
+                ~User.email.endswith(  # ty: ignore[invalid-argument-type]
+                    get_api_key_email_pattern()
+                ),
+                User.email != ANONYMOUS_USER_EMAIL,  # ty: ignore[invalid-argument-type]
+                User.email
+                != NO_AUTH_PLACEHOLDER_USER_EMAIL,  # ty: ignore[invalid-argument-type]
+            )
+        )
+        .unique()
+        .scalars()
+        .all()
+    )

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -570,15 +570,13 @@ def get_active_admin_users(db_session: Session) -> list[User]:
     `onyx/db/auth.py` so callers that email or surface UI to admins reuse
     the same filter set.
     """
-    from onyx.db.api_key import get_api_key_email_pattern
-
     email_col: KeyedColumnElement[Any] = User.__table__.c.email
     is_active_col: KeyedColumnElement[Any] = User.__table__.c.is_active
 
     stmt = select(User).where(
         is_active_col.is_(True),
         User.role == UserRole.ADMIN,
-        expression.not_(email_col.endswith(get_api_key_email_pattern())),
+        expression.not_(email_col.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN)),
         email_col != ANONYMOUS_USER_EMAIL,
         email_col != NO_AUTH_PLACEHOLDER_USER_EMAIL,
     )

--- a/backend/tests/external_dependency_unit/ee/onyx/background/celery/test_license_notifications_task.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/background/celery/test_license_notifications_task.py
@@ -1,0 +1,112 @@
+"""External dependency unit tests for the license-expiry beat task.
+
+Verifies the task short-circuits correctly when:
+- Multi-tenant cloud mode is enabled
+- No license row exists
+- License signature verification fails
+- Stage derivation returns NONE
+
+And dispatches to ``notify_admins_for_stage`` only when there is a real,
+verifiable, in-window license.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ee.onyx.background.celery.tasks.license_notifications.tasks import (
+    check_license_expiry_notifications_task,
+)
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
+
+_TASK_MODULE = "ee.onyx.background.celery.tasks.license_notifications.tasks"
+
+
+pytestmark = pytest.mark.usefixtures("db_session", "tenant_context")
+
+
+def _fake_payload(expires_in_days: int = 25) -> MagicMock:
+    payload = MagicMock()
+    payload.expires_at = datetime.now(timezone.utc) + timedelta(days=expires_in_days)
+    return payload
+
+
+def _fake_license_row() -> MagicMock:
+    row = MagicMock()
+    row.license_data = "fake-base64-license"
+    return row
+
+
+def test_multi_tenant_short_circuits() -> None:
+    with (
+        patch(f"{_TASK_MODULE}.MULTI_TENANT", True),
+        patch(f"{_TASK_MODULE}.notify_admins_for_stage") as notify,
+        patch(f"{_TASK_MODULE}.get_license") as get_license_fn,
+    ):
+        check_license_expiry_notifications_task(tenant_id="anything")
+
+    assert notify.call_count == 0
+    assert get_license_fn.call_count == 0
+
+
+def test_no_license_row_skips() -> None:
+    with (
+        patch(f"{_TASK_MODULE}.MULTI_TENANT", False),
+        patch(f"{_TASK_MODULE}.get_license", return_value=None),
+        patch(f"{_TASK_MODULE}.notify_admins_for_stage") as notify,
+    ):
+        check_license_expiry_notifications_task(tenant_id="t")
+
+    assert notify.call_count == 0
+
+
+def test_signature_failure_skips() -> None:
+    with (
+        patch(f"{_TASK_MODULE}.MULTI_TENANT", False),
+        patch(f"{_TASK_MODULE}.get_license", return_value=_fake_license_row()),
+        patch(
+            f"{_TASK_MODULE}.verify_license_signature",
+            side_effect=ValueError("bad sig"),
+        ),
+        patch(f"{_TASK_MODULE}.notify_admins_for_stage") as notify,
+    ):
+        check_license_expiry_notifications_task(tenant_id="t")
+
+    assert notify.call_count == 0
+
+
+def test_stage_none_skips() -> None:
+    """License valid but >30 days out → stage NONE → no notification work."""
+    with (
+        patch(f"{_TASK_MODULE}.MULTI_TENANT", False),
+        patch(f"{_TASK_MODULE}.get_license", return_value=_fake_license_row()),
+        patch(
+            f"{_TASK_MODULE}.verify_license_signature",
+            return_value=_fake_payload(expires_in_days=120),
+        ),
+        patch(f"{_TASK_MODULE}.notify_admins_for_stage") as notify,
+    ):
+        check_license_expiry_notifications_task(tenant_id="t")
+
+    assert notify.call_count == 0
+
+
+def test_in_window_dispatches_to_notify() -> None:
+    """License within T_30D window → notify_admins_for_stage called once."""
+    payload = _fake_payload(expires_in_days=25)
+    with (
+        patch(f"{_TASK_MODULE}.MULTI_TENANT", False),
+        patch(f"{_TASK_MODULE}.get_license", return_value=_fake_license_row()),
+        patch(f"{_TASK_MODULE}.verify_license_signature", return_value=payload),
+        patch(f"{_TASK_MODULE}.notify_admins_for_stage") as notify,
+    ):
+        check_license_expiry_notifications_task(tenant_id="t")
+
+    assert notify.call_count == 1
+    call_kwargs = notify.call_args.kwargs
+    assert call_kwargs["stage"] == ExpiryWarningStage.T_30D
+    assert call_kwargs["expires_at"] == payload.expires_at

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
@@ -5,7 +5,6 @@ against a real PostgreSQL database. The email send path is patched so we can
 assert "fresh insert only" behavior without configuring SendGrid.
 """
 
-from datetime import date
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -25,7 +24,6 @@ from onyx.db.models import UserRole
 from tests.external_dependency_unit.conftest import create_test_user
 
 EXPIRES_AT = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-TODAY = date(2026, 5, 1)
 
 
 @pytest.fixture
@@ -72,10 +70,7 @@ def test_stage_none_short_circuits(db_session: Session) -> None:
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email:
-        result = notify_admins_for_stage(
-            db_session, ExpiryWarningStage.NONE, EXPIRES_AT, today=TODAY
-        )
-    assert result == 0
+        notify_admins_for_stage(db_session, ExpiryWarningStage.NONE, EXPIRES_AT)
     assert send_email.call_count == 0
 
 
@@ -86,9 +81,7 @@ def test_basic_users_are_not_notified(
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email:
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
     assert _count_license_notifs(db_session, basic_user.id) == 0
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
     targeted = {c.kwargs["user_email"] for c in send_email.call_args_list}
@@ -102,13 +95,9 @@ def test_first_call_creates_notification_and_sends_email(
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email:
-        result = notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
-    assert result >= 1
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
-
     admin_email_calls = [
         c for c in send_email.call_args_list if c.kwargs["user_email"] == admin.email
     ]
@@ -118,18 +107,13 @@ def test_first_call_creates_notification_and_sends_email(
 def test_second_call_same_stage_is_noop(db_session: Session, admin: User) -> None:
     """Second invocation with identical (stage, expires_at) — no new row, no email."""
     with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email_2:
-        result = notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
-    assert result == 0
     admin_email_calls = [
         c for c in send_email_2.call_args_list if c.kwargs["user_email"] == admin.email
     ]
@@ -142,18 +126,13 @@ def test_stage_transition_creates_new_notification(
 ) -> None:
     """T_30D then T_14D → distinct rows + distinct email per stage."""
     with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email_2:
-        result = notify_admins_for_stage(
-            db_session, ExpiryWarningStage.T_14D, EXPIRES_AT, today=TODAY
-        )
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_14D, EXPIRES_AT)
 
-    assert result >= 1
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
     assert _count_license_notifs(db_session, admin.id, "t_14d") == 1
     admin_email_calls = [
@@ -164,23 +143,27 @@ def test_stage_transition_creates_new_notification(
 
 def test_grace_period_fires_once_per_day(db_session: Session, admin: User) -> None:
     """Grace stage with same expires_at but different sent_date → new fire."""
-    day1 = date(2026, 6, 5)
-    day2 = date(2026, 6, 6)
     grace_expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    day1 = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+    day2 = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
 
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email_d1:
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.GRACE, grace_expires, today=day1
-        )
+    with (
+        patch("ee.onyx.utils.license_notifications.datetime") as dt,
+        patch(
+            "ee.onyx.utils.license_notifications._send_email_for_stage"
+        ) as send_email_d1,
+    ):
+        dt.now.return_value = day1
+        notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email_d2:
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.GRACE, grace_expires, today=day2
-        )
+    with (
+        patch("ee.onyx.utils.license_notifications.datetime") as dt,
+        patch(
+            "ee.onyx.utils.license_notifications._send_email_for_stage"
+        ) as send_email_d2,
+    ):
+        dt.now.return_value = day2
+        notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
     d1_calls = [
         c for c in send_email_d1.call_args_list if c.kwargs["user_email"] == admin.email
@@ -195,22 +178,25 @@ def test_grace_period_fires_once_per_day(db_session: Session, admin: User) -> No
 
 def test_grace_period_same_day_is_noop(db_session: Session, admin: User) -> None:
     """Grace stage called twice with same sent_date → no second email."""
-    same_day = date(2026, 6, 5)
     grace_expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    same_day = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
 
-    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
-        notify_admins_for_stage(
-            db_session, ExpiryWarningStage.GRACE, grace_expires, today=same_day
-        )
+    with (
+        patch("ee.onyx.utils.license_notifications.datetime") as dt,
+        patch("ee.onyx.utils.license_notifications._send_email_for_stage"),
+    ):
+        dt.now.return_value = same_day
+        notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email_2:
-        result = notify_admins_for_stage(
-            db_session, ExpiryWarningStage.GRACE, grace_expires, today=same_day
-        )
+    with (
+        patch("ee.onyx.utils.license_notifications.datetime") as dt,
+        patch(
+            "ee.onyx.utils.license_notifications._send_email_for_stage"
+        ) as send_email_2,
+    ):
+        dt.now.return_value = same_day
+        notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
-    assert result == 0
     admin_email_calls = [
         c for c in send_email_2.call_args_list if c.kwargs["user_email"] == admin.email
     ]
@@ -224,14 +210,12 @@ def test_two_admins_both_get_notified(
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email:
-        result = notify_admins_for_stage(
+        notify_admins_for_stage(
             db_session,
             ExpiryWarningStage.T_1D,
             EXPIRES_AT + timedelta(days=10),
-            today=TODAY,
         )
 
-    assert result >= 2
     assert _count_license_notifs(db_session, a1.id, "t_1d") == 1
     assert _count_license_notifs(db_session, a2.id, "t_1d") == 1
     targeted_emails = {c.kwargs["user_email"] for c in send_email.call_args_list}

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
@@ -79,8 +79,10 @@ def test_stage_none_short_circuits(db_session: Session) -> None:
     assert send_email.call_count == 0
 
 
-def test_no_active_admins_returns_zero(db_session: Session, basic_user: User) -> None:
-    """BASIC users must not be notified."""
+def test_basic_users_are_not_notified(
+    db_session: Session, admin: User, basic_user: User
+) -> None:
+    """The role filter excludes BASIC users — only ADMINs get notified."""
     with patch(
         "ee.onyx.utils.license_notifications._send_email_for_stage"
     ) as send_email:
@@ -88,8 +90,10 @@ def test_no_active_admins_returns_zero(db_session: Session, basic_user: User) ->
             db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
         )
     assert _count_license_notifs(db_session, basic_user.id) == 0
-    for call in send_email.call_args_list:
-        assert call.kwargs["user_email"] != basic_user.email
+    assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
+    targeted = {c.kwargs["user_email"] for c in send_email.call_args_list}
+    assert basic_user.email not in targeted
+    assert admin.email in targeted
 
 
 def test_first_call_creates_notification_and_sends_email(

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
@@ -1,0 +1,235 @@
+"""External dependency unit tests for license-expiry notification orchestration.
+
+Verifies idempotency, stage-transition behavior, and grace-period daily cadence
+against a real PostgreSQL database. The email send path is patched so we can
+assert "fresh insert only" behavior without configuring SendGrid.
+"""
+
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
+from ee.onyx.utils.license_notifications import notify_admins_for_stage
+from onyx.configs.constants import NotificationType
+from onyx.db.models import Notification
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from tests.external_dependency_unit.conftest import create_test_user
+
+EXPIRES_AT = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+TODAY = date(2026, 5, 1)
+
+
+@pytest.fixture
+def admin(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> User:
+    return create_test_user(db_session, "license_admin", role=UserRole.ADMIN)
+
+
+@pytest.fixture
+def two_admins(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> list[User]:
+    return [
+        create_test_user(db_session, "license_admin1", role=UserRole.ADMIN),
+        create_test_user(db_session, "license_admin2", role=UserRole.ADMIN),
+    ]
+
+
+@pytest.fixture
+def basic_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> User:
+    return create_test_user(db_session, "license_basic", role=UserRole.BASIC)
+
+
+def _count_license_notifs(
+    db_session: Session, user_id: UUID, stage_value: str | None = None
+) -> int:
+    query = select(Notification).where(
+        Notification.user_id == user_id,
+        Notification.notif_type == NotificationType.LICENSE_EXPIRY_WARNING,
+    )
+    rows = db_session.execute(query).scalars().all()
+    if stage_value is None:
+        return len(rows)
+    return sum(1 for r in rows if (r.additional_data or {}).get("stage") == stage_value)
+
+
+def test_stage_none_short_circuits(db_session: Session) -> None:
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email:
+        result = notify_admins_for_stage(
+            db_session, ExpiryWarningStage.NONE, EXPIRES_AT, today=TODAY
+        )
+    assert result == 0
+    assert send_email.call_count == 0
+
+
+def test_no_active_admins_returns_zero(db_session: Session, basic_user: User) -> None:
+    """BASIC users must not be notified."""
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email:
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
+        )
+    assert _count_license_notifs(db_session, basic_user.id) == 0
+    for call in send_email.call_args_list:
+        assert call.kwargs["user_email"] != basic_user.email
+
+
+def test_first_call_creates_notification_and_sends_email(
+    db_session: Session, admin: User
+) -> None:
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email:
+        result = notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
+        )
+
+    assert result >= 1
+    assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
+
+    admin_email_calls = [
+        c for c in send_email.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    assert len(admin_email_calls) == 1
+
+
+def test_second_call_same_stage_is_noop(db_session: Session, admin: User) -> None:
+    """Second invocation with identical (stage, expires_at) — no new row, no email."""
+    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
+        )
+
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email_2:
+        result = notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
+        )
+
+    assert result == 0
+    admin_email_calls = [
+        c for c in send_email_2.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    assert len(admin_email_calls) == 0
+    assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
+
+
+def test_stage_transition_creates_new_notification(
+    db_session: Session, admin: User
+) -> None:
+    """T_30D then T_14D → distinct rows + distinct email per stage."""
+    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_30D, EXPIRES_AT, today=TODAY
+        )
+
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email_2:
+        result = notify_admins_for_stage(
+            db_session, ExpiryWarningStage.T_14D, EXPIRES_AT, today=TODAY
+        )
+
+    assert result >= 1
+    assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
+    assert _count_license_notifs(db_session, admin.id, "t_14d") == 1
+    admin_email_calls = [
+        c for c in send_email_2.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    assert len(admin_email_calls) == 1
+
+
+def test_grace_period_fires_once_per_day(db_session: Session, admin: User) -> None:
+    """Grace stage with same expires_at but different sent_date → new fire."""
+    day1 = date(2026, 6, 5)
+    day2 = date(2026, 6, 6)
+    grace_expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email_d1:
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.GRACE, grace_expires, today=day1
+        )
+
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email_d2:
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.GRACE, grace_expires, today=day2
+        )
+
+    d1_calls = [
+        c for c in send_email_d1.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    d2_calls = [
+        c for c in send_email_d2.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    assert len(d1_calls) == 1
+    assert len(d2_calls) == 1
+    assert _count_license_notifs(db_session, admin.id, "grace") == 2
+
+
+def test_grace_period_same_day_is_noop(db_session: Session, admin: User) -> None:
+    """Grace stage called twice with same sent_date → no second email."""
+    same_day = date(2026, 6, 5)
+    grace_expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
+        notify_admins_for_stage(
+            db_session, ExpiryWarningStage.GRACE, grace_expires, today=same_day
+        )
+
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email_2:
+        result = notify_admins_for_stage(
+            db_session, ExpiryWarningStage.GRACE, grace_expires, today=same_day
+        )
+
+    assert result == 0
+    admin_email_calls = [
+        c for c in send_email_2.call_args_list if c.kwargs["user_email"] == admin.email
+    ]
+    assert len(admin_email_calls) == 0
+
+
+def test_two_admins_both_get_notified(
+    db_session: Session, two_admins: list[User]
+) -> None:
+    a1, a2 = two_admins
+    with patch(
+        "ee.onyx.utils.license_notifications._send_email_for_stage"
+    ) as send_email:
+        result = notify_admins_for_stage(
+            db_session,
+            ExpiryWarningStage.T_1D,
+            EXPIRES_AT + timedelta(days=10),
+            today=TODAY,
+        )
+
+    assert result >= 2
+    assert _count_license_notifs(db_session, a1.id, "t_1d") == 1
+    assert _count_license_notifs(db_session, a2.id, "t_1d") == 1
+    targeted_emails = {c.kwargs["user_email"] for c in send_email.call_args_list}
+    assert a1.email in targeted_emails
+    assert a2.email in targeted_emails

--- a/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
@@ -30,8 +30,8 @@ NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
         (timedelta(hours=-1), ExpiryWarningStage.GRACE),
         (timedelta(days=-1), ExpiryWarningStage.GRACE),
         (timedelta(days=-13), ExpiryWarningStage.GRACE),
-        (timedelta(days=-14), ExpiryWarningStage.GRACE),
-        (timedelta(days=-14, seconds=-1), ExpiryWarningStage.NONE),
+        (timedelta(days=-14, seconds=1), ExpiryWarningStage.GRACE),
+        (timedelta(days=-14), ExpiryWarningStage.NONE),
         (timedelta(days=-30), ExpiryWarningStage.NONE),
     ],
 )

--- a/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+import pytest
+
+from ee.onyx.utils.license_expiry import ExpiryWarningStage
+from ee.onyx.utils.license_expiry import get_expiry_warning_stage
+from ee.onyx.utils.license_expiry import get_grace_days_remaining
+from ee.onyx.utils.license_expiry import LICENSE_GRACE_PERIOD_DAYS
+
+NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "delta,want",
+    [
+        (timedelta(days=60), ExpiryWarningStage.NONE),
+        (timedelta(days=31), ExpiryWarningStage.NONE),
+        (timedelta(days=30), ExpiryWarningStage.T_30D),
+        (timedelta(days=15), ExpiryWarningStage.T_30D),
+        (timedelta(days=14, seconds=1), ExpiryWarningStage.T_30D),
+        (timedelta(days=14), ExpiryWarningStage.T_14D),
+        (timedelta(days=2), ExpiryWarningStage.T_14D),
+        (timedelta(days=1, seconds=1), ExpiryWarningStage.T_14D),
+        (timedelta(days=1), ExpiryWarningStage.T_1D),
+        (timedelta(hours=12), ExpiryWarningStage.T_1D),
+        (timedelta(seconds=1), ExpiryWarningStage.T_1D),
+        (timedelta(0), ExpiryWarningStage.GRACE),
+        (timedelta(hours=-1), ExpiryWarningStage.GRACE),
+        (timedelta(days=-1), ExpiryWarningStage.GRACE),
+        (timedelta(days=-13), ExpiryWarningStage.GRACE),
+        (timedelta(days=-14), ExpiryWarningStage.GRACE),
+        (timedelta(days=-14, seconds=-1), ExpiryWarningStage.NONE),
+        (timedelta(days=-30), ExpiryWarningStage.NONE),
+    ],
+)
+def test_get_expiry_warning_stage_boundaries(
+    delta: timedelta, want: ExpiryWarningStage
+) -> None:
+    assert get_expiry_warning_stage(NOW + delta, now=NOW) == want
+
+
+def test_grace_days_remaining_full_window() -> None:
+    just_expired = NOW - timedelta(seconds=1)
+    assert get_grace_days_remaining(just_expired, now=NOW) == LICENSE_GRACE_PERIOD_DAYS
+
+
+def test_grace_days_remaining_one_day_left() -> None:
+    expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS - 1)
+    assert get_grace_days_remaining(expires, now=NOW) == 1
+
+
+def test_grace_days_remaining_exhausted() -> None:
+    expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
+    assert get_grace_days_remaining(expires, now=NOW) == 0

--- a/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
@@ -54,3 +54,48 @@ def test_grace_days_remaining_one_day_left() -> None:
 def test_grace_days_remaining_exhausted() -> None:
     expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
     assert get_grace_days_remaining(expires, now=NOW) == 0
+
+
+def test_get_grace_period_end_is_expires_plus_window() -> None:
+    from ee.onyx.utils.license_expiry import get_grace_period_end
+
+    expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    assert get_grace_period_end(expires) == expires + timedelta(
+        days=LICENSE_GRACE_PERIOD_DAYS
+    )
+
+
+def _status_with_default_grace(expires: datetime, now: datetime) -> str:
+    """Reproduce the wiring in `update_license_cache`: derive the grace
+    period end from `expires_at` and feed it to `get_license_status` so the
+    middleware-facing status is consistent with the banner stage."""
+    from unittest.mock import MagicMock
+
+    from ee.onyx.utils.license import get_license_status
+    from ee.onyx.utils.license_expiry import get_grace_period_end
+
+    payload = MagicMock()
+    payload.expires_at = expires
+    grace_end = get_grace_period_end(expires)
+    # Patch datetime.now inside get_license_status by passing a custom now is
+    # not supported; instead validate via boundary expiry values.
+    with __import__("unittest.mock", fromlist=["patch"]).patch(
+        "ee.onyx.utils.license.datetime"
+    ) as dt_mock:
+        dt_mock.now.return_value = now
+        return get_license_status(payload, grace_end).value
+
+
+def test_default_grace_keeps_active_status_pre_expiry() -> None:
+    expires = NOW + timedelta(days=10)
+    assert _status_with_default_grace(expires, now=NOW) == "active"
+
+
+def test_default_grace_returns_grace_period_within_window() -> None:
+    expires = NOW - timedelta(days=5)
+    assert _status_with_default_grace(expires, now=NOW) == "grace_period"
+
+
+def test_default_grace_gates_after_window_exhausted() -> None:
+    expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS + 1)
+    assert _status_with_default_grace(expires, now=NOW) == "gated_access"

--- a/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
@@ -1,15 +1,24 @@
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from unittest.mock import patch
 
 import pytest
 
 from ee.onyx.utils.license_expiry import ExpiryWarningStage
 from ee.onyx.utils.license_expiry import get_expiry_warning_stage
 from ee.onyx.utils.license_expiry import get_grace_days_remaining
+from ee.onyx.utils.license_expiry import get_grace_period_end
 from ee.onyx.utils.license_expiry import LICENSE_GRACE_PERIOD_DAYS
 
 NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _patch_now() -> object:
+    p = patch("ee.onyx.utils.license_expiry.datetime")
+    mock = p.start()
+    mock.now.return_value = NOW
+    return p
 
 
 @pytest.mark.parametrize(
@@ -38,64 +47,65 @@ NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
 def test_get_expiry_warning_stage_boundaries(
     delta: timedelta, want: ExpiryWarningStage
 ) -> None:
-    assert get_expiry_warning_stage(NOW + delta, now=NOW) == want
+    with patch("ee.onyx.utils.license_expiry.datetime") as dt:
+        dt.now.return_value = NOW
+        assert get_expiry_warning_stage(NOW + delta) == want
 
 
 def test_grace_days_remaining_full_window() -> None:
     just_expired = NOW - timedelta(seconds=1)
-    assert get_grace_days_remaining(just_expired, now=NOW) == LICENSE_GRACE_PERIOD_DAYS
+    with patch("ee.onyx.utils.license_expiry.datetime") as dt:
+        dt.now.return_value = NOW
+        assert get_grace_days_remaining(just_expired) == LICENSE_GRACE_PERIOD_DAYS
 
 
 def test_grace_days_remaining_one_day_left() -> None:
     expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS - 1)
-    assert get_grace_days_remaining(expires, now=NOW) == 1
+    with patch("ee.onyx.utils.license_expiry.datetime") as dt:
+        dt.now.return_value = NOW
+        assert get_grace_days_remaining(expires) == 1
 
 
 def test_grace_days_remaining_exhausted() -> None:
     expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS)
-    assert get_grace_days_remaining(expires, now=NOW) == 0
+    with patch("ee.onyx.utils.license_expiry.datetime") as dt:
+        dt.now.return_value = NOW
+        assert get_grace_days_remaining(expires) == 0
 
 
 def test_get_grace_period_end_is_expires_plus_window() -> None:
-    from ee.onyx.utils.license_expiry import get_grace_period_end
-
     expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
     assert get_grace_period_end(expires) == expires + timedelta(
         days=LICENSE_GRACE_PERIOD_DAYS
     )
 
 
-def _status_with_default_grace(expires: datetime, now: datetime) -> str:
+def _status_with_default_grace(expires: datetime) -> str:
     """Reproduce the wiring in `update_license_cache`: derive the grace
     period end from `expires_at` and feed it to `get_license_status` so the
     middleware-facing status is consistent with the banner stage."""
     from unittest.mock import MagicMock
 
     from ee.onyx.utils.license import get_license_status
-    from ee.onyx.utils.license_expiry import get_grace_period_end
 
     payload = MagicMock()
     payload.expires_at = expires
     grace_end = get_grace_period_end(expires)
-    # Patch datetime.now inside get_license_status by passing a custom now is
-    # not supported; instead validate via boundary expiry values.
-    with __import__("unittest.mock", fromlist=["patch"]).patch(
-        "ee.onyx.utils.license.datetime"
-    ) as dt_mock:
-        dt_mock.now.return_value = now
+    with patch("ee.onyx.utils.license.datetime") as dt_mock:
+        dt_mock.now.return_value = NOW
         return get_license_status(payload, grace_end).value
 
 
 def test_default_grace_keeps_active_status_pre_expiry() -> None:
     expires = NOW + timedelta(days=10)
-    assert _status_with_default_grace(expires, now=NOW) == "active"
+    assert _status_with_default_grace(expires) == "active"
 
 
 def test_default_grace_returns_grace_period_within_window() -> None:
     expires = NOW - timedelta(days=5)
-    assert _status_with_default_grace(expires, now=NOW) == "grace_period"
+    assert _status_with_default_grace(expires) == "grace_period"
 
 
 def test_default_grace_gates_after_window_exhausted() -> None:
     expires = NOW - timedelta(days=LICENSE_GRACE_PERIOD_DAYS + 1)
-    assert _status_with_default_grace(expires, now=NOW) == "gated_access"
+    assert _status_with_default_grace(expires) == "gated_access"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import StatsOverlayLoader from "@/components/dev/StatsOverlayLoader";
 import { cn } from "@opal/utils";
 import AppHealthBanner from "@/sections/AppHealthBanner";
+import LicenseExpiryBanner from "@/sections/LicenseExpiryBanner";
 import CustomAnalyticsScript from "@/providers/CustomAnalyticsScript";
 import ProductGatingWrapper from "@/providers/ProductGatingWrapper";
 import SWRConfigProvider from "@/providers/SWRConfigProvider";
@@ -106,6 +107,7 @@ export default function RootLayout({
               <PHProvider>
                 <SWRConfigProvider>
                   <AppHealthBanner />
+                  <LicenseExpiryBanner />
                   <AppProvider>
                     <DynamicMetadata />
                     <CustomAnalyticsScript />

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -49,7 +49,6 @@ export interface LicenseStatus {
   grace_period_end: string | null;
   status: ApplicationStatus | null;
   expiry_warning_stage: ExpiryWarningStage;
-  grace_days_remaining: number;
   source: LicenseSource | null;
 }
 

--- a/web/src/lib/billing/interfaces.ts
+++ b/web/src/lib/billing/interfaces.ts
@@ -21,6 +21,8 @@ export type ApplicationStatus =
   | "expired"
   | "seat_limit_exceeded";
 
+export type ExpiryWarningStage = "none" | "t_30d" | "t_14d" | "t_1d" | "grace";
+
 /**
  * Billing status from Stripe subscription.
  */
@@ -46,6 +48,8 @@ export interface LicenseStatus {
   expires_at: string | null;
   grace_period_end: string | null;
   status: ApplicationStatus | null;
+  expiry_warning_stage: ExpiryWarningStage;
+  grace_days_remaining: number;
   source: LicenseSource | null;
 }
 

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -12,6 +12,7 @@ export function getNotificationIcon(
       return SvgAlertCircle;
 
     case NotificationType.TRIAL_ENDS_TWO_DAYS:
+    case NotificationType.LICENSE_EXPIRY_WARNING:
       return SvgAlertTriangle;
 
     case NotificationType.RELEASE_NOTES:

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -6,6 +6,7 @@ export enum NotificationType {
 
   // SvgAlertTriangle
   TRIAL_ENDS_TWO_DAYS = "two_day_trial_ending",
+  LICENSE_EXPIRY_WARNING = "license_expiry_warning",
 
   // SvgBullhorn
   RELEASE_NOTES = "release_notes",

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -66,6 +66,13 @@ function buildCopy(
   return null;
 }
 
+function computeGraceDaysRemaining(gracePeriodEnd: string | null): number {
+  if (!gracePeriodEnd) return 0;
+  const msLeft = new Date(gracePeriodEnd).getTime() - Date.now();
+  if (msLeft <= 0) return 0;
+  return Math.max(1, Math.ceil(msLeft / 86400000));
+}
+
 function dismissKey(
   stage: ExpiryWarningStage,
   expiresAt: string | null
@@ -163,7 +170,7 @@ export default function LicenseExpiryBanner() {
 
   const stage = data?.expiry_warning_stage ?? "none";
   const expiresAt = data?.expires_at ?? null;
-  const graceDays = data?.grace_days_remaining ?? 0;
+  const graceDays = computeGraceDaysRemaining(data?.grace_period_end ?? null);
   const hasLicense = data?.has_license ?? false;
   const key = dismissKey(stage, expiresAt);
 

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import useSWR from "swr";
 import { MessageCard } from "@opal/components";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -104,55 +104,6 @@ export function LicenseExpiryBannerView({
   );
 }
 
-const MOCK_STAGES: ReadonlySet<ExpiryWarningStage> =
-  new Set<ExpiryWarningStage>(["t_30d", "t_14d", "t_1d", "grace"]);
-
-function useMockLicenseStatus(): {
-  stage: ExpiryWarningStage;
-  expiresAt: string | null;
-  graceDays: number;
-  hasLicense: boolean;
-} | null {
-  const params = useSearchParams();
-  return useMemo(() => {
-    const raw = params?.get("mock_license_stage");
-    if (!raw || !MOCK_STAGES.has(raw as ExpiryWarningStage)) return null;
-    const stage = raw as ExpiryWarningStage;
-    const dayMs = 86400 * 1000;
-    const now = Date.now();
-    if (stage === "t_30d") {
-      return {
-        stage,
-        expiresAt: new Date(now + 25 * dayMs).toISOString(),
-        graceDays: 0,
-        hasLicense: true,
-      };
-    }
-    if (stage === "t_14d") {
-      return {
-        stage,
-        expiresAt: new Date(now + 10 * dayMs).toISOString(),
-        graceDays: 0,
-        hasLicense: true,
-      };
-    }
-    if (stage === "t_1d") {
-      return {
-        stage,
-        expiresAt: new Date(now + 1 * dayMs).toISOString(),
-        graceDays: 0,
-        hasLicense: true,
-      };
-    }
-    return {
-      stage,
-      expiresAt: new Date(now - 3 * dayMs).toISOString(),
-      graceDays: 11,
-      hasLicense: true,
-    };
-  }, [params]);
-}
-
 function useMainContainerOffset(): { left: number; width: number } {
   const pathname = usePathname();
   const [bounds, setBounds] = useState<{ left: number; width: number }>({
@@ -207,14 +158,13 @@ export default function LicenseExpiryBanner() {
     SWR_KEYS.license,
     errorHandlingFetcher
   );
-  const mock = useMockLicenseStatus();
   const [dismissed, setDismissed] = useState(false);
   const { left, width } = useMainContainerOffset();
 
-  const stage = mock?.stage ?? data?.expiry_warning_stage ?? "none";
-  const expiresAt = mock?.expiresAt ?? data?.expires_at ?? null;
-  const graceDays = mock?.graceDays ?? data?.grace_days_remaining ?? 0;
-  const hasLicense = mock?.hasLicense ?? data?.has_license ?? false;
+  const stage = data?.expiry_warning_stage ?? "none";
+  const expiresAt = data?.expires_at ?? null;
+  const graceDays = data?.grace_days_remaining ?? 0;
+  const hasLicense = data?.has_license ?? false;
   const key = dismissKey(stage, expiresAt);
 
   useEffect(() => {

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -185,7 +185,7 @@ export default function LicenseExpiryBanner() {
 
   return (
     <div
-      className="fixed top-3 z-[100] flex justify-center px-3 pointer-events-none"
+      className="fixed top-3 z-toast flex justify-center px-3 pointer-events-none"
       style={{ left, width: width || undefined }}
     >
       <div className="w-full max-w-3xl pointer-events-auto">

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -2,14 +2,9 @@
 
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
-import useSWR from "swr";
 import { MessageCard } from "@opal/components";
-import { errorHandlingFetcher } from "@/lib/fetcher";
-import { SWR_KEYS } from "@/lib/swr-keys";
-import type {
-  ExpiryWarningStage,
-  LicenseStatus,
-} from "@/lib/billing/interfaces";
+import type { ExpiryWarningStage } from "@/lib/billing/interfaces";
+import { useLicense } from "@/hooks/useLicense";
 
 const DISMISS_STORAGE_KEY = "license-expiry-banner-dismissed";
 
@@ -161,10 +156,7 @@ function useMainContainerOffset(): { left: number; width: number } {
 }
 
 export default function LicenseExpiryBanner() {
-  const { data } = useSWR<LicenseStatus>(
-    SWR_KEYS.license,
-    errorHandlingFetcher
-  );
+  const { data } = useLicense();
   const [dismissed, setDismissed] = useState(false);
   const { left, width } = useMainContainerOffset();
 

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -1,25 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 import useSWR from "swr";
-import { Button } from "@opal/components";
-import { SvgAlertCircle, SvgAlertTriangle, SvgX } from "@opal/icons";
-import { Content } from "@opal/layouts";
+import { MessageCard } from "@opal/components";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type {
   ExpiryWarningStage,
   LicenseStatus,
 } from "@/lib/billing/interfaces";
-import { cn } from "@opal/utils";
 
 const DISMISS_STORAGE_KEY = "license-expiry-banner-dismissed";
+
+type BannerVariant = "warning" | "error";
 
 interface BannerCopy {
   title: string;
   description: string;
-  className: string;
-  icon: typeof SvgAlertCircle;
+  variant: BannerVariant;
 }
 
 function buildCopy(
@@ -33,37 +32,35 @@ function buildCopy(
 
   if (stage === "t_30d") {
     return {
-      title: `Onyx license expires ${expiresDisplay}`,
+      title: `Your Onyx license expires on ${expiresDisplay}.`,
       description:
-        "Your license will expire in approximately 30 days. Contact your Onyx representative to renew.",
-      className: "bg-status-warning-01",
-      icon: SvgAlertCircle,
+        "Renewal is due in approximately 30 days. Contact your Onyx representative to renew.",
+      variant: "warning",
     };
   }
   if (stage === "t_14d") {
     return {
-      title: `Onyx license expires ${expiresDisplay}`,
+      title: `Your Onyx license expires on ${expiresDisplay}.`,
       description:
-        "Your license will expire in approximately 2 weeks. Renewal must be completed soon to avoid service interruption.",
-      className: "bg-status-warning-01",
-      icon: SvgAlertTriangle,
+        "Renewal is due in approximately 2 weeks. Complete renewal soon to avoid service interruption.",
+      variant: "warning",
     };
   }
   if (stage === "t_1d") {
     return {
-      title: `Onyx license expires tomorrow (${expiresDisplay})`,
+      title: `Your Onyx license expires tomorrow (${expiresDisplay}).`,
       description:
-        "Your license expires within 24 hours. Renew immediately to avoid service interruption.",
-      className: "bg-status-error-01",
-      icon: SvgAlertTriangle,
+        "Renewal is due within 24 hours. Renew now to avoid service interruption.",
+      variant: "error",
     };
   }
   if (stage === "grace") {
     return {
-      title: `Onyx license expired — ${graceDaysRemaining} grace day(s) remaining`,
-      description: `Your license expired on ${expiresDisplay}. Renew immediately to avoid service interruption.`,
-      className: "bg-status-error-01",
-      icon: SvgAlertTriangle,
+      title: `Your Onyx license expired on ${expiresDisplay}.`,
+      description: `${graceDaysRemaining} grace day${
+        graceDaysRemaining === 1 ? "" : "s"
+      } remaining before access is gated. Renew now.`,
+      variant: "error",
     };
   }
   return null;
@@ -73,7 +70,136 @@ function dismissKey(
   stage: ExpiryWarningStage,
   expiresAt: string | null
 ): string {
-  return `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
+  const base = `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
+  if (stage === "grace") {
+    const today = new Date().toISOString().slice(0, 10);
+    return `${base}:${today}`;
+  }
+  return base;
+}
+
+interface LicenseExpiryBannerViewProps {
+  stage: ExpiryWarningStage;
+  expiresAt: string | null;
+  graceDaysRemaining: number;
+  onDismiss?: () => void;
+}
+
+export function LicenseExpiryBannerView({
+  stage,
+  expiresAt,
+  graceDaysRemaining,
+  onDismiss,
+}: LicenseExpiryBannerViewProps) {
+  const copy = buildCopy(stage, expiresAt, graceDaysRemaining);
+  if (!copy) return null;
+
+  return (
+    <MessageCard
+      variant={copy.variant}
+      title={copy.title}
+      description={copy.description}
+      onClose={onDismiss}
+    />
+  );
+}
+
+const MOCK_STAGES: ReadonlySet<ExpiryWarningStage> =
+  new Set<ExpiryWarningStage>(["t_30d", "t_14d", "t_1d", "grace"]);
+
+function useMockLicenseStatus(): {
+  stage: ExpiryWarningStage;
+  expiresAt: string | null;
+  graceDays: number;
+  hasLicense: boolean;
+} | null {
+  const params = useSearchParams();
+  return useMemo(() => {
+    const raw = params?.get("mock_license_stage");
+    if (!raw || !MOCK_STAGES.has(raw as ExpiryWarningStage)) return null;
+    const stage = raw as ExpiryWarningStage;
+    const dayMs = 86400 * 1000;
+    const now = Date.now();
+    if (stage === "t_30d") {
+      return {
+        stage,
+        expiresAt: new Date(now + 25 * dayMs).toISOString(),
+        graceDays: 0,
+        hasLicense: true,
+      };
+    }
+    if (stage === "t_14d") {
+      return {
+        stage,
+        expiresAt: new Date(now + 10 * dayMs).toISOString(),
+        graceDays: 0,
+        hasLicense: true,
+      };
+    }
+    if (stage === "t_1d") {
+      return {
+        stage,
+        expiresAt: new Date(now + 1 * dayMs).toISOString(),
+        graceDays: 0,
+        hasLicense: true,
+      };
+    }
+    return {
+      stage,
+      expiresAt: new Date(now - 3 * dayMs).toISOString(),
+      graceDays: 11,
+      hasLicense: true,
+    };
+  }, [params]);
+}
+
+function useMainContainerOffset(): { left: number; width: number } {
+  const pathname = usePathname();
+  const [bounds, setBounds] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let target: HTMLElement | null = null;
+    let frame = 0;
+
+    function update() {
+      const el = document.querySelector<HTMLElement>("[data-main-container]");
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        setBounds({ left: rect.left, width: rect.width });
+        if (target !== el) {
+          ro.disconnect();
+          ro.observe(el);
+          target = el;
+        }
+      } else {
+        setBounds({ left: 0, width: window.innerWidth });
+        target = null;
+      }
+    }
+
+    const ro = new ResizeObserver(update);
+    const mo = new MutationObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(update);
+    });
+
+    update();
+    mo.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", update);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [pathname]);
+
+  return bounds;
 }
 
 export default function LicenseExpiryBanner() {
@@ -81,55 +207,45 @@ export default function LicenseExpiryBanner() {
     SWR_KEYS.license,
     errorHandlingFetcher
   );
+  const mock = useMockLicenseStatus();
   const [dismissed, setDismissed] = useState(false);
+  const { left, width } = useMainContainerOffset();
 
-  const stage = data?.expiry_warning_stage ?? "none";
-  const expiresAt = data?.expires_at ?? null;
-  const graceDays = data?.grace_days_remaining ?? 0;
+  const stage = mock?.stage ?? data?.expiry_warning_stage ?? "none";
+  const expiresAt = mock?.expiresAt ?? data?.expires_at ?? null;
+  const graceDays = mock?.graceDays ?? data?.grace_days_remaining ?? 0;
+  const hasLicense = mock?.hasLicense ?? data?.has_license ?? false;
   const key = dismissKey(stage, expiresAt);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    setDismissed(window.sessionStorage.getItem(key) === "1");
+    setDismissed(window.localStorage.getItem(key) === "1");
   }, [key]);
 
-  if (!data?.has_license || stage === "none" || dismissed) {
+  if (!hasLicense || stage === "none" || dismissed) {
     return null;
   }
 
-  const copy = buildCopy(stage, expiresAt, graceDays);
-  if (!copy) return null;
-
   function handleDismiss() {
     if (typeof window !== "undefined") {
-      window.sessionStorage.setItem(key, "1");
+      window.localStorage.setItem(key, "1");
     }
     setDismissed(true);
   }
 
   return (
     <div
-      className={cn(
-        "fixed top-0 left-0 z-[100] w-full p-3 flex items-start gap-2",
-        copy.className
-      )}
+      className="fixed top-3 z-[100] flex justify-center px-3 pointer-events-none"
+      style={{ left, width: width || undefined }}
     >
-      <div className="flex-1">
-        <Content
-          icon={copy.icon}
-          title={copy.title}
-          description={copy.description}
-          sizePreset="main-content"
-          variant="section"
+      <div className="w-full max-w-3xl pointer-events-auto">
+        <LicenseExpiryBannerView
+          stage={stage}
+          expiresAt={expiresAt}
+          graceDaysRemaining={graceDays}
+          onDismiss={handleDismiss}
         />
       </div>
-      <Button
-        variant="default"
-        prominence="tertiary"
-        size="sm"
-        icon={SvgX}
-        onClick={handleDismiss}
-      />
     </div>
   );
 }

--- a/web/src/sections/LicenseExpiryBanner.tsx
+++ b/web/src/sections/LicenseExpiryBanner.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR from "swr";
+import { Button } from "@opal/components";
+import { SvgAlertCircle, SvgAlertTriangle, SvgX } from "@opal/icons";
+import { Content } from "@opal/layouts";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import type {
+  ExpiryWarningStage,
+  LicenseStatus,
+} from "@/lib/billing/interfaces";
+import { cn } from "@opal/utils";
+
+const DISMISS_STORAGE_KEY = "license-expiry-banner-dismissed";
+
+interface BannerCopy {
+  title: string;
+  description: string;
+  className: string;
+  icon: typeof SvgAlertCircle;
+}
+
+function buildCopy(
+  stage: ExpiryWarningStage,
+  expiresAt: string | null,
+  graceDaysRemaining: number
+): BannerCopy | null {
+  const expiresDisplay = expiresAt
+    ? new Date(expiresAt).toLocaleDateString()
+    : "soon";
+
+  if (stage === "t_30d") {
+    return {
+      title: `Onyx license expires ${expiresDisplay}`,
+      description:
+        "Your license will expire in approximately 30 days. Contact your Onyx representative to renew.",
+      className: "bg-status-warning-01",
+      icon: SvgAlertCircle,
+    };
+  }
+  if (stage === "t_14d") {
+    return {
+      title: `Onyx license expires ${expiresDisplay}`,
+      description:
+        "Your license will expire in approximately 2 weeks. Renewal must be completed soon to avoid service interruption.",
+      className: "bg-status-warning-01",
+      icon: SvgAlertTriangle,
+    };
+  }
+  if (stage === "t_1d") {
+    return {
+      title: `Onyx license expires tomorrow (${expiresDisplay})`,
+      description:
+        "Your license expires within 24 hours. Renew immediately to avoid service interruption.",
+      className: "bg-status-error-01",
+      icon: SvgAlertTriangle,
+    };
+  }
+  if (stage === "grace") {
+    return {
+      title: `Onyx license expired — ${graceDaysRemaining} grace day(s) remaining`,
+      description: `Your license expired on ${expiresDisplay}. Renew immediately to avoid service interruption.`,
+      className: "bg-status-error-01",
+      icon: SvgAlertTriangle,
+    };
+  }
+  return null;
+}
+
+function dismissKey(
+  stage: ExpiryWarningStage,
+  expiresAt: string | null
+): string {
+  return `${DISMISS_STORAGE_KEY}:${stage}:${expiresAt ?? "unknown"}`;
+}
+
+export default function LicenseExpiryBanner() {
+  const { data } = useSWR<LicenseStatus>(
+    SWR_KEYS.license,
+    errorHandlingFetcher
+  );
+  const [dismissed, setDismissed] = useState(false);
+
+  const stage = data?.expiry_warning_stage ?? "none";
+  const expiresAt = data?.expires_at ?? null;
+  const graceDays = data?.grace_days_remaining ?? 0;
+  const key = dismissKey(stage, expiresAt);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setDismissed(window.sessionStorage.getItem(key) === "1");
+  }, [key]);
+
+  if (!data?.has_license || stage === "none" || dismissed) {
+    return null;
+  }
+
+  const copy = buildCopy(stage, expiresAt, graceDays);
+  if (!copy) return null;
+
+  function handleDismiss() {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.setItem(key, "1");
+    }
+    setDismissed(true);
+  }
+
+  return (
+    <div
+      className={cn(
+        "fixed top-0 left-0 z-[100] w-full p-3 flex items-start gap-2",
+        copy.className
+      )}
+    >
+      <div className="flex-1">
+        <Content
+          icon={copy.icon}
+          title={copy.title}
+          description={copy.description}
+          sizePreset="main-content"
+          variant="section"
+        />
+      </div>
+      <Button
+        variant="default"
+        prominence="tertiary"
+        size="sm"
+        icon={SvgX}
+        onClick={handleDismiss}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Self-hosted licenses currently insta-expire with no warning, no grace period, and no admin email — surfaced when a customer's instance went down with no notice.

This adds tiered notifications driven by a daily Celery task (self-hosted only):

- **Pre-expiry banner + email + in-app notification** at 30d, 14d, and 1d before `expires_at`.
- **14-day post-expiry grace period** — instance stays up, persistent banner, one admin email per UTC date until renewal.

### Idempotency

Reuses the existing `notification` table's `(user_id, notif_type, COALESCE(additional_data, '{}'::jsonb))` unique index — no new tables, no new License columns. Email is sent only to admins whose row was actually inserted (`INSERT ... ON CONFLICT DO NOTHING RETURNING user_id`), so concurrent beat ticks can't double-email. `additional_data` keys: `{stage, expires_at}` for pre-expiry, `{stage, expires_at, sent_date}` for grace.

### API

`LicenseMetadata` (cached in Redis) gains `expiry_warning_stage` and `grace_days_remaining` fields, surfaced via the `/license` endpoint.

### Frontend

`LicenseExpiryBanner` renders via Opal `MessageCard` (matches billing-page style) — `warning` variant for T_30D / T_14D, `error` variant for T_1D / GRACE. Centered over `[data-main-container]` (sidebar excluded), fixed-positioned, overlays content. Re-measures on route change + DOM mutations so chat and admin layouts both center correctly.

Dismissal persists per stage in `localStorage`. Grace-stage key includes UTC date so each daily fire is independently dismissable.

Dev affordance: `?mock_license_stage=t_30d|t_14d|t_1d|grace` renders the banner against synthetic data on any page.

### Tests

- 21 unit tests for stage derivation across all boundaries.
- 8 external-dependency unit tests for `notify_admins_for_stage` covering the race-safe `INSERT...RETURNING` path: first call inserts + emails, second is a no-op, stage transitions and grace daily cadence each fire exactly once, basic users are never targeted, multiple admins all get notified.
- 5 external-dependency unit tests for the celery beat task covering multi-tenant skip, missing license row, signature failure, stage NONE short-circuit, and dispatch when in-window.

Multi-tenant cloud licensing is unaffected.

## How Has This Been Tested?


<img width="1469" height="958" alt="Screenshot 2026-05-01 at 3 11 18 PM" src="https://github.com/user-attachments/assets/169989cd-0a33-46d1-b0c1-dbb5615e7085" />


<img width="1913" height="959" alt="Screenshot 2026-05-01 at 1 37 24 PM" src="https://github.com/user-attachments/assets/6ff9ef59-2f46-485c-af9c-8345849a6d33" />


<img width="1914" height="949" alt="Screenshot 2026-05-01 at 1 37 14 PM" src="https://github.com/user-attachments/assets/78cfe100-5a10-4aad-add3-259503c3bbd4" />

<img width="1915" height="954" alt="Screenshot 2026-05-01 at 1 37 05 PM" src="https://github.com/user-attachments/assets/b141392b-9bfc-4f97-baa7-9862a23cca03" />

## Additional Options


- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check