### PR TITLE
chore(security): `uv-audit` on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ default_install_hook_types:
   - post-merge
   - post-rewrite
 repos:
-  - repo: https://github.com/astral-sh/uv-pre-commit
-    # From: https://github.com/astral-sh/uv-pre-commit/pull/53/commits/d30b4298e4fb63ce8609e29acdbcf4c9018a483c
-    rev: d30b4298e4fb63ce8609e29acdbcf4c9018a483c
+  - repo: https://github.com/jmelahman/uv-pre-commit
+    rev: cde0de1dff6ec6355f627c6741ec460995d2485a
     hooks:
       - id: uv-sync
       - id: uv-lock
+      - id: uv-audit
       - id: uv-export
         name: uv-export default.txt
         args:
@@ -64,7 +64,7 @@ repos:
         files: ^(pyproject\.toml|uv\.lock|backend/requirements/.*\.txt)$
       - id: uv-run
         name: Check lazy imports
-        args: ["--active", "--with=onyx-devtools", "ods", "check-lazy-imports"]
+        args: ["--with=onyx-devtools", "ods", "check-lazy-imports"]
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$
       - id: uv-run


### PR DESCRIPTION
## Description



## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `uv-audit` to pre-commit to catch vulnerable Python dependencies before commits. Switch to the `jmelahman/uv-pre-commit` fork to enable the audit hook.

- **New Features**
  - Runs `uv-audit` during pre-commit alongside `uv-sync`, `uv-lock`, and `uv-export`.
  - Uses `jmelahman/uv-pre-commit` until upstream exposes the audit hook.

- **Bug Fixes**
  - Removed the `--active` flag from the "Check lazy imports" `uv-run` step.

<sup>Written for commit 02c4a762b19733b28ef5c5f76327205933690732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

