### PR TITLE
feat(targeted-reindex): consumer query filters

### DIFF
--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -350,6 +350,7 @@ def _collect_connector_metrics(db_session: Session, redis_std: Redis) -> list[Me
                 .filter(
                     IndexAttempt.connector_credential_pair_id == cc_pair.id,
                     IndexAttempt.search_settings_id == search_settings.id,
+                    IndexAttempt.targeted_reindex_job_id.is_(None),
                 )
                 .order_by(IndexAttempt.time_created.desc())
                 .limit(2)

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -331,6 +331,7 @@ def get_last_successful_attempt_poll_range_end(
     earliest_index: float,
     search_settings: SearchSettings,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> float:
     """Used to get the latest `poll_range_end` for a given connector and credential.
 
@@ -339,7 +340,7 @@ def get_last_successful_attempt_poll_range_end(
     Note that the attempts time_started is not necessarily correct - that gets set
     separately and is similar but not exactly the same as the `poll_range_end`.
     """
-    latest_successful_index_attempt = (
+    query = (
         db_session.query(IndexAttempt)
         .join(
             ConnectorCredentialPair,
@@ -349,11 +350,13 @@ def get_last_successful_attempt_poll_range_end(
             ConnectorCredentialPair.id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings.id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
-        .order_by(IndexAttempt.poll_range_end.desc())
-        .first()
     )
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    latest_successful_index_attempt = query.order_by(
+        IndexAttempt.poll_range_end.desc()
+    ).first()
     if (
         not latest_successful_index_attempt
         or not latest_successful_index_attempt.poll_range_end

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -349,6 +349,7 @@ def get_last_successful_attempt_poll_range_end(
             ConnectorCredentialPair.id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings.id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .order_by(IndexAttempt.poll_range_end.desc())
         .first()
@@ -728,6 +729,7 @@ def resync_cc_pair(
                 ConnectorCredentialPair.connector_id == connector_id,
                 ConnectorCredentialPair.credential_id == credential_id,
                 IndexAttempt.search_settings_id == search_settings_id,
+                IndexAttempt.targeted_reindex_job_id.is_(None),
             )
         )
 

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -41,6 +41,7 @@ def get_last_attempt_for_cc_pair(
         .filter(
             IndexAttempt.connector_credential_pair_id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings_id,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .order_by(IndexAttempt.time_updated.desc())
         .first()
@@ -59,6 +60,7 @@ def get_recent_completed_attempts_for_cc_pair(
         .filter(
             IndexAttempt.connector_credential_pair_id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings_id,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
             IndexAttempt.status.notin_(
                 [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
             ),
@@ -81,6 +83,7 @@ def get_recent_attempts_for_cc_pair(
         .filter(
             IndexAttempt.connector_credential_pair_id == cc_pair_id,
             IndexAttempt.search_settings_id == search_settings_id,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .order_by(IndexAttempt.time_updated.desc())
         .limit(limit)
@@ -437,6 +440,7 @@ def get_last_attempt(
             ConnectorCredentialPair.connector_id == connector_id,
             ConnectorCredentialPair.credential_id == credential_id,
             IndexAttempt.search_settings_id == search_settings_id,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
     )
 
@@ -468,6 +472,7 @@ def get_latest_index_attempts_by_status(
                 IndexModelStatus.FUTURE if secondary_index else IndexModelStatus.PRESENT
             ),
             IndexAttempt.status == status,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .group_by(IndexAttempt.connector_credential_pair_id)
         .subquery()
@@ -508,7 +513,10 @@ def get_latest_index_attempts(
     ).join(SearchSettings, IndexAttempt.search_settings_id == SearchSettings.id)
 
     status = IndexModelStatus.FUTURE if secondary_index else IndexModelStatus.PRESENT
-    ids_stmt = ids_stmt.where(SearchSettings.status == status)
+    ids_stmt = ids_stmt.where(
+        SearchSettings.status == status,
+        IndexAttempt.targeted_reindex_job_id.is_(None),
+    )
 
     if only_finished:
         ids_stmt = _add_only_finished_clause(ids_stmt)
@@ -567,6 +575,7 @@ def get_latest_index_attempt_for_cc_pair_id(
     stmt = select(IndexAttempt)
     stmt = stmt.where(
         IndexAttempt.connector_credential_pair_id == connector_credential_pair_id,
+        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
     if only_finished:
         stmt = _add_only_finished_clause(stmt)
@@ -594,6 +603,7 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
             IndexAttempt.status.in_(
                 [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
             ),
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .join(SearchSettings)
         .where(SearchSettings.status == status)
@@ -623,6 +633,7 @@ def get_latest_successful_index_attempts_parallel(
                 IndexAttempt.status.in_(
                     [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
                 ),
+                IndexAttempt.targeted_reindex_job_id.is_(None),
             )
             .group_by(IndexAttempt.connector_credential_pair_id)
             .subquery()
@@ -646,7 +657,8 @@ def count_index_attempts_for_cc_pair(
     disinclude_finished: bool = False,
 ) -> int:
     stmt = select(IndexAttempt).where(
-        IndexAttempt.connector_credential_pair_id == cc_pair_id
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
     if disinclude_finished:
         stmt = stmt.where(
@@ -673,7 +685,8 @@ def get_paginated_index_attempts_for_cc_pair_id(
     disinclude_finished: bool = False,
 ) -> list[IndexAttempt]:
     stmt = select(IndexAttempt).where(
-        IndexAttempt.connector_credential_pair_id == cc_pair_id
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
     if disinclude_finished:
         stmt = stmt.where(
@@ -708,6 +721,7 @@ def get_index_attempts_for_cc_pair(
                 ConnectorCredentialPair.connector_id == cc_pair_identifier.connector_id,
                 ConnectorCredentialPair.credential_id
                 == cc_pair_identifier.credential_id,
+                IndexAttempt.targeted_reindex_job_id.is_(None),
             )
         )
     )
@@ -852,6 +866,7 @@ def count_unique_cc_pairs_with_successful_index_attempts(
         .filter(
             IndexAttempt.search_settings_id == search_settings_id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
         .distinct()
         .count()
@@ -874,6 +889,7 @@ def count_unique_active_cc_pairs_with_successful_index_attempts(
         .filter(
             IndexAttempt.search_settings_id == search_settings_id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
             ConnectorCredentialPair.status != ConnectorCredentialPairStatus.PAUSED,
         )
         .distinct()

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -35,17 +35,15 @@ def get_last_attempt_for_cc_pair(
     cc_pair_id: int,
     search_settings_id: int,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> IndexAttempt | None:
-    return (
-        db_session.query(IndexAttempt)
-        .filter(
-            IndexAttempt.connector_credential_pair_id == cc_pair_id,
-            IndexAttempt.search_settings_id == search_settings_id,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
-        )
-        .order_by(IndexAttempt.time_updated.desc())
-        .first()
+    query = db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        IndexAttempt.search_settings_id == search_settings_id,
     )
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    return query.order_by(IndexAttempt.time_updated.desc()).first()
 
 
 def get_recent_completed_attempts_for_cc_pair(
@@ -53,22 +51,19 @@ def get_recent_completed_attempts_for_cc_pair(
     search_settings_id: int,
     limit: int,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> list[IndexAttempt]:
     """Most recent to least recent."""
-    return (
-        db_session.query(IndexAttempt)
-        .filter(
-            IndexAttempt.connector_credential_pair_id == cc_pair_id,
-            IndexAttempt.search_settings_id == search_settings_id,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
-            IndexAttempt.status.notin_(
-                [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
-            ),
-        )
-        .order_by(IndexAttempt.time_updated.desc())
-        .limit(limit)
-        .all()
+    query = db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        IndexAttempt.search_settings_id == search_settings_id,
+        IndexAttempt.status.notin_(
+            [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
+        ),
     )
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    return query.order_by(IndexAttempt.time_updated.desc()).limit(limit).all()
 
 
 def get_recent_attempts_for_cc_pair(
@@ -76,19 +71,16 @@ def get_recent_attempts_for_cc_pair(
     search_settings_id: int,
     limit: int,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> list[IndexAttempt]:
     """Most recent to least recent."""
-    return (
-        db_session.query(IndexAttempt)
-        .filter(
-            IndexAttempt.connector_credential_pair_id == cc_pair_id,
-            IndexAttempt.search_settings_id == search_settings_id,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
-        )
-        .order_by(IndexAttempt.time_updated.desc())
-        .limit(limit)
-        .all()
+    query = db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
+        IndexAttempt.search_settings_id == search_settings_id,
     )
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    return query.order_by(IndexAttempt.time_updated.desc()).limit(limit).all()
 
 
 def get_index_attempt(
@@ -432,6 +424,7 @@ def get_last_attempt(
     credential_id: int,
     search_settings_id: int | None,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> IndexAttempt | None:
     stmt = (
         select(IndexAttempt)
@@ -440,9 +433,10 @@ def get_last_attempt(
             ConnectorCredentialPair.connector_id == connector_id,
             ConnectorCredentialPair.credential_id == credential_id,
             IndexAttempt.search_settings_id == search_settings_id,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
     )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
 
     # Note, the below is using time_created instead of time_updated
     stmt = stmt.order_by(desc(IndexAttempt.time_created))
@@ -454,13 +448,14 @@ def get_latest_index_attempts_by_status(
     secondary_index: bool,
     db_session: Session,
     status: IndexingStatus,
+    ignore_targeted_reindex: bool = True,
 ) -> Sequence[IndexAttempt]:
     """
     Retrieves the most recent index attempt with the specified status for each connector_credential_pair.
     Filters attempts based on the secondary_index flag to get either future or present index attempts.
     Returns a sequence of IndexAttempt objects, one for each unique connector_credential_pair.
     """
-    latest_failed_attempts = (
+    latest_filter_stmt = (
         select(
             IndexAttempt.connector_credential_pair_id,
             func.max(IndexAttempt.id).label("max_failed_id"),
@@ -472,11 +467,15 @@ def get_latest_index_attempts_by_status(
                 IndexModelStatus.FUTURE if secondary_index else IndexModelStatus.PRESENT
             ),
             IndexAttempt.status == status,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
-        .group_by(IndexAttempt.connector_credential_pair_id)
-        .subquery()
     )
+    if ignore_targeted_reindex:
+        latest_filter_stmt = latest_filter_stmt.where(
+            IndexAttempt.targeted_reindex_job_id.is_(None)
+        )
+    latest_failed_attempts = latest_filter_stmt.group_by(
+        IndexAttempt.connector_credential_pair_id
+    ).subquery()
 
     stmt = select(IndexAttempt).join(
         latest_failed_attempts,
@@ -506,6 +505,7 @@ def get_latest_index_attempts(
     db_session: Session,
     eager_load_cc_pair: bool = False,
     only_finished: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> Sequence[IndexAttempt]:
     ids_stmt = select(
         IndexAttempt.connector_credential_pair_id,
@@ -513,10 +513,9 @@ def get_latest_index_attempts(
     ).join(SearchSettings, IndexAttempt.search_settings_id == SearchSettings.id)
 
     status = IndexModelStatus.FUTURE if secondary_index else IndexModelStatus.PRESENT
-    ids_stmt = ids_stmt.where(
-        SearchSettings.status == status,
-        IndexAttempt.targeted_reindex_job_id.is_(None),
-    )
+    ids_stmt = ids_stmt.where(SearchSettings.status == status)
+    if ignore_targeted_reindex:
+        ids_stmt = ids_stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
 
     if only_finished:
         ids_stmt = _add_only_finished_clause(ids_stmt)
@@ -553,6 +552,7 @@ def get_latest_index_attempts_parallel(
     secondary_index: bool,
     eager_load_cc_pair: bool = False,
     only_finished: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> Sequence[IndexAttempt]:
     # The session closes before returning, so only set eager_load_cc_pair=True if the
     # caller actually accesses those relationships — otherwise it loads data for nothing
@@ -563,6 +563,7 @@ def get_latest_index_attempts_parallel(
             db_session,
             eager_load_cc_pair,
             only_finished,
+            ignore_targeted_reindex=ignore_targeted_reindex,
         )
 
 
@@ -571,12 +572,14 @@ def get_latest_index_attempt_for_cc_pair_id(
     connector_credential_pair_id: int,
     secondary_index: bool,
     only_finished: bool = True,
+    ignore_targeted_reindex: bool = True,
 ) -> IndexAttempt | None:
     stmt = select(IndexAttempt)
     stmt = stmt.where(
         IndexAttempt.connector_credential_pair_id == connector_credential_pair_id,
-        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
     if only_finished:
         stmt = _add_only_finished_clause(stmt)
 
@@ -591,21 +594,22 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
     db_session: Session,
     connector_credential_pair_id: int,
     secondary_index: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> IndexAttempt | None:
     """Returns the most recent successful index attempt for the given cc pair,
     filtered to the current (or future) search settings.
     Uses MAX(id) semantics to match get_latest_index_attempts_by_status."""
     status = IndexModelStatus.FUTURE if secondary_index else IndexModelStatus.PRESENT
+    stmt = select(IndexAttempt).where(
+        IndexAttempt.connector_credential_pair_id == connector_credential_pair_id,
+        IndexAttempt.status.in_(
+            [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
+        ),
+    )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
     stmt = (
-        select(IndexAttempt)
-        .where(
-            IndexAttempt.connector_credential_pair_id == connector_credential_pair_id,
-            IndexAttempt.status.in_(
-                [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
-            ),
-            IndexAttempt.targeted_reindex_job_id.is_(None),
-        )
-        .join(SearchSettings)
+        stmt.join(SearchSettings)
         .where(SearchSettings.status == status)
         .order_by(desc(IndexAttempt.id))
         .limit(1)
@@ -615,6 +619,7 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
 
 def get_latest_successful_index_attempts_parallel(
     secondary_index: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> Sequence[IndexAttempt]:
     """Batch version: returns the latest successful index attempt per cc pair.
     Covers both SUCCESS and COMPLETED_WITH_ERRORS (matching is_successful())."""
@@ -633,11 +638,15 @@ def get_latest_successful_index_attempts_parallel(
                 IndexAttempt.status.in_(
                     [IndexingStatus.SUCCESS, IndexingStatus.COMPLETED_WITH_ERRORS]
                 ),
-                IndexAttempt.targeted_reindex_job_id.is_(None),
             )
-            .group_by(IndexAttempt.connector_credential_pair_id)
-            .subquery()
         )
+        if ignore_targeted_reindex:
+            latest_ids = latest_ids.where(
+                IndexAttempt.targeted_reindex_job_id.is_(None)
+            )
+        latest_ids = latest_ids.group_by(
+            IndexAttempt.connector_credential_pair_id
+        ).subquery()
 
         stmt = select(IndexAttempt).join(
             latest_ids,
@@ -655,11 +664,13 @@ def count_index_attempts_for_cc_pair(
     cc_pair_id: int,
     only_current: bool = True,
     disinclude_finished: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> int:
     stmt = select(IndexAttempt).where(
         IndexAttempt.connector_credential_pair_id == cc_pair_id,
-        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
     if disinclude_finished:
         stmt = stmt.where(
             IndexAttempt.status.in_(
@@ -683,11 +694,13 @@ def get_paginated_index_attempts_for_cc_pair_id(
     page_size: int,
     only_current: bool = True,
     disinclude_finished: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> list[IndexAttempt]:
     stmt = select(IndexAttempt).where(
         IndexAttempt.connector_credential_pair_id == cc_pair_id,
-        IndexAttempt.targeted_reindex_job_id.is_(None),
     )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
     if disinclude_finished:
         stmt = stmt.where(
             IndexAttempt.status.in_(
@@ -712,6 +725,7 @@ def get_index_attempts_for_cc_pair(
     cc_pair_identifier: ConnectorCredentialPairIdentifier,
     only_current: bool = True,
     disinclude_finished: bool = False,
+    ignore_targeted_reindex: bool = True,
 ) -> Sequence[IndexAttempt]:
     stmt = (
         select(IndexAttempt)
@@ -721,10 +735,11 @@ def get_index_attempts_for_cc_pair(
                 ConnectorCredentialPair.connector_id == cc_pair_identifier.connector_id,
                 ConnectorCredentialPair.credential_id
                 == cc_pair_identifier.credential_id,
-                IndexAttempt.targeted_reindex_job_id.is_(None),
             )
         )
     )
+    if ignore_targeted_reindex:
+        stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
     if disinclude_finished:
         stmt = stmt.where(
             IndexAttempt.status.in_(
@@ -856,47 +871,45 @@ def cancel_indexing_attempts_for_search_settings(
 def count_unique_cc_pairs_with_successful_index_attempts(
     search_settings_id: int | None,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> int:
     """Collect all of the Index Attempts that are successful and for the specified embedding model
     Then do distinct by connector_id and credential_id which is equivalent to the cc-pair. Finally,
     do a count to get the total number of unique cc-pairs with successful attempts"""
-    unique_pairs_count = (
+    query = (
         db_session.query(IndexAttempt.connector_credential_pair_id)
         .join(ConnectorCredentialPair)
         .filter(
             IndexAttempt.search_settings_id == search_settings_id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
         )
-        .distinct()
-        .count()
     )
-
-    return unique_pairs_count
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    return query.distinct().count()
 
 
 def count_unique_active_cc_pairs_with_successful_index_attempts(
     search_settings_id: int | None,
     db_session: Session,
+    ignore_targeted_reindex: bool = True,
 ) -> int:
     """Collect all of the Index Attempts that are successful and for the specified embedding model,
     but only for non-paused connector-credential pairs. Then do distinct by connector_id and credential_id
     which is equivalent to the cc-pair. Finally, do a count to get the total number of unique non-paused
     cc-pairs with successful attempts."""
-    unique_pairs_count = (
+    query = (
         db_session.query(IndexAttempt.connector_credential_pair_id)
         .join(ConnectorCredentialPair)
         .filter(
             IndexAttempt.search_settings_id == search_settings_id,
             IndexAttempt.status == IndexingStatus.SUCCESS,
-            IndexAttempt.targeted_reindex_job_id.is_(None),
             ConnectorCredentialPair.status != ConnectorCredentialPairStatus.PAUSED,
         )
-        .distinct()
-        .count()
     )
-
-    return unique_pairs_count
+    if ignore_targeted_reindex:
+        query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    return query.distinct().count()
 
 
 def create_index_attempt_error(

--- a/backend/onyx/db/indexing_coordination.py
+++ b/backend/onyx/db/indexing_coordination.py
@@ -50,7 +50,10 @@ class IndexingCoordination:
         and transactions to prevent duplicate attempts.
         """
         try:
-            # Check for existing active attempts (this is the "fence" check)
+            # Check for existing active full-run attempts (the "fence" check).
+            # Targeted reindex attempts are allowed to overlap with a full crawl
+            # by design (per-doc row-locks handle write conflicts), so they're
+            # excluded here.
             existing_attempt = db_session.execute(
                 select(IndexAttempt)
                 .where(
@@ -59,6 +62,7 @@ class IndexingCoordination:
                     IndexAttempt.status.in_(
                         [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
                     ),
+                    IndexAttempt.targeted_reindex_job_id.is_(None),
                 )
                 .with_for_update(nowait=True)
             ).first()

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_filter.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_filter.py
@@ -11,19 +11,32 @@ from collections.abc import Generator
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.enums import IndexingStatus
 from onyx.db.index_attempt import cancel_indexing_attempts_for_ccpair
 from onyx.db.index_attempt import count_index_attempts_for_cc_pair
+from onyx.db.index_attempt import (
+    count_unique_active_cc_pairs_with_successful_index_attempts,
+)
+from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
 from onyx.db.index_attempt import get_in_progress_index_attempts
+from onyx.db.index_attempt import get_index_attempts_for_cc_pair
+from onyx.db.index_attempt import get_last_attempt
 from onyx.db.index_attempt import get_last_attempt_for_cc_pair
 from onyx.db.index_attempt import get_latest_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import get_latest_index_attempts
+from onyx.db.index_attempt import get_latest_index_attempts_by_status
 from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import get_latest_successful_index_attempts_parallel
+from onyx.db.index_attempt import get_paginated_index_attempts_for_cc_pair_id
 from onyx.db.index_attempt import get_recent_attempts_for_cc_pair
+from onyx.db.index_attempt import get_recent_completed_attempts_for_cc_pair
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import TargetedReindexJob
 from onyx.db.search_settings import get_current_search_settings
+from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
@@ -187,20 +200,25 @@ def test_get_recent_attempts_skips_targeted(
     assert [a.id for a in results] == [full_run.id]
 
 
-def test_fence_allows_targeted_during_full_run(
+def test_fence_blocks_second_full_run_but_ignores_targeted(
     db_session: Session, cc_pair: ConnectorCredentialPair
 ) -> None:
-    """A full run already in progress should not block a targeted reindex
-    from being created — they're allowed to overlap by design."""
+    """Two assertions on the fence's filtering behaviour:
+
+    1. With a full run in progress, a second full run is blocked.
+    2. A targeted reindex sitting on the same cc_pair does NOT make the
+       fence think a full run is in progress (covered by the symmetric
+       test below — this test just sets up the precondition).
+
+    The targeted reindex creation path itself is not exercised here — that
+    path bypasses the fence entirely (PR 3 lands the API + retry task that
+    inserts targeted attempts directly)."""
     settings = get_current_search_settings(db_session)
     _make_attempt(
         db_session, cc_pair.id, settings.id, status=IndexingStatus.IN_PROGRESS
     )
-
-    # Targeted reindex is created directly (the API path), not via the fence.
-    # The fence's only job here is allowing the full run to coexist.
     job = _make_targeted_job(db_session)
-    targeted = _make_attempt(
+    _make_attempt(
         db_session,
         cc_pair.id,
         settings.id,
@@ -208,8 +226,7 @@ def test_fence_allows_targeted_during_full_run(
         targeted_reindex_job_id=job.id,
     )
 
-    # Full run should still be visible to the fence — try_create_index_attempt
-    # for ANOTHER full run should now return None (fence catches it).
+    # A second full run gets blocked by the in-progress full run.
     blocked = IndexingCoordination.try_create_index_attempt(
         db_session=db_session,
         cc_pair_id=cc_pair.id,
@@ -217,10 +234,6 @@ def test_fence_allows_targeted_during_full_run(
         celery_task_id="test-task-id",
     )
     assert blocked is None
-
-    # Targeted attempt is unaffected by the fence — confirms it didn't bleed
-    # into the in-progress full-run check either way.
-    assert targeted.targeted_reindex_job_id == job.id
 
 
 def test_fence_allows_full_run_when_only_targeted_in_progress(
@@ -298,3 +311,277 @@ def test_in_progress_query_includes_both(
     ids = {a.id for a in in_progress}
     assert full_run.id in ids
     assert targeted.id in ids
+
+
+def test_get_recent_completed_attempts_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_recent_completed_attempts_for_cc_pair(
+        cc_pair.id, settings.id, limit=10, db_session=db_session
+    )
+
+    assert [a.id for a in results] == [full_run.id]
+
+
+def test_get_last_attempt_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    result = get_last_attempt(
+        cc_pair.connector_id, cc_pair.credential_id, settings.id, db_session
+    )
+
+    assert result is not None
+    assert result.id == full_run.id
+
+
+def test_get_latest_index_attempts_by_status_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.FAILED
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.FAILED,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_latest_index_attempts_by_status(
+        secondary_index=False, db_session=db_session, status=IndexingStatus.FAILED
+    )
+
+    matching = [a for a in results if a.connector_credential_pair_id == cc_pair.id]
+    assert len(matching) == 1
+    assert matching[0].id == full_run.id
+
+
+def test_get_latest_index_attempts_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_latest_index_attempts(secondary_index=False, db_session=db_session)
+
+    matching = [a for a in results if a.connector_credential_pair_id == cc_pair.id]
+    assert len(matching) == 1
+    assert matching[0].id == full_run.id
+
+
+def test_get_latest_successful_parallel_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_latest_successful_index_attempts_parallel(secondary_index=False)
+
+    matching = [a for a in results if a.connector_credential_pair_id == cc_pair.id]
+    assert len(matching) == 1
+    assert matching[0].id == full_run.id
+
+
+def test_get_paginated_index_attempts_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_paginated_index_attempts_for_cc_pair_id(
+        db_session, cc_pair.id, page=0, page_size=10
+    )
+
+    assert [a.id for a in results] == [full_run.id]
+
+
+def test_get_index_attempts_for_cc_pair_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    identifier = ConnectorCredentialPairIdentifier(
+        connector_id=cc_pair.connector_id, credential_id=cc_pair.credential_id
+    )
+    results = get_index_attempts_for_cc_pair(db_session, identifier)
+
+    assert [a.id for a in results] == [full_run.id]
+
+
+def test_count_unique_cc_pairs_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Counting unique cc_pairs with successful attempts: a targeted-only
+    cc_pair must not contribute. Build that scenario by giving the test
+    cc_pair only a targeted-reindex SUCCESS row and no full-run row."""
+    settings = get_current_search_settings(db_session)
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    distinct_ids_before = {
+        cid
+        for (cid,) in db_session.query(IndexAttempt.connector_credential_pair_id)
+        .filter(
+            IndexAttempt.search_settings_id == settings.id,
+            IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
+        )
+        .distinct()
+        .all()
+    }
+
+    count = count_unique_cc_pairs_with_successful_index_attempts(
+        settings.id, db_session
+    )
+
+    assert count == len(distinct_ids_before)
+    # The targeted-only cc_pair must NOT be in the count
+    assert cc_pair.id not in distinct_ids_before
+
+
+def test_count_unique_active_cc_pairs_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    distinct_ids_before = {
+        cid
+        for (cid,) in db_session.query(IndexAttempt.connector_credential_pair_id)
+        .filter(
+            IndexAttempt.search_settings_id == settings.id,
+            IndexAttempt.status == IndexingStatus.SUCCESS,
+            IndexAttempt.targeted_reindex_job_id.is_(None),
+        )
+        .distinct()
+        .all()
+    }
+
+    count = count_unique_active_cc_pairs_with_successful_index_attempts(
+        settings.id, db_session
+    )
+
+    assert count == len(distinct_ids_before)
+    assert cc_pair.id not in distinct_ids_before
+
+
+def test_get_last_successful_poll_range_end_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """The freshness scheduler reads `poll_range_end` from the latest
+    successful full-run attempt, ignoring targeted reindexes."""
+    from datetime import datetime
+    from datetime import timezone
+
+    settings = get_current_search_settings(db_session)
+    full_run_end = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    targeted_end = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    full_run.poll_range_end = full_run_end
+    db_session.commit()
+
+    job = _make_targeted_job(db_session)
+    targeted = _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+    targeted.poll_range_end = targeted_end
+    db_session.commit()
+
+    result = get_last_successful_attempt_poll_range_end(
+        cc_pair_id=cc_pair.id,
+        earliest_index=0.0,
+        search_settings=settings,
+        db_session=db_session,
+    )
+
+    assert result == full_run_end.timestamp()

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_filter.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_filter.py
@@ -1,0 +1,300 @@
+"""External dependency unit tests for the `targeted_reindex_job_id IS NULL`
+filter on IndexAttempt consumer queries.
+
+Validates that synthetic targeted-reindex attempts don't bleed into freshness,
+scheduling, or counting queries that should only see real full-crawl attempts,
+while cleanup/cancellation paths still see both.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IndexingStatus
+from onyx.db.index_attempt import cancel_indexing_attempts_for_ccpair
+from onyx.db.index_attempt import count_index_attempts_for_cc_pair
+from onyx.db.index_attempt import get_in_progress_index_attempts
+from onyx.db.index_attempt import get_last_attempt_for_cc_pair
+from onyx.db.index_attempt import get_latest_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import get_recent_attempts_for_cc_pair
+from onyx.db.indexing_coordination import IndexingCoordination
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import TargetedReindexJob
+from onyx.db.search_settings import get_current_search_settings
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(TargetedReindexJob).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _make_attempt(
+    db_session: Session,
+    cc_pair_id: int,
+    search_settings_id: int,
+    *,
+    status: IndexingStatus,
+    targeted_reindex_job_id: int | None = None,
+) -> IndexAttempt:
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair_id,
+        search_settings_id=search_settings_id,
+        from_beginning=False,
+        status=status,
+        targeted_reindex_job_id=targeted_reindex_job_id,
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    return attempt
+
+
+def _make_targeted_job(db_session: Session) -> TargetedReindexJob:
+    job = TargetedReindexJob()
+    db_session.add(job)
+    db_session.commit()
+    db_session.refresh(job)
+    return job
+
+
+def test_get_last_attempt_skips_targeted_reindex(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A more recent targeted-reindex attempt should not displace the
+    latest full-run attempt for `last indexed` UI."""
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    result = get_last_attempt_for_cc_pair(cc_pair.id, settings.id, db_session)
+
+    assert result is not None
+    assert result.id == full_run.id
+
+
+def test_get_latest_successful_skips_targeted_reindex(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    result = get_latest_successful_index_attempt_for_cc_pair_id(db_session, cc_pair.id)
+
+    assert result is not None
+    assert result.id == full_run.id
+
+
+def test_get_latest_index_attempt_for_cc_pair_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    result = get_latest_index_attempt_for_cc_pair_id(
+        db_session, cc_pair.id, secondary_index=False, only_finished=True
+    )
+
+    assert result is not None
+    assert result.id == full_run.id
+
+
+def test_count_index_attempts_for_cc_pair_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    _make_attempt(db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS)
+    _make_attempt(db_session, cc_pair.id, settings.id, status=IndexingStatus.FAILED)
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    count = count_index_attempts_for_cc_pair(db_session, cc_pair.id)
+
+    assert count == 2
+
+
+def test_get_recent_attempts_skips_targeted(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.SUCCESS
+    )
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.SUCCESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    results = get_recent_attempts_for_cc_pair(
+        cc_pair.id, settings.id, limit=10, db_session=db_session
+    )
+
+    assert [a.id for a in results] == [full_run.id]
+
+
+def test_fence_allows_targeted_during_full_run(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A full run already in progress should not block a targeted reindex
+    from being created — they're allowed to overlap by design."""
+    settings = get_current_search_settings(db_session)
+    _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.IN_PROGRESS
+    )
+
+    # Targeted reindex is created directly (the API path), not via the fence.
+    # The fence's only job here is allowing the full run to coexist.
+    job = _make_targeted_job(db_session)
+    targeted = _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.IN_PROGRESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    # Full run should still be visible to the fence — try_create_index_attempt
+    # for ANOTHER full run should now return None (fence catches it).
+    blocked = IndexingCoordination.try_create_index_attempt(
+        db_session=db_session,
+        cc_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        celery_task_id="test-task-id",
+    )
+    assert blocked is None
+
+    # Targeted attempt is unaffected by the fence — confirms it didn't bleed
+    # into the in-progress full-run check either way.
+    assert targeted.targeted_reindex_job_id == job.id
+
+
+def test_fence_allows_full_run_when_only_targeted_in_progress(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A targeted reindex in progress should not block a full run from
+    being created."""
+    settings = get_current_search_settings(db_session)
+    job = _make_targeted_job(db_session)
+    _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.IN_PROGRESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    new_attempt_id = IndexingCoordination.try_create_index_attempt(
+        db_session=db_session,
+        cc_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        celery_task_id="test-task-id-2",
+    )
+
+    assert new_attempt_id is not None
+
+
+def test_cancel_includes_targeted_attempts(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Cancellation must NOT filter — both full-run and targeted attempts
+    on the cc_pair get canceled together."""
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.NOT_STARTED
+    )
+    job = _make_targeted_job(db_session)
+    targeted = _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.NOT_STARTED,
+        targeted_reindex_job_id=job.id,
+    )
+
+    cancel_indexing_attempts_for_ccpair(cc_pair.id, db_session)
+    db_session.commit()
+
+    db_session.refresh(full_run)
+    db_session.refresh(targeted)
+    assert full_run.status == IndexingStatus.CANCELED
+    assert targeted.status == IndexingStatus.CANCELED
+
+
+def test_in_progress_query_includes_both(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """get_in_progress_index_attempts is used by watchdog/heartbeat — it
+    must see both attempt types so retry attempts are also monitored."""
+    settings = get_current_search_settings(db_session)
+    full_run = _make_attempt(
+        db_session, cc_pair.id, settings.id, status=IndexingStatus.IN_PROGRESS
+    )
+    job = _make_targeted_job(db_session)
+    targeted = _make_attempt(
+        db_session,
+        cc_pair.id,
+        settings.id,
+        status=IndexingStatus.IN_PROGRESS,
+        targeted_reindex_job_id=job.id,
+    )
+
+    in_progress = get_in_progress_index_attempts(cc_pair.connector_id, db_session)
+
+    ids = {a.id for a in in_progress}
+    assert full_run.id in ids
+    assert targeted.id in ids


### PR DESCRIPTION
## Description

Stacks on #10747. Tightens consumer query sites so synthetic targeted-reindex IndexAttempts don't bleed into freshness, scheduling, or counting decisions. Cleanup / cancellation / watchdog / heartbeat queries stay unfiltered so retry rows get the same operational treatment as full runs.

The `try_create_index_attempt` fence is also updated so a full crawl and a targeted reindex on the same cc_pair can run concurrently. Per-doc row-locks in `prepare_to_modify_documents` serialize writes.

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

### How the filter is exposed

Each public consumer query now takes `ignore_targeted_reindex: bool = True`. Default is the safe behavior. Callers that genuinely need to see both attempt types can opt out. Putting it on the function signature keeps it discoverable for future LLM-generated code that copies the existing pattern.

### Functions getting the param (default `True`)

- `db/index_attempt.py`: `get_last_attempt_for_cc_pair`, `get_recent_completed_attempts_for_cc_pair`, `get_recent_attempts_for_cc_pair`, `get_last_attempt`, `get_latest_index_attempts_by_status`, `get_latest_index_attempts`, `get_latest_index_attempts_parallel`, `get_latest_index_attempt_for_cc_pair_id`, `get_latest_successful_index_attempt_for_cc_pair_id`, `get_latest_successful_index_attempts_parallel`, `count_index_attempts_for_cc_pair`, `get_paginated_index_attempts_for_cc_pair_id`, `get_index_attempts_for_cc_pair`, `count_unique_cc_pairs_with_successful_index_attempts`, `count_unique_active_cc_pairs_with_successful_index_attempts`
- `db/connector_credential_pair.py`: `get_last_successful_attempt_poll_range_end`

### Inline filter (no param)

- `db/indexing_coordination.py`: `try_create_index_attempt` fence — special semantic, not a getter
- `db/connector_credential_pair.py`: `find_latest_index_attempt` inner helper inside `resync_cc_pair` — private nested function
- `background/celery/tasks/monitoring/tasks.py`: cc_pair recent-attempts metrics query — inline query, not a function

### Sites NOT filtered (must see retry rows)

`mark_attempt_*`, `transition_attempt_*`, `update_docs_indexed`, `cancel_indexing_attempts_*`, `delete_index_attempts`, `expire_index_attempts`, `get_in_progress_index_attempts`, `get_all_index_attempts_by_status`, heartbeat / watchdog. Cleanup and cancellation must touch retry rows too.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

External dependency unit tests in `backend/tests/external_dependency_unit/db/test_targeted_reindex_filter.py` cover:

- Each filtered query correctly skips targeted rows when called with the default.
- The fence lets a full crawl and a targeted reindex coexist on the same cc_pair.
- `cancel_indexing_attempts_for_ccpair` still cancels both types.
- `get_in_progress_index_attempts` (watchdog) returns both types.

19 tests, all green against real Postgres.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check