### PR TITLE
fix: dont check per sync creds for public connectors

### DIFF
--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -1,6 +1,7 @@
 from onyx.connectors.confluence.connector import ConfluenceConnector
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.interfaces import BaseConnector
+from onyx.connectors.sharepoint.connector import SharepointConnector
 
 
 def validate_confluence_perm_sync(connector: ConfluenceConnector) -> None:
@@ -15,6 +16,18 @@ def validate_drive_perm_sync(connector: GoogleDriveConnector) -> None:
     """
 
 
+def validate_sharepoint_perm_sync(connector: SharepointConnector) -> None:
+    """
+    Validate that the connector is configured correctly for permissions syncing.
+
+    SharePoint RoleAssignments enumeration uses the SharePoint REST surface,
+    which is granted separately from the Graph permissions used by the
+    non-perm-sync indexing path. Probe it here so non-perm-sync connectors
+    aren't forced to grant 'Sites.FullControl.All'.
+    """
+    connector.probe_role_assignments_permission()
+
+
 def validate_perm_sync(connector: BaseConnector) -> None:
     """
     Override this if your connector needs to validate permissions syncing.
@@ -26,3 +39,5 @@ def validate_perm_sync(connector: BaseConnector) -> None:
         validate_confluence_perm_sync(connector)
     elif isinstance(connector, GoogleDriveConnector):
         validate_drive_perm_sync(connector)
+    elif isinstance(connector, SharepointConnector):
+        validate_sharepoint_perm_sync(connector)

--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -20,12 +20,16 @@ def validate_sharepoint_perm_sync(connector: SharepointConnector) -> None:
     """
     Validate that the connector is configured correctly for permissions syncing.
 
-    SharePoint RoleAssignments enumeration uses the SharePoint REST surface,
-    which is granted separately from the Graph permissions used by the
-    non-perm-sync indexing path. Probe it here so non-perm-sync connectors
-    aren't forced to grant 'Sites.FullControl.All'.
+    Two distinct permission surfaces are needed for SharePoint perm sync,
+    neither of which the non-perm-sync indexing path requires:
+      1. SharePoint REST 'Sites.FullControl.All' to enumerate RoleAssignments.
+      2. Microsoft Graph 'GroupMember.Read.All' (or equivalent) to expand
+         Azure AD groups attached to those RoleAssignments.
+    Probe both here so misconfigured apps fail fast at connector creation
+    instead of mid-index.
     """
     connector.probe_role_assignments_permission()
+    connector.probe_group_members_permission()
 
 
 def validate_perm_sync(connector: BaseConnector) -> None:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -81,6 +81,7 @@ from onyx.file_processing.image_utils import make_image_callback
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.url import SSRFException
 from onyx.utils.url import validate_outbound_http_url
 
@@ -143,6 +144,12 @@ DEFAULT_SHAREPOINT_DOMAIN_SUFFIX = "sharepoint.com"
 GRAPH_API_BASE = f"{DEFAULT_GRAPH_API_HOST}/v1.0"
 GRAPH_API_MAX_RETRIES = 5
 GRAPH_API_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+# Cap how many configured sites the perm-sync RoleAssignments probe checks at
+# validation time. Each probe is one HTTP round-trip, so we trade exhaustive
+# coverage for keeping connector creation responsive on tenants with many
+# configured sites.
+ROLE_ASSIGNMENTS_PROBE_MAX_SITES = 5
 
 
 class DriveItemData(BaseModel):
@@ -399,6 +406,30 @@ def acquire_token_for_rest(
         scopes=[f"https://{sp_tenant_domain}.{sharepoint_domain_suffix}/.default"]
     )
     return TokenResponse.from_json(token)
+
+
+def _probe_site_role_assignments_authorized(
+    site_url: str, headers: dict[str, str]
+) -> bool:
+    """Issue a single RoleAssignments REST probe against `site_url`.
+
+    Returns True if the SharePoint REST surface accepts the call (any non-401/403
+    status), False if SP rejected it as unauthorized. Transport-level errors are
+    swallowed and treated as authorized so a transient network blip doesn't fail
+    validation; the runtime perm-sync code will surface real failures.
+
+    Designed to be called via run_functions_tuples_in_parallel — keep it side-
+    effect free aside from logging.
+    """
+    probe_url = f"{site_url.rstrip('/')}/_api/web/roleassignments?$top=1"
+    try:
+        resp = requests.get(probe_url, headers=headers, timeout=10)
+    except Exception as e:
+        logger.warning(
+            f"RoleAssignments permission probe failed for {site_url} (non-blocking): {e}"
+        )
+        return True
+    return resp.status_code not in (401, 403)
 
 
 def _create_document_failure(
@@ -1011,8 +1042,12 @@ class SharepointConnector(
         """Verify the Azure AD app can read SharePoint RoleAssignments.
 
         Required for permission sync (RoleAssignments enumeration uses the
-        SharePoint REST surface, which is granted separately from Graph).
-        Only runs when credentials have been loaded.
+        SharePoint REST surface, which is granted separately from Graph and
+        can be granted unevenly across sites under the Sites.Selected model).
+        Probes up to the first ROLE_ASSIGNMENTS_PROBE_MAX_SITES configured
+        sites in parallel and fails if any of them rejects the request, so
+        per-site permission gaps surface at validation time rather than
+        mid-index. Only runs when credentials have been loaded.
         """
         if not (self.msal_app and self.sp_tenant_domain and self.sites):
             return
@@ -1022,24 +1057,72 @@ class SharepointConnector(
                 self.sp_tenant_domain,
                 self.sharepoint_domain_suffix,
             )
-            probe_url = f"{self.sites[0].rstrip('/')}/_api/web/roleassignments?$top=1"
-            resp = requests.get(
-                probe_url,
-                headers={"Authorization": f"Bearer {token_response.accessToken}"},
-                timeout=10,
-            )
-            if resp.status_code in (401, 403):
-                raise ConnectorValidationError(
-                    "The Azure AD app registration is missing the required SharePoint permission "
-                    "to read role assignments. Please grant 'Sites.FullControl.All' "
-                    "(application permission) in the Azure portal and re-run admin consent."
-                )
-        except ConnectorValidationError:
-            raise
         except Exception as e:
             logger.warning(
                 "RoleAssignments permission probe failed (non-blocking): %s", e
             )
+            return
+
+        sites_to_probe = self.sites[:ROLE_ASSIGNMENTS_PROBE_MAX_SITES]
+        headers = {"Authorization": f"Bearer {token_response.accessToken}"}
+        results = run_functions_tuples_in_parallel(
+            [
+                (_probe_site_role_assignments_authorized, (site_url, headers))
+                for site_url in sites_to_probe
+            ],
+            allow_failures=True,
+        )
+        unauthorized_sites: list[str] = [
+            site_url
+            for site_url, authorized in zip(sites_to_probe, results)
+            if authorized is False
+        ]
+
+        if not unauthorized_sites:
+            return
+
+        sites_summary = ", ".join(unauthorized_sites)
+        raise ConnectorValidationError(
+            "The Azure AD app registration is missing the required SharePoint permission "
+            "to read role assignments on the following site(s): "
+            f"{sites_summary}. Please grant 'Sites.FullControl.All' "
+            "(application permission) in the Azure portal and re-run admin consent. "
+            "If using the 'Sites.Selected' model, ensure the app has been explicitly "
+            "granted full-control on each affected site collection."
+        )
+
+    def probe_group_members_permission(self) -> None:
+        """Verify the Azure AD app can enumerate Azure AD group members via Graph.
+
+        Required for permission sync, which expands Azure AD groups attached to
+        SharePoint role assignments via `GET /v1.0/groups/{id}/members`. Tested
+        via `GET /v1.0/groups?$top=1`, which requires the same permission set
+        (GroupMember.Read.All / Group.Read.All / Directory.Read.All) so a 403
+        here reliably predicts a 403 on the members call. Only runs when
+        credentials have been loaded.
+        """
+        if not self.msal_app:
+            return
+        try:
+            access_token = self._get_graph_access_token()
+            probe_url = f"{self.graph_api_base}/groups"
+            resp = requests.get(
+                probe_url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params={"$top": "1", "$select": "id"},
+                timeout=10,
+            )
+            if resp.status_code in (401, 403):
+                raise ConnectorValidationError(
+                    "The Azure AD app registration is missing the required Microsoft Graph "
+                    "permission to enumerate Azure AD group members. Please grant "
+                    "'GroupMember.Read.All' (application permission) in the Azure portal "
+                    "and re-run admin consent."
+                )
+        except ConnectorValidationError:
+            raise
+        except Exception as e:
+            logger.warning(f"Group members permission probe failed (non-blocking): {e}")
 
     def _extract_tenant_domain_from_sites(self) -> str | None:
         """Extract the tenant domain from configured site URLs.

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1007,35 +1007,39 @@ class SharepointConnector(
                     f"Invalid site URL '{site_url}': {e}"
                 ) from e
 
-        # Probe RoleAssignments permission — required for permission sync.
-        # Only runs when credentials have been loaded.
-        if self.msal_app and self.sp_tenant_domain and self.sites:
-            try:
-                token_response = acquire_token_for_rest(
-                    self.msal_app,
-                    self.sp_tenant_domain,
-                    self.sharepoint_domain_suffix,
+    def probe_role_assignments_permission(self) -> None:
+        """Verify the Azure AD app can read SharePoint RoleAssignments.
+
+        Required for permission sync (RoleAssignments enumeration uses the
+        SharePoint REST surface, which is granted separately from Graph).
+        Only runs when credentials have been loaded.
+        """
+        if not (self.msal_app and self.sp_tenant_domain and self.sites):
+            return
+        try:
+            token_response = acquire_token_for_rest(
+                self.msal_app,
+                self.sp_tenant_domain,
+                self.sharepoint_domain_suffix,
+            )
+            probe_url = f"{self.sites[0].rstrip('/')}/_api/web/roleassignments?$top=1"
+            resp = requests.get(
+                probe_url,
+                headers={"Authorization": f"Bearer {token_response.accessToken}"},
+                timeout=10,
+            )
+            if resp.status_code in (401, 403):
+                raise ConnectorValidationError(
+                    "The Azure AD app registration is missing the required SharePoint permission "
+                    "to read role assignments. Please grant 'Sites.FullControl.All' "
+                    "(application permission) in the Azure portal and re-run admin consent."
                 )
-                probe_url = (
-                    f"{self.sites[0].rstrip('/')}/_api/web/roleassignments?$top=1"
-                )
-                resp = requests.get(
-                    probe_url,
-                    headers={"Authorization": f"Bearer {token_response.accessToken}"},
-                    timeout=10,
-                )
-                if resp.status_code in (401, 403):
-                    raise ConnectorValidationError(
-                        "The Azure AD app registration is missing the required SharePoint permission "
-                        "to read role assignments. Please grant 'Sites.FullControl.All' "
-                        "(application permission) in the Azure portal and re-run admin consent."
-                    )
-            except ConnectorValidationError:
-                raise
-            except Exception as e:
-                logger.warning(
-                    "RoleAssignments permission probe failed (non-blocking): %s", e
-                )
+        except ConnectorValidationError:
+            raise
+        except Exception as e:
+            logger.warning(
+                "RoleAssignments permission probe failed (non-blocking): %s", e
+            )
 
     def _extract_tenant_domain_from_sites(self) -> str | None:
         """Extract the tenant domain from configured site URLs.

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -426,7 +426,9 @@ def _probe_site_role_assignments_authorized(
         resp = requests.get(probe_url, headers=headers, timeout=10)
     except Exception as e:
         logger.warning(
-            f"RoleAssignments permission probe failed for {site_url} (non-blocking): {e}"
+            "RoleAssignments permission probe failed for %s (non-blocking): %s",
+            site_url,
+            e,
         )
         return True
     return resp.status_code not in (401, 403)
@@ -1122,7 +1124,9 @@ class SharepointConnector(
         except ConnectorValidationError:
             raise
         except Exception as e:
-            logger.warning(f"Group members permission probe failed (non-blocking): {e}")
+            logger.warning(
+                "Group members permission probe failed (non-blocking): %s", e
+            )
 
     def _extract_tenant_domain_from_sites(self) -> str | None:
         """Extract the tenant domain from configured site URLs.

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -184,70 +184,164 @@ def test_retrieve_all_slim_docs_does_not_fetch_permissions(
 
 
 # ---------------------------------------------------------------------------
-# validate_connector_settings — RoleAssignments permission probe
+# probe_role_assignments_permission — perm-sync RoleAssignments REST probe
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("status_code", [401, 403])
 @patch("onyx.connectors.sharepoint.connector.requests.get")
-@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
 @patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
-def test_validate_raises_on_401_or_403(
+def test_probe_role_assignments_raises_on_401_or_403(
     mock_acquire: MagicMock,
-    _mock_validate_url: MagicMock,
     mock_get: MagicMock,
     status_code: int,
 ) -> None:
-    """validate_connector_settings raises ConnectorValidationError when probe returns 401 or 403."""
+    """probe raises ConnectorValidationError naming the rejecting site."""
     mock_acquire.return_value = MagicMock(accessToken="tok")
     mock_get.return_value = MagicMock(status_code=status_code)
 
     connector = _make_connector()
 
-    with pytest.raises(ConnectorValidationError, match="Sites.FullControl.All"):
-        connector.validate_connector_settings()
+    with pytest.raises(ConnectorValidationError) as exc_info:
+        connector.probe_role_assignments_permission()
+    assert "Sites.FullControl.All" in str(exc_info.value)
+    assert SITE_URL in str(exc_info.value)
 
 
 @patch("onyx.connectors.sharepoint.connector.requests.get")
-@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
 @patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
-def test_validate_passes_on_200(
+def test_probe_role_assignments_passes_on_200(
     mock_acquire: MagicMock,
-    _mock_validate_url: MagicMock,
     mock_get: MagicMock,
 ) -> None:
-    """validate_connector_settings does not raise when probe returns 200."""
+    """A 200 response means the app has the required permission."""
     mock_acquire.return_value = MagicMock(accessToken="tok")
     mock_get.return_value = MagicMock(status_code=200)
 
     connector = _make_connector()
-    connector.validate_connector_settings()  # should not raise
+    connector.probe_role_assignments_permission()  # should not raise
 
 
 @patch("onyx.connectors.sharepoint.connector.requests.get")
-@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
 @patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
-def test_validate_passes_on_network_error(
+def test_probe_role_assignments_skips_on_network_error(
     mock_acquire: MagicMock,
-    _mock_validate_url: MagicMock,
     mock_get: MagicMock,
 ) -> None:
-    """Network errors during the probe are non-blocking (logged as warning only)."""
+    """Per-site transport errors are non-blocking (treated as authorized)."""
     mock_acquire.return_value = MagicMock(accessToken="tok")
     mock_get.side_effect = Exception("timeout")
 
     connector = _make_connector()
-    connector.validate_connector_settings()  # should not raise
+    connector.probe_role_assignments_permission()  # should not raise
 
 
-@patch("onyx.connectors.sharepoint.connector.validate_outbound_http_url")
 @patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
-def test_validate_skips_probe_without_credentials(
+def test_probe_role_assignments_skips_without_credentials(
     mock_acquire: MagicMock,
-    _mock_validate_url: MagicMock,
 ) -> None:
-    """Probe is skipped when credentials have not been loaded."""
+    """Probe is a no-op when credentials have not been loaded."""
     connector = SharepointConnector(sites=[SITE_URL])
     # msal_app and sp_tenant_domain are None — probe must be skipped.
-    connector.validate_connector_settings()  # should not raise
+    connector.probe_role_assignments_permission()  # should not raise
     mock_acquire.assert_not_called()
+
+
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_probe_role_assignments_aggregates_unauthorized_sites(
+    mock_acquire: MagicMock,
+    mock_get: MagicMock,
+) -> None:
+    """When some sites 401 and others 200, the error names every failing site."""
+    mock_acquire.return_value = MagicMock(accessToken="tok")
+
+    site_ok = "https://tenant.sharepoint.com/sites/Allowed"
+    site_bad_1 = "https://tenant.sharepoint.com/teams/Forbidden1"
+    site_bad_2 = "https://tenant.sharepoint.com/teams/Forbidden2"
+
+    def _fake_get(url: str, **_kwargs: object) -> MagicMock:
+        if site_bad_1 in url:
+            return MagicMock(status_code=401)
+        if site_bad_2 in url:
+            return MagicMock(status_code=403)
+        return MagicMock(status_code=200)
+
+    mock_get.side_effect = _fake_get
+
+    connector = _make_connector()
+    # _make_connector seeds a single site; override with a mixed list.
+    connector.sites = [site_ok, site_bad_1, site_bad_2]
+
+    with pytest.raises(ConnectorValidationError) as exc_info:
+        connector.probe_role_assignments_permission()
+
+    message = str(exc_info.value)
+    assert site_bad_1 in message
+    assert site_bad_2 in message
+    assert site_ok not in message
+    # All three sites should have been probed (in parallel).
+    assert mock_get.call_count == 3
+
+
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch("onyx.connectors.sharepoint.connector.acquire_token_for_rest")
+def test_probe_role_assignments_caps_probed_sites(
+    mock_acquire: MagicMock,
+    mock_get: MagicMock,
+) -> None:
+    """Only the first ROLE_ASSIGNMENTS_PROBE_MAX_SITES sites are probed."""
+    from onyx.connectors.sharepoint.connector import ROLE_ASSIGNMENTS_PROBE_MAX_SITES
+
+    mock_acquire.return_value = MagicMock(accessToken="tok")
+    mock_get.return_value = MagicMock(status_code=200)
+
+    connector = _make_connector()
+    connector.sites = [
+        f"https://tenant.sharepoint.com/sites/Site{i}"
+        for i in range(ROLE_ASSIGNMENTS_PROBE_MAX_SITES + 2)
+    ]
+
+    connector.probe_role_assignments_permission()
+    assert mock_get.call_count == ROLE_ASSIGNMENTS_PROBE_MAX_SITES
+
+
+# ---------------------------------------------------------------------------
+# probe_group_members_permission — perm-sync Graph group-members probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._get_graph_access_token"
+)
+def test_probe_group_members_raises_on_401_or_403(
+    mock_token: MagicMock,
+    mock_get: MagicMock,
+    status_code: int,
+) -> None:
+    """probe raises ConnectorValidationError naming GroupMember.Read.All when Graph rejects."""
+    mock_token.return_value = "tok"
+    mock_get.return_value = MagicMock(status_code=status_code)
+
+    connector = _make_connector()
+
+    with pytest.raises(ConnectorValidationError, match="GroupMember.Read.All"):
+        connector.probe_group_members_permission()
+
+
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._get_graph_access_token"
+)
+def test_probe_group_members_passes_on_200(
+    mock_token: MagicMock,
+    mock_get: MagicMock,
+) -> None:
+    """A 200 response means the app has the required Graph permission."""
+    mock_token.return_value = "tok"
+    mock_get.return_value = MagicMock(status_code=200)
+
+    connector = _make_connector()
+    connector.probe_group_members_permission()  # should not raise

--- a/web/src/hooks/useToast.ts
+++ b/web/src/hooks/useToast.ts
@@ -97,6 +97,21 @@ function removeToast(id: string): void {
   notify();
 }
 
+function setAutoDismiss(id: string, duration: number): void {
+  const existing = timers.get(id);
+  if (existing) {
+    clearTimeout(existing);
+    timers.delete(id);
+  }
+  if (duration === Infinity) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    removeToast(id);
+  }, duration);
+  timers.set(id, timer);
+}
+
 function markLeaving(id: string): void {
   toasts = toasts.map((t) => (t.id === id ? { ...t, leaving: true } : t));
   notify();
@@ -144,6 +159,12 @@ interface ToastFn {
   ) => string;
   dismiss: (id: string) => void;
   clearAll: () => void;
+  /**
+   * Reset (or cancel) a toast's auto-dismiss timer. Pass `Infinity` to make the
+   * toast persistent. Used by ToastContainer when the user expands a truncated
+   * toast and needs more time to read it.
+   */
+  setAutoDismiss: (id: string, duration: number) => void;
   /** @internal – used by ToastContainer for exit animation */
   _markLeaving: (id: string) => void;
 }
@@ -163,6 +184,7 @@ export const toast: ToastFn = Object.assign(toastBase, {
     addToast({ ...opts, message, level: "info" }),
   dismiss: removeToast,
   clearAll,
+  setAutoDismiss,
   _markLeaving: markLeaving,
 });
 

--- a/web/src/providers/ToastProvider.tsx
+++ b/web/src/providers/ToastProvider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import { cn } from "@opal/utils";
-import { MessageCard } from "@opal/components";
+import { MessageCard, Text } from "@opal/components";
 import type { StatusVariants } from "@opal/types";
 import { NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK } from "@/lib/constants";
 import { toast, toastStore, MAX_VISIBLE_TOASTS } from "@/hooks/useToast";
@@ -10,6 +10,9 @@ import type { Toast, ToastLevel } from "@/hooks/useToast";
 
 const ANIMATION_DURATION = 200; // matches tailwind fade-out-scale (0.2s)
 const MAX_TOAST_MESSAGE_LENGTH = 150;
+// How long a toast lingers after the user clicks to expand it. Long enough to
+// read a multi-line stack trace / API error without forcing a manual dismiss.
+const EXPANDED_DURATION_MS = 30000;
 
 const LEVEL_TO_VARIANT: Record<ToastLevel, StatusVariants> = {
   success: "success",
@@ -30,12 +33,27 @@ function buildDescription(t: Toast): string | undefined {
   return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
+interface ExpandedDetailsProps {
+  message: string;
+}
+
+function ExpandedDetails({ message }: ExpandedDetailsProps) {
+  return (
+    <div className="px-3 py-2 max-h-72 overflow-y-auto whitespace-pre-wrap break-words">
+      <Text font="secondary-body" color="text-03" as="p">
+        {message}
+      </Text>
+    </div>
+  );
+}
+
 function ToastContainer() {
   const allToasts = useSyncExternalStore(
     toastStore.subscribe,
     toastStore.getSnapshot,
     toastStore.getSnapshot
   );
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
   const visible = allToasts.slice(-MAX_VISIBLE_TOASTS);
 
@@ -43,7 +61,25 @@ function ToastContainer() {
     toast._markLeaving(id);
     setTimeout(() => {
       toast.dismiss(id);
+      setExpandedIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
     }, ANIMATION_DURATION);
+  }, []);
+
+  const handleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    // Reset the auto-dismiss timer so the user has time to read the full
+    // message before it fades.
+    toast.setAutoDismiss(id, EXPANDED_DURATION_MS);
   }, []);
 
   if (visible.length === 0) return null;
@@ -54,24 +90,45 @@ function ToastContainer() {
       className="fixed bottom-4 right-4 z-[var(--z-toast)] flex flex-col gap-2 items-end max-w-[var(--toast-width)] w-full"
     >
       {visible.map((t) => {
-        const text =
-          t.message.length > MAX_TOAST_MESSAGE_LENGTH
-            ? t.message.slice(0, MAX_TOAST_MESSAGE_LENGTH) + "\u2026"
-            : t.message;
+        const isTruncatable = t.message.length > MAX_TOAST_MESSAGE_LENGTH;
+        const isExpanded = expandedIds.has(t.id);
+        const truncatedTitle = isTruncatable
+          ? t.message.slice(0, MAX_TOAST_MESSAGE_LENGTH) + "\u2026"
+          : t.message;
+        const expandable = isTruncatable && !isExpanded;
         return (
           <div
             key={t.id}
             className={cn(
               "w-full",
-              t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale"
+              t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale",
+              expandable && "cursor-pointer"
             )}
+            onClick={
+              expandable
+                ? (e) => {
+                    // Don't intercept clicks on the inner close button.
+                    if (
+                      (e.target as HTMLElement).closest(
+                        'button[aria-label="Close"]'
+                      )
+                    ) {
+                      return;
+                    }
+                    handleExpand(t.id);
+                  }
+                : undefined
+            }
           >
             <MessageCard
               variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
-              title={text}
+              title={truncatedTitle}
               description={buildDescription(t)}
               padding="xs"
               onClose={t.dismissible ? () => handleClose(t.id) : undefined}
+              bottomChildren={
+                isExpanded ? <ExpandedDetails message={t.message} /> : undefined
+              }
             />
           </div>
         );


### PR DESCRIPTION
## Description

We were previously probing role assignments for every connector validation, but this endpoint isn't necessary for creating public sharepoint connectors. This PR narrows the probe to only be used when the user is creating a permission synced connector.

Also updated the UI to allow expanding the validation error toast.

## How Has This Been Tested?

tested in UI + added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip permission-sync credential checks for public SharePoint connectors; run SharePoint permission probes only when permission sync is enabled. Adds expandable validation error toasts with extended auto-dismiss.

- **Bug Fixes**
  - SharePoint: run RoleAssignments (REST) and Graph group-members probes only for perm-sync connectors, handled in perm-sync validation.
  - RoleAssignments probe checks the first 5 sites in parallel and lists every unauthorized site in the error; network errors are non-blocking.
  - Tests updated for probe aggregation, site cap, and Graph `GroupMember.Read.All` validation.

- **New Features**
  - Toasts: click truncated messages to expand full content; auto-dismiss extends to 30s on expand.
  - Added `toast.setAutoDismiss(id, duration)` to reset or cancel timers.

<sup>Written for commit 5e985185ea213628096cd46fdf88fd3bb57ec037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

