### PR TITLE
fix(embedding): Fix broken retries for embedding

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -22,7 +22,12 @@ from httpx import HTTPError
 from requests import JSONDecodeError
 from requests import RequestException
 from requests import Response
-from retry import retry
+from tenacity import retry
+from tenacity import retry_if_exception_type
+from tenacity import stop_after_attempt
+from tenacity import wait_exponential
+from tenacity import wait_fixed
+from tenacity import wait_random
 
 from onyx.configs.app_configs import INDEXING_EMBEDDING_MODEL_NUM_THREADS
 from onyx.configs.app_configs import LARGE_CHUNK_RATIO
@@ -72,9 +77,12 @@ from shared_configs.utils import batch_list
 
 logger = setup_logger()
 
-# If we are not only indexing, dont want retry very long
-_RETRY_DELAY = 10 if INDEXING_ONLY else 0.1
-_RETRY_TRIES = 10 if INDEXING_ONLY else 2
+# If we are not only indexing, dont want retry very long.
+# Indexing path: wait_exponential(multiplier=1, max=60) gives waits of
+# 1, 2, 4, 8, 16, 32, 60s before the cap repeats. With 8 attempts (7 waits)
+# we hit the 60s cap exactly once, totaling ~123s before giving up.
+_RETRY_DELAY = 1 if INDEXING_ONLY else 0.1
+_RETRY_TRIES = 8 if INDEXING_ONLY else 2
 
 # OpenAI only allows 2048 embeddings to be computed at once
 _OPENAI_MAX_INPUT_LEN = 2048
@@ -473,7 +481,12 @@ class CloudEmbedding:
         result = response.json()
         return [embedding["embedding"] for embedding in result["data"]]
 
-    @retry(tries=_RETRY_TRIES, delay=_RETRY_DELAY)
+    @retry(
+        retry=retry_if_exception_type((RuntimeError, httpx.HTTPError)),
+        stop=stop_after_attempt(_RETRY_TRIES),
+        wait=wait_exponential(multiplier=_RETRY_DELAY, max=60) + wait_random(0, 2),
+        reraise=True,
+    )
     async def embed(
         self,
         *,
@@ -810,13 +823,19 @@ class EmbeddingModel:
         # retries + handling for rate limiting
         if embed_request.text_type == EmbedTextType.PASSAGE:
             final_make_request_func = retry(
-                tries=3,
-                delay=5,
-                exceptions=(RequestException, ValueError, JSONDecodeError),
+                retry=retry_if_exception_type(
+                    (RequestException, ValueError, JSONDecodeError)
+                ),
+                stop=stop_after_attempt(3),
+                wait=wait_fixed(5),
+                reraise=True,
             )(final_make_request_func)
             # use 10 second delay as per Azure suggestion
             final_make_request_func = retry(
-                tries=10, delay=10, exceptions=ModelServerRateLimitError
+                retry=retry_if_exception_type(ModelServerRateLimitError),
+                stop=stop_after_attempt(10),
+                wait=wait_fixed(10),
+                reraise=True,
             )(final_make_request_func)
 
         response: Response | None = None

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -482,7 +482,7 @@ class CloudEmbedding:
         return [embedding["embedding"] for embedding in result["data"]]
 
     @retry(
-        retry=retry_if_exception_type((RuntimeError, httpx.HTTPError)),
+        retry=retry_if_exception_type(RuntimeError),
         stop=stop_after_attempt(_RETRY_TRIES),
         wait=wait_exponential(multiplier=_RETRY_DELAY, max=60) + wait_random(0, 2),
         reraise=True,

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -129,6 +129,60 @@ async def test_cloud_embedding_retries_on_transient_failure() -> None:
     assert result == [[0.1, 0.2, 0.3]]
 
 
+@pytest.mark.asyncio
+async def test_cloud_embedding_retries_on_vertex_429() -> None:
+    """
+    Reproduces the exact Vertex 429 RESOURCE_EXHAUSTED error path (a
+    google.genai.errors.ClientError that is neither httpx.HTTPStatusError nor
+    openai.AuthenticationError) and asserts embed() retries after such a
+    failure. This is the production failure mode driving these retries.
+    """
+    from google.genai.errors import ClientError
+
+    vertex_429_message = (
+        "429 RESOURCE_EXHAUSTED. {'error': {'code': 429, "
+        "'message': 'Resource exhausted. Please try again later. Please refer "
+        "to https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429 "
+        "for more details.', 'status': 'RESOURCE_EXHAUSTED'}}"
+    )
+
+    call_count = 0
+
+    async def flaky_embed_vertex(
+        self: CloudEmbedding,  # noqa: ARG001
+        texts: list[str],
+        model: str | None,  # noqa: ARG001
+        embedding_type: str,  # noqa: ARG001
+        reduced_dimension: int | None,  # noqa: ARG001
+    ) -> list[list[float]]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # google.genai.errors.ClientError requires (code, response_json, response)
+            raise ClientError(429, {"message": vertex_429_message})
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    with patch.object(
+        CloudEmbedding,
+        CloudEmbedding._embed_vertex.__name__,
+        new=flaky_embed_vertex,
+    ):
+        async with CloudEmbedding(
+            '{"project_id": "fake", "type": "service_account"}',
+            EmbeddingProvider.GOOGLE,
+        ) as embedding:
+            result = await embedding.embed(
+                texts=["test"],
+                text_type=EmbedTextType.PASSAGE,
+            )
+
+    assert call_count == 2, (
+        f"expected @retry to re-invoke after a Vertex 429, "
+        f"but the provider was called {call_count} time(s)"
+    )
+    assert result == [[0.1, 0.2, 0.3]]
+
+
 # ------------------------------------------------------------------------------
 # _batch_encode_texts tests
 #

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -1,5 +1,7 @@
 from collections.abc import AsyncGenerator
 from threading import Lock
+from typing import Any
+from typing import cast
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -7,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 from litellm.exceptions import RateLimitError
+from tenacity import wait_none
 
 from onyx.llm.constants import LlmProviderNames
 from onyx.natural_language_processing.search_nlp_models import CloudEmbedding
@@ -111,10 +114,13 @@ async def test_cloud_embedding_retries_on_transient_failure() -> None:
             raise RuntimeError("simulated transient failure on attempt 1")
         return [[0.1, 0.2, 0.3] for _ in texts]
 
-    with patch.object(
-        CloudEmbedding,
-        CloudEmbedding._embed_openai.__name__,
-        new=flaky_embed_openai,
+    with (
+        patch.object(cast(Any, CloudEmbedding.embed).retry, "wait", wait_none()),
+        patch.object(
+            CloudEmbedding,
+            CloudEmbedding._embed_openai.__name__,
+            new=flaky_embed_openai,
+        ),
     ):
         async with CloudEmbedding("fake-key", EmbeddingProvider.OPENAI) as embedding:
             result = await embedding.embed(
@@ -162,10 +168,13 @@ async def test_cloud_embedding_retries_on_vertex_429() -> None:
             raise ClientError(429, {"message": vertex_429_message})
         return [[0.1, 0.2, 0.3] for _ in texts]
 
-    with patch.object(
-        CloudEmbedding,
-        CloudEmbedding._embed_vertex.__name__,
-        new=flaky_embed_vertex,
+    with (
+        patch.object(cast(Any, CloudEmbedding.embed).retry, "wait", wait_none()),
+        patch.object(
+            CloudEmbedding,
+            CloudEmbedding._embed_vertex.__name__,
+            new=flaky_embed_vertex,
+        ),
     ):
         async with CloudEmbedding(
             '{"project_id": "fake", "type": "service_account"}',

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -90,6 +90,45 @@ async def test_rate_limit_handling() -> None:
             )
 
 
+@pytest.mark.asyncio
+async def test_cloud_embedding_retries_on_transient_failure() -> None:
+    """
+    The @retry decorator on CloudEmbedding.embed should re-invoke the provider
+    after a transient failure. We simulate a failure on the first attempt and
+    a success on the second, and assert embed() returns the successful result.
+    """
+    call_count = 0
+
+    async def flaky_embed_openai(
+        self: CloudEmbedding,  # noqa: ARG001
+        texts: list[str],
+        model: str | None,  # noqa: ARG001
+        reduced_dimension: int | None,  # noqa: ARG001
+    ) -> list[list[float]]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("simulated transient failure on attempt 1")
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    with patch.object(
+        CloudEmbedding,
+        CloudEmbedding._embed_openai.__name__,
+        new=flaky_embed_openai,
+    ):
+        async with CloudEmbedding("fake-key", EmbeddingProvider.OPENAI) as embedding:
+            result = await embedding.embed(
+                texts=["test"],
+                text_type=EmbedTextType.PASSAGE,
+            )
+
+    assert call_count == 2, (
+        f"expected @retry to re-invoke the provider after a transient failure, "
+        f"but the provider was called {call_count} time(s)"
+    )
+    assert result == [[0.1, 0.2, 0.3]]
+
+
 # ------------------------------------------------------------------------------
 # _batch_encode_texts tests
 #


### PR DESCRIPTION
## Description
The current retry library used for embeddings only supports sync functions. The embedding functions are async. As such, the current library does not retry.

This PR changes the retry library to use one that does support async

## How Has This Been Tested?
Unit + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken retries for async embedding requests by switching to `tenacity` with exponential backoff and jitter. Retries now work for transient provider errors and Vertex 429s across providers.

- **Bug Fixes**
  - Decorate `embed()` with `tenacity` (retry_if_exception_type, reraise) using exponential backoff (cap 60s) + small jitter.
  - Retry timing: indexing uses 8 attempts starting at 1s; non-indexing uses 2 quick attempts.
  - Passage requests: 3 attempts @ 5s for network/JSON errors; 10 attempts @ 10s for `ModelServerRateLimitError`.
  - Add tests for transient failures and Vertex 429 RESOURCE_EXHAUSTED to confirm retries.

- **Dependencies**
  - Replace `retry` with `tenacity`.

<sup>Written for commit 23fc89b9b1fdd7decfbbb535401aaed4939715fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

