### PR TITLE
chore(doc-processing): add per-attempt doc-processing batch counters

### DIFF
--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -12,6 +12,12 @@ from celery.signals import worker_ready
 from celery.signals import worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base
+from onyx.background.celery.tasks.docprocessing.batch_counters import (
+    on_docprocessing_task_postrun,
+)
+from onyx.background.celery.tasks.docprocessing.batch_counters import (
+    on_docprocessing_task_prerun,
+)
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_DOCPROCESSING_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.metrics.celery_task_metrics import on_celery_task_postrun
@@ -44,6 +50,7 @@ def on_task_prerun(
     app_base.on_task_prerun(sender, task_id, task, args, kwargs, **kwds)
     on_celery_task_prerun(task_id, task)
     on_indexing_task_prerun(task_id, task, kwargs)
+    on_docprocessing_task_prerun(task_id, task, kwargs)
 
 
 @signals.task_postrun.connect
@@ -60,6 +67,7 @@ def on_task_postrun(
     app_base.on_task_postrun(sender, task_id, task, args, kwargs, retval, state, **kwds)
     on_celery_task_postrun(task_id, task, state)
     on_indexing_task_postrun(task_id, task, kwargs, state)
+    on_docprocessing_task_postrun(task_id, task, kwargs, state)
 
 
 @signals.task_retry.connect

--- a/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
@@ -9,8 +9,11 @@ from queue backlogs (in_flight = 0, pending > 0) when the heartbeat stops.
 """
 
 from celery import Task
+from sqlalchemy import update
 
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import IndexAttempt
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger
@@ -34,6 +37,24 @@ def on_docprocessing_task_prerun(
     tenant_id = kwargs.get("tenant_id")
     if index_attempt_id is None:
         return
+
+    # Emit a heartbeat before moving the counter to in_flight. This ensures
+    # the monitor never sees in_flight > 0 with a stale heartbeat for a live
+    # worker — picking up a batch is proof of life.
+    try:
+        with get_session_with_current_tenant() as db_session:
+            db_session.execute(
+                update(IndexAttempt)
+                .where(IndexAttempt.id == index_attempt_id)
+                .values(heartbeat_counter=IndexAttempt.heartbeat_counter + 1)
+            )
+            db_session.commit()
+    except Exception:
+        logger.debug(
+            "Failed to emit heartbeat on prerun for attempt %s",
+            index_attempt_id,
+            exc_info=True,
+        )
 
     try:
         r = get_redis_client(tenant_id=tenant_id)

--- a/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
@@ -1,0 +1,73 @@
+"""Batch counter signal handlers for docprocessing tasks.
+
+Maintains two per-attempt Redis counters:
+  docprocessing_pending_{id}   - batches dispatched but not yet picked up
+  docprocessing_in_flight_{id} - batches picked up but not yet completed
+
+These counters let the monitor distinguish worker crashes (in_flight > 0)
+from queue backlogs (in_flight = 0, pending > 0) when the heartbeat stops.
+"""
+
+from celery import Task
+
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.redis.redis_docprocessing import RedisDocprocessing
+from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_TRACKED_TASK = OnyxCeleryTask.DOCPROCESSING_TASK
+
+
+def on_docprocessing_task_prerun(
+    task_id: str | None,
+    task: Task | None,
+    kwargs: dict | None,
+) -> None:
+    if task is None or task_id is None or kwargs is None:
+        return
+    if (task.name or "") != _TRACKED_TASK:
+        return
+
+    index_attempt_id = kwargs.get("index_attempt_id")
+    tenant_id = kwargs.get("tenant_id")
+    if index_attempt_id is None:
+        return
+
+    try:
+        r = get_redis_client(tenant_id=tenant_id)
+        RedisDocprocessing(index_attempt_id, r).decr_pending_incr_in_flight()
+    except Exception:
+        logger.debug(
+            "Failed to update docprocessing counters on prerun for attempt %s",
+            index_attempt_id,
+            exc_info=True,
+        )
+
+
+def on_docprocessing_task_postrun(
+    task_id: str | None,
+    task: Task | None,
+    kwargs: dict | None,
+    state: str | None,  # noqa: ARG001
+) -> None:
+    if task is None or task_id is None or kwargs is None:
+        return
+    if (task.name or "") != _TRACKED_TASK:
+        return
+
+    index_attempt_id = kwargs.get("index_attempt_id")
+    tenant_id = kwargs.get("tenant_id")
+    if index_attempt_id is None:
+        return
+
+    try:
+        r = get_redis_client(tenant_id=tenant_id)
+        RedisDocprocessing(index_attempt_id, r).decr_in_flight()
+    except Exception:
+        logger.debug(
+            "Failed to update docprocessing counters on postrun for attempt %s",
+            index_attempt_id,
+            exc_info=True,
+        )

--- a/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/batch_counters.py
@@ -1,6 +1,6 @@
 """Batch counter signal handlers for docprocessing tasks.
 
-Maintains two per-attempt Redis counters:
+Maintains two per-attempt Redis counters (id = IndexAttempt.id):
   docprocessing_pending_{id}   - batches dispatched but not yet picked up
   docprocessing_in_flight_{id} - batches picked up but not yet completed
 
@@ -12,11 +12,12 @@ from celery import Task
 from sqlalchemy import update
 
 from onyx.configs.constants import OnyxCeleryTask
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import IndexAttempt
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 logger = setup_logger()
 
@@ -41,8 +42,13 @@ def on_docprocessing_task_prerun(
     # Emit a heartbeat before moving the counter to in_flight. This ensures
     # the monitor never sees in_flight > 0 with a stale heartbeat for a live
     # worker — picking up a batch is proof of life.
+    # Use get_session_with_tenant() with the explicit tenant_id from kwargs
+    # because task_prerun fires before TenantAwareTask.__call__ sets the
+    # tenant context var, so get_session_with_current_tenant() would use the
+    # wrong tenant.
+    resolved_tenant_id = tenant_id or POSTGRES_DEFAULT_SCHEMA
     try:
-        with get_session_with_current_tenant() as db_session:
+        with get_session_with_tenant(tenant_id=resolved_tenant_id) as db_session:
             db_session.execute(
                 update(IndexAttempt)
                 .where(IndexAttempt.id == index_attempt_id)

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -69,6 +69,7 @@ from onyx.file_store.staging import RawFileCallback
 from onyx.file_store.staging import reap_prior_attempt_staged_files
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import cache_hierarchy_nodes_batch
 from onyx.redis.redis_hierarchy import ensure_source_node_exists
 from onyx.redis.redis_hierarchy import get_node_id_from_raw_id
@@ -862,6 +863,17 @@ def connector_document_extraction(
                     with time_stage(
                         IndexAttemptStage.DOC_BATCH_ENQUEUE, index_attempt_id
                     ):
+                        try:
+                            RedisDocprocessing(
+                                index_attempt_id,
+                                get_redis_client(tenant_id=tenant_id),
+                            ).incr_pending()
+                        except Exception:
+                            logger.debug(
+                                "Failed to increment pending counter for attempt %s",
+                                index_attempt_id,
+                                exc_info=True,
+                            )
                         app.send_task(
                             OnyxCeleryTask.DOCPROCESSING_TASK,
                             kwargs=processing_batch_data,
@@ -1053,6 +1065,17 @@ def reissue_old_batches(
         if path_info.cc_pair_id != cc_pair_id:
             raise RuntimeError(f"Batch {batch_id} is not for cc pair {cc_pair_id}")
 
+        try:
+            RedisDocprocessing(
+                index_attempt_id,
+                get_redis_client(tenant_id=tenant_id),
+            ).incr_pending()
+        except Exception:
+            logger.debug(
+                "Failed to increment pending counter for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
         app.send_task(
             OnyxCeleryTask.DOCPROCESSING_TASK,
             kwargs={

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -23,6 +23,8 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptError
 from onyx.db.models import SearchSettings
+from onyx.redis.redis_docprocessing import RedisDocprocessing
+from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import optional_telemetry
@@ -291,6 +293,16 @@ def mark_attempt_succeeded(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
+        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
+        # stale counters in case cleanup() failed and left them behind.
+        try:
+            RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
+        except Exception:
+            logger.debug(
+                "Failed to clean up docprocessing counters for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
         return attempt
     except Exception:
         db_session.rollback()
@@ -321,6 +333,16 @@ def mark_attempt_partially_succeeded(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
+        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
+        # stale counters in case cleanup() failed and left them behind.
+        try:
+            RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
+        except Exception:
+            logger.debug(
+                "Failed to clean up docprocessing counters for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
         return attempt
     except Exception:
         db_session.rollback()
@@ -354,6 +376,16 @@ def mark_attempt_canceled(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
+        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
+        # stale counters in case cleanup() failed and left them behind.
+        try:
+            RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
+        except Exception:
+            logger.debug(
+                "Failed to clean up docprocessing counters for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
     except Exception:
         db_session.rollback()
         raise
@@ -389,6 +421,16 @@ def mark_attempt_failed(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
+        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
+        # stale counters in case cleanup() failed and left them behind.
+        try:
+            RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
+        except Exception:
+            logger.debug(
+                "Failed to clean up docprocessing counters for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
     except Exception:
         db_session.rollback()
         raise

--- a/backend/onyx/redis/redis_docprocessing.py
+++ b/backend/onyx/redis/redis_docprocessing.py
@@ -1,43 +1,54 @@
+from typing import cast
+
 import redis
 
 # Safety-net TTL against leaked keys if cleanup() fails silently. Long enough
 # that no legitimate sync will hit it; keys are normally deleted by cleanup().
 _COUNTER_TTL_SECONDS = 15 * 24 * 3600  # 15 days
 
-# Atomically increment pending and set TTL on first dispatch only.
-# KEYS[1]=pending, ARGV[1]=ttl_seconds
-_INCR_PENDING_SCRIPT = """
-local val = redis.call('INCR', KEYS[1])
-if val == 1 then
-    redis.call('EXPIRE', KEYS[1], ARGV[1])
-end
-return val
-"""
+# Why Lua scripts for decrements:
+#
+# Redis executes each individual command atomically, but two separate commands
+# (e.g. GET then DECR) from different clients can interleave. With multiple
+# concurrent docprocessing workers, two workers finishing batches at the same
+# time could both read the same counter value and both decrement, causing one
+# decrement to be silently lost. Lost decrements leave in_flight overcounted,
+# which would cause the monitor to incorrectly detect a worker crash.
+#
+# Lua scripts run single-threaded on the Redis server — no other client command
+# can interleave while a script is executing. This serializes the GET+DECR into
+# one uninterruptible unit, preventing lost decrements. Note that Lua does NOT
+# provide rollback (unlike a DB transaction); if the script errors mid-way,
+# partial writes persist. That is acceptable here since counters are soft
+# signals and the monitor tolerates minor imprecision.
+#
+# Plain Python INCR is used for incr_pending since concurrent increments cannot
+# lose updates — each adds 1 regardless of ordering.
 
 # Atomically move one batch from pending → in_flight.
-# Guards against pending underflow and sets TTL on in_flight on first pickup.
+# The if-guard prevents pending from going negative if cleanup() races with a
+# late task_prerun signal. Serialized execution on the Redis server prevents
+# lost decrements when multiple workers pick up batches concurrently.
 # KEYS[1]=pending, KEYS[2]=in_flight, ARGV[1]=ttl_seconds
 _PICKUP_SCRIPT = """
 if tonumber(redis.call('GET', KEYS[1]) or 0) > 0 then
     redis.call('DECR', KEYS[1])
-    local val = redis.call('INCR', KEYS[2])
-    if val == 1 then
-        redis.call('EXPIRE', KEYS[2], ARGV[1])
-    end
-    return 1
 end
-return 0
+local inflight = redis.call('INCR', KEYS[2])
+if inflight == 1 then
+    redis.call('EXPIRE', KEYS[2], ARGV[1])
+end
 """
 
 # Atomically decrement in_flight, guarding against underflow.
-# Prevents -1 recreation if task_postrun fires after cleanup() has already
-# deleted the key (e.g. the attempt reached a terminal state before postrun).
+# The if-guard prevents in_flight from going negative if cleanup() races with
+# a late task_postrun signal. Serialized execution on the Redis server prevents
+# lost decrements when multiple workers complete batches concurrently.
+# KEYS[1]=in_flight
 _DECR_IN_FLIGHT_SCRIPT = """
 if tonumber(redis.call('GET', KEYS[1]) or 0) > 0 then
     redis.call('DECR', KEYS[1])
-    return 1
 end
-return 0
 """
 
 
@@ -50,6 +61,8 @@ class RedisDocprocessing:
 
     Together they let the monitor distinguish worker crashes (in_flight > 0)
     from queue backlogs (in_flight = 0, pending > 0) when the heartbeat stops.
+
+    Counter keys are namespaced by IndexAttempt.id.
     """
 
     PENDING_PREFIX = "docprocessing_pending"
@@ -63,12 +76,10 @@ class RedisDocprocessing:
         self.in_flight_key: str = f"{self.IN_FLIGHT_PREFIX}_{index_attempt_id}"
 
     def incr_pending(self) -> None:
-        self.redis.eval(
-            _INCR_PENDING_SCRIPT,
-            1,
-            self.pending_key,
-            str(_COUNTER_TTL_SECONDS),
-        )
+        val = self.redis.incr(self.pending_key)
+        if val == 1:
+            # Set TTL on first dispatch — safety net against leaked keys.
+            self.redis.expire(self.pending_key, _COUNTER_TTL_SECONDS)
 
     def decr_pending_incr_in_flight(self) -> None:
         self.redis.eval(
@@ -81,6 +92,12 @@ class RedisDocprocessing:
 
     def decr_in_flight(self) -> None:
         self.redis.eval(_DECR_IN_FLIGHT_SCRIPT, 1, self.in_flight_key)
+
+    def pending(self) -> int:
+        return max(0, int(cast(bytes, self.redis.get(self.pending_key)) or 0))
+
+    def in_flight(self) -> int:
+        return max(0, int(cast(bytes, self.redis.get(self.in_flight_key)) or 0))
 
     def cleanup(self) -> None:
         self.redis.delete(self.pending_key, self.in_flight_key)

--- a/backend/onyx/redis/redis_docprocessing.py
+++ b/backend/onyx/redis/redis_docprocessing.py
@@ -1,0 +1,86 @@
+import redis
+
+# Safety-net TTL against leaked keys if cleanup() fails silently. Long enough
+# that no legitimate sync will hit it; keys are normally deleted by cleanup().
+_COUNTER_TTL_SECONDS = 15 * 24 * 3600  # 15 days
+
+# Atomically increment pending and set TTL on first dispatch only.
+# KEYS[1]=pending, ARGV[1]=ttl_seconds
+_INCR_PENDING_SCRIPT = """
+local val = redis.call('INCR', KEYS[1])
+if val == 1 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return val
+"""
+
+# Atomically move one batch from pending → in_flight.
+# Guards against pending underflow and sets TTL on in_flight on first pickup.
+# KEYS[1]=pending, KEYS[2]=in_flight, ARGV[1]=ttl_seconds
+_PICKUP_SCRIPT = """
+if tonumber(redis.call('GET', KEYS[1]) or 0) > 0 then
+    redis.call('DECR', KEYS[1])
+    local val = redis.call('INCR', KEYS[2])
+    if val == 1 then
+        redis.call('EXPIRE', KEYS[2], ARGV[1])
+    end
+    return 1
+end
+return 0
+"""
+
+# Atomically decrement in_flight, guarding against underflow.
+# Prevents -1 recreation if task_postrun fires after cleanup() has already
+# deleted the key (e.g. the attempt reached a terminal state before postrun).
+_DECR_IN_FLIGHT_SCRIPT = """
+if tonumber(redis.call('GET', KEYS[1]) or 0) > 0 then
+    redis.call('DECR', KEYS[1])
+    return 1
+end
+return 0
+"""
+
+
+class RedisDocprocessing:
+    """Manages per-attempt docprocessing batch counters in Redis.
+
+    Two counters track batches as they move through the lifecycle:
+      pending   - dispatched to queue, not yet picked up by a worker
+      in_flight - picked up by a worker, not yet completed
+
+    Together they let the monitor distinguish worker crashes (in_flight > 0)
+    from queue backlogs (in_flight = 0, pending > 0) when the heartbeat stops.
+    """
+
+    PENDING_PREFIX = "docprocessing_pending"
+    IN_FLIGHT_PREFIX = "docprocessing_in_flight"
+
+    def __init__(self, index_attempt_id: int, r: redis.Redis) -> None:
+        self.index_attempt_id = index_attempt_id
+        self.redis = r
+
+        self.pending_key: str = f"{self.PENDING_PREFIX}_{index_attempt_id}"
+        self.in_flight_key: str = f"{self.IN_FLIGHT_PREFIX}_{index_attempt_id}"
+
+    def incr_pending(self) -> None:
+        self.redis.eval(
+            _INCR_PENDING_SCRIPT,
+            1,
+            self.pending_key,
+            str(_COUNTER_TTL_SECONDS),
+        )
+
+    def decr_pending_incr_in_flight(self) -> None:
+        self.redis.eval(
+            _PICKUP_SCRIPT,
+            2,
+            self.pending_key,
+            self.in_flight_key,
+            str(_COUNTER_TTL_SECONDS),
+        )
+
+    def decr_in_flight(self) -> None:
+        self.redis.eval(_DECR_IN_FLIGHT_SCRIPT, 1, self.in_flight_key)
+
+    def cleanup(self) -> None:
+        self.redis.delete(self.pending_key, self.in_flight_key)


### PR DESCRIPTION
## Description

Introduces two Redis counters per `IndexAttempt` — `docprocessing_pending_{id}` and `docprocessing_in_flight_{id}` — that track batches as they move through the docprocessing lifecycle. `pending` increments on dispatch and decrements when a worker picks up a batch; `in_flight` increments on pickup and decrements on completion or failure. These counters are purely observational — no existing behavior changes. They lay the groundwork for a follow-up PR that updates the monitor task to use them for precise crash vs. backlog detection, replacing the current blunt 24-hour timeout.

https://docs.google.com/document/d/1uhL54rzkwJVW3ZBFZlw3_v00-pPZAZ1AeUWP4GobmCE/edit?tab=t.0
https://linear.app/onyx-app/issue/ENG-4092/improve-the-doc-processing-robustness

## How Has This Been Tested?

- Verified all imports and key naming via `python -c` smoke test
- Ran `backend/tests/unit/server/metrics/` (128 tests pass)
- Ruff passes on all changed files


tested locally

Everything worked perfectly:

  - status changed to SUCCESS
  - completed_batches reached 17/17
  - cleanup() fired — both counter keys are deleted (empty response on GET)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-attempt Redis counters for docprocessing to track pending and in-flight batches and emits a DB heartbeat before pickup, enabling precise crash vs. backlog detection (supports ENG-4092). No task behavior changes.

- **New Features**
  - Track per-`IndexAttempt` batch counts (tenant-aware): `docprocessing_pending_{id}` and `docprocessing_in_flight_{id}`.
  - On enqueue/reissue, increment `pending`; on Celery prerun, emit a DB heartbeat then atomically move `pending → in_flight`; on postrun, decrement `in_flight`.
  - Wire prerun/postrun handlers into the docprocessing Celery app; increment `pending` at enqueue and reissue call sites.
  - Cleanup counters when an attempt ends (success, partial, canceled, failed); add a 15-day safety TTL; use Lua for atomicity and underflow guards; log-and-ignore Redis errors so tasks keep running.

<sup>Written for commit f91b7abaa7fe1b49964f1ee2a12938758b332a2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



