### PR TITLE
chore(tooling): unify ruff and black versions via uv-run pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,18 @@ repos:
         args: ["ty", "check"]
         pass_filenames: true
         types_or: [python]
+      - id: uv-run
+        alias: ruff
+        name: ruff
+        args: ["ruff", "check", "--fix"]
+        pass_filenames: true
+        types_or: [python]
+      - id: uv-run
+        alias: black
+        name: black
+        args: ["black"]
+        pass_filenames: true
+        types_or: [python]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
@@ -97,25 +109,12 @@ repos:
             deployment/docker_compose/install\.sh
           )$
 
-  - repo: https://github.com/psf/black
-    rev: 8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # frozen: 25.1.0
-    hooks:
-      - id: black
-        language_version: python3.11
-
   - repo: https://github.com/golangci/golangci-lint
     rev: 5d1e709b7be35cb2025444e19de266b056b7b7ee # frozen: v2.10.1
     hooks:
       - id: golangci-lint
         language_version: "1.26.1"
         entry: bash -c "find . -name go.mod -not -path './.venv/*' -print0 | xargs -0 -I{} bash -c 'cd \"$(dirname {})\" && golangci-lint run ./...'"
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: 971923581912ef60a6b70dbf0c3e9a39563c9d47 # frozen: v0.11.4
-    hooks:
-      - id: ruff
-        args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: ffb6a759a979008c0e6dff86e39f4745a2d9eac4 # frozen: v3.1.0

--- a/backend/alembic/versions/01f8e6d95a33_populate_flow_mapping_data.py
+++ b/backend/alembic/versions/01f8e6d95a33_populate_flow_mapping_data.py
@@ -18,8 +18,7 @@ depends_on = None
 def upgrade() -> None:
     # Add each model config to the conversation flow, setting the global default if it exists
     # Exclude models that are part of ImageGenerationConfig
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO llm_model_flow (llm_model_flow_type, is_default, model_configuration_id)
         SELECT
             'CHAT' AS llm_model_flow_type,
@@ -35,12 +34,10 @@ def upgrade() -> None:
             SELECT 1 FROM image_generation_config igc
             WHERE igc.model_configuration_id = mc.id
         );
-        """
-    )
+        """)
 
     # Add models with supports_image_input to the vision flow
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO llm_model_flow (llm_model_flow_type, is_default, model_configuration_id)
         SELECT
             'VISION' AS llm_model_flow_type,
@@ -53,14 +50,12 @@ def upgrade() -> None:
         LEFT JOIN llm_provider lp
             ON lp.id = mc.llm_provider_id
         WHERE mc.supports_image_input IS TRUE;
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
     # Populate vision defaults from model_flow
-    op.execute(
-        """
+    op.execute("""
         UPDATE llm_provider AS lp
         SET
             is_default_vision_provider = TRUE,
@@ -70,12 +65,10 @@ def downgrade() -> None:
         WHERE mf.llm_model_flow_type = 'VISION'
           AND mf.is_default = TRUE
           AND mc.llm_provider_id = lp.id;
-        """
-    )
+        """)
 
     # Populate conversation defaults from model_flow
-    op.execute(
-        """
+    op.execute("""
         UPDATE llm_provider AS lp
         SET
             is_default_provider = TRUE,
@@ -85,14 +78,12 @@ def downgrade() -> None:
         WHERE mf.llm_model_flow_type = 'CHAT'
           AND mf.is_default = TRUE
           AND mc.llm_provider_id = lp.id;
-        """
-    )
+        """)
 
     # For providers that have conversation flow mappings but aren't the default,
     # we still need a default_model_name (it was NOT NULL originally)
     # Pick the first visible model or any model for that provider
-    op.execute(
-        """
+    op.execute("""
         UPDATE llm_provider AS lp
         SET default_model_name = (
             SELECT mc.name
@@ -104,8 +95,7 @@ def downgrade() -> None:
             LIMIT 1
         )
         WHERE lp.default_model_name IS NULL;
-        """
-    )
+        """)
 
     # Delete all model_flow entries (reverse the inserts from upgrade)
     op.execute("DELETE FROM llm_model_flow;")

--- a/backend/alembic/versions/0cd424f32b1d_user_file_data_preparation_and_backfill.py
+++ b/backend/alembic/versions/0cd424f32b1d_user_file_data_preparation_and_backfill.py
@@ -49,8 +49,7 @@ def upgrade() -> None:
 
             while True:
                 result = bind.execute(
-                    text(
-                        """
+                    text("""
                     UPDATE user_file
                     SET new_id = gen_random_uuid()
                     WHERE new_id IS NULL
@@ -59,8 +58,7 @@ def upgrade() -> None:
                         WHERE new_id IS NULL
                         LIMIT :batch_size
                     )
-                """
-                    ),
+                """),
                     {"batch_size": batch_size},
                 )
 
@@ -98,14 +96,10 @@ def upgrade() -> None:
         logger.info("Populating persona__user_file.user_file_id_uuid...")
 
         # Count rows needing update
-        null_count = bind.execute(
-            text(
-                """
+        null_count = bind.execute(text("""
             SELECT COUNT(*) FROM persona__user_file
             WHERE user_file_id IS NOT NULL AND user_file_id_uuid IS NULL
-        """
-            )
-        ).scalar_one()
+        """)).scalar_one()
 
         if null_count > 0:
             logger.info("Updating %s persona__user_file records...", null_count)
@@ -116,8 +110,7 @@ def upgrade() -> None:
 
             while True:
                 result = bind.execute(
-                    text(
-                        """
+                    text("""
                     UPDATE persona__user_file p
                     SET user_file_id_uuid = uf.new_id
                     FROM user_file uf
@@ -129,8 +122,7 @@ def upgrade() -> None:
                         WHERE user_file_id_uuid IS NULL
                         LIMIT :batch_size
                     )
-                """
-                    ),
+                """),
                     {"batch_size": batch_size},
                 )
 
@@ -145,14 +137,10 @@ def upgrade() -> None:
             logger.info("Updated %s persona__user_file records", total_updated)
 
         # Verify all records are populated
-        remaining_null = bind.execute(
-            text(
-                """
+        remaining_null = bind.execute(text("""
             SELECT COUNT(*) FROM persona__user_file
             WHERE user_file_id IS NOT NULL AND user_file_id_uuid IS NULL
-        """
-            )
-        ).scalar_one()
+        """)).scalar_one()
 
         if remaining_null > 0:
             raise Exception(
@@ -166,9 +154,7 @@ def upgrade() -> None:
     if "chat_folder" in inspector.get_table_names():
         logger.info("Creating user_project records from chat_folder...")
 
-        result = bind.execute(
-            text(
-                """
+        result = bind.execute(text("""
             INSERT INTO user_project (user_id, name)
             SELECT cf.user_id, cf.name
             FROM chat_folder cf
@@ -177,9 +163,7 @@ def upgrade() -> None:
                 FROM user_project up
                 WHERE up.user_id = cf.user_id AND up.name = cf.name
             )
-        """
-            )
-        )
+        """))
 
         logger.info("Created %s user_project records from chat_folder", result.rowcount)
 
@@ -192,41 +176,29 @@ def upgrade() -> None:
         logger.info("Populating chat_session.project_id...")
 
         # Count sessions needing update
-        null_count = bind.execute(
-            text(
-                """
+        null_count = bind.execute(text("""
             SELECT COUNT(*) FROM chat_session
             WHERE project_id IS NULL AND folder_id IS NOT NULL
-        """
-            )
-        ).scalar_one()
+        """)).scalar_one()
 
         if null_count > 0:
             logger.info("Updating %s chat_session records...", null_count)
 
-            result = bind.execute(
-                text(
-                    """
+            result = bind.execute(text("""
                 UPDATE chat_session cs
                 SET project_id = up.id
                 FROM chat_folder cf
                 JOIN user_project up ON up.user_id = cf.user_id AND up.name = cf.name
                 WHERE cs.folder_id = cf.id AND cs.project_id IS NULL
-            """
-                )
-            )
+            """))
 
             logger.info("Updated %s chat_session records", result.rowcount)
 
         # Verify all records are populated
-        remaining_null = bind.execute(
-            text(
-                """
+        remaining_null = bind.execute(text("""
             SELECT COUNT(*) FROM chat_session
             WHERE project_id IS NULL AND folder_id IS NOT NULL
-        """
-            )
-        ).scalar_one()
+        """)).scalar_one()
 
         if remaining_null > 0:
             logger.warning(
@@ -241,46 +213,36 @@ def upgrade() -> None:
     logger.info("Updating plaintext FileRecord ids and display names to UUID scheme...")
 
     # Count legacy plaintext records that can be mapped to UUID user_file ids
-    count_query = text(
-        """
+    count_query = text("""
         SELECT COUNT(*)
         FROM file_record fr
         JOIN user_file uf ON fr.file_id = CONCAT('plaintext_', uf.id::text)
         WHERE LOWER(fr.file_origin::text) = 'plaintext_cache'
-        """
-    )
+        """)
     legacy_count = bind.execute(count_query).scalar_one()
 
     if legacy_count and legacy_count > 0:
         logger.info("Found %s legacy plaintext file records to update", legacy_count)
 
         # Update display_name first for readability (safe regardless of rename)
-        bind.execute(
-            text(
-                """
+        bind.execute(text("""
                 UPDATE file_record fr
                 SET display_name = CONCAT('Plaintext for user file ', uf.new_id::text)
                 FROM user_file uf
                 WHERE LOWER(fr.file_origin::text) = 'plaintext_cache'
                     AND fr.file_id = CONCAT('plaintext_', uf.id::text)
-                """
-            )
-        )
+                """))
 
         # Remap file_id from 'plaintext_<int>' -> 'plaintext_<uuid>' using transitional new_id
         # Use a single UPDATE ... WHERE file_id LIKE 'plain_text_%'
         # and ensure it aligns to existing user_file ids to avoid renaming unrelated rows
-        result = bind.execute(
-            text(
-                """
+        result = bind.execute(text("""
                 UPDATE file_record fr
                 SET file_id = CONCAT('plaintext_', uf.new_id::text)
                 FROM user_file uf
                 WHERE LOWER(fr.file_origin::text) = 'plaintext_cache'
                     AND fr.file_id = CONCAT('plaintext_', uf.id::text)
-                """
-            )
-        )
+                """))
         logger.info(
             "Updated %s plaintext file_record ids to UUID scheme", result.rowcount
         )
@@ -290,24 +252,18 @@ def upgrade() -> None:
     # Existing rows that had a legacy document_id should be marked as not migrated to be processed.
 
     # Backfill existing records: if document_id is not null, set to FALSE
-    bind.execute(
-        text(
-            """
+    bind.execute(text("""
             UPDATE user_file
             SET document_id_migrated = FALSE
             WHERE document_id IS NOT NULL
-            """
-        )
-    )
+            """))
 
     # === Step 7: Backfill user_file.status from index_attempt ===
     logger.info("Backfilling user_file.status from index_attempt...")
 
     # Update user_file status based on latest index attempt
     # Using CTEs instead of temp tables for asyncpg compatibility
-    result = bind.execute(
-        text(
-            """
+    result = bind.execute(text("""
         WITH latest_attempt AS (
             SELECT DISTINCT ON (ia.connector_credential_pair_id)
                 ia.connector_credential_pair_id,
@@ -335,9 +291,7 @@ def upgrade() -> None:
             ON la.connector_credential_pair_id = ufc.cc_pair_id
         WHERE uf.id = ufc.uf_id
         AND uf.status = 'PROCESSING'
-    """
-        )
-    )
+    """))
 
     logger.info("Updated status for %s user_file records", result.rowcount)
 

--- a/backend/alembic/versions/12635f6655b7_drive_canonical_ids.py
+++ b/backend/alembic/versions/12635f6655b7_drive_canonical_ids.py
@@ -32,13 +32,9 @@ SKIP_CANON_DRIVE_IDS = os.environ.get("SKIP_CANON_DRIVE_IDS", "true").lower() ==
 
 
 def active_search_settings() -> tuple[SearchSettings, SearchSettings | None]:
-    result = op.get_bind().execute(
-        sa.text(
-            """
+    result = op.get_bind().execute(sa.text("""
         SELECT * FROM search_settings WHERE status = 'PRESENT' ORDER BY id DESC LIMIT 1
-        """
-        )
-    )
+        """))
     search_settings_fetch = result.fetchall()
     search_settings = (
         SearchSettings(**search_settings_fetch[0]._asdict())
@@ -46,13 +42,9 @@ def active_search_settings() -> tuple[SearchSettings, SearchSettings | None]:
         else None
     )
 
-    result2 = op.get_bind().execute(
-        sa.text(
-            """
+    result2 = op.get_bind().execute(sa.text("""
         SELECT * FROM search_settings WHERE status = 'FUTURE' ORDER BY id DESC LIMIT 1
-        """
-        )
-    )
+        """))
     search_settings_future_fetch = result2.fetchall()
     search_settings_future = (
         SearchSettings(**search_settings_future_fetch[0]._asdict())
@@ -92,9 +84,7 @@ def normalize_google_drive_url(url: str) -> str:
 def get_google_drive_documents_from_database() -> list[dict]:
     """Get all Google Drive documents from the database."""
     bind = op.get_bind()
-    result = bind.execute(
-        sa.text(
-            """
+    result = bind.execute(sa.text("""
             SELECT d.id
             FROM document d
             JOIN document_by_connector_credential_pair dcc ON d.id = dcc.id
@@ -102,9 +92,7 @@ def get_google_drive_documents_from_database() -> list[dict]:
                 AND dcc.credential_id = cc.credential_id
             JOIN connector c ON cc.connector_id = c.id
             WHERE c.source = 'GOOGLE_DRIVE'
-        """
-        )
-    )
+        """))
 
     documents = []
     for row in result:
@@ -136,8 +124,7 @@ def update_document_id_in_database(
     # Use a conservative approach to handle columns that might not exist in all installations
     try:
         bind.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO document (id, from_ingestion_api, boost, hidden, semantic_id,
                                     link, doc_updated_at, primary_owners, secondary_owners,
                                     external_user_emails, external_user_group_ids, is_public,
@@ -148,8 +135,7 @@ def update_document_id_in_database(
                        chunk_count, last_modified, last_synced, kg_stage, kg_processing_time
                 FROM document
                 WHERE id = :old_id
-            """
-            ),
+            """),
             {"new_id": new_doc_id, "old_id": old_doc_id},
         )
         # print(f"Successfully updated database tables for document {old_doc_id} -> {new_doc_id}")
@@ -157,16 +143,14 @@ def update_document_id_in_database(
         # If the full INSERT fails, try a more basic version with only core columns
         logger.warning("Full INSERT failed, trying basic version: %s", e)
         bind.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO document (id, from_ingestion_api, boost, hidden, semantic_id,
                                     link, doc_updated_at, primary_owners, secondary_owners)
                 SELECT :new_id, from_ingestion_api, boost, hidden, semantic_id,
                        link, doc_updated_at, primary_owners, secondary_owners
                 FROM document
                 WHERE id = :old_id
-            """
-            ),
+            """),
             {"new_id": new_doc_id, "old_id": old_doc_id},
         )
 
@@ -258,13 +242,11 @@ def update_document_id_in_database(
         # print(f"Successfully updated chunk_stats table for document {old_doc_id} -> {new_doc_id}")
         # Update chunk_stats ID field which includes document_id
         bind.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE chunk_stats
                 SET id = REPLACE(id, :old_id, :new_id)
                 WHERE id LIKE :old_id_pattern
-            """
-            ),
+            """),
             {
                 "new_id": new_doc_id,
                 "old_id": old_doc_id,
@@ -404,27 +386,23 @@ def delete_document_from_db(current_doc_id: str, index_name: str) -> None:
         # Delete from agent-related tables first (order matters due to foreign keys)
         # Delete from agent__sub_query__search_doc first since it references search_doc
         bind.execute(
-            sa.text(
-                """
+            sa.text("""
                 DELETE FROM agent__sub_query__search_doc
                 WHERE search_doc_id IN (
                     SELECT id FROM search_doc WHERE document_id = :doc_id
                 )
-                """
-            ),
+                """),
             {"doc_id": current_doc_id},
         )
 
         # Delete from chat_message__search_doc
         bind.execute(
-            sa.text(
-                """
+            sa.text("""
                 DELETE FROM chat_message__search_doc
                 WHERE search_doc_id IN (
                     SELECT id FROM search_doc WHERE document_id = :doc_id
                 )
-                """
-            ),
+                """),
             {"doc_id": current_doc_id},
         )
 

--- a/backend/alembic/versions/16c37a30adf2_user_file_relationship_migration.py
+++ b/backend/alembic/versions/16c37a30adf2_user_file_relationship_migration.py
@@ -41,8 +41,7 @@ def upgrade() -> None:
             )
 
             # Count relationships to migrate (asyncpg-compatible)
-            count_query = text(
-                """
+            count_query = text("""
                 SELECT COUNT(*)
                 FROM (
                     SELECT DISTINCT puf.persona_id, uf.id
@@ -55,8 +54,7 @@ def upgrade() -> None:
                         AND p2.user_file_id = uf.id
                     )
                 ) AS distinct_pairs
-            """
-            )
+            """)
             to_migrate = bind.execute(count_query).scalar_one()
 
             if to_migrate > 0:
@@ -69,8 +67,7 @@ def upgrade() -> None:
                 while True:
                     # Insert batch directly using subquery (asyncpg compatible)
                     result = bind.execute(
-                        text(
-                            """
+                        text("""
                         INSERT INTO persona__user_file (persona_id, user_file_id, user_file_id_uuid)
                         SELECT DISTINCT puf.persona_id, uf.id as file_id, uf.new_id
                         FROM persona__user_folder puf
@@ -82,8 +79,7 @@ def upgrade() -> None:
                             AND p2.user_file_id = uf.id
                         )
                         LIMIT :batch_size
-                    """
-                        ),
+                    """),
                         {"batch_size": batch_size},
                     )
 
@@ -126,8 +122,7 @@ def upgrade() -> None:
         logger.info("Populating project__user_file from folder relationships...")
 
         # Count relationships to create
-        count_query = text(
-            """
+        count_query = text("""
             SELECT COUNT(*)
             FROM user_file uf
             WHERE uf.folder_id IS NOT NULL
@@ -137,8 +132,7 @@ def upgrade() -> None:
                 WHERE puf.project_id = uf.folder_id
                 AND puf.user_file_id = uf.new_id
             )
-        """
-        )
+        """)
         to_create = bind.execute(count_query).scalar_one()
 
         if to_create > 0:
@@ -150,8 +144,7 @@ def upgrade() -> None:
 
             while True:
                 result = bind.execute(
-                    text(
-                        """
+                    text("""
                     INSERT INTO project__user_file (project_id, user_file_id)
                     SELECT uf.folder_id, uf.new_id
                     FROM user_file uf
@@ -164,8 +157,7 @@ def upgrade() -> None:
                     )
                     LIMIT :batch_size
                     ON CONFLICT (project_id, user_file_id) DO NOTHING
-                """
-                    ),
+                """),
                     {"batch_size": batch_size},
                 )
 
@@ -241,9 +233,7 @@ def downgrade() -> None:
     ):
         user_file_columns = [col["name"] for col in inspector.get_columns("user_file")]
         if "folder_id" in user_file_columns:
-            result = bind.execute(
-                text(
-                    """
+            result = bind.execute(text("""
                 DELETE FROM persona__user_file puf
                 WHERE EXISTS (
                     SELECT 1
@@ -253,9 +243,7 @@ def downgrade() -> None:
                     WHERE puf.persona_id = puf2.persona_id
                     AND puf.user_file_id = uf.id
                 )
-            """
-                )
-            )
+            """))
             logger.info(
                 "Removed %s migrated persona__user_file relationships", result.rowcount
             )

--- a/backend/alembic/versions/19c0ccb01687_migrate_to_contextual_rag_model.py
+++ b/backend/alembic/versions/19c0ccb01687_migrate_to_contextual_rag_model.py
@@ -30,8 +30,7 @@ def upgrade() -> None:
     # For every search_settings row that has contextual rag configured,
     # create an llm_model_flow entry. is_default is TRUE if the row
     # belongs to the PRESENT search settings, FALSE otherwise.
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO llm_model_flow (llm_model_flow_type, model_configuration_id, is_default)
         SELECT DISTINCT
             'CONTEXTUAL_RAG',
@@ -49,17 +48,14 @@ def upgrade() -> None:
         ON CONFLICT (llm_model_flow_type, model_configuration_id)
             DO UPDATE SET is_default = EXCLUDED.is_default
             WHERE EXCLUDED.is_default = TRUE
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM llm_model_flow
         WHERE llm_model_flow_type = 'CONTEXTUAL_RAG'
-        """
-    )
+        """)
 
     op.alter_column(
         "llm_model_flow",

--- a/backend/alembic/versions/238b84885828_add_foreign_key_to_user__external_user_.py
+++ b/backend/alembic/versions/238b84885828_add_foreign_key_to_user__external_user_.py
@@ -17,12 +17,10 @@ depends_on = None
 
 def upgrade() -> None:
     # First, clean up any entries that don't have a valid cc_pair_id
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM user__external_user_group_id
         WHERE cc_pair_id NOT IN (SELECT id FROM connector_credential_pair)
-        """
-    )
+        """)
 
     # Add foreign key constraint with cascade delete
     op.create_foreign_key(

--- a/backend/alembic/versions/26b931506ecb_default_chosen_assistants_to_none.py
+++ b/backend/alembic/versions/26b931506ecb_default_chosen_assistants_to_none.py
@@ -22,16 +22,14 @@ def upgrade() -> None:
         "user", sa.Column("chosen_assistants_new", postgresql.JSONB(), nullable=True)
     )
 
-    op.execute(
-        """
+    op.execute("""
     UPDATE "user"
     SET chosen_assistants_new =
         CASE
             WHEN chosen_assistants = '[-2, -1, 0]' THEN NULL
             ELSE chosen_assistants
         END
-    """
-    )
+    """)
 
     op.drop_column("user", "chosen_assistants")
 
@@ -51,16 +49,14 @@ def downgrade() -> None:
         ),
     )
 
-    op.execute(
-        """
+    op.execute("""
     UPDATE "user"
     SET chosen_assistants_old =
         CASE
             WHEN chosen_assistants IS NULL THEN '[-2, -1, 0]'::jsonb
             ELSE chosen_assistants
         END
-    """
-    )
+    """)
 
     op.drop_column("user", "chosen_assistants")
 

--- a/backend/alembic/versions/2acdef638fc2_add_switchover_type_field.py
+++ b/backend/alembic/versions/2acdef638fc2_add_switchover_type_field.py
@@ -32,15 +32,13 @@ def upgrade() -> None:
 
     # Migrate existing data: set switchover_type based on background_reindex_enabled
     # REINDEX where background_reindex_enabled=True, INSTANT where False
-    op.execute(
-        """
+    op.execute("""
         UPDATE search_settings
         SET switchover_type = CASE
             WHEN background_reindex_enabled = true THEN 'REINDEX'
             ELSE 'INSTANT'
         END
-        """
-    )
+        """)
 
     # Remove the background_reindex_enabled column (replaced by switchover_type)
     op.drop_column("search_settings", "background_reindex_enabled")
@@ -58,14 +56,12 @@ def downgrade() -> None:
         ),
     )
     # Set background_reindex_enabled based on switchover_type
-    op.execute(
-        """
+    op.execute("""
         UPDATE search_settings
         SET background_reindex_enabled = CASE
             WHEN switchover_type = 'INSTANT' THEN false
             ELSE true
         END
-        """
-    )
+        """)
     # Remove the switchover_type column
     op.drop_column("search_settings", "switchover_type")

--- a/backend/alembic/versions/2b75d0a8ffcb_user_file_schema_cleanup.py
+++ b/backend/alembic/versions/2b75d0a8ffcb_user_file_schema_cleanup.py
@@ -39,14 +39,10 @@ def upgrade() -> None:
         col["name"] for col in inspector.get_columns("chat_session")
     ]
     if "folder_id" in chat_session_columns:
-        orphaned_count = bind.execute(
-            text(
-                """
+        orphaned_count = bind.execute(text("""
             SELECT COUNT(*) FROM chat_session
             WHERE folder_id IS NOT NULL AND project_id IS NULL
-        """
-            )
-        ).scalar_one()
+        """)).scalar_one()
 
         if orphaned_count > 0:
             logger.warning(
@@ -114,9 +110,7 @@ def upgrade() -> None:
         logger.info("Dropping user_file.cc_pair_id...")
 
         # Drop any remaining foreign key constraints
-        bind.execute(
-            text(
-                """
+        bind.execute(text("""
             DO $$
             DECLARE r RECORD;
             BEGIN
@@ -135,9 +129,7 @@ def upgrade() -> None:
                 EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT IF EXISTS %I', r.conname);
               END LOOP;
             END$$;
-        """
-            )
-        )
+        """))
 
         op.drop_column("user_file", "cc_pair_id")
         logger.info("Dropped user_file.cc_pair_id")

--- a/backend/alembic/versions/2c2430828bdf_add_unique_constraint_to_inputprompt_.py
+++ b/backend/alembic/versions/2c2430828bdf_add_unique_constraint_to_inputprompt_.py
@@ -27,13 +27,11 @@ def upgrade() -> None:
     # Create partial unique index for public prompts (where user_id IS NULL)
     # PostgreSQL unique constraints don't enforce uniqueness for NULL values,
     # so we need a partial index to ensure public prompt names are also unique
-    op.execute(
-        """
+    op.execute("""
         CREATE UNIQUE INDEX uq_inputprompt_prompt_public
         ON inputprompt (prompt)
         WHERE user_id IS NULL
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/2cdeff6d8c93_set_built_in_to_default.py
+++ b/backend/alembic/versions/2cdeff6d8c93_set_built_in_to_default.py
@@ -19,13 +19,11 @@ def upgrade() -> None:
     # Prior to this migration / point in the codebase history,
     # built in personas were implicitly treated as default personas (with no option to change this)
     # This migration makes that explicit
-    op.execute(
-        """
+    op.execute("""
         UPDATE persona
         SET is_default_persona = TRUE
         WHERE builtin_persona = TRUE
-    """
-    )
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/33cb72ea4d80_single_tool_call_per_message.py
+++ b/backend/alembic/versions/33cb72ea4d80_single_tool_call_per_message.py
@@ -19,9 +19,7 @@ depends_on = None
 def upgrade() -> None:
     # Step 1: Delete extraneous ToolCall entries
     # Keep only the ToolCall with the smallest 'id' for each 'message_id'
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             DELETE FROM tool_call
             WHERE id NOT IN (
                 SELECT MIN(id)
@@ -29,9 +27,7 @@ def upgrade() -> None:
                 WHERE message_id IS NOT NULL
                 GROUP BY message_id
             );
-        """
-        )
-    )
+        """))
 
     # Step 2: Add a unique constraint on message_id
     op.create_unique_constraint(

--- a/backend/alembic/versions/33ea50e88f24_foreign_key_input_prompts.py
+++ b/backend/alembic/versions/33ea50e88f24_foreign_key_input_prompts.py
@@ -17,18 +17,14 @@ depends_on = None
 
 def upgrade() -> None:
     # Safely drop constraints if exists
-    op.execute(
-        """
+    op.execute("""
         ALTER TABLE inputprompt__user
         DROP CONSTRAINT IF EXISTS inputprompt__user_input_prompt_id_fkey
-        """
-    )
-    op.execute(
-        """
+        """)
+    op.execute("""
         ALTER TABLE inputprompt__user
         DROP CONSTRAINT IF EXISTS inputprompt__user_user_id_fkey
-        """
-    )
+        """)
 
     # Recreate with ON DELETE CASCADE
     op.create_foreign_key(

--- a/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
+++ b/backend/alembic/versions/35e6853a51d5_server_default_chosen_assistants.py
@@ -24,8 +24,7 @@ def upgrade() -> None:
     # This upgrades existing users without ordered assistant
     # to have default assistants set to visible assistants which are
     # accessible by them.
-    op.execute(
-        """
+    op.execute("""
         UPDATE "user" u
         SET chosen_assistants = (
             SELECT jsonb_agg(
@@ -42,8 +41,7 @@ def upgrade() -> None:
         OR chosen_assistants = 'null'
         OR jsonb_typeof(chosen_assistants) = 'null'
         OR (jsonb_typeof(chosen_assistants) = 'string' AND chosen_assistants = '"null"')
-    """
-    )
+    """)
 
     # Step 2: Alter the column to make it non-nullable
     op.alter_column(

--- a/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
+++ b/backend/alembic/versions/36e9220ab794_update_kg_trigger_functions.py
@@ -37,9 +37,7 @@ def upgrade() -> None:
     alphanum_pattern = r"[^a-z0-9]+"
     truncate_length = 1000
     function = "update_kg_entity_name"
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             CREATE OR REPLACE FUNCTION "{tenant_id}".{function}()
             RETURNS TRIGGER AS $$
             DECLARE
@@ -70,26 +68,20 @@ def upgrade() -> None:
                 RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
-            """
-        )
-    )
+            """))
     trigger = f"{function}_trigger"
     op.execute(f'DROP TRIGGER IF EXISTS {trigger} ON "{tenant_id}".kg_entity')
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE TRIGGER {trigger}
             BEFORE INSERT OR UPDATE OF name
             ON "{tenant_id}".kg_entity
             FOR EACH ROW
             EXECUTE FUNCTION "{tenant_id}".{function}();
-        """
-    )
+        """)
 
     # Create kg_entity trigger to update kg_entity.name and its trigrams
     function = "update_kg_entity_name_from_doc"
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             CREATE OR REPLACE FUNCTION "{tenant_id}".{function}()
             RETURNS TRIGGER AS $$
             DECLARE
@@ -116,20 +108,16 @@ def upgrade() -> None:
                 RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
-            """
-        )
-    )
+            """))
     trigger = f"{function}_trigger"
     op.execute(f'DROP TRIGGER IF EXISTS {trigger} ON "{tenant_id}".document')
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE TRIGGER {trigger}
             AFTER UPDATE OF semantic_id
             ON "{tenant_id}".document
             FOR EACH ROW
             EXECUTE FUNCTION "{tenant_id}".{function}();
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/3934b1bc7b62_update_github_connector_repo_name_to_.py
+++ b/backend/alembic/versions/3934b1bc7b62_update_github_connector_repo_name_to_.py
@@ -25,15 +25,11 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     # First get all GitHub connectors
-    github_connectors = conn.execute(
-        sa.text(
-            """
+    github_connectors = conn.execute(sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = 'GITHUB'
-            """
-        )
-    ).fetchall()
+            """)).fetchall()
 
     # Update each connector's config
     updated_count = 0
@@ -57,13 +53,11 @@ def upgrade() -> None:
 
             # Update the connector with the new config
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     UPDATE connector
                     SET connector_specific_config = :new_config
                     WHERE id = :connector_id
-                    """
-                ),
+                    """),
                 {"connector_id": connector_id, "new_config": json.dumps(new_config)},
             )
             updated_count += 1
@@ -79,15 +73,11 @@ def downgrade() -> None:
         "Starting rollback of GitHub connectors from repositories to repo_name"
     )
 
-    github_connectors = conn.execute(
-        sa.text(
-            """
+    github_connectors = conn.execute(sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = 'GITHUB'
-            """
-        )
-    ).fetchall()
+            """)).fetchall()
 
     logger.debug("Found %s GitHub connectors to rollback", len(github_connectors))
 
@@ -112,13 +102,11 @@ def downgrade() -> None:
 
             # Update the connector with the new config
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     UPDATE connector
                     SET connector_specific_config = :new_config
                     WHERE id = :connector_id
-                    """
-                ),
+                    """),
                 {"new_config": json.dumps(new_config), "connector_id": connector_id},
             )
             reverted_count += 1

--- a/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
+++ b/backend/alembic/versions/3a78dba1080a_user_file_legacy_data_cleanup.py
@@ -106,18 +106,14 @@ def upgrade() -> None:
     logger.info("Identifying user-file documents to delete...")
 
     # Get document IDs to delete
-    doc_rows = bind.execute(
-        text(
-            """
+    doc_rows = bind.execute(text("""
         SELECT DISTINCT dcc.id AS document_id
         FROM document_by_connector_credential_pair dcc
         JOIN connector_credential_pair u
           ON u.connector_id = dcc.connector_id
          AND u.credential_id = dcc.credential_id
         WHERE u.is_user_file IS TRUE
-    """
-        )
-    ).fetchall()
+    """)).fetchall()
 
     doc_ids = [r[0] for r in doc_rows]
 
@@ -155,15 +151,11 @@ def upgrade() -> None:
     logger.info("Cleaning up user-file connector_credential_pairs...")
 
     # Get cc_pair IDs
-    cc_pair_rows = bind.execute(
-        text(
-            """
+    cc_pair_rows = bind.execute(text("""
         SELECT id AS cc_pair_id
         FROM connector_credential_pair
         WHERE is_user_file IS TRUE
-    """
-        )
-    ).fetchall()
+    """)).fetchall()
 
     cc_pair_ids = [r[0] for r in cc_pair_rows]
 
@@ -195,9 +187,7 @@ def upgrade() -> None:
     logger.info("Identifying orphaned connectors and credentials...")
 
     # Get connectors used only by user-file cc_pairs
-    connector_rows = bind.execute(
-        text(
-            """
+    connector_rows = bind.execute(text("""
         SELECT DISTINCT ccp.connector_id
         FROM connector_credential_pair ccp
         WHERE ccp.is_user_file IS TRUE
@@ -208,16 +198,12 @@ def upgrade() -> None:
             WHERE c2.connector_id = ccp.connector_id
               AND c2.is_user_file IS NOT TRUE
           )
-    """
-        )
-    ).fetchall()
+    """)).fetchall()
 
     userfile_only_connector_ids = [r[0] for r in connector_rows]
 
     # Get credentials used only by user-file cc_pairs
-    credential_rows = bind.execute(
-        text(
-            """
+    credential_rows = bind.execute(text("""
         SELECT DISTINCT ccp.credential_id
         FROM connector_credential_pair ccp
         WHERE ccp.is_user_file IS TRUE
@@ -228,18 +214,14 @@ def upgrade() -> None:
             WHERE c2.credential_id = ccp.credential_id
               AND c2.is_user_file IS NOT TRUE
           )
-    """
-        )
-    ).fetchall()
+    """)).fetchall()
 
     userfile_only_credential_ids = [r[0] for r in credential_rows]
 
     # === Step 4: Delete the cc_pairs themselves ===
     if cc_pair_ids:
         # Remove FK dependency from user_file first
-        bind.execute(
-            text(
-                """
+        bind.execute(text("""
             DO $$
             DECLARE r RECORD;
             BEGIN
@@ -255,9 +237,7 @@ def upgrade() -> None:
                 EXECUTE format('ALTER TABLE user_file DROP CONSTRAINT IF EXISTS %I', r.conname);
               END LOOP;
             END$$;
-        """
-            )
-        )
+        """))
 
         # Delete cc_pairs
         deleted = batch_delete(

--- a/backend/alembic/versions/3bd4c84fe72f_improved_index.py
+++ b/backend/alembic/versions/3bd4c84fe72f_improved_index.py
@@ -35,38 +35,30 @@ def upgrade() -> None:
     op.execute("ALTER TABLE chat_session DROP COLUMN IF EXISTS description_tsv;")
 
     # Create a GIN index for full-text search on chat_message.message
-    op.execute(
-        """
+    op.execute("""
         ALTER TABLE chat_message
         ADD COLUMN message_tsv tsvector
         GENERATED ALWAYS AS (to_tsvector('english', message)) STORED;
-        """
-    )
+        """)
 
-    op.execute(
-        """
+    op.execute("""
         CREATE INDEX IF NOT EXISTS idx_chat_message_tsv
         ON chat_message
         USING GIN (message_tsv)
-        """
-    )
+        """)
 
     # Also add a stored tsvector column for chat_session.description
-    op.execute(
-        """
+    op.execute("""
         ALTER TABLE chat_session
         ADD COLUMN description_tsv tsvector
         GENERATED ALWAYS AS (to_tsvector('english', coalesce(description, ''))) STORED;
-        """
-    )
+        """)
 
-    op.execute(
-        """
+    op.execute("""
         CREATE INDEX IF NOT EXISTS idx_chat_session_desc_tsv
         ON chat_session
         USING GIN (description_tsv)
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/43cbbb3f5e6a_rename_index_origin_to_index_recursively.py
+++ b/backend/alembic/versions/43cbbb3f5e6a_rename_index_origin_to_index_recursively.py
@@ -16,8 +16,7 @@ depends_on: None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector
         SET connector_specific_config = jsonb_set(
             connector_specific_config,
@@ -25,13 +24,11 @@ def upgrade() -> None:
             'true'::jsonb
         ) - 'index_origin'
         WHERE connector_specific_config ? 'index_origin'
-    """
-    )
+    """)
 
 
 def downgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector
         SET connector_specific_config = jsonb_set(
             connector_specific_config,
@@ -39,5 +36,4 @@ def downgrade() -> None:
             connector_specific_config->'index_recursively'
         ) - 'index_recursively'
         WHERE connector_specific_config ? 'index_recursively'
-    """
-    )
+    """)

--- a/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
+++ b/backend/alembic/versions/495cb26ce93e_create_knowlege_graph_tables.py
@@ -42,9 +42,7 @@ def upgrade() -> None:
         if not (DB_READONLY_USER and DB_READONLY_PASSWORD):
             raise Exception("DB_READONLY_USER or DB_READONLY_PASSWORD is not set")
 
-        op.execute(
-            text(
-                f"""
+        op.execute(text(f"""
                 DO $$
                 BEGIN
                     -- Check if the read-only user already exists
@@ -59,14 +57,10 @@ def upgrade() -> None:
                     END IF;
                 END
                 $$;
-                """
-            )
-        )
+                """))
 
     # Grant usage on current schema to readonly user
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             DO $$
             BEGIN
                 IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{DB_READONLY_USER}') THEN
@@ -74,9 +68,7 @@ def upgrade() -> None:
                 END IF;
             END
             $$;
-            """
-        )
-    )
+            """))
 
     op.execute("DROP TABLE IF EXISTS kg_config CASCADE")
     op.create_table(
@@ -486,9 +478,7 @@ def upgrade() -> None:
     alphanum_pattern = r"[^a-z0-9]+"
     truncate_length = 1000
     function = "update_kg_entity_name"
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             CREATE OR REPLACE FUNCTION {function}()
             RETURNS TRIGGER AS $$
             DECLARE
@@ -519,26 +509,20 @@ def upgrade() -> None:
                 RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
-            """
-        )
-    )
+            """))
     trigger = f"{function}_trigger"
     op.execute(f"DROP TRIGGER IF EXISTS {trigger} ON kg_entity")
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE TRIGGER {trigger}
             BEFORE INSERT OR UPDATE OF name
             ON kg_entity
             FOR EACH ROW
             EXECUTE FUNCTION {function}();
-        """
-    )
+        """)
 
     # Create kg_entity trigger to update kg_entity.name and its trigrams
     function = "update_kg_entity_name_from_doc"
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             CREATE OR REPLACE FUNCTION {function}()
             RETURNS TRIGGER AS $$
             DECLARE
@@ -565,27 +549,22 @@ def upgrade() -> None:
                 RETURN NEW;
             END;
             $$ LANGUAGE plpgsql;
-            """
-        )
-    )
+            """))
     trigger = f"{function}_trigger"
     op.execute(f"DROP TRIGGER IF EXISTS {trigger} ON document")
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE TRIGGER {trigger}
             AFTER UPDATE OF semantic_id
             ON document
             FOR EACH ROW
             EXECUTE FUNCTION {function}();
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
 
     #  Drop all views that start with 'kg_'
-    op.execute(
-        """
+    op.execute("""
                 DO $$
                 DECLARE
                     view_name text;
@@ -601,11 +580,9 @@ def downgrade() -> None:
                         EXECUTE 'DROP VIEW IF EXISTS ' || quote_ident(view_name);
                     END LOOP;
                 END $$;
-            """
-    )
+            """)
 
-    op.execute(
-        """
+    op.execute("""
                 DO $$
                 DECLARE
                     view_name text;
@@ -621,8 +598,7 @@ def downgrade() -> None:
                         EXECUTE 'DROP VIEW IF EXISTS ' || quote_ident(view_name);
                     END LOOP;
                 END $$;
-            """
-    )
+            """)
 
     for table, function in (
         ("kg_entity", "update_kg_entity_name"),
@@ -651,9 +627,7 @@ def downgrade() -> None:
     op.drop_table("kg_config")
 
     # Revoke usage on current schema for the readonly user
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             DO $$
             BEGIN
                 IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{DB_READONLY_USER}') THEN
@@ -661,17 +635,13 @@ def downgrade() -> None:
                 END IF;
             END
             $$;
-            """
-        )
-    )
+            """))
 
     if not MULTI_TENANT:
         # Drop read-only db user here only in single tenant mode. For multi-tenant mode,
         # the user is dropped in the alembic_tenants migration.
 
-        op.execute(
-            text(
-                f"""
+        op.execute(text(f"""
             DO $$
             BEGIN
                 IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{DB_READONLY_USER}') THEN
@@ -682,7 +652,5 @@ def downgrade() -> None:
                 END IF;
             END
             $$;
-        """
-            )
-        )
+        """))
         op.execute(text("DROP EXTENSION IF EXISTS pg_trgm"))

--- a/backend/alembic/versions/4a951134c801_moved_status_to_connector_credential_.py
+++ b/backend/alembic/versions/4a951134c801_moved_status_to_connector_credential_.py
@@ -33,8 +33,7 @@ def upgrade() -> None:
     )
 
     # Update status of connector_credential_pair based on connector's disabled status
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector_credential_pair
         SET status = CASE
             WHEN (
@@ -44,8 +43,7 @@ def upgrade() -> None:
             ) = FALSE THEN 'ACTIVE'
             ELSE 'PAUSED'
         END
-        """
-    )
+        """)
 
     # Make the status column not nullable after setting values
     op.alter_column("connector_credential_pair", "status", nullable=False)
@@ -60,8 +58,7 @@ def downgrade() -> None:
     )
 
     # Update disabled status of connector based on connector_credential_pair's status
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector
         SET disabled = CASE
             WHEN EXISTS (
@@ -72,8 +69,7 @@ def downgrade() -> None:
             ) THEN FALSE
             ELSE TRUE
         END
-        """
-    )
+        """)
 
     # Make the disabled column not nullable after setting values
     op.alter_column("connector", "disabled", nullable=False)

--- a/backend/alembic/versions/4b08d97e175a_change_default_prune_freq.py
+++ b/backend/alembic/versions/4b08d97e175a_change_default_prune_freq.py
@@ -16,20 +16,16 @@ depends_on: None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector
         SET prune_freq = 2592000
         WHERE prune_freq = 86400
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector
         SET prune_freq = 86400
         WHERE prune_freq = 2592000
-        """
-    )
+        """)

--- a/backend/alembic/versions/4ea2c93919c1_add_type_to_credentials.py
+++ b/backend/alembic/versions/4ea2c93919c1_add_type_to_credentials.py
@@ -39,20 +39,17 @@ def upgrade() -> None:
     # This is needed because a credential can be associated with multiple connectors,
     # but we want to assign a single source to each credential.
     # We use DISTINCT ON to ensure we only get one row per credential_id.
-    op.execute(
-        """
+    op.execute("""
     CREATE TEMPORARY TABLE temp_connector_credential AS
     SELECT DISTINCT ON (cc.credential_id)
         cc.credential_id,
         c.source AS connector_source
     FROM connector_credential_pair cc
     JOIN connector c ON cc.connector_id = c.id
-    """
-    )
+    """)
 
     # Update the 'source' column in the 'credential' table
-    op.execute(
-        """
+    op.execute("""
     UPDATE credential cred
     SET source = COALESCE(
         (SELECT connector_source
@@ -60,8 +57,7 @@ def upgrade() -> None:
          WHERE cred.id = temp.credential_id),
         'NOT_APPLICABLE'
     )
-    """
-    )
+    """)
 
     # Drop the temporary table to avoid conflicts if migration runs again
     # (e.g., during upgrade -> downgrade -> upgrade cycles in tests)

--- a/backend/alembic/versions/4f8a2b3c1d9e_add_open_url_tool.py
+++ b/backend/alembic/versions/4f8a2b3c1d9e_add_open_url_tool.py
@@ -40,26 +40,22 @@ def upgrade() -> None:
         tool_id = existing[0]
         # Update existing tool
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE tool
                 SET name = :name,
                     display_name = :display_name,
                     description = :description
                 WHERE in_code_tool_id = :in_code_tool_id
-                """
-            ),
+                """),
             OPEN_URL_TOOL,
         )
     else:
         # Insert new tool
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO tool (name, display_name, description, in_code_tool_id, enabled)
                 VALUES (:name, :display_name, :description, :in_code_tool_id, :enabled)
-                """
-            ),
+                """),
             OPEN_URL_TOOL,
         )
         # Get the newly inserted tool's id
@@ -76,23 +72,19 @@ def upgrade() -> None:
     for (persona_id,) in persona_ids:
         # Check if association already exists
         exists = conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 SELECT 1 FROM persona__tool
                 WHERE persona_id = :persona_id AND tool_id = :tool_id
-                """
-            ),
+                """),
             {"persona_id": persona_id, "tool_id": tool_id},
         ).fetchone()
 
         if not exists:
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     INSERT INTO persona__tool (persona_id, tool_id)
                     VALUES (:persona_id, :tool_id)
-                    """
-                ),
+                    """),
                 {"persona_id": persona_id, "tool_id": tool_id},
             )
 

--- a/backend/alembic/versions/505c488f6662_merge_default_assistants_into_unified.py
+++ b/backend/alembic/versions/505c488f6662_merge_default_assistants_into_unified.py
@@ -92,8 +92,7 @@ def upgrade() -> None:
     if search_assistant:
         # Update existing Search assistant to be the unified assistant
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE persona
                 SET name = :name,
                     description = :description,
@@ -111,15 +110,13 @@ def upgrade() -> None:
                     datetime_aware = :datetime_aware,
                     starter_messages = null
                 WHERE id = 0
-            """
-            ),
+            """),
             INSERT_DICT,
         )
     else:
         # Create new unified assistant with ID 0
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO persona (
                     id, name, description, system_prompt, num_chunks,
                     is_default_persona, is_visible, deleted, display_priority,
@@ -132,21 +129,16 @@ def upgrade() -> None:
                     :llm_relevance_filter, :recency_bias, :chunks_above, :chunks_below,
                     :datetime_aware, null, true
                 )
-            """
-            ),
+            """),
             INSERT_DICT,
         )
 
     # Step 2: Mark ALL builtin assistants as deleted (except the unified assistant ID 0)
-    conn.execute(
-        sa.text(
-            """
+    conn.execute(sa.text("""
             UPDATE persona
             SET deleted = true, is_visible = false, is_default_persona = false
             WHERE builtin_persona = true AND id != 0
-        """
-        )
-    )
+        """))
 
     # Step 3: Add all built-in tools to the unified assistant
     # First, get the tool IDs for SearchTool, ImageGenerationTool, and WebSearchTool
@@ -178,74 +170,56 @@ def upgrade() -> None:
 
     # Add tools to the unified assistant
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO persona__tool (persona_id, tool_id)
             VALUES (0, :tool_id)
             ON CONFLICT DO NOTHING
-        """
-        ),
+        """),
         {"tool_id": search_tool[0]},
     )
 
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO persona__tool (persona_id, tool_id)
             VALUES (0, :tool_id)
             ON CONFLICT DO NOTHING
-        """
-        ),
+        """),
         {"tool_id": image_gen_tool[0]},
     )
 
     if web_search_tool:
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO persona__tool (persona_id, tool_id)
                 VALUES (0, :tool_id)
                 ON CONFLICT DO NOTHING
-            """
-            ),
+            """),
             {"tool_id": web_search_tool[0]},
         )
 
     # Step 4: Migrate existing chat sessions from all builtin assistants to unified assistant
-    conn.execute(
-        sa.text(
-            """
+    conn.execute(sa.text("""
             UPDATE chat_session
             SET persona_id = 0
             WHERE persona_id IN (
                 SELECT id FROM persona WHERE builtin_persona = true AND id != 0
             )
-        """
-        )
-    )
+        """))
 
     # Step 5: Migrate user preferences - remove references to all builtin assistants
     # First, get all builtin assistant IDs (except 0)
-    builtin_assistants_result = conn.execute(
-        sa.text(
-            """
+    builtin_assistants_result = conn.execute(sa.text("""
             SELECT id FROM persona
             WHERE builtin_persona = true AND id != 0
-        """
-        )
-    ).fetchall()
+        """)).fetchall()
     builtin_assistant_ids = [row[0] for row in builtin_assistants_result]
 
     # Get all users with preferences
-    users_result = conn.execute(
-        sa.text(
-            """
+    users_result = conn.execute(sa.text("""
             SELECT id, chosen_assistants, visible_assistants,
                    hidden_assistants, pinned_assistants
             FROM "user"
-        """
-        )
-    ).fetchall()
+        """)).fetchall()
 
     for user_row in users_result:
         user = UserRow(*user_row)
@@ -308,43 +282,35 @@ def downgrade() -> None:
 
     # Only restore General (ID -1) and Art (ID -3) assistants
     # Step 1: Keep Search assistant (ID 0) as default but restore original state
-    conn.execute(
-        sa.text(
-            """
+    conn.execute(sa.text("""
             UPDATE persona
             SET is_default_persona = true,
                 is_visible = true,
                 deleted = false
             WHERE id = 0
-        """
-        )
-    )
+        """))
 
     # Step 2: Restore General assistant (ID -1)
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET deleted = false,
                 is_visible = true,
                 is_default_persona = true
             WHERE id = :general_assistant_id
-        """
-        ),
+        """),
         {"general_assistant_id": GENERAL_ASSISTANT_ID},
     )
 
     # Step 3: Restore Art assistant (ID -3)
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET deleted = false,
                 is_visible = true,
                 is_default_persona = true
             WHERE id = :art_assistant_id
-        """
-        ),
+        """),
         {"art_assistant_id": ART_ASSISTANT_ID},
     )
 

--- a/backend/alembic/versions/52a219fb5233_add_last_synced_and_last_modified_to_document_table.py
+++ b/backend/alembic/versions/52a219fb5233_add_last_synced_and_last_modified_to_document_table.py
@@ -38,12 +38,10 @@ def upgrade() -> None:
     )
 
     # Set last_synced to the same value as last_modified for existing rows
-    op.execute(
-        """
+    op.execute("""
         UPDATE document
         SET last_synced = last_modified
-        """
-    )
+        """)
 
     op.create_index(
         op.f("ix_document_last_modified"),

--- a/backend/alembic/versions/57122d037335_add_python_tool_on_default.py
+++ b/backend/alembic/versions/57122d037335_add_python_tool_on_default.py
@@ -35,13 +35,11 @@ def upgrade() -> None:
 
     # Attach to the default persona (id=0) if not already attached
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO persona__tool (persona_id, tool_id)
             VALUES (0, :tool_id)
             ON CONFLICT DO NOTHING
-            """
-        ),
+            """),
         {"tool_id": tool_id},
     )
 
@@ -58,11 +56,9 @@ def downgrade() -> None:
         return
 
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             DELETE FROM persona__tool
             WHERE persona_id = 0 AND tool_id = :tool_id
-            """
-        ),
+            """),
         {"tool_id": result[0]},
     )

--- a/backend/alembic/versions/5b29123cd710_nullable_search_settings_for_historic_.py
+++ b/backend/alembic/versions/5b29123cd710_nullable_search_settings_for_historic_.py
@@ -40,12 +40,10 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Warning: This will delete all index attempts that don't have search settings
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM index_attempt
         WHERE search_settings_id IS NULL
-    """
-    )
+    """)
 
     # Drop foreign key constraint
     op.drop_constraint(

--- a/backend/alembic/versions/5e6f7a8b9c0d_update_default_persona_prompt.py
+++ b/backend/alembic/versions/5e6f7a8b9c0d_update_default_persona_prompt.py
@@ -37,13 +37,11 @@ You can use Markdown tables to format your responses for data, lists, and other 
 def upgrade() -> None:
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET system_prompt = :system_prompt
             WHERE id = :persona_id
-            """
-        ),
+            """),
         {"system_prompt": DEFAULT_SYSTEM_PROMPT, "persona_id": DEFAULT_PERSONA_ID},
     )
 

--- a/backend/alembic/versions/62c3a055a141_add_file_names_to_file_connector_config.py
+++ b/backend/alembic/versions/62c3a055a141_add_file_names_to_file_connector_config.py
@@ -36,15 +36,11 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     # Get all FILE connectors with their configs
-    file_connectors = conn.execute(
-        sa.text(
-            """
+    file_connectors = conn.execute(sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = 'FILE'
-        """
-        )
-    ).fetchall()
+        """)).fetchall()
 
     for connector_id, config in file_connectors:
         # Parse config if it's a string
@@ -58,13 +54,11 @@ def upgrade() -> None:
         file_names = []
         for file_id in file_locations:
             result = conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     SELECT display_name
                     FROM file_record
                     WHERE file_id = :file_id
-                """
-                ),
+                """),
                 {"file_id": file_id},
             ).fetchone()
 
@@ -79,13 +73,11 @@ def upgrade() -> None:
 
         # Update the connector
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE connector
                 SET connector_specific_config = :new_config
                 WHERE id = :connector_id
-            """
-            ),
+            """),
             {"connector_id": connector_id, "new_config": json.dumps(new_config)},
         )
 
@@ -95,15 +87,11 @@ def downgrade() -> None:
     conn = op.get_bind()
 
     # Remove file_names from all FILE connectors
-    file_connectors = conn.execute(
-        sa.text(
-            """
+    file_connectors = conn.execute(sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = 'FILE'
-        """
-        )
-    ).fetchall()
+        """)).fetchall()
 
     for connector_id, config in file_connectors:
         # Parse config if it's a string
@@ -117,13 +105,11 @@ def downgrade() -> None:
 
             # Update the connector
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     UPDATE connector
                     SET connector_specific_config = :new_config
                     WHERE id = :connector_id
-                """
-                ),
+                """),
                 {
                     "connector_id": connector_id,
                     "new_config": json.dumps(new_config),

--- a/backend/alembic/versions/6756efa39ada_id_uuid_for_chat_session.py
+++ b/backend/alembic/versions/6756efa39ada_id_uuid_for_chat_session.py
@@ -45,14 +45,12 @@ def upgrade() -> None:
         sa.Column("new_chat_session_id", sa.UUID(as_uuid=True), nullable=True),
     )
 
-    op.execute(
-        """
+    op.execute("""
         UPDATE chat_message
         SET new_chat_session_id = cs.new_id
         FROM chat_session cs
         WHERE chat_message.chat_session_id = cs.id;
-        """
-    )
+        """)
 
     op.drop_constraint(
         "chat_message_chat_session_id_fkey", "chat_message", type_="foreignkey"
@@ -108,14 +106,12 @@ def downgrade() -> None:
         sa.Column("old_chat_session_id", sa.Integer, nullable=True),
     )
 
-    op.execute(
-        """
+    op.execute("""
         UPDATE chat_message
         SET old_chat_session_id = cs.old_id
         FROM chat_session cs
         WHERE chat_message.chat_session_id = cs.id;
-        """
-    )
+        """)
 
     op.drop_column("chat_message", "chat_session_id")
     op.alter_column(

--- a/backend/alembic/versions/699221885109_nullify_default_task_prompt.py
+++ b/backend/alembic/versions/699221885109_nullify_default_task_prompt.py
@@ -30,13 +30,11 @@ def upgrade() -> None:
     # Set task_prompt to NULL for the default persona
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET task_prompt = NULL
             WHERE id = :persona_id
-            """
-        ),
+            """),
         {"persona_id": DEFAULT_PERSONA_ID},
     )
 
@@ -45,26 +43,20 @@ def downgrade() -> None:
     # Restore task_prompt to empty string for the default persona
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET task_prompt = ''
             WHERE id = :persona_id AND task_prompt IS NULL
-            """
-        ),
+            """),
         {"persona_id": DEFAULT_PERSONA_ID},
     )
 
     # Set any remaining NULL task_prompts to empty string before making non-nullable
-    conn.execute(
-        sa.text(
-            """
+    conn.execute(sa.text("""
             UPDATE persona
             SET task_prompt = ''
             WHERE task_prompt IS NULL
-            """
-        )
-    )
+            """))
 
     # Revert task_prompt column to not nullable
     op.alter_column(

--- a/backend/alembic/versions/6d562f86c78b_remove_default_bot.py
+++ b/backend/alembic/versions/6d562f86c78b_remove_default_bot.py
@@ -17,9 +17,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             DELETE FROM slack_bot
             WHERE name = 'Default Bot'
             AND bot_token = ''
@@ -28,19 +26,13 @@ def upgrade() -> None:
                 SELECT 1 FROM slack_channel_config
                 WHERE slack_channel_config.slack_bot_id = slack_bot.id
             )
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             INSERT INTO slack_bot (name, enabled, bot_token, app_token)
             SELECT 'Default Bot', true, '', ''
             WHERE NOT EXISTS (SELECT 1 FROM slack_bot)
             RETURNING id;
-            """
-        )
-    )
+            """))

--- a/backend/alembic/versions/6fc7886d665d_make_categories_labels_and_many_to_many.py
+++ b/backend/alembic/versions/6fc7886d665d_make_categories_labels_and_many_to_many.py
@@ -38,12 +38,10 @@ def upgrade() -> None:
     )
 
     # Copy existing relationships to the new table
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO persona__persona_label (persona_id, persona_label_id)
         SELECT id, category_id FROM persona WHERE category_id IS NOT NULL
-    """
-    )
+    """)
 
     # Remove the old category_id column from persona table
     op.drop_column("persona", "category_id")
@@ -64,8 +62,7 @@ def downgrade() -> None:
     )
 
     # Copy the first label relationship back to the persona table
-    op.execute(
-        """
+    op.execute("""
         UPDATE persona
         SET category_id = (
             SELECT persona_label_id
@@ -73,8 +70,7 @@ def downgrade() -> None:
             WHERE persona__persona_label.persona_id = persona.id
             LIMIT 1
         )
-    """
-    )
+    """)
 
     # Drop the association table
     op.drop_table("persona__persona_label")

--- a/backend/alembic/versions/70f00c45c0f2_more_descriptive_filestore.py
+++ b/backend/alembic/versions/70f00c45c0f2_more_descriptive_filestore.py
@@ -43,8 +43,7 @@ def upgrade() -> None:
         ),
     )
 
-    op.execute(
-        """
+    op.execute("""
         UPDATE file_store
         SET file_origin = CASE
             WHEN file_name LIKE 'chat__%' THEN 'chat_upload'
@@ -58,8 +57,7 @@ def upgrade() -> None:
             WHEN file_name LIKE 'chat__%' THEN 'image/png'
             ELSE 'text/plain'
         END
-    """
-    )
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/7cc3fcc116c1_user_file_uuid_primary_key_swap.py
+++ b/backend/alembic/versions/7cc3fcc116c1_user_file_uuid_primary_key_swap.py
@@ -234,22 +234,18 @@ def downgrade() -> None:
     )
 
     # Populate the new integer foreign key columns by mapping from the UUID IDs
-    op.execute(
-        """
+    op.execute("""
         UPDATE persona__user_file AS p
         SET user_file_id_int = uf.id_int
         FROM user_file AS uf
         WHERE p.user_file_id = uf.id
-        """
-    )
-    op.execute(
-        """
+        """)
+    op.execute("""
         UPDATE project__user_file AS p
         SET user_file_id_int = uf.id_int
         FROM user_file AS uf
         WHERE p.user_file_id = uf.id
-        """
-    )
+        """)
 
     op.alter_column(
         "persona__user_file",
@@ -300,16 +296,14 @@ def downgrade() -> None:
         server_default=sa.text("nextval('user_file_id_seq')"),
     )
     op.execute("ALTER SEQUENCE user_file_id_seq OWNED BY user_file.id")
-    op.execute(
-        """
+    op.execute("""
         SELECT setval(
             'user_file_id_seq',
             GREATEST(COALESCE(MAX(id), 1), 1),
             MAX(id) IS NOT NULL
         )
         FROM user_file
-        """
-    )
+        """)
     op.create_primary_key("user_file_pkey", "user_file", ["id"])
 
     # Restore primary keys on referencing tables

--- a/backend/alembic/versions/7e490836d179_nullify_default_system_prompt.py
+++ b/backend/alembic/versions/7e490836d179_nullify_default_system_prompt.py
@@ -44,13 +44,11 @@ def upgrade() -> None:
     # Set system_prompt to NULL where it matches the previous default
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET system_prompt = NULL
             WHERE system_prompt = :previous_default
-            """
-        ),
+            """),
         {"previous_default": PREVIOUS_DEFAULT_SYSTEM_PROMPT},
     )
 
@@ -61,13 +59,11 @@ def downgrade() -> None:
     # before this migration, but there's no way to distinguish them
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET system_prompt = :previous_default
             WHERE system_prompt IS NULL
-            """
-        ),
+            """),
         {"previous_default": PREVIOUS_DEFAULT_SYSTEM_PROMPT},
     )
 

--- a/backend/alembic/versions/8188861f4e92_csv_to_tabular_chat_file_type.py
+++ b/backend/alembic/versions/8188861f4e92_csv_to_tabular_chat_file_type.py
@@ -16,8 +16,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE chat_message
         SET files = (
             SELECT jsonb_agg(
@@ -30,13 +29,11 @@ def upgrade() -> None:
             FROM jsonb_array_elements(files) AS elem
         )
         WHERE files::text LIKE '%"type": "csv"%'
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE chat_message
         SET files = (
             SELECT jsonb_agg(
@@ -49,5 +46,4 @@ def downgrade() -> None:
             FROM jsonb_array_elements(files) AS elem
         )
         WHERE files::text LIKE '%"type": "tabular"%'
-        """
-    )
+        """)

--- a/backend/alembic/versions/81c22b1e2e78_hierarchy_nodes_v1.py
+++ b/backend/alembic/versions/81c22b1e2e78_hierarchy_nodes_v1.py
@@ -122,15 +122,11 @@ def upgrade() -> None:
     # Add partial unique index to ensure only one SOURCE-type node per source
     # This prevents duplicate source root nodes from being created
     # NOTE: node_type stores enum NAME ('SOURCE'), not value ('source')
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             CREATE UNIQUE INDEX uq_hierarchy_node_one_source_per_type
             ON hierarchy_node (source)
             WHERE node_type = 'SOURCE'
-            """
-        )
-    )
+            """))
 
     # 2. Create hierarchy_fetch_attempt table
     op.create_table(
@@ -190,13 +186,11 @@ def upgrade() -> None:
             source_value, source_value.replace("_", " ").title()
         )
         op.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO hierarchy_node (raw_node_id, display_name, source, node_type, parent_id, is_public)
                 VALUES (:raw_node_id, :display_name, :source, 'SOURCE', NULL, true)
                 ON CONFLICT (raw_node_id, source) DO NOTHING
-                """
-            ).bindparams(
+                """).bindparams(
                 raw_node_id=source_value,  # Use .value for raw_node_id (human-readable identifier)
                 display_name=display_name,
                 source=source_name,  # Use .name for source column (SQLAlchemy enum storage)
@@ -227,9 +221,7 @@ def upgrade() -> None:
     # For documents with multiple connectors, we pick one source deterministically (MIN connector_id)
     # NOTE: Both connector.source and hierarchy_node.source store enum NAMEs (e.g., 'GOOGLE_DRIVE')
     # because SQLAlchemy Enum(native_enum=False) uses the enum name for storage.
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             UPDATE document d
             SET parent_hierarchy_node_id = hn.id
             FROM (
@@ -243,9 +235,7 @@ def upgrade() -> None:
             ) doc_source
             JOIN hierarchy_node hn ON hn.source = doc_source.source AND hn.node_type = 'SOURCE'
             WHERE d.id = doc_source.doc_id
-            """
-        )
-    )
+            """))
 
     # Create the persona__hierarchy_node association table
     op.create_table(

--- a/backend/alembic/versions/8405ca81cc83_notifications_constraint.py
+++ b/backend/alembic/versions/8405ca81cc83_notifications_constraint.py
@@ -26,21 +26,17 @@ def upgrade() -> None:
     # Clean up legacy notifications first
     op.execute("DELETE FROM notification WHERE title = 'New Notification'")
 
-    op.execute(
-        """
+    op.execute("""
         CREATE UNIQUE INDEX IF NOT EXISTS ix_notification_user_type_data
         ON notification (user_id, notif_type, COALESCE(additional_data, '{}'::jsonb))
-        """
-    )
+        """)
 
     # Create index for efficient notification sorting by user
     # Covers: WHERE user_id = ? ORDER BY dismissed, first_shown DESC
-    op.execute(
-        """
+    op.execute("""
         CREATE INDEX IF NOT EXISTS ix_notification_user_sort
         ON notification (user_id, dismissed, first_shown DESC)
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/87c52ec39f84_update_default_system_prompt.py
+++ b/backend/alembic/versions/87c52ec39f84_update_default_system_prompt.py
@@ -37,13 +37,11 @@ You can use Markdown tables to format your responses for data, lists, and other 
 def upgrade() -> None:
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             UPDATE persona
             SET system_prompt = :system_prompt
             WHERE id = :persona_id
-            """
-        ),
+            """),
         {"system_prompt": DEFAULT_SYSTEM_PROMPT, "persona_id": DEFAULT_PERSONA_ID},
     )
 

--- a/backend/alembic/versions/8a87bd6ec550_associate_index_attempts_with_ccpair.py
+++ b/backend/alembic/versions/8a87bd6ec550_associate_index_attempts_with_ccpair.py
@@ -33,8 +33,7 @@ def upgrade() -> None:
     )
 
     # Populate the new connector_credential_pair_id column using existing connector_id and credential_id
-    op.execute(
-        """
+    op.execute("""
         UPDATE index_attempt ia
         SET connector_credential_pair_id = (
             SELECT id FROM connector_credential_pair ccp
@@ -44,16 +43,13 @@ def upgrade() -> None:
             LIMIT 1
         )
         WHERE ia.connector_id IS NOT NULL OR ia.credential_id IS NOT NULL
-        """
-    )
+        """)
 
     # For good measure
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM index_attempt
         WHERE connector_credential_pair_id IS NULL
-        """
-    )
+        """)
 
     # Make the new connector_credential_pair_id column non-nullable
     op.alter_column("index_attempt", "connector_credential_pair_id", nullable=False)
@@ -80,14 +76,12 @@ def downgrade() -> None:
     )
 
     # Populate the old connector_id and credential_id columns using the connector_credential_pair_id
-    op.execute(
-        """
+    op.execute("""
         UPDATE index_attempt ia
         SET connector_id = ccp.connector_id, credential_id = ccp.credential_id
         FROM connector_credential_pair ccp
         WHERE ia.connector_credential_pair_id = ccp.id
-        """
-    )
+        """)
 
     # Make the old connector_id and credential_id columns non-nullable
     op.alter_column("index_attempt", "connector_id", nullable=False)

--- a/backend/alembic/versions/9087b548dd69_seed_default_image_gen_config.py
+++ b/backend/alembic/versions/9087b548dd69_seed_default_image_gen_config.py
@@ -37,15 +37,13 @@ def upgrade() -> None:
 
     # Find the first OpenAI LLM provider
     openai_provider = conn.execute(
-        sa.text(
-            """
+        sa.text("""
             SELECT id, api_key
             FROM llm_provider
             WHERE provider = :provider
             ORDER BY id
             LIMIT 1
-            """
-        ),
+            """),
         {"provider": PROVIDER_NAME},
     ).fetchone()
 
@@ -57,8 +55,7 @@ def upgrade() -> None:
 
     # Create new LLM provider for image generation (clone only api_key)
     result = conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO llm_provider (
                 name, provider, api_key, api_base, api_version,
                 deployment_name, default_model_name, is_public,
@@ -70,8 +67,7 @@ def upgrade() -> None:
                 NULL, NULL, :is_auto_mode
             )
             RETURNING id
-            """
-        ),
+            """),
         {
             "name": f"Image Gen - {IMAGE_PROVIDER_ID}",
             "provider": PROVIDER_NAME,
@@ -85,8 +81,7 @@ def upgrade() -> None:
 
     # Create model configuration
     result = conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO model_configuration (
                 llm_provider_id, name, is_visible, max_input_tokens,
                 supports_image_input, display_name
@@ -96,8 +91,7 @@ def upgrade() -> None:
                 :supports_image_input, :display_name
             )
             RETURNING id
-            """
-        ),
+            """),
         {
             "llm_provider_id": new_provider_id,
             "name": MODEL_NAME,
@@ -111,16 +105,14 @@ def upgrade() -> None:
 
     # Create image generation config
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO image_generation_config (
                 image_provider_id, model_configuration_id, is_default
             )
             VALUES (
                 :image_provider_id, :model_configuration_id, :is_default
             )
-            """
-        ),
+            """),
         {
             "image_provider_id": IMAGE_PROVIDER_ID,
             "model_configuration_id": model_config_id,

--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -63,16 +63,12 @@ def set_is_list_for_known_tags() -> None:
 
     bind = op.get_bind()
     for source, key in LIST_METADATA:
-        bind.execute(
-            sa.text(
-                f"""
+        bind.execute(sa.text(f"""
                 UPDATE tag
                 SET is_list = true
                 WHERE tag_key = '{key}'
                 AND source = '{source}'
-                """
-            )
-        )
+                """))
 
 
 def set_is_list_for_list_tags() -> None:
@@ -82,9 +78,7 @@ def set_is_list_for_list_tags() -> None:
     from the database.
     """
     bind = op.get_bind()
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
             UPDATE tag
             SET is_list = true
             FROM (
@@ -96,23 +90,17 @@ def set_is_list_for_list_tags() -> None:
             ) AS list_tags
             WHERE tag.tag_key = list_tags.tag_key
             AND tag.source = list_tags.source
-            """
-        )
-    )
+            """))
 
 
 def log_list_tags() -> None:
     bind = op.get_bind()
-    result = bind.execute(
-        sa.text(
-            """
+    result = bind.execute(sa.text("""
             SELECT DISTINCT source, tag_key
             FROM tag
             WHERE is_list
             ORDER BY source, tag_key
-            """
-        )
-    ).fetchall()
+            """)).fetchall()
     logger.info(
         "List tags:\n" + "\n".join(f"  {source}: {key}" for source, key in result)
     )
@@ -155,27 +143,19 @@ def remove_old_tags() -> None:
 
             # delete old document__tags
             bind = op.get_bind()
-            result = bind.execute(
-                sa.text(
-                    f"""
+            result = bind.execute(sa.text(f"""
                     DELETE FROM document__tag
                     WHERE document_id = '{document_id}'
                     AND tag_id IN ({",".join(to_delete)})
-                    """
-                )
-            )
+                    """))
             n_deleted += result.rowcount
         logger.info("Processed %s documents and deleted %s tags", len(batch), n_deleted)
 
 
 def active_search_settings() -> tuple[SearchSettings, SearchSettings | None]:
-    result = op.get_bind().execute(
-        sa.text(
-            """
+    result = op.get_bind().execute(sa.text("""
         SELECT * FROM search_settings WHERE status = 'PRESENT' ORDER BY id DESC LIMIT 1
-        """
-        )
-    )
+        """))
     search_settings_fetch = result.fetchall()
     search_settings = (
         SearchSettings(**search_settings_fetch[0]._asdict())
@@ -183,13 +163,9 @@ def active_search_settings() -> tuple[SearchSettings, SearchSettings | None]:
         else None
     )
 
-    result2 = op.get_bind().execute(
-        sa.text(
-            """
+    result2 = op.get_bind().execute(sa.text("""
         SELECT * FROM search_settings WHERE status = 'FUTURE' ORDER BY id DESC LIMIT 1
-        """
-        )
-    )
+        """))
     search_settings_future_fetch = result2.fetchall()
     search_settings_future = (
         SearchSettings(**search_settings_future_fetch[0]._asdict())
@@ -224,9 +200,7 @@ def _get_batch_documents_with_multiple_tags(
     bind = op.get_bind()
 
     while True:
-        batch = bind.execute(
-            sa.text(
-                f"""
+        batch = bind.execute(sa.text(f"""
                 SELECT DISTINCT document__tag.document_id
                 FROM tag
                 JOIN document__tag ON tag.id = document__tag.tag_id
@@ -234,9 +208,7 @@ def _get_batch_documents_with_multiple_tags(
                 HAVING count(*) > 1 {offset_clause}
                 ORDER BY document__tag.document_id
                 LIMIT {batch_size}
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
         if not batch:
             break
         doc_ids = [document_id for (document_id,) in batch]
@@ -275,16 +247,12 @@ def _get_vespa_metadata(
 
 def _get_document_tags(document_id: str) -> list[tuple[int, str, str]]:
     bind = op.get_bind()
-    result = bind.execute(
-        sa.text(
-            f"""
+    result = bind.execute(sa.text(f"""
             SELECT tag.id, tag.tag_key, tag.tag_value
             FROM tag
             JOIN document__tag ON tag.id = document__tag.tag_id
             WHERE document__tag.document_id = '{document_id}'
-            """
-        )
-    ).fetchall()
+            """)).fetchall()
     return cast(list[tuple[int, str, str]], result)
 
 

--- a/backend/alembic/versions/93560ba1b118_add_web_ui_option_to_slack_config.py
+++ b/backend/alembic/versions/93560ba1b118_add_web_ui_option_to_slack_config.py
@@ -17,20 +17,16 @@ depends_on = None
 
 def upgrade() -> None:
     # Add show_continue_in_web_ui with default False to all existing channel_configs
-    op.execute(
-        """
+    op.execute("""
         UPDATE slack_channel_config
         SET channel_config = channel_config || '{"show_continue_in_web_ui": false}'::jsonb
         WHERE NOT channel_config ? 'show_continue_in_web_ui'
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
     # Remove show_continue_in_web_ui from all channel_configs
-    op.execute(
-        """
+    op.execute("""
         UPDATE slack_channel_config
         SET channel_config = channel_config - 'show_continue_in_web_ui'
-        """
-    )
+        """)

--- a/backend/alembic/versions/9c00a2bccb83_chat_message_agentic.py
+++ b/backend/alembic/versions/9c00a2bccb83_chat_message_agentic.py
@@ -21,8 +21,7 @@ def upgrade() -> None:
     op.add_column("chat_message", sa.Column("is_agentic", sa.Boolean(), nullable=True))
 
     # Update existing rows based on presence of SubQuestions
-    op.execute(
-        """
+    op.execute("""
         UPDATE chat_message
         SET is_agentic = EXISTS (
             SELECT 1
@@ -30,8 +29,7 @@ def upgrade() -> None:
             WHERE agent__sub_question.primary_question_id = chat_message.id
         )
         WHERE is_agentic IS NULL
-    """
-    )
+    """)
 
     # Make the column non-nullable with a default value of False
     op.alter_column(

--- a/backend/alembic/versions/9drpiiw74ljy_add_config_to_federated_connector.py
+++ b/backend/alembic/versions/9drpiiw74ljy_add_config_to_federated_connector.py
@@ -21,17 +21,13 @@ def upgrade() -> None:
     connection = op.get_bind()
 
     # Check if column already exists in current schema
-    result = connection.execute(
-        sa.text(
-            """
+    result = connection.execute(sa.text("""
             SELECT column_name
             FROM information_schema.columns
             WHERE table_schema = current_schema()
             AND table_name = 'federated_connector'
             AND column_name = 'config'
-            """
-        )
-    )
+            """))
     column_exists = result.fetchone() is not None
 
     # Add config column with default empty object (only if it doesn't exist)
@@ -44,9 +40,7 @@ def upgrade() -> None:
         )
 
     # Data migration: Single bulk update for all Slack connectors
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             WITH connector_configs AS (
                 SELECT
                     fc.id as connector_id,
@@ -88,9 +82,7 @@ def upgrade() -> None:
             SET config = cc.config
             FROM connector_configs cc
             WHERE fc.id = cc.connector_id
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/a852cbe15577_new_chat_history.py
+++ b/backend/alembic/versions/a852cbe15577_new_chat_history.py
@@ -81,14 +81,12 @@ def upgrade() -> None:
     )
 
     # Populate chat_session_id from the related chat_message
-    op.execute(
-        """
+    op.execute("""
         UPDATE tool_call
         SET chat_session_id = chat_message.chat_session_id
         FROM chat_message
         WHERE tool_call.message_id = chat_message.id
-    """
-    )
+    """)
 
     # Now make it NOT NULL and add FK
     op.alter_column("tool_call", "chat_session_id", nullable=False)
@@ -157,13 +155,11 @@ def upgrade() -> None:
     op.alter_column("tool_call", "tool_result", new_column_name="tool_call_response")
 
     # Change tool_call_response type from JSONB to Text
-    op.execute(
-        """
+    op.execute("""
         ALTER TABLE tool_call
         ALTER COLUMN tool_call_response TYPE TEXT
         USING tool_call_response::text
-    """
-    )
+    """)
 
     # Drop old columns
     op.drop_column("tool_call", "tool_name")
@@ -206,13 +202,11 @@ def downgrade() -> None:
     )
 
     # Change tool_call_response back to JSONB
-    op.execute(
-        """
+    op.execute("""
         ALTER TABLE tool_call
         ALTER COLUMN tool_call_response TYPE JSONB
         USING tool_call_response::jsonb
-    """
-    )
+    """)
 
     op.alter_column("tool_call", "tool_call_response", new_column_name="tool_result")
     op.alter_column(

--- a/backend/alembic/versions/b156fa702355_chat_reworked.py
+++ b/backend/alembic/versions/b156fa702355_chat_reworked.py
@@ -158,9 +158,7 @@ def upgrade() -> None:
     result = bind.execute(sa.text("SELECT 1 FROM persona WHERE id = 0"))
     exists = result.fetchone()
     if not exists:
-        op.execute(
-            sa.text(
-                """
+        op.execute(sa.text("""
                 INSERT INTO persona (
                     id, user_id, name, description, search_type, num_chunks,
                     llm_relevance_filter, llm_filter_extraction, recency_bias,
@@ -169,15 +167,11 @@ def upgrade() -> None:
                     0, NULL, '', '', 'HYBRID', NULL,
                     TRUE, TRUE, 'BASE_DECAY', NULL, TRUE, FALSE
                 )
-                """
-            )
-        )
-    delete_statement = sa.text(
-        """
+                """))
+    delete_statement = sa.text("""
         DELETE FROM persona
         WHERE name = 'Danswer' AND default_persona = TRUE AND id != 0
-        """
-    )
+        """)
 
     bind.execute(delete_statement)
 

--- a/backend/alembic/versions/b30353be4eec_add_mcp_auth_performer.py
+++ b/backend/alembic/versions/b30353be4eec_add_mcp_auth_performer.py
@@ -42,52 +42,36 @@ def upgrade() -> None:
     bind = op.get_bind()
 
     # 1) OAUTH servers are always PER_USER
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server
         SET auth_performer = 'PER_USER'
         WHERE auth_type = 'OAUTH'
-        """
-        )
-    )
+        """))
 
     # 2) If there is no admin connection config, mark as ADMIN (and not set yet)
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server
         SET auth_performer = 'ADMIN'
         WHERE admin_connection_config_id IS NULL
           AND auth_performer IS NULL
-        """
-        )
-    )
+        """))
 
     # 3) If there exists any user-specific connection config (user_email != ''), mark as PER_USER
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server AS ms
         SET auth_performer = 'PER_USER'
         FROM mcp_connection_config AS mcc
         WHERE mcc.mcp_server_id = ms.id
           AND COALESCE(mcc.user_email, '') <> ''
           AND ms.auth_performer IS NULL
-        """
-        )
-    )
+        """))
 
     # 4) Default any remaining nulls to ADMIN (covers API_TOKEN admin-managed and NONE)
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server
         SET auth_performer = 'ADMIN'
         WHERE auth_performer IS NULL
-        """
-        )
-    )
+        """))
 
     # Finally, make the column non-nullable
     op.alter_column(
@@ -98,15 +82,11 @@ def upgrade() -> None:
     )
 
     # Backfill transport for existing rows to STREAMABLE_HTTP, then make non-nullable
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server
         SET transport = 'STREAMABLE_HTTP'
         WHERE transport IS NULL
-        """
-        )
-    )
+        """))
 
     op.alter_column(
         "mcp_server",

--- a/backend/alembic/versions/b51c6844d1df_seed_memory_tool.py
+++ b/backend/alembic/versions/b51c6844d1df_seed_memory_tool.py
@@ -37,25 +37,21 @@ def upgrade() -> None:
 
     if existing:
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE tool
                 SET name = :name,
                     display_name = :display_name,
                     description = :description
                 WHERE in_code_tool_id = :in_code_tool_id
-                """
-            ),
+                """),
             MEMORY_TOOL,
         )
     else:
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO tool (name, display_name, description, in_code_tool_id, enabled)
                 VALUES (:name, :display_name, :description, :in_code_tool_id, :enabled)
-                """
-            ),
+                """),
             MEMORY_TOOL,
         )
 

--- a/backend/alembic/versions/b558f51620b4_pause_finished_user_file_connectors.py
+++ b/backend/alembic/versions/b558f51620b4_pause_finished_user_file_connectors.py
@@ -18,14 +18,12 @@ depends_on = None
 def upgrade() -> None:
     # Set all user file connector credential pairs with ACTIVE status to PAUSED
     # This ensures user files don't continue to run indexing tasks after processing
-    op.execute(
-        """
+    op.execute("""
         UPDATE connector_credential_pair
         SET status = 'PAUSED'
         WHERE is_user_file = true
         AND status = 'ACTIVE'
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/b72ed7a5db0e_remove_description_from_starter_messages.py
+++ b/backend/alembic/versions/b72ed7a5db0e_remove_description_from_starter_messages.py
@@ -17,9 +17,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             UPDATE persona
             SET starter_messages = (
                 SELECT jsonb_agg(elem - 'description')
@@ -27,15 +25,11 @@ def upgrade() -> None:
             )
             WHERE starter_messages IS NOT NULL
               AND jsonb_typeof(starter_messages) = 'array'
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             UPDATE persona
             SET starter_messages = (
                 SELECT jsonb_agg(elem || '{"description": ""}')
@@ -43,6 +37,4 @@ def downgrade() -> None:
             )
             WHERE starter_messages IS NOT NULL
               AND jsonb_typeof(starter_messages) = 'array'
-            """
-        )
-    )
+            """))

--- a/backend/alembic/versions/b85f02ec1308_fix_file_type_migration.py
+++ b/backend/alembic/versions/b85f02ec1308_fix_file_type_migration.py
@@ -16,12 +16,10 @@ depends_on: None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE file_store
         SET file_origin = UPPER(file_origin)
-    """
-    )
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/bd7c3bf8beba_migrate_agent_responses_to_research_.py
+++ b/backend/alembic/versions/bd7c3bf8beba_migrate_agent_responses_to_research_.py
@@ -22,9 +22,7 @@ def upgrade() -> None:
 
     # First, insert data into research_agent_iteration table
     # This creates one iteration record per primary_question_id using the earliest time_created
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             INSERT INTO research_agent_iteration (primary_question_id, created_at, iteration_nr, purpose, reasoning)
             SELECT
                 primary_question_id,
@@ -38,15 +36,11 @@ def upgrade() -> None:
                 AND chat_message.is_agentic = true
             GROUP BY primary_question_id
             ON CONFLICT DO NOTHING;
-        """
-        )
-    )
+        """))
 
     # Then, insert data into research_agent_iteration_sub_step table
     # This migrates each sub-question as a sub-step
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             INSERT INTO research_agent_iteration_sub_step (
                 primary_question_id,
                 iteration_nr,
@@ -71,32 +65,22 @@ def upgrade() -> None:
             WHERE chat_message.is_agentic = true
             AND primary_question_id IS NOT NULL
             ON CONFLICT DO NOTHING;
-        """
-        )
-    )
+        """))
 
     # Update chat_message records: set legacy agentic type and answer purpose for existing agentic messages
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             UPDATE chat_message
             SET research_answer_purpose = 'ANSWER'
             WHERE is_agentic = true
             AND research_type IS NULL and
                 message_type = 'ASSISTANT';
-        """
-        )
-    )
-    connection.execute(
-        sa.text(
-            """
+        """))
+    connection.execute(sa.text("""
             UPDATE chat_message
             SET research_type = 'LEGACY_AGENTIC'
             WHERE is_agentic = true
             AND research_type IS NULL;
-        """
-        )
-    )
+        """))
 
 
 def downgrade() -> None:
@@ -108,39 +92,27 @@ def downgrade() -> None:
     # if it was deleted after this migration
 
     # Delete all research_agent_iteration_sub_step records that were migrated
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             DELETE FROM research_agent_iteration_sub_step
             USING chat_message
             WHERE research_agent_iteration_sub_step.primary_question_id = chat_message.id
             AND chat_message.research_type = 'LEGACY_AGENTIC';
-        """
-        )
-    )
+        """))
 
     # Delete all research_agent_iteration records that were migrated
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             DELETE FROM research_agent_iteration
             USING chat_message
             WHERE research_agent_iteration.primary_question_id = chat_message.id
             AND chat_message.research_type = 'LEGACY_AGENTIC';
-        """
-        )
-    )
+        """))
 
     # Revert chat_message updates: clear research fields for legacy agentic messages
-    connection.execute(
-        sa.text(
-            """
+    connection.execute(sa.text("""
             UPDATE chat_message
             SET research_type = NULL,
                 research_answer_purpose = NULL
             WHERE is_agentic = true
             AND research_type = 'LEGACY_AGENTIC'
             AND message_type = 'ASSISTANT';
-        """
-        )
-    )
+        """))

--- a/backend/alembic/versions/be2ab2aa50ee_fix_capitalization.py
+++ b/backend/alembic/versions/be2ab2aa50ee_fix_capitalization.py
@@ -16,8 +16,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE document
         SET
             external_user_group_ids = ARRAY(
@@ -29,8 +28,7 @@ def upgrade() -> None:
             AND external_user_group_ids::text[] <> ARRAY(
                 SELECT LOWER(unnest(external_user_group_ids))
             )::text[]
-    """
-    )
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/c0aab6edb6dd_delete_workspace.py
+++ b/backend/alembic/versions/c0aab6edb6dd_delete_workspace.py
@@ -16,13 +16,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
     UPDATE connector
     SET connector_specific_config = connector_specific_config - 'workspace'
     WHERE source = 'SLACK'
-    """
-    )
+    """)
 
 
 def downgrade() -> None:
@@ -64,8 +62,7 @@ def downgrade() -> None:
 
             # Update only the connectors linked to this credential
             # (and which are Slack connectors).
-            op.execute(
-                f"""
+            op.execute(f"""
                 UPDATE connector AS c
                 SET connector_specific_config = jsonb_set(
                     connector_specific_config,
@@ -76,8 +73,7 @@ def downgrade() -> None:
                 WHERE ccp.connector_id = c.id
                   AND c.source = 'SLACK'
                   AND ccp.credential_id = {credential_id}
-            """
-            )
+            """)
         except Exception:
             print(
                 f"We were unable to get the workspace url for your Slack Connector with id {credential_id}."

--- a/backend/alembic/versions/c1d2e3f4a5b6_add_deep_research_tool.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_add_deep_research_tool.py
@@ -27,12 +27,10 @@ DEEP_RESEARCH_TOOL = {
 def upgrade() -> None:
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO tool (name, display_name, description, in_code_tool_id, enabled)
             VALUES (:name, :display_name, :description, :in_code_tool_id, false)
-            """
-        ),
+            """),
         DEEP_RESEARCH_TOOL,
     )
 
@@ -40,11 +38,9 @@ def upgrade() -> None:
 def downgrade() -> None:
     conn = op.get_bind()
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             DELETE FROM tool
             WHERE in_code_tool_id = :in_code_tool_id
-            """
-        ),
+            """),
         {"in_code_tool_id": DEEP_RESEARCH_TOOL["in_code_tool_id"]},
     )

--- a/backend/alembic/versions/c7e9f4a3b2d1_add_python_tool.py
+++ b/backend/alembic/versions/c7e9f4a3b2d1_add_python_tool.py
@@ -22,12 +22,10 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO tool (name, display_name, description, in_code_tool_id, enabled)
             VALUES (:name, :display_name, :description, :in_code_tool_id, :enabled)
-            """
-        ),
+            """),
         {
             "name": "PythonTool",
             # in the UI, call it `Code Interpreter` since this is a well known term for this tool
@@ -58,12 +56,10 @@ def downgrade() -> None:
     conn = op.get_bind()
 
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             DELETE FROM tool
             WHERE in_code_tool_id = :in_code_tool_id
-            """
-        ),
+            """),
         {
             "in_code_tool_id": "PythonTool",
         },

--- a/backend/alembic/versions/c99d76fcd298_add_nullable_to_persona_id_in_chat_.py
+++ b/backend/alembic/versions/c99d76fcd298_add_nullable_to_persona_id_in_chat_.py
@@ -36,42 +36,34 @@ def downgrade() -> None:
     """
 
     # Delete dependent records first
-    op.execute(
-        f"""
+    op.execute(f"""
         DELETE FROM document_retrieval_feedback
         WHERE chat_message_id IN (
             {chat_messages_query}
         )
-    """
-    )
-    op.execute(
-        f"""
+    """)
+    op.execute(f"""
         DELETE FROM chat_message__search_doc
         WHERE chat_message_id IN (
             {chat_messages_query}
         )
-    """
-    )
+    """)
 
     # Delete chat messages
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM chat_message
         WHERE chat_session_id IN (
             SELECT id
             FROM chat_session
             WHERE persona_id IS NULL
         )
-    """
-    )
+    """)
 
     # Now we can safely delete the chat sessions
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM chat_session
         WHERE persona_id IS NULL
-    """
-    )
+    """)
 
     op.alter_column(
         "chat_session",

--- a/backend/alembic/versions/cbc03e08d0f3_add_opensearch_migration_tables.py
+++ b/backend/alembic/versions/cbc03e08d0f3_add_opensearch_migration_tables.py
@@ -93,14 +93,10 @@ def upgrade() -> None:
     )
 
     # 4. Create unique index on constant to enforce singleton pattern.
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             CREATE UNIQUE INDEX idx_opensearch_tenant_migration_singleton
             ON opensearch_tenant_migration_record ((true))
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/d09fc20a3c66_seed_builtin_tools.py
+++ b/backend/alembic/versions/d09fc20a3c66_seed_builtin_tools.py
@@ -86,16 +86,14 @@ def upgrade() -> None:
         ):
             # Rename the existing InternetSearchTool row in place and update fields
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     UPDATE tool
                     SET name = :name,
                         display_name = :display_name,
                         description = :description,
                         in_code_tool_id = :in_code_tool_id
                     WHERE in_code_tool_id = 'InternetSearchTool'
-                    """
-                ),
+                    """),
                 tool,
             )
             # Keep the local view of existing ids in sync to avoid duplicate insert
@@ -106,26 +104,22 @@ def upgrade() -> None:
         if in_code_id in existing_tool_ids:
             # Update existing tool
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     UPDATE tool
                     SET name = :name,
                         display_name = :display_name,
                         description = :description
                     WHERE in_code_tool_id = :in_code_tool_id
-                    """
-                ),
+                    """),
                 tool,
             )
         else:
             # Insert new tool
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     INSERT INTO tool (name, display_name, description, in_code_tool_id)
                     VALUES (:name, :display_name, :description, :in_code_tool_id)
-                    """
-                ),
+                    """),
                 tool,
             )
 

--- a/backend/alembic/versions/d1b637d7050a_sync_exa_api_key_to_content_provider.py
+++ b/backend/alembic/versions/d1b637d7050a_sync_exa_api_key_to_content_provider.py
@@ -23,29 +23,23 @@ def upgrade() -> None:
     connection = op.get_bind()
 
     # Check if Exa search provider exists with an API key
-    result = connection.execute(
-        text(
-            """
+    result = connection.execute(text("""
             SELECT api_key FROM internet_search_provider
             WHERE provider_type = 'exa' AND api_key IS NOT NULL
             LIMIT 1
-            """
-        )
-    )
+            """))
     row = result.fetchone()
 
     if row:
         api_key = row[0]
         # Create Exa content provider with the shared key
         connection.execute(
-            text(
-                """
+            text("""
                 INSERT INTO internet_content_provider
                 (name, provider_type, api_key, is_active)
                 VALUES ('Exa', 'exa', :api_key, false)
                 ON CONFLICT (name) DO NOTHING
-                """
-            ),
+                """),
             {"api_key": api_key},
         )
 
@@ -53,11 +47,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Remove the Exa content provider that was created by this migration
     connection = op.get_bind()
-    connection.execute(
-        text(
-            """
+    connection.execute(text("""
             DELETE FROM internet_content_provider
             WHERE provider_type = 'exa'
-            """
-        )
-    )
+            """))

--- a/backend/alembic/versions/d25168c2beee_tool_name_consistency.py
+++ b/backend/alembic/versions/d25168c2beee_tool_name_consistency.py
@@ -50,13 +50,11 @@ def upgrade() -> None:
     # Update the name column for each tool based on its in_code_tool_id
     for in_code_tool_id, expected_name in tool_name_mapping.items():
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE tool
                 SET name = :expected_name
                 WHERE in_code_tool_id = :in_code_tool_id
-                """
-            ),
+                """),
             {
                 "expected_name": expected_name,
                 "in_code_tool_id": in_code_tool_id,
@@ -71,13 +69,11 @@ def downgrade() -> None:
     # This matches the original pattern where name was the class name
     for in_code_tool_id in CURRENT_TOOL_NAME_MAPPING:
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE tool
                 SET name = :current_name
                 WHERE in_code_tool_id = :in_code_tool_id
-                """
-            ),
+                """),
             {
                 "current_name": in_code_tool_id,
                 "in_code_tool_id": in_code_tool_id,

--- a/backend/alembic/versions/d3fd499c829c_add_file_reader_tool.py
+++ b/backend/alembic/versions/d3fd499c829c_add_file_reader_tool.py
@@ -39,41 +39,35 @@ def upgrade() -> None:
     if existing:
         # Update existing tool
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE tool
                 SET name = :name,
                     display_name = :display_name,
                     description = :description
                 WHERE in_code_tool_id = :in_code_tool_id
-                """
-            ),
+                """),
             FILE_READER_TOOL,
         )
         tool_id = existing[0]
     else:
         # Insert new tool
         result = conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 INSERT INTO tool (name, display_name, description, in_code_tool_id, enabled)
                 VALUES (:name, :display_name, :description, :in_code_tool_id, :enabled)
                 RETURNING id
-                """
-            ),
+                """),
             FILE_READER_TOOL,
         )
         tool_id = result.scalar_one()
 
     # Attach to the default persona (id=0) if not already attached
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO persona__tool (persona_id, tool_id)
             VALUES (0, :tool_id)
             ON CONFLICT DO NOTHING
-            """
-        ),
+            """),
         {"tool_id": tool_id},
     )
 
@@ -84,14 +78,12 @@ def downgrade() -> None:
 
     # Remove persona associations first (FK constraint)
     conn.execute(
-        sa.text(
-            """
+        sa.text("""
             DELETE FROM persona__tool
             WHERE tool_id IN (
                 SELECT id FROM tool WHERE in_code_tool_id = :in_code_tool_id
             )
-            """
-        ),
+            """),
         {"in_code_tool_id": in_code_tool_id},
     )
 

--- a/backend/alembic/versions/d716b0791ddd_combined_slack_id_fields.py
+++ b/backend/alembic/versions/d716b0791ddd_combined_slack_id_fields.py
@@ -16,8 +16,7 @@ depends_on: None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
     UPDATE slack_bot_config
     SET channel_config = jsonb_set(
         channel_config,
@@ -25,13 +24,11 @@ def upgrade() -> None:
         coalesce(channel_config->'respond_team_member_list', '[]'::jsonb) ||
         coalesce(channel_config->'respond_slack_group_list', '[]'::jsonb)
     ) - 'respond_team_member_list' - 'respond_slack_group_list'
-    """
-    )
+    """)
 
 
 def downgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
     UPDATE slack_bot_config
     SET channel_config = jsonb_set(
         jsonb_set(
@@ -42,5 +39,4 @@ def downgrade() -> None:
         '{respond_slack_group_list}',
         '[]'::jsonb
     )
-    """
-    )
+    """)

--- a/backend/alembic/versions/d9ec13955951_remove__dim_suffix_from_model_name.py
+++ b/backend/alembic/versions/d9ec13955951_remove__dim_suffix_from_model_name.py
@@ -16,13 +16,11 @@ depends_on: None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE embedding_model
         SET model_name = regexp_replace(model_name, '__danswer_alt_index$', '')
         WHERE model_name LIKE '%__danswer_alt_index'
-    """
-    )
+    """)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/da42808081e3_migrate_jira_connectors_to_new_format.py
+++ b/backend/alembic/versions/da42808081e3_migrate_jira_connectors_to_new_format.py
@@ -29,13 +29,11 @@ def upgrade() -> None:
 
     # First get all Jira connectors
     jira_connectors = conn.execute(
-        sa.text(
-            """
+        sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = :source
-            """
-        ),
+            """),
         {"source": DocumentSource.JIRA.value.upper()},
     ).fetchall()
 
@@ -70,13 +68,11 @@ def upgrade() -> None:
 
         # Update the connector config
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE connector
                 SET connector_specific_config = :new_config
                 WHERE id = :id
-                """
-            ),
+                """),
             {"id": connector_id, "new_config": json.dumps(new_config)},
         )
 
@@ -87,13 +83,11 @@ def downgrade() -> None:
 
     # First get all Jira connectors
     jira_connectors = conn.execute(
-        sa.text(
-            """
+        sa.text("""
             SELECT id, connector_specific_config
             FROM connector
             WHERE source = :source
-            """
-        ),
+            """),
         {"source": DocumentSource.JIRA.value.upper()},
     ).fetchall()
 
@@ -119,12 +113,10 @@ def downgrade() -> None:
 
         # Update the connector config
         conn.execute(
-            sa.text(
-                """
+            sa.text("""
                 UPDATE connector
                 SET connector_specific_config = :old_config
                 WHERE id = :id
-                """
-            ),
+                """),
             {"id": connector_id, "old_config": json.dumps(old_config)},
         )

--- a/backend/alembic/versions/dfbe9e93d3c7_extended_role_for_non_web.py
+++ b/backend/alembic/versions/dfbe9e93d3c7_extended_role_for_non_web.py
@@ -17,13 +17,11 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
+    op.execute("""
         UPDATE "user"
         SET role = 'EXT_PERM_USER'
         WHERE has_web_login = false
-    """
-    )
+    """)
     op.drop_column("user", "has_web_login")
 
 
@@ -33,11 +31,9 @@ def downgrade() -> None:
         sa.Column("has_web_login", sa.Boolean(), nullable=False, server_default="true"),
     )
 
-    op.execute(
-        """
+    op.execute("""
         UPDATE "user"
         SET has_web_login = false,
             role = 'BASIC'
         WHERE role IN ('SLACK_USER', 'EXT_PERM_USER')
-    """
-    )
+    """)

--- a/backend/alembic/versions/e7f8a9b0c1d2_create_anonymous_user.py
+++ b/backend/alembic/versions/e7f8a9b0c1d2_create_anonymous_user.py
@@ -40,9 +40,7 @@ def _dedupe_null_notifications(connection: sa.Connection) -> None:
     # NULL user_id values as distinct. Before migrating them to the anonymous
     # user, collapse duplicates and remove rows that would conflict with an
     # already-existing anonymous notification.
-    result = connection.execute(
-        sa.text(
-            """
+    result = connection.execute(sa.text("""
             WITH ranked_null_notifications AS (
                 SELECT
                     id,
@@ -59,15 +57,12 @@ def _dedupe_null_notifications(connection: sa.Connection) -> None:
                 FROM ranked_null_notifications
                 WHERE row_num > 1
             )
-            """
-        )
-    )
+            """))
     if result.rowcount > 0:
         print(f"Deleted {result.rowcount} duplicate NULL-owned notifications")
 
     result = connection.execute(
-        sa.text(
-            """
+        sa.text("""
             DELETE FROM notification AS null_owned
             USING notification AS anonymous_owned
             WHERE null_owned.user_id IS NULL
@@ -75,8 +70,7 @@ def _dedupe_null_notifications(connection: sa.Connection) -> None:
               AND null_owned.notif_type = anonymous_owned.notif_type
               AND COALESCE(null_owned.additional_data, '{}'::jsonb) =
                   COALESCE(anonymous_owned.additional_data, '{}'::jsonb)
-            """
-        ),
+            """),
         {"user_id": ANONYMOUS_USER_UUID},
     )
     if result.rowcount > 0:
@@ -94,13 +88,11 @@ def upgrade() -> None:
 
     # Create the anonymous user (using ON CONFLICT to be idempotent)
     connection.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO "user" (id, email, hashed_password, is_active, is_superuser, is_verified, role)
             VALUES (:id, :email, :hashed_password, :is_active, :is_superuser, :is_verified, :role)
             ON CONFLICT (id) DO NOTHING
-            """
-        ),
+            """),
         {
             "id": ANONYMOUS_USER_UUID,
             "email": ANONYMOUS_USER_EMAIL,
@@ -136,13 +128,11 @@ def upgrade() -> None:
                 condition = "user_id IS NULL"
 
             result = connection.execute(
-                sa.text(
-                    f"""
+                sa.text(f"""
                     UPDATE "{table}"
                     SET user_id = :user_id
                     WHERE {condition}
-                    """
-                ),
+                    """),
                 {"user_id": ANONYMOUS_USER_UUID},
             )
             if result.rowcount > 0:
@@ -161,13 +151,11 @@ def downgrade() -> None:
     for table in TABLES_WITH_USER_ID:
         with connection.begin_nested():
             connection.execute(
-                sa.text(
-                    f"""
+                sa.text(f"""
                     UPDATE "{table}"
                     SET user_id = NULL
                     WHERE user_id = :user_id
-                    """
-                ),
+                    """),
                 {"user_id": ANONYMOUS_USER_UUID},
             )
 

--- a/backend/alembic/versions/e8f0d2a38171_add_status_to_mcp_server_and_make_auth_.py
+++ b/backend/alembic/versions/e8f0d2a38171_add_status_to_mcp_server_and_make_auth_.py
@@ -64,16 +64,12 @@ def upgrade() -> None:
 
     # For existing records, mark status as CONNECTED
     bind = op.get_bind()
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
         UPDATE mcp_server
         SET status = 'CONNECTED'
         WHERE status != 'CONNECTED'
         and admin_connection_config_id IS NOT NULL
-        """
-        )
-    )
+        """))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/eaa3b5593925_add_default_slack_channel_config.py
+++ b/backend/alembic/versions/eaa3b5593925_add_default_slack_channel_config.py
@@ -46,8 +46,7 @@ def upgrade() -> None:
 
         if not existing_default:
             conn.execute(
-                sa.text(
-                    """
+                sa.text("""
                     INSERT INTO slack_channel_config (
                         slack_bot_id, persona_id, channel_config, enable_auto_filters, is_default
                     ) VALUES (
@@ -59,8 +58,7 @@ def upgrade() -> None:
                         '"respond_tag_only": true}',
                         FALSE, TRUE
                     )
-                """
-                ),
+                """),
                 {"bot_id": slack_bot_id},
             )
 

--- a/backend/alembic/versions/f11b408e39d3_force_lowercase_all_users.py
+++ b/backend/alembic/versions/f11b408e39d3_force_lowercase_all_users.py
@@ -17,12 +17,10 @@ def upgrade() -> None:
     # 1) Convert all existing user emails to lowercase
     from alembic import op
 
-    op.execute(
-        """
+    op.execute("""
         UPDATE "user"
         SET email = LOWER(email)
-        """
-    )
+        """)
 
     # 2) Add a check constraint to ensure emails are always lowercase
     op.create_check_constraint("ensure_lowercase_email", "user", "email = LOWER(email)")

--- a/backend/alembic/versions/f17bf3b0d9f1_embedding_provider_by_provider_type.py
+++ b/backend/alembic/versions/f17bf3b0d9f1_embedding_provider_by_provider_type.py
@@ -49,16 +49,14 @@ def upgrade() -> None:
     )
 
     # Update provider_type for existing embedding models
-    op.execute(
-        """
+    op.execute("""
         UPDATE embedding_model
         SET provider_type = (
             SELECT provider_type
             FROM embedding_provider
             WHERE embedding_provider.id = embedding_model.cloud_provider_id
         )
-    """
-    )
+    """)
 
     # Drop the old id column from embedding_provider
     op.drop_column("embedding_provider", "id")
@@ -95,19 +93,14 @@ def downgrade() -> None:
     op.add_column("embedding_provider", sa.Column("id", sa.Integer(), nullable=True))
 
     # Assign incrementing IDs to embedding providers
-    op.execute(
-        """
-        CREATE SEQUENCE IF NOT EXISTS embedding_provider_id_seq;"""
-    )
-    op.execute(
-        """
+    op.execute("""
+        CREATE SEQUENCE IF NOT EXISTS embedding_provider_id_seq;""")
+    op.execute("""
         UPDATE embedding_provider SET id = nextval('embedding_provider_id_seq');
-    """
-    )
+    """)
 
     # Update cloud_provider_id based on provider_type
-    op.execute(
-        """
+    op.execute("""
         UPDATE embedding_model
         SET cloud_provider_id = CASE
             WHEN provider_type IS NULL THEN NULL
@@ -117,8 +110,7 @@ def downgrade() -> None:
                 WHERE embedding_provider.provider_type = embedding_model.provider_type
             )
         END
-    """
-    )
+    """)
 
     # Drop the provider_type column from embedding_model
     op.drop_column("embedding_model", "provider_type")
@@ -136,8 +128,7 @@ def downgrade() -> None:
     op.create_primary_key("embedding_provider_pkey", "embedding_provider", ["id"])
 
     # Update name with existing provider_type values
-    op.execute(
-        """
+    op.execute("""
         UPDATE embedding_provider
         SET name = CASE
             WHEN provider_type = 'OPENAI' THEN 'OpenAI'
@@ -146,8 +137,7 @@ def downgrade() -> None:
             WHEN provider_type = 'VOYAGE' THEN 'Voyage'
             ELSE provider_type
         END
-    """
-    )
+    """)
 
     # Drop the provider_type column from embedding_provider
     op.drop_column("embedding_provider", "provider_type")

--- a/backend/alembic/versions/f5437cc136c5_delete_non_search_assistants.py
+++ b/backend/alembic/versions/f5437cc136c5_delete_non_search_assistants.py
@@ -21,8 +21,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Fix: split the statements into multiple op.execute() calls
-    op.execute(
-        """
+    op.execute("""
         WITH personas_without_search AS (
             SELECT p.id
             FROM persona p
@@ -34,11 +33,9 @@ def downgrade() -> None:
         UPDATE slack_channel_config
         SET persona_id = NULL
         WHERE is_default = TRUE AND persona_id IN (SELECT id FROM personas_without_search)
-        """
-    )
+        """)
 
-    op.execute(
-        """
+    op.execute("""
         WITH personas_without_search AS (
             SELECT p.id
             FROM persona p
@@ -49,5 +46,4 @@ def downgrade() -> None:
         )
         DELETE FROM slack_channel_config
         WHERE is_default = FALSE AND persona_id IN (SELECT id FROM personas_without_search)
-        """
-    )
+        """)

--- a/backend/alembic/versions/f7ca3e2f45d9_migrate_no_auth_data_to_placeholder.py
+++ b/backend/alembic/versions/f7ca3e2f45d9_migrate_no_auth_data_to_placeholder.py
@@ -177,12 +177,10 @@ def upgrade() -> None:
 
     # Create the placeholder user
     connection.execute(
-        sa.text(
-            """
+        sa.text("""
             INSERT INTO "user" (id, email, hashed_password, is_active, is_superuser, is_verified, role)
             VALUES (:id, :email, :hashed_password, :is_active, :is_superuser, :is_verified, :role)
-            """
-        ),
+            """),
         {
             "id": NO_AUTH_PLACEHOLDER_USER_UUID,
             "email": NO_AUTH_PLACEHOLDER_USER_EMAIL,
@@ -212,13 +210,11 @@ def upgrade() -> None:
             elif table == "inputprompt":
                 condition += " AND is_public = FALSE"
             result = connection.execute(
-                sa.text(
-                    f"""
+                sa.text(f"""
                     UPDATE "{table}"
                     SET user_id = :user_id
                     WHERE {condition}
-                    """
-                ),
+                    """),
                 {"user_id": NO_AUTH_PLACEHOLDER_USER_UUID},
             )
             if result.rowcount > 0:
@@ -261,13 +257,11 @@ def downgrade() -> None:
     for table in tables_to_update:
         try:
             connection.execute(
-                sa.text(
-                    f"""
+                sa.text(f"""
                     UPDATE "{table}"
                     SET user_id = NULL
                     WHERE user_id = :user_id
-                    """
-                ),
+                    """),
                 {"user_id": NO_AUTH_PLACEHOLDER_USER_UUID},
             )
         except Exception:

--- a/backend/alembic/versions/fad14119fb92_delete_tags_with_wrong_enum.py
+++ b/backend/alembic/versions/fad14119fb92_delete_tags_with_wrong_enum.py
@@ -18,22 +18,18 @@ depends_on: None = None
 def upgrade() -> None:
     # Some documents may lose their tags but this is the only way as the enum
     # mapping may have changed since tag switched to string (it will be reindexed anyway)
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM document__tag
         WHERE tag_id IN (
             SELECT id FROM tag
             WHERE source ~ '^[0-9]+$'
         )
-        """
-    )
+        """)
 
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM tag
         WHERE source ~ '^[0-9]+$'
-        """
-    )
+        """)
 
 
 def downgrade() -> None:

--- a/backend/alembic_tenants/versions/34e3630c7f32_lowercase_multi_tenant_user_auth.py
+++ b/backend/alembic_tenants/versions/34e3630c7f32_lowercase_multi_tenant_user_auth.py
@@ -17,12 +17,10 @@ depends_on = None
 
 def upgrade() -> None:
     # 1) Convert all existing rows to lowercase
-    op.execute(
-        """
+    op.execute("""
         UPDATE user_tenant_mapping
         SET email = LOWER(email)
-        """
-    )
+        """)
     # 2) Add a check constraint so that emails cannot be written in uppercase
     op.create_check_constraint(
         "ensure_lowercase_email",

--- a/backend/alembic_tenants/versions/3b9f09038764_add_read_only_kg_user.py
+++ b/backend/alembic_tenants/versions/3b9f09038764_add_read_only_kg_user.py
@@ -27,9 +27,7 @@ def upgrade() -> None:
     if not (DB_READONLY_USER and DB_READONLY_PASSWORD):
         raise Exception("DB_READONLY_USER or DB_READONLY_PASSWORD is not set")
 
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
             DO $$
             BEGIN
                 -- Check if the read-only user already exists
@@ -44,15 +42,11 @@ def upgrade() -> None:
                 END IF;
             END
             $$;
-            """
-        )
-    )
+            """))
 
 
 def downgrade() -> None:
-    op.execute(
-        text(
-            f"""
+    op.execute(text(f"""
         DO $$
         BEGIN
             IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{DB_READONLY_USER}') THEN
@@ -65,7 +59,5 @@ def downgrade() -> None:
             END IF;
         END
         $$;
-    """
-        )
-    )
+    """))
     op.execute(text("DROP EXTENSION IF EXISTS pg_trgm"))

--- a/backend/onyx/configs/kg_configs.py
+++ b/backend/onyx/configs/kg_configs.py
@@ -140,5 +140,7 @@ KG_MAX_SEARCH_DOCUMENTS: int = int(os.environ.get("KG_MAX_SEARCH_DOCUMENTS", "15
 KG_MAX_DECOMPOSITION_SEGMENTS: int = int(
     os.environ.get("KG_MAX_DECOMPOSITION_SEGMENTS", "10")
 )
-KG_BETA_ASSISTANT_DESCRIPTION = "The KG Beta assistant uses the Onyx Knowledge Graph (beta) structure \
+KG_BETA_ASSISTANT_DESCRIPTION = (
+    "The KG Beta assistant uses the Onyx Knowledge Graph (beta) structure \
 to answer questions"
+)

--- a/backend/onyx/connectors/salesforce/sqlite_functions.py
+++ b/backend/onyx/connectors/salesforce/sqlite_functions.py
@@ -157,51 +157,43 @@ class OnyxSalesforceSQLite:
                 cursor.execute("PRAGMA cache_size=-2000000")  # Use 2GB memory for cache
 
             # Main table for storing Salesforce objects
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE IF NOT EXISTS salesforce_objects (
                     id TEXT PRIMARY KEY,
                     object_type TEXT NOT NULL,
                     data TEXT NOT NULL,  -- JSON serialized data
                     last_modified INTEGER DEFAULT (strftime('%s', 'now'))  -- Add timestamp for better cache management
                 ) WITHOUT ROWID  -- Optimize for primary key lookups
-            """
-            )
+            """)
 
             # NOTE(rkuo): this seems completely redundant with relationship_types
             # Table for parent-child relationships with covering index
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE IF NOT EXISTS relationships (
                     child_id TEXT NOT NULL,
                     parent_id TEXT NOT NULL,
                     PRIMARY KEY (child_id, parent_id)
                 ) WITHOUT ROWID  -- Optimize for primary key lookups
-            """
-            )
+            """)
 
             # New table for caching parent-child relationships with object types
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE IF NOT EXISTS relationship_types (
                     child_id TEXT NOT NULL,
                     parent_id TEXT NOT NULL,
                     parent_type TEXT NOT NULL,
                     PRIMARY KEY (child_id, parent_id, parent_type)
                 ) WITHOUT ROWID
-            """
-            )
+            """)
 
             # Create a table for User email to ID mapping if it doesn't exist
-            cursor.execute(
-                """
+            cursor.execute("""
                 CREATE TABLE IF NOT EXISTS user_email_map (
                     email TEXT PRIMARY KEY,
                     user_id TEXT,  -- Nullable to allow for users without IDs
                     FOREIGN KEY (user_id) REFERENCES salesforce_objects(id)
                 ) WITHOUT ROWID
-            """
-            )
+            """)
 
             # Create indexes if they don't exist (SQLite ignores IF NOT EXISTS for indexes)
             def create_index_if_not_exists(
@@ -800,15 +792,13 @@ class OnyxSalesforceSQLite:
         Called internally by update_sf_db_with_csv when User objects are updated.
         """
 
-        cursor.execute(
-            """
+        cursor.execute("""
             INSERT OR REPLACE INTO user_email_map (email, user_id)
             SELECT json_extract(data, '$.Email'), id
             FROM salesforce_objects
             WHERE object_type = 'User'
             AND json_extract(data, '$.Email') IS NOT NULL
-            """
-        )
+            """)
 
     def make_basic_expert_info_from_record(
         self,

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -308,8 +308,7 @@ def start_playwright() -> Tuple[Playwright, BrowserContext]:
     )
 
     # Add a script to modify navigator properties to avoid detection
-    context.add_init_script(
-        """
+    context.add_init_script("""
         Object.defineProperty(navigator, 'webdriver', {
             get: () => undefined
         });
@@ -319,8 +318,7 @@ def start_playwright() -> Tuple[Playwright, BrowserContext]:
         Object.defineProperty(navigator, 'languages', {
             get: () => ['en-US', 'en']
         });
-    """
-    )
+    """)
 
     if (
         WEB_CONNECTOR_OAUTH_CLIENT_ID

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -41,9 +41,7 @@ def get_schemas_needing_migration(
             )
         )
 
-        conn.execute(
-            text(
-                """
+        conn.execute(text("""
                 DO $$
                 DECLARE
                     s        text;
@@ -77,9 +75,7 @@ def get_schemas_needing_migration(
                     END LOOP;
                 END;
                 $$
-                """
-            )
-        )
+                """))
 
         rows = conn.execute(
             text("SELECT schema_name, version_num FROM _alembic_version_snapshot")

--- a/backend/onyx/prompts/deep_research/orchestration_layer.py
+++ b/backend/onyx/prompts/deep_research/orchestration_layer.py
@@ -107,9 +107,7 @@ Before calling {GENERATE_REPORT_TOOL_NAME}, double check that all aspects of the
 
 INTERNAL_SEARCH_RESEARCH_TASK_GUIDANCE = """
  If necessary, clarify if the research agent should focus mostly on organization internal searches, web searches, or a combination of both. If the task doesn't require a clear priority, don't add sourcing guidance.
-""".strip(
-    "\n"
-)
+""".strip("\n")
 
 
 USER_ORCHESTRATOR_PROMPT = """

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -457,8 +457,7 @@ class KubernetesSandboxManager(SandboxManager):
             image="peakcom/s5cmd:v2.3.0",
             env=_get_local_aws_credential_env_vars(),
             command=["/bin/sh", "-c"],
-            args=[
-                f"""
+            args=[f"""
 # Handle signals for graceful container termination
 trap 'echo "Shutting down"; exit 0' TERM INT
 
@@ -490,8 +489,7 @@ while true; do
     sleep 30 &
     wait $!
 done
-"""
-            ],
+"""],
             volume_mounts=[
                 client.V1VolumeMount(name="files", mount_path="/workspace/files"),
                 # Mount sessions directory so file-sync can create snapshots

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -147,11 +147,9 @@ def _unsafe_deletion(
 
 
 def _delete_connector(cc_pair_id: int, db_session: Session) -> None:
-    user_input = input(
-        "DO NOT USE THIS UNLESS YOU KNOW WHAT YOU ARE DOING. \
+    user_input = input("DO NOT USE THIS UNLESS YOU KNOW WHAT YOU ARE DOING. \
         IT MAY CAUSE ISSUES with your Onyx instance! \
-        Are you SURE you want to continue? (enter 'Y' to continue): "
-    )
+        Are you SURE you want to continue? (enter 'Y' to continue): ")
     if user_input != "Y":
         logger.notice("You entered %s. Exiting!", user_input)
         return

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -26,15 +26,13 @@ BATCH_SIZE = 100
 
 def _get_orphaned_document_ids(db_session: Session, limit: int) -> list[str]:
     """Get document IDs that don't have any entries in document_by_connector_credential_pair"""
-    query = text(
-        """
+    query = text("""
         SELECT d.id
         FROM document d
         LEFT JOIN document_by_connector_credential_pair dbcc ON d.id = dbcc.id
         WHERE dbcc.id IS NULL
         LIMIT :limit
-    """
-    )
+    """)
     orphaned_ids = [doc_id[0] for doc_id in db_session.execute(query, {"limit": limit})]
     print(f"Found {len(orphaned_ids)} orphaned documents in this batch")
     return orphaned_ids

--- a/backend/scripts/reset_postgres.py
+++ b/backend/scripts/reset_postgres.py
@@ -32,13 +32,11 @@ def wipe_all_rows(database: str) -> None:
     cur.execute("SET session_replication_role = 'replica';")
 
     # Fetch all table names in the current database
-    cur.execute(
-        """
+    cur.execute("""
         SELECT tablename
         FROM pg_tables
         WHERE schemaname = 'public'
-    """
-    )
+    """)
 
     tables = cur.fetchall()
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -25,13 +25,11 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
     try:
         with get_session_with_shared_schema() as session:
             # First, verify the schema exists
-            check_schema_query = text(
-                """
+            check_schema_query = text("""
                 SELECT nspname
                 FROM pg_namespace
                 WHERE nspname = :schema_name
-            """
-            )
+            """)
 
             result = session.execute(
                 check_schema_query, {"schema_name": tenant_id}
@@ -52,12 +50,10 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
             print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
 
             # Delete the tenant mapping from user_tenant_mapping table
-            delete_mapping_query = text(
-                """
+            delete_mapping_query = text("""
                 DELETE FROM user_tenant_mapping
                 WHERE tenant_id = :tenant_id
-                """
-            )
+                """)
             session.execute(delete_mapping_query, {"tenant_id": tenant_id})
             session.commit()
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
@@ -14,21 +14,14 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
     """Return a list of dicts, one per tenant, with last query info, doc count, and user count."""
 
     # Step 1: fetch all tenant schemas
-    tenant_schemas = [
-        row[0]
-        for row in session.execute(
-            text(
-                """
+    tenant_schemas = [row[0] for row in session.execute(text("""
             SELECT nspname
             FROM pg_namespace
             WHERE nspname NOT IN ('pg_catalog', 'information_schema', 'public')
                 AND nspname NOT LIKE 'pg_toast%%'
                 AND nspname NOT LIKE 'pg_temp%%'
             ORDER BY nspname
-        """
-            )
-        )
-    ]
+        """))]
 
     print(f"Found {len(tenant_schemas)} tenant schemas", file=sys.stderr)
 
@@ -41,8 +34,7 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
 
         try:
             # Use a single query to get all data at once
-            query = text(
-                f"""
+            query = text(f"""
                 SELECT
                     :tenant_id AS tenant_id,
                     (
@@ -61,8 +53,7 @@ def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:
                     ) AS last_query_text,
                     (SELECT COUNT(*) FROM "{schema}".document) AS num_documents,
                     (SELECT COUNT(*) FROM "{schema}".user) AS num_users
-            """
-            )
+            """)
 
             result = session.execute(query, {"tenant_id": schema}).mappings().first()
 

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -92,15 +92,13 @@ def downgrade_postgres(
         cur = conn.cursor()
 
         # Close any existing connections to the schema before dropping
-        cur.execute(
-            f"""
+        cur.execute(f"""
             SELECT pg_terminate_backend(pg_stat_activity.pid)
             FROM pg_stat_activity
             WHERE pg_stat_activity.datname = '{database}'
             AND pg_stat_activity.state = 'idle in transaction'
             AND pid <> pg_backend_pid();
-        """
-        )
+        """)
 
         # Drop and recreate the public schema - this removes ALL objects
         cur.execute(f"DROP SCHEMA {schema} CASCADE;")
@@ -208,40 +206,34 @@ def drop_multitenant_postgres_task(dbname: str) -> None:
 
     logger.info("Selecting tenant schemas.")
     # Get all tenant schemas
-    cur.execute(
-        """
+    cur.execute("""
         SELECT schema_name
         FROM information_schema.schemata
         WHERE schema_name LIKE 'tenant_%'
-        """
-    )
+        """)
     tenant_schemas = cur.fetchall()
 
     # Drop all tenant schemas
     logger.info("Dropping all tenant schemas.")
     for schema in tenant_schemas:
         # Close any existing connections to the schema before dropping
-        cur.execute(
-            """
+        cur.execute("""
             SELECT pg_terminate_backend(pg_stat_activity.pid)
             FROM pg_stat_activity
             WHERE pg_stat_activity.datname = 'postgres'
             AND pg_stat_activity.state = 'idle in transaction'
             AND pid <> pg_backend_pid();
-        """
-        )
+        """)
 
         schema_name = schema[0]
         cur.execute(f'DROP SCHEMA "{schema_name}" CASCADE')
 
     # Drop tables in the public schema
     logger.info("Selecting public schema tables.")
-    cur.execute(
-        """
+    cur.execute("""
         SELECT tablename FROM pg_tables
         WHERE schemaname = 'public'
-        """
-    )
+        """)
     public_tables = cur.fetchall()
 
     logger.info("Dropping public schema tables.")

--- a/backend/tests/integration/tests/migrations/test_assistant_consolidation_migration.py
+++ b/backend/tests/integration/tests/migrations/test_assistant_consolidation_migration.py
@@ -22,16 +22,12 @@ def test_cold_startup_default_assistant() -> None:
 
     with get_session_with_current_tenant() as db_session:
         # Check only default assistant exists
-        result = db_session.execute(
-            text(
-                """
+        result = db_session.execute(text("""
                 SELECT id, name, builtin_persona, is_featured, deleted
                 FROM persona
                 WHERE builtin_persona = true
                 ORDER BY id
-                """
-            )
-        )
+                """))
         assistants = result.fetchall()
 
         # Should have exactly one builtin assistant
@@ -44,17 +40,13 @@ def test_cold_startup_default_assistant() -> None:
         assert default[4] is False, "Should not be deleted"
 
         # Check tools are properly associated
-        result = db_session.execute(
-            text(
-                """
+        result = db_session.execute(text("""
                 SELECT t.name, t.display_name
                 FROM tool t
                 JOIN persona__tool pt ON t.id = pt.tool_id
                 WHERE pt.persona_id = 0
                 ORDER BY t.name
-                """
-            )
-        )
+                """))
         tool_associations = result.fetchall()
         tool_names = [row[0] for row in tool_associations]
         tool_display_names = [row[1] for row in tool_associations]

--- a/backend/tests/integration/tests/migrations/test_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_migrations.py
@@ -56,8 +56,7 @@ def test_fix_capitalization_migration() -> None:
     with get_session_with_current_tenant() as db_session:
         for doc in test_data:
             db_session.execute(
-                text(
-                    """
+                text("""
                     INSERT INTO document (
                         id,
                         external_user_group_ids,
@@ -76,8 +75,7 @@ def test_fix_capitalization_migration() -> None:
                         :from_ingestion_api,
                         :last_modified
                     )
-                    """
-                ),
+                    """),
                 {
                     "id": doc["id"],
                     "group_ids": doc["external_user_group_ids"],
@@ -92,16 +90,12 @@ def test_fix_capitalization_migration() -> None:
 
     # Verify the data was inserted correctly
     with get_session_with_current_tenant() as db_session:
-        results = db_session.execute(
-            text(
-                """
+        results = db_session.execute(text("""
                 SELECT id, external_user_group_ids
                 FROM document
                 WHERE id IN ('test_doc_1', 'test_doc_2')
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         # Verify initial state
         assert len(results) == 2
@@ -115,16 +109,12 @@ def test_fix_capitalization_migration() -> None:
 
     # Verify the fix was applied
     with get_session_with_current_tenant() as db_session:
-        results = db_session.execute(
-            text(
-                """
+        results = db_session.execute(text("""
                 SELECT id, external_user_group_ids
                 FROM document
                 WHERE id IN ('test_doc_1', 'test_doc_2')
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         # Verify all group IDs are lowercase
         assert len(results) == 2
@@ -181,8 +171,7 @@ def test_jira_connector_migration() -> None:
     with get_session_with_current_tenant() as db_session:
         for connector in test_data:
             db_session.execute(
-                text(
-                    """
+                text("""
                     INSERT INTO connector (
                         id,
                         name,
@@ -195,8 +184,7 @@ def test_jira_connector_migration() -> None:
                         :source,
                         :config
                     )
-                    """
-                ),
+                    """),
                 {
                     "id": connector["id"],
                     "name": connector["name"],
@@ -208,16 +196,12 @@ def test_jira_connector_migration() -> None:
 
     # Verify the data was inserted correctly
     with get_session_with_current_tenant() as db_session:
-        results = db_session.execute(
-            text(
-                """
+        results = db_session.execute(text("""
                 SELECT id, connector_specific_config
                 FROM connector
                 WHERE source = 'JIRA'
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         # Verify initial state
         assert len(results) == 3
@@ -240,16 +224,12 @@ def test_jira_connector_migration() -> None:
     )
     # Verify the upgrade was applied correctly
     with get_session_with_current_tenant() as db_session:
-        results = db_session.execute(
-            text(
-                """
+        results = db_session.execute(text("""
                 SELECT id, connector_specific_config
                 FROM connector
                 WHERE source = 'JIRA'
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         # Verify new format
         assert len(results) == 3
@@ -285,16 +265,12 @@ def test_jira_connector_migration() -> None:
 
     # Verify the downgrade was applied correctly
     with get_session_with_current_tenant() as db_session:
-        results = db_session.execute(
-            text(
-                """
+        results = db_session.execute(text("""
                 SELECT id, connector_specific_config
                 FROM connector
                 WHERE source = 'JIRA'
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         # Verify reverted to old format
         assert len(results) == 3
@@ -335,9 +311,7 @@ def test_anonymous_user_migration_dedupes_null_notifications() -> None:
     )
 
     with get_session_with_current_tenant() as db_session:
-        db_session.execute(
-            text(
-                """
+        db_session.execute(text("""
                 INSERT INTO notification (
                     id,
                     notif_type,
@@ -372,9 +346,7 @@ def test_anonymous_user_migration_dedupes_null_notifications() -> None:
                         'Check out what''s new in v2.10.0',
                         '{"version":"v2.10.0","link":"https://docs.onyx.app/changelog#v2-10-0"}'::jsonb
                     )
-                """
-            )
-        )
+                """))
         db_session.commit()
 
     upgrade_postgres(
@@ -382,24 +354,18 @@ def test_anonymous_user_migration_dedupes_null_notifications() -> None:
     )
 
     with get_session_with_current_tenant() as db_session:
-        notifications = db_session.execute(
-            text(
-                """
+        notifications = db_session.execute(text("""
                 SELECT id, user_id
                 FROM notification
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
         anonymous_user = db_session.execute(
-            text(
-                """
+            text("""
                 SELECT id, email, role
                 FROM "user"
                 WHERE id = :user_id
-                """
-            ),
+                """),
             {"user_id": ANONYMOUS_USER_UUID},
         ).fetchone()
 
@@ -428,19 +394,16 @@ def test_anonymous_user_migration_collision_with_existing_anonymous_notification
     with get_session_with_current_tenant() as db_session:
         # Create the anonymous user early so we can insert a notification owned by it
         db_session.execute(
-            text(
-                """
+            text("""
                 INSERT INTO "user" (id, email, hashed_password, is_active, is_superuser, is_verified, role)
                 VALUES (:id, 'anonymous@onyx.app', '', TRUE, FALSE, TRUE, 'LIMITED')
                 ON CONFLICT (id) DO NOTHING
-                """
-            ),
+                """),
             {"id": ANONYMOUS_USER_UUID},
         )
         # Insert an anonymous-owned notification (already migrated in a prior partial run)
         db_session.execute(
-            text(
-                """
+            text("""
                 INSERT INTO notification (
                     id, notif_type, user_id, dismissed, last_shown, first_shown,
                     title, description, additional_data
@@ -458,8 +421,7 @@ def test_anonymous_user_migration_collision_with_existing_anonymous_notification
                         'Check out what''s new in v2.10.0',
                         '{"version":"v2.10.0","link":"https://docs.onyx.app/changelog#v2-10-0"}'::jsonb
                     )
-                """
-            ),
+                """),
             {"user_id": ANONYMOUS_USER_UUID},
         )
         db_session.commit()
@@ -469,15 +431,11 @@ def test_anonymous_user_migration_collision_with_existing_anonymous_notification
     )
 
     with get_session_with_current_tenant() as db_session:
-        notifications = db_session.execute(
-            text(
-                """
+        notifications = db_session.execute(text("""
                 SELECT id, user_id
                 FROM notification
                 ORDER BY id
-                """
-            )
-        ).fetchall()
+                """)).fetchall()
 
     # Only the original anonymous-owned notification should remain;
     # the NULL-owned duplicate should have been deleted

--- a/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
+++ b/backend/tests/integration/tests/migrations/test_run_multitenant_migrations.py
@@ -67,16 +67,14 @@ def _force_drop_schema(engine: Engine, schema: str) -> None:
         try:
             with engine.connect() as conn:
                 conn.execute(
-                    text(
-                        """
+                    text("""
                         SELECT pg_terminate_backend(l.pid)
                         FROM pg_locks l
                         JOIN pg_class c ON c.oid = l.relation
                         JOIN pg_namespace n ON n.oid = c.relnamespace
                         WHERE n.nspname = :schema
                           AND l.pid != pg_backend_pid()
-                        """
-                    ),
+                        """),
                     {"schema": schema},
                 )
                 conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))

--- a/backend/tests/integration/tests/migrations/test_tool_seeding.py
+++ b/backend/tests/integration/tests/migrations/test_tool_seeding.py
@@ -92,16 +92,12 @@ def test_tool_seeding_migration() -> None:
 
     # Verify tools were created
     with get_session_with_current_tenant() as db_session:
-        result = db_session.execute(
-            text(
-                """
+        result = db_session.execute(text("""
                 SELECT id, name, display_name, description, in_code_tool_id,
                        user_id
                 FROM tool
                 ORDER BY id
-                """
-            )
-        )
+                """))
         tools = result.fetchall()
 
         # Should have all 9 builtin tools

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
@@ -106,8 +106,7 @@ if __name__ == "__main__":
     print("🎉 All tests passed! The custom query configuration is working correctly.")
     print()
     print("Example usage:")
-    print(
-        """
+    print("""
 # Custom configuration approach
 custom_config = {
     ACCOUNT_OBJECT_TYPE: {
@@ -125,5 +124,4 @@ connector = SalesforceConnector(custom_query_config=custom_config)
 
 # Traditional approach (still works)
 connector = SalesforceConnector(requested_objects=[ACCOUNT_OBJECT_TYPE, "Contact"])
-"""
-    )
+""")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,9 @@ include = ["backend"]
 exclude = ["backend/generated", "backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/pptx", "backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv"]
 typeCheckingMode = "off"
 
+[tool.black]
+target-version = ["py311"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"


### PR DESCRIPTION
## Description

Ruff (0.11.4 vs 0.12.0) and black (25.1.0 vs 26.3.1) were pinned separately in `.pre-commit-config.yaml` and `pyproject.toml`, causing version drift and inconsistent formatting between `uv run black` and `pre-commit run black`.

This switches both to `uv-run` hooks (same pattern already used by `ty` and `ods check-lazy-imports`) so `pyproject.toml` is the single source of truth. Also adds `[tool.black] target-version = ["py311"]` to avoid the Python 3.14 parse warning introduced in black 26.x.

Most file changes are cosmetic reformats from the black version bump (25.1.0 → 26.3.1), primarily blank line removals in alembic migrations.

## How Has This Been Tested?

- `uv run pre-commit run ruff --all-files` — passes
- `uv run pre-commit run black --all-files` — passes
- `uv run black backend/` and `uv run pre-commit run black` now produce identical results

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `ruff` and `black` versions by running them via `uv-run` pre-commit hooks with `pyproject.toml` as the single source of truth. Sets `black` target-version to `py311` and applies repo-wide auto-formatting from the Black 26.x style.

- **Refactors**
  - Switched `.pre-commit-config.yaml` to `uv-run` hooks for `ruff` and `black`; versions now come from `pyproject.toml` (matching existing `ty` and `ods check-lazy-imports`).
  - `ruff` now runs with `--fix` via `uv-run`.
  - Added `[tool.black] target-version = ["py311"]`.
  - Reformatted migrations, scripts, and tests to the new Black style; no logic changes.

- **Migration**
  - Ensure `uv` is installed and run `uv run pre-commit run --all-files`; `uv run black` and `pre-commit run black` now match.

<sup>Written for commit b3c4d3082f8c1670d783a511cd98a8eda957730d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

