### PR TITLE
fix(sharepoint): add slim connector so it does not need to fetch permission during pruning (#10750) to release v3.3

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -35,6 +35,7 @@ from office365.sharepoint.client_context import ClientContext
 from pydantic import BaseModel
 from pydantic import Field
 from requests.exceptions import HTTPError
+from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -54,6 +55,7 @@ from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import IndexingHeartbeatInterface
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.microsoft_graph_env import resolve_microsoft_environment
 from onyx.connectors.models import BasicExpertInfo
@@ -923,7 +925,8 @@ def _convert_sitepage_to_slim_document(
     treat_sharing_link_as_public: bool = False,
 ) -> SlimDocument:
     """Convert a SharePoint site page to a SlimDocument object."""
-    if site_page.get("id") is None:
+    page_id = site_page.get("id")
+    if page_id is None:
         raise ValueError("Site page ID is required")
 
     external_access = get_sharepoint_external_access(
@@ -932,17 +935,16 @@ def _convert_sitepage_to_slim_document(
         site_page=site_page,
         treat_sharing_link_as_public=treat_sharing_link_as_public,
     )
-    id = site_page.get("id")
-    if id is None:
-        raise ValueError("Site page ID is required")
+
     return SlimDocument(
-        id=id,
+        id=page_id,
         external_access=external_access,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
     )
 
 
 class SharepointConnector(
+    SlimConnector,
     SlimConnectorWithPermSync,
     CheckpointedConnectorWithPermSync[SharepointConnectorCheckpoint],
 ):
@@ -1853,6 +1855,7 @@ class SharepointConnector(
         self,
         start: datetime | None = None,
         end: datetime | None = None,
+        include_permissions: bool = True,
     ) -> GenerateSlimDocumentOutput:
         site_descriptors = self._filter_excluded_sites(
             self.site_descriptors or self.fetch_sites()
@@ -1911,17 +1914,28 @@ class SharepointConnector(
 
                     try:
                         logger.debug(f"Processing: {driveitem.web_url}")
-                        ctx = self._create_rest_client_context(site_descriptor.url)
-                        doc_batch.append(
-                            _convert_driveitem_to_slim_document(
-                                driveitem,
-                                drive_name,
-                                ctx,
-                                self.graph_client,
-                                parent_hierarchy_raw_node_id=parent_hierarchy_url,
-                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        if include_permissions:
+                            ctx = self._create_rest_client_context(site_descriptor.url)
+                            doc_batch.append(
+                                _convert_driveitem_to_slim_document(
+                                    driveitem,
+                                    drive_name,
+                                    ctx,
+                                    self.graph_client,
+                                    parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                                )
                             )
-                        )
+                        else:
+                            if driveitem.id is None:
+                                raise ValueError("DriveItem ID is required")
+                            doc_batch.append(
+                                SlimDocument(
+                                    id=driveitem.id,
+                                    external_access=ExternalAccess.empty(),
+                                    parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                                )
+                            )
                     except Exception as e:
                         logger.warning(f"Failed to process driveitem: {str(e)}")
 
@@ -1939,16 +1953,28 @@ class SharepointConnector(
                         f"Processing site page: {site_page.get('webUrl', site_page.get('name', 'Unknown'))}"
                     )
                     try:
-                        ctx = self._create_rest_client_context(site_descriptor.url)
-                        doc_batch.append(
-                            _convert_sitepage_to_slim_document(
-                                site_page,
-                                ctx,
-                                self.graph_client,
-                                parent_hierarchy_raw_node_id=site_descriptor.url,
-                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        if include_permissions:
+                            ctx = self._create_rest_client_context(site_descriptor.url)
+                            doc_batch.append(
+                                _convert_sitepage_to_slim_document(
+                                    site_page,
+                                    ctx,
+                                    self.graph_client,
+                                    parent_hierarchy_raw_node_id=site_descriptor.url,
+                                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                                )
                             )
-                        )
+                        else:
+                            page_id = site_page.get("id")
+                            if page_id is None:
+                                raise ValueError("Site page ID is required")
+                            doc_batch.append(
+                                SlimDocument(
+                                    id=page_id,
+                                    external_access=ExternalAccess.empty(),
+                                    parent_hierarchy_raw_node_id=site_descriptor.url,
+                                )
+                            )
                     except Exception as e:
                         logger.warning(
                             f"Failed to process site page "
@@ -2661,6 +2687,28 @@ class SharepointConnector(
     ) -> SharepointConnectorCheckpoint:
         return SharepointConnectorCheckpoint.model_validate_json(checkpoint_json)
 
+    @override
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
+    ) -> GenerateSlimDocumentOutput:
+        start_dt = (
+            datetime.fromtimestamp(start, tz=timezone.utc)
+            if start is not None
+            else None
+        )
+        end_dt = (
+            datetime.fromtimestamp(end, tz=timezone.utc) if end is not None else None
+        )
+        yield from self._fetch_slim_documents_from_sharepoint(
+            start=start_dt,
+            end=end_dt,
+            include_permissions=False,
+        )
+
+    @override
     def retrieve_all_slim_docs_perm_sync(
         self,
         start: SecondsSinceUnixEpoch | None = None,
@@ -2678,6 +2726,7 @@ class SharepointConnector(
         yield from self._fetch_slim_documents_from_sharepoint(
             start=start_dt,
             end=end_dt,
+            include_permissions=True,
         )
 
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -125,6 +125,65 @@ def test_all_site_pages_fail_does_not_crash(
 
 
 # ---------------------------------------------------------------------------
+# retrieve_all_slim_docs — pruning path skips permission fetching
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "onyx.connectors.sharepoint.connector.SharepointConnector._create_rest_client_context"
+)
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_site_pages")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_driveitems")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector.fetch_sites")
+def test_retrieve_all_slim_docs_does_not_fetch_permissions(
+    mock_fetch_sites: MagicMock,
+    mock_fetch_driveitems: MagicMock,
+    mock_fetch_site_pages: MagicMock,
+    mock_create_ctx: MagicMock,
+) -> None:
+    """retrieve_all_slim_docs (pruning path) never calls _create_rest_client_context
+    and returns SlimDocuments with empty ExternalAccess."""
+    from onyx.connectors.models import ExternalAccess
+    from onyx.connectors.models import SlimDocument
+    from onyx.connectors.sharepoint.connector import DriveItemData
+
+    connector = _make_connector()
+    connector.include_site_documents = True
+    connector.include_site_pages = True
+
+    site = MagicMock()
+    site.url = SITE_URL
+    mock_fetch_sites.return_value = [site]
+
+    driveitem = MagicMock(spec=DriveItemData)
+    driveitem.id = "item-1"
+    driveitem.web_url = SITE_URL + "/doc.docx"
+    driveitem.parent_reference_path = None
+    mock_fetch_driveitems.return_value = [
+        (driveitem, "Documents", None),
+    ]
+
+    mock_fetch_site_pages.return_value = [
+        {"id": "page-1", "webUrl": SITE_URL + "/SitePages/Home.aspx"},
+    ]
+
+    results = [
+        doc
+        for batch in connector.retrieve_all_slim_docs()
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    ]
+
+    # Permissions were never fetched — no REST client context created.
+    mock_create_ctx.assert_not_called()
+
+    assert any(d.id == "item-1" for d in results)
+    assert any(d.id == "page-1" for d in results)
+    for doc in results:
+        assert doc.external_access == ExternalAccess.empty()
+
+
+# ---------------------------------------------------------------------------
 # validate_connector_settings — RoleAssignments permission probe
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Cherry-pick of commit 774da68c8739d5a7e6260a8ce380410cf2b1fb1f to release/v3.3 branch.

Original PR: #10750

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip permission fetching during SharePoint pruning by adding a slim connector path. This reduces SharePoint/Graph calls and speeds up pruning in v3.3.

- **Bug Fixes**
  - Implemented `SlimConnector` for SharePoint; new `retrieve_all_slim_docs` returns `SlimDocument` with `ExternalAccess.empty()` and never creates a REST context.
  - Updated `_fetch_slim_documents_from_sharepoint` with `include_permissions` to share logic; pruning sets it to false, perm sync keeps it true.
  - Hardened site page ID handling and added a unit test to ensure pruning does not fetch permissions.

<sup>Written for commit 0eea2a5d97ce7cc9be650b98420b74e68d4e5eea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

