### PR TITLE
fix(a11y): add missing aria-labels to interactive components

### DIFF
--- a/web/src/components/admin/connectors/CredentialForm.tsx
+++ b/web/src/components/admin/connectors/CredentialForm.tsx
@@ -94,12 +94,13 @@ export function CredentialForm<T extends Yup.AnyObject>({
                 type="submit"
                 color="green"
                 disabled={isSubmitting}
-                className="mx-auto w-64 inline-flex items-center 
-                justify-center whitespace-nowrap rounded-md text-sm 
+                className="mx-auto w-64 inline-flex items-center
+                justify-center whitespace-nowrap rounded-md text-sm
                 font-medium transition-colors  bg-background-200 text-primary-foreground
-                focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring 
-                disabled:pointer-events-none disabled:opacity-50 
+                focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring
+                disabled:pointer-events-none disabled:opacity-50
                 shadow hover:bg-primary/90 h-9 px-4 py-2"
+                aria-label="Update credentials"
               >
                 Update
               </button>

--- a/web/src/components/chat/MCPApiKeyModal.tsx
+++ b/web/src/components/chat/MCPApiKeyModal.tsx
@@ -207,6 +207,11 @@ export default function MCPApiKeyModal({
                         type="button"
                         onClick={() => toggleCredentialVisibility(field)}
                         className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
+                        aria-label={
+                          showCredentials[field]
+                            ? "Hide credential"
+                            : "Show credential"
+                        }
                       >
                         {showCredentials[field] ? (
                           <SvgEyeClosed className="h-4 w-4" />
@@ -238,6 +243,7 @@ export default function MCPApiKeyModal({
                     type="button"
                     onClick={() => setShowApiKey(!showApiKey)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-subtle hover:text-emphasis"
+                    aria-label={showApiKey ? "Hide API key" : "Show API key"}
                   >
                     {showApiKey ? (
                       <SvgEyeClosed className="h-4 w-4" />

--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -131,6 +131,7 @@ function CredentialSelectionTable({
                         disabled={!editable}
                         onClick={() => onEditCredential(credential)}
                         className="cursor-pointer my-auto"
+                        aria-label="Edit credential"
                       >
                         <SvgEdit />
                       </button>

--- a/web/src/components/search/DocumentDisplay.tsx
+++ b/web/src/components/search/DocumentDisplay.tsx
@@ -141,6 +141,9 @@ export function CompactDocumentCard({
           openDocument(document, updatePresentingDocument);
         }}
         className="max-w-[20rem] p-3 flex flex-col gap-1"
+        aria-label={`Open document: ${
+          document.semantic_identifier ?? document.document_id
+        }`}
       >
         <div className="flex flex-row gap-2 items-center w-full">
           {isWebSource && document.link ? (


### PR DESCRIPTION
## Description

Adds `aria-label` attributes to buttons across several legacy components that were missing accessible labels for screen readers. This improves keyboard and assistive technology navigation throughout the app.

**Components updated:**
- `MCPApiKeyModal`: credential/API key visibility toggle buttons now announce "Show/Hide credential" and "Show/Hide API key"
- `ModifyCredential`: icon-only edit button now announces "Edit credential"
- `SignedUpUserTable`: role filter chip dismiss buttons now announce "Remove {role} filter"
- `CredentialForm`: submit button now announces "Update credentials"
- `DocumentDisplay`: document card button now announces "Open document: {name}"
- `ModelSelector`: model selection button now announces "Select {model}" or "{model} is selected"

## How Has This Been Tested?

- TypeScript type check passes
- Prettier formatting verified
- No behavioral changes — only adds aria attributes

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing aria-labels to icon-only and action buttons so screen readers announce each action. No UI or behavior changes.

- **Bug Fixes**
  - MCPApiKeyModal: visibility toggles announce "Show/Hide credential" and "Show/Hide API key".
  - ModifyCredential: edit button announces "Edit credential".
  - CredentialForm: submit button announces "Update credentials".
  - DocumentDisplay: open button announces "Open document: {name or id}".

<sup>Written for commit a7b7dedf78e6a8704c626b6af7526628286294ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

