### PR TITLE
perf(db): add eager loading to get_document_set_by_id

### DIFF
--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -409,7 +409,11 @@ def monitor_document_set_taskset(
 
     document_set = cast(
         DocumentSet,
-        get_document_set_by_id(db_session=db_session, document_set_id=document_set_id),
+        get_document_set_by_id(
+            db_session=db_session,
+            document_set_id=document_set_id,
+            prefetch_relationships=True,
+        ),
     )  # casting since we "know" a document set with this ID exists
     if document_set:
         has_connector_pairs = bool(document_set.connector_credential_pairs)

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -126,7 +126,10 @@ def get_document_set_by_id_for_user(
     stmt = (
         select(DocumentSetDBModel)
         .distinct()
-        .options(selectinload(DocumentSetDBModel.federated_connectors))
+        .options(
+            selectinload(DocumentSetDBModel.connector_credential_pairs),
+            selectinload(DocumentSetDBModel.federated_connectors),
+        )
     )
     stmt = stmt.where(DocumentSetDBModel.id == document_set_id)
     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -137,7 +137,14 @@ def get_document_set_by_id(
     db_session: Session,
     document_set_id: int,
 ) -> DocumentSetDBModel | None:
-    stmt = select(DocumentSetDBModel).distinct()
+    stmt = (
+        select(DocumentSetDBModel)
+        .distinct()
+        .options(
+            selectinload(DocumentSetDBModel.connector_credential_pairs),
+            selectinload(DocumentSetDBModel.federated_connectors),
+        )
+    )
     stmt = stmt.where(DocumentSetDBModel.id == document_set_id)
     return db_session.scalar(stmt)
 

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -123,14 +123,7 @@ def get_document_set_by_id_for_user(
     user: User,
     get_editable: bool = True,
 ) -> DocumentSetDBModel | None:
-    stmt = (
-        select(DocumentSetDBModel)
-        .distinct()
-        .options(
-            selectinload(DocumentSetDBModel.connector_credential_pairs),
-            selectinload(DocumentSetDBModel.federated_connectors),
-        )
-    )
+    stmt = select(DocumentSetDBModel).distinct()
     stmt = stmt.where(DocumentSetDBModel.id == document_set_id)
     stmt = _add_user_filters(stmt=stmt, user=user, get_editable=get_editable)
     return db_session.scalar(stmt)
@@ -139,15 +132,14 @@ def get_document_set_by_id_for_user(
 def get_document_set_by_id(
     db_session: Session,
     document_set_id: int,
+    prefetch_relationships: bool = False,
 ) -> DocumentSetDBModel | None:
-    stmt = (
-        select(DocumentSetDBModel)
-        .distinct()
-        .options(
+    stmt = select(DocumentSetDBModel).distinct()
+    if prefetch_relationships:
+        stmt = stmt.options(
             selectinload(DocumentSetDBModel.connector_credential_pairs),
             selectinload(DocumentSetDBModel.federated_connectors),
         )
-    )
     stmt = stmt.where(DocumentSetDBModel.id == document_set_id)
     return db_session.scalar(stmt)
 

--- a/backend/tests/unit/onyx/utils/test_vespa_tasks.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_tasks.py
@@ -38,7 +38,7 @@ def _setup_common_patches(monkeypatch: Any, document_set: Any) -> dict[str, bool
     monkeypatch.setattr(
         vespa_tasks,
         "get_document_set_by_id",
-        lambda db_session, document_set_id: document_set,  # noqa: ARG005
+        lambda db_session, document_set_id, prefetch_relationships=False: document_set,  # noqa: ARG005
     )
 
     def _delete(document_set_row: Any, db_session: Any) -> None:  # noqa: ARG001


### PR DESCRIPTION
## Description

Adds `selectinload` for `connector_credential_pairs` and `federated_connectors` relationships to `get_document_set_by_id`.

The Vespa sync completion handler (`vespa/tasks.py:410-419`) accesses both `document_set.connector_credential_pairs` and `document_set.federated_connectors` on the returned object, which previously triggered lazy loads (separate DB queries per relationship). This adds eager loading to prevent those N+1 round trips.

Note: `get_document_set_by_id_for_user` already had `selectinload` for `federated_connectors` — this brings the non-user variant to parity and adds `connector_credential_pairs` coverage.

## How Has This Been Tested?

- Pre-commit hooks (ruff, black, ty) pass
- No behavioral change — same data loaded, just in fewer queries

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional eager loading to `get_document_set_by_id` behind a `prefetch_relationships` flag for `connector_credential_pairs` and `federated_connectors`, and enable it in the Vespa sync handler to avoid N+1 queries. Remove eager loading from `get_document_set_by_id_for_user` to keep other callers unchanged.

<sup>Written for commit 00678c598a0a57d29fcc0fbcf620bc963767460a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

