### PR TITLE
perf(db): add eager loading for chat message feedbacks and search docs

### DIFF
--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -130,7 +130,9 @@ def snapshot_from_chat_session(
     try:
         # Older chats may not have the right structure
         messages = create_chat_history_chain(
-            chat_session_id=chat_session.id, db_session=db_session
+            chat_session_id=chat_session.id,
+            db_session=db_session,
+            prefetch_message_details=True,
         )
     except RuntimeError:
         return None

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -163,6 +163,7 @@ def create_chat_history_chain(
     chat_session_id: UUID,
     db_session: Session,
     prefetch_top_two_level_tool_calls: bool = True,
+    prefetch_message_details: bool = False,
     # Optional id at which we finish processing
     stop_at_message_id: int | None = None,
 ) -> list[ChatMessage]:
@@ -175,6 +176,7 @@ def create_chat_history_chain(
         db_session=db_session,
         skip_permission_check=True,
         prefetch_top_two_level_tool_calls=prefetch_top_two_level_tool_calls,
+        prefetch_message_details=prefetch_message_details,
     )
 
     if not all_chat_messages:

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -541,6 +541,7 @@ def get_chat_messages_by_session(
     db_session: Session,
     skip_permission_check: bool = False,
     prefetch_top_two_level_tool_calls: bool = True,
+    prefetch_message_details: bool = False,
 ) -> list[ChatMessage]:
     if not skip_permission_check:
         # bug if we ever call this expecting the permission check to not be skipped
@@ -554,10 +555,11 @@ def get_chat_messages_by_session(
         .order_by(nullsfirst(ChatMessage.parent_message_id))
     )
 
-    stmt = stmt.options(
-        selectinload(ChatMessage.chat_message_feedbacks),
-        selectinload(ChatMessage.search_docs),
-    )
+    if prefetch_message_details:
+        stmt = stmt.options(
+            selectinload(ChatMessage.chat_message_feedbacks),
+            selectinload(ChatMessage.search_docs),
+        )
 
     # This should handle both the top level tool calls and deep research
     # If there are future nested agents, this can be extended.

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -554,6 +554,11 @@ def get_chat_messages_by_session(
         .order_by(nullsfirst(ChatMessage.parent_message_id))
     )
 
+    stmt = stmt.options(
+        selectinload(ChatMessage.chat_message_feedbacks),
+        selectinload(ChatMessage.search_docs),
+    )
+
     # This should handle both the top level tool calls and deep research
     # If there are future nested agents, this can be extended.
     if prefetch_top_two_level_tool_calls:

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -326,6 +326,7 @@ def get_chat_session(
         skip_permission_check=True,
         # we need the tool call objs anyways, so just fetch them in a single call
         prefetch_top_two_level_tool_calls=True,
+        prefetch_message_details=True,
     )
 
     # Convert messages to ChatMessageDetail format


### PR DESCRIPTION
## Description

`get_chat_messages_by_session` already eagerly loads `tool_calls` (via `selectinload`) but was lazy-loading `chat_message_feedbacks` and `search_docs`. Since `translate_db_message_to_chat_message_detail` accesses both of these relationships for every message in the session, this caused **2N additional queries** per chat session load (N messages = N feedback queries + N search_docs queries).

Adding `selectinload` for both relationships reduces this to **2 fixed queries** regardless of message count — a significant improvement for long chat sessions.

## How Has This Been Tested?

- Pre-commit hooks (ruff, black, ty) pass
- No behavioral change — same data loaded, just in fewer DB round trips
- The `unique()` call on the result set already handles potential duplicates from the joined loads

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in eager loading for chat message feedbacks and search docs to remove N+1 queries when building message details. Introduces prefetch_message_details (default False) in `get_chat_messages_by_session` and `create_chat_history_chain`; session-detail and query-history snapshot enable it, reducing 2N extra queries to 2 fixed queries with no behavior change.

<sup>Written for commit 73f8a4862eb611e718791bda0019780c52deb3fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

