### PR TITLE
chore(frontend): deprecate legacy Text component, migrate preview modal variants

### DIFF
--- a/web/src/refresh-components/texts/Text.tsx
+++ b/web/src/refresh-components/texts/Text.tsx
@@ -57,6 +57,7 @@ const colors = {
   },
 };
 
+/** @deprecated Use `Text` from `@opal/components` with string-enum `font` and `color` props instead. */
 export interface TextProps extends Omit<HTMLAttributes<HTMLElement>, "as"> {
   nowrap?: boolean;
 
@@ -97,6 +98,7 @@ export interface TextProps extends Omit<HTMLAttributes<HTMLElement>, "as"> {
   as?: "p" | "span" | "li";
 }
 
+/** @deprecated Use `Text` from `@opal/components` with string-enum `font` and `color` props instead. */
 export default function Text({
   nowrap,
   headingH1,

--- a/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/codeVariant.tsx
@@ -1,4 +1,4 @@
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { getCodeLanguage } from "@/lib/languages";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
@@ -27,8 +27,8 @@ export const codeVariant: PreviewVariant = {
   ),
 
   renderFooterLeft: (ctx) => (
-    <Text text03 mainUiBody className="select-none">
-      {ctx.lineCount} {ctx.lineCount === 1 ? "line" : "lines"}
+    <Text font="main-ui-body" color="text-03">
+      {`${ctx.lineCount} ${ctx.lineCount === 1 ? "line" : "lines"}`}
     </Text>
   ),
 

--- a/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/dataVariant.tsx
@@ -1,4 +1,4 @@
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { getDataLanguage, getLanguageByMime } from "@/lib/languages";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
@@ -42,8 +42,8 @@ export const dataVariant: PreviewVariant = {
   },
 
   renderFooterLeft: (ctx) => (
-    <Text text03 mainUiBody className="select-none">
-      {ctx.lineCount} {ctx.lineCount === 1 ? "line" : "lines"}
+    <Text font="main-ui-body" color="text-03">
+      {`${ctx.lineCount} ${ctx.lineCount === 1 ? "line" : "lines"}`}
     </Text>
   ),
 

--- a/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/textVariant.tsx
@@ -1,4 +1,4 @@
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { CodePreview } from "@/sections/modals/PreviewModal/variants/CodePreview";
@@ -41,8 +41,8 @@ export const textVariant: PreviewVariant = {
   ),
 
   renderFooterLeft: (ctx) => (
-    <Text text03 mainUiBody className="select-none">
-      {ctx.lineCount} {ctx.lineCount === 1 ? "line" : "lines"}
+    <Text font="main-ui-body" color="text-03">
+      {`${ctx.lineCount} ${ctx.lineCount === 1 ? "line" : "lines"}`}
     </Text>
   ),
 

--- a/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@opal/components";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 
@@ -13,7 +13,7 @@ export const unsupportedVariant: PreviewVariant = {
 
   renderContent: (ctx) => (
     <div className="flex flex-col items-center justify-center flex-1 w-full min-h-0 gap-4 p-6">
-      <Text as="p" text03 mainUiBody>
+      <Text as="p" font="main-ui-body" color="text-03">
         This file format is not supported for preview.
       </Text>
       <a href={ctx.fileUrl} download={ctx.fileName}>

--- a/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/unsupportedVariant.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@opal/components";
-import { Text } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
 import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
 


### PR DESCRIPTION
## Description

Adds `@deprecated` JSDoc annotations to the legacy boolean-prop `Text` component (`refresh-components/texts/Text.tsx`) and its `TextProps` interface, directing developers to use the Opal `Text` component (`@opal/components`) with string-enum `font` and `color` props.

Migrates 4 preview modal variant files as examples of the migration pattern:

| Legacy API | Opal API |
|---|---|
| `<Text text03 mainUiBody>` | `<Text font="main-ui-body" color="text-03">` |
| `import Text from "@/refresh-components/texts/Text"` | `import { Text } from "@opal/components"` |

**Files migrated:**
- `textVariant.tsx`
- `codeVariant.tsx`
- `unsupportedVariant.tsx`
- `dataVariant.tsx`

~40 more files still use the legacy API and can be migrated incrementally.

## How Has This Been Tested?

- TypeScript type check passes
- Prettier formatting verified
- Opal Text component renders identically to legacy for the same font/color combinations

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the legacy boolean-prop `Text` and migrates four PreviewModal variants to the `@opal/components` `Text` with enum-based props for consistency.

- **Refactors**
  - Marked legacy `Text` and `TextProps` as `@deprecated`, pointing to `Text` from `@opal/components`.
  - Switched imports to `@opal/components` and replaced boolean props with `font`/`color`; consolidated imports in `unsupportedVariant`.
  - Migrated: `textVariant.tsx`, `codeVariant.tsx`, `unsupportedVariant.tsx`, `dataVariant.tsx`.

<sup>Written for commit f52c3e6c64020373602578fcbc21e286a3e9768f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

