### PR TITLE
fix: paginate role assignments (#10749) to release v3.3

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -43,6 +43,16 @@ LIMITED_ACCESS_ROLE_NAMES = ["Limited Access", "Web-Only Limited Access"]
 
 AD_GROUP_ENUMERATION_THRESHOLD = 100_000
 
+# Page size for SharePoint REST RoleAssignments queries with
+# $expand=Member,RoleDefinitionBindings. Without an explicit $top, SharePoint
+# can stream the entire collection in one chunked response which has been
+# observed to be terminated mid-stream by upstream gateways
+# (ChunkedEncodingError: Response ended prematurely) on items with many
+# assignments. 100 matches Microsoft Graph / SharePoint UI defaults for
+# paged collections and keeps each page well under typical proxy buffer
+# limits while not making the round-trip count overwhelming.
+ROLE_ASSIGNMENTS_PAGE_SIZE = 100
+
 
 def _graph_api_get(
     url: str,
@@ -607,6 +617,7 @@ def get_external_access_from_sharepoint(
 
         sleep_and_retry(
             item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
+                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
                 page_loaded=add_user_and_group_to_sets,
             ),
             "get_external_access_from_sharepoint",
@@ -626,6 +637,7 @@ def get_external_access_from_sharepoint(
 
         sleep_and_retry(
             item.role_assignments.expand(["Member", "RoleDefinitionBindings"]).get_all(
+                page_size=ROLE_ASSIGNMENTS_PAGE_SIZE,
                 page_loaded=add_user_and_group_to_sets,
             ),
             "get_external_access_from_sharepoint",
@@ -773,7 +785,7 @@ def get_sharepoint_external_groups(
     sleep_and_retry(
         client_context.web.role_assignments.expand(
             ["Member", "RoleDefinitionBindings"]
-        ).get_all(page_loaded=add_group_to_sets),
+        ).get_all(page_size=ROLE_ASSIGNMENTS_PAGE_SIZE, page_loaded=add_group_to_sets),
         "get_sharepoint_external_groups",
     )
     groups_and_members: GroupsResult = _get_groups_and_members_recursively(


### PR DESCRIPTION
Cherry-pick of commit 9d7740a1a25b438aa90aac60ac0a02197c364358 to release/v3.3 branch.

Original PR: #10749

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paginated SharePoint `RoleAssignments` fetches to prevent mid-stream truncation and `ChunkedEncodingError`. Sets a 100-item page size for `.get_all` calls with `$expand=Member,RoleDefinitionBindings` to stabilize external permissions sync.

- **Bug Fixes**
  - Added `ROLE_ASSIGNMENTS_PAGE_SIZE = 100` and passed `page_size` to all `role_assignments.get_all(...)` calls.
  - Matches Microsoft defaults; keeps pages under proxy limits without excessive round trips.

<sup>Written for commit 36c5bc83411a88e8ac2934745858dfb2b24eec0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

