### PR TITLE
feat(chat): make MAX_LLM_CYCLES env-configurable

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -24,6 +24,7 @@ from onyx.chat.prompt_utils import build_reminder_message
 from onyx.chat.prompt_utils import build_system_prompt
 from onyx.chat.prompt_utils import get_default_base_system_prompt
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
+from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
@@ -234,14 +235,15 @@ def _try_fallback_tool_extraction(
     return llm_step_result, True
 
 
-# Hardcoded oppinionated value, might breaks down to something like:
+# Default 6 covers the common search → open_url pattern:
 # Cycle 1: Calls web_search for something
 # Cycle 2: Calls open_url for some results
 # Cycle 3: Calls web_search for some other aspect of the question
 # Cycle 4: Calls open_url for some results
 # Cycle 5: Maybe call open_url for some additional results or because last set failed
 # Cycle 6: No more tools available, forced to answer
-MAX_LLM_CYCLES = 6
+# Override via the MAX_LLM_CYCLES env var when running with tool-heavy MCPs
+# that legitimately need more turns. Imported from chat_configs.
 
 
 def _build_context_file_citation_mapping(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -7,6 +7,12 @@ NUM_RETURNED_HITS = 50
 # May be less depending on model
 MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
 
+# Maximum number of LLM cycles (one tool-call round-trip per cycle) before the
+# agent is forced to answer. Default 6 covers the common search → open_url
+# pattern documented at the call site; raise via env when integrating with
+# tool-heavy MCPs that legitimately need more turns.
+MAX_LLM_CYCLES = int(os.environ.get("MAX_LLM_CYCLES") or 6)
+
 # 1 / (1 + DOC_TIME_DECAY * doc-age-in-years), set to 0 to have no decay
 # Capped in Vespa at 0.5
 DOC_TIME_DECAY = float(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -11,7 +11,7 @@ MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
 # agent is forced to answer. Default 6 covers the common search → open_url
 # pattern documented at the call site; raise via env when integrating with
 # tool-heavy MCPs that legitimately need more turns.
-MAX_LLM_CYCLES = int(os.environ.get("MAX_LLM_CYCLES") or 6)
+MAX_LLM_CYCLES: int = int(os.environ.get("MAX_LLM_CYCLES") or 6)
 
 # 1 / (1 + DOC_TIME_DECAY * doc-age-in-years), set to 0 to have no decay
 # Capped in Vespa at 0.5


### PR DESCRIPTION
## Description

Today, `MAX_LLM_CYCLES` (the agent's tool-call iteration cap) is hardcoded at `6` in `backend/onyx/chat/llm_loop.py`:

```python
# Hardcoded oppinionated value, might breaks down to something like:
# Cycle 1: Calls web_search for something
# ...
# Cycle 6: No more tools available, forced to answer
MAX_LLM_CYCLES = 6
```

The default is fine for the documented `web_search → open_url` flow, but tool-heavy MCP integrations (multiple Microsoft Graph + data-warehouse + custom MCPs in one conversation) hit this ceiling well before they're ready to answer, and operators today have to fork and patch the source — or volume-mount a patched copy of `llm_loop.py` over the upstream image — to raise it.

This change moves the constant to `backend/onyx/configs/chat_configs.py` and makes it env-driven, following the same `int(os.environ.get("X") or DEFAULT)` pattern already used by neighbouring chat tunables (`MAX_CHUNKS_FED_TO_CHAT`, `CONTEXT_CHUNKS_ABOVE`, `CONTEXT_CHUNKS_BELOW`, `LLM_SOCKET_READ_TIMEOUT`).

**Behaviour:**
- **Default unchanged** — when `MAX_LLM_CYCLES` is unset, the constant resolves to `6`, identical to current behaviour.
- **No call-site changes** — `llm_loop.py` imports the constant from `chat_configs` instead of redefining it; the in-line comment describing the cycle pattern is preserved at the call-site as helpful context, with a note pointing operators to the env override.
- **No signature, schema, or API surface change.**

**Diff size:** +10 / −2 across 2 files.

## How Has This Been Tested?

Verified locally on the latest `main` (HEAD: `9bf76ac`) by patching the running `onyxdotapp/onyx-backend:latest` container and exercising the import path under several env settings:

```
$ docker exec onyx-api_server-1 python -c \
    "from onyx.configs.chat_configs import MAX_LLM_CYCLES; print(MAX_LLM_CYCLES)"
6
$ docker exec -e MAX_LLM_CYCLES=40 onyx-api_server-1 python -c \
    "from onyx.configs.chat_configs import MAX_LLM_CYCLES; print(MAX_LLM_CYCLES)"
40
$ docker exec -e MAX_LLM_CYCLES=99 onyx-api_server-1 python -c \
    "from onyx.chat.llm_loop import MAX_LLM_CYCLES; print(MAX_LLM_CYCLES)"
99
```

The api_server boots healthy with the patched files and `nginx → /api/health` returns `200`. Default value, override, and the import path through `llm_loop.py` (which is what the agent loop actually consumes) all behave correctly.

`uv run ruff check`, `uv run black --check`, and `uv run ty check` are all clean on both modified files.

No existing tests reference `MAX_LLM_CYCLES` directly, and the constant is only consumed inside the iteration loop (`backend/onyx/chat/llm_loop.py:722-724`), so no test changes are required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the agent’s tool-call iteration limit configurable via the `MAX_LLM_CYCLES` environment variable. The default stays 6; the constant now lives in `backend/onyx/configs/chat_configs.py` (with an explicit `int` annotation) and is imported in `backend/onyx/chat/llm_loop.py`, with no API changes.

<sup>Written for commit bb2b12b78a4240eadf22896e192abe0b86390389. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

