### PR TITLE
chore: [Running GitHub actions for #10780]

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -24,6 +24,7 @@ from onyx.chat.prompt_utils import build_reminder_message
 from onyx.chat.prompt_utils import build_system_prompt
 from onyx.chat.prompt_utils import get_default_base_system_prompt
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
+from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
@@ -234,14 +235,15 @@ def _try_fallback_tool_extraction(
     return llm_step_result, True
 
 
-# Hardcoded oppinionated value, might breaks down to something like:
+# Default 6 covers the common search → open_url pattern:
 # Cycle 1: Calls web_search for something
 # Cycle 2: Calls open_url for some results
 # Cycle 3: Calls web_search for some other aspect of the question
 # Cycle 4: Calls open_url for some results
 # Cycle 5: Maybe call open_url for some additional results or because last set failed
 # Cycle 6: No more tools available, forced to answer
-MAX_LLM_CYCLES = 6
+# Override via the MAX_LLM_CYCLES env var when running with tool-heavy MCPs
+# that legitimately need more turns. Imported from chat_configs.
 
 
 def _build_context_file_citation_mapping(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -7,6 +7,12 @@ NUM_RETURNED_HITS = 50
 # May be less depending on model
 MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
 
+# Maximum number of LLM cycles (one tool-call round-trip per cycle) before the
+# agent is forced to answer. Default 6 covers the common search → open_url
+# pattern documented at the call site; raise via env when integrating with
+# tool-heavy MCPs that legitimately need more turns.
+MAX_LLM_CYCLES = int(os.environ.get("MAX_LLM_CYCLES") or 6)
+
 # 1 / (1 + DOC_TIME_DECAY * doc-age-in-years), set to 0 to have no decay
 # Capped in Vespa at 0.5
 DOC_TIME_DECAY = float(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -11,7 +11,7 @@ MAX_CHUNKS_FED_TO_CHAT = int(os.environ.get("MAX_CHUNKS_FED_TO_CHAT") or 25)
 # agent is forced to answer. Default 6 covers the common search → open_url
 # pattern documented at the call site; raise via env when integrating with
 # tool-heavy MCPs that legitimately need more turns.
-MAX_LLM_CYCLES = int(os.environ.get("MAX_LLM_CYCLES") or 6)
+MAX_LLM_CYCLES: int = int(os.environ.get("MAX_LLM_CYCLES") or 6)
 
 # 1 / (1 + DOC_TIME_DECAY * doc-age-in-years), set to 0 to have no decay
 # Capped in Vespa at 0.5


### PR DESCRIPTION
Automated mirror of PR #10780 so private CI can run.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch. 
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the agent’s tool-call cycle limit configurable via the `MAX_LLM_CYCLES` env var so operators can raise it without code changes. Default remains 6 for the common search → open_url flow.

- **New Features**
  - Added `MAX_LLM_CYCLES` to `chat_configs` (env-driven, default 6; explicit type).
  - Updated `llm_loop` to import the constant and keep inline guidance.
  - No behavior change unless `MAX_LLM_CYCLES` is set.

<sup>Written for commit bb2b12b78a4240eadf22896e192abe0b86390389. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

