### PR TITLE
chore(embedding): Cache query embeddings

### DIFF
--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -8,12 +8,14 @@ TTL_KEY_NOT_FOUND = -2
 TTL_NO_EXPIRY = -1
 
 CACHE_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (RedisError, SQLAlchemyError)
-"""Exception types that represent transient cache connectivity / operational
-failures.  Callers that want to fail-open (or fail-closed) on cache errors
-should catch this tuple instead of bare ``Exception``.
+"""
+Exception types that represent transient cache connectivity / operational
+failures. Callers that want to fail-open (or fail-closed) on cache errors should
+catch this tuple instead of bare ``Exception``.
 
-When adding a new ``CacheBackend`` implementation, add its transient error
-base class(es) here so all call-sites pick it up automatically."""
+When adding a new ``CacheBackend`` implementation, add its transient error base
+class(es) here so all call-sites pick it up automatically.
+"""
 
 
 class CacheBackendType(str, Enum):

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -86,6 +86,13 @@ CACHE_BACKEND = CacheBackendType(
     os.environ.get("CACHE_BACKEND", CacheBackendType.REDIS)
 )
 
+# Cache query embeddings in the configured cache backend so identical queries
+# (across users / agentic sub-queries) don't re-hit the embedding provider.
+QUERY_EMBEDDING_CACHE_ENABLED = (
+    os.environ.get("QUERY_EMBEDDING_CACHE_ENABLED", "true").lower() == "true"
+)
+QUERY_EMBEDDING_CACHE_TTL_S = int(os.environ.get("QUERY_EMBEDDING_CACHE_TTL_S", "900"))
+
 # If set to true, will show extra/uncommon connectors in the "Other" category
 SHOW_EXTRA_CONNECTORS = os.environ.get("SHOW_EXTRA_CONNECTORS", "").lower() == "true"
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -91,7 +91,11 @@ CACHE_BACKEND = CacheBackendType(
 QUERY_EMBEDDING_CACHE_ENABLED = (
     os.environ.get("QUERY_EMBEDDING_CACHE_ENABLED", "true").lower() == "true"
 )
-QUERY_EMBEDDING_CACHE_TTL_S = int(os.environ.get("QUERY_EMBEDDING_CACHE_TTL_S", "900"))
+assert (
+    QUERY_EMBEDDING_CACHE_TTL_S := int(
+        os.environ.get("QUERY_EMBEDDING_CACHE_TTL_S", "900")
+    )
+) > 0, "QUERY_EMBEDDING_CACHE_TTL_S must be positive."
 
 # If set to true, will show extra/uncommon connectors in the "Other" category
 SHOW_EXTRA_CONNECTORS = os.environ.get("SHOW_EXTRA_CONNECTORS", "").lower() == "true"

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -99,13 +99,12 @@ def get_query_embeddings(
         # Cache key needs search_settings.id even when the caller already
         # supplied an embedding_model.
         search_settings = get_current_search_settings(db_session)
+    assert search_settings is not None, "Bug: search_settings is None."
 
     result: list[Embedding] = []
-    cache_usable = (
-        QUERY_EMBEDDING_CACHE_ENABLED and search_settings is not None and bool(queries)
-    )
+    cache_usable: bool = QUERY_EMBEDDING_CACHE_ENABLED and bool(queries)
     if not cache_usable:
-        if queries and search_settings is not None:
+        if queries:
             record_cache_skipped(embedding_model.provider_type, count=len(queries))
         result = embedding_model.encode(queries, text_type=EmbedTextType.QUERY)
         assert len(result) == len(
@@ -113,7 +112,6 @@ def get_query_embeddings(
         ), "Bug: The length of embeddings does not match the length of queries."
         return result
 
-    assert search_settings is not None, "Bug: search_settings is None."
     cached = get_cached_query_embeddings(
         queries=queries,
         search_settings_id=search_settings.id,

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -4,13 +4,23 @@ from typing import TypeVar
 
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import QUERY_EMBEDDING_CACHE_ENABLED
+from onyx.configs.app_configs import QUERY_EMBEDDING_CACHE_TTL_S
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import SavedSearchDoc
 from onyx.context.search.models import SavedSearchDocWithContent
 from onyx.context.search.models import SearchDoc
 from onyx.db.document import get_document_id_to_file_id_map
+from onyx.db.models import SearchSettings
 from onyx.db.search_settings import get_current_search_settings
+from onyx.natural_language_processing.query_embedding_cache import (
+    cache_query_embeddings,
+)
+from onyx.natural_language_processing.query_embedding_cache import (
+    get_cached_query_embeddings,
+)
+from onyx.natural_language_processing.query_embedding_cache import record_cache_skipped
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.utils.logger import setup_logger
 from onyx.utils.timing import log_function_time
@@ -75,6 +85,7 @@ def get_query_embeddings(
     db_session: Session | None = None,
     embedding_model: EmbeddingModel | None = None,
 ) -> list[Embedding]:
+    search_settings: SearchSettings | None = None
     if embedding_model is None:
         if db_session is None:
             raise ValueError("Either db_session or embedding_model must be provided")
@@ -84,9 +95,63 @@ def get_query_embeddings(
             server_host=MODEL_SERVER_HOST,
             server_port=MODEL_SERVER_PORT,
         )
+    elif db_session is not None:
+        # Cache key needs search_settings.id even when the caller already
+        # supplied an embedding_model.
+        search_settings = get_current_search_settings(db_session)
 
-    query_embedding = embedding_model.encode(queries, text_type=EmbedTextType.QUERY)
-    return query_embedding
+    result: list[Embedding] = []
+    cache_usable = (
+        QUERY_EMBEDDING_CACHE_ENABLED and search_settings is not None and bool(queries)
+    )
+    if not cache_usable:
+        if queries and search_settings is not None:
+            record_cache_skipped(embedding_model.provider_type, count=len(queries))
+        result = embedding_model.encode(queries, text_type=EmbedTextType.QUERY)
+        assert len(result) == len(
+            queries
+        ), "Bug: The length of embeddings does not match the length of queries."
+        return result
+
+    assert search_settings is not None, "Bug: search_settings is None."
+    cached = get_cached_query_embeddings(
+        queries=queries,
+        search_settings_id=search_settings.id,
+        provider_type=embedding_model.provider_type,
+        ttl_seconds=QUERY_EMBEDDING_CACHE_TTL_S,
+    )
+
+    miss_indices = [i for i, value in enumerate(cached) if value is None]
+    if not miss_indices:
+        result = [emb for emb in cached if emb is not None]
+        assert len(result) == len(
+            queries
+        ), "Bug: The length of embeddings does not match the length of queries."
+        return result
+
+    miss_queries = [queries[i] for i in miss_indices]
+    fresh_embeddings = embedding_model.encode(
+        miss_queries, text_type=EmbedTextType.QUERY
+    )
+
+    cache_query_embeddings(
+        queries=miss_queries,
+        embeddings=fresh_embeddings,
+        search_settings_id=search_settings.id,
+        provider_type=embedding_model.provider_type,
+        ttl_seconds=QUERY_EMBEDDING_CACHE_TTL_S,
+    )
+
+    fresh_iter = iter(fresh_embeddings)
+    for value in cached:
+        if value is None:
+            result.append(next(fresh_iter))
+        else:
+            result.append(value)
+    assert len(result) == len(
+        queries
+    ), "Bug: The length of embeddings does not match the length of queries."
+    return result
 
 
 @log_function_time(print_only=True, debug_only=True)

--- a/backend/onyx/context/search/utils.py
+++ b/backend/onyx/context/search/utils.py
@@ -99,10 +99,11 @@ def get_query_embeddings(
         # Cache key needs search_settings.id even when the caller already
         # supplied an embedding_model.
         search_settings = get_current_search_settings(db_session)
-    assert search_settings is not None, "Bug: search_settings is None."
 
     result: list[Embedding] = []
-    cache_usable: bool = QUERY_EMBEDDING_CACHE_ENABLED and bool(queries)
+    cache_usable: bool = (
+        QUERY_EMBEDDING_CACHE_ENABLED and bool(queries) and search_settings is not None
+    )
     if not cache_usable:
         if queries:
             record_cache_skipped(embedding_model.provider_type, count=len(queries))
@@ -111,6 +112,7 @@ def get_query_embeddings(
             queries
         ), "Bug: The length of embeddings does not match the length of queries."
         return result
+    assert search_settings is not None, "Bug: search_settings is None."
 
     cached = get_cached_query_embeddings(
         queries=queries,

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -105,9 +105,11 @@ def get_opensearch_doc_chunk_id(
         )
     except DocumentIDTooLongError:
         # If the document ID is too long, use a hash instead.
-        # We use blake2b because it is faster and equally secure as SHA256, and
+        # We use blake2b because it is faster and equally secure as SHA-256, and
         # accepts digest_size which controls the number of bytes returned in the
-        # hash.
+        # hash. Edit: Actually modern CPUs have good hardware acceleration
+        # specifically for SHA-256 so really blake2b is not expected to be
+        # faster in some production settings.
         # digest_size is the size of the returned hash in bytes. Since we're
         # decoding the hash bytes as a hex string, the digest_size should be
         # half the max target size of the hash string.

--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -64,6 +64,9 @@ def _safe_unpack_or_none(buf: bytes) -> Embedding | None:
     Returns:
         The deserialized embedding or None if the unpacking failed.
     """
+    if len(buf) % 4 != 0 or len(buf) == 0:
+        logger.warning("Invalid embedding buffer length: %d bytes.", len(buf))
+        return None
     try:
         num_floats = len(buf) // 4
         return list(struct.unpack(f"<{num_floats}f", buf))

--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -1,0 +1,254 @@
+"""Tenant-scoped Redis/Postgres cache for query embeddings.
+
+Sits in front of ``EmbeddingModel.encode`` for ``EmbedTextType.QUERY`` calls. A
+cache hit avoids a network round-trip to the embedding provider.
+
+Tenancy is handled by ``TenantRedis`` automatically prefixing every key with the
+current tenant id, so two tenants never share an entry even if model id and
+query text are identical. Model identity comes from ``search_settings.id`` —
+``PRESERVED_SEARCH_FIELDS`` guarantees that every field that affects the
+resulting vector is immutable for a given id, so a model swap allocates a new
+row + new id and old entries simply expire.
+
+Vectors are stored as packed little-endian ``float32`` (``4 * dim`` bytes); the
+consumer already knows the dim from ``SearchSettings`` so no length prefix is
+needed.
+"""
+
+import hashlib
+import struct
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.server.metrics.embedding import observe_query_embedding_cache_lookup
+from onyx.server.metrics.embedding import observe_query_embedding_cache_write
+from onyx.server.metrics.embedding import QueryEmbeddingCacheLookupOutcome
+from onyx.server.metrics.embedding import QueryEmbeddingCacheWriteOutcome
+from onyx.utils.logger import setup_logger
+from shared_configs.enums import EmbeddingProvider
+from shared_configs.model_server_models import Embedding
+
+logger = setup_logger()
+
+
+_EMBEDDING_CACHE_KEY_PREFIX = "query_emb"
+
+
+def _build_key(query: str, search_settings_id: int) -> str:
+    digest = hashlib.sha256(query.encode("utf-8")).hexdigest()
+    return f"{_EMBEDDING_CACHE_KEY_PREFIX}:{search_settings_id}:{digest}"
+
+
+def _pack(vector: Embedding) -> bytes:
+    """Serializes an embedding to a little-endian float32 buffer.
+
+    Args:
+        vector: The embedding to serialize.
+
+    Returns:
+        The little-endian float32 buffer.
+    """
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def _unpack(buf: bytes) -> Embedding:
+    """Deserializes a little-endian float32 buffer to an embedding.
+
+    Args:
+        buf: The little-endian float32 buffer to deserialize.
+
+    Returns:
+        The deserialized embedding.
+    """
+    num_floats = len(buf) // 4
+    return list(struct.unpack(f"<{num_floats}f", buf))
+
+
+def get_cached_query_embeddings(
+    queries: list[str],
+    search_settings_id: int,
+    provider_type: EmbeddingProvider | None,
+    ttl_seconds: int,
+) -> list[Embedding | None]:
+    """Looks up each query in the cache.
+
+    Returns a list aligned with ``queries``: ``Embedding`` for hits, ``None``
+    for misses. On a hit, the entry's TTL is refreshed so hot keys stay resident
+    and cold ones expire.
+
+    Fails open: any ``CACHE_TRANSIENT_ERRORS`` is logged and treated as a miss
+    for that query.
+
+    Args:
+        queries: The queries to look up.
+        search_settings_id: The row ID of the search settings. NOTE: This is
+            only uniquely-identifying within a tenant. This function must use a
+            Redis client that is scoped to the current tenant.
+        provider_type: The type of the embedding provider. Only used for
+            observability.
+        ttl_seconds: The TTL for the cache entries in seconds.
+
+    Returns:
+        The list of embeddings or None for misses.
+    """
+    if not queries:
+        return []
+
+    results: list[Embedding | None] = [None] * len(queries)
+    try:
+        backend = get_cache_backend()
+    except CACHE_TRANSIENT_ERRORS:
+        logger.warning(
+            "Failed to obtain cache backend for query embedding cache; "
+            "treating all queries as misses.",
+            exc_info=True,
+        )
+        observe_query_embedding_cache_lookup(
+            provider_type,
+            outcome=QueryEmbeddingCacheLookupOutcome.ERROR,
+            count=len(queries),
+        )
+        return results
+
+    hits = 0
+    misses = 0
+    errors = 0
+
+    for i, query in enumerate(queries):
+        key = _build_key(query, search_settings_id)
+        try:
+            raw = backend.get(key)
+        except CACHE_TRANSIENT_ERRORS:
+            logger.warning(
+                "Query embedding cache get failed; treating as miss.", exc_info=True
+            )
+            errors += 1
+            continue
+
+        if raw is None:
+            misses += 1
+            continue
+
+        try:
+            results[i] = _unpack(raw)
+        except struct.error:
+            # Corrupt entry — treat as miss; will be overwritten on the
+            # next encode + write.
+            logger.warning(
+                "Corrupt query embedding cache entry at %s; treating as miss.", key
+            )
+            misses += 1
+            continue
+
+        hits += 1
+        # Refresh TTL by re-setting the value. ``backend.expire`` would be a
+        # cheaper round trip but ``TenantRedis`` doesn't currently prefix
+        # ``EXPIRE`` calls, so the EXPIRE would target the wrong key. Re-set is
+        # one byte heavier on the wire and entirely safe.
+        try:
+            backend.set(key, raw, ex=ttl_seconds)
+        except CACHE_TRANSIENT_ERRORS:
+            logger.debug("Failed to refresh TTL for %s.", key, exc_info=True)
+
+    observe_query_embedding_cache_lookup(
+        provider_type, outcome=QueryEmbeddingCacheLookupOutcome.HIT, count=hits
+    )
+    observe_query_embedding_cache_lookup(
+        provider_type, outcome=QueryEmbeddingCacheLookupOutcome.MISS, count=misses
+    )
+    observe_query_embedding_cache_lookup(
+        provider_type, outcome=QueryEmbeddingCacheLookupOutcome.ERROR, count=errors
+    )
+
+    logger.debug(
+        "Query embedding cache lookup: hits=%d misses=%d errors=%d total=%d",
+        hits,
+        misses,
+        errors,
+        len(queries),
+    )
+    return results
+
+
+def cache_query_embeddings(
+    queries: list[str],
+    embeddings: list[Embedding],
+    search_settings_id: int,
+    provider_type: EmbeddingProvider | None,
+    ttl_seconds: int,
+) -> None:
+    """Writes each (query, embedding) pair into the cache with the given TTL.
+
+    Fails open: any ``CACHE_TRANSIENT_ERRORS`` is logged and swallowed so cache
+    write errors never break a search.
+
+    Args:
+        queries: The queries to cache.
+        embeddings: The embeddings to cache.
+        search_settings_id: The row ID of the search settings. NOTE: This is
+            only uniquely-identifying within a tenant. This function must use a
+            Redis client that is scoped to the current tenant.
+        provider_type: The type of the embedding provider. Only used for
+            observability.
+        ttl_seconds: The TTL for the cache entries in seconds.
+
+    Raises:
+        ValueError: If the length of ``queries`` and ``embeddings`` are not the
+            same.
+    """
+    if not queries:
+        return
+
+    if len(queries) != len(embeddings):
+        raise ValueError(
+            f"queries ({len(queries)}) and embeddings ({len(embeddings)}) "
+            "must be the same length."
+        )
+
+    try:
+        backend = get_cache_backend()
+    except CACHE_TRANSIENT_ERRORS:
+        logger.warning(
+            "Failed to obtain cache backend for query embedding cache write.",
+            exc_info=True,
+        )
+        observe_query_embedding_cache_write(
+            provider_type,
+            outcome=QueryEmbeddingCacheWriteOutcome.ERROR,
+            count=len(queries),
+        )
+        return
+
+    successes = 0
+    errors = 0
+    for query, embedding in zip(queries, embeddings):
+        key = _build_key(query, search_settings_id)
+        try:
+            backend.set(key, _pack(embedding), ex=ttl_seconds)
+            successes += 1
+        except CACHE_TRANSIENT_ERRORS:
+            logger.warning(
+                "Query embedding cache set failed; continuing.", exc_info=True
+            )
+            errors += 1
+
+    observe_query_embedding_cache_write(
+        provider_type,
+        outcome=QueryEmbeddingCacheWriteOutcome.SUCCESS,
+        count=successes,
+    )
+    observe_query_embedding_cache_write(
+        provider_type, outcome=QueryEmbeddingCacheWriteOutcome.ERROR, count=errors
+    )
+
+
+def record_cache_skipped(provider_type: EmbeddingProvider | None, count: int) -> None:
+    """
+    Records that the cache was skipped for ``count`` queries (e.g. because the
+    kill-switch is off, or no ``search_settings`` was available).
+    """
+    observe_query_embedding_cache_lookup(
+        provider_type,
+        outcome=QueryEmbeddingCacheLookupOutcome.SKIPPED,
+        count=count,
+    )

--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -39,29 +39,37 @@ def _build_key(query: str, search_settings_id: int) -> str:
     return f"{_EMBEDDING_CACHE_KEY_PREFIX}:{search_settings_id}:{digest}"
 
 
-def _pack(vector: Embedding) -> bytes:
+def _safe_pack_or_none(vector: Embedding) -> bytes | None:
     """Serializes an embedding to a little-endian float32 buffer.
 
     Args:
         vector: The embedding to serialize.
 
     Returns:
-        The little-endian float32 buffer.
+        The little-endian float32 buffer or None if the packing failed.
     """
-    return struct.pack(f"<{len(vector)}f", *vector)
+    try:
+        return struct.pack(f"<{len(vector)}f", *vector)
+    except struct.error:
+        logger.warning("Failed to pack embedding.", exc_info=True)
+        return None
 
 
-def _unpack(buf: bytes) -> Embedding:
+def _safe_unpack_or_none(buf: bytes) -> Embedding | None:
     """Deserializes a little-endian float32 buffer to an embedding.
 
     Args:
         buf: The little-endian float32 buffer to deserialize.
 
     Returns:
-        The deserialized embedding.
+        The deserialized embedding or None if the unpacking failed.
     """
-    num_floats = len(buf) // 4
-    return list(struct.unpack(f"<{num_floats}f", buf))
+    try:
+        num_floats = len(buf) // 4
+        return list(struct.unpack(f"<{num_floats}f", buf))
+    except struct.error:
+        logger.warning("Failed to unpack embedding.", exc_info=True)
+        return None
 
 
 def get_cached_query_embeddings(
@@ -96,7 +104,7 @@ def get_cached_query_embeddings(
 
     results: list[Embedding | None] = [None] * len(queries)
     try:
-        backend = get_cache_backend()
+        cache_backend = get_cache_backend()
     except CACHE_TRANSIENT_ERRORS:
         logger.warning(
             "Failed to obtain cache backend for query embedding cache; "
@@ -117,7 +125,7 @@ def get_cached_query_embeddings(
     for i, query in enumerate(queries):
         key = _build_key(query, search_settings_id)
         try:
-            raw = backend.get(key)
+            raw = cache_backend.get(key)
         except CACHE_TRANSIENT_ERRORS:
             logger.warning(
                 "Query embedding cache get failed; treating as miss.", exc_info=True
@@ -129,11 +137,8 @@ def get_cached_query_embeddings(
             misses += 1
             continue
 
-        try:
-            results[i] = _unpack(raw)
-        except struct.error:
-            # Corrupt entry — treat as miss; will be overwritten on the
-            # next encode + write.
+        results[i] = _safe_unpack_or_none(raw)
+        if results[i] is None:
             logger.warning(
                 "Corrupt query embedding cache entry at %s; treating as miss.", key
             )
@@ -146,7 +151,7 @@ def get_cached_query_embeddings(
         # ``EXPIRE`` calls, so the EXPIRE would target the wrong key. Re-set is
         # one byte heavier on the wire and entirely safe.
         try:
-            backend.set(key, raw, ex=ttl_seconds)
+            cache_backend.set(key, raw, ex=ttl_seconds)
         except CACHE_TRANSIENT_ERRORS:
             logger.debug("Failed to refresh TTL for %s.", key, exc_info=True)
 
@@ -206,7 +211,7 @@ def cache_query_embeddings(
         )
 
     try:
-        backend = get_cache_backend()
+        cache_backend = get_cache_backend()
     except CACHE_TRANSIENT_ERRORS:
         logger.warning(
             "Failed to obtain cache backend for query embedding cache write.",
@@ -224,7 +229,11 @@ def cache_query_embeddings(
     for query, embedding in zip(queries, embeddings):
         key = _build_key(query, search_settings_id)
         try:
-            backend.set(key, _pack(embedding), ex=ttl_seconds)
+            packed = _safe_pack_or_none(embedding)
+            if packed is None:
+                errors += 1
+                continue
+            cache_backend.set(key, packed, ex=ttl_seconds)
             successes += 1
         except CACHE_TRANSIENT_ERRORS:
             logger.warning(

--- a/backend/onyx/server/metrics/embedding.py
+++ b/backend/onyx/server/metrics/embedding.py
@@ -1,15 +1,13 @@
 """Prometheus metrics for embedding generation latency and throughput.
 
 Tracks client-side round-trip latency (as seen by callers of
-``EmbeddingModel.encode``) and server-side execution time (as measured inside
-the model server for the local-model path). Both API-provider and local-model
-paths flow through the client-side metric; only the local path populates the
-server-side metric.
+``EmbeddingModel.encode``).
 """
 
 import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from enum import Enum
 
 from prometheus_client import Counter
 from prometheus_client import Gauge
@@ -17,6 +15,19 @@ from prometheus_client import Histogram
 
 from shared_configs.enums import EmbeddingProvider
 from shared_configs.enums import EmbedTextType
+
+
+class QueryEmbeddingCacheLookupOutcome(str, Enum):
+    HIT = "hit"
+    MISS = "miss"
+    ERROR = "error"
+    SKIPPED = "skipped"
+
+
+class QueryEmbeddingCacheWriteOutcome(str, Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +83,20 @@ _embeddings_in_progress = Gauge(
     [PROVIDER_LABEL_NAME, TEXT_TYPE_LABEL_NAME],
 )
 
+CACHE_OUTCOME_LABEL_NAME = "outcome"
+
+_query_embedding_cache_lookups_total = Counter(
+    "onyx_query_embedding_cache_lookups_total",
+    "Query-embedding cache lookups, labeled by outcome.",
+    [PROVIDER_LABEL_NAME, CACHE_OUTCOME_LABEL_NAME],
+)
+
+_query_embedding_cache_writes_total = Counter(
+    "onyx_query_embedding_cache_writes_total",
+    "Query-embedding cache writes, labeled by outcome.",
+    [PROVIDER_LABEL_NAME, CACHE_OUTCOME_LABEL_NAME],
+)
+
 
 def provider_label(provider: EmbeddingProvider | None) -> str:
     if provider is None:
@@ -117,6 +142,42 @@ def observe_embedding_client(
             ).inc(num_chars)
     except Exception:
         logger.warning("Failed to record embedding client metrics.", exc_info=True)
+
+
+def observe_query_embedding_cache_lookup(
+    provider: EmbeddingProvider | None,
+    outcome: QueryEmbeddingCacheLookupOutcome,
+    count: int = 1,
+) -> None:
+    """Records the result of cache lookups for query embeddings."""
+    if count <= 0:
+        return
+    try:
+        _query_embedding_cache_lookups_total.labels(
+            provider=provider_label(provider), outcome=outcome.value
+        ).inc(count)
+    except Exception:
+        logger.warning(
+            "Failed to record query-embedding cache lookup metric.", exc_info=True
+        )
+
+
+def observe_query_embedding_cache_write(
+    provider: EmbeddingProvider | None,
+    outcome: QueryEmbeddingCacheWriteOutcome,
+    count: int = 1,
+) -> None:
+    """Records the result of cache writes for query embeddings."""
+    if count <= 0:
+        return
+    try:
+        _query_embedding_cache_writes_total.labels(
+            provider=provider_label(provider), outcome=outcome.value
+        ).inc(count)
+    except Exception:
+        logger.warning(
+            "Failed to record query-embedding cache write metric.", exc_info=True
+        )
 
 
 @contextmanager

--- a/backend/tests/external_dependency_unit/natural_language_processing/conftest.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/conftest.py
@@ -1,0 +1,12 @@
+import struct
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def test_embedding() -> list[float]:
+    # Each value is narrowed to float32 then back to float64 so it survives the
+    # cache's float32 packing exactly — tests can assert with `==` instead of
+    # tolerating rounding via pytest.approx.
+    raw = [0.5, -0.5, 0.25, 0.1, -0.2, 3.4, 0.0, 1e-3]
+    return [struct.unpack("<f", struct.pack("<f", v))[0] for v in raw]

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
+from uuid import uuid4
 
-import pytest
 from sqlalchemy.orm import Session
 
 from onyx.context.search.utils import get_query_embeddings
@@ -28,6 +28,7 @@ class TestWiring:
         self,
         full_deployment_setup: None,  # noqa: ARG002
         db_session: Session,
+        test_embedding: list[float],
     ) -> None:
         """
         Tests that the second call to get_query_embeddings skips the encode call
@@ -35,8 +36,8 @@ class TestWiring:
         """
         # Precondition.
         # Make a unique query so prior test runs don't pollute the assertion.
-        query = "testing wiring"
-        emb = [[0.5, -0.5, 0.25]]
+        query = f"testing wiring {uuid4().hex[:8]}"
+        emb = [test_embedding]
 
         model, encode = _make_fake_embedding_model(emb)
         first = get_query_embeddings(
@@ -56,7 +57,7 @@ class TestWiring:
 
         # Postcondition.
         assert encode2.call_count == 0
-        assert second[0] == pytest.approx(first[0])
+        assert second == first
 
     def test_partial_fill_only_encodes_misses(
         self,
@@ -68,7 +69,7 @@ class TestWiring:
         in the cache.
         """
         # Precondition.
-        q_hit = "testing partial hit"
+        q_hit = f"testing partial hit {uuid4().hex[:8]}"
         q_miss = "testing partial miss"
 
         model, encode = _make_fake_embedding_model([[1.0, 1.0]])
@@ -94,9 +95,9 @@ class TestWiring:
         assert miss_call.args[0] == [q_miss]
         assert miss_call.kwargs.get("text_type") == EmbedTextType.QUERY
 
-        assert results[0] == pytest.approx([1.0, 1.0])
-        assert results[1] == pytest.approx([2.0, 2.0])
-        assert results[2] == pytest.approx([1.0, 1.0])
+        assert results[0] == [1.0, 1.0]
+        assert results[1] == [2.0, 2.0]
+        assert results[2] == [1.0, 1.0]
 
     def test_disabled_flag_skips_cache(
         self,
@@ -133,7 +134,7 @@ class TestWiring:
         even for the same query.
         """
         # Precondition.
-        query = "testing search settings isolation"
+        query = f"testing search settings isolation {uuid4().hex[:8]}"
         emb = [[9.0, 9.0]]
 
         model, _ = _make_fake_embedding_model(emb)

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
@@ -70,7 +70,7 @@ class TestWiring:
         """
         # Precondition.
         q_hit = f"testing partial hit {uuid4().hex[:8]}"
-        q_miss = "testing partial miss"
+        q_miss = f"testing partial miss {uuid4().hex[:8]}"
 
         model, encode = _make_fake_embedding_model([[1.0, 1.0]])
         get_query_embeddings(

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
@@ -46,7 +46,7 @@ class TestWiring:
         assert first == emb
         assert encode.call_count == 1
 
-        # Same query, fresh model → cache hit, encode must NOT be invoked. This
+        # Same query, fresh model -> cache hit, encode must NOT be invoked. This
         # is because SearchSettings ID is used for the cache key, not the model.
         model2, encode2 = _make_fake_embedding_model([[0.0, 0.0, 0.0]])
 

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_get_query_embeddings.py
@@ -1,0 +1,162 @@
+"""Tests that the cache is wired correctly into ``get_query_embeddings``."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.context.search.utils import get_query_embeddings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
+from shared_configs.enums import EmbedTextType
+
+
+def _make_fake_embedding_model(
+    encode_return: list[list[float]],
+) -> tuple[MagicMock, MagicMock]:
+    """Returns ``(model_mock, encode_mock)`` so callers can inspect calls."""
+    model = MagicMock(spec=EmbeddingModel)
+    model.provider_type = None
+    encode = MagicMock(return_value=encode_return)
+    model.encode = encode
+    return model, encode
+
+
+class TestWiring:
+    def test_second_call_skips_encode_after_cache_warm(
+        self,
+        full_deployment_setup: None,  # noqa: ARG002
+        db_session: Session,
+    ) -> None:
+        """
+        Tests that the second call to get_query_embeddings skips the encode call
+        after the cache is warmed.
+        """
+        # Precondition.
+        # Make a unique query so prior test runs don't pollute the assertion.
+        query = "testing wiring"
+        emb = [[0.5, -0.5, 0.25]]
+
+        model, encode = _make_fake_embedding_model(emb)
+        first = get_query_embeddings(
+            queries=[query], db_session=db_session, embedding_model=model
+        )
+        assert first == emb
+        assert encode.call_count == 1
+
+        # Same query, fresh model → cache hit, encode must NOT be invoked. This
+        # is because SearchSettings ID is used for the cache key, not the model.
+        model2, encode2 = _make_fake_embedding_model([[0.0, 0.0, 0.0]])
+
+        # Under test.
+        second = get_query_embeddings(
+            queries=[query], db_session=db_session, embedding_model=model2
+        )
+
+        # Postcondition.
+        assert encode2.call_count == 0
+        assert second[0] == pytest.approx(first[0])
+
+    def test_partial_fill_only_encodes_misses(
+        self,
+        full_deployment_setup: None,  # noqa: ARG002
+        db_session: Session,
+    ) -> None:
+        """
+        Tests that the encode call is only called for the queries that are not
+        in the cache.
+        """
+        # Precondition.
+        q_hit = "testing partial hit"
+        q_miss = "testing partial miss"
+
+        model, encode = _make_fake_embedding_model([[1.0, 1.0]])
+        get_query_embeddings(
+            queries=[q_hit], db_session=db_session, embedding_model=model
+        )
+        assert encode.call_count == 1
+
+        # Now ask for [hit, miss, hit]; encode must be called only once,
+        # with exactly the missing query.
+        model2, encode2 = _make_fake_embedding_model([[2.0, 2.0]])
+
+        # Under test.
+        results = get_query_embeddings(
+            queries=[q_hit, q_miss, q_hit],
+            db_session=db_session,
+            embedding_model=model2,
+        )
+
+        # Postcondition.
+        assert encode2.call_count == 1
+        miss_call = encode2.call_args_list[0]
+        assert miss_call.args[0] == [q_miss]
+        assert miss_call.kwargs.get("text_type") == EmbedTextType.QUERY
+
+        assert results[0] == pytest.approx([1.0, 1.0])
+        assert results[1] == pytest.approx([2.0, 2.0])
+        assert results[2] == pytest.approx([1.0, 1.0])
+
+    def test_disabled_flag_skips_cache(
+        self,
+        full_deployment_setup: None,  # noqa: ARG002
+        db_session: Session,
+    ) -> None:
+        """
+        Tests that the cache is skipped when the cache is disabled.
+        """
+        # Precondition.
+        query = "testing disabled cache"
+
+        model, encode = _make_fake_embedding_model([[7.0]])
+        with patch("onyx.context.search.utils.QUERY_EMBEDDING_CACHE_ENABLED", False):
+            # Under test.
+            get_query_embeddings(
+                queries=[query], db_session=db_session, embedding_model=model
+            )
+            # Second call should also encode, since cache is off.
+            get_query_embeddings(
+                queries=[query], db_session=db_session, embedding_model=model
+            )
+
+        # Postcondition.
+        assert encode.call_count == 2
+
+    def test_search_settings_id_drives_isolation(
+        self,
+        full_deployment_setup: None,  # noqa: ARG002
+        db_session: Session,
+    ) -> None:
+        """
+        Tests that different search settings IDs are isolated from each other
+        even for the same query.
+        """
+        # Precondition.
+        query = "testing search settings isolation"
+        emb = [[9.0, 9.0]]
+
+        model, _ = _make_fake_embedding_model(emb)
+        get_query_embeddings(
+            queries=[query], db_session=db_session, embedding_model=model
+        )
+
+        # Pretend a different active model is in use; the cache key is
+        # built from search_settings.id, so a different id means a miss.
+        real_settings = get_current_search_settings(db_session)
+        fake = MagicMock()
+        fake.id = real_settings.id + 999_999
+        with patch(
+            "onyx.context.search.utils.get_current_search_settings",
+            return_value=fake,
+        ):
+            # Under test.
+            model2, encode2 = _make_fake_embedding_model([[8.0, 8.0]])
+            get_query_embeddings(
+                queries=[query],
+                db_session=db_session,
+                embedding_model=model2,
+            )
+
+            # Postcondition.
+            assert encode2.call_count == 1

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_query_embedding_cache.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_query_embedding_cache.py
@@ -38,16 +38,15 @@ def _write_count(provider: str, outcome: str) -> float:
 
 
 class TestCacheThenRetrieve:
-    def test_round_trip_preserves_floats(self) -> None:
+    def test_round_trip_preserves_floats(self, test_embedding: list[float]) -> None:
         """
         Tests that the cache round trip preserves the floats.
         """
         # Precondition.
         query = _unique_query()
-        embedding = [0.1, -0.2, 3.4, 0.0, 1e-3]
         cache_query_embeddings(
             queries=[query],
-            embeddings=[embedding],
+            embeddings=[test_embedding],
             search_settings_id=1,
             provider_type=None,
             ttl_seconds=60,
@@ -63,7 +62,7 @@ class TestCacheThenRetrieve:
 
         # Postcondition.
         assert got[0] is not None
-        assert got[0] == embedding
+        assert got[0] == test_embedding
 
     def test_miss_returns_none(self) -> None:
         """
@@ -158,7 +157,7 @@ class TestTenantIsolation:
             ttl_seconds=60,
         )
 
-        other_tenant = f"tenant_{uuid4().hex[:8]}"
+        other_tenant = f"tenant_test_other_{uuid4().hex[:8]}"
         token = CURRENT_TENANT_ID_CONTEXTVAR.set(other_tenant)
         try:
             # Under test.

--- a/backend/tests/external_dependency_unit/natural_language_processing/test_query_embedding_cache.py
+++ b/backend/tests/external_dependency_unit/natural_language_processing/test_query_embedding_cache.py
@@ -1,0 +1,260 @@
+"""Tests for the query embedding cache module against a real cache backend."""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from prometheus_client import REGISTRY
+from redis.exceptions import RedisError
+
+from onyx.cache.factory import get_cache_backend
+from onyx.natural_language_processing.query_embedding_cache import _build_key
+from onyx.natural_language_processing.query_embedding_cache import (
+    cache_query_embeddings,
+)
+from onyx.natural_language_processing.query_embedding_cache import (
+    get_cached_query_embeddings,
+)
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def _unique_query() -> str:
+    return f"hello world {uuid4().hex[:8]}"
+
+
+def _lookup_count(provider: str, outcome: str) -> float:
+    value = REGISTRY.get_sample_value(
+        "onyx_query_embedding_cache_lookups_total",
+        {"provider": provider, "outcome": outcome},
+    )
+    return value or 0.0
+
+
+def _write_count(provider: str, outcome: str) -> float:
+    value = REGISTRY.get_sample_value(
+        "onyx_query_embedding_cache_writes_total",
+        {"provider": provider, "outcome": outcome},
+    )
+    return value or 0.0
+
+
+class TestCacheThenRetrieve:
+    def test_round_trip_preserves_floats(self) -> None:
+        """
+        Tests that the cache round trip preserves the floats.
+        """
+        # Precondition.
+        query = _unique_query()
+        embedding = [0.1, -0.2, 3.4, 0.0, 1e-3]
+        cache_query_embeddings(
+            queries=[query],
+            embeddings=[embedding],
+            search_settings_id=1,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Under test.
+        got = get_cached_query_embeddings(
+            queries=[query],
+            search_settings_id=1,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Postcondition.
+        assert got[0] is not None
+        assert got[0] == embedding
+
+    def test_miss_returns_none(self) -> None:
+        """
+        Tests that a miss returns None.
+        """
+        # Under test.
+        got = get_cached_query_embeddings(
+            queries=[_unique_query()],
+            search_settings_id=1,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Postcondition.
+        assert got == [None]
+
+
+class TestPartialFill:
+    def test_partial_fill_preserves_order(self) -> None:
+        """
+        Tests that the partial fill preserves the order of the queries.
+        """
+        # Precondition.
+        q_hit_a = _unique_query()
+        q_hit_b = _unique_query()
+        q_miss = _unique_query()
+
+        emb_a = [1.0, 2.0]
+        emb_b = [3.0, 4.0]
+
+        cache_query_embeddings(
+            queries=[q_hit_a, q_hit_b],
+            embeddings=[emb_a, emb_b],
+            search_settings_id=42,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Under test.
+        results = get_cached_query_embeddings(
+            queries=[q_hit_a, q_miss, q_hit_b],
+            search_settings_id=42,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Postcondition.
+        assert results[0] is not None and results[0] == emb_a
+        assert results[1] is None
+        assert results[2] is not None and results[2] == emb_b
+
+
+class TestModelIdIsolation:
+    def test_different_search_settings_ids_do_not_collide(self) -> None:
+        """
+        Tests that different search settings IDs are isolated from each other.
+        """
+        # Precondition.
+        query = _unique_query()
+        cache_query_embeddings(
+            queries=[query],
+            embeddings=[[1.0, 2.0]],
+            search_settings_id=100,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Under test.
+        got = get_cached_query_embeddings(
+            queries=[query],
+            search_settings_id=101,  # Different search settings ID.
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        # Postcondition.
+        assert got == [None]
+
+
+class TestTenantIsolation:
+    def test_other_tenant_does_not_see_entry(self) -> None:
+        """
+        Tests that tenants do not see entries for other tenants.
+        """
+        # Precondition.
+        query = _unique_query()
+        cache_query_embeddings(
+            queries=[query],
+            embeddings=[[1.0, 2.0]],
+            search_settings_id=200,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        other_tenant = f"tenant_{uuid4().hex[:8]}"
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(other_tenant)
+        try:
+            # Under test.
+            got = get_cached_query_embeddings(
+                queries=[query],
+                search_settings_id=200,
+                provider_type=None,
+                ttl_seconds=60,
+            )
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        # Postcondition.
+        assert got == [None]
+
+
+class TestTTLRefresh:
+    def test_hit_refreshes_ttl(self) -> None:
+        """
+        Tests that a hit refreshes the TTL.
+        """
+        # Precondition.
+        query = _unique_query()
+        cache_query_embeddings(
+            queries=[query],
+            embeddings=[[1.0]],
+            search_settings_id=300,
+            provider_type=None,
+            ttl_seconds=1,
+        )
+        backend = get_cache_backend()
+        key = _build_key(query, 300)
+        assert backend.ttl(key) <= 1
+
+        # Under test.
+        get_cached_query_embeddings(
+            queries=[query],
+            search_settings_id=300,
+            provider_type=None,
+            ttl_seconds=600,
+        )
+
+        # Postcondition.
+        # After hit, TTL should be back near the new ttl.
+        ttl_after = backend.ttl(key)
+        assert 1 <= ttl_after <= 600
+
+
+class TestFailOpen:
+    def test_get_swallows_backend_error(self) -> None:
+        """
+        Tests that a get swallows a backend error.
+        """
+        # Precondition.
+        query = _unique_query()
+        # Pre-populate so we'd otherwise hit; the error must still flow through
+        # as a miss.
+        cache_query_embeddings(
+            queries=[query],
+            embeddings=[[1.0]],
+            search_settings_id=400,
+            provider_type=None,
+            ttl_seconds=60,
+        )
+
+        with patch(
+            "onyx.cache.redis_backend.RedisCacheBackend.get",
+            side_effect=RedisError("boom"),
+        ):
+            # Under test.
+            got = get_cached_query_embeddings(
+                queries=[query],
+                search_settings_id=400,
+                provider_type=None,
+                ttl_seconds=60,
+            )
+
+        # Postcondition.
+        assert got == [None]
+
+    def test_set_swallows_backend_error(self) -> None:
+        """
+        Tests that a set swallows a backend error.
+        """
+        # Precondition.
+        query = _unique_query()
+        with patch(
+            "onyx.cache.redis_backend.RedisCacheBackend.set",
+            side_effect=RedisError("boom"),
+        ):
+            # Under test.
+            # Must not raise.
+            cache_query_embeddings(
+                queries=[query],
+                embeddings=[[1.0]],
+                search_settings_id=401,
+                provider_type=None,
+                ttl_seconds=60,
+            )


### PR DESCRIPTION
## Description
Query embeddings are now cached per-tenant on search settings ID and query hash with relatively short TTL. If a tenant produces identical document index query strings within this TTL the query embeddings will be read from cache.

## How Has This Been Tested?
Added external dependency unit tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches per-tenant query embeddings to avoid repeat provider calls and speed up search. Wired into `get_query_embeddings` with packed little-endian float32 storage, short TTL, and Prometheus metrics.

- **New Features**
  - Tenant-scoped cache keyed by `search_settings.id` + SHA-256(query); controlled by `QUERY_EMBEDDING_CACHE_ENABLED` (default true) and `QUERY_EMBEDDING_CACHE_TTL_S` (default 900s; must be positive).
  - `get_query_embeddings` serves hits, encodes only misses, preserves order, refreshes TTL on hits, fails open on cache errors, records skipped lookups when the cache isn’t used, and emits Prometheus counters for lookups and writes by outcome (hit/miss/error/skipped, success/error) and provider.

<sup>Written for commit d18a221ffb1e9d1a6370c9222ee47c27114e98fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

