### PR TITLE
chore: perm sync vis setup

### DIFF
--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -14,6 +14,7 @@ from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import DocumentSource
 from onyx.db.enums import PermissionSyncStatus
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -325,6 +326,7 @@ def get_recent_external_group_sync_attempts_for_cc_pair(
 
 def get_relevant_external_group_sync_attempts_for_cc_pair(
     cc_pair_id: int,
+    source: DocumentSource,
     limit: int,
     db_session: Session,
 ) -> list[ExternalGroupPermissionSyncAttempt]:
@@ -344,27 +346,22 @@ def get_relevant_external_group_sync_attempts_for_cc_pair(
     Caveat: deployments with multiple independent instances of the same
     source (e.g. two distinct Confluence sites) will get a merged view here.
     Properly scoping per-instance is an existing architectural limitation.
-    """
-    cc_pair = db_session.execute(
-        select(ConnectorCredentialPair)
-        .join(ConnectorCredentialPair.connector)
-        .where(ConnectorCredentialPair.id == cc_pair_id)
-    ).scalar_one_or_none()
-    if cc_pair is None:
-        return []
 
+    Callers are expected to have already authorized the cc-pair and
+    resolved its ``source``; we trust both inputs and avoid re-fetching.
+    """
     is_agnostic: bool = fetch_ee_implementation_or_noop(
         "onyx.external_permissions.sync_params",
         "source_group_sync_is_cc_pair_agnostic",
         noop_return_value=False,
-    )(cc_pair.connector.source)
+    )(source)
 
     stmt = select(ExternalGroupPermissionSyncAttempt)
     if is_agnostic:
         sibling_cc_pair_ids_stmt = (
             select(ConnectorCredentialPair.id)
             .join(ConnectorCredentialPair.connector)
-            .where(Connector.source == cc_pair.connector.source)
+            .where(Connector.source == source)
         )
         stmt = stmt.where(
             ExternalGroupPermissionSyncAttempt.connector_credential_pair_id.in_(

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -15,12 +15,14 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import PermissionSyncStatus
+from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import DocPermissionSyncAttempt
 from onyx.db.models import ExternalGroupPermissionSyncAttempt
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 logger = setup_logger()
 
@@ -310,6 +312,69 @@ def get_recent_external_group_sync_attempts_for_cc_pair(
     else:
         stmt = stmt.where(
             ExternalGroupPermissionSyncAttempt.connector_credential_pair_id.is_(None)
+        )
+
+    return list(
+        db_session.execute(
+            stmt.order_by(ExternalGroupPermissionSyncAttempt.time_created.desc()).limit(
+                limit
+            )
+        ).scalars()
+    )
+
+
+def get_relevant_external_group_sync_attempts_for_cc_pair(
+    cc_pair_id: int,
+    limit: int,
+    db_session: Session,
+) -> list[ExternalGroupPermissionSyncAttempt]:
+    """Returns the group sync attempts a user looking at this cc-pair would
+    expect to see, most recent first.
+
+    For sources whose group sync runs at the source level rather than the
+    cc-pair level (Confluence, Jira — see
+    ``source_group_sync_is_cc_pair_agnostic``), a single sync run is intended
+    to cover every cc-pair sharing that source but is logged against
+    whichever cc-pair triggered it. Filtering strictly by ``cc_pair_id``
+    would hide attempts that are conceptually relevant — so we widen the
+    query to the source for those cases.
+
+    For all other sources, this is equivalent to filtering by ``cc_pair_id``.
+
+    Caveat: deployments with multiple independent instances of the same
+    source (e.g. two distinct Confluence sites) will get a merged view here.
+    Properly scoping per-instance is an existing architectural limitation.
+    """
+    cc_pair = db_session.execute(
+        select(ConnectorCredentialPair)
+        .join(ConnectorCredentialPair.connector)
+        .where(ConnectorCredentialPair.id == cc_pair_id)
+    ).scalar_one_or_none()
+    if cc_pair is None:
+        return []
+
+    is_agnostic: bool = fetch_ee_implementation_or_noop(
+        "onyx.external_permissions.sync_params",
+        "source_group_sync_is_cc_pair_agnostic",
+        noop_return_value=False,
+    )(cc_pair.connector.source)
+
+    stmt = select(ExternalGroupPermissionSyncAttempt)
+    if is_agnostic:
+        sibling_cc_pair_ids_stmt = (
+            select(ConnectorCredentialPair.id)
+            .join(ConnectorCredentialPair.connector)
+            .where(Connector.source == cc_pair.connector.source)
+        )
+        stmt = stmt.where(
+            ExternalGroupPermissionSyncAttempt.connector_credential_pair_id.in_(
+                sibling_cc_pair_ids_stmt
+            )
+        )
+    else:
+        stmt = stmt.where(
+            ExternalGroupPermissionSyncAttempt.connector_credential_pair_id
+            == cc_pair_id
         )
 
     return list(

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -15,6 +15,7 @@ from onyx.auth.users import current_curator_or_admin_user
 from onyx.background.celery.tasks.pruning.tasks import try_creating_prune_generator_task
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import PUBLIC_API_TAGS
@@ -53,6 +54,9 @@ from onyx.db.permission_sync_attempt import (
 from onyx.db.permission_sync_attempt import (
     get_recent_doc_permission_sync_attempts_for_cc_pair,
 )
+from onyx.db.permission_sync_attempt import (
+    get_relevant_external_group_sync_attempts_for_cc_pair,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_connector import RedisConnector
@@ -60,16 +64,18 @@ from onyx.redis.redis_connector_utils import get_deletion_attempt_snapshot
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.documents.models import CCPairFullInfo
+from onyx.server.documents.models import CCPairSyncAttemptsResponse
 from onyx.server.documents.models import CCPropertyUpdateRequest
 from onyx.server.documents.models import CCStatusUpdateRequest
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.server.documents.models import ConnectorCredentialPairMetadata
+from onyx.server.documents.models import DocPermissionSyncAttemptSnapshot
 from onyx.server.documents.models import DocumentSyncStatus
+from onyx.server.documents.models import ExternalGroupSyncAttemptSnapshot
 from onyx.server.documents.models import IndexAttemptSnapshot
 from onyx.server.documents.models import IndexAttemptStageMetricSnapshot
 from onyx.server.documents.models import IndexAttemptStageMetricsResponse
 from onyx.server.documents.models import PaginatedReturn
-from onyx.server.documents.models import PermissionSyncAttemptSnapshot
 from onyx.server.models import StatusResponse
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
@@ -156,6 +162,46 @@ def get_index_attempt_stage_metrics(
     )
 
 
+# Cap on how many recent attempts the per-cc-pair sync-history endpoints
+# will scan when computing pagination. The frontend pages over this fixed
+# pool client-side; older attempts beyond the cap are not surfaced. Matches
+# the previous (pre-CCPairSyncAttemptsResponse) behavior.
+_SYNC_ATTEMPTS_HISTORY_LIMIT = 1000
+
+
+def _get_cc_pair_source_or_raise(
+    cc_pair_id: int,
+    user: User,
+    db_session: Session,
+) -> DocumentSource:
+    """Authorize ``user`` for ``cc_pair_id`` and return its source.
+
+    Raises ``OnyxError(NOT_FOUND)`` if the cc-pair doesn't exist or the user
+    can't see it. Co-located with the sync-history endpoints because both
+    routes need the same cc-pair lookup + auth + source resolution.
+    """
+    if not verify_user_has_access_to_cc_pair(
+        cc_pair_id, db_session, user, get_editable=False
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
+        )
+
+    cc_pair = get_connector_credential_pair_from_id_for_user(
+        cc_pair_id=cc_pair_id,
+        db_session=db_session,
+        user=user,
+        get_editable=False,
+    )
+    if cc_pair is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
+        )
+    return cc_pair.connector.source
+
+
 @router.get("/admin/cc-pair/{cc_pair_id}/permission-sync-attempts")
 def get_cc_pair_permission_sync_attempts(
     cc_pair_id: int,
@@ -163,33 +209,93 @@ def get_cc_pair_permission_sync_attempts(
     page_size: int = Query(10, ge=1, le=1000),
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> PaginatedReturn[PermissionSyncAttemptSnapshot]:
-    if user:
-        user_has_access = verify_user_has_access_to_cc_pair(
-            cc_pair_id, db_session, user, get_editable=False
-        )
-        if not user_has_access:
-            raise HTTPException(
-                status_code=400, detail="CC Pair not found for current user permissions"
-            )
+) -> CCPairSyncAttemptsResponse[DocPermissionSyncAttemptSnapshot]:
+    """Recent doc-permission sync attempts for a cc-pair, paginated.
 
-    # Get all permission sync attempts for this cc pair
+    Returns ``applicable=False`` when the source does not run a separate
+    doc-permission sync job (e.g. Salesforce, where ACLs are pulled inline
+    during indexing). The frontend uses ``applicable`` to distinguish
+    "this kind of sync isn't applicable" from "no attempts yet".
+    """
+    source = _get_cc_pair_source_or_raise(cc_pair_id, user, db_session)
+
+    source_requires_doc_sync = fetch_ee_implementation_or_noop(
+        "onyx.external_permissions.sync_params",
+        "source_requires_doc_sync",
+        noop_return_value=False,
+    )
+    if not source_requires_doc_sync(source):
+        return CCPairSyncAttemptsResponse[DocPermissionSyncAttemptSnapshot](
+            applicable=False,
+            items=[],
+            total_items=0,
+        )
+
     all_attempts = get_recent_doc_permission_sync_attempts_for_cc_pair(
         cc_pair_id=cc_pair_id,
-        limit=1000,
+        limit=_SYNC_ATTEMPTS_HISTORY_LIMIT,
         db_session=db_session,
     )
-
     start_idx = page_num * page_size
     end_idx = start_idx + page_size
-    paginated_attempts = all_attempts[start_idx:end_idx]
-    items = [
-        PermissionSyncAttemptSnapshot.from_permission_sync_attempt_db_model(attempt)
-        for attempt in paginated_attempts
-    ]
+    return CCPairSyncAttemptsResponse[DocPermissionSyncAttemptSnapshot](
+        applicable=True,
+        items=[
+            DocPermissionSyncAttemptSnapshot.from_doc_permission_sync_attempt_db_model(
+                attempt
+            )
+            for attempt in all_attempts[start_idx:end_idx]
+        ],
+        total_items=len(all_attempts),
+    )
 
-    return PaginatedReturn(
-        items=items,
+
+@router.get("/admin/cc-pair/{cc_pair_id}/external-group-sync-attempts")
+def get_cc_pair_external_group_sync_attempts(
+    cc_pair_id: int,
+    page_num: int = Query(0, ge=0),
+    page_size: int = Query(10, ge=1, le=1000),
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> CCPairSyncAttemptsResponse[ExternalGroupSyncAttemptSnapshot]:
+    """Recent external-group sync attempts a viewer of this cc-pair would
+    expect to see, paginated.
+
+    Returns ``applicable=False`` when the source does not run a separate
+    external-group sync job. For sources whose group sync is logically
+    source-wide (Confluence, Jira), attempts triggered against any sibling
+    cc-pair sharing the source are included — see
+    ``get_relevant_external_group_sync_attempts_for_cc_pair``.
+    """
+    source = _get_cc_pair_source_or_raise(cc_pair_id, user, db_session)
+
+    source_requires_external_group_sync = fetch_ee_implementation_or_noop(
+        "onyx.external_permissions.sync_params",
+        "source_requires_external_group_sync",
+        noop_return_value=False,
+    )
+    if not source_requires_external_group_sync(source):
+        return CCPairSyncAttemptsResponse[ExternalGroupSyncAttemptSnapshot](
+            applicable=False,
+            items=[],
+            total_items=0,
+        )
+
+    all_attempts = get_relevant_external_group_sync_attempts_for_cc_pair(
+        cc_pair_id=cc_pair_id,
+        limit=_SYNC_ATTEMPTS_HISTORY_LIMIT,
+        db_session=db_session,
+    )
+    start_idx = page_num * page_size
+    end_idx = start_idx + page_size
+    return CCPairSyncAttemptsResponse[ExternalGroupSyncAttemptSnapshot](
+        applicable=True,
+        items=[
+            ExternalGroupSyncAttemptSnapshot.from_external_group_sync_attempt_db_model(
+                attempt
+            )
+            for attempt in all_attempts[start_idx:end_idx]
+        ],
         total_items=len(all_attempts),
     )
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -283,6 +283,7 @@ def get_cc_pair_external_group_sync_attempts(
 
     all_attempts = get_relevant_external_group_sync_attempts_for_cc_pair(
         cc_pair_id=cc_pair_id,
+        source=source,
         limit=_SYNC_ATTEMPTS_HISTORY_LIMIT,
         db_session=db_session,
     )

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -27,6 +27,7 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import DocPermissionSyncAttempt
 from onyx.db.models import Document as DbDocument
+from onyx.db.models import ExternalGroupPermissionSyncAttempt
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptStageMetric
 from onyx.db.models import IndexingStatus
@@ -283,7 +284,7 @@ class IndexAttemptStageMetricsResponse(BaseModel):
 PaginatedType = TypeVar("PaginatedType", bound=BaseModel)
 
 
-class PermissionSyncAttemptSnapshot(BaseModel):
+class DocPermissionSyncAttemptSnapshot(BaseModel):
     id: int
     status: PermissionSyncStatus
     error_message: str | None
@@ -294,10 +295,10 @@ class PermissionSyncAttemptSnapshot(BaseModel):
     time_finished: str | None
 
     @classmethod
-    def from_permission_sync_attempt_db_model(
+    def from_doc_permission_sync_attempt_db_model(
         cls, attempt: DocPermissionSyncAttempt
-    ) -> "PermissionSyncAttemptSnapshot":
-        return PermissionSyncAttemptSnapshot(
+    ) -> "DocPermissionSyncAttemptSnapshot":
+        return DocPermissionSyncAttemptSnapshot(
             id=attempt.id,
             status=attempt.status,
             error_message=attempt.error_message,
@@ -313,7 +314,56 @@ class PermissionSyncAttemptSnapshot(BaseModel):
         )
 
 
+class ExternalGroupSyncAttemptSnapshot(BaseModel):
+    id: int
+    status: PermissionSyncStatus
+    error_message: str | None
+    total_users_processed: int
+    total_groups_processed: int
+    total_group_memberships_synced: int
+    time_created: str
+    time_started: str | None
+    time_finished: str | None
+
+    @classmethod
+    def from_external_group_sync_attempt_db_model(
+        cls, attempt: ExternalGroupPermissionSyncAttempt
+    ) -> "ExternalGroupSyncAttemptSnapshot":
+        return ExternalGroupSyncAttemptSnapshot(
+            id=attempt.id,
+            status=attempt.status,
+            error_message=attempt.error_message,
+            total_users_processed=attempt.total_users_processed or 0,
+            total_groups_processed=attempt.total_groups_processed or 0,
+            total_group_memberships_synced=attempt.total_group_memberships_synced or 0,
+            time_created=attempt.time_created.isoformat(),
+            time_started=(
+                attempt.time_started.isoformat() if attempt.time_started else None
+            ),
+            time_finished=(
+                attempt.time_finished.isoformat() if attempt.time_finished else None
+            ),
+        )
+
+
 class PaginatedReturn(BaseModel, Generic[PaginatedType]):
+    items: list[PaginatedType]
+    total_items: int
+
+
+class CCPairSyncAttemptsResponse(BaseModel, Generic[PaginatedType]):
+    """Paginated response for the per-cc-pair sync-attempt history endpoints.
+
+    ``applicable`` is False when the cc-pair's source does not run the kind
+    of sync this endpoint reports on (e.g. Slack has no group sync; Salesforce
+    has neither doc sync nor group sync). The frontend uses this to render an
+    explanatory message instead of an empty-state — the two are distinct
+    states: ``applicable=True, items=[], total_items=0`` legitimately means
+    "no attempts yet" and must not be confused with "this kind of sync isn't
+    applicable for this source".
+    """
+
+    applicable: bool
     items: list[PaginatedType]
     total_items: int
 

--- a/backend/tests/external_dependency_unit/permission_sync/test_cc_pair_sync_attempts_routes.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_cc_pair_sync_attempts_routes.py
@@ -1,0 +1,411 @@
+"""Tests for the per-cc-pair sync-attempt history endpoints.
+
+Covers:
+
+* The new ``get_relevant_external_group_sync_attempts_for_cc_pair`` helper
+  in ``onyx.db.permission_sync_attempt`` — including the source-wide query
+  used for cc-pair-agnostic sources (Confluence, Jira).
+* The migrated ``GET /admin/cc-pair/{id}/permission-sync-attempts`` route,
+  now wrapped in ``CCPairSyncAttemptsResponse`` and raising ``OnyxError``.
+* The new ``GET /admin/cc-pair/{id}/external-group-sync-attempts`` route.
+
+We invoke the FastAPI route functions directly with a constructed admin
+``User`` and the test ``db_session`` rather than going through TestClient —
+matching the pattern used elsewhere in ``external_dependency_unit``. The
+``applicable`` logic depends on EE-only ``sync_params`` helpers, so any
+test that needs ``applicable=True`` uses the ``enable_ee`` fixture from
+the root ``backend/tests/conftest.py``.
+"""
+
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import PermissionSyncStatus
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.db.permission_sync_attempt import create_doc_permission_sync_attempt
+from onyx.db.permission_sync_attempt import create_external_group_sync_attempt
+from onyx.db.permission_sync_attempt import (
+    get_relevant_external_group_sync_attempts_for_cc_pair,
+)
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.documents.cc_pair import get_cc_pair_external_group_sync_attempts
+from onyx.server.documents.cc_pair import get_cc_pair_permission_sync_attempts
+from tests.external_dependency_unit.conftest import create_test_user
+
+# Every applicable=True path here depends on the EE-only ``sync_params``
+# helpers (``source_requires_doc_sync`` etc.); the no-op fallback would
+# otherwise short-circuit those paths to ``applicable=False``. Applied
+# module-wide so individual tests don't need to wire the fixture in.
+pytestmark = pytest.mark.usefixtures("enable_ee")
+
+# --------------------------------------------------------------------------- #
+# Setup helpers
+# --------------------------------------------------------------------------- #
+
+
+def _create_cc_pair(
+    db_session: Session,
+    source: DocumentSource = DocumentSource.GOOGLE_DRIVE,
+) -> ConnectorCredentialPair:
+    """Create a fully wired ``ConnectorCredentialPair`` for the given source.
+
+    Mirrors ``_create_test_connector_credential_pair`` in the sibling test
+    files but kept local so changes here don't ripple into those tests.
+    """
+    user = create_test_user(db_session, "fixture_user")
+
+    connector = Connector(
+        name=f"Test {source.value} Connector",
+        source=source,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=datetime.now(timezone.utc),
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        credential_json={},
+        user_id=user.id,
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+    db_session.expire(credential)
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"Test CC Pair {source.value}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.SYNC,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+    return cc_pair
+
+
+def _admin_user(db_session: Session) -> User:
+    return create_test_user(db_session, "admin", role=UserRole.ADMIN)
+
+
+# --------------------------------------------------------------------------- #
+# Helper: get_relevant_external_group_sync_attempts_for_cc_pair
+# --------------------------------------------------------------------------- #
+
+
+class TestGetRelevantExternalGroupSyncAttemptsForCcPair:
+    def test_returns_empty_when_cc_pair_does_not_exist(
+        self, db_session: Session
+    ) -> None:
+        result = get_relevant_external_group_sync_attempts_for_cc_pair(
+            cc_pair_id=999_999,
+            limit=10,
+            db_session=db_session,
+        )
+        assert result == []
+
+    def test_filters_by_cc_pair_when_source_is_not_agnostic(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Google Drive's group sync is per-cc-pair; sibling cc-pair attempts
+        with the same source must NOT bleed into the result."""
+        cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+        sibling_cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        own_attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+        sibling_attempt_id = create_external_group_sync_attempt(
+            sibling_cc_pair.id, db_session
+        )
+
+        result = get_relevant_external_group_sync_attempts_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            limit=50,
+            db_session=db_session,
+        )
+        result_ids = {attempt.id for attempt in result}
+        assert own_attempt_id in result_ids
+        assert sibling_attempt_id not in result_ids
+
+    def test_widens_to_source_when_agnostic(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Confluence's group sync is source-wide; sibling cc-pair attempts
+        sharing the source should be included even though they are recorded
+        against a different cc-pair."""
+        cc_pair = _create_cc_pair(db_session, DocumentSource.CONFLUENCE)
+        sibling_cc_pair = _create_cc_pair(db_session, DocumentSource.CONFLUENCE)
+        unrelated_cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        own_attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+        sibling_attempt_id = create_external_group_sync_attempt(
+            sibling_cc_pair.id, db_session
+        )
+        unrelated_attempt_id = create_external_group_sync_attempt(
+            unrelated_cc_pair.id, db_session
+        )
+
+        result = get_relevant_external_group_sync_attempts_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            limit=100,
+            db_session=db_session,
+        )
+        result_ids = {attempt.id for attempt in result}
+        assert own_attempt_id in result_ids
+        assert sibling_attempt_id in result_ids
+        assert unrelated_attempt_id not in result_ids
+
+    def test_orders_most_recent_first_and_respects_limit(
+        self,
+        db_session: Session,
+    ) -> None:
+        cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        attempt_ids = [
+            create_external_group_sync_attempt(cc_pair.id, db_session) for _ in range(5)
+        ]
+
+        result = get_relevant_external_group_sync_attempts_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            limit=3,
+            db_session=db_session,
+        )
+
+        assert len(result) == 3
+        # Created sequentially -> most recent first means the last 3 attempt
+        # ids in creation order, listed in reverse.
+        assert [attempt.id for attempt in result] == list(reversed(attempt_ids[-3:]))
+
+
+# --------------------------------------------------------------------------- #
+# Route: GET /admin/cc-pair/{id}/permission-sync-attempts
+# --------------------------------------------------------------------------- #
+
+
+class TestGetCcPairPermissionSyncAttemptsRoute:
+    def test_raises_not_found_for_unknown_cc_pair(self, db_session: Session) -> None:
+        admin = _admin_user(db_session)
+
+        with pytest.raises(OnyxError) as exc_info:
+            get_cc_pair_permission_sync_attempts(
+                cc_pair_id=999_999,
+                page_num=0,
+                page_size=10,
+                user=admin,
+                db_session=db_session,
+            )
+
+        assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+
+    def test_applicable_false_when_source_does_not_require_doc_sync(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Salesforce has no doc-sync config — only chunk censoring — so the
+        endpoint must short-circuit with ``applicable=False`` even if the
+        cc-pair somehow has rows in the table."""
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.SALESFORCE)
+
+        response = get_cc_pair_permission_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=10,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert response.applicable is False
+        assert response.items == []
+        assert response.total_items == 0
+
+    def test_returns_attempts_when_applicable(
+        self,
+        db_session: Session,
+    ) -> None:
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        attempt_ids = [
+            create_doc_permission_sync_attempt(cc_pair.id, db_session) for _ in range(3)
+        ]
+
+        response = get_cc_pair_permission_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=10,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert response.applicable is True
+        assert response.total_items == 3
+        returned_ids = [item.id for item in response.items]
+        assert set(returned_ids) == set(attempt_ids)
+        # Snapshot fields populated and statuses default to NOT_STARTED.
+        for item in response.items:
+            assert item.status == PermissionSyncStatus.NOT_STARTED
+            assert item.total_docs_synced == 0
+            assert item.docs_with_permission_errors == 0
+            assert item.time_finished is None
+
+    def test_pagination_slices_correctly(
+        self,
+        db_session: Session,
+    ) -> None:
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        attempt_ids = [
+            create_doc_permission_sync_attempt(cc_pair.id, db_session) for _ in range(5)
+        ]
+
+        first_page = get_cc_pair_permission_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=2,
+            user=admin,
+            db_session=db_session,
+        )
+        second_page = get_cc_pair_permission_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=1,
+            page_size=2,
+            user=admin,
+            db_session=db_session,
+        )
+        third_page = get_cc_pair_permission_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=2,
+            page_size=2,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert first_page.applicable is True
+        assert second_page.applicable is True
+        assert third_page.applicable is True
+        assert first_page.total_items == 5
+        assert len(first_page.items) == 2
+        assert len(second_page.items) == 2
+        assert len(third_page.items) == 1
+
+        all_returned = (
+            [item.id for item in first_page.items]
+            + [item.id for item in second_page.items]
+            + [item.id for item in third_page.items]
+        )
+        assert set(all_returned) == set(attempt_ids)
+
+
+# --------------------------------------------------------------------------- #
+# Route: GET /admin/cc-pair/{id}/external-group-sync-attempts
+# --------------------------------------------------------------------------- #
+
+
+class TestGetCcPairExternalGroupSyncAttemptsRoute:
+    def test_raises_not_found_for_unknown_cc_pair(self, db_session: Session) -> None:
+        admin = _admin_user(db_session)
+
+        with pytest.raises(OnyxError) as exc_info:
+            get_cc_pair_external_group_sync_attempts(
+                cc_pair_id=999_999,
+                page_num=0,
+                page_size=10,
+                user=admin,
+                db_session=db_session,
+            )
+
+        assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+
+    def test_applicable_false_when_source_has_no_group_sync(
+        self,
+        db_session: Session,
+    ) -> None:
+        """Slack has doc sync but no separate group sync, so the group-sync
+        endpoint must report ``applicable=False`` for it."""
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.SLACK)
+
+        response = get_cc_pair_external_group_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=10,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert response.applicable is False
+        assert response.items == []
+        assert response.total_items == 0
+
+    def test_returns_only_own_attempts_for_non_agnostic_source(
+        self,
+        db_session: Session,
+    ) -> None:
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+        sibling_cc_pair = _create_cc_pair(db_session, DocumentSource.GOOGLE_DRIVE)
+
+        own_attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+        sibling_attempt_id = create_external_group_sync_attempt(
+            sibling_cc_pair.id, db_session
+        )
+
+        response = get_cc_pair_external_group_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=50,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert response.applicable is True
+        returned_ids = {item.id for item in response.items}
+        assert own_attempt_id in returned_ids
+        assert sibling_attempt_id not in returned_ids
+
+    def test_includes_sibling_attempts_for_agnostic_source(
+        self,
+        db_session: Session,
+    ) -> None:
+        """For Confluence (cc-pair-agnostic), an attempt logged against a
+        sibling cc-pair sharing the source must be visible from this cc-pair's
+        perspective."""
+        admin = _admin_user(db_session)
+        cc_pair = _create_cc_pair(db_session, DocumentSource.CONFLUENCE)
+        sibling_cc_pair = _create_cc_pair(db_session, DocumentSource.CONFLUENCE)
+
+        own_attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+        sibling_attempt_id = create_external_group_sync_attempt(
+            sibling_cc_pair.id, db_session
+        )
+
+        response = get_cc_pair_external_group_sync_attempts(
+            cc_pair_id=cc_pair.id,
+            page_num=0,
+            page_size=100,
+            user=admin,
+            db_session=db_session,
+        )
+
+        assert response.applicable is True
+        returned_ids = {item.id for item in response.items}
+        assert own_attempt_id in returned_ids
+        assert sibling_attempt_id in returned_ids

--- a/backend/tests/external_dependency_unit/permission_sync/test_cc_pair_sync_attempts_routes.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_cc_pair_sync_attempts_routes.py
@@ -109,16 +109,6 @@ def _admin_user(db_session: Session) -> User:
 
 
 class TestGetRelevantExternalGroupSyncAttemptsForCcPair:
-    def test_returns_empty_when_cc_pair_does_not_exist(
-        self, db_session: Session
-    ) -> None:
-        result = get_relevant_external_group_sync_attempts_for_cc_pair(
-            cc_pair_id=999_999,
-            limit=10,
-            db_session=db_session,
-        )
-        assert result == []
-
     def test_filters_by_cc_pair_when_source_is_not_agnostic(
         self,
         db_session: Session,
@@ -135,6 +125,7 @@ class TestGetRelevantExternalGroupSyncAttemptsForCcPair:
 
         result = get_relevant_external_group_sync_attempts_for_cc_pair(
             cc_pair_id=cc_pair.id,
+            source=DocumentSource.GOOGLE_DRIVE,
             limit=50,
             db_session=db_session,
         )
@@ -163,6 +154,7 @@ class TestGetRelevantExternalGroupSyncAttemptsForCcPair:
 
         result = get_relevant_external_group_sync_attempts_for_cc_pair(
             cc_pair_id=cc_pair.id,
+            source=DocumentSource.CONFLUENCE,
             limit=100,
             db_session=db_session,
         )
@@ -183,6 +175,7 @@ class TestGetRelevantExternalGroupSyncAttemptsForCcPair:
 
         result = get_relevant_external_group_sync_attempts_for_cc_pair(
             cc_pair_id=cc_pair.id,
+            source=DocumentSource.GOOGLE_DRIVE,
             limit=3,
             db_session=db_session,
         )


### PR DESCRIPTION
## Description

Some setup for permission sync visibility in the FE

## How Has This Been Tested?

added tests, will test E2E in a future PR

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend support for permission sync visibility. New per-CC pair endpoints return doc-permission and external-group sync history with an “applicable” flag, correct source scoping, and fewer redundant DB lookups for group attempts.

- **New Features**
  - GET /admin/cc-pair/{id}/permission-sync-attempts returns CCPairSyncAttemptsResponse[DocPermissionSyncAttemptSnapshot]; sets applicable=false for sources that don’t run doc sync; scans up to 1000 recent attempts.
  - GET /admin/cc-pair/{id}/external-group-sync-attempts returns CCPairSyncAttemptsResponse[ExternalGroupSyncAttemptSnapshot]; sets applicable by source; widens to source-level for cc-pair-agnostic sources (e.g., Confluence, Jira); avoids an extra DB fetch by trusting the pre-resolved source.
  - Added source-aware helper get_relevant_external_group_sync_attempts_for_cc_pair for group sync history.
  - Routes now return NOT_FOUND for missing/inaccessible cc-pairs.

- **Migration**
  - Update UI to consume CCPairSyncAttemptsResponse (applicable, items, total_items) and render a distinct “not applicable” state when applicable=false.
  - Replace uses of PermissionSyncAttemptSnapshot with DocPermissionSyncAttemptSnapshot for the doc-permission history route.
  - Use the new external-group endpoint for group sync history; no client-side source scoping needed.

<sup>Written for commit 08df3af45e393d301e4f2089f29c88d121a464f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

