### PR TITLE
feat: frontend models and components for perm sync vis

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  createTableColumns,
+  MessageCard,
+  Pagination,
+  Table,
+  Text,
+} from "@opal/components";
+import { Section } from "@/layouts/general-layouts";
+import { localizeAndPrettify } from "@/lib/time";
+import { PermissionSyncStatusBadge } from "./PermissionSyncStatusBadge";
+import type { DocPermissionSyncAttemptSnapshot } from "./types";
+
+/**
+ * Renders one page of `DocPermissionSyncAttempt` rows for the
+ * connector-detail "Document Permissions" tab.
+ *
+ * Pagination is **driven externally** — the parent owns the SWR /
+ * `usePaginatedFetch` state and passes the current page slice in. This
+ * mirrors `IndexAttemptsTable`'s API so `SyncAttemptsTabs` (PR C) can
+ * wire all three tables uniformly.
+ *
+ * Empty state ("no attempts yet but the sync IS applicable") is
+ * distinct from the not-applicable state, which is rendered higher up
+ * by `SyncAttemptsTabs` and never reaches this component. We render a
+ * neutral `MessageCard` here only when `attempts.length === 0` AND the
+ * caller has decided this tab is applicable.
+ */
+
+const tc = createTableColumns<DocPermissionSyncAttemptSnapshot>();
+
+const COLUMNS = [
+  tc.column("time_started", {
+    header: "Time Started",
+    weight: 22,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {value ? localizeAndPrettify(value) : "-"}
+      </Text>
+    ),
+  }),
+  tc.column("status", {
+    header: "Status",
+    weight: 18,
+    enableSorting: false,
+    cell: (value, row) => (
+      <PermissionSyncStatusBadge status={value} errorMsg={row.error_message} />
+    ),
+  }),
+  tc.column("total_docs_synced", {
+    header: "Docs Synced",
+    weight: 14,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {String(value)}
+      </Text>
+    ),
+  }),
+  tc.column("docs_with_permission_errors", {
+    header: "Permission Errors",
+    weight: 18,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {String(value)}
+      </Text>
+    ),
+  }),
+  tc.column("error_message", {
+    header: "Error Message",
+    weight: 28,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="secondary-body" color="text-03" maxLines={2}>
+        {value ?? "-"}
+      </Text>
+    ),
+  }),
+];
+
+export interface DocPermissionSyncAttemptsTableProps {
+  attempts: DocPermissionSyncAttemptSnapshot[];
+  /** 1-based page index, matching `IndexAttemptsTable`. */
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export function DocPermissionSyncAttemptsTable({
+  attempts,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: DocPermissionSyncAttemptsTableProps) {
+  // `COLUMNS` is module-scope so identity is stable across renders, but
+  // memoizing here keeps the contract obvious to future readers and
+  // matches the convention in `UsersTable`.
+  const columns = useMemo(() => COLUMNS, []);
+
+  if (!attempts.length) {
+    return (
+      <MessageCard
+        variant="info"
+        title="No document permission sync attempts scheduled yet"
+        description="Document-permission sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds."
+      />
+    );
+  }
+
+  return (
+    <Section gap={0.75} alignItems="stretch" height="auto">
+      <Table
+        data={attempts}
+        columns={columns}
+        getRowId={(row) => String(row.id)}
+      />
+      {totalPages > 1 && (
+        <Section
+          flexDirection="row"
+          justifyContent="center"
+          height="auto"
+          className="pt-1"
+        >
+          <Pagination
+            variant="list"
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onChange={onPageChange}
+          />
+        </Section>
+      )}
+    </Section>
+  );
+}

--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import {
   createTableColumns,
   MessageCard,
@@ -96,11 +95,6 @@ export function DocPermissionSyncAttemptsTable({
   totalPages,
   onPageChange,
 }: DocPermissionSyncAttemptsTableProps) {
-  // `COLUMNS` is module-scope so identity is stable across renders, but
-  // memoizing here keeps the contract obvious to future readers and
-  // matches the convention in `UsersTable`.
-  const columns = useMemo(() => COLUMNS, []);
-
   if (!attempts.length) {
     return (
       <MessageCard
@@ -115,7 +109,7 @@ export function DocPermissionSyncAttemptsTable({
     <Section gap={0.75} alignItems="stretch" height="auto">
       <Table
         data={attempts}
-        columns={columns}
+        columns={COLUMNS}
         getRowId={(row) => String(row.id)}
       />
       {totalPages > 1 && (

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import {
   createTableColumns,
   MessageCard,
@@ -111,8 +110,6 @@ export function ExternalGroupSyncAttemptsTable({
   totalPages,
   onPageChange,
 }: ExternalGroupSyncAttemptsTableProps) {
-  const columns = useMemo(() => COLUMNS, []);
-
   if (!attempts.length) {
     return (
       <MessageCard
@@ -127,7 +124,7 @@ export function ExternalGroupSyncAttemptsTable({
     <Section gap={0.75} alignItems="stretch" height="auto">
       <Table
         data={attempts}
-        columns={columns}
+        columns={COLUMNS}
         getRowId={(row) => String(row.id)}
       />
       {totalPages > 1 && (

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  createTableColumns,
+  MessageCard,
+  Pagination,
+  Table,
+  Text,
+} from "@opal/components";
+import { Section } from "@/layouts/general-layouts";
+import { localizeAndPrettify } from "@/lib/time";
+import { PermissionSyncStatusBadge } from "./PermissionSyncStatusBadge";
+import type { ExternalGroupSyncAttemptSnapshot } from "./types";
+
+/**
+ * Renders one page of `ExternalGroupPermissionSyncAttempt` rows for the
+ * connector-detail "Group Membership" tab.
+ *
+ * Pagination is driven externally (parent owns the SWR /
+ * `usePaginatedFetch` state), matching the `IndexAttemptsTable` and
+ * `DocPermissionSyncAttemptsTable` shape so all three tables can be
+ * mounted uniformly inside `SyncAttemptsTabs` (PR C).
+ *
+ * Note on row attribution for cc-pair-agnostic sources (Confluence,
+ * Jira): the backend's `external-group-sync-attempts` endpoint widens
+ * its query to all sibling cc-pairs of the same source for these
+ * sources, so a row shown here may have been triggered against a
+ * **different** cc-pair than the one being viewed. That's intentional
+ * — a single source-wide group sync run logically applies to every
+ * cc-pair sharing the source. See
+ * `get_relevant_external_group_sync_attempts_for_cc_pair` in
+ * `backend/onyx/db/permission_sync_attempt.py` for the resolution
+ * rules and the multi-instance caveat.
+ */
+
+const tc = createTableColumns<ExternalGroupSyncAttemptSnapshot>();
+
+const COLUMNS = [
+  tc.column("time_started", {
+    header: "Time Started",
+    weight: 20,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {value ? localizeAndPrettify(value) : "-"}
+      </Text>
+    ),
+  }),
+  tc.column("status", {
+    header: "Status",
+    weight: 16,
+    enableSorting: false,
+    cell: (value, row) => (
+      <PermissionSyncStatusBadge status={value} errorMsg={row.error_message} />
+    ),
+  }),
+  tc.column("total_users_processed", {
+    header: "Users Processed",
+    weight: 14,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {String(value)}
+      </Text>
+    ),
+  }),
+  tc.column("total_groups_processed", {
+    header: "Groups Processed",
+    weight: 14,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {String(value)}
+      </Text>
+    ),
+  }),
+  tc.column("total_group_memberships_synced", {
+    header: "Memberships Synced",
+    weight: 14,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {String(value)}
+      </Text>
+    ),
+  }),
+  tc.column("error_message", {
+    header: "Error Message",
+    weight: 22,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="secondary-body" color="text-03" maxLines={2}>
+        {value ?? "-"}
+      </Text>
+    ),
+  }),
+];
+
+export interface ExternalGroupSyncAttemptsTableProps {
+  attempts: ExternalGroupSyncAttemptSnapshot[];
+  /** 1-based page index, matching `IndexAttemptsTable`. */
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export function ExternalGroupSyncAttemptsTable({
+  attempts,
+  currentPage,
+  totalPages,
+  onPageChange,
+}: ExternalGroupSyncAttemptsTableProps) {
+  const columns = useMemo(() => COLUMNS, []);
+
+  if (!attempts.length) {
+    return (
+      <MessageCard
+        variant="info"
+        title="No group membership sync attempts scheduled yet"
+        description="Group-membership sync runs are scheduled in the background. They may take some time to appear — try refreshing in ~30 seconds."
+      />
+    );
+  }
+
+  return (
+    <Section gap={0.75} alignItems="stretch" height="auto">
+      <Table
+        data={attempts}
+        columns={columns}
+        getRowId={(row) => String(row.id)}
+      />
+      {totalPages > 1 && (
+        <Section
+          flexDirection="row"
+          justifyContent="center"
+          height="auto"
+          className="pt-1"
+        >
+          <Pagination
+            variant="list"
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onChange={onPageChange}
+          />
+        </Section>
+      )}
+    </Section>
+  );
+}

--- a/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
@@ -31,8 +31,9 @@ import { PermissionSyncStatusEnum } from "./types";
  *   - NOT_STARTED → gray Tag, "Scheduled"
  *   - null / unknown → gray Tag, "Not Started"
  *
- * Failed rows are wrapped in a Tooltip with `errorMsg` when one is
- * supplied — same affordance the legacy badge offered.
+ * Failed and completed-with-errors rows are wrapped in a Tooltip with
+ * `errorMsg` when one is supplied — same affordance the legacy badge
+ * offered.
  */
 
 interface BadgeConfig {
@@ -80,9 +81,15 @@ const FALLBACK_CONFIG: BadgeConfig = {
   label: "Not Started",
 };
 
+const STATUSES_WITH_ERROR_TOOLTIP: ReadonlySet<PermissionSyncStatusEnum> =
+  new Set([
+    PermissionSyncStatusEnum.FAILED,
+    PermissionSyncStatusEnum.COMPLETED_WITH_ERRORS,
+  ]);
+
 interface PermissionSyncStatusBadgeProps {
   status: PermissionSyncStatusEnum | null;
-  /** Shown in a tooltip when status === FAILED. */
+  /** Shown in a tooltip when the status is FAILED or COMPLETED_WITH_ERRORS. */
   errorMsg?: string | null;
 }
 
@@ -95,7 +102,7 @@ export function PermissionSyncStatusBadge({
     <Tag color={config.color} icon={config.icon} title={config.label} />
   );
 
-  if (status === PermissionSyncStatusEnum.FAILED && errorMsg) {
+  if (status && STATUSES_WITH_ERROR_TOOLTIP.has(status) && errorMsg) {
     return (
       <Tooltip tooltip={errorMsg} side="bottom">
         <Section width="fit" height="auto" className="cursor-pointer">

--- a/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/PermissionSyncStatusBadge.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Tag, Tooltip } from "@opal/components";
+import type { TagColor } from "@opal/components";
+import type { IconFunctionComponent } from "@opal/types";
+import {
+  SvgAlertTriangle,
+  SvgCheckCircle,
+  SvgClock,
+  SvgXOctagon,
+} from "@opal/icons";
+import { Section } from "@/layouts/general-layouts";
+import { PermissionSyncStatusEnum } from "./types";
+
+/**
+ * Per-row status badge shown inside both the doc-permission and
+ * external-group sync attempt tables in this folder.
+ *
+ * Functionally equivalent to the legacy `PermissionSyncStatus` component
+ * in `web/src/components/Status.tsx`, but built on Opal `Tag` per the
+ * `@/components/`-no-import rule (see `.cursor/skills/web/no-legacy-components`).
+ *
+ * Visual mapping:
+ *   - SUCCESS → green Tag, "Succeeded"
+ *   - COMPLETED_WITH_ERRORS → amber Tag, "Completed with errors"
+ *   - FAILED → amber Tag with XOctagon icon, "Failed" (Opal's `Tag`
+ *     palette has no red variant — amber + the Octagon icon is the
+ *     closest "danger" treatment available without introducing a new
+ *     Tag color)
+ *   - IN_PROGRESS → blue Tag, "In Progress"
+ *   - NOT_STARTED → gray Tag, "Scheduled"
+ *   - null / unknown → gray Tag, "Not Started"
+ *
+ * Failed rows are wrapped in a Tooltip with `errorMsg` when one is
+ * supplied — same affordance the legacy badge offered.
+ */
+
+interface BadgeConfig {
+  color: TagColor;
+  icon: IconFunctionComponent;
+  label: string;
+}
+
+const STATUS_CONFIG: Record<PermissionSyncStatusEnum, BadgeConfig> = {
+  [PermissionSyncStatusEnum.SUCCESS]: {
+    color: "green",
+    icon: SvgCheckCircle,
+    label: "Succeeded",
+  },
+  [PermissionSyncStatusEnum.COMPLETED_WITH_ERRORS]: {
+    color: "amber",
+    icon: SvgAlertTriangle,
+    label: "Completed with errors",
+  },
+  [PermissionSyncStatusEnum.FAILED]: {
+    color: "amber",
+    icon: SvgXOctagon,
+    label: "Failed",
+  },
+  [PermissionSyncStatusEnum.IN_PROGRESS]: {
+    color: "blue",
+    icon: SvgClock,
+    label: "In Progress",
+  },
+  [PermissionSyncStatusEnum.NOT_STARTED]: {
+    color: "gray",
+    icon: SvgClock,
+    label: "Scheduled",
+  },
+  [PermissionSyncStatusEnum.CANCELED]: {
+    color: "gray",
+    icon: SvgClock,
+    label: "Canceled",
+  },
+};
+
+const FALLBACK_CONFIG: BadgeConfig = {
+  color: "gray",
+  icon: SvgClock,
+  label: "Not Started",
+};
+
+interface PermissionSyncStatusBadgeProps {
+  status: PermissionSyncStatusEnum | null;
+  /** Shown in a tooltip when status === FAILED. */
+  errorMsg?: string | null;
+}
+
+export function PermissionSyncStatusBadge({
+  status,
+  errorMsg,
+}: PermissionSyncStatusBadgeProps) {
+  const config = (status && STATUS_CONFIG[status]) ?? FALLBACK_CONFIG;
+  const tag = (
+    <Tag color={config.color} icon={config.icon} title={config.label} />
+  );
+
+  if (status === PermissionSyncStatusEnum.FAILED && errorMsg) {
+    return (
+      <Tooltip tooltip={errorMsg} side="bottom">
+        <Section width="fit" height="auto" className="cursor-pointer">
+          {tag}
+        </Section>
+      </Tooltip>
+    );
+  }
+
+  return tag;
+}

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -75,6 +75,65 @@ export interface PaginatedIndexAttempts {
   total_pages: number;
 }
 
+/**
+ * One row of the document-permission-sync attempt history. Mirrors
+ * `DocPermissionSyncAttemptSnapshot` in
+ * `backend/onyx/server/documents/models.py`.
+ *
+ * Note: timestamps are pre-serialized to ISO strings on the backend
+ * (matching `IndexAttemptSnapshot.time_started`/`time_updated`), so the
+ * frontend never has to handle `Date` objects directly here.
+ */
+export interface DocPermissionSyncAttemptSnapshot {
+  id: number;
+  status: PermissionSyncStatusEnum;
+  error_message: string | null;
+  total_docs_synced: number;
+  docs_with_permission_errors: number;
+  time_created: string;
+  time_started: string | null;
+  time_finished: string | null;
+}
+
+/**
+ * One row of the external-group-sync attempt history. Mirrors
+ * `ExternalGroupSyncAttemptSnapshot` in
+ * `backend/onyx/server/documents/models.py`. The progress fields differ
+ * from the doc-sync shape because group sync tracks user/group/membership
+ * counts rather than document-level counts.
+ */
+export interface ExternalGroupSyncAttemptSnapshot {
+  id: number;
+  status: PermissionSyncStatusEnum;
+  error_message: string | null;
+  total_users_processed: number;
+  total_groups_processed: number;
+  total_group_memberships_synced: number;
+  time_created: string;
+  time_started: string | null;
+  time_finished: string | null;
+}
+
+/**
+ * Response wrapper used by both per-cc-pair sync-attempt endpoints
+ * (`/permission-sync-attempts` and `/external-group-sync-attempts`).
+ * Mirrors `CCPairSyncAttemptsResponse` in
+ * `backend/onyx/server/documents/models.py`.
+ *
+ * `applicable === false` means the cc-pair's source does not run this
+ * kind of sync job at all (e.g. Salesforce has no doc sync; Slack has
+ * no group sync) and `items` will always be `[]`. The frontend MUST
+ * use this flag to render the explanatory "this connector does not use
+ * a separate ... syncing job" message rather than the generic empty
+ * state — the two cases are different and `items.length === 0` alone
+ * does NOT distinguish them.
+ */
+export interface CCPairSyncAttemptsResponse<T> {
+  applicable: boolean;
+  items: T[];
+  total_items: number;
+}
+
 export interface IndexAttemptError {
   id: number;
   connector_credential_pair_id: number;


### PR DESCRIPTION
## Description

just some components  and models for the upcoming perm sync vis improvements

## How Has This Been Tested?

not tested yet, will test e2e in the final PR in the stack

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"chore/perm-sync-vis-setup","parentHead":"20bd485de20253521e60712f43230d0d165aa15b","parentPull":10789,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add UI and types to show permission sync history in connector details. Includes document permission attempts, external group sync attempts (source-wide across sibling cc-pairs when applicable), and a shared status badge using `@opal/components`.

- **New Features**
  - `DocPermissionSyncAttemptsTable` and `ExternalGroupSyncAttemptsTable` with external, 1-based pagination and an info `MessageCard` when applicable but empty. Columns: start time, status, progress counts, and error message.
  - `PermissionSyncStatusBadge` built on `Tag` from `@opal/components`, mapping SUCCESS, COMPLETED_WITH_ERRORS, FAILED (tooltip with error), IN_PROGRESS, NOT_STARTED, and CANCELED.
  - Types in `types.ts`: `DocPermissionSyncAttemptSnapshot`, `ExternalGroupSyncAttemptSnapshot`, and `CCPairSyncAttemptsResponse` (includes `applicable` and `total_items`).

<sup>Written for commit 9809a4b29d577b472bd899aff9d48dc4b85ac08c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

