### PR TITLE
feat: more frontend models for perm sync vis

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+
+import { MessageCard } from "@opal/components";
+
+import { Section } from "@/layouts/general-layouts";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
+import Tabs from "@/refresh-components/Tabs";
+import type { IndexAttemptSnapshot } from "@/lib/types";
+
+import { DocPermissionSyncAttemptsTable } from "./DocPermissionSyncAttemptsTable";
+import { ExternalGroupSyncAttemptsTable } from "./ExternalGroupSyncAttemptsTable";
+import { IndexAttemptsTable } from "./IndexAttemptsTable";
+import { buildCCPairInfoUrl } from "./lib";
+import type {
+  CCPairFullInfo,
+  DocPermissionSyncAttemptSnapshot,
+  ExternalGroupSyncAttemptSnapshot,
+} from "./types";
+import useSyncAttemptsPaginatedFetch from "./useSyncAttemptsPaginatedFetch";
+
+/**
+ * Three-way tabbed view of attempt history for a permission-synced
+ * connector. Renders inside the existing "Advanced" collapsible on
+ * `/admin/connector/[ccPairId]` (wired up in PR D).
+ *
+ * Tabs: `Indexing` | `Document Permissions` | `Group Membership`.
+ *
+ * - The `Indexing` tab is driven by data passed in from `page.tsx`. The
+ *   page-level `usePaginatedFetch` is needed regardless (e.g. for
+ *   `latestIndexAttempt[0]`), so duplicating the fetch inside this tab
+ *   would be wasteful.
+ * - The two permission-sync tabs each lazy-mount their own
+ *   `useSyncAttemptsPaginatedFetch` hook. Radix `Tabs.Content` defaults
+ *   to unmounting inactive tabs, so a hook for an inactive tab does not
+ *   fire — fetches happen only when the user opens that tab.
+ *
+ * For the two permission-sync tabs, the body's render path is:
+ *
+ *   probe loading           → spinner
+ *   probe error             → `MessageCard` (error)
+ *   `applicable === false`  → `MessageCard` (info, "no separate ... job")
+ *   first page loading      → spinner
+ *   page error              → `MessageCard` (error)
+ *   no attempts             → empty-state `MessageCard` rendered by the
+ *                              table component itself
+ *   attempts present        → table with pagination
+ */
+
+const ITEMS_PER_PAGE = 8;
+const PAGES_PER_BATCH = 4;
+
+const NOT_APPLICABLE_DOC_PERMISSIONS_MESSAGE =
+  "This connector does not use a separate document-permission syncing job.";
+
+const NOT_APPLICABLE_GROUP_MEMBERSHIP_MESSAGE =
+  "This connector does not use a separate group-membership syncing job.";
+
+enum SyncAttemptsTab {
+  INDEXING = "indexing",
+  DOC_PERMISSIONS = "doc_permissions",
+  GROUP_MEMBERSHIP = "group_membership",
+}
+
+export interface SyncAttemptsTabsProps {
+  ccPair: CCPairFullInfo;
+  /**
+   * Indexing-tab data is owned by the parent page (which also reads
+   * `indexAttempts[0]` for header-card status). The tab simply renders
+   * what it's given so we don't double-fetch the indexing endpoint.
+   */
+  indexAttempts: IndexAttemptSnapshot[];
+  indexCurrentPage: number;
+  indexTotalPages: number;
+  onIndexPageChange: (page: number) => void;
+}
+
+export function SyncAttemptsTabs({
+  ccPair,
+  indexAttempts,
+  indexCurrentPage,
+  indexTotalPages,
+  onIndexPageChange,
+}: SyncAttemptsTabsProps) {
+  const [tab, setTab] = useState<SyncAttemptsTab>(SyncAttemptsTab.INDEXING);
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(value) => setTab(value as SyncAttemptsTab)}
+    >
+      <Tabs.List variant="contained">
+        <Tabs.Trigger value={SyncAttemptsTab.INDEXING}>Indexing</Tabs.Trigger>
+        <Tabs.Trigger value={SyncAttemptsTab.DOC_PERMISSIONS}>
+          Document Permissions
+        </Tabs.Trigger>
+        <Tabs.Trigger value={SyncAttemptsTab.GROUP_MEMBERSHIP}>
+          Group Membership
+        </Tabs.Trigger>
+      </Tabs.List>
+
+      <Tabs.Content value={SyncAttemptsTab.INDEXING}>
+        <IndexAttemptsTable
+          ccPair={ccPair}
+          indexAttempts={indexAttempts}
+          currentPage={indexCurrentPage}
+          totalPages={indexTotalPages}
+          onPageChange={onIndexPageChange}
+        />
+      </Tabs.Content>
+
+      <Tabs.Content value={SyncAttemptsTab.DOC_PERMISSIONS}>
+        <DocPermissionsTabBody ccPairId={ccPair.id} />
+      </Tabs.Content>
+
+      <Tabs.Content value={SyncAttemptsTab.GROUP_MEMBERSHIP}>
+        <GroupMembershipTabBody ccPairId={ccPair.id} />
+      </Tabs.Content>
+    </Tabs>
+  );
+}
+
+function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
+  const endpoint = `${buildCCPairInfoUrl(ccPairId)}/permission-sync-attempts`;
+  const result =
+    useSyncAttemptsPaginatedFetch<DocPermissionSyncAttemptSnapshot>({
+      endpoint,
+      itemsPerPage: ITEMS_PER_PAGE,
+      pagesPerBatch: PAGES_PER_BATCH,
+    });
+
+  const gate = renderTabGate(result, NOT_APPLICABLE_DOC_PERMISSIONS_MESSAGE);
+  if (gate !== null) return gate;
+
+  return (
+    <DocPermissionSyncAttemptsTable
+      attempts={result.currentPageData ?? []}
+      currentPage={result.currentPage}
+      totalPages={result.totalPages}
+      onPageChange={result.goToPage}
+    />
+  );
+}
+
+function GroupMembershipTabBody({ ccPairId }: { ccPairId: number }) {
+  const endpoint = `${buildCCPairInfoUrl(
+    ccPairId
+  )}/external-group-sync-attempts`;
+  const result =
+    useSyncAttemptsPaginatedFetch<ExternalGroupSyncAttemptSnapshot>({
+      endpoint,
+      itemsPerPage: ITEMS_PER_PAGE,
+      pagesPerBatch: PAGES_PER_BATCH,
+    });
+
+  const gate = renderTabGate(result, NOT_APPLICABLE_GROUP_MEMBERSHIP_MESSAGE);
+  if (gate !== null) return gate;
+
+  return (
+    <ExternalGroupSyncAttemptsTable
+      attempts={result.currentPageData ?? []}
+      currentPage={result.currentPage}
+      totalPages={result.totalPages}
+      onPageChange={result.goToPage}
+    />
+  );
+}
+
+interface TabGateInputs {
+  applicable: boolean | null;
+  applicableIsLoading: boolean;
+  applicableError: Error | null;
+  isLoading: boolean;
+  error: Error | null;
+  currentPageData: unknown[] | null;
+}
+
+/**
+ * Compresses the loading / error / not-applicable / first-page-loading
+ * branches both permission-sync tabs share into one place. Returns
+ * `null` when the caller should render its own table.
+ */
+function renderTabGate(
+  inputs: TabGateInputs,
+  notApplicableMessage: string
+): React.ReactElement | null {
+  const {
+    applicable,
+    applicableIsLoading,
+    applicableError,
+    isLoading,
+    error,
+    currentPageData,
+  } = inputs;
+
+  if (applicableError) {
+    return (
+      <MessageCard
+        variant="error"
+        title="Failed to load sync attempts"
+        description={applicableError.message}
+      />
+    );
+  }
+  if (applicableIsLoading || applicable === null) {
+    return <SyncAttemptsTabSpinner />;
+  }
+  if (applicable === false) {
+    return (
+      <MessageCard
+        variant="info"
+        title="Not applicable"
+        description={notApplicableMessage}
+      />
+    );
+  }
+  if (isLoading && currentPageData === null) {
+    return <SyncAttemptsTabSpinner />;
+  }
+  if (error) {
+    return (
+      <MessageCard
+        variant="error"
+        title="Failed to load sync attempts"
+        description={error.message}
+      />
+    );
+  }
+  return null;
+}
+
+function SyncAttemptsTabSpinner() {
+  return (
+    <Section
+      flexDirection="row"
+      justifyContent="center"
+      alignItems="center"
+      height="auto"
+      className="py-6"
+    >
+      <SimpleLoader className="h-6 w-6" />
+    </Section>
+  );
+}

--- a/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/SyncAttemptsTabs.tsx
@@ -7,12 +7,12 @@ import { MessageCard } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import Tabs from "@/refresh-components/Tabs";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import type { IndexAttemptSnapshot } from "@/lib/types";
 
 import { DocPermissionSyncAttemptsTable } from "./DocPermissionSyncAttemptsTable";
 import { ExternalGroupSyncAttemptsTable } from "./ExternalGroupSyncAttemptsTable";
 import { IndexAttemptsTable } from "./IndexAttemptsTable";
-import { buildCCPairInfoUrl } from "./lib";
 import type {
   CCPairFullInfo,
   DocPermissionSyncAttemptSnapshot,
@@ -122,10 +122,10 @@ export function SyncAttemptsTabs({
 }
 
 function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
-  const endpoint = `${buildCCPairInfoUrl(ccPairId)}/permission-sync-attempts`;
   const result =
     useSyncAttemptsPaginatedFetch<DocPermissionSyncAttemptSnapshot>({
-      endpoint,
+      endpoint: SWR_KEYS.ccPairPermissionSyncAttempts(ccPairId),
+      swrProbeKey: SWR_KEYS.ccPairPermissionSyncAttemptsProbe(ccPairId),
       itemsPerPage: ITEMS_PER_PAGE,
       pagesPerBatch: PAGES_PER_BATCH,
     });
@@ -144,12 +144,10 @@ function DocPermissionsTabBody({ ccPairId }: { ccPairId: number }) {
 }
 
 function GroupMembershipTabBody({ ccPairId }: { ccPairId: number }) {
-  const endpoint = `${buildCCPairInfoUrl(
-    ccPairId
-  )}/external-group-sync-attempts`;
   const result =
     useSyncAttemptsPaginatedFetch<ExternalGroupSyncAttemptSnapshot>({
-      endpoint,
+      endpoint: SWR_KEYS.ccPairExternalGroupSyncAttempts(ccPairId),
+      swrProbeKey: SWR_KEYS.ccPairExternalGroupSyncAttemptsProbe(ccPairId),
       itemsPerPage: ITEMS_PER_PAGE,
       pagesPerBatch: PAGES_PER_BATCH,
     });

--- a/web/src/app/admin/connector/[ccPairId]/useSyncAttemptsPaginatedFetch.ts
+++ b/web/src/app/admin/connector/[ccPairId]/useSyncAttemptsPaginatedFetch.ts
@@ -27,7 +27,6 @@ import type { CCPairSyncAttemptsResponse } from "./types";
  * @see plans/permission-sync-attempt-tabs.md (PR C, option B)
  */
 
-const APPLICABILITY_PROBE_PAGE_SIZE = 1;
 const ATTEMPTS_REFRESH_INTERVAL_MS = 5000;
 
 interface PaginatedItem {
@@ -38,8 +37,17 @@ export interface UseSyncAttemptsPaginatedFetchConfig {
   /**
    * Base API URL for the sync-attempts endpoint, without query params.
    * E.g. `/api/manage/admin/cc-pair/123/permission-sync-attempts`.
+   * Should be sourced from `SWR_KEYS` so that any future `mutate()` callers
+   * can target the same key.
    */
   endpoint: string;
+  /**
+   * SWR cache key for the applicability probe (the `?page_num=0&page_size=1`
+   * read). Must be a `SWR_KEYS` entry so that callers wanting to force-refresh
+   * the probe can do so without re-deriving the URL inline. See the
+   * `ccPair*SyncAttemptsProbe` builders in `web/src/lib/swr-keys.ts`.
+   */
+  swrProbeKey: string;
   itemsPerPage: number;
   pagesPerBatch: number;
 }
@@ -75,16 +83,16 @@ interface ApplicabilityProbeResponse {
 
 export default function useSyncAttemptsPaginatedFetch<T extends PaginatedItem>({
   endpoint,
+  swrProbeKey,
   itemsPerPage,
   pagesPerBatch,
 }: UseSyncAttemptsPaginatedFetchConfig): UseSyncAttemptsPaginatedFetchReturn<T> {
-  const probeUrl = `${endpoint}?page_num=0&page_size=${APPLICABILITY_PROBE_PAGE_SIZE}`;
   const {
     data: probeData,
     error: probeError,
     isLoading: applicableIsLoading,
   } = useSWR<CCPairSyncAttemptsResponse<T> | ApplicabilityProbeResponse>(
-    probeUrl,
+    swrProbeKey,
     errorHandlingFetcher
   );
 

--- a/web/src/app/admin/connector/[ccPairId]/useSyncAttemptsPaginatedFetch.ts
+++ b/web/src/app/admin/connector/[ccPairId]/useSyncAttemptsPaginatedFetch.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import useSWR from "swr";
+
+import usePaginatedFetch from "@/hooks/usePaginatedFetch";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+
+import type { CCPairSyncAttemptsResponse } from "./types";
+
+/**
+ * Thin wrapper around `usePaginatedFetch` that adapts the
+ * `CCPairSyncAttemptsResponse` shape used by both per-cc-pair sync-attempt
+ * endpoints (`/permission-sync-attempts` and
+ * `/external-group-sync-attempts`).
+ *
+ * The standard `usePaginatedFetch` hook expects `{ items, total_items }`,
+ * which is a strict subset of `CCPairSyncAttemptsResponse` — so the
+ * underlying paginated fetch works against either endpoint without
+ * modification, ignoring the extra `applicable` field on the wire.
+ *
+ * Surfacing `applicable` requires a separate read because
+ * `usePaginatedFetch` does not expose the raw response. The applicability
+ * value is invariant per (cc_pair, sync_kind), so a single SWR probe with
+ * `page_size=1` is the cheapest correct way to read it. SWR's URL-keyed
+ * cache shares the result across concurrent renders.
+ *
+ * @see plans/permission-sync-attempt-tabs.md (PR C, option B)
+ */
+
+const APPLICABILITY_PROBE_PAGE_SIZE = 1;
+const ATTEMPTS_REFRESH_INTERVAL_MS = 5000;
+
+interface PaginatedItem {
+  id: number | string;
+}
+
+export interface UseSyncAttemptsPaginatedFetchConfig {
+  /**
+   * Base API URL for the sync-attempts endpoint, without query params.
+   * E.g. `/api/manage/admin/cc-pair/123/permission-sync-attempts`.
+   */
+  endpoint: string;
+  itemsPerPage: number;
+  pagesPerBatch: number;
+}
+
+export interface UseSyncAttemptsPaginatedFetchReturn<T extends PaginatedItem> {
+  /**
+   * `null` while the applicability probe is in flight; `true`/`false`
+   * once known. The two non-null values map to "render the table" vs
+   * "render the not-applicable message" — they are NOT redundant with
+   * `items.length === 0`, see `CCPairSyncAttemptsResponse`.
+   */
+  applicable: boolean | null;
+  applicableError: Error | null;
+  applicableIsLoading: boolean;
+
+  // Standard pagination state, only meaningful when `applicable === true`.
+  // The underlying endpoint short-circuits to `items=[], total_items=0`
+  // when not applicable, so reading these in that state is harmless but
+  // misleading — gate on `applicable` first.
+  currentPageData: T[] | null;
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  goToPage: (page: number) => void;
+  refresh: () => Promise<void>;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+interface ApplicabilityProbeResponse {
+  applicable: boolean;
+}
+
+export default function useSyncAttemptsPaginatedFetch<T extends PaginatedItem>({
+  endpoint,
+  itemsPerPage,
+  pagesPerBatch,
+}: UseSyncAttemptsPaginatedFetchConfig): UseSyncAttemptsPaginatedFetchReturn<T> {
+  const probeUrl = `${endpoint}?page_num=0&page_size=${APPLICABILITY_PROBE_PAGE_SIZE}`;
+  const {
+    data: probeData,
+    error: probeError,
+    isLoading: applicableIsLoading,
+  } = useSWR<CCPairSyncAttemptsResponse<T> | ApplicabilityProbeResponse>(
+    probeUrl,
+    errorHandlingFetcher
+  );
+
+  const applicable = probeData ? probeData.applicable : null;
+
+  // Once we know the source has no applicable sync, stop polling — the
+  // backend will keep returning `applicable=false, items=[]` every 5s
+  // for the rest of the session otherwise.
+  const refreshIntervalInMs =
+    applicable === false ? 0 : ATTEMPTS_REFRESH_INTERVAL_MS;
+
+  const paginated = usePaginatedFetch<T>({
+    endpoint,
+    itemsPerPage,
+    pagesPerBatch,
+    refreshIntervalInMs,
+  });
+
+  return {
+    applicable,
+    applicableError: (probeError as Error | undefined) ?? null,
+    applicableIsLoading,
+
+    currentPageData: paginated.currentPageData,
+    currentPage: paginated.currentPage,
+    totalPages: paginated.totalPages,
+    totalItems: paginated.totalItems,
+    goToPage: paginated.goToPage,
+    refresh: paginated.refresh,
+    isLoading: paginated.isLoading,
+    error: paginated.error,
+  };
+}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -186,4 +186,17 @@ export const SWR_KEYS = {
   // ── Index Attempts ────────────────────────────────────────────────────────
   indexAttemptStageMetrics: (indexAttemptId: number) =>
     `/api/manage/admin/index-attempt/${indexAttemptId}/stage-metrics`,
+
+  // ── CC-Pair Sync Attempts ─────────────────────────────────────────────────
+  // The `*Probe` variants are single-row reads used to surface the
+  // `applicable` flag without paying for a full page; see
+  // `useSyncAttemptsPaginatedFetch`.
+  ccPairPermissionSyncAttempts: (ccPairId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/permission-sync-attempts`,
+  ccPairPermissionSyncAttemptsProbe: (ccPairId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/permission-sync-attempts?page_num=0&page_size=1`,
+  ccPairExternalGroupSyncAttempts: (ccPairId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts`,
+  ccPairExternalGroupSyncAttemptsProbe: (ccPairId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts?page_num=0&page_size=1`,
 } as const;


### PR DESCRIPTION
## Description

built on #10790, some more components for perm sync visibility

## How Has This Been Tested?

will be tested E2E in the next PR

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"chore/perm-sync-vis-setup2","parentHead":"5829d3ff5d9729be0571b4c768c745051a3fc996","parentPull":10790,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a tabbed attempts history UI for permission-synced connectors and a new paginated fetch hook that reads applicability and stops polling when not needed. Also added `SWR_KEYS` entries and probe URLs to support efficient checks.

- New Features
  - `SyncAttemptsTabs` with tabs for Indexing, Document Permissions, and Group Membership on `/admin/connector/[ccPairId]`.
  - Indexing tab renders parent-provided data to avoid duplicate fetches; permission-sync tabs lazy-mount hooks only when opened.
  - Shared gate for loader, errors, and not-applicable states using `MessageCard` and `SimpleLoader` from `@opal/components`.
  - `useSyncAttemptsPaginatedFetch` wraps `usePaginatedFetch` with a `useSWR` probe (`page_size=1`) to read `applicable`, and stops polling when not applicable.
  - Added `SWR_KEYS` for cc-pair sync attempts and their probe variants to standardize cache keys.
  - Pagination: 8 items per page, 4-page batches, 5s refresh when applicable.

<sup>Written for commit f4e000b19b6e4df3622f953876fed00b1527a732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

