### PR TITLE
chore(deps): upgrade litellm to latest w/ `override-dependencies`

### DIFF
--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -3,7 +3,7 @@ LiteLLM Monkey Patches
 
 This module addresses the following issues in LiteLLM:
 
-Status checked against LiteLLM v1.83.0 (2026-03-31):
+Status checked against LiteLLM v1.83.14 (2026-05-04):
 
 1. Ollama Streaming Reasoning Content (_patch_ollama_chunk_parser):
    - LiteLLM's chunk_parser doesn't properly handle reasoning content in streaming
@@ -187,7 +187,12 @@ def _patch_ollama_chunk_parser() -> None:
                 tool_calls=tool_calls,
             )
             if chunk["done"] is True:
-                finish_reason = chunk.get("done_reason", "stop")
+                finish_reason = chunk.get("done_reason") or "stop"
+                # Mirror upstream's fix for BerriAI/litellm#18922: when tool
+                # calls are present, override done_reason to "tool_calls" so
+                # downstream consumers branch correctly.
+                if tool_calls is not None:
+                    finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(
                         delta=delta,
@@ -499,11 +504,17 @@ def _patch_responses_api_usage_format() -> None:
                             total_tokens=usage.get("total_tokens", 0),
                         )
                     elif "input_tokens" in usage or "output_tokens" in usage:
-                        # Already in Responses API format, just convert to proper type
+                        # Already in Responses API format, just convert to proper type.
+                        # List every field explicitly so a new field added upstream
+                        # surfaces here (and in the audit header) instead of being
+                        # silently dropped or silently absorbed.
                         values["usage"] = ResponseAPIUsage(
                             input_tokens=usage.get("input_tokens", 0),
+                            input_tokens_details=usage.get("input_tokens_details"),
                             output_tokens=usage.get("output_tokens", 0),
+                            output_tokens_details=usage.get("output_tokens_details"),
                             total_tokens=usage.get("total_tokens", 0),
+                            cost=usage.get("cost"),
                         )
 
         # Call original model_construct (need to call it as unbound method)
@@ -544,7 +555,7 @@ def _patch_logging_assembled_streaming_response() -> None:
         return
 
     def _patched_get_assembled_streaming_response(
-        self: Any,  # noqa: ARG001
+        self: Any,
         result: Any,
         start_time: Any,  # noqa: ARG001
         end_time: Any,  # noqa: ARG001
@@ -559,6 +570,8 @@ def _patch_logging_assembled_streaming_response() -> None:
         This patch uses model_construct to rebuild the response with the transformed
         usage, ensuring proper typing.
         """
+        if self.stream is not True:
+            return None
         if isinstance(result, ModelResponse):
             return result
         elif isinstance(result, TextCompletionResponse):

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -775,9 +775,7 @@ durationpy==0.10 \
 email-validator==2.2.0 \
     --hash=sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631 \
     --hash=sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7
-    # via
-    #   fastapi-users
-    #   pydantic
+    # via fastapi-users
 emoji==2.15.0 \
     --hash=sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb \
     --hash=sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4
@@ -1242,10 +1240,6 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-h2==4.3.0 \
-    --hash=sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1 \
-    --hash=sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd
-    # via httpx
 hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' \
     --hash=sha256:0392c79b7cf48418cd61478c1a925246cf10639f4cd9d94368d8ca1e8df9ea07 \
     --hash=sha256:1feb0f3abeacee143367c326a128a2e2b60868ec12a36c225afb1d6c5a05e6d2 \
@@ -1273,10 +1267,6 @@ hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or 
     --hash=sha256:e23717ce4186b265f69afa66e6f0069fe7efbf331546f5c313d00e123dc84583 \
     --hash=sha256:fc360b70c815bf340ed56c7b8c63aacf11762a4b099b2fe2c9bd6d6068668c08
     # via huggingface-hub
-hpack==4.1.0 \
-    --hash=sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496 \
-    --hash=sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca
-    # via h2
 html5lib==1.1 \
     --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
     --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
@@ -1333,10 +1323,6 @@ humanfriendly==10.0 \
     --hash=sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477 \
     --hash=sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc
     # via coloredlogs
-hyperframe==6.1.0 \
-    --hash=sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5 \
-    --hash=sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08
-    # via h2
 idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
@@ -1351,9 +1337,15 @@ importlib-metadata==8.7.0 \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
     # via
     #   dask
+    #   google-api-core
+    #   hubspot-api-client
     #   keyring
     #   litellm
     #   opentelemetry-api
+    #   pywikibot
+    #   redis
+    #   sqlalchemy
+    #   trafilatura
 inflection==0.5.1 \
     --hash=sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417 \
     --hash=sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2
@@ -1545,9 +1537,9 @@ langsmith==0.7.32 \
 lazy-imports==1.0.1 \
     --hash=sha256:7d3e4b1547cb574ec7ef3c47a074673e2612330b2b50bf7eec939f2c393fc261 \
     --hash=sha256:eb5accc33bf9987e5197e79476bbeb960b74a2c16619bdf41281b3240f730846
-litellm==1.83.0 \
-    --hash=sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a \
-    --hash=sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8
+litellm==1.83.14 \
+    --hash=sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9 \
+    --hash=sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb
     # via onyx
 locket==1.0.0 \
     --hash=sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632 \

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -1122,7 +1122,12 @@ idna==3.11 \
 importlib-metadata==8.7.0 \
     --hash=sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000 \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
-    # via litellm
+    # via
+    #   google-api-core
+    #   jupyter-client
+    #   litellm
+    #   sqlalchemy
+    #   virtualenv
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
@@ -1342,9 +1347,9 @@ kubernetes==31.0.0 \
     --hash=sha256:28945de906c8c259c1ebe62703b56a03b714049372196f854105afe4e6d014c0 \
     --hash=sha256:bf141e2d380c8520eada8b351f4e319ffee9636328c137aa432bc486ca1200e1
     # via onyx
-litellm==1.83.0 \
-    --hash=sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a \
-    --hash=sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8
+litellm==1.83.14 \
+    --hash=sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9 \
+    --hash=sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb
     # via onyx
 mako==1.3.11 \
     --hash=sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069 \

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -856,7 +856,9 @@ idna==3.11 \
 importlib-metadata==8.7.0 \
     --hash=sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000 \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
-    # via litellm
+    # via
+    #   google-api-core
+    #   litellm
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
@@ -962,9 +964,9 @@ kubernetes==31.0.0 \
     --hash=sha256:28945de906c8c259c1ebe62703b56a03b714049372196f854105afe4e6d014c0 \
     --hash=sha256:bf141e2d380c8520eada8b351f4e319ffee9636328c137aa432bc486ca1200e1
     # via onyx
-litellm==1.83.0 \
-    --hash=sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a \
-    --hash=sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8
+litellm==1.83.14 \
+    --hash=sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9 \
+    --hash=sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb
     # via onyx
 markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -896,7 +896,10 @@ idna==3.11 \
 importlib-metadata==8.7.0 \
     --hash=sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000 \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
-    # via litellm
+    # via
+    #   google-api-core
+    #   litellm
+    #   triton
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
@@ -1012,9 +1015,9 @@ kubernetes==31.0.0 \
     --hash=sha256:28945de906c8c259c1ebe62703b56a03b714049372196f854105afe4e6d014c0 \
     --hash=sha256:bf141e2d380c8520eada8b351f4e319ffee9636328c137aa432bc486ca1200e1
     # via onyx
-litellm==1.83.0 \
-    --hash=sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a \
-    --hash=sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8
+litellm==1.83.14 \
+    --hash=sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9 \
+    --hash=sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb
     # via onyx
 markdown-it-py==4.0.0 \
     --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \

--- a/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
+++ b/backend/tests/external_dependency_unit/llm/test_ollama_streaming.py
@@ -94,3 +94,64 @@ def test_streaming_separates_reasoning_content_from_visible_content(
     assert (
         "<think>" not in full_reasoning and "</think>" not in full_reasoning
     ), f"Raw <think> tags leaked into reasoning_content: {full_reasoning!r}"
+
+
+@pytest.mark.secrets(TestSecret.OLLAMA_API_KEY)
+def test_streaming_tool_call_finish_reason_is_tool_calls(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """When a streaming Ollama response ends with tool calls, the terminal
+    chunk's `finish_reason` must be `"tool_calls"`, not `"stop"`.
+
+    Upstream LiteLLM ships this override for BerriAI/litellm#18922 directly
+    in `OllamaChatCompletionResponseIterator.chunk_parser`. Our
+    `_patch_ollama_chunk_parser` replaces that method wholesale, so the
+    override has to be re-applied inside the patch. This test guards that
+    we don't drop it on a future LiteLLM bump.
+    """
+    llm = LitellmLLM(
+        api_key=test_secrets[TestSecret.OLLAMA_API_KEY],
+        model_provider=LlmProviderNames.OLLAMA_CHAT,
+        model_name=_THINKING_MODEL,
+        api_base="https://ollama.com",
+        max_input_tokens=8192,
+        timeout=120,
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content="Use the get_weather tool to look up the weather in Paris.",
+        )
+    ]
+
+    finish_reasons: list[str] = []
+    saw_tool_call = False
+    for chunk in llm.stream(prompt=prompt, tools=tools):
+        if chunk.choice.delta.tool_calls:
+            saw_tool_call = True
+        if chunk.choice.finish_reason:
+            finish_reasons.append(chunk.choice.finish_reason)
+
+    assert saw_tool_call, "Model did not emit a tool call; cannot test finish_reason"
+    assert finish_reasons, "Stream produced no terminal chunk with finish_reason"
+    assert finish_reasons[-1] == "tool_calls", (
+        f"Expected terminal finish_reason='tool_calls' when model issues a "
+        f"tool call, got {finish_reasons[-1]!r}. All finish_reasons: "
+        f"{finish_reasons!r}"
+    )

--- a/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_openai_responses_api.py
@@ -10,9 +10,15 @@ behavior of that bridge that cannot be reached with mocks:
 - Reasoning summary sections are separated by a blank line in the streamed
   `reasoning_content` (covered by `_patch_responses_reasoning_summary_newlines`
   in `monkey_patches.py`).
+- Non-streaming reasoning summary parts are joined with blank lines
+  (covered by `_patch_openai_responses_transform_response`).
+- No Pydantic serializer warnings escape during a Responses API stream
+  (covered by `_patch_responses_api_usage_format` and
+  `_patch_logging_assembled_streaming_response`).
 """
 
 import json
+import warnings
 
 import pytest
 
@@ -220,3 +226,81 @@ def test_streaming_reasoning_summary_sections_are_separated_by_blank_line(
     assert (
         "\n\n" in full_reasoning
     ), f"Expected double-newline separator between summary sections: {full_reasoning!r}"
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_non_streaming_reasoning_summary_sections_are_separated_by_blank_line(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Non-streaming `reasoning_content` must contain a `\\n\\n` separator
+    between distinct reasoning summary sections.
+
+    Sister test to
+    `test_streaming_reasoning_summary_sections_are_separated_by_blank_line`.
+    LiteLLM's `LiteLLMResponsesTransformationHandler.transform_response`
+    joins multiple reasoning summary parts with a single space, which renders
+    as a wall of text. `_patch_openai_responses_transform_response` (in
+    `monkey_patches.py`) post-processes the result to join with `\\n\\n`. This
+    test guards that the patch fires on the non-stream path.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(
+            role="user",
+            content=(
+                "Plan a 3-day trip to Tokyo for someone with a peanut allergy on a $2000 budget. "
+                "First plan the itinerary, then verify each restaurant choice is safe, then check "
+                "the budget math."
+            ),
+        )
+    ]
+
+    response = llm.invoke(prompt=prompt)
+    reasoning = response.choice.message.reasoning_content or ""
+
+    assert (
+        "\n\n" in reasoning
+    ), f"Expected double-newline separator between summary sections: {reasoning!r}"
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_emits_no_pydantic_serializer_warnings(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Streaming a Responses API call must not emit Pydantic serializer
+    warnings.
+
+    LiteLLM's logging path calls `model_dump()` on a
+    `ResponsesAPIResponse` whose `usage` field has been mutated to a chat-
+    completion-shaped dict, which triggers a `Pydantic serializer warnings:
+    PydanticSerializationUnexpectedValue` `UserWarning`. Two patches
+    cooperate to silence it: `_patch_responses_api_usage_format` ensures
+    `model_construct` rebuilds usage as a typed `ResponseAPIUsage`, and
+    `_patch_logging_assembled_streaming_response` deep-copies the response
+    before mutation so the original keeps its proper type. This test
+    captures the symptom rather than either patch's internals — if the
+    warning escapes, at least one patch is broken or upstream regressed.
+    """
+    llm = _build_openai_llm("gpt-5.4-nano", test_secrets[TestSecret.OPENAI_API_KEY])
+
+    prompt: list[ChatCompletionMessage] = [
+        UserMessage(role="user", content="Reply with exactly the word: ok")
+    ]
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        for _ in llm.stream(prompt=prompt):
+            pass
+
+    serializer_warnings = [
+        w
+        for w in captured
+        if "Pydantic serializer warnings" in str(w.message)
+        or "PydanticSerializationUnexpectedValue" in str(w.message)
+    ]
+    assert not serializer_warnings, (
+        "Pydantic serializer warning(s) escaped during Responses API stream; "
+        "monkey patches for usage format / assembled streaming response are "
+        f"not silencing them: {[str(w.message) for w in serializer_warnings]!r}"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "cohere==5.6.1",
     "fastapi==0.133.1",
     "google-genai==1.52.0",
-    "litellm[google]==1.83.0",
+    "litellm[google]==1.83.14",
     "openai==2.14.0",
     "pydantic==2.11.7",
     "prometheus_client>=0.21.1",
@@ -194,6 +194,28 @@ model_server = [
 
 [tool.uv]
 default-groups = ["backend", "dev", "ee", "model_server"]
+
+# litellm >=1.83.x switched from loose ranges to exact `==` pins on its
+# transitive dependencies (see https://github.com/BerriAI/litellm/issues/25280),
+# which forces downgrades of packages we already pin to newer versions and
+# regressions on transitively resolved packages. Replace those exact pins with
+# the loose ranges litellm declared prior to 1.83.1 so that uv's resolver is
+# free to pick versions consistent with our top-level pins (or newer).
+override-dependencies = [
+    "aiohttp>=3.10",
+    "click",
+    "fastuuid>=0.13.0",
+    "httpx>=0.23.0",
+    "importlib-metadata>=6.8.0",
+    "jinja2>=3.1.2,<4.0.0",
+    "jsonschema>=4.23.0,<5.0.0",
+    "openai",
+    "pydantic",
+    "python-dotenv",
+    "tiktoken",
+    "tokenizers",
+    "google-cloud-aiplatform>=1.38.0",
+]
 
 [tool.ty.environment]
 python-version = "3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 
+[manifest]
+overrides = [
+    { name = "aiohttp", specifier = ">=3.10" },
+    { name = "click" },
+    { name = "fastuuid", specifier = ">=0.13.0" },
+    { name = "google-cloud-aiplatform", specifier = ">=1.38.0" },
+    { name = "httpx", specifier = ">=0.23.0" },
+    { name = "importlib-metadata", specifier = ">=6.8.0" },
+    { name = "jinja2", specifier = ">=3.1.2,<4.0.0" },
+    { name = "jsonschema", specifier = ">=4.23.0,<5.0.0" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+
 [[package]]
 name = "accelerate"
 version = "1.6.0"
@@ -1338,7 +1355,7 @@ dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
     { name = "fsspec" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "importlib-metadata" },
     { name = "packaging" },
     { name = "partd" },
     { name = "pyyaml" },
@@ -1761,7 +1778,7 @@ dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -2049,6 +2066,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
+    { name = "importlib-metadata" },
     { name = "proto-plus" },
     { name = "protobuf" },
     { name = "requests" },
@@ -2426,19 +2444,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
-]
-
-[[package]]
 name = "hatchling"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2483,15 +2488,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
-]
-
-[[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -2563,11 +2559,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
-[package.optional-dependencies]
-http2 = [
-    { name = "h2" },
-]
-
 [[package]]
 name = "httpx-oauth"
 version = "0.15.1"
@@ -2595,6 +2586,7 @@ version = "11.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
+    { name = "importlib-metadata" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "six" },
@@ -2635,15 +2627,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
-name = "hyperframe"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -3026,6 +3009,7 @@ name = "jupyter-client"
 version = "8.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "jupyter-core" },
     { name = "python-dateutil" },
     { name = "pyzmq" },
@@ -3067,7 +3051,7 @@ name = "keyring"
 version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "importlib-metadata" },
     { name = "jaraco-classes" },
     { name = "jaraco-context" },
     { name = "jaraco-functools" },
@@ -3287,7 +3271,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.83.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3303,9 +3287,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [package.optional-dependencies]
@@ -4436,7 +4420,7 @@ backend = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "httpcore" },
-    { name = "httpx", extra = ["http2"] },
+    { name = "httpx" },
     { name = "httpx-oauth" },
     { name = "hubspot-api-client" },
     { name = "inflection" },
@@ -4567,7 +4551,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
-    { name = "litellm", extras = ["google"], specifier = "==1.83.0" },
+    { name = "litellm", extras = ["google"], specifier = "==1.83.14" },
     { name = "openai", specifier = "==2.14.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==7.1.0" },
@@ -5683,11 +5667,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
-]
-
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
@@ -6222,6 +6201,7 @@ name = "pywikibot"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "mwparserfromhell" },
     { name = "packaging" },
     { name = "requests" },
@@ -6437,6 +6417,7 @@ version = "5.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "importlib-metadata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/10/defc227d65ea9c2ff5244645870859865cba34da7373477c8376629746ec/redis-5.0.8.tar.gz", hash = "sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870", size = 4595651, upload-time = "2024-07-30T14:11:52.137Z" }
 wheels = [
@@ -7157,6 +7138,7 @@ version = "2.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/b1/127b7612dc8625dd34eb202efc594dac86f5208aef4ff467dfd630e76f9d/SQLAlchemy-2.0.15.tar.gz", hash = "sha256:2e940a8659ef870ae10e0d9e2a6d5aaddf0ff6e91f7d0d7732afc9e8c4be9bbc", size = 9296612, upload-time = "2023-05-20T01:00:13.011Z" }
@@ -7480,6 +7462,7 @@ dependencies = [
     { name = "charset-normalizer" },
     { name = "courlan" },
     { name = "htmldate" },
+    { name = "importlib-metadata" },
     { name = "justext" },
     { name = "lxml" },
     { name = "urllib3" },
@@ -7522,6 +7505,9 @@ wheels = [
 name = "triton"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "sys_platform != 'win32'" },
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/72/ec90c3519eaf168f22cb1757ad412f3a2add4782ad3a92861c9ad135d886/triton-3.5.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61413522a48add32302353fdbaaf92daaaab06f6b5e3229940d21b5207f47579", size = 170425802, upload-time = "2025-11-11T17:40:53.209Z" },
     { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
@@ -7928,6 +7914,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
+    { name = "importlib-metadata" },
     { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }


### PR DESCRIPTION
## Description

Upgrades LiteLLM to latest.

## How Has This Been Tested?

Integration tests included

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `litellm` to 1.83.14 and added `uv` `override-dependencies` to prevent forced downgrades from `litellm`’s exact pins. Updated our patches and tests to keep streaming, tool-calls, and Responses API behavior correct and warning-free.

- **Dependencies**
  - Bumped `litellm` to `1.83.14` across all requirement sets and `pyproject.toml` (with `[google]`).
  - Added `[tool.uv].override-dependencies` to relax `litellm`’s exact pins (e.g., `aiohttp`, `httpx`, `importlib-metadata`, `jsonschema`, `google-cloud-aiplatform`) so resolution stays aligned with our pins.
  - Dropped `httpx[http2]` to remove `h2`/`hpack`/`hyperframe` from the tree.
  - Regenerated `uv.lock` with the overrides and transitive updates.

- **Bug Fixes**
  - Ollama streaming: terminal `finish_reason` is `tool_calls` when tool calls are present.
  - Responses API: rebuild `usage` as a typed `ResponseAPIUsage` with explicit fields (`input_tokens_details`, `output_tokens_details`, `cost`) to avoid field loss and silence Pydantic warnings.
  - Streaming logging: only assemble streaming responses when `stream=True` to avoid mutations that triggered warnings.
  - Tests added for Ollama tool-call finish reason, non‑stream reasoning summary separation, and no Pydantic serializer warnings during Responses API streaming.

<sup>Written for commit be2345437cbde8890a646b53b2dcfa800ab09c6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

