### PR TITLE
refactor(web): internalize sidebar fold state into SidebarRoot

### DIFF
--- a/web/src/layouts/admin/ClientLayout.tsx
+++ b/web/src/layouts/admin/ClientLayout.tsx
@@ -15,8 +15,7 @@ export interface ClientLayoutProps {
 }
 
 export default function ClientLayout({ children }: ClientLayoutProps) {
-  const { folded: sidebarFolded, setFolded: setSidebarFolded } =
-    useSidebarState();
+  const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
@@ -47,10 +46,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
         <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">{children}</div>
       ) : (
         <>
-          <AdminSidebar
-            folded={sidebarFolded}
-            onFoldChange={setSidebarFolded}
-          />
+          <AdminSidebar />
           <div
             data-main-container
             className="flex flex-1 flex-col min-w-0 min-h-0 overflow-y-auto"
@@ -60,7 +56,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
                 <Button
                   prominence="internal"
                   icon={SvgSidebar}
-                  onClick={() => setSidebarFolded(false)}
+                  onClick={() => setFolded(false)}
                 />
               </div>
             )}

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -45,7 +45,6 @@ import FrostedDiv from "@/refresh-components/FrostedDiv";
 import Popover, { PopoverMenu } from "@/refresh-components/Popover";
 import { PopoverSearchInput } from "@/sections/sidebar/ChatButton";
 import SimplePopover from "@/refresh-components/SimplePopover";
-import { Interactive } from "@opal/core";
 import { Button, LineItemButton, OpenButton } from "@opal/components";
 import { useSidebarState } from "@/layouts/sidebar-layouts";
 import useScreenSize from "@/hooks/useScreenSize";

--- a/web/src/layouts/sidebar-layouts.tsx
+++ b/web/src/layouts/sidebar-layouts.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 /**
  * Sidebar Layout Components
  *
@@ -151,12 +150,6 @@ export function useSidebarFolded(): boolean {
 
 interface SidebarRootProps {
   /**
-   * Whether the sidebar is currently folded (desktop) or off-screen (mobile).
-   */
-  folded: boolean;
-  /** Callback to update the fold state. Compatible with `useState` setters. */
-  onFoldChange: Dispatch<SetStateAction<boolean>>;
-  /**
    * Whether the sidebar supports folding on desktop.
    * When `false` (the default), the sidebar is always expanded on desktop and
    * the fold button is hidden. Mobile overlay behavior is always enabled
@@ -166,19 +159,12 @@ interface SidebarRootProps {
   children: React.ReactNode;
 }
 
-function SidebarRoot({
-  folded,
-  onFoldChange,
-  foldable = false,
-  children,
-}: SidebarRootProps) {
+function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
   const { isMobile, isMediumScreen } = useScreenSize();
+  const { folded, setFolded } = useSidebarState();
 
-  const close = useCallback(() => onFoldChange(true), [onFoldChange]);
-  const toggle = useCallback(
-    () => onFoldChange((prev) => !prev),
-    [onFoldChange]
-  );
+  const close = useCallback(() => setFolded(true), [setFolded]);
+  const toggle = useCallback(() => setFolded((prev) => !prev), [setFolded]);
 
   // On mobile the sidebar content is always visually expanded — the overlay
   // transform handles visibility. On desktop, only foldable sidebars honour

--- a/web/src/layouts/sidebar-layouts.tsx
+++ b/web/src/layouts/sidebar-layouts.tsx
@@ -8,14 +8,13 @@
  * @example
  * ```tsx
  * import * as SidebarLayouts from "@/layouts/sidebar-layouts";
- * import { useSidebarState, useSidebarFolded } from "@/layouts/sidebar-layouts";
+ * import { useSidebarFolded } from "@/layouts/sidebar-layouts";
  *
  * function MySidebar() {
- *   const { folded, setFolded } = useSidebarState();
  *   const contentFolded = useSidebarFolded();
  *
  *   return (
- *     <SidebarLayouts.Root folded={folded} onFoldChange={setFolded} foldable>
+ *     <SidebarLayouts.Root foldable>
  *       <SidebarLayouts.Header>
  *         <NewSessionButton folded={contentFolded} />
  *       </SidebarLayouts.Header>
@@ -34,7 +33,6 @@
 import {
   createContext,
   useContext,
-  useCallback,
   useState,
   useEffect,
   type Dispatch,
@@ -163,8 +161,12 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
   const { isMobile, isMediumScreen } = useScreenSize();
   const { folded, setFolded } = useSidebarState();
 
-  const close = useCallback(() => setFolded(true), [setFolded]);
-  const toggle = useCallback(() => setFolded((prev) => !prev), [setFolded]);
+  function closeSidebar() {
+    setFolded(true);
+  }
+  function toggleSidebar() {
+    setFolded((prev) => !prev);
+  }
 
   // On mobile the sidebar content is always visually expanded — the overlay
   // transform handles visibility. On desktop, only foldable sidebars honour
@@ -184,7 +186,7 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
             folded ? "-translate-x-full" : "translate-x-0"
           )}
         >
-          <SidebarWrapper folded={false} onFoldClick={close}>
+          <SidebarWrapper folded={false} onFoldClick={closeSidebar}>
             {inner}
           </SidebarWrapper>
         </div>
@@ -197,7 +199,7 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
               ? "opacity-0 pointer-events-none"
               : "opacity-100 pointer-events-auto"
           )}
-          onClick={close}
+          onClick={closeSidebar}
         />
       </SidebarFoldedContext.Provider>
     );
@@ -213,7 +215,7 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
 
         {/* Sidebar — fixed so it overlays content when expanded */}
         <div className="fixed inset-y-0 left-0 z-50">
-          <SidebarWrapper folded={folded} onFoldClick={toggle}>
+          <SidebarWrapper folded={folded} onFoldClick={toggleSidebar}>
             {inner}
           </SidebarWrapper>
         </div>
@@ -226,7 +228,7 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
               ? "opacity-0 pointer-events-none"
               : "opacity-100 pointer-events-auto"
           )}
-          onClick={close}
+          onClick={closeSidebar}
         />
       </SidebarFoldedContext.Provider>
     );
@@ -236,7 +238,7 @@ function SidebarRoot({ foldable = false, children }: SidebarRootProps) {
     <SidebarFoldedContext.Provider value={contentFolded}>
       <SidebarWrapper
         folded={foldable ? folded : undefined}
-        onFoldClick={foldable ? toggle : undefined}
+        onFoldClick={foldable ? toggleSidebar : undefined}
       >
         {inner}
       </SidebarWrapper>

--- a/web/src/layouts/sidebar-layouts.tsx
+++ b/web/src/layouts/sidebar-layouts.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 /**
  * Sidebar Layout Components
  *

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -402,16 +402,15 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
   // Auto-fold sidebar when a multi-model message is submitted.
   // Stays collapsed until the user exits multi-model mode (removes models).
-  const { folded: sidebarFolded, setFolded: setSidebarFolded } =
-    useSidebarState();
+  const { folded: sidebarFolded, setFolded } = useSidebarState();
   const preMultiModelFoldedRef = useRef<boolean | null>(null);
 
   const foldSidebarForMultiModel = useCallback(() => {
     if (preMultiModelFoldedRef.current === null) {
       preMultiModelFoldedRef.current = sidebarFolded;
-      setSidebarFolded(true);
+      setFolded(true);
     }
-  }, [sidebarFolded, setSidebarFolded]);
+  }, [sidebarFolded, setFolded]);
 
   // Restore sidebar when user exits multi-model mode
   useEffect(() => {
@@ -419,7 +418,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
       !multiModel.isMultiModelActive &&
       preMultiModelFoldedRef.current !== null
     ) {
-      setSidebarFolded(preMultiModelFoldedRef.current);
+      setFolded(preMultiModelFoldedRef.current);
       preMultiModelFoldedRef.current = null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import SidebarSection from "@/sections/sidebar/SidebarSection";
@@ -32,6 +25,7 @@ import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import useFilter from "@/hooks/useFilter";
 import { IconFunctionComponent } from "@opal/types";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
+import { useSidebarState } from "@/layouts/sidebar-layouts";
 
 const SECTIONS = {
   UNLABELED: "",
@@ -187,16 +181,8 @@ function groupBySection(items: SidebarItemEntry[]) {
   return groups;
 }
 
-interface AdminSidebarProps {
-  folded: boolean;
-  onFoldChange: Dispatch<SetStateAction<boolean>>;
-}
-
-interface AdminSidebarInnerProps {
-  onFoldChange: Dispatch<SetStateAction<boolean>>;
-}
-
-function AdminSidebarInner({ onFoldChange }: AdminSidebarInnerProps) {
+function AdminSidebarInner() {
+  const { setFolded } = useSidebarState();
   const folded = useSidebarFolded();
   const searchRef = useRef<HTMLInputElement>(null);
   const [focusSearch, setFocusSearch] = useState(false);
@@ -255,7 +241,7 @@ function AdminSidebarInner({ onFoldChange }: AdminSidebarInnerProps) {
             icon={SvgSearch}
             folded
             onClick={() => {
-              onFoldChange(false);
+              setFolded(false);
               setFocusSearch(true);
             }}
           >
@@ -335,13 +321,10 @@ function AdminSidebarInner({ onFoldChange }: AdminSidebarInnerProps) {
   );
 }
 
-export default function AdminSidebar({
-  folded,
-  onFoldChange,
-}: AdminSidebarProps) {
+export default function AdminSidebar() {
   return (
-    <SidebarLayouts.Root folded={folded} onFoldChange={onFoldChange}>
-      <AdminSidebarInner onFoldChange={onFoldChange} />
+    <SidebarLayouts.Root>
+      <AdminSidebarInner />
     </SidebarLayouts.Root>
   );
 }

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -33,7 +33,6 @@ import SidebarSection from "@/sections/sidebar/SidebarSection";
 import useChatSessions from "@/hooks/useChatSessions";
 import { useProjects } from "@/lib/hooks/useProjects";
 import { useAgents, useCurrentAgent, usePinnedAgents } from "@/hooks/useAgents";
-import { useSidebarState } from "@/layouts/sidebar-layouts";
 import ProjectFolderButton from "@/sections/sidebar/ProjectFolderButton";
 import CreateProjectModal from "@/components/modals/CreateProjectModal";
 import MoveCustomAgentChatModal from "@/components/modals/MoveCustomAgentChatModal";
@@ -745,10 +744,8 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
 });
 
 export default function AppSidebar() {
-  const { folded, setFolded } = useSidebarState();
-
   return (
-    <SidebarLayouts.Root folded={folded} onFoldChange={setFolded} foldable>
+    <SidebarLayouts.Root foldable>
       <MemoizedAppSidebarInner />
     </SidebarLayouts.Root>
   );


### PR DESCRIPTION
## Description

`SidebarRoot` previously required callers to pass `folded` and `onFoldChange` as props, which meant every sidebar consumer had to read from `useSidebarState()` and thread the values down. This PR moves that responsibility inside `SidebarRoot` itself — it now calls `useSidebarState()` directly.

**Changes:**

- `sidebar-layouts.tsx`: `SidebarRoot` drops `folded`/`onFoldChange` from its prop interface and reads them from `useSidebarState()` internally
- `AdminSidebar.tsx`: `AdminSidebarProps` and `AdminSidebarInnerProps` interfaces deleted; `AdminSidebar` and `AdminSidebarInner` become zero-prop components; `onFoldChange` sourced from `useSidebarState()` inside `AdminSidebarInner`
- `AppSidebar.tsx`: Same — `AppSidebar` becomes a zero-prop component, `SidebarLayouts.Root` called with just `foldable`
- `ClientLayout.tsx`: `<AdminSidebar />` call simplified to zero props
- `app-layouts.tsx`: Remove unused `Interactive` import
- `AppPage.tsx`: Rename `setSidebarFolded` → `setFolded` to match updated hook destructuring

## Screenshots + Videos

No UI changes; screenshots / videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Internalized sidebar fold state into `SidebarLayouts.Root` so callers no longer pass `folded`/`onFoldChange`. This simplifies sidebars and removes prop threading.

- **Refactors**
  - `SidebarLayouts.Root` reads `folded`/`setFolded` from `useSidebarState()`; dropped those props and replaced `useCallback` handlers with simple functions.
  - `AdminSidebar` and `AppSidebar` are zero-prop; `AdminSidebarInner` uses `useSidebarState()` and calls `setFolded` when focusing search.
  - `ClientLayout` renders `<AdminSidebar />`; header toggle calls `setFolded(false)`.
  - `AppPage` uses `{ folded, setFolded }` and restores pre–multi-model state via `setFolded`.
  - Minor cleanup: removed unused `Interactive` import in `app-layouts.tsx`; restored blank line after "use client" in `sidebar-layouts.tsx`.

<sup>Written for commit f05eaca318ea040a2bdad50b0c83038e4665a36c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

