### PR TITLE
fix(auth): refresh OAuth tokens for any OIDC provider, not just Google [mirror of #10794]

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -30,32 +31,55 @@ REFRESH_ENDPOINTS: Dict[str, str] = {
 # .well-known/openid-configuration document is only retrieved once per process.
 _OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str] = {}
 
+# Lazily-initialized lock guarding concurrent first-time fetches of the OIDC
+# discovery document. Created on first use so it binds to the running event
+# loop rather than at import time.
+_OIDC_TOKEN_ENDPOINT_LOCK: Optional[asyncio.Lock] = None
+
+
+def _get_oidc_lock() -> asyncio.Lock:
+    """Return the module-level OIDC discovery lock, creating it on first call."""
+    global _OIDC_TOKEN_ENDPOINT_LOCK
+    if _OIDC_TOKEN_ENDPOINT_LOCK is None:
+        _OIDC_TOKEN_ENDPOINT_LOCK = asyncio.Lock()
+    return _OIDC_TOKEN_ENDPOINT_LOCK
+
 
 async def _get_oidc_token_endpoint() -> Optional[str]:
     """Resolve the OAuth2 token endpoint for the configured OIDC provider.
 
     Reads `token_endpoint` from the OPENID_CONFIG_URL discovery document so
     refresh works for any OIDC provider (Microsoft Entra, Okta, Keycloak,
-    Auth0, ...) without hardcoding provider-specific URLs.
+    Auth0, ...) without hardcoding provider-specific URLs. The lock + double
+    check ensures concurrent callers (e.g. multiple tokens expiring at once
+    after a server restart) coalesce into a single discovery request.
     """
     cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
     if cached:
         return cached
     if not OPENID_CONFIG_URL:
         return None
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(OPENID_CONFIG_URL, timeout=10.0)
-            response.raise_for_status()
-            config: Dict[str, Any] = response.json()
-    except httpx.HTTPError as e:
-        logger.warning("Failed to fetch OIDC discovery document: %s", e)
+    async with _get_oidc_lock():
+        # Re-check inside the lock — another coroutine may have populated
+        # the cache while we were waiting to acquire it.
+        cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+        if cached:
+            return cached
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(OPENID_CONFIG_URL, timeout=10.0)
+                response.raise_for_status()
+                config: Dict[str, Any] = response.json()
+        except (httpx.HTTPError, ValueError) as e:
+            # ValueError covers json.JSONDecodeError when the IdP returns a
+            # non-JSON body (e.g. an HTML error page from a misconfigured URL).
+            logger.warning("Failed to fetch OIDC discovery document: %s", e)
+            return None
+        token_endpoint = config.get("token_endpoint")
+        if isinstance(token_endpoint, str) and token_endpoint:
+            _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
+            return token_endpoint
         return None
-    token_endpoint = config.get("token_endpoint")
-    if isinstance(token_endpoint, str) and token_endpoint:
-        _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
-        return token_endpoint
-    return None
 
 
 async def _resolve_token_endpoint(provider: str) -> Optional[str]:

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
+from onyx.configs.app_configs import OPENID_CONFIG_URL
 from onyx.configs.app_configs import TRACK_EXTERNAL_IDP_EXPIRY
 from onyx.db.models import OAuthAccount
 from onyx.db.models import User
@@ -19,10 +20,57 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Standard OAuth refresh token endpoints
-REFRESH_ENDPOINTS = {
+# Standard OAuth refresh token endpoints, keyed by `oauth_account.oauth_name`.
+REFRESH_ENDPOINTS: Dict[str, str] = {
     "google": "https://oauth2.googleapis.com/token",
 }
+
+# Token endpoint resolved from the configured OIDC discovery document.
+# Populated lazily on first successful fetch and re-used thereafter, so the
+# .well-known/openid-configuration document is only retrieved once per process.
+_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str] = {}
+
+
+async def _get_oidc_token_endpoint() -> Optional[str]:
+    """Resolve the OAuth2 token endpoint for the configured OIDC provider.
+
+    Reads `token_endpoint` from the OPENID_CONFIG_URL discovery document so
+    refresh works for any OIDC provider (Microsoft Entra, Okta, Keycloak,
+    Auth0, ...) without hardcoding provider-specific URLs.
+    """
+    cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+    if cached:
+        return cached
+    if not OPENID_CONFIG_URL:
+        return None
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(OPENID_CONFIG_URL, timeout=10.0)
+            response.raise_for_status()
+            config: Dict[str, Any] = response.json()
+    except httpx.HTTPError as e:
+        logger.warning("Failed to fetch OIDC discovery document: %s", e)
+        return None
+    token_endpoint = config.get("token_endpoint")
+    if isinstance(token_endpoint, str) and token_endpoint:
+        _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
+        return token_endpoint
+    return None
+
+
+async def _resolve_token_endpoint(provider: str) -> Optional[str]:
+    """Return the OAuth2 token endpoint URL for a given provider.
+
+    Falls back to the OIDC discovery document when the provider is "openid"
+    (the default name used by httpx_oauth's generic OIDC client) so any
+    OIDC-compliant identity provider supports token refresh, not just Google.
+    """
+    static = REFRESH_ENDPOINTS.get(provider)
+    if static:
+        return static
+    if provider == "openid":
+        return await _get_oidc_token_endpoint()
+    return None
 
 
 # NOTE: Keeping this as a utility function for potential future debugging,
@@ -77,7 +125,8 @@ async def refresh_oauth_token(
         return False
 
     provider = oauth_account.oauth_name
-    if provider not in REFRESH_ENDPOINTS:
+    token_endpoint = await _resolve_token_endpoint(provider)
+    if not token_endpoint:
         logger.warning("Refresh endpoint not configured for provider: %s", provider)
         return False
 
@@ -86,7 +135,7 @@ async def refresh_oauth_token(
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                REFRESH_ENDPOINTS[provider],
+                token_endpoint,
                 data={
                     "client_id": OAUTH_CLIENT_ID,
                     "client_secret": OAUTH_CLIENT_SECRET,

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from onyx.auth import oauth_refresher
+from onyx.auth.oauth_refresher import _resolve_token_endpoint
 from onyx.auth.oauth_refresher import _test_expire_oauth_token
 from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
 from onyx.auth.oauth_refresher import check_oauth_account_has_refresh_token
@@ -235,6 +237,122 @@ async def test_check_oauth_account_has_refresh_token(
         mock_user, mock_oauth_account
     )
     assert has_token is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_google_static(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Static provider URLs (e.g. Google) bypass discovery."""
+    # Clear discovery cache so a misbehaving fallback would surface as a fetch.
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    endpoint = await _resolve_token_endpoint("google")
+    assert endpoint == "https://oauth2.googleapis.com/token"
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_via_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For OIDC ("openid"), the token endpoint is read from the discovery doc."""
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    monkeypatch.setattr(
+        oauth_refresher,
+        "OPENID_CONFIG_URL",
+        "https://idp.example.com/.well-known/openid-configuration",
+    )
+
+    discovery_response = MagicMock()
+    discovery_response.status_code = 200
+    discovery_response.json.return_value = {
+        "token_endpoint": "https://idp.example.com/oauth2/v2.0/token",
+    }
+    discovery_response.raise_for_status.return_value = None
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = discovery_response
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+        endpoint = await _resolve_token_endpoint("openid")
+
+    assert endpoint == "https://idp.example.com/oauth2/v2.0/token"
+    # Cached after first successful fetch.
+    assert (
+        oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+        == "https://idp.example.com/oauth2/v2.0/token"
+    )
+
+    # Subsequent calls do not re-fetch the discovery document.
+    mock_client.get.reset_mock()
+    endpoint_cached = await _resolve_token_endpoint("openid")
+    assert endpoint_cached == "https://idp.example.com/oauth2/v2.0/token"
+    mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_no_config_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without OPENID_CONFIG_URL configured, "openid" resolves to None."""
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    monkeypatch.setattr(oauth_refresher, "OPENID_CONFIG_URL", "")
+    endpoint = await _resolve_token_endpoint("openid")
+    assert endpoint is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_unknown_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown providers return None and trigger no network calls."""
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    endpoint = await _resolve_token_endpoint("github")
+    assert endpoint is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_oauth_token_openid_provider(
+    mock_user: MagicMock,
+    mock_oauth_account: MagicMock,
+    mock_user_manager: MagicMock,
+    mock_db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OIDC ("openid") accounts refresh via the discovery-resolved endpoint."""
+    # Pre-populate the cache so the refresh test does not depend on the
+    # discovery-doc fetch path (covered separately above).
+    monkeypatch.setattr(
+        oauth_refresher,
+        "_OIDC_TOKEN_ENDPOINT_CACHE",
+        {"url": "https://idp.example.com/oauth2/v2.0/token"},
+    )
+
+    mock_oauth_account.oauth_name = "openid"
+    mock_oauth_account.refresh_token = "old_refresh_token"
+
+    token_response = MagicMock()
+    token_response.status_code = 200
+    token_response.json.return_value = {
+        "access_token": "new_token",
+        "refresh_token": "new_refresh_token",
+        "expires_in": 3600,
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = token_response
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+        result = await refresh_oauth_token(
+            mock_user, mock_oauth_account, mock_db_session, mock_user_manager
+        )
+
+    assert result is True
+    mock_client.post.assert_called_once()
+    posted_url = mock_client.post.call_args[0][0]
+    assert posted_url == "https://idp.example.com/oauth2/v2.0/token"
+    mock_user_manager.user_db.update_oauth_account.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -312,6 +312,89 @@ async def test_resolve_token_endpoint_unknown_provider(
 
 
 @pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_invalid_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-JSON discovery body degrades to None instead of crashing."""
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(
+        oauth_refresher,
+        "OPENID_CONFIG_URL",
+        "https://idp.example.com/.well-known/openid-configuration",
+    )
+
+    discovery_response = MagicMock()
+    discovery_response.status_code = 200
+    discovery_response.raise_for_status.return_value = None
+    # Simulate an HTML error page or any non-JSON body.
+    discovery_response.json.side_effect = ValueError("not valid JSON")
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = discovery_response
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+        endpoint = await _resolve_token_endpoint("openid")
+
+    assert endpoint is None
+    # Cache stays empty so a subsequent call retries cleanly.
+    assert oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_concurrent_fetches_coalesce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent callers must trigger only one discovery request."""
+    import asyncio as _asyncio
+
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(
+        oauth_refresher,
+        "OPENID_CONFIG_URL",
+        "https://idp.example.com/.well-known/openid-configuration",
+    )
+
+    fetch_started = _asyncio.Event()
+    release_fetch = _asyncio.Event()
+
+    async def slow_get(*_args: object, **_kwargs: object) -> MagicMock:
+        # Park the first caller inside the discovery fetch so subsequent
+        # callers must wait on the lock; the test fails (call_count > 1) if
+        # they slip past the lock and fire their own fetch.
+        fetch_started.set()
+        await release_fetch.wait()
+        response = MagicMock()
+        response.status_code = 200
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "token_endpoint": "https://idp.example.com/oauth2/v2.0/token",
+        }
+        return response
+
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = slow_get
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+
+        first = _asyncio.create_task(_resolve_token_endpoint("openid"))
+        await fetch_started.wait()
+        # Second + third callers must block on the lock until `first` finishes.
+        second = _asyncio.create_task(_resolve_token_endpoint("openid"))
+        third = _asyncio.create_task(_resolve_token_endpoint("openid"))
+        # Yield control so the queued tasks reach the lock.
+        await _asyncio.sleep(0)
+        release_fetch.set()
+        results = await _asyncio.gather(first, second, third)
+
+    assert all(r == "https://idp.example.com/oauth2/v2.0/token" for r in results)
+    assert mock_client.get.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_refresh_oauth_token_openid_provider(
     mock_user: MagicMock,
     mock_oauth_account: MagicMock,


### PR DESCRIPTION
Automated mirror of PR #10794 so private CI can run.

- [x] [Required] I have considered whether this PR needs to be cherry-picked to the latest beta branch. 
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable OAuth token refresh for any OIDC provider by resolving the token endpoint from the configured discovery document, not just Google. Fixes silent refresh failures for `openid` accounts and adds caching and a concurrency lock for stability.

- **Bug Fixes**
  - Resolve `token_endpoint` from `OPENID_CONFIG_URL` for `openid`; keep Google’s static URL; cache the result per process.
  - Add an async lock to coalesce concurrent discovery requests and handle non-JSON/HTTP errors gracefully.
  - Update `refresh_oauth_token` to use the new resolver and add targeted unit tests, including end-to-end `openid` refresh.

<sup>Written for commit 61b92eacee7c235f663051b0255438bb30fb45ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

