### PR TITLE
feat: paste tiles in contentEditable input bar

### DIFF
--- a/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
+++ b/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
@@ -1,7 +1,7 @@
 """add paste_as_tile to user
 
 Revision ID: 74379b447d4c
-Revises: a7c3e2b1d4f8
+Revises: 31bd8c17325e
 Create Date: 2026-04-23 18:30:42.452355
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "74379b447d4c"
-down_revision = "a7c3e2b1d4f8"
+down_revision = "31bd8c17325e"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
+++ b/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
@@ -1,0 +1,29 @@
+"""add paste_as_tile to user
+
+Revision ID: 74379b447d4c
+Revises: a7c3e2b1d4f8
+Create Date: 2026-04-23 18:30:42.452355
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "74379b447d4c"
+down_revision = "a7c3e2b1d4f8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "paste_as_tile", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "paste_as_tile")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -379,6 +379,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     # organized in typical structured fashion
     # formatted as `displayName__provider__modelName`
 
+    # Input preferences
+    paste_as_tile: Mapped[bool] = mapped_column(Boolean, default=False)
+
     # Voice preferences
     voice_auto_send: Mapped[bool] = mapped_column(Boolean, default=False)
     voice_auto_playback: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/backend/onyx/db/user_preferences.py
+++ b/backend/onyx/db/user_preferences.py
@@ -158,6 +158,20 @@ def update_user_shortcut_enabled(
     db_session.commit()
 
 
+def update_user_paste_as_tile(
+    user_id: UUID,
+    paste_as_tile: bool,
+    db_session: Session,
+) -> None:
+    """Update user's paste-as-tile setting."""
+    db_session.execute(
+        update(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .values(paste_as_tile=paste_as_tile)
+    )
+    db_session.commit()
+
+
 def update_user_auto_scroll(
     user_id: UUID,
     auto_scroll: bool | None,

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -84,6 +84,9 @@ class UserPreferences(BaseModel):
     chat_background: str | None = None
     default_app_mode: DefaultAppMode = DefaultAppMode.CHAT
 
+    # Input preferences
+    paste_as_tile: bool | None = None
+
     # Voice preferences
     voice_auto_send: bool | None = None
     voice_auto_playback: bool | None = None
@@ -169,6 +172,7 @@ class UserInfo(BaseModel):
                     theme_preference=user.theme_preference,
                     chat_background=user.chat_background,
                     default_app_mode=user.default_app_mode,
+                    paste_as_tile=user.paste_as_tile,
                     voice_auto_send=user.voice_auto_send,
                     voice_auto_playback=user.voice_auto_playback,
                     voice_playback_speed=user.voice_playback_speed,

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -70,6 +70,7 @@ from onyx.db.user_preferences import update_user_auto_scroll
 from onyx.db.user_preferences import update_user_chat_background
 from onyx.db.user_preferences import update_user_default_app_mode
 from onyx.db.user_preferences import update_user_default_model
+from onyx.db.user_preferences import update_user_paste_as_tile
 from onyx.db.user_preferences import update_user_personalization
 from onyx.db.user_preferences import update_user_pinned_assistants
 from onyx.db.user_preferences import update_user_role
@@ -971,6 +972,15 @@ def update_user_shortcut_enabled_api(
     db_session: Session = Depends(get_session),
 ) -> None:
     update_user_shortcut_enabled(user.id, shortcut_enabled, db_session)
+
+
+@router.patch("/paste-as-tile")
+def update_user_paste_as_tile_api(
+    paste_as_tile: bool,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_user_paste_as_tile(user.id, paste_as_tile, db_session)
 
 
 @router.patch("/auto-scroll")

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10545,7 +10545,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10545,6 +10545,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -13,6 +13,7 @@ import {
 import { useRouter } from "next/navigation";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { isImageFile } from "@/lib/utils";
+import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import {
@@ -172,8 +173,16 @@ const InputBar = memo(
         handleInput: onInput,
         handleCompositionStart,
         handleCompositionEnd,
-        insertTextAtCursor,
+        pasteText,
+        handleCopy,
+        handleCut,
         setCursorToEnd,
+        handleTileMouseDown,
+        handleTileClick,
+        handleTileKeyDown,
+        tilePopover,
+        dismissTilePopover,
+        updateTileText,
       } = useContentEditable({
         wrapperRef: inputWrapperRef,
       });
@@ -227,9 +236,10 @@ const InputBar = memo(
           event.preventDefault();
           const text = event.clipboardData.getData("text/plain");
           if (!text) return;
-          insertTextAtCursor(text);
+
+          pasteText(text);
         },
-        [disabled, uploadFiles, insertTextAtCursor]
+        [disabled, uploadFiles, pasteText]
       );
 
       const handleSubmit = useCallback(() => {
@@ -261,6 +271,8 @@ const InputBar = memo(
 
       const handleKeyDown = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {
+          if (handleTileKeyDown(event)) return;
+
           // Shift+Enter falls through to browser default: inserts <br>
           if (
             event.key === "Enter" &&
@@ -271,7 +283,7 @@ const InputBar = memo(
             handleSubmit();
           }
         },
-        [handleSubmit]
+        [handleSubmit, handleTileKeyDown]
       );
 
       const canSubmit =
@@ -282,6 +294,7 @@ const InputBar = memo(
         !sandboxInitializing;
 
       return (
+        <>
         <Disabled disabled={disabled}>
           <div
             ref={containerRef}
@@ -350,6 +363,10 @@ const InputBar = memo(
                 aria-placeholder={placeholder}
                 data-placeholder={placeholder}
                 data-empty={!message ? "" : undefined}
+                onCopy={handleCopy}
+                onCut={handleCut}
+                onMouseDown={handleTileMouseDown}
+                onClick={handleTileClick}
               />
             </div>
 
@@ -407,6 +424,16 @@ const InputBar = memo(
             </div>
           </div>
         </Disabled>
+
+        {tilePopover && (
+          <PasteTilePopover
+            text={tilePopover.text}
+            rect={tilePopover.rect}
+            onDismiss={dismissTilePopover}
+            onTextChange={updateTileText}
+          />
+        )}
+      </>
       );
     }
   )

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -185,6 +185,7 @@ const InputBar = memo(
         updateTileText,
       } = useContentEditable({
         wrapperRef: inputWrapperRef,
+        pasteTilesEnabled: true,
       });
 
       const containerRef = useRef<HTMLDivElement>(null);

--- a/web/src/app/css/content-editable.css
+++ b/web/src/app/css/content-editable.css
@@ -1,0 +1,82 @@
+/* contentEditable placeholder */
+[data-placeholder][data-empty] {
+  position: relative;
+}
+[data-placeholder][data-empty]::before {
+  content: attr(data-placeholder);
+  color: var(--text-03);
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: inherit;
+}
+
+/* Rich Input Tile — shared by React component and contentEditable DOM utility */
+.rich-input-tile {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--border-radius-08);
+  background: var(--background-neutral-01);
+  border: 1px solid var(--border-01);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  max-width: 100%;
+  vertical-align: baseline;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color 150ms,
+    border-color 150ms;
+}
+
+.rich-input-tile:hover {
+  background: var(--background-neutral-02);
+}
+
+.rich-input-tile-selected {
+  box-shadow: inset 0 0 0 1.5px var(--action-link-02);
+  background: var(--background-neutral-02);
+}
+
+.rich-input-tile-in-selection {
+  box-shadow: inset 0 0 0 1.5px var(--action-link-02);
+}
+
+.rich-input-tile-icon {
+  flex-shrink: 0;
+  color: var(--text-03);
+}
+
+.rich-input-tile-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-04);
+  max-width: 14rem;
+}
+
+.rich-input-tile-meta {
+  color: var(--text-03);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.rich-input-tile-remove {
+  cursor: pointer;
+  color: var(--text-03);
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: var(--border-radius-04);
+}
+
+.rich-input-tile-remove:hover {
+  background: var(--background-neutral-02);
+  color: var(--text-05);
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "css/attachment-button.css";
 @import "css/button.css";
+@import "css/content-editable.css";
 @import "css/card.css";
 @import "css/code.css";
 @import "css/color-swatch.css";
@@ -482,18 +483,4 @@ textarea {
 
 .container {
   margin-bottom: 1rem;
-}
-
-/* contentEditable placeholder */
-[data-placeholder][data-empty] {
-  position: relative;
-}
-[data-placeholder][data-empty]::before {
-  content: attr(data-placeholder);
-  color: var(--text-03);
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-  padding: inherit;
 }

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -8,6 +8,8 @@ import {
   getAdjacentPasteTile,
   getTextContent,
   shouldCreatePasteTile,
+  getPasteTilePreview,
+  getPasteTileMeta,
 } from "@/lib/contentEditable";
 
 export interface UseContentEditableOptions {
@@ -15,6 +17,7 @@ export interface UseContentEditableOptions {
   wrapperRef: React.RefObject<HTMLDivElement | null>;
   minHeight?: number;
   maxHeight?: number;
+  pasteTilesEnabled?: boolean;
   onContentChange?: (text: string) => void;
   disabled?: boolean;
 }
@@ -47,6 +50,7 @@ export function useContentEditable({
   wrapperRef,
   minHeight = 44,
   maxHeight = 200,
+  pasteTilesEnabled = false,
   onContentChange,
   disabled = false,
 }: UseContentEditableOptions): UseContentEditableReturn {
@@ -207,7 +211,7 @@ export function useContentEditable({
         }
       });
     },
-    [resize]
+    [resize, clearTileSelection]
   );
 
   const clearMessage = useCallback(() => {
@@ -221,7 +225,6 @@ export function useContentEditable({
     setMessageState("");
     resize();
     onContentChangeRef.current?.("");
-<<<<<<< HEAD
   }, [resize, clearTileSelection]);
 
   const insertTextAtCursor = useCallback(
@@ -252,13 +255,13 @@ export function useContentEditable({
 
   const pasteText = useCallback(
     (text: string) => {
-      if (shouldCreatePasteTile(text)) {
+      if (pasteTilesEnabled && shouldCreatePasteTile(text)) {
         insertTileAtCursor(text);
       } else {
         insertTextAtCursor(text);
       }
     },
-    [insertTileAtCursor, insertTextAtCursor]
+    [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor]
   );
 
   const handleTileMouseDown = useCallback(
@@ -293,15 +296,19 @@ export function useContentEditable({
         setTilePopover({ text, rect, tile });
       } else {
         setTilePopover(null);
+        clearTileSelection();
       }
     },
-    []
+    [clearTileSelection]
   );
 
   const dismissTilePopover = useCallback(() => {
     setTilePopover(null);
     ref.current?.focus();
-    if (selectedTileRef.current) {
+    if (
+      selectedTileRef.current &&
+      ref.current?.contains(selectedTileRef.current)
+    ) {
       const s = window.getSelection();
       if (s) {
         const r = document.createRange();
@@ -322,17 +329,11 @@ export function useContentEditable({
 
       const preview = tile.querySelector(".rich-input-tile-preview");
       if (preview) {
-        const firstLine = newText.split("\n")[0]?.trim() ?? "";
-        preview.textContent =
-          firstLine.length > 20 ? firstLine.slice(0, 20) + "…" : firstLine;
+        preview.textContent = getPasteTilePreview(newText);
       }
       const meta = tile.querySelector(".rich-input-tile-meta");
       if (meta) {
-        const lines = newText.split("\n");
-        meta.textContent =
-          lines.length > 1
-            ? `${lines.length} lines`
-            : `${newText.length} chars`;
+        meta.textContent = getPasteTileMeta(newText);
       }
 
       syncFromDOM();
@@ -392,20 +393,12 @@ export function useContentEditable({
         }
 
         if (isDelete) {
-          const direction = event.key === "Backspace" ? "before" : "after";
-          const adjacent = getAdjacentPasteTile(
-            window.getSelection()!.getRangeAt(0),
-            direction
-          );
-          if (adjacent === selected) {
-            // Second delete press on same tile → remove it
-            event.preventDefault();
-            selected.remove();
-            selectedTileRef.current = null;
-            syncFromDOM();
-            resize();
-            return true;
-          }
+          event.preventDefault();
+          selected.remove();
+          selectedTileRef.current = null;
+          syncFromDOM();
+          resize();
+          return true;
         }
 
         clearTileSelection();

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   setCursorToEnd as setCursorToEndUtil,
+  setCursorAfterNode,
   insertTextAtCursor as insertTextAtCursorUtil,
+  insertNodeAtCursor as insertNodeAtCursorUtil,
+  createRichInputTileNode,
+  getAdjacentPasteTile,
   getTextContent,
+  shouldCreatePasteTile,
 } from "@/lib/contentEditable";
 
 export interface UseContentEditableOptions {
@@ -23,8 +28,18 @@ export interface UseContentEditableReturn {
   handleCompositionStart: () => void;
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
+  insertTileAtCursor: (text: string) => void;
+  pasteText: (text: string) => void;
+  handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
+  handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   setCursorToEnd: () => void;
   resize: () => void;
+  handleTileMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+  handleTileClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+  handleTileKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => boolean;
+  tilePopover: { text: string; rect: DOMRect; tile: HTMLElement } | null;
+  dismissTilePopover: () => void;
+  updateTileText: (newText: string) => void;
 }
 
 export function useContentEditable({
@@ -42,6 +57,12 @@ export function useContentEditable({
   const onContentChangeRef = useRef(onContentChange);
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
+  const selectedTileRef = useRef<HTMLElement | null>(null);
+  const [tilePopover, setTilePopover] = useState<{
+    text: string;
+    rect: DOMRect;
+    tile: HTMLElement;
+  } | null>(null);
 
   useEffect(() => {
     onContentChangeRef.current = onContentChange;
@@ -68,6 +89,41 @@ export function useContentEditable({
     };
   }, []);
 
+  // Track text selection to highlight tiles within the selection range.
+  useEffect(() => {
+    function handleSelectionChange() {
+      const el = ref.current;
+      if (!el || !el.contains(document.activeElement ?? null)) return;
+
+      const sel = window.getSelection();
+      const tiles = el.querySelectorAll("[data-paste-tile]");
+      tiles.forEach((tile) => {
+        const htmlTile = tile as HTMLElement;
+        if (
+          sel &&
+          sel.rangeCount > 0 &&
+          !sel.isCollapsed &&
+          sel.getRangeAt(0).intersectsNode(tile)
+        ) {
+          htmlTile.classList.add("rich-input-tile-in-selection");
+        } else {
+          htmlTile.classList.remove("rich-input-tile-in-selection");
+        }
+      });
+    }
+
+    document.addEventListener("selectionchange", handleSelectionChange);
+    return () =>
+      document.removeEventListener("selectionchange", handleSelectionChange);
+  }, []);
+
+  const clearTileSelection = useCallback(() => {
+    if (selectedTileRef.current) {
+      selectedTileRef.current.classList.remove("rich-input-tile-selected");
+      selectedTileRef.current = null;
+    }
+  }, []);
+
   const resize = useCallback(() => {
     const wrapper = wrapperRef.current;
     const div = ref.current;
@@ -85,8 +141,6 @@ export function useContentEditable({
     const el = ref.current;
     if (!el) return "";
 
-    // Clean up stale <br> that browsers leave in empty contentEditable divs.
-    // Only when not composing and when the only content is non-text nodes (e.g. <br>).
     if (!isComposingRef.current && !el.textContent && el.innerHTML) {
       el.innerHTML = "";
     }
@@ -101,11 +155,12 @@ export function useContentEditable({
   const handleInput = useCallback(
     (_event: React.SyntheticEvent<HTMLDivElement>): string => {
       if (isComposingRef.current) return messageRef.current;
+      clearTileSelection();
       const text = syncFromDOM();
       resize();
       return text;
     },
-    [syncFromDOM, resize]
+    [syncFromDOM, resize, clearTileSelection]
   );
 
   const handleCompositionStart = useCallback(() => {
@@ -129,6 +184,9 @@ export function useContentEditable({
   const setMessage = useCallback(
     (text: string) => {
       if (!ref.current) return;
+
+      clearTileSelection();
+      setTilePopover(null);
 
       ref.current.textContent = text;
       messageRef.current = text;
@@ -155,17 +213,291 @@ export function useContentEditable({
   const clearMessage = useCallback(() => {
     if (!ref.current) return;
 
+    clearTileSelection();
+    setTilePopover(null);
+
     ref.current.innerHTML = "";
     messageRef.current = "";
     setMessageState("");
     resize();
     onContentChangeRef.current?.("");
-  }, [resize]);
+<<<<<<< HEAD
+  }, [resize, clearTileSelection]);
 
   const insertTextAtCursor = useCallback(
     (text: string) => {
       if (!ref.current) return;
       insertTextAtCursorUtil(ref.current, text);
+      syncFromDOM();
+      resize();
+    },
+    [syncFromDOM, resize]
+  );
+
+  const insertTileAtCursor = useCallback(
+    (text: string) => {
+      if (!ref.current) return;
+      const tile = createRichInputTileNode(text);
+      insertNodeAtCursorUtil(ref.current, tile);
+
+      const space = document.createTextNode(" ");
+      tile.after(space);
+      setCursorAfterNode(space);
+
+      syncFromDOM();
+      resize();
+    },
+    [syncFromDOM, resize]
+  );
+
+  const pasteText = useCallback(
+    (text: string) => {
+      if (shouldCreatePasteTile(text)) {
+        insertTileAtCursor(text);
+      } else {
+        insertTextAtCursor(text);
+      }
+    },
+    [insertTileAtCursor, insertTextAtCursor]
+  );
+
+  const handleTileMouseDown = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      clearTileSelection();
+
+      const target = event.target as HTMLElement;
+      const removeBtn = target.closest("[data-paste-tile-remove]");
+      if (!removeBtn) return;
+
+      event.preventDefault();
+      const tile = removeBtn.closest("[data-paste-tile]");
+      if (tile) {
+        tile.remove();
+        setTilePopover(null);
+        syncFromDOM();
+        resize();
+      }
+    },
+    [syncFromDOM, resize, clearTileSelection]
+  );
+
+  const handleTileClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement;
+      if (target.closest("[data-paste-tile-remove]")) return;
+
+      const tile = target.closest("[data-paste-tile]") as HTMLElement | null;
+      if (tile) {
+        const text = tile.getAttribute("data-text") ?? "";
+        const rect = tile.getBoundingClientRect();
+        setTilePopover({ text, rect, tile });
+      } else {
+        setTilePopover(null);
+      }
+    },
+    []
+  );
+
+  const dismissTilePopover = useCallback(() => {
+    setTilePopover(null);
+    ref.current?.focus();
+    if (selectedTileRef.current) {
+      const s = window.getSelection();
+      if (s) {
+        const r = document.createRange();
+        r.selectNode(selectedTileRef.current);
+        s.removeAllRanges();
+        s.addRange(r);
+      }
+    }
+  }, []);
+
+  const updateTileText = useCallback(
+    (newText: string) => {
+      if (!tilePopover?.tile || !ref.current?.contains(tilePopover.tile))
+        return;
+      const { tile } = tilePopover;
+      tile.setAttribute("data-text", newText);
+      tile.title = newText.length > 200 ? newText.slice(0, 200) + "…" : newText;
+
+      const preview = tile.querySelector(".rich-input-tile-preview");
+      if (preview) {
+        const firstLine = newText.split("\n")[0]?.trim() ?? "";
+        preview.textContent =
+          firstLine.length > 20 ? firstLine.slice(0, 20) + "…" : firstLine;
+      }
+      const meta = tile.querySelector(".rich-input-tile-meta");
+      if (meta) {
+        const lines = newText.split("\n");
+        meta.textContent =
+          lines.length > 1
+            ? `${lines.length} lines`
+            : `${newText.length} chars`;
+      }
+
+      syncFromDOM();
+    },
+    [tilePopover, syncFromDOM]
+  );
+
+  const handleTileKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
+      const isNav = event.key === "ArrowLeft" || event.key === "ArrowRight";
+      const isDelete = event.key === "Backspace" || event.key === "Delete";
+
+      // Enter on selected tile → open popover
+      if (event.key === "Enter" && selectedTileRef.current) {
+        event.preventDefault();
+        const tile = selectedTileRef.current;
+        const text = tile.getAttribute("data-text") ?? "";
+        const rect = tile.getBoundingClientRect();
+        setTilePopover({ text, rect, tile });
+        return true;
+      }
+
+      // Unrelated keys clear selection
+      if (!isNav && !isDelete) {
+        setTilePopover(null);
+        clearTileSelection();
+        return false;
+      }
+
+      setTilePopover(null);
+
+      // If a tile is already selected, handle second press
+      if (selectedTileRef.current) {
+        const selected = selectedTileRef.current;
+
+        if (isNav) {
+          // Arrow on selected tile → deselect and move cursor past it
+          event.preventDefault();
+          clearTileSelection();
+          if (event.key === "ArrowRight") {
+            setCursorAfterNode(selected);
+            const next = selected.nextSibling;
+            if (next?.nodeType === Node.TEXT_NODE && next.textContent === " ") {
+              setCursorAfterNode(next);
+            }
+          } else {
+            const s = window.getSelection();
+            if (s) {
+              const r = document.createRange();
+              r.setStartBefore(selected);
+              r.collapse(true);
+              s.removeAllRanges();
+              s.addRange(r);
+            }
+          }
+          return true;
+        }
+
+        if (isDelete) {
+          const direction = event.key === "Backspace" ? "before" : "after";
+          const adjacent = getAdjacentPasteTile(
+            window.getSelection()!.getRangeAt(0),
+            direction
+          );
+          if (adjacent === selected) {
+            // Second delete press on same tile → remove it
+            event.preventDefault();
+            selected.remove();
+            selectedTileRef.current = null;
+            syncFromDOM();
+            resize();
+            return true;
+          }
+        }
+
+        clearTileSelection();
+        return false;
+      }
+
+      // No tile selected — check if cursor is adjacent to a tile
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
+        return false;
+      }
+
+      const range = sel.getRangeAt(0);
+      let direction: "before" | "after";
+      if (isDelete) {
+        direction = event.key === "Backspace" ? "before" : "after";
+      } else {
+        direction = event.key === "ArrowLeft" ? "before" : "after";
+      }
+
+      let tile = getAdjacentPasteTile(range, direction);
+
+      // For arrow keys, skip whitespace-only text nodes (e.g. trailing space)
+      if (!tile && isNav) {
+        const { startContainer } = range;
+        if (
+          startContainer.nodeType === Node.TEXT_NODE &&
+          startContainer.textContent?.trim() === ""
+        ) {
+          const sibling =
+            direction === "before"
+              ? startContainer.previousSibling
+              : startContainer.nextSibling;
+          if (
+            sibling?.nodeType === Node.ELEMENT_NODE &&
+            (sibling as HTMLElement).hasAttribute("data-paste-tile")
+          ) {
+            tile = sibling as HTMLElement;
+          }
+        }
+      }
+
+      if (!tile) return false;
+
+      // First press: highlight the tile and select it to hide the caret
+      event.preventDefault();
+      tile.classList.add("rich-input-tile-selected");
+      selectedTileRef.current = tile;
+      const s = window.getSelection();
+      if (s) {
+        const r = document.createRange();
+        r.selectNode(tile);
+        s.removeAllRanges();
+        s.addRange(r);
+      }
+      return true;
+    },
+    [syncFromDOM, resize, clearTileSelection]
+  );
+
+  const handleCopy = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return;
+
+      const range = sel.getRangeAt(0);
+      if (!ref.current?.contains(range.commonAncestorContainer)) return;
+
+      event.preventDefault();
+      const fragment = range.cloneContents();
+      const temp = document.createElement("div");
+      temp.appendChild(fragment);
+      event.clipboardData.setData("text/plain", getTextContent(temp));
+    },
+    []
+  );
+
+  const handleCut = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return;
+
+      const range = sel.getRangeAt(0);
+      if (!ref.current?.contains(range.commonAncestorContainer)) return;
+
+      event.preventDefault();
+      const fragment = range.cloneContents();
+      const temp = document.createElement("div");
+      temp.appendChild(fragment);
+      event.clipboardData.setData("text/plain", getTextContent(temp));
+
+      range.deleteContents();
       syncFromDOM();
       resize();
     },
@@ -186,7 +518,17 @@ export function useContentEditable({
     handleCompositionStart,
     handleCompositionEnd,
     insertTextAtCursor,
+    insertTileAtCursor,
+    pasteText,
+    handleCopy,
+    handleCut,
     setCursorToEnd,
     resize,
+    handleTileMouseDown,
+    handleTileClick,
+    handleTileKeyDown,
+    tilePopover,
+    dismissTilePopover,
+    updateTileText,
   };
 }

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -1,6 +1,5 @@
-/**
- * Move cursor to end of a contentEditable element.
- */
+// ─── Cursor Utilities ───────────────────────────────────────────────────────
+
 export function setCursorToEnd(element: HTMLElement): void {
   const selection = window.getSelection();
   if (!selection) return;
@@ -11,11 +10,18 @@ export function setCursorToEnd(element: HTMLElement): void {
   selection.addRange(range);
 }
 
-/**
- * Insert a plain-text string at the current cursor position within a
- * contentEditable element. If the element doesn't have focus or a valid
- * selection, appends to the end. Returns the element's new text content.
- */
+export function setCursorAfterNode(node: Node): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+  const range = document.createRange();
+  range.setStartAfter(node);
+  range.setEndAfter(node);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+// ─── Text Insertion ─────────────────────────────────────────────────────────
+
 export function insertTextAtCursor(element: HTMLElement, text: string): string {
   const selection = window.getSelection();
   if (!selection || selection.rangeCount === 0) {
@@ -48,10 +54,32 @@ export function insertTextAtCursor(element: HTMLElement, text: string): string {
   return getTextContent(element);
 }
 
-/**
- * Read the plain-text content of a contentEditable element, converting
- * <br> elements to newlines via DOM traversal (avoids innerText reflow).
- */
+export function insertNodeAtCursor(element: HTMLElement, node: Node): void {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) {
+    element.appendChild(node);
+    setCursorAfterNode(node);
+    element.normalize();
+    return;
+  }
+
+  const range = selection.getRangeAt(0);
+
+  if (!element.contains(range.commonAncestorContainer)) {
+    element.appendChild(node);
+    setCursorAfterNode(node);
+    element.normalize();
+    return;
+  }
+
+  range.deleteContents();
+  range.insertNode(node);
+  setCursorAfterNode(node);
+  element.normalize();
+}
+
+// ─── Text Content Extraction ────────────────────────────────────────────────
+
 const BLOCK_TAGS = new Set([
   "DIV",
   "P",
@@ -74,7 +102,9 @@ export function getTextContent(element: HTMLElement): string {
       parts.push(node.textContent ?? "");
     } else if (node.nodeType === Node.ELEMENT_NODE) {
       const el = node as HTMLElement;
-      if (el.tagName === "BR") {
+      if (el.hasAttribute("data-paste-tile")) {
+        parts.push(el.getAttribute("data-text") ?? "");
+      } else if (el.tagName === "BR") {
         parts.push("\n");
       } else {
         if (i > 0 && BLOCK_TAGS.has(el.tagName)) {
@@ -85,4 +115,136 @@ export function getTextContent(element: HTMLElement): string {
     }
   }
   return parts.join("");
+}
+
+// ─── Paste Tile ─────────────────────────────────────────────────────────────
+
+export const PASTE_TILE_THRESHOLD_CHARS = 200;
+export const PASTE_TILE_THRESHOLD_LINES = 3;
+
+export function shouldCreatePasteTile(text: string): boolean {
+  return (
+    text.length > PASTE_TILE_THRESHOLD_CHARS ||
+    text.split("\n").length > PASTE_TILE_THRESHOLD_LINES
+  );
+}
+
+export function getPasteTilePreview(text: string, maxLength = 18): string {
+  const firstLine = text.split("\n")[0]?.trim() ?? "";
+  if (firstLine.length > maxLength) {
+    return firstLine.slice(0, maxLength) + "…";
+  }
+  return firstLine;
+}
+
+export function getPasteTileMeta(text: string): string {
+  const lines = text.split("\n");
+  if (lines.length > 1) {
+    return `${lines.length} lines`;
+  }
+  return `${text.length} chars`;
+}
+
+// Path data mirrored from @opal/icons — keep in sync with:
+//   clipboard.tsx (SvgClipboard, viewBox 0 0 16 16)
+//   x.tsx (SvgX, viewBox 0 0 28 28)
+// We can't import the React icon components here because paste tiles are
+// created as raw DOM nodes inside a contentEditable div (React doesn't
+// manage the div's children), so we build the SVGs imperatively.
+const CLIPBOARD_PATH =
+  "M10.6667 2.66665H12C12.3536 2.66665 12.6927 2.80712 12.9428 3.05717C13.1928 3.30722 13.3333 3.64636 13.3333 3.99998V13.3333C13.3333 13.6869 13.1928 14.0261 12.9428 14.2761C12.6927 14.5262 12.3536 14.6666 12 14.6666H3.99999C3.64637 14.6666 3.30723 14.5262 3.05718 14.2761C2.80713 14.0261 2.66666 13.6869 2.66666 13.3333V3.99998C2.66666 3.64636 2.80713 3.30722 3.05718 3.05717C3.30723 2.80712 3.64637 2.66665 3.99999 2.66665H5.33332M10.6667 2.66665V1.99998C10.6667 1.63179 10.3682 1.33331 9.99999 1.33331H5.99999C5.6318 1.33331 5.33332 1.63179 5.33332 1.99998V2.66665M10.6667 2.66665V3.33331C10.6667 3.7015 10.3682 3.99998 9.99999 3.99998H5.99999C5.6318 3.99998 5.33332 3.7015 5.33332 3.33331V2.66665";
+
+const X_PATH = "M21 7L7 21M7 7L21 21";
+
+function createSvgIcon(
+  path: string,
+  viewBox: string,
+  size: number,
+  strokeWidth: number
+): SVGSVGElement {
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("width", String(size));
+  svg.setAttribute("height", String(size));
+  svg.setAttribute("viewBox", viewBox);
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", String(strokeWidth));
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  const pathEl = document.createElementNS(ns, "path");
+  pathEl.setAttribute("d", path);
+  svg.appendChild(pathEl);
+  return svg;
+}
+
+export function createRichInputTileNode(text: string): HTMLSpanElement {
+  const tile = document.createElement("span");
+  tile.contentEditable = "false";
+  tile.setAttribute("data-paste-tile", "");
+  tile.setAttribute("data-text", text);
+  tile.className = "rich-input-tile";
+  tile.title = text.length > 200 ? text.slice(0, 200) + "…" : text;
+
+  const icon = createSvgIcon(CLIPBOARD_PATH, "0 0 16 16", 14, 1.5);
+  icon.classList.add("rich-input-tile-icon");
+  tile.appendChild(icon);
+
+  const previewSpan = document.createElement("span");
+  previewSpan.className = "rich-input-tile-preview";
+  previewSpan.textContent = getPasteTilePreview(text);
+  tile.appendChild(previewSpan);
+
+  const metaSpan = document.createElement("span");
+  metaSpan.className = "rich-input-tile-meta";
+  metaSpan.textContent = getPasteTileMeta(text);
+  tile.appendChild(metaSpan);
+
+  const removeBtn = document.createElement("span");
+  removeBtn.className = "rich-input-tile-remove";
+  removeBtn.setAttribute("data-paste-tile-remove", "");
+  removeBtn.setAttribute("role", "button");
+  removeBtn.setAttribute("aria-label", "Remove pasted text");
+  removeBtn.appendChild(createSvgIcon(X_PATH, "0 0 28 28", 10, 2.5));
+  tile.appendChild(removeBtn);
+
+  return tile;
+}
+
+export function getAdjacentPasteTile(
+  range: Range,
+  direction: "before" | "after"
+): HTMLElement | null {
+  const { startContainer, startOffset } = range;
+
+  let candidate: Node | null = null;
+
+  if (direction === "before") {
+    if (startContainer.nodeType === Node.TEXT_NODE && startOffset === 0) {
+      candidate = startContainer.previousSibling;
+    } else if (
+      startContainer.nodeType === Node.ELEMENT_NODE &&
+      startOffset > 0
+    ) {
+      candidate = startContainer.childNodes[startOffset - 1] ?? null;
+    }
+  } else {
+    if (
+      startContainer.nodeType === Node.TEXT_NODE &&
+      startOffset === (startContainer.textContent?.length ?? 0)
+    ) {
+      candidate = startContainer.nextSibling;
+    } else if (startContainer.nodeType === Node.ELEMENT_NODE) {
+      candidate = startContainer.childNodes[startOffset] ?? null;
+    }
+  }
+
+  if (
+    candidate?.nodeType === Node.ELEMENT_NODE &&
+    (candidate as HTMLElement).hasAttribute("data-paste-tile")
+  ) {
+    return candidate as HTMLElement;
+  }
+
+  return null;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -32,6 +32,8 @@ interface UserPreferences {
   theme_preference: ThemePreference | null;
   chat_background: string | null;
   default_app_mode: "AUTO" | "CHAT" | "SEARCH";
+  // Input preferences
+  paste_as_tile?: boolean;
   // Voice preferences
   voice_auto_send?: boolean;
   voice_auto_playback?: boolean;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -35,6 +35,7 @@ interface UserContextType {
   authTypeMetadata: AuthTypeMetadata;
   updateUserAutoScroll: (autoScroll: boolean) => Promise<void>;
   updateUserShortcuts: (enabled: boolean) => Promise<void>;
+  updateUserPasteAsTile: (enabled: boolean) => Promise<void>;
   toggleAgentPinnedStatus: (
     currentPinnedAgentIDs: number[],
     agentId: number,
@@ -218,6 +219,41 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       }
     } catch (error) {
       console.error("Error updating user shortcut setting:", error);
+      throw error;
+    }
+  };
+
+  const updateUserPasteAsTile = async (enabled: boolean) => {
+    try {
+      setUpToDateUser((prevUser) => {
+        if (prevUser) {
+          return {
+            ...prevUser,
+            preferences: {
+              ...prevUser.preferences,
+              paste_as_tile: enabled,
+            },
+          };
+        }
+        return prevUser;
+      });
+
+      const response = await fetch(
+        `/api/paste-as-tile?paste_as_tile=${enabled}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!response.ok) {
+        await refreshUser();
+        throw new Error("Failed to update paste tile setting");
+      }
+    } catch (error) {
+      console.error("Error updating paste tile setting:", error);
       throw error;
     }
   };
@@ -516,6 +552,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         authTypeMetadata,
         updateUserAutoScroll,
         updateUserShortcuts,
+        updateUserPasteAsTile,
         updateUserTemperatureOverrideEnabled,
         updateUserPersonalization,
         updateUserThemePreference,

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -770,6 +770,7 @@ function ChatPreferencesSettings() {
     updateUserPersonalization,
     updateUserAutoScroll,
     updateUserShortcuts,
+    updateUserPasteAsTile,
     updateUserDefaultModel,
     updateUserDefaultAppMode,
     updateUserVoiceSettings,
@@ -1015,6 +1016,29 @@ function ChatPreferencesSettings() {
           </InputHorizontal>
 
           {user?.preferences?.shortcut_enabled && <PromptShortcuts />}
+        </Card>
+      </Section>
+
+      <Section gap={0.75}>
+        <Content
+          title="Input"
+          sizePreset="main-content"
+          variant="section"
+          width="full"
+        />
+        <Card>
+          <InputHorizontal
+            title="Collapse Large Pastes"
+            description="When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text."
+            withLabel
+          >
+            <Switch
+              checked={user?.preferences?.paste_as_tile ?? false}
+              onCheckedChange={(checked) => {
+                updateUserPasteAsTile(checked);
+              }}
+            />
+          </InputHorizontal>
         </Card>
       </Section>
 

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -21,6 +21,7 @@ import { ChatState } from "@/app/app/interfaces";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
+import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import { useUser } from "@/providers/UserProvider";
@@ -151,8 +152,16 @@ const AppInputBar = React.memo(
       handleInput,
       handleCompositionStart,
       handleCompositionEnd,
-      insertTextAtCursor,
+      pasteText,
+      handleCopy,
+      handleCut,
       setCursorToEnd,
+      handleTileMouseDown,
+      handleTileClick,
+      handleTileKeyDown,
+      tilePopover,
+      dismissTilePopover,
+      updateTileText,
     } = useContentEditable({
       initialContent: initialMessage,
       wrapperRef: inputWrapperRef,
@@ -355,7 +364,8 @@ const AppInputBar = React.memo(
       event.preventDefault();
       const text = event.clipboardData.getData("text/plain");
       if (!text) return;
-      insertTextAtCursor(text);
+
+      pasteText(text);
     }
 
     const handleRemoveMessageFile = useCallback(
@@ -811,6 +821,10 @@ const AppInputBar = React.memo(
                       contentEditable={!disabled}
                       suppressContentEditableWarning
                       onPaste={handlePaste}
+                      onCopy={handleCopy}
+                      onCut={handleCut}
+                      onMouseDown={handleTileMouseDown}
+                      onClick={handleTileClick}
                       onBlur={() => setHighlightedQueueIndex(null)}
                       onKeyDownCapture={handleKeyDownForPromptShortcuts}
                       onInput={handleContentEditableInput}
@@ -838,6 +852,8 @@ const AppInputBar = React.memo(
                       }
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
+                        if (handleTileKeyDown(event)) return;
+
                         // Queue navigation mode
                         if (highlightedQueueIndex !== null) {
                           if (event.key === "Enter") {
@@ -1022,6 +1038,15 @@ const AppInputBar = React.memo(
             )}
           </div>
         </Disabled>
+
+        {tilePopover && (
+          <PasteTilePopover
+            text={tilePopover.text}
+            rect={tilePopover.rect}
+            onDismiss={dismissTilePopover}
+            onTextChange={updateTileText}
+          />
+        )}
       </>
     );
   }

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -142,6 +142,7 @@ const AppInputBar = React.memo(
     const [highlightedQueueIndex, setHighlightedQueueIndex] = useState<
       number | null
     >(null);
+    const { user, isAdmin } = useUser();
     const isAutoSending = useRef(false);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const {
@@ -165,12 +166,12 @@ const AppInputBar = React.memo(
     } = useContentEditable({
       initialContent: initialMessage,
       wrapperRef: inputWrapperRef,
+      pasteTilesEnabled: user?.preferences?.paste_as_tile ?? false,
     });
 
     const filesWrapperRef = useRef<HTMLDivElement>(null);
     const filesContentRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    const { user, isAdmin } = useUser();
     const { state } = useQueryController();
     const isClassifying = state.phase === "classifying";
     const isSearchActive =

--- a/web/src/sections/input/PasteTilePopover.tsx
+++ b/web/src/sections/input/PasteTilePopover.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+interface PasteTilePopoverProps {
+  text: string;
+  rect: DOMRect;
+  onDismiss: () => void;
+  onTextChange: (newText: string) => void;
+}
+
+function PasteTilePopover({
+  text,
+  rect,
+  onDismiss,
+  onTextChange,
+}: PasteTilePopoverProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") onDismiss();
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onDismiss]);
+
+  const POPOVER_MAX_H = 340;
+  const POPOVER_MAX_W = 400;
+  const GAP = 4;
+  const fitsBelow = rect.bottom + GAP + POPOVER_MAX_H < window.innerHeight;
+  const left = Math.min(rect.left, window.innerWidth - POPOVER_MAX_W - GAP);
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-40" aria-hidden onClick={onDismiss} />
+      <div
+        role="dialog"
+        aria-label="Edit pasted text"
+        className="fixed z-50 bg-background-neutral-00 border border-border-01 rounded-08 shadow-02 p-1 max-w-[400px]"
+        style={{
+          left: Math.max(GAP, left),
+          ...(fitsBelow
+            ? { top: rect.bottom + GAP }
+            : { bottom: window.innerHeight - rect.top + GAP }),
+        }}
+      >
+        <textarea
+          ref={textareaRef}
+          defaultValue={text}
+          onChange={(e) => onTextChange(e.target.value)}
+          className="w-full resize-none rounded-04 border-none bg-transparent p-2 font-mono outline-none"
+          style={{
+            fontSize: "0.8125rem",
+            color: "var(--text-04)",
+            minHeight: "4rem",
+            maxHeight: "16rem",
+            fieldSizing: "content",
+          }}
+        />
+      </div>
+    </>,
+    document.body
+  );
+}
+
+export type { PasteTilePopoverProps };
+export default PasteTilePopover;

--- a/web/src/sections/input/RichInputTile.tsx
+++ b/web/src/sections/input/RichInputTile.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { getPasteTilePreview, getPasteTileMeta } from "@/lib/contentEditable";
+import { SvgClipboard, SvgX } from "@opal/icons";
+
+type RichInputTileColor = "neutral";
+
+interface RichInputTileProps {
+  text: string;
+  preview?: string;
+  meta?: string;
+  color?: RichInputTileColor;
+  onRemove?: () => void;
+  onClick?: () => void;
+  className?: string;
+}
+
+const COLOR_CLASS: Record<RichInputTileColor, string> = {
+  neutral: "rich-input-tile",
+};
+
+function RichInputTile({
+  text,
+  preview,
+  meta,
+  color = "neutral",
+  onRemove,
+  onClick,
+  className,
+}: RichInputTileProps) {
+  const displayPreview = preview ?? getPasteTilePreview(text);
+  const displayMeta = meta ?? getPasteTileMeta(text);
+
+  return (
+    <span
+      className={cn(COLOR_CLASS[color], className)}
+      title={text.length > 200 ? text.slice(0, 200) + "…" : text}
+      onClick={onClick}
+    >
+      <SvgClipboard size={14} className="rich-input-tile-icon" />
+      <span className="rich-input-tile-preview">{displayPreview}</span>
+      <span className="rich-input-tile-meta">{displayMeta}</span>
+      {onRemove && (
+        <span
+          className="rich-input-tile-remove"
+          role="button"
+          aria-label="Remove pasted text"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+        >
+          <SvgX size={10} />
+        </span>
+      )}
+    </span>
+  );
+}
+
+export type { RichInputTileProps, RichInputTileColor };
+export default RichInputTile;

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -634,6 +634,333 @@ test.describe("Keyboard Edge Cases", () => {
   });
 });
 
+const TILE_SELECTOR = "[data-paste-tile]";
+const TILE_REMOVE_SELECTOR = "[data-paste-tile-remove]";
+const TILE_POPOVER_SELECTOR = "[role='dialog'][aria-label='Edit pasted text']";
+
+const LARGE_TEXT = `function fibonacci(n) {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+
+for (let i = 0; i < 10; i++) {
+  console.log(fibonacci(i));
+}`;
+
+async function pasteLargeText(page: import("@playwright/test").Page) {
+  await page.evaluate((text) => {
+    const el = document.getElementById("onyx-chat-input-textbox")!;
+    el.focus();
+    const dt = new DataTransfer();
+    dt.setData("text/plain", text);
+    el.dispatchEvent(
+      new ClipboardEvent("paste", {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+  }, LARGE_TEXT);
+}
+
+test.describe("Paste Tiles", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+    await mockChatEndpoint(page, buildMockStream("Mock response"));
+  });
+
+  test("pasting large text creates a tile instead of inline text", async ({
+    page,
+  }) => {
+    await pasteLargeText(page);
+    const tile = page.locator(TILE_SELECTOR);
+    await expect(tile).toBeVisible();
+    await expect(tile).toHaveAttribute("data-text", LARGE_TEXT);
+  });
+
+  test("tile shows truncated preview and line count", async ({ page }) => {
+    await pasteLargeText(page);
+    const preview = page.locator(".rich-input-tile-preview");
+    const meta = page.locator(".rich-input-tile-meta");
+    await expect(preview).toBeVisible();
+    await expect(meta).toContainText("lines");
+    const previewText = await preview.textContent();
+    expect(previewText!.length).toBeLessThanOrEqual(25);
+  });
+
+  test("small text (<200 chars, <=3 lines) does not create a tile", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      const dt = new DataTransfer();
+      dt.setData("text/plain", "short text here");
+      el.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(0);
+    await expect(page.locator(INPUT_SELECTOR)).toContainText("short text here");
+  });
+
+  test("clicking × removes the tile", async ({ page }) => {
+    await pasteLargeText(page);
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(1);
+    await page.locator(TILE_REMOVE_SELECTOR).click();
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("submitting a message with a tile includes the full tile text", async ({
+    page,
+  }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("Context: ");
+    await pasteLargeText(page);
+    await page.keyboard.press("Enter");
+    const msg = page.locator(HUMAN_MESSAGE_SELECTOR);
+    await expect(msg).toContainText("Context:");
+    await expect(msg).toContainText("function fibonacci");
+    await expect(msg).toContainText("console.log");
+  });
+
+  test("tile has trailing space for cursor visibility", async ({ page }) => {
+    await pasteLargeText(page);
+    const hasSpace = await page.evaluate(() => {
+      const tile = document.querySelector("[data-paste-tile]")!;
+      const next = tile.nextSibling;
+      return next?.nodeType === Node.TEXT_NODE && next.textContent === " ";
+    });
+    expect(hasSpace).toBe(true);
+  });
+
+  test("clicking tile opens editable popover", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.locator(TILE_SELECTOR).click();
+    const popover = page.locator(TILE_POPOVER_SELECTOR);
+    await expect(popover).toBeVisible();
+    const textarea = popover.locator("textarea");
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue(LARGE_TEXT);
+  });
+
+  test("editing text in popover updates the tile data", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.locator(TILE_SELECTOR).click();
+    const textarea = page.locator(`${TILE_POPOVER_SELECTOR} textarea`);
+    await textarea.fill("modified text\nline 2\nline 3\nline 4");
+    const dataText = await page
+      .locator(TILE_SELECTOR)
+      .getAttribute("data-text");
+    expect(dataText).toBe("modified text\nline 2\nline 3\nline 4");
+  });
+
+  test("Escape closes popover and refocuses input", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.locator(TILE_SELECTOR).click();
+    await expect(page.locator(TILE_POPOVER_SELECTOR)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator(TILE_POPOVER_SELECTOR)).toHaveCount(0);
+    const focused = await page.evaluate(
+      () => document.activeElement?.id === "onyx-chat-input-textbox"
+    );
+    expect(focused).toBe(true);
+  });
+
+  test("ArrowLeft into tile highlights it", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.keyboard.press("ArrowLeft");
+    const highlighted = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(highlighted).toBe(true);
+  });
+
+  test("ArrowRight into tile highlights it", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("abc");
+    await pasteLargeText(page);
+    await page.keyboard.press("Home");
+    // Move to end of "abc" text, then one more right into the tile
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    const highlighted = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(highlighted).toBe(true);
+  });
+
+  test("Enter on highlighted tile opens popover", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("Enter");
+    await expect(page.locator(TILE_POPOVER_SELECTOR)).toBeVisible();
+  });
+
+  test("Enter on highlighted tile does NOT send message", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.keyboard.press("ArrowLeft");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(500);
+    await expect(page.locator(HUMAN_MESSAGE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("typing deselects highlighted tile", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.keyboard.press("ArrowLeft");
+    const before = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(before).toBe(true);
+    await page.keyboard.type("x");
+    const after = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(after).toBe(false);
+  });
+
+  test("second ArrowLeft moves cursor past the tile", async ({ page }) => {
+    const input = page.locator(INPUT_SELECTOR);
+    await input.focus();
+    await page.keyboard.type("abc");
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    // First ArrowLeft highlights tile
+    await page.keyboard.press("ArrowLeft");
+    // Second ArrowLeft deselects and moves before tile
+    await page.keyboard.press("ArrowLeft");
+    const highlighted = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(highlighted).toBe(false);
+  });
+
+  test("Backspace highlights tile, second Backspace deletes it", async ({
+    page,
+  }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    // First backspace highlights
+    await page.keyboard.press("ArrowLeft");
+    const highlighted = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-selected")
+    );
+    expect(highlighted).toBe(true);
+    // Second backspace deletes
+    await page.keyboard.press("Backspace");
+    await page.keyboard.press("Backspace");
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(0);
+  });
+
+  test("Ctrl+A highlights tiles with blue border", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.waitForTimeout(100);
+    const inSelection = await page.evaluate(
+      () =>
+        document
+          .querySelector("[data-paste-tile]")
+          ?.classList.contains("rich-input-tile-in-selection")
+    );
+    expect(inSelection).toBe(true);
+  });
+
+  test("Ctrl+C on tile copies the full text", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+c");
+    // Clear and paste back
+    await page.keyboard.press("Delete");
+    await page.keyboard.press("ControlOrMeta+v");
+    // Should create a new tile since the full text was on clipboard
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(1);
+    const dataText = await page
+      .locator(TILE_SELECTOR)
+      .getAttribute("data-text");
+    expect(dataText).toContain("function fibonacci");
+  });
+
+  test("Ctrl+X on tile cuts the full text and clears input", async ({
+    page,
+  }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.press("ControlOrMeta+x");
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(0);
+    const text = await page.locator(INPUT_SELECTOR).textContent();
+    expect(text?.trim()).toBe("");
+  });
+
+  test("multiple tiles can coexist", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      const dt = new DataTransfer();
+      dt.setData(
+        "text/plain",
+        "const x = 1;\nconst y = 2;\nconst z = 3;\nconst w = 4;"
+      );
+      el.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(2);
+  });
+
+  test("cursor is hidden when tile is highlighted", async ({ page }) => {
+    await pasteLargeText(page);
+    await page.keyboard.press("End");
+    await page.keyboard.press("ArrowLeft");
+    const selectionCollapsed = await page.evaluate(() => {
+      const sel = window.getSelection();
+      return sel?.isCollapsed;
+    });
+    expect(selectionCollapsed).toBe(false);
+  });
+});
+
 test.describe("Visual Regression", () => {
   test.beforeEach(async ({ page }, testInfo) => {
     resetTurnCounter();

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -670,10 +670,22 @@ test.describe("Paste Tiles", () => {
     await loginAsWorkerUser(page, testInfo.workerIndex);
     await page.goto("/app");
     await page.waitForLoadState("networkidle");
+    // Enable paste tiles for this test suite
+    await page.evaluate(() =>
+      fetch("/api/paste-as-tile?paste_as_tile=true", { method: "PATCH" })
+    );
+    await page.reload();
+    await page.waitForLoadState("networkidle");
     await page
       .locator(INPUT_SELECTOR)
       .waitFor({ state: "visible", timeout: 10000 });
     await mockChatEndpoint(page, buildMockStream("Mock response"));
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.evaluate(() =>
+      fetch("/api/paste-as-tile?paste_as_tile=false", { method: "PATCH" })
+    );
   });
 
   test("pasting large text creates a tile instead of inline text", async ({
@@ -958,6 +970,60 @@ test.describe("Paste Tiles", () => {
       return sel?.isCollapsed;
     });
     expect(selectionCollapsed).toBe(false);
+  });
+});
+
+test.describe("Paste Tiles — User Setting", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    resetTurnCounter();
+    await page.context().clearCookies();
+    await loginAsWorkerUser(page, testInfo.workerIndex);
+  });
+
+  test("paste tiles are disabled by default (paste_as_tile = false)", async ({
+    page,
+  }) => {
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+
+    await pasteLargeText(page);
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(0);
+    await expect(page.locator(INPUT_SELECTOR)).toContainText(
+      "function fibonacci"
+    );
+  });
+
+  test("paste tiles are created when user enables paste_as_tile", async ({
+    page,
+  }) => {
+    // Enable the setting via API before navigating
+    await page.goto("/app");
+    await page.waitForLoadState("networkidle");
+    await page.evaluate(() =>
+      fetch("/api/paste-as-tile?paste_as_tile=true", { method: "PATCH" })
+    );
+
+    // Reload to pick up the new preference
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await page
+      .locator(INPUT_SELECTOR)
+      .waitFor({ state: "visible", timeout: 10000 });
+
+    await pasteLargeText(page);
+    await expect(page.locator(TILE_SELECTOR)).toHaveCount(1);
+    await expect(page.locator(TILE_SELECTOR)).toHaveAttribute(
+      "data-text",
+      LARGE_TEXT
+    );
+
+    // Clean up: disable the setting
+    await page.evaluate(() =>
+      fetch("/api/paste-as-tile?paste_as_tile=false", { method: "PATCH" })
+    );
   });
 });
 

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -542,9 +542,9 @@ test.describe("Focus Management", () => {
     await input.focus();
     await expect(input).toBeFocused();
 
-    await page
-      .locator("[data-main-container]")
-      .click({ position: { x: 5, y: 5 } });
+    const button = page.locator("[data-main-container] button").first();
+    await button.waitFor({ state: "visible", timeout: 5000 });
+    await button.click();
     await expect(input).not.toBeFocused();
 
     await page.keyboard.press("Escape");

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -542,9 +542,9 @@ test.describe("Focus Management", () => {
     await input.focus();
     await expect(input).toBeFocused();
 
-    const button = page.locator("[data-main-container] button").first();
-    await button.waitFor({ state: "visible", timeout: 5000 });
-    await button.click();
+    await page
+      .locator("[data-main-container]")
+      .click({ position: { x: 5, y: 5 } });
     await expect(input).not.toBeFocused();
 
     await page.keyboard.press("Escape");


### PR DESCRIPTION
## Description

Adds "paste tiles" — when pasting long text (>200 chars or >3 lines) into the chat or craft input bar, the content collapses into a compact, interactive tile instead of flooding the input area. Users can click a tile to view/edit its full text via a popover, copy/cut tiles, and remove them with the X button.

This builds on the contentEditable input bar refactor (`whuang/refactor-input-bar-content-editable`). Key changes:

- **Paste tile rendering**: Large pastes become inline `<span>` tiles with clipboard icon, text preview, line/char count, and remove button — all built as raw DOM nodes (since React doesn't manage contentEditable children)
- **Tile interactions**: Click to open popover, Backspace/Delete to remove, copy/cut serialize tile text back to clipboard, arrow keys navigate around tiles
- **User preference**: `paste_as_tile` boolean on the user model (default false), togglable in settings. Migration adds the column.
- **CSS**: Tile styles in `content-editable.css`, including selection highlighting and hover states
- **Shared hook**: `useContentEditable` extended with `pasteText`, `handleCopy`, `handleCut`, tile selection, and popover state

## How Has This Been Tested?

- Playwright E2E tests in `web/tests/e2e/chat/input_bar_behaviors.spec.ts` covering paste tile creation, removal, copy/cut, popover editing, and preference toggle
- Manual testing in Chrome and Safari for paste behavior, tile interactions, multi-line input, and IME composition

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “paste tiles” to the chat/craft input: long pasted text collapses into a compact tile with a popover to view/edit, keeping the input clean. The chat input respects a new user setting (off by default); the craft input always enables tiles.

- **New Features**
  - Long pastes (>200 chars or >3 lines) become inline tiles with a preview and line/char counts; click to open a popover; remove with X.
  - Keyboard/clipboard support: Arrow and Backspace/Delete navigate/delete tiles; Enter opens the popover when a tile is selected; copy/cut copies the tile’s text.
  - Settings → Input adds “Collapse Large Pastes” (stored as `paste_as_tile`); Chat uses this preference, Craft forces tiles on. Tile and placeholder styles live in `content-editable.css`.

- **Migration**
  - Run the Alembic migration adding `paste_as_tile` to the `user` table.
  - The chat input is now contentEditable; the element id is `onyx-chat-input-textbox` (update any selectors).
  - Preference can be toggled via `PATCH /api/paste-as-tile?paste_as_tile=true|false`.

<sup>Written for commit 1595ee20fa28a8ee432a158aba490f70f0d5047b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

