### PR TITLE
fix(billing): add /tenants/seats/update alias for cloud FE

### DIFF
--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -21,7 +21,11 @@ import asyncio
 import httpx
 from fastapi import APIRouter
 from fastapi import Depends
+from sqlalchemy.orm import Session
 
+from ee.onyx.server.billing.api import update_seats as _admin_update_seats
+from ee.onyx.server.billing.models import SeatUpdateRequest
+from ee.onyx.server.billing.models import SeatUpdateResponse
 from ee.onyx.server.tenants.access import control_plane_dep
 from ee.onyx.server.tenants.billing import fetch_billing_information
 from ee.onyx.server.tenants.billing import fetch_customer_portal_session
@@ -42,6 +46,7 @@ from onyx.auth.users import User
 from onyx.configs.app_configs import STRIPE_PUBLISHABLE_KEY_OVERRIDE
 from onyx.configs.app_configs import STRIPE_PUBLISHABLE_KEY_URL
 from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -105,6 +110,16 @@ async def billing_information(
     logger.info("Fetching billing information")
     tenant_id = get_current_tenant_id()
     return fetch_billing_information(tenant_id)
+
+
+@router.post("/seats/update")
+async def update_seats(
+    request: SeatUpdateRequest,
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SeatUpdateResponse:
+    """Cloud alias for /admin/billing/seats/update (ENG-3533 migration)."""
+    return await _admin_update_seats(request, user, db_session)
 
 
 @router.post("/create-customer-portal-session")


### PR DESCRIPTION
## Description

Cloud frontend constructs its billing base URL via `NEXT_PUBLIC_CLOUD_ENABLED` (`web/src/lib/billing/svc.ts:29-31`) and posts to `/api/tenants/seats/update`. That route was never registered in `tenants/billing_api.py`, so cloud tenants got 404 when adjusting seats.

This adds a thin alias under the legacy `/tenants` router that delegates to the unified `/admin/billing/seats/update` handler. No business-logic duplication; the alias is removed once ENG-3533 fully migrates the FE.

Customer-impacting (404 visible in seat-management UI on cloud).

## How Has This Been Tested?

- Verified route registration: `POST /tenants/seats/update` now appears in `tenants_router` route list.
- Pre-commit (ruff, ty, black) passes.
- Manual verification pending; logic delegates to existing covered handler.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Refs ENG-3533.