### PR TITLE
feat: add paste_as_tile user preference

### DIFF
--- a/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
+++ b/backend/alembic/versions/74379b447d4c_add_paste_as_tile_to_user.py
@@ -1,0 +1,29 @@
+"""add paste_as_tile to user
+
+Revision ID: 74379b447d4c
+Revises: 31bd8c17325e
+Create Date: 2026-04-23 18:30:42.452355
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "74379b447d4c"
+down_revision = "31bd8c17325e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "paste_as_tile", sa.Boolean(), nullable=False, server_default="false"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "paste_as_tile")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -379,6 +379,9 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     # organized in typical structured fashion
     # formatted as `displayName__provider__modelName`
 
+    # Input preferences
+    paste_as_tile: Mapped[bool] = mapped_column(Boolean, default=False)
+
     # Voice preferences
     voice_auto_send: Mapped[bool] = mapped_column(Boolean, default=False)
     voice_auto_playback: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/backend/onyx/db/user_preferences.py
+++ b/backend/onyx/db/user_preferences.py
@@ -158,6 +158,20 @@ def update_user_shortcut_enabled(
     db_session.commit()
 
 
+def update_user_paste_as_tile(
+    user_id: UUID,
+    paste_as_tile: bool,
+    db_session: Session,
+) -> None:
+    """Update user's paste-as-tile setting."""
+    db_session.execute(
+        update(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .values(paste_as_tile=paste_as_tile)
+    )
+    db_session.commit()
+
+
 def update_user_auto_scroll(
     user_id: UUID,
     auto_scroll: bool | None,

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -84,6 +84,9 @@ class UserPreferences(BaseModel):
     chat_background: str | None = None
     default_app_mode: DefaultAppMode = DefaultAppMode.CHAT
 
+    # Input preferences
+    paste_as_tile: bool | None = None
+
     # Voice preferences
     voice_auto_send: bool | None = None
     voice_auto_playback: bool | None = None
@@ -169,6 +172,7 @@ class UserInfo(BaseModel):
                     theme_preference=user.theme_preference,
                     chat_background=user.chat_background,
                     default_app_mode=user.default_app_mode,
+                    paste_as_tile=user.paste_as_tile,
                     voice_auto_send=user.voice_auto_send,
                     voice_auto_playback=user.voice_auto_playback,
                     voice_playback_speed=user.voice_playback_speed,

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -70,6 +70,7 @@ from onyx.db.user_preferences import update_user_auto_scroll
 from onyx.db.user_preferences import update_user_chat_background
 from onyx.db.user_preferences import update_user_default_app_mode
 from onyx.db.user_preferences import update_user_default_model
+from onyx.db.user_preferences import update_user_paste_as_tile
 from onyx.db.user_preferences import update_user_personalization
 from onyx.db.user_preferences import update_user_pinned_assistants
 from onyx.db.user_preferences import update_user_role
@@ -971,6 +972,15 @@ def update_user_shortcut_enabled_api(
     db_session: Session = Depends(get_session),
 ) -> None:
     update_user_shortcut_enabled(user.id, shortcut_enabled, db_session)
+
+
+@router.patch("/paste-as-tile")
+def update_user_paste_as_tile_api(
+    paste_as_tile: bool,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_user_paste_as_tile(user.id, paste_as_tile, db_session)
 
 
 @router.patch("/auto-scroll")

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -32,6 +32,8 @@ interface UserPreferences {
   theme_preference: ThemePreference | null;
   chat_background: string | null;
   default_app_mode: "AUTO" | "CHAT" | "SEARCH";
+  // Input preferences
+  paste_as_tile?: boolean;
   // Voice preferences
   voice_auto_send?: boolean;
   voice_auto_playback?: boolean;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -35,6 +35,7 @@ interface UserContextType {
   authTypeMetadata: AuthTypeMetadata;
   updateUserAutoScroll: (autoScroll: boolean) => Promise<void>;
   updateUserShortcuts: (enabled: boolean) => Promise<void>;
+  updateUserPasteAsTile: (enabled: boolean) => Promise<void>;
   toggleAgentPinnedStatus: (
     currentPinnedAgentIDs: number[],
     agentId: number,
@@ -218,6 +219,41 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       }
     } catch (error) {
       console.error("Error updating user shortcut setting:", error);
+      throw error;
+    }
+  };
+
+  const updateUserPasteAsTile = async (enabled: boolean) => {
+    try {
+      setUpToDateUser((prevUser) => {
+        if (prevUser) {
+          return {
+            ...prevUser,
+            preferences: {
+              ...prevUser.preferences,
+              paste_as_tile: enabled,
+            },
+          };
+        }
+        return prevUser;
+      });
+
+      const response = await fetch(
+        `/api/paste-as-tile?paste_as_tile=${enabled}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!response.ok) {
+        await refreshUser();
+        throw new Error("Failed to update paste tile setting");
+      }
+    } catch (error) {
+      console.error("Error updating paste tile setting:", error);
       throw error;
     }
   };
@@ -516,6 +552,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
         authTypeMetadata,
         updateUserAutoScroll,
         updateUserShortcuts,
+        updateUserPasteAsTile,
         updateUserTemperatureOverrideEnabled,
         updateUserPersonalization,
         updateUserThemePreference,

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -891,6 +891,19 @@ function ChatPreferencesSettings() {
             />
           </InputHorizontal>
 
+          <InputHorizontal
+            title="Collapse Large Pastes"
+            description="When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text."
+            withLabel
+          >
+            <Switch
+              checked={user?.preferences?.paste_as_tile ?? false}
+              onCheckedChange={(checked) => {
+                updateUserPasteAsTile(checked);
+              }}
+            />
+          </InputHorizontal>
+
           {isPaidEnterpriseFeaturesEnabled && (
             <Tooltip
               tooltip={
@@ -1016,29 +1029,6 @@ function ChatPreferencesSettings() {
           </InputHorizontal>
 
           {user?.preferences?.shortcut_enabled && <PromptShortcuts />}
-        </Card>
-      </Section>
-
-      <Section gap={0.75}>
-        <Content
-          title="Input"
-          sizePreset="main-content"
-          variant="section"
-          width="full"
-        />
-        <Card>
-          <InputHorizontal
-            title="Collapse Large Pastes"
-            description="When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text."
-            withLabel
-          >
-            <Switch
-              checked={user?.preferences?.paste_as_tile ?? false}
-              onCheckedChange={(checked) => {
-                updateUserPasteAsTile(checked);
-              }}
-            />
-          </InputHorizontal>
         </Card>
       </Section>
 

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -770,6 +770,7 @@ function ChatPreferencesSettings() {
     updateUserPersonalization,
     updateUserAutoScroll,
     updateUserShortcuts,
+    updateUserPasteAsTile,
     updateUserDefaultModel,
     updateUserDefaultAppMode,
     updateUserVoiceSettings,
@@ -1015,6 +1016,29 @@ function ChatPreferencesSettings() {
           </InputHorizontal>
 
           {user?.preferences?.shortcut_enabled && <PromptShortcuts />}
+        </Card>
+      </Section>
+
+      <Section gap={0.75}>
+        <Content
+          title="Input"
+          sizePreset="main-content"
+          variant="section"
+          width="full"
+        />
+        <Card>
+          <InputHorizontal
+            title="Collapse Large Pastes"
+            description="When pasting text longer than 3 lines or 200 characters, collapse it into a compact tile instead of inserting it inline. Click the tile to view or edit the full text."
+            withLabel
+          >
+            <Switch
+              checked={user?.preferences?.paste_as_tile ?? false}
+              onCheckedChange={(checked) => {
+                updateUserPasteAsTile(checked);
+              }}
+            />
+          </InputHorizontal>
         </Card>
       </Section>
 


### PR DESCRIPTION
## Description

Add a per-user boolean preference to control whether large pastes collapse into compact tiles. Includes DB migration, API endpoint, UserProvider integration, and Settings UI toggle.

Migration + UI setting only. Paste tiles PR will proceed.

<img width="1004" height="498" alt="image" src="https://github.com/user-attachments/assets/a0e72eb7-d592-43ac-a38c-dec1b837b645" />


## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
