### PR TITLE
fix(web): mutate currentSearchSettings on cancel re-index

### DIFF
--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -895,7 +895,7 @@ export default function IndexSettingsPage() {
           <Formik<IndexSettingsFormValues>
             enableReinitialize
             initialValues={initialFormValues}
-            onSubmit={async (values, { resetForm }) => {
+            onSubmit={async (values) => {
               // Custom self-hosted models live outside the static registry,
               // so the form carries their spec (`modelDim`, `normalize`, etc.)
               // in `custom_model` for submission. The provider, however, is
@@ -929,7 +929,6 @@ export default function IndexSettingsPage() {
               }
 
               toast.success("Re-indexing started");
-              resetForm({ values });
               setSwitchoverType(SwitchoverType.REINDEX);
               await Promise.all([
                 mutate(SWR_KEYS.currentSearchSettings),

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -827,6 +827,7 @@ export default function IndexSettingsPage() {
     cancelReindexModal.toggle(false);
     toast.success("Re-indexing canceled");
     await Promise.all([
+      mutate(SWR_KEYS.currentSearchSettings),
       mutate(SWR_KEYS.secondarySearchSettings),
       mutate(SWR_KEYS.indexingStatus),
     ]);


### PR DESCRIPTION
## Description

After clicking **Cancel Re-index** on the Index Settings page, the re-index warning banner failed to reappear even though the new embedding model was still shown as selected.

**Root cause:** `handleCancelReindex` was mutating `secondarySearchSettings` and `indexingStatus` but not `currentSearchSettings`. This left the SWR cache stale — `currentEmbeddingModel` continued to show the new model, so `initialFormValues.model_name` stayed equal to `values.model_name`, Formik saw `dirty = false`, and the banner was suppressed.

**Fix:** Add `mutate(SWR_KEYS.currentSearchSettings)` to the cancel handler, matching what `onSubmit` already does. After cancellation the cache refetches, `currentEmbeddingModel` reverts to the old model, `enableReinitialize` resets Formik to it, and the form correctly reflects server state.

## Screenshots + Videos

### Before

Notice how after cancelling the re-index, the NEW model is still selected, but the top prompt to re-index is missing.

https://github.com/user-attachments/assets/b06534d5-f4bd-4a4e-8525-af039f2e5003

### After

Now, after cancelling the re-index, the NEW model is still selected AND the top prompt re-index prompt is present.

https://github.com/user-attachments/assets/ec01f0d6-0873-492f-aad2-45fc2794a7aa

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Index Settings re-index flow. Cancel now mutates `SWR_KEYS.currentSearchSettings` to refetch the cache, and we removed the `resetForm` call in onSubmit so Formik stays dirty and the previous model plus the re-index banner/action buttons display correctly during and after re-indexing.

<sup>Written for commit 825ee211a9d6a6dbe79901e98271ab45f27d325e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->