### PR TITLE
fix(auth): refresh OIDC access tokens on every authenticated request (follow-up to #10794)

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import time
+import uuid
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -54,6 +55,34 @@ def _get_oidc_lock() -> asyncio.Lock:
     if _OIDC_TOKEN_ENDPOINT_LOCK is None:
         _OIDC_TOKEN_ENDPOINT_LOCK = asyncio.Lock()
     return _OIDC_TOKEN_ENDPOINT_LOCK
+
+
+# Per-user locks coalescing concurrent token-refresh attempts. Without this,
+# two requests for the same user near expiry could both POST a refresh, and
+# IdPs that rotate refresh tokens (e.g. Microsoft Entra) would invalidate one
+# of them with `400 invalid_grant`. The lock pairs with a re-read inside
+# `check_and_refresh_oauth_tokens` so the second coroutine skips the redundant
+# request entirely once the first has succeeded.
+_USER_REFRESH_LOCKS: Dict[uuid.UUID, asyncio.Lock] = {}
+_USER_REFRESH_LOCKS_GUARD: Optional[asyncio.Lock] = None
+
+
+def _get_user_refresh_locks_guard() -> asyncio.Lock:
+    """Lazy-init the meta-lock that protects the per-user lock dict itself."""
+    global _USER_REFRESH_LOCKS_GUARD
+    if _USER_REFRESH_LOCKS_GUARD is None:
+        _USER_REFRESH_LOCKS_GUARD = asyncio.Lock()
+    return _USER_REFRESH_LOCKS_GUARD
+
+
+async def _get_user_refresh_lock(user_id: uuid.UUID) -> asyncio.Lock:
+    """Get-or-create a per-user lock keyed by `user.id`."""
+    async with _get_user_refresh_locks_guard():
+        lock = _USER_REFRESH_LOCKS.get(user_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _USER_REFRESH_LOCKS[user_id] = lock
+        return lock
 
 
 def _cached_token_endpoint() -> Optional[str]:
@@ -273,17 +302,40 @@ async def check_and_refresh_oauth_tokens(
             oauth_account.expires_at
             and oauth_account.expires_at - now_timestamp < buffer_seconds
         ):
-            logger.info(
-                "OAuth token for %s is about to expire - refreshing", user.email
-            )
-            success = await refresh_oauth_token(
-                user, oauth_account, db_session, user_manager
-            )
+            # Coalesce concurrent refreshes for the same user. Re-read the
+            # account inside the lock so the second coroutine sees the
+            # refreshed `expires_at` (and `refresh_token` for IdPs that
+            # rotate) and skips the redundant POST.
+            user_lock = await _get_user_refresh_lock(user.id)
+            async with user_lock:
+                try:
+                    await db_session.refresh(oauth_account)
+                except Exception:
+                    # `db_session.refresh` can fail when oauth_account is
+                    # detached from this session (e.g. pre-loaded by the
+                    # caller). Fall through and attempt the refresh anyway —
+                    # at worst the second coroutine sees the same stale
+                    # state we'd see without the lock.
+                    pass
 
-            if not success:
-                logger.warning(
-                    "Failed to refresh OAuth token. User may need to re-authenticate."
+                if (
+                    oauth_account.expires_at
+                    and oauth_account.expires_at - now_timestamp >= buffer_seconds
+                ):
+                    # Another coroutine already refreshed this account.
+                    continue
+
+                logger.info(
+                    "OAuth token for %s is about to expire - refreshing", user.email
                 )
+                success = await refresh_oauth_token(
+                    user, oauth_account, db_session, user_manager
+                )
+
+                if not success:
+                    logger.warning(
+                        "Failed to refresh OAuth token. User may need to re-authenticate."
+                    )
 
 
 async def check_oauth_account_has_refresh_token(

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import time
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -27,9 +29,18 @@ REFRESH_ENDPOINTS: Dict[str, str] = {
 }
 
 # Token endpoint resolved from the configured OIDC discovery document.
-# Populated lazily on first successful fetch and re-used thereafter, so the
-# .well-known/openid-configuration document is only retrieved once per process.
-_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str] = {}
+# Populated lazily on first successful fetch and re-used until the entry's
+# `fetched_at` exceeds OIDC_DISCOVERY_CACHE_TTL_SECONDS, at which point it is
+# re-fetched. The TTL guards against the IdP rotating its `token_endpoint`
+# without us noticing (rare for major IdPs but possible across tenant moves
+# or app-reg migrations).
+_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, Any] = {}
+
+# Default 1 hour: matches Microsoft Entra's default access-token lifetime, so
+# at worst one refresh fails after an endpoint rotation before we self-heal.
+OIDC_DISCOVERY_CACHE_TTL_SECONDS: int = int(
+    os.environ.get("OIDC_DISCOVERY_CACHE_TTL_SECONDS") or 3600
+)
 
 # Lazily-initialized lock guarding concurrent first-time fetches of the OIDC
 # discovery document. Created on first use so it binds to the running event
@@ -45,6 +56,17 @@ def _get_oidc_lock() -> asyncio.Lock:
     return _OIDC_TOKEN_ENDPOINT_LOCK
 
 
+def _cached_token_endpoint() -> Optional[str]:
+    """Return the cached endpoint if still within its TTL, else None."""
+    cached_url = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+    fetched_at = _OIDC_TOKEN_ENDPOINT_CACHE.get("fetched_at")
+    if not isinstance(cached_url, str) or not isinstance(fetched_at, float):
+        return None
+    if (time.monotonic() - fetched_at) >= OIDC_DISCOVERY_CACHE_TTL_SECONDS:
+        return None
+    return cached_url
+
+
 async def _get_oidc_token_endpoint() -> Optional[str]:
     """Resolve the OAuth2 token endpoint for the configured OIDC provider.
 
@@ -52,9 +74,10 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
     refresh works for any OIDC provider (Microsoft Entra, Okta, Keycloak,
     Auth0, ...) without hardcoding provider-specific URLs. The lock + double
     check ensures concurrent callers (e.g. multiple tokens expiring at once
-    after a server restart) coalesce into a single discovery request.
+    after a server restart) coalesce into a single discovery request, and the
+    TTL ensures we re-fetch periodically in case the IdP rotates the endpoint.
     """
-    cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+    cached = _cached_token_endpoint()
     if cached:
         return cached
     if not OPENID_CONFIG_URL:
@@ -62,7 +85,7 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
     async with _get_oidc_lock():
         # Re-check inside the lock — another coroutine may have populated
         # the cache while we were waiting to acquire it.
-        cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+        cached = _cached_token_endpoint()
         if cached:
             return cached
         try:
@@ -78,6 +101,7 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
         token_endpoint = config.get("token_endpoint")
         if isinstance(token_endpoint, str) and token_endpoint:
             _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
+            _OIDC_TOKEN_ENDPOINT_CACHE["fetched_at"] = time.monotonic()
             return token_endpoint
         return None
 

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -35,7 +35,7 @@ REFRESH_ENDPOINTS: Dict[str, str] = {
 # re-fetched. The TTL guards against the IdP rotating its `token_endpoint`
 # without us noticing (rare for major IdPs but possible across tenant moves
 # or app-reg migrations).
-_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, Any] = {}
+_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str | float] = {}
 
 # Default 1 hour: matches Microsoft Entra's default access-token lifetime, so
 # at worst one refresh fails after an endpoint rotation before we self-heal.

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1614,13 +1614,53 @@ async def _check_for_saml_and_jwt(
     return user
 
 
+async def _maybe_refresh_oidc_tokens(
+    user: User,
+    async_db_session: AsyncSession,
+    user_manager: BaseUserManager[User, uuid.UUID],
+) -> None:
+    """Best-effort refresh of any near-expiry OAuth access tokens.
+
+    PT_OAUTH MCP tools and any custom HTTP tool with bearer pass-through
+    forward `user.oauth_accounts[0].access_token` directly to the upstream
+    service. The web client's /auth/refresh ticker is gated off for
+    OIDC/SAML (see `web/src/hooks/useTokenRefresh.ts`), so without this hook
+    the stored access_token would rot at the IdP's lifetime (~1 h on
+    Microsoft Entra default) and downstream calls would 401 until the user
+    signs out and back in.
+
+    Refreshing here on every authenticated request is cheap — the underlying
+    `check_and_refresh_oauth_tokens` short-circuits when no account is
+    within the 5-minute renewal buffer. Failures log and return, so a
+    misconfigured IdP can never break authentication of an otherwise-valid
+    request.
+    """
+    # Local import mirrors the pattern at `get_refresh_router` to keep the
+    # auth module's load order resilient.
+    from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
+
+    try:
+        await check_and_refresh_oauth_tokens(
+            user=user,
+            db_session=async_db_session,
+            user_manager=cast(Any, user_manager),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to opportunistically refresh OAuth tokens for %s",
+            user.email,
+        )
+
+
 async def optional_user(
     request: Request,
     async_db_session: AsyncSession = Depends(get_async_session),
     user: User | None = Depends(optional_fastapi_current_user),
+    user_manager: BaseUserManager[User, uuid.UUID] = Depends(get_user_manager),
 ) -> User | None:
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
+        await _maybe_refresh_oidc_tokens(user, async_db_session, user_manager)
         return user
 
     try:
@@ -1632,6 +1672,8 @@ async def optional_user(
         logger.warning("Issue with validating authentication token")
         return None
 
+    if user is not None:
+        await _maybe_refresh_oidc_tokens(user, async_db_session, user_manager)
     return user
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1614,7 +1614,7 @@ async def _check_for_saml_and_jwt(
     return user
 
 
-async def _maybe_refresh_oidc_tokens(
+async def _maybe_refresh_oauth_tokens(
     user: User,
     async_db_session: AsyncSession,
     user_manager: BaseUserManager[User, uuid.UUID],
@@ -1660,7 +1660,7 @@ async def optional_user(
 ) -> User | None:
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
-        await _maybe_refresh_oidc_tokens(user, async_db_session, user_manager)
+        await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
         return user
 
     try:
@@ -1673,7 +1673,7 @@ async def optional_user(
         return None
 
     if user is not None:
-        await _maybe_refresh_oidc_tokens(user, async_db_session, user_manager)
+        await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
     return user
 
 

--- a/backend/tests/unit/onyx/auth/conftest.py
+++ b/backend/tests/unit/onyx/auth/conftest.py
@@ -40,4 +40,9 @@ def mock_user_manager() -> MagicMock:
 @pytest.fixture
 def mock_db_session() -> MagicMock:
     """Creates a mock database session for testing."""
-    return MagicMock()
+    session = MagicMock()
+    # `check_and_refresh_oauth_tokens` calls `await db_session.refresh(...)`
+    # inside the per-user lock to re-read the latest expires_at from DB; the
+    # AsyncMock here lets that await resolve without raising.
+    session.refresh = AsyncMock()
+    return session

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -176,6 +176,72 @@ async def test_check_and_refresh_oauth_tokens(
 
 
 @pytest.mark.asyncio
+async def test_check_and_refresh_oauth_tokens_coalesces_concurrent_refresh(
+    mock_user_manager: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent refreshes for the same user trigger only one IdP POST.
+
+    Mirrors the post-refresh in-memory state by having the mocked
+    `refresh_oauth_token` update `account.expires_at` to a fresh value
+    (the way `update_oauth_account` would refresh the SQLAlchemy object on
+    success). The second coroutine must observe the fresh `expires_at`
+    inside the per-user lock and skip its redundant POST.
+    """
+    import asyncio as _asyncio
+
+    monkeypatch.setattr(oauth_refresher, "_USER_REFRESH_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_USER_REFRESH_LOCKS_GUARD", None)
+
+    now_timestamp = datetime.now(timezone.utc).timestamp()
+
+    account = MagicMock(spec=OAuthAccount)
+    account.oauth_name = "openid"
+    account.refresh_token = "rt"
+    account.expires_at = now_timestamp + 60  # within renewal buffer
+
+    user = MagicMock()
+    user.id = "concurrent-test-user"
+    user.email = "concurrent@example.com"
+    user.oauth_accounts = [account]
+
+    db_session = MagicMock()
+    db_session.refresh = AsyncMock()
+
+    refresh_started = _asyncio.Event()
+    release_refresh = _asyncio.Event()
+
+    async def slow_refresh(
+        _u: MagicMock, a: MagicMock, *_args: object, **_kwargs: object
+    ) -> bool:
+        # Park the first caller inside refresh_oauth_token so the second
+        # caller has a chance to reach the lock; the test fails
+        # (call_count > 1) if the lock doesn't coalesce them.
+        refresh_started.set()
+        await release_refresh.wait()
+        a.expires_at = now_timestamp + 3600  # simulate post-refresh state
+        return True
+
+    with patch(
+        "onyx.auth.oauth_refresher.refresh_oauth_token",
+        AsyncMock(side_effect=slow_refresh),
+    ) as mock_refresh:
+        first = _asyncio.create_task(
+            check_and_refresh_oauth_tokens(user, db_session, mock_user_manager)
+        )
+        await refresh_started.wait()
+        second = _asyncio.create_task(
+            check_and_refresh_oauth_tokens(user, db_session, mock_user_manager)
+        )
+        # Yield once so the second task reaches the lock acquisition.
+        await _asyncio.sleep(0)
+        release_refresh.set()
+        await _asyncio.gather(first, second)
+
+    assert mock_refresh.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_get_oauth_accounts_requiring_refresh_token(mock_user: MagicMock) -> None:
     """Test identifying OAuth accounts that need refresh tokens."""
     # Create accounts with and without refresh tokens

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -256,6 +256,9 @@ async def test_resolve_token_endpoint_openid_via_discovery(
 ) -> None:
     """For OIDC ("openid"), the token endpoint is read from the discovery doc."""
     monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    # Reset the lock so it gets created in the current test's event loop;
+    # without this, a prior test's lock could be bound to a different loop.
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -288,6 +291,50 @@ async def test_resolve_token_endpoint_openid_via_discovery(
     endpoint_cached = await _resolve_token_endpoint("openid")
     assert endpoint_cached == "https://idp.example.com/oauth2/v2.0/token"
     mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_cache_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An expired cache entry triggers a fresh discovery fetch."""
+    import time as _time
+
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(
+        oauth_refresher,
+        "OPENID_CONFIG_URL",
+        "https://idp.example.com/.well-known/openid-configuration",
+    )
+    monkeypatch.setattr(oauth_refresher, "OIDC_DISCOVERY_CACHE_TTL_SECONDS", 1)
+    # Pre-populate the cache with an entry that's already past TTL.
+    expired_fetched_at = _time.monotonic() - 60.0
+    monkeypatch.setattr(
+        oauth_refresher,
+        "_OIDC_TOKEN_ENDPOINT_CACHE",
+        {
+            "url": "https://idp.example.com/old-token-endpoint",
+            "fetched_at": expired_fetched_at,
+        },
+    )
+
+    discovery_response = MagicMock()
+    discovery_response.status_code = 200
+    discovery_response.raise_for_status.return_value = None
+    discovery_response.json.return_value = {
+        "token_endpoint": "https://idp.example.com/new-token-endpoint",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = discovery_response
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+        endpoint = await _resolve_token_endpoint("openid")
+
+    # Must NOT return the stale cached URL; a fresh fetch is required.
+    assert endpoint == "https://idp.example.com/new-token-endpoint"
+    mock_client.get.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -403,12 +450,18 @@ async def test_refresh_oauth_token_openid_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """OIDC ("openid") accounts refresh via the discovery-resolved endpoint."""
+    import time as _time
+
     # Pre-populate the cache so the refresh test does not depend on the
-    # discovery-doc fetch path (covered separately above).
+    # discovery-doc fetch path (covered separately above). Include a fresh
+    # `fetched_at` so the entry is well within the TTL window.
     monkeypatch.setattr(
         oauth_refresher,
         "_OIDC_TOKEN_ENDPOINT_CACHE",
-        {"url": "https://idp.example.com/oauth2/v2.0/token"},
+        {
+            "url": "https://idp.example.com/oauth2/v2.0/token",
+            "fetched_at": _time.monotonic(),
+        },
     )
 
     mock_oauth_account.oauth_name = "openid"

--- a/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
+++ b/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from onyx.auth.users import _maybe_refresh_oidc_tokens
+from onyx.db.models import User
+
+
+@pytest.mark.asyncio
+async def test_maybe_refresh_oidc_tokens_invokes_check_and_refresh(
+    mock_user: MagicMock,
+    mock_user_manager: MagicMock,
+    mock_db_session: AsyncSession,
+) -> None:
+    """Happy path: the helper delegates to `check_and_refresh_oauth_tokens`.
+
+    `check_and_refresh_oauth_tokens` already short-circuits when no
+    oauth_account is within the 5-minute renewal buffer, so calling it on
+    every authenticated request is the right granularity for this hook.
+    """
+    with patch(
+        "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
+        AsyncMock(return_value=None),
+    ) as mock_refresh:
+        await _maybe_refresh_oidc_tokens(mock_user, mock_db_session, mock_user_manager)
+
+    mock_refresh.assert_awaited_once()
+    await_args = mock_refresh.await_args
+    assert await_args is not None
+    assert await_args.kwargs["user"] is mock_user
+    assert await_args.kwargs["db_session"] is mock_db_session
+    assert await_args.kwargs["user_manager"] is mock_user_manager
+
+
+@pytest.mark.asyncio
+async def test_maybe_refresh_oidc_tokens_swallows_failures(
+    mock_user: MagicMock,
+    mock_user_manager: MagicMock,
+    mock_db_session: AsyncSession,
+) -> None:
+    """A misconfigured IdP must NOT break authentication of a valid request.
+
+    `check_and_refresh_oauth_tokens` raising should be logged and the
+    helper should return None — leaving the caller (`optional_user`) to
+    return the resolved user with whatever access_token is already stored.
+    """
+    with patch(
+        "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
+        AsyncMock(side_effect=RuntimeError("IdP unreachable")),
+    ):
+        result = await _maybe_refresh_oidc_tokens(
+            mock_user, mock_db_session, mock_user_manager
+        )
+
+    # The helper has no return value; the assertion that matters is that
+    # the exception did NOT propagate.
+    assert result is None
+
+
+@pytest.fixture
+def mock_user() -> MagicMock:
+    user = MagicMock(spec=User)
+    user.email = "test@example.com"
+    return user
+
+
+@pytest.fixture
+def mock_user_manager() -> MagicMock:
+    user_manager = MagicMock()
+    user_manager.user_db = MagicMock()
+    user_manager.user_db.update_oauth_account = AsyncMock()
+    user_manager.user_db.update = AsyncMock()
+    return user_manager
+
+
+@pytest.fixture
+def mock_db_session() -> MagicMock:
+    return MagicMock()

--- a/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
+++ b/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
@@ -5,12 +5,12 @@ from unittest.mock import patch
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from onyx.auth.users import _maybe_refresh_oidc_tokens
+from onyx.auth.users import _maybe_refresh_oauth_tokens
 from onyx.db.models import User
 
 
 @pytest.mark.asyncio
-async def test_maybe_refresh_oidc_tokens_invokes_check_and_refresh(
+async def test_maybe_refresh_oauth_tokens_invokes_check_and_refresh(
     mock_user: MagicMock,
     mock_user_manager: MagicMock,
     mock_db_session: AsyncSession,
@@ -25,7 +25,7 @@ async def test_maybe_refresh_oidc_tokens_invokes_check_and_refresh(
         "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
         AsyncMock(return_value=None),
     ) as mock_refresh:
-        await _maybe_refresh_oidc_tokens(mock_user, mock_db_session, mock_user_manager)
+        await _maybe_refresh_oauth_tokens(mock_user, mock_db_session, mock_user_manager)
 
     mock_refresh.assert_awaited_once()
     await_args = mock_refresh.await_args
@@ -36,7 +36,7 @@ async def test_maybe_refresh_oidc_tokens_invokes_check_and_refresh(
 
 
 @pytest.mark.asyncio
-async def test_maybe_refresh_oidc_tokens_swallows_failures(
+async def test_maybe_refresh_oauth_tokens_swallows_failures(
     mock_user: MagicMock,
     mock_user_manager: MagicMock,
     mock_db_session: AsyncSession,
@@ -51,7 +51,7 @@ async def test_maybe_refresh_oidc_tokens_swallows_failures(
         "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
         AsyncMock(side_effect=RuntimeError("IdP unreachable")),
     ):
-        result = await _maybe_refresh_oidc_tokens(
+        result = await _maybe_refresh_oauth_tokens(
             mock_user, mock_db_session, mock_user_manager
         )
 


### PR DESCRIPTION
## Description

Follow-up to #10794. That PR taught `oauth_refresher` how to refresh tokens for any OIDC provider via the discovery doc, but nothing on the request path actually invoked it for OIDC users — `web/src/hooks/useTokenRefresh.ts:31-38` returns early for `AuthType.OIDC` because `/api/auth/refresh` isn't registered for OIDC strategies. So the stored `oauth_accounts.access_token` rotted at the IdP's lifetime (~1 h on Microsoft Entra default) and any flow that forwarded `user.oauth_accounts[0].access_token` (PT_OAUTH MCP tools, custom HTTP tools with bearer pass-through) would 401 until the user signed out and back in.

This PR adds a small async helper `_maybe_refresh_oidc_tokens` and calls it from `optional_user` after the user is resolved. `check_and_refresh_oauth_tokens` already short-circuits when no `oauth_account` is within the 5-minute renewal buffer, so per-request overhead is one `expires_at` comparison in the common case and an HTTPS roundtrip to the IdP at most every ~55 min per user when the access_token is actually about to expire. The call is wrapped in `try/except` so a misconfigured IdP can never break authentication of an otherwise-valid request — failures log and the request proceeds with the stored token (same worst-case as before this PR; never worse).

Two additional commits address the bot review nits surfaced on the mirror of #10794:

- **TTL on the OIDC discovery cache** (greptile P2 from #10798): the cache now records `fetched_at` alongside the URL and re-fetches when an entry is older than `OIDC_DISCOVERY_CACHE_TTL_SECONDS` (default 1 h, env-overridable). Worst-case self-heal after a `token_endpoint` rotation is therefore one TTL window.
- **Lock reset in `test_resolve_token_endpoint_openid_via_discovery`** (greptile + cubic P2 from #10798): aligns this test with its siblings so `_OIDC_TOKEN_ENDPOINT_LOCK` is created in the current event loop, eliminating a "lock bound to a different event loop" flake under pytest loop reuse.

## How Has This Been Tested?

### Unit tests

17 tests across `backend/tests/unit/onyx/auth/test_oauth_refresher.py` (15) and `backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py` (2 new):

```
17 passed in 0.49s
```

`uv run ty check` clean. `uv run ruff check` clean. The full `backend/tests/unit/onyx/auth/` suite (190 tests) passes with no regressions.

### Live verification on a real Onyx-on-Entra deployment

Deployed both files as a volume-mount overlay on a private production Onyx instance (Microsoft Entra OIDC, ~30 s recreate, fully reversible). Within seconds of the api_server coming back up, the api_server logs showed the refresh chain firing successfully for multiple distinct users whose `expires_at` was negative-by-millions-of-seconds, with the expected log shape:

```
INFO oauth_refresher.py:276  [API:xxxxxxxx] OAuth token for <user> is about to expire - refreshing
INFO oauth_refresher.py:182  [API:xxxxxxxx] Refreshing OAuth token for <user>'s openid account
INFO oauth_refresher.py:242  [API:xxxxxxxx] Successfully refreshed OAuth token for <user>
```

Across the first ~5 minutes after the recreate: **5+ distinct users refreshed end-to-end, zero refresh failures, zero auth-related tracebacks, zero nginx 502s**. The discovery document was fetched once (the lock + double-checked locking from #10794 worked as designed under real-world concurrent load) and every subsequent refresh used the cached endpoint.

DB confirmation: previously-stale `oauth_accounts` rows now have `expires_at ≈ now + 58 min` instead of being weeks in the past, and they continue to roll forward as users keep using the app.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check