### PR TITLE
feat(web): show Index Settings in sidebar for cloud deployments

### DIFF
--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,16 +1081,18 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <Card border="solid" rounding="lg" padding="sm">
-                        <GeneralLayouts.Section padding={0.5}>
-                          <Content
-                            icon={SvgVector}
-                            title="Embedding model and settings are managed by Onyx Cloud."
-                            sizePreset="main-ui"
-                            variant="section"
-                          />
-                        </GeneralLayouts.Section>
-                      </Card>
+                      <CloudDisabled>
+                        <Card border="solid" rounding="lg" padding="sm">
+                          <GeneralLayouts.Section padding={0.5}>
+                            <Content
+                              icon={SvgVector}
+                              title="Embedding model and settings are managed by Onyx Cloud."
+                              sizePreset="main-ui"
+                              variant="section"
+                            />
+                          </GeneralLayouts.Section>
+                        </Card>
+                      </CloudDisabled>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,18 +1081,16 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <Disabled disabled allowClick>
-                        <Card border="solid" rounding="lg" padding="sm">
-                          <GeneralLayouts.Section padding={0.5}>
-                            <Content
-                              icon={SvgVector}
-                              title="Embedding model and settings are managed by Onyx Cloud."
-                              sizePreset="main-ui"
-                              variant="section"
-                            />
-                          </GeneralLayouts.Section>
-                        </Card>
-                      </Disabled>
+                      <Card border="solid" rounding="lg" padding="sm">
+                        <GeneralLayouts.Section padding={0.5}>
+                          <Content
+                            icon={SvgVector}
+                            title="Embedding model and settings are managed by Onyx Cloud."
+                            sizePreset="main-ui"
+                            variant="section"
+                          />
+                        </GeneralLayouts.Section>
+                      </Card>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,16 +1081,18 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <Card border="solid" rounding="lg" padding="sm">
-                        <GeneralLayouts.Section padding={0.5}>
-                          <Content
-                            icon={SvgVector}
-                            title="Embedding model and settings are managed by Onyx Cloud."
-                            sizePreset="main-ui"
-                            variant="section"
-                          />
-                        </GeneralLayouts.Section>
-                      </Card>
+                      <Disabled disabled allowClick>
+                        <Card border="solid" rounding="lg" padding="sm">
+                          <GeneralLayouts.Section padding={0.5}>
+                            <Content
+                              icon={SvgVector}
+                              title="Embedding model and settings are managed by Onyx Cloud."
+                              sizePreset="main-ui"
+                              variant="section"
+                            />
+                          </GeneralLayouts.Section>
+                        </Card>
+                      </Disabled>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled
@@ -1515,7 +1517,7 @@ export default function IndexSettingsPage() {
                       variant="section"
                     />
 
-                    <CloudDisabled
+                    <Disabled
                       disabled={!hasAnyVisionLlm}
                       tooltip={
                         !hasAnyVisionLlm
@@ -1604,7 +1606,7 @@ export default function IndexSettingsPage() {
                           </Disabled>
                         </GeneralLayouts.Section>
                       </Card>
-                    </CloudDisabled>
+                    </Disabled>
                   </GeneralLayouts.Section>
                 </>
               );

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -98,7 +98,7 @@ function buildItems(
     add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.INDEXING_STATUS);
     add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.ADD_CONNECTOR);
     add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.DOCUMENT_SETS);
-    if (!isCurator && !enableCloud) {
+    if (!isCurator) {
       items.push({
         ...sidebarItem(ADMIN_ROUTES.INDEX_SETTINGS),
         section: SECTIONS.DOCUMENTS_AND_KNOWLEDGE,


### PR DESCRIPTION
## Description

Index Settings was gated behind `!enableCloud` in the admin sidebar, making the entire page inaccessible on cloud deployments. This was incorrect — the **embedding model** and **Retrieval Optimization** sections are cloud-managed. **Image processing** is a self-service feature that cloud users should be able to configure.

The page already handles the cloud/self-hosted split correctly:
- Embedding models + retrieval optimization sections: disabled with a tooltip explaining why.
- Image processing: rendered unconditionally.

This PR removes the `!enableCloud` gate from the sidebar so cloud users can reach the page.

## Screenshots + Videos

### Before

Before, on cloud deployments, the "Index Settings" tab would be gated from rendering.

<img width="249" height="1847" alt="image" src="https://github.com/user-attachments/assets/c685ab91-5c50-420d-9e86-5805a83a1321" />

### After

Now, it renders. Furthermore, there is special UI inside the actual page to prevent modifying cloud-gated settings. However (*most importantly*), the "Image Processing" section is NOT gated. This is intentional. We allow end-users to update image-processing settings.

<img width="1664" height="1829" alt="image" src="https://github.com/user-attachments/assets/7d19d691-d3f8-49b3-8597-ac8e91357d1b" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Index Settings in the admin sidebar on cloud by removing the `!enableCloud` gate; still hidden for curators. On cloud, the embedding model section is non-editable with a “managed by Onyx Cloud” placeholder, while image processing and retrieval optimization remain self-serve; image processing uses `Disabled` (not `CloudDisabled`) so cloud tenants can edit it when a vision LLM is available.

<sup>Written for commit 308b05ec6a6b1cb4f2e45a20d17d241d61f509a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

