### PR TITLE
feat(web): enterprise-tab tooltips + InlineMarkdown fixes

### DIFF
--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -140,7 +140,16 @@ function SidebarTab({
     </div>
   );
 
-  if (typeof children !== "string") return content;
+  if (typeof children !== "string") {
+    if (tooltip) {
+      return (
+        <Tooltip tooltip={tooltip} side="right">
+          {content}
+        </Tooltip>
+      );
+    }
+    return content;
+  }
   const resolvedTooltip = tooltip ?? (folded ? children : undefined);
   if (resolvedTooltip) {
     return (

--- a/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
+++ b/web/lib/opal/src/components/buttons/sidebar-tab/components.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import type { ButtonType, IconFunctionComponent } from "@opal/types";
+import type { ButtonType, IconFunctionComponent, RichStr } from "@opal/types";
 import type { Route } from "next";
 import { Interactive, type InteractiveStatefulVariant } from "@opal/core";
 import { ContentAction } from "@opal/layouts";
@@ -42,6 +42,9 @@ interface SidebarTabProps {
 
   /** Content rendered on the right side (e.g. action buttons). */
   rightChildren?: React.ReactNode;
+
+  /** Tooltip shown on hover. Takes precedence over the folded-name tooltip. */
+  tooltip?: string | RichStr;
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +70,7 @@ function SidebarTab({
   type,
   icon,
   rightChildren,
+  tooltip,
   children,
 }: SidebarTabProps) {
   const Icon =
@@ -137,9 +141,10 @@ function SidebarTab({
   );
 
   if (typeof children !== "string") return content;
-  if (folded) {
+  const resolvedTooltip = tooltip ?? (folded ? children : undefined);
+  if (resolvedTooltip) {
     return (
-      <Tooltip tooltip={children} side="right">
+      <Tooltip tooltip={resolvedTooltip} side="right">
         {content}
       </Tooltip>
     );

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import Link from "next/link";
+import type { Route } from "next";
 
 import type { RichStr } from "@opal/types";
 
@@ -19,15 +21,20 @@ const INLINE_COMPONENTS = {
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
     if (!href) return <>{children}</>;
     const isRelative = href.startsWith("/") || href.startsWith("#");
-    if (!isRelative && !SAFE_PROTOCOL.test(href)) {
-      return <>{children}</>;
+    if (isRelative) {
+      return (
+        <Link href={href as Route} className="underline underline-offset-2">
+          {children}
+        </Link>
+      );
     }
-    const isHttp = /^https?:/i.test(href);
+    if (!SAFE_PROTOCOL.test(href)) return <>{children}</>;
     return (
       <a
         href={href}
         className="underline underline-offset-2"
-        {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+        target="_blank"
+        rel="noopener noreferrer"
       >
         {children}
       </a>

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import rehypeSanitize from "rehype-sanitize";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import Link from "next/link";
 import type { Route } from "next";
 
@@ -10,6 +10,14 @@ import type { RichStr } from "@opal/types";
 // ---------------------------------------------------------------------------
 // InlineMarkdown
 // ---------------------------------------------------------------------------
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), "tel"],
+  },
+};
 
 const ALLOWED_ELEMENTS = ["p", "br", "a", "strong", "em", "code", "del"];
 
@@ -62,7 +70,7 @@ export default function InlineMarkdown({ content }: InlineMarkdownProps) {
       allowedElements={ALLOWED_ELEMENTS}
       unwrapDisallowed
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
+      rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}
     >
       {normalized}
     </ReactMarkdown>

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
 import Link from "next/link";
 import type { Route } from "next";
 
@@ -10,8 +11,6 @@ import type { RichStr } from "@opal/types";
 // InlineMarkdown
 // ---------------------------------------------------------------------------
 
-const SAFE_PROTOCOL = /^https?:|^mailto:|^tel:/i;
-
 const ALLOWED_ELEMENTS = ["p", "br", "a", "strong", "em", "code", "del"];
 
 const INLINE_COMPONENTS = {
@@ -20,8 +19,8 @@ const INLINE_COMPONENTS = {
   ),
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
     if (!href) return <>{children}</>;
-    const isRelative =
-      (href.startsWith("/") && !href.startsWith("//")) || href.startsWith("#");
+    // rehype-sanitize has already stripped unsafe hrefs — routing decision only.
+    const isRelative = href.startsWith("/") || href.startsWith("#");
     if (isRelative) {
       return (
         <Link href={href as Route} className="underline underline-offset-2">
@@ -29,7 +28,6 @@ const INLINE_COMPONENTS = {
         </Link>
       );
     }
-    if (!SAFE_PROTOCOL.test(href)) return <>{children}</>;
     const isHttp = /^https?:/i.test(href);
     return (
       <a
@@ -64,6 +62,7 @@ export default function InlineMarkdown({ content }: InlineMarkdownProps) {
       allowedElements={ALLOWED_ELEMENTS}
       unwrapDisallowed
       remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeSanitize]}
     >
       {normalized}
     </ReactMarkdown>

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -20,7 +20,8 @@ const INLINE_COMPONENTS = {
   ),
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
     if (!href) return <>{children}</>;
-    const isRelative = href.startsWith("/") || href.startsWith("#");
+    const isRelative =
+      (href.startsWith("/") && !href.startsWith("//")) || href.startsWith("#");
     if (isRelative) {
       return (
         <Link href={href as Route} className="underline underline-offset-2">
@@ -29,12 +30,12 @@ const INLINE_COMPONENTS = {
       );
     }
     if (!SAFE_PROTOCOL.test(href)) return <>{children}</>;
+    const isHttp = /^https?:/i.test(href);
     return (
       <a
         href={href}
         className="underline underline-offset-2"
-        target="_blank"
-        rel="noopener noreferrer"
+        {...(isHttp ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       >
         {children}
       </a>

--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -17,7 +17,9 @@ const INLINE_COMPONENTS = {
     <span className="block">{children}</span>
   ),
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
-    if (!href || !SAFE_PROTOCOL.test(href)) {
+    if (!href) return <>{children}</>;
+    const isRelative = href.startsWith("/") || href.startsWith("#");
+    if (!isRelative && !SAFE_PROTOCOL.test(href)) {
       return <>{children}</>;
     }
     const isHttp = /^https?:/i.test(href);

--- a/web/lib/opal/src/components/tooltip/components.tsx
+++ b/web/lib/opal/src/components/tooltip/components.tsx
@@ -100,7 +100,7 @@ function Tooltip({
 
   const content =
     typeof tooltip === "string" || isRichStr(tooltip) ? (
-      <Text font="secondary-body" color="inherit">
+      <Text font="secondary-body" color="inherit" as="p">
         {tooltip}
       </Text>
     ) : (

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,7 +1081,7 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <CloudDisabled>
+                      <Disabled disabled allowClick>
                         <Card border="solid" rounding="lg" padding="sm">
                           <GeneralLayouts.Section padding={0.5}>
                             <Content
@@ -1092,7 +1092,7 @@ export default function IndexSettingsPage() {
                             />
                           </GeneralLayouts.Section>
                         </Card>
-                      </CloudDisabled>
+                      </Disabled>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,16 +1081,18 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <Card border="solid" rounding="lg" padding="sm">
-                        <GeneralLayouts.Section padding={0.5}>
-                          <Content
-                            icon={SvgVector}
-                            title="Embedding model and settings are managed by Onyx Cloud."
-                            sizePreset="main-ui"
-                            variant="section"
-                          />
-                        </GeneralLayouts.Section>
-                      </Card>
+                      <CloudDisabled>
+                        <Card border="solid" rounding="lg" padding="sm">
+                          <GeneralLayouts.Section padding={0.5}>
+                            <Content
+                              icon={SvgVector}
+                              title="Embedding model and settings are managed by Onyx Cloud."
+                              sizePreset="main-ui"
+                              variant="section"
+                            />
+                          </GeneralLayouts.Section>
+                        </Card>
+                      </CloudDisabled>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -1081,18 +1081,16 @@ export default function IndexSettingsPage() {
                     />
 
                     {NEXT_PUBLIC_CLOUD_ENABLED ? (
-                      <Disabled disabled allowClick>
-                        <Card border="solid" rounding="lg" padding="sm">
-                          <GeneralLayouts.Section padding={0.5}>
-                            <Content
-                              icon={SvgVector}
-                              title="Embedding model and settings are managed by Onyx Cloud."
-                              sizePreset="main-ui"
-                              variant="section"
-                            />
-                          </GeneralLayouts.Section>
-                        </Card>
-                      </Disabled>
+                      <Card border="solid" rounding="lg" padding="sm">
+                        <GeneralLayouts.Section padding={0.5}>
+                          <Content
+                            icon={SvgVector}
+                            title="Embedding model and settings are managed by Onyx Cloud."
+                            sizePreset="main-ui"
+                            variant="section"
+                          />
+                        </GeneralLayouts.Section>
+                      </Card>
                     ) : (
                       currentEmbeddingModel && (
                         <Disabled

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -26,6 +26,7 @@ import useFilter from "@/hooks/useFilter";
 import { IconFunctionComponent } from "@opal/types";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
 import { useSidebarState } from "@/layouts/sidebar-layouts";
+import { markdown } from "@opal/utils";
 
 const SECTIONS = {
   UNLABELED: "",
@@ -292,7 +293,14 @@ function AdminSidebarInner() {
             disabled
           >
             {group.items.map(({ link, icon, name }) => (
-              <SidebarTab key={link} disabled icon={icon}>
+              <SidebarTab
+                key={link}
+                disabled
+                icon={icon}
+                tooltip={markdown(
+                  "This feature is available on the [Business or Enterprise version of Onyx](/admin/billing) only."
+                )}
+              >
                 {name}
               </SidebarTab>
             ))}


### PR DESCRIPTION
## Description

- **`SidebarTab`**: adds an optional `tooltip?: string | RichStr` prop. When provided, it takes precedence over the folded-name auto-tooltip; when absent, the existing folded-name behaviour is preserved.
- **`AdminSidebar`**: disabled (enterprise-only) tabs now show `"This feature is available in the enterprise version of Onyx only."` on hover.
- **`Tooltip`**: uses `<Text as="p">` for `string | RichStr` content instead of the default `<span>`, eliminating dead space caused by block children inside an inline container.
- **`InlineMarkdown`**: relative hrefs (`/…` and `#…`) are now passed through to `<a>`. The prior `SAFE_PROTOCOL` check only matched absolute schemes (`https?`, `mailto`, `tel`), causing internal links to be silently stripped.

## Screenshots + Videos

https://github.com/user-attachments/assets/bc938707-3cba-4074-a29c-d8866608f16c

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hover tooltips to disabled Business/Enterprise admin tabs and tightens `InlineMarkdown` link handling. Internal links use `next/link`, unsafe URLs are stripped by `rehype-sanitize`, and `mailto:`/`tel:` are preserved.

- **New Features**
  - `SidebarTab` adds `tooltip?: string | RichStr` to override the folded-name tooltip; used in Admin to link to `/admin/billing`.

- **Bug Fixes**
  - `SidebarTab` now respects `tooltip` when `children` isn’t a string.
  - `InlineMarkdown` extends `rehype-sanitize` to allow `tel:` and handles routing after sanitization.
  - `Tooltip` renders string/RichStr as a paragraph to remove extra spacing.

<sup>Written for commit ddc5e05b774a326f525b197aa860cee09188fdfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

