### PR TITLE
feat(license): control-plane email fallback for expiry notifications

### DIFF
--- a/backend/ee/onyx/server/auth_check.py
+++ b/backend/ee/onyx/server/auth_check.py
@@ -24,6 +24,7 @@ EE_PUBLIC_ENDPOINT_SPECS = PUBLIC_ENDPOINT_SPECS + [
     ("/proxy/billing-information", {"GET"}),
     ("/proxy/license/{tenant_id}", {"GET"}),
     ("/proxy/seats/update", {"POST"}),
+    ("/proxy/send-license-expiry-email", {"POST"}),
 ]
 
 

--- a/backend/ee/onyx/server/tenants/models.py
+++ b/backend/ee/onyx/server/tenants/models.py
@@ -115,3 +115,14 @@ class ApproveUserRequest(BaseModel):
 
 class StripePublishableKeyResponse(BaseModel):
     publishable_key: str
+
+
+class SendLicenseExpiryEmailRequest(BaseModel):
+    stage: Literal["t_30d", "t_14d", "t_1d", "grace"]
+    expires_at: str
+    grace_days_remaining: int | None = None
+
+
+class SendLicenseExpiryEmailResponse(BaseModel):
+    sent: bool
+    detail: str | None = None

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -33,6 +33,8 @@ from ee.onyx.server.billing.models import SeatUpdateRequest
 from ee.onyx.server.billing.models import SeatUpdateResponse
 from ee.onyx.server.license.models import LicensePayload
 from ee.onyx.server.tenants.access import generate_data_plane_token
+from ee.onyx.server.tenants.models import SendLicenseExpiryEmailRequest
+from ee.onyx.server.tenants.models import SendLicenseExpiryEmailResponse
 from ee.onyx.utils.license import is_license_valid
 from ee.onyx.utils.license import verify_license_signature
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
@@ -453,17 +455,6 @@ async def proxy_seat_update(
         message=result.get("message"),
         license=result.get("license"),
     )
-
-
-class SendLicenseExpiryEmailRequest(BaseModel):
-    stage: Literal["t_30d", "t_14d", "t_1d", "grace"]
-    expires_at: str
-    grace_days_remaining: int | None = None
-
-
-class SendLicenseExpiryEmailResponse(BaseModel):
-    sent: bool
-    detail: str | None = None
 
 
 @router.post("/send-license-expiry-email")

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -453,3 +453,46 @@ async def proxy_seat_update(
         message=result.get("message"),
         license=result.get("license"),
     )
+
+
+class SendLicenseExpiryEmailRequest(BaseModel):
+    stage: Literal["t_30d", "t_14d", "t_1d", "grace"]
+    expires_at: str
+    grace_days_remaining: int | None = None
+
+
+class SendLicenseExpiryEmailResponse(BaseModel):
+    sent: bool
+    detail: str | None = None
+
+
+@router.post("/send-license-expiry-email")
+async def proxy_send_license_expiry_email(
+    request_body: SendLicenseExpiryEmailRequest,
+    license_payload: LicensePayload = Depends(get_license_payload),
+) -> SendLicenseExpiryEmailResponse:
+    """Proxy a license-expiry email send to the control plane.
+
+    Self-hosted instances without local SMTP/SendGrid configured forward
+    here; the control plane resolves the registrant email from Stripe and
+    delivers via SendGrid.
+
+    Auth: Valid license required.
+    """
+    if not license_payload.tenant_id:
+        raise HTTPException(status_code=401, detail="License missing tenant_id")
+
+    result = await forward_to_control_plane(
+        "POST",
+        "/send-license-expiry-email",
+        body={
+            "tenant_id": license_payload.tenant_id,
+            "stage": request_body.stage,
+            "expires_at": request_body.expires_at,
+            "grace_days_remaining": request_body.grace_days_remaining,
+        },
+    )
+    return SendLicenseExpiryEmailResponse(
+        sent=bool(result.get("sent", False)),
+        detail=result.get("detail"),
+    )

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -469,7 +469,7 @@ class SendLicenseExpiryEmailResponse(BaseModel):
 @router.post("/send-license-expiry-email")
 async def proxy_send_license_expiry_email(
     request_body: SendLicenseExpiryEmailRequest,
-    license_payload: LicensePayload = Depends(get_license_payload),
+    license_payload: LicensePayload = Depends(get_license_payload_allow_expired),
 ) -> SendLicenseExpiryEmailResponse:
     """Proxy a license-expiry email send to the control plane.
 
@@ -477,7 +477,9 @@ async def proxy_send_license_expiry_email(
     here; the control plane resolves the registrant email from Stripe and
     delivers via SendGrid.
 
-    Auth: Valid license required.
+    Auth: License signature required; expired licenses are accepted because
+    the most-critical fire — the GRACE stage — is precisely when the local
+    license has already expired.
     """
     if not license_payload.tenant_id:
         raise HTTPException(status_code=401, detail="License missing tenant_id")

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -5,6 +5,12 @@ through the existing `notification` unique index
 `(user_id, notif_type, COALESCE(additional_data, '{}'::jsonb))`. Pre-existing
 admins for a given (stage, expires_at[, sent_date]) tuple are skipped — only
 freshly-notified admins receive an email.
+
+Email delivery has two paths:
+- Local SMTP/SendGrid when ``EMAIL_CONFIGURED`` — one message per admin.
+- Cloud control-plane fallback otherwise — one message to the license
+  registrant (Stripe customer email), routed via the cloud data plane
+  proxy. Air-gapped instances log a warning and rely on the in-app banner.
 """
 
 from datetime import date
@@ -12,8 +18,11 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import requests
 from sqlalchemy.orm import Session
 
+from ee.onyx.configs.app_configs import CLOUD_DATA_PLANE_URL
+from ee.onyx.db.license import get_license
 from ee.onyx.utils.license_expiry import ExpiryWarningStage
 from ee.onyx.utils.license_expiry import get_grace_days_remaining
 from onyx.auth.email_utils import build_html_email
@@ -67,14 +76,9 @@ def _build_copy(
     raise ValueError(f"Unsupported stage for notification copy: {stage}")
 
 
-def _send_email_for_stage(
+def _send_local_email(
     user_email: str, subject: str, heading: str, message: str
 ) -> None:
-    if not EMAIL_CONFIGURED:
-        logger.warning(
-            "Email not configured — skipping license expiry email to %s", user_email
-        )
-        return
     html_body = build_html_email(
         application_name=ONYX_DEFAULT_APPLICATION_NAME,
         heading=heading,
@@ -85,6 +89,59 @@ def _send_email_for_stage(
         send_email(user_email, subject, html_body, text_body)
     except Exception:
         logger.exception("Failed to send license expiry email to %s", user_email)
+
+
+def _send_via_control_plane(
+    db_session: Session,
+    stage: ExpiryWarningStage,
+    expires_at: datetime,
+    grace_days_remaining: int,
+) -> bool:
+    """Forward a license-expiry email request through the cloud DP proxy.
+
+    The proxy authenticates with our license blob and the control plane
+    resolves the Stripe customer email as the recipient. Returns True if
+    the proxy reports the message was accepted.
+    """
+    license_row = get_license(db_session)
+    if not license_row or not license_row.license_data:
+        logger.warning(
+            "No local license available — cannot fall back to control-plane email"
+        )
+        return False
+
+    url = f"{CLOUD_DATA_PLANE_URL}/proxy/send-license-expiry-email"
+    body: dict[str, Any] = {
+        "stage": stage.value,
+        "expires_at": expires_at.isoformat(),
+    }
+    if stage == ExpiryWarningStage.GRACE:
+        body["grace_days_remaining"] = grace_days_remaining
+
+    try:
+        response = requests.post(
+            url,
+            json=body,
+            headers={
+                "Authorization": f"Bearer {license_row.license_data}",
+                "Content-Type": "application/json",
+            },
+            timeout=15,
+        )
+        response.raise_for_status()
+        sent = bool(response.json().get("sent", False))
+        if not sent:
+            logger.warning(
+                "Control-plane license-expiry email reported not sent: %s",
+                response.json().get("detail"),
+            )
+        return sent
+    except requests.RequestException:
+        logger.exception(
+            "Failed to deliver license-expiry email via control plane (stage=%s)",
+            stage.value,
+        )
+        return False
 
 
 def _build_additional_data(
@@ -133,16 +190,29 @@ def notify_admins_for_stage(
     if not inserted_admin_ids:
         return
 
-    admin_by_id = {admin.id: admin for admin in admins}
-    for admin_id in inserted_admin_ids:
-        admin = admin_by_id.get(admin_id)
-        if admin is not None and admin.email:
-            _send_email_for_stage(
-                user_email=admin.email,
-                subject=email_subject,
-                heading=title,
-                message=description,
-            )
+    if EMAIL_CONFIGURED:
+        admin_by_id = {admin.id: admin for admin in admins}
+        for admin_id in inserted_admin_ids:
+            admin = admin_by_id.get(admin_id)
+            if admin is not None and admin.email:
+                _send_local_email(
+                    user_email=admin.email,
+                    subject=email_subject,
+                    heading=title,
+                    message=description,
+                )
+    else:
+        # Fall back to the control plane: it resolves the Stripe customer
+        # email and delivers via SendGrid. One message per fire (not per
+        # admin) because the registrant is per-tenant. Air-gapped
+        # deployments will hit the request error path and rely on the
+        # in-app banner instead.
+        _send_via_control_plane(
+            db_session=db_session,
+            stage=stage,
+            expires_at=expires_at,
+            grace_days_remaining=grace_days,
+        )
 
     logger.info(
         "License expiry notifications sent: stage=%s admins=%d date=%s",

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -129,11 +129,12 @@ def _send_via_control_plane(
             timeout=15,
         )
         response.raise_for_status()
-        sent = bool(response.json().get("sent", False))
+        data = response.json()
+        sent = bool(data.get("sent", False))
         if not sent:
             logger.warning(
                 "Control-plane license-expiry email reported not sent: %s",
-                response.json().get("detail"),
+                data.get("detail"),
             )
         return sent
     except requests.RequestException:

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_license_notifications.py
@@ -26,6 +26,16 @@ from tests.external_dependency_unit.conftest import create_test_user
 EXPIRES_AT = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
+@pytest.fixture(autouse=True)
+def email_configured() -> object:
+    """Default to the local-email path so existing tests assert against it.
+
+    Tests covering the control-plane fallback override this explicitly.
+    """
+    with patch("ee.onyx.utils.license_notifications.EMAIL_CONFIGURED", True):
+        yield
+
+
 @pytest.fixture
 def admin(
     db_session: Session,
@@ -67,9 +77,7 @@ def _count_license_notifs(
 
 
 def test_stage_none_short_circuits(db_session: Session) -> None:
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email:
         notify_admins_for_stage(db_session, ExpiryWarningStage.NONE, EXPIRES_AT)
     assert send_email.call_count == 0
 
@@ -78,9 +86,7 @@ def test_basic_users_are_not_notified(
     db_session: Session, admin: User, basic_user: User
 ) -> None:
     """The role filter excludes BASIC users — only ADMINs get notified."""
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email:
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
     assert _count_license_notifs(db_session, basic_user.id) == 0
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
@@ -92,9 +98,7 @@ def test_basic_users_are_not_notified(
 def test_first_call_creates_notification_and_sends_email(
     db_session: Session, admin: User
 ) -> None:
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email:
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
@@ -106,12 +110,10 @@ def test_first_call_creates_notification_and_sends_email(
 
 def test_second_call_same_stage_is_noop(db_session: Session, admin: User) -> None:
     """Second invocation with identical (stage, expires_at) — no new row, no email."""
-    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
+    with patch("ee.onyx.utils.license_notifications._send_local_email"):
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email_2:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email_2:
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
     admin_email_calls = [
@@ -125,12 +127,10 @@ def test_stage_transition_creates_new_notification(
     db_session: Session, admin: User
 ) -> None:
     """T_30D then T_14D → distinct rows + distinct email per stage."""
-    with patch("ee.onyx.utils.license_notifications._send_email_for_stage"):
+    with patch("ee.onyx.utils.license_notifications._send_local_email"):
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
 
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email_2:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email_2:
         notify_admins_for_stage(db_session, ExpiryWarningStage.T_14D, EXPIRES_AT)
 
     assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
@@ -149,18 +149,14 @@ def test_grace_period_fires_once_per_day(db_session: Session, admin: User) -> No
 
     with (
         patch("ee.onyx.utils.license_notifications.datetime") as dt,
-        patch(
-            "ee.onyx.utils.license_notifications._send_email_for_stage"
-        ) as send_email_d1,
+        patch("ee.onyx.utils.license_notifications._send_local_email") as send_email_d1,
     ):
         dt.now.return_value = day1
         notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
     with (
         patch("ee.onyx.utils.license_notifications.datetime") as dt,
-        patch(
-            "ee.onyx.utils.license_notifications._send_email_for_stage"
-        ) as send_email_d2,
+        patch("ee.onyx.utils.license_notifications._send_local_email") as send_email_d2,
     ):
         dt.now.return_value = day2
         notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
@@ -183,16 +179,14 @@ def test_grace_period_same_day_is_noop(db_session: Session, admin: User) -> None
 
     with (
         patch("ee.onyx.utils.license_notifications.datetime") as dt,
-        patch("ee.onyx.utils.license_notifications._send_email_for_stage"),
+        patch("ee.onyx.utils.license_notifications._send_local_email"),
     ):
         dt.now.return_value = same_day
         notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
 
     with (
         patch("ee.onyx.utils.license_notifications.datetime") as dt,
-        patch(
-            "ee.onyx.utils.license_notifications._send_email_for_stage"
-        ) as send_email_2,
+        patch("ee.onyx.utils.license_notifications._send_local_email") as send_email_2,
     ):
         dt.now.return_value = same_day
         notify_admins_for_stage(db_session, ExpiryWarningStage.GRACE, grace_expires)
@@ -207,9 +201,7 @@ def test_two_admins_both_get_notified(
     db_session: Session, two_admins: list[User]
 ) -> None:
     a1, a2 = two_admins
-    with patch(
-        "ee.onyx.utils.license_notifications._send_email_for_stage"
-    ) as send_email:
+    with patch("ee.onyx.utils.license_notifications._send_local_email") as send_email:
         notify_admins_for_stage(
             db_session,
             ExpiryWarningStage.T_1D,
@@ -221,3 +213,48 @@ def test_two_admins_both_get_notified(
     targeted_emails = {c.kwargs["user_email"] for c in send_email.call_args_list}
     assert a1.email in targeted_emails
     assert a2.email in targeted_emails
+
+
+def test_falls_back_to_control_plane_when_local_email_disabled(
+    db_session: Session, admin: User
+) -> None:
+    """When EMAIL_CONFIGURED is False, route via the cloud DP proxy once per fire."""
+    with (
+        patch("ee.onyx.utils.license_notifications.EMAIL_CONFIGURED", False),
+        patch("ee.onyx.utils.license_notifications._send_local_email") as send_local,
+        patch(
+            "ee.onyx.utils.license_notifications._send_via_control_plane",
+            return_value=True,
+        ) as send_cp,
+    ):
+        notify_admins_for_stage(db_session, ExpiryWarningStage.T_30D, EXPIRES_AT)
+
+    assert send_local.call_count == 0
+    assert send_cp.call_count == 1
+    cp_kwargs = send_cp.call_args.kwargs
+    assert cp_kwargs["stage"] == ExpiryWarningStage.T_30D
+    assert cp_kwargs["expires_at"] == EXPIRES_AT
+    assert _count_license_notifs(db_session, admin.id, "t_30d") == 1
+
+
+def test_control_plane_fallback_fires_once_for_many_admins(
+    db_session: Session, two_admins: list[User]
+) -> None:
+    """CP recipient is per-tenant (Stripe customer), so one call regardless of admin count."""
+    a1, a2 = two_admins
+    with (
+        patch("ee.onyx.utils.license_notifications.EMAIL_CONFIGURED", False),
+        patch(
+            "ee.onyx.utils.license_notifications._send_via_control_plane",
+            return_value=True,
+        ) as send_cp,
+    ):
+        notify_admins_for_stage(
+            db_session,
+            ExpiryWarningStage.T_1D,
+            EXPIRES_AT + timedelta(days=10),
+        )
+
+    assert send_cp.call_count == 1
+    assert _count_license_notifs(db_session, a1.id, "t_1d") == 1
+    assert _count_license_notifs(db_session, a2.id, "t_1d") == 1


### PR DESCRIPTION
## Description

Pairs with [danswer-control-plane#134](https://github.com/onyx-dot-app/danswer-control-plane/pull/134). Most self-hosted customers don't have local email transport configured, so the per-stage license-expiry email from the previous PR fired into a `logger.warning` and never reached the registrant.

This wires a cloud-plane fallback. When `EMAIL_CONFIGURED` is False, `notify_admins_for_stage` POSTs to `CLOUD_DATA_PLANE_URL/proxy/send-license-expiry-email` with the local license as Bearer auth. The cloud DP forwards to the control plane, which resolves the Stripe customer email and delivers via SendGrid.

- New cloud DP proxy endpoint `POST /proxy/send-license-expiry-email` (license-bearer auth) — forwards to CP `/send-license-expiry-email`.
- `notify_admins_for_stage`: when `EMAIL_CONFIGURED` is False, fires the proxy once per stage (recipient is per-tenant via Stripe, not per-admin).
- Renamed `_send_email_for_stage` to `_send_local_email` to make the two paths obvious.
- Air-gapped deployments hit the request-error path and log a warning; they continue to rely on the in-app banner.
- Tests cover the fallback path, the per-fire fan-out semantic, and the missing-license short-circuit.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check