### PR TITLE
fix(targeted-reindex): keep staged files of concurrent in-progress attempts

### DIFF
--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -1,12 +1,16 @@
 from sqlalchemy import and_
+from sqlalchemy import cast
 from sqlalchemy import select
+from sqlalchemy import String
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
 from onyx.background.task_utils import QUERY_REPORT_NAME_PREFIX
 from onyx.configs.constants import FileOrigin
 from onyx.configs.constants import FileType
+from onyx.db.enums import IndexingStatus
 from onyx.db.models import FileRecord
+from onyx.db.models import IndexAttempt
 
 
 def get_query_history_export_files(
@@ -101,9 +105,23 @@ def get_staged_file_ids_for_cc_pair_excluding_attempt(
     db_session: Session,
 ) -> list[str]:
     """Return `INDEXING_STAGING` file_ids for this cc_pair owned by any
-    attempt OTHER than `excluding_attempt_id`. Used for the start-of-run
-    orphan sweep — anything matching is by definition left over from a
-    previous attempt on the same cc_pair."""
+    TERMINAL attempt OTHER than `excluding_attempt_id`. Used for the
+    start-of-run orphan sweep.
+
+    Files belonging to a still-running attempt (e.g. a concurrent
+    targeted reindex on the same cc_pair) are kept — those binaries
+    are still being consumed and must not be wiped.
+    """
+    terminal_attempt_ids_subq = select(cast(IndexAttempt.id, String)).where(
+        IndexAttempt.status.in_(
+            [
+                IndexingStatus.SUCCESS,
+                IndexingStatus.COMPLETED_WITH_ERRORS,
+                IndexingStatus.CANCELED,
+                IndexingStatus.FAILED,
+            ]
+        )
+    )
     return list(
         db_session.scalars(
             select(FileRecord.file_id)
@@ -115,6 +133,11 @@ def get_staged_file_ids_for_cc_pair_excluding_attempt(
             .where(
                 FileRecord.file_metadata["index_attempt_id"].as_string()
                 != str(excluding_attempt_id)
+            )
+            .where(
+                FileRecord.file_metadata["index_attempt_id"]
+                .as_string()
+                .in_(terminal_attempt_ids_subq)
             )
         ).all()
     )

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -104,23 +104,22 @@ def get_staged_file_ids_for_cc_pair_excluding_attempt(
     excluding_attempt_id: int,
     db_session: Session,
 ) -> list[str]:
-    """Return `INDEXING_STAGING` file_ids for this cc_pair owned by any
-    TERMINAL attempt OTHER than `excluding_attempt_id`. Used for the
-    start-of-run orphan sweep.
+    """Return `INDEXING_STAGING` file_ids for this cc_pair eligible for
+    the start-of-run orphan sweep — anything tagged with a different
+    `index_attempt_id` whose owning attempt is NOT still running.
 
-    Files belonging to a still-running attempt (e.g. a concurrent
-    targeted reindex on the same cc_pair) are kept — those binaries
-    are still being consumed and must not be wiped.
+    Files belonging to a non-terminal attempt (e.g. a concurrent
+    targeted reindex on the same cc_pair) are kept; their binaries are
+    still being consumed and must not be wiped. Files whose owning
+    attempt no longer exists in the DB at all (deleted by retention,
+    test fixtures with synthetic IDs, etc.) are still reaped, since
+    nothing is going to consume them.
     """
-    terminal_attempt_ids_subq = select(cast(IndexAttempt.id, String)).where(
+    non_terminal_cc_pair_attempt_ids_subq = select(cast(IndexAttempt.id, String)).where(
+        IndexAttempt.connector_credential_pair_id == cc_pair_id,
         IndexAttempt.status.in_(
-            [
-                IndexingStatus.SUCCESS,
-                IndexingStatus.COMPLETED_WITH_ERRORS,
-                IndexingStatus.CANCELED,
-                IndexingStatus.FAILED,
-            ]
-        )
+            [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
+        ),
     )
     return list(
         db_session.scalars(
@@ -137,7 +136,7 @@ def get_staged_file_ids_for_cc_pair_excluding_attempt(
             .where(
                 FileRecord.file_metadata["index_attempt_id"]
                 .as_string()
-                .in_(terminal_attempt_ids_subq)
+                .notin_(non_terminal_cc_pair_attempt_ids_subq)
             )
         ).all()
     )

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -115,11 +115,10 @@ def get_staged_file_ids_for_cc_pair_excluding_attempt(
     test fixtures with synthetic IDs, etc.) are still reaped, since
     nothing is going to consume them.
     """
+    non_terminal_statuses = [s for s in IndexingStatus if not s.is_terminal()]
     non_terminal_cc_pair_attempt_ids_subq = select(cast(IndexAttempt.id, String)).where(
         IndexAttempt.connector_credential_pair_id == cc_pair_id,
-        IndexAttempt.status.in_(
-            [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
-        ),
+        IndexAttempt.status.in_(non_terminal_statuses),
     )
     return list(
         db_session.scalars(

--- a/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
+++ b/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
@@ -142,4 +142,94 @@ def test_sweep_skips_files_owned_by_non_terminal_attempt(
             fs.delete_file(fid)
         except Exception:
             pass
+
+
+def test_sweep_skips_files_owned_by_not_started_attempt(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    initialize_file_store: None,  # noqa: ARG001
+) -> None:
+    """A `NOT_STARTED` attempt is also non-terminal — its staged files
+    must survive the sweep. This covers the case where a worker wrote
+    files but crashed before the attempt status moved out of NOT_STARTED."""
+    from onyx.db.search_settings import get_current_search_settings
+
+    settings = get_current_search_settings(db_session)
+
+    not_started = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.NOT_STARTED
+    )
+    current = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.IN_PROGRESS
+    )
+
+    file_for_not_started = _stage_file(
+        cc_pair.id, not_started.id, TEST_TENANT_ID, b"not started payload"
+    )
+    db_session.commit()
+
+    deleted_count = reap_prior_attempt_staged_files(
+        current_attempt_id=current.id,
+        cc_pair_id=cc_pair.id,
+        tenant_id=TEST_TENANT_ID,
+        db_session=db_session,
+    )
+
+    assert deleted_count == 0
+
+    from onyx.db.file_record import get_filerecord_by_file_id_optional
+
+    db_session.expire_all()
+
+    assert (
+        get_filerecord_by_file_id_optional(file_for_not_started, db_session) is not None
+    ), "NOT_STARTED attempt's staged file must NOT be reaped"
+
+    # Cleanup
+    from onyx.file_store.file_store import get_default_file_store
+
+    fs = get_default_file_store()
+    try:
+        fs.delete_file(file_for_not_started)
+    except Exception:
+        pass
+
+
+def test_sweep_reaps_orphan_with_no_owning_attempt(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    initialize_file_store: None,  # noqa: ARG001
+) -> None:
+    """Files tagged with an `index_attempt_id` that doesn't match any
+    real `IndexAttempt` row (deleted by retention, never recorded) are
+    still reapable — nothing is going to consume them."""
+    from onyx.db.search_settings import get_current_search_settings
+
+    settings = get_current_search_settings(db_session)
+    current = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.IN_PROGRESS
+    )
+
+    # Use an attempt id that doesn't correspond to any IndexAttempt row.
+    orphan_attempt_id = 999_999_999
+    file_for_orphan = _stage_file(
+        cc_pair.id, orphan_attempt_id, TEST_TENANT_ID, b"orphan payload"
+    )
+    db_session.commit()
+
+    deleted_count = reap_prior_attempt_staged_files(
+        current_attempt_id=current.id,
+        cc_pair_id=cc_pair.id,
+        tenant_id=TEST_TENANT_ID,
+        db_session=db_session,
+    )
+
+    assert deleted_count == 1
+
+    from onyx.db.file_record import get_filerecord_by_file_id_optional
+
+    db_session.expire_all()
+    assert (
+        get_filerecord_by_file_id_optional(file_for_orphan, db_session) is None
+    ), "orphaned staged file (no owning attempt) should be reaped"
     db_session.commit()

--- a/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
+++ b/backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py
@@ -1,0 +1,145 @@
+"""Test that the start-of-run staging sweep skips files whose owning
+attempt is still non-terminal.
+
+The sweep at the start of a docfetching attempt deletes orphan staged
+files left behind by previous attempts on the same cc_pair. Without
+the terminal-status filter, a concurrent in-progress attempt (such as
+a targeted reindex) would have its in-flight binaries wiped out from
+under it. This test creates that exact race scenario and verifies the
+fix.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.file_store.staging import reap_prior_attempt_staged_files
+from onyx.file_store.staging import stage_raw_file
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _make_attempt(
+    db_session: Session,
+    cc_pair_id: int,
+    search_settings_id: int,
+    status: IndexingStatus,
+) -> IndexAttempt:
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair_id,
+        search_settings_id=search_settings_id,
+        from_beginning=False,
+        status=status,
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    return attempt
+
+
+def _stage_file(
+    cc_pair_id: int, attempt_id: int, tenant_id: str, payload: bytes
+) -> str:
+    return stage_raw_file(
+        content=BytesIO(payload),
+        content_type="application/octet-stream",
+        metadata={
+            "index_attempt_id": attempt_id,
+            "cc_pair_id": cc_pair_id,
+            "tenant_id": tenant_id,
+            "test_marker": uuid4().hex,
+        },
+    )
+
+
+def test_sweep_skips_files_owned_by_non_terminal_attempt(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    initialize_file_store: None,  # noqa: ARG001
+) -> None:
+    """A concurrent in-progress attempt's staged files must survive the
+    start-of-run sweep, even though they belong to a different attempt
+    on the same cc_pair."""
+    from onyx.db.search_settings import get_current_search_settings
+
+    settings = get_current_search_settings(db_session)
+
+    terminal_old = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.FAILED
+    )
+    in_progress_concurrent = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.IN_PROGRESS
+    )
+    current = _make_attempt(
+        db_session, cc_pair.id, settings.id, IndexingStatus.IN_PROGRESS
+    )
+
+    file_for_terminal = _stage_file(
+        cc_pair.id, terminal_old.id, TEST_TENANT_ID, b"terminal payload"
+    )
+    file_for_in_progress = _stage_file(
+        cc_pair.id, in_progress_concurrent.id, TEST_TENANT_ID, b"concurrent payload"
+    )
+    file_for_current = _stage_file(
+        cc_pair.id, current.id, TEST_TENANT_ID, b"current payload"
+    )
+    db_session.commit()
+
+    # Run the sweep as if `current` is starting up.
+    deleted_count = reap_prior_attempt_staged_files(
+        current_attempt_id=current.id,
+        cc_pair_id=cc_pair.id,
+        tenant_id=TEST_TENANT_ID,
+        db_session=db_session,
+    )
+
+    # Only the terminal attempt's file should have been reaped.
+    assert deleted_count == 1
+
+    from onyx.db.file_record import get_filerecord_by_file_id_optional
+
+    db_session.expire_all()
+
+    assert (
+        get_filerecord_by_file_id_optional(file_for_terminal, db_session) is None
+    ), "terminal attempt's staged file should be reaped"
+    assert (
+        get_filerecord_by_file_id_optional(file_for_in_progress, db_session) is not None
+    ), "concurrent in-progress attempt's staged file must NOT be reaped"
+    assert (
+        get_filerecord_by_file_id_optional(file_for_current, db_session) is not None
+    ), "current attempt's own file must NOT be reaped (excluded by current_attempt_id)"
+
+    # Cleanup: remove the survivors so other tests don't see them.
+    from onyx.file_store.file_store import get_default_file_store
+
+    fs = get_default_file_store()
+    for fid in (file_for_in_progress, file_for_current):
+        try:
+            fs.delete_file(fid)
+        except Exception:
+            pass
+    db_session.commit()


### PR DESCRIPTION
## Description

\`reap_prior_attempt_staged_files\` runs at the start of every docfetching attempt and deletes orphan staged files left behind by previous attempts on the same cc_pair. Without a status filter, a concurrent in-progress attempt (e.g. a targeted reindex on the same cc_pair, landing soon) would have its in-flight binaries wiped from under it.

The fix excludes files whose owning attempt is in a non-terminal state (\`NOT_STARTED\` or \`IN_PROGRESS\`). The subquery is scoped to the current cc_pair so it doesn't scan the whole \`index_attempt\` table. The exclusion is expressed as \`NOT IN (non-terminal attempt ids)\`, which keeps orphans whose owning attempt no longer exists in the DB at all (deleted by retention, synthetic ids in test fixtures, etc.) reapable — nothing is going to consume them.

Part of the targeted-reindex hardening called out in the design doc under "Risks worth calling out — Staging-files sweep."

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

\`backend/tests/external_dependency_unit/file_store/test_staging_concurrent_attempt_skip.py\` covers four cases against real Postgres + file store:
- Concurrent \`IN_PROGRESS\` attempt's file is kept; sibling terminal-old file is reaped
- \`NOT_STARTED\` attempt's file is kept (worker may have crashed before status advanced)
- Orphan with no owning \`IndexAttempt\` row at all is reaped
- Current attempt's own file is kept (excluded by \`current_attempt_id\`)

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check