### PR TITLE
fix(slack): key bot auth ID cache by (tenant_id, slack_bot_id)

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -136,6 +136,7 @@ def handle_generate_answer_button(
 
     thread_messages = read_slack_thread(
         tenant_id=client._tenant_id,
+        slack_bot_id=client.slack_bot_id,
         channel=channel_id,
         thread=thread_ts,
         client=client.web_client,

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -687,7 +687,7 @@ def prefilter_requests(req: SocketModeRequest, client: TenantSocketModeClient) -
     tenant_id = get_current_tenant_id()
 
     bot_token_user_id, bot_token_bot_id = get_onyx_bot_auth_ids(
-        tenant_id, client.web_client
+        tenant_id, client.slack_bot_id, client.web_client
     )
     logger.info(
         "prefilter_requests: bot_token_user_id=%r bot_token_bot_id=%r",
@@ -743,7 +743,9 @@ def prefilter_requests(req: SocketModeRequest, client: TenantSocketModeClient) -
 
         if (
             msg in _SLACK_GREETINGS_TO_IGNORE
-            or remove_onyx_bot_tag(tenant_id, msg, client=client.web_client)
+            or remove_onyx_bot_tag(
+                tenant_id, client.slack_bot_id, msg, client=client.web_client
+            )
             in _SLACK_GREETINGS_TO_IGNORE
         ):
             channel_specific_logger.error(
@@ -762,7 +764,7 @@ def prefilter_requests(req: SocketModeRequest, client: TenantSocketModeClient) -
             return False
 
         bot_token_user_id, bot_token_bot_id = get_onyx_bot_auth_ids(
-            tenant_id, client.web_client
+            tenant_id, client.slack_bot_id, client.web_client
         )
         if event_type == "message":
             is_onyx_bot_msg = False
@@ -922,7 +924,9 @@ def build_request_details(
         channel = cast(str, event["channel"])
 
         # Check for both app_mention events and messages containing bot tag
-        bot_token_user_id, _ = get_onyx_bot_auth_ids(tenant_id, client.web_client)
+        bot_token_user_id, _ = get_onyx_bot_auth_ids(
+            tenant_id, client.slack_bot_id, client.web_client
+        )
         message_ts = event.get("ts")
         thread_ts = event.get("thread_ts")
         sender_id = event.get("user") or None
@@ -931,7 +935,9 @@ def build_request_details(
         )
         email = expert_info.email if expert_info else None
 
-        msg = remove_onyx_bot_tag(tenant_id, msg, client=client.web_client)
+        msg = remove_onyx_bot_tag(
+            tenant_id, client.slack_bot_id, msg, client=client.web_client
+        )
 
         logger.info("Received Slack message: %s", msg)
 
@@ -967,6 +973,7 @@ def build_request_details(
         if thread_ts != message_ts and thread_ts is not None:
             thread_messages: list[ThreadMessage] = read_slack_thread(
                 tenant_id=tenant_id,
+                slack_bot_id=client.slack_bot_id,
                 channel=channel,
                 thread=thread_ts,
                 client=client.web_client,

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -67,16 +67,19 @@ def get_onyx_bot_auth_ids(
 
     cache_key = (tenant_id, slack_bot_id)
 
-    # Single critical section: concurrent first-time callers for the same
-    # (tenant_id, slack_bot_id) share a single auth_test() round-trip rather
-    # than racing to populate the cache.
     with slack_token_lock:
         user_id = slack_token_user_ids.get(cache_key)
         bot_id = slack_token_bot_ids.get(cache_key)
-        if user_id is None or bot_id is None:
-            response = web_client.auth_test()
-            user_id = response.get("user_id")
-            bot_id = response.get("bot_id")
+
+    if user_id is None or bot_id is None:
+        # Network I/O happens outside the lock so that an in-flight or slow
+        # auth_test() for one (tenant, bot) does not block cache reads for
+        # other keys. A rare duplicate auth_test() on cold-start for the
+        # same key returns identical values and is harmless.
+        response = web_client.auth_test()
+        user_id = response.get("user_id")
+        bot_id = response.get("bot_id")
+        with slack_token_lock:
             slack_token_user_ids[cache_key] = user_id
             slack_token_bot_ids[cache_key] = bot_id
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -67,15 +67,16 @@ def get_onyx_bot_auth_ids(
 
     cache_key = (tenant_id, slack_bot_id)
 
+    # Single critical section: concurrent first-time callers for the same
+    # (tenant_id, slack_bot_id) share a single auth_test() round-trip rather
+    # than racing to populate the cache.
     with slack_token_lock:
         user_id = slack_token_user_ids.get(cache_key)
         bot_id = slack_token_bot_ids.get(cache_key)
-
-    if user_id is None or bot_id is None:
-        response = web_client.auth_test()
-        user_id = response.get("user_id")
-        bot_id = response.get("bot_id")
-        with slack_token_lock:
+        if user_id is None or bot_id is None:
+            response = web_client.auth_test()
+            user_id = response.get("user_id")
+            bot_id = response.get("bot_id")
             slack_token_user_ids[cache_key] = user_id
             slack_token_bot_ids[cache_key] = bot_id
 

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -41,8 +41,8 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
-slack_token_user_ids: dict[str, str | None] = {}
-slack_token_bot_ids: dict[str, str | None] = {}
+slack_token_user_ids: dict[tuple[str, int], str | None] = {}
+slack_token_bot_ids: dict[tuple[str, int], str | None] = {}
 slack_token_lock = threading.Lock()
 
 _ONYX_BOT_MESSAGE_COUNT: int = 0
@@ -50,9 +50,14 @@ _ONYX_BOT_COUNT_START_TIME: float = time.time()
 
 
 def get_onyx_bot_auth_ids(
-    tenant_id: str, web_client: WebClient
+    tenant_id: str, slack_bot_id: int, web_client: WebClient
 ) -> tuple[str | None, str | None]:
-    """Returns a tuple of user_id and bot_id."""
+    """Returns a tuple of user_id and bot_id for the given (tenant, slack_bot).
+
+    The cache must be keyed by (tenant_id, slack_bot_id) — multiple Slack apps
+    in the same tenant have distinct user/bot IDs and previously collided on
+    a tenant-only key.
+    """
 
     user_id: str | None
     bot_id: str | None
@@ -60,17 +65,19 @@ def get_onyx_bot_auth_ids(
     global slack_token_user_ids
     global slack_token_bot_ids
 
+    cache_key = (tenant_id, slack_bot_id)
+
     with slack_token_lock:
-        user_id = slack_token_user_ids.get(tenant_id)
-        bot_id = slack_token_bot_ids.get(tenant_id)
+        user_id = slack_token_user_ids.get(cache_key)
+        bot_id = slack_token_bot_ids.get(cache_key)
 
     if user_id is None or bot_id is None:
         response = web_client.auth_test()
         user_id = response.get("user_id")
         bot_id = response.get("bot_id")
         with slack_token_lock:
-            slack_token_user_ids[tenant_id] = user_id
-            slack_token_bot_ids[tenant_id] = bot_id
+            slack_token_user_ids[cache_key] = user_id
+            slack_token_bot_ids[cache_key] = bot_id
 
     return user_id, bot_id
 
@@ -178,8 +185,12 @@ def update_emote_react(
     return
 
 
-def remove_onyx_bot_tag(tenant_id: str, message_str: str, client: WebClient) -> str:
-    bot_token_user_id, _ = get_onyx_bot_auth_ids(tenant_id, web_client=client)
+def remove_onyx_bot_tag(
+    tenant_id: str, slack_bot_id: int, message_str: str, client: WebClient
+) -> str:
+    bot_token_user_id, _ = get_onyx_bot_auth_ids(
+        tenant_id, slack_bot_id, web_client=client
+    )
     return re.sub(rf"<@{bot_token_user_id}>\s*", "", message_str)
 
 
@@ -556,7 +567,11 @@ def fetch_user_semantic_id_from_id(
 
 
 def read_slack_thread(
-    tenant_id: str, channel: str, thread: str, client: WebClient
+    tenant_id: str,
+    slack_bot_id: int,
+    channel: str,
+    thread: str,
+    client: WebClient,
 ) -> list[ThreadMessage]:
     thread_messages: list[ThreadMessage] = []
     response = client.conversations_replies(channel=channel, ts=thread)
@@ -577,7 +592,7 @@ def read_slack_thread(
             reply_bot_id = reply.get("bot_id")
 
             self_slack_bot_user_id, self_slack_bot_bot_id = get_onyx_bot_auth_ids(
-                tenant_id, client
+                tenant_id, slack_bot_id, client
             )
             if reply_user is not None and reply_user == self_slack_bot_user_id:
                 is_onyx_bot_response = True
@@ -631,7 +646,7 @@ def read_slack_thread(
                 logger.warning("Skipping Slack thread message, no text found")
                 continue
 
-        message = remove_onyx_bot_tag(tenant_id, message, client=client)
+        message = remove_onyx_bot_tag(tenant_id, slack_bot_id, message, client=client)
         thread_messages.append(
             ThreadMessage(message=message, sender=user_sem_id, role=message_type)
         )


### PR DESCRIPTION
## Description

Reported on Discord: https://discord.com/channels/1119886360506023946/1500811277210222713

Two Slack apps in the same tenant share `slack_token_user_ids` / `slack_token_bot_ids` keyed only by `tenant_id`. Whichever app calls `auth_test()` first poisons the cache for the other.

Downstream, `read_slack_thread` uses the cached `self_slack_bot_user_id` to classify thread replies as `ASSISTANT` vs `USER`. With a poisoned cache, Bot B sees its own prior in-character replies fall into the "other bot" branch and get relabeled `MessageType.USER`, injecting them as user turns in the LLM context. Result: cross-persona drift mid-thread (Bot B replies with Bot A's identity), matching the reporter's symptom and the alternating behavior across api_server replicas.

Fix: cache key is now `(tenant_id, slack_bot_id)`. Callers pass `client.slack_bot_id` through `get_onyx_bot_auth_ids`, `remove_onyx_bot_tag`, and `read_slack_thread`. Cache reads/writes use short locks; `auth_test()` runs outside the lock so concurrent cold-start initialisations do not block each other across tenants.

## How Has This Been Tested?

- ruff, black, ty pre-commit hooks pass
- Module imports cleanly under py3.11
- Manual code trace against the reported scenario; all call sites updated (`listener.py`, `utils.py`, `handlers/handle_buttons.py`)

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check