### PR TITLE
feat(targeted-reindex): API endpoints + DB writes + stub celery task

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -1,0 +1,81 @@
+"""Celery task for executing a targeted reindex.
+
+Stub for now: transitions the job to IN_PROGRESS, then to a terminal
+state without doing any actual reindex work. The real implementation
+(connector.reindex(), pipeline plumbing, error resolution, stale-write
+mitigation) lands in the follow-up PR.
+
+Lives here so the task name is registered with the celery app and the
+API path's `apply_async` resolves. Without this stub, the task name
+would route to a non-existent handler and the worker would log
+`unknown task` errors on every retry submission.
+"""
+
+import datetime
+import logging
+
+from celery import shared_task
+from celery import Task
+
+from onyx.background.celery.apps.app_base import task_logger
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import IndexingStatus
+from onyx.db.targeted_reindex import get_targeted_reindex_job
+
+# Soft and hard time limits scoped generously for the eventual real
+# implementation; stub completes in milliseconds.
+_TARGETED_REINDEX_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
+_TARGETED_REINDEX_TIME_LIMIT = _TARGETED_REINDEX_SOFT_TIME_LIMIT + 60
+
+
+@shared_task(
+    name=OnyxCeleryTask.TARGETED_REINDEX_TASK,
+    soft_time_limit=_TARGETED_REINDEX_SOFT_TIME_LIMIT,
+    time_limit=_TARGETED_REINDEX_TIME_LIMIT,
+    bind=True,
+)
+def targeted_reindex_task(
+    self: Task,
+    *,
+    targeted_reindex_job_id: int,
+) -> None:
+    """Stub: mark the job IN_PROGRESS and immediately COMPLETED.
+
+    Real implementation in a follow-up PR will:
+      - load targets, group by cc_pair
+      - build connector for each cc_pair, call `connector.reindex(refs)`
+      - pipe Documents through `index_doc_batch_with_handler`
+      - mark `index_attempt_errors.is_resolved=True` for targets with
+        a non-null `source_error_id` whose docs successfully landed
+      - track `resolved_count` / `still_failing_count` on the job row
+      - snapshot `resolved_summary` at completion
+    """
+    log = logging.LoggerAdapter(
+        task_logger,
+        extra={
+            "targeted_reindex_job_id": targeted_reindex_job_id,
+            "celery_task_id": self.request.id,
+        },
+    )
+    log.info("Targeted reindex task picked up job (stub implementation)")
+
+    with get_session_with_current_tenant() as db_session:
+        job = get_targeted_reindex_job(db_session, targeted_reindex_job_id)
+        if job is None:
+            log.warning("Job not found, dropping task")
+            return
+
+        if job.status.is_terminal():
+            log.info("Job already terminal, dropping task")
+            return
+
+        job.status = IndexingStatus.IN_PROGRESS
+        db_session.commit()
+
+        # Stub: nothing else to do yet. Mark complete.
+        job.status = IndexingStatus.SUCCESS
+        job.completed_at = datetime.datetime.now(datetime.timezone.utc)
+        db_session.commit()
+
+    log.info("Stub targeted reindex task done")

--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -39,6 +39,7 @@ def targeted_reindex_task(
     self: Task,
     *,
     targeted_reindex_job_id: int,
+    tenant_id: str,  # noqa: ARG001  # consumed by TenantAwareTask wrapper
 ) -> None:
     """Stub: mark the job IN_PROGRESS and immediately COMPLETED.
 

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -32,6 +32,9 @@ from onyx.background.celery.tasks.docfetching.task_creation_utils import (
 )
 from onyx.background.celery.tasks.docprocessing.heartbeat import start_heartbeat
 from onyx.background.celery.tasks.docprocessing.heartbeat import stop_heartbeat
+from onyx.background.celery.tasks.docprocessing.targeted_reindex_task import (  # noqa: F401  # registers @shared_task with celery
+    targeted_reindex_task,
+)
 from onyx.background.celery.tasks.docprocessing.utils import IndexingCallback
 from onyx.background.celery.tasks.docprocessing.utils import is_in_repeated_error_state
 from onyx.background.celery.tasks.docprocessing.utils import should_index

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -431,6 +431,9 @@ class OnyxCeleryQueues:
     DOCPROCESSING = "docprocessing"
     CONNECTOR_DOC_FETCHING = "connector_doc_fetching"
 
+    # Targeted reindex queue
+    TARGETED_REINDEX = "targeted_reindex"
+
     # Monitoring queue
     MONITORING = "monitoring"
 
@@ -572,6 +575,9 @@ class OnyxCeleryTask:
     PROCESS_SINGLE_USER_FILE_PROJECT_SYNC = "process_single_user_file_project_sync"
     CHECK_FOR_USER_FILE_DELETE = "check_for_user_file_delete"
     DELETE_SINGLE_USER_FILE = "delete_single_user_file"
+
+    # Targeted reindex
+    TARGETED_REINDEX_TASK = "targeted_reindex_task"
 
     # Connector checkpoint cleanup
     CHECK_FOR_CHECKPOINT_CLEANUP = "check_for_checkpoint_cleanup"

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -431,9 +431,6 @@ class OnyxCeleryQueues:
     DOCPROCESSING = "docprocessing"
     CONNECTOR_DOC_FETCHING = "connector_doc_fetching"
 
-    # Targeted reindex queue
-    TARGETED_REINDEX = "targeted_reindex"
-
     # Monitoring queue
     MONITORING = "monitoring"
 

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -140,6 +140,7 @@ def create_targeted_reindex_job(
     db_session: Session,
     requested_by_user_id: UUID | None,
     targets: Sequence[TargetSpec],
+    upstream_skipped_count: int = 0,
 ) -> CreateTargetedReindexJobResult:
     """Persist a targeted reindex request.
 
@@ -147,6 +148,12 @@ def create_targeted_reindex_job(
     `(cc_pair_id, search_settings_id)` tuple. Pre-allocates the celery
     task UUID so the orphan-detector can clean up if `apply_async` fails
     after this returns.
+
+    `upstream_skipped_count` is added to the dedup-skipped count and
+    persisted on the job row so the GET status endpoint can return the
+    full at-create-time skip count (e.g. error_ids that resolved to
+    already-resolved or entity-level rows in the API layer). The task
+    later folds in any runtime skips.
 
     The caller (API endpoint) is responsible for enqueueing the celery
     task with the returned `celery_task_id` after this commits.
@@ -174,14 +181,6 @@ def create_targeted_reindex_job(
 
     celery_task_id = str(uuid4())
 
-    job = TargetedReindexJob(
-        requested_by_user_id=requested_by_user_id,
-        celery_task_id=celery_task_id,
-        status=IndexingStatus.NOT_STARTED,
-    )
-    db_session.add(job)
-    db_session.flush()
-
     # Dedup at the (cc_pair_id, document_id) level — composite PK on the
     # target table would catch this anyway, but better to error early.
     seen: set[tuple[int, str]] = set()
@@ -192,6 +191,18 @@ def create_targeted_reindex_job(
             continue
         seen.add(key)
         deduped.append(t)
+
+    dedup_skipped = len(targets) - len(deduped)
+    initial_skipped = dedup_skipped + upstream_skipped_count
+
+    job = TargetedReindexJob(
+        requested_by_user_id=requested_by_user_id,
+        celery_task_id=celery_task_id,
+        status=IndexingStatus.NOT_STARTED,
+        skipped_count=initial_skipped,
+    )
+    db_session.add(job)
+    db_session.flush()
 
     for t in deduped:
         db_session.add(
@@ -230,7 +241,7 @@ def create_targeted_reindex_job(
         targeted_reindex_job_id=job.id,
         celery_task_id=celery_task_id,
         queued_count=len(deduped),
-        skipped_count=len(targets) - len(deduped),
+        skipped_count=initial_skipped,
         cc_pair_search_settings_pairs=pairs,
         synthetic_attempt_ids=attempt_ids,
     )

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -25,13 +25,13 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptError
 from onyx.db.models import SearchSettings
 from onyx.db.models import TargetedReindexJob
 from onyx.db.models import TargetedReindexJobTarget
-from onyx.db.search_settings import get_current_search_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -114,17 +114,26 @@ def _group_targets_by_search_settings(
     """Map cc_pair_id → set of `search_settings_id` it should write to.
 
     A targeted reindex needs to write to whatever search settings the
-    cc_pair currently indexes against. In multi-search-settings setups
-    (e.g. during an embedding swap) this is more than one. Today the
-    cc_pair tracks a single `processing_mode`/source pairing, so we
-    just use the current PRESENT search settings for every cc_pair the
-    targets span.
+    cc_pair currently indexes against. During an embedding-model swap
+    that's both PRESENT and FUTURE — otherwise the FUTURE index lags
+    by the targeted-reindex delta until the next full crawl.
     """
     cc_pair_ids = {t.cc_pair_id for t in targets}
     if not cc_pair_ids:
         return {}
-    settings = get_current_search_settings(db_session)
-    return {cc_pair_id: {settings.id} for cc_pair_id in cc_pair_ids}
+    active_settings = (
+        db_session.execute(
+            select(SearchSettings).where(
+                SearchSettings.status.in_(
+                    [IndexModelStatus.PRESENT, IndexModelStatus.FUTURE]
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    settings_ids = {s.id for s in active_settings}
+    return {cc_pair_id: settings_ids for cc_pair_id in cc_pair_ids}
 
 
 def create_targeted_reindex_job(
@@ -238,15 +247,4 @@ def count_targets_for_job(db_session: Session, job_id: int) -> int:
         db_session.query(TargetedReindexJobTarget)
         .filter(TargetedReindexJobTarget.targeted_reindex_job_id == job_id)
         .count()
-    )
-
-
-def _validate_search_settings_exists(
-    db_session: Session, search_settings_id: int
-) -> bool:
-    return (
-        db_session.execute(
-            select(SearchSettings.id).where(SearchSettings.id == search_settings_id)
-        ).first()
-        is not None
     )

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -25,13 +25,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import IndexingStatus
-from onyx.db.enums import IndexModelStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import IndexAttemptError
-from onyx.db.models import SearchSettings
 from onyx.db.models import TargetedReindexJob
 from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_active_search_settings_list
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -55,6 +54,25 @@ class TargetSpec(BaseModel):
 
 
 class CreateTargetedReindexJobResult(BaseModel):
+    """Return value of `create_targeted_reindex_job`.
+
+    - `targeted_reindex_job_id`: row id; the FE polls the GET status
+      endpoint with this value.
+    - `celery_task_id`: pre-allocated UUID. Caller (API endpoint) uses
+      this as the `task_id` arg to `apply_async` so the orphan-detector
+      can clean up if dispatch fails after the DB rows commit.
+    - `queued_count`: targets that survived dedup and got persisted.
+    - `skipped_count`: dedup + caller-supplied upstream skips, persisted
+      on the job row so the GET endpoint returns it before the task
+      runs.
+    - `cc_pair_search_settings_pairs`: the (cc_pair_id, search_settings_id)
+      tuples we spawned synthetic IndexAttempts for. Mostly informational
+      — the task re-queries by `targeted_reindex_job_id` and doesn't
+      need this field directly.
+    - `synthetic_attempt_ids`: the IndexAttempt rows the task will
+      transition through the lifecycle.
+    """
+
     targeted_reindex_job_id: int
     celery_task_id: str
     queued_count: int
@@ -108,34 +126,6 @@ def resolve_error_ids_to_targets(
     return targets, skipped
 
 
-def _group_targets_by_search_settings(
-    db_session: Session, targets: Sequence[TargetSpec]
-) -> dict[int, set[int]]:
-    """Map cc_pair_id → set of `search_settings_id` it should write to.
-
-    A targeted reindex needs to write to whatever search settings the
-    cc_pair currently indexes against. During an embedding-model swap
-    that's both PRESENT and FUTURE — otherwise the FUTURE index lags
-    by the targeted-reindex delta until the next full crawl.
-    """
-    cc_pair_ids = {t.cc_pair_id for t in targets}
-    if not cc_pair_ids:
-        return {}
-    active_settings = (
-        db_session.execute(
-            select(SearchSettings).where(
-                SearchSettings.status.in_(
-                    [IndexModelStatus.PRESENT, IndexModelStatus.FUTURE]
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    settings_ids = {s.id for s in active_settings}
-    return {cc_pair_id: settings_ids for cc_pair_id in cc_pair_ids}
-
-
 def create_targeted_reindex_job(
     db_session: Session,
     requested_by_user_id: UUID | None,
@@ -183,14 +173,19 @@ def create_targeted_reindex_job(
 
     # Dedup at the (cc_pair_id, document_id) level — composite PK on the
     # target table would catch this anyway, but better to error early.
-    seen: set[tuple[int, str]] = set()
-    deduped: list[TargetSpec] = []
+    # When the same (cc_pair, doc) appears more than once, prefer the
+    # spec that carries `source_error_id`. The API can hand us derived
+    # (failure-driven) and manual specs in any order; the linkage-bearing
+    # one must win or the task can't mark the original error resolved.
+    by_key: dict[tuple[int, str], TargetSpec] = {}
     for t in targets:
         key = (t.cc_pair_id, t.document_id)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(t)
+        existing = by_key.get(key)
+        if existing is None or (
+            existing.source_error_id is None and t.source_error_id is not None
+        ):
+            by_key[key] = t
+    deduped: list[TargetSpec] = list(by_key.values())
 
     dedup_skipped = len(targets) - len(deduped)
     initial_skipped = dedup_skipped + upstream_skipped_count
@@ -217,14 +212,18 @@ def create_targeted_reindex_job(
     # Spawn a synthetic IndexAttempt per (cc_pair_id, search_settings_id).
     # These bypass try_create_index_attempt — full crawls are allowed to
     # overlap with retries (per-doc row-locks handle write conflicts).
-    grouped = _group_targets_by_search_settings(db_session, deduped)
+    # Active search settings = primary plus the secondary if a model swap
+    # is in progress (FUTURE); reusing the canonical helper here keeps
+    # the targeted-reindex flow aligned with the main indexing path.
+    cc_pair_ids = {t.cc_pair_id for t in deduped}
+    active_search_settings = get_active_search_settings_list(db_session)
     attempt_ids: list[int] = []
     pairs: list[tuple[int, int]] = []
-    for cc_pair_id, search_settings_ids in grouped.items():
-        for search_settings_id in search_settings_ids:
+    for cc_pair_id in cc_pair_ids:
+        for search_settings in active_search_settings:
             attempt = IndexAttempt(
                 connector_credential_pair_id=cc_pair_id,
-                search_settings_id=search_settings_id,
+                search_settings_id=search_settings.id,
                 from_beginning=False,
                 status=IndexingStatus.NOT_STARTED,
                 targeted_reindex_job_id=job.id,
@@ -232,7 +231,7 @@ def create_targeted_reindex_job(
             db_session.add(attempt)
             db_session.flush()
             attempt_ids.append(attempt.id)
-            pairs.append((cc_pair_id, search_settings_id))
+            pairs.append((cc_pair_id, search_settings.id))
 
     db_session.commit()
     db_session.refresh(job)

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -162,7 +162,7 @@ def create_targeted_reindex_job(
         raise ValueError("at least one target required")
     if len(targets) > MAX_TARGETS_PER_REQUEST:
         raise ValueError(
-            f"too many targets: {len(targets)} > {MAX_TARGETS_PER_REQUEST}"
+            "too many targets: %s > %s" % (len(targets), MAX_TARGETS_PER_REQUEST)
         )
 
     # Validate cc_pair_ids exist before writing anything.
@@ -177,7 +177,7 @@ def create_targeted_reindex_job(
     }
     missing = cc_pair_ids - existing_pairs
     if missing:
-        raise ValueError(f"unknown cc_pair_ids: {sorted(missing)}")
+        raise ValueError("unknown cc_pair_ids: %s" % sorted(missing))
 
     celery_task_id = str(uuid4())
 

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -1,0 +1,252 @@
+"""DB helpers for the targeted-reindex flow.
+
+The API path takes a list of error IDs (failure-driven retry) or a list
+of `(cc_pair_id, document_id)` tuples (arbitrary reindex), validates +
+dedups them, then writes:
+
+    1. one `targeted_reindex_job` row,
+    2. N `targeted_reindex_job_target` rows (one per doc),
+    3. one synthetic `IndexAttempt` per `(cc_pair_id, search_settings_id)`
+       tuple the targets span. The synthetic attempts carry
+       `targeted_reindex_job_id` and skip the
+       `try_create_index_attempt` fence (full crawls are allowed to
+       overlap with retries by design).
+
+Nothing here enqueues celery work — that's the caller's job. Helpers
+return the job_id + per-request counts for the API response.
+"""
+
+from collections.abc import Sequence
+from uuid import UUID
+from uuid import uuid4
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import SearchSettings
+from onyx.db.models import TargetedReindexJob
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_current_search_settings
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+# Cap per request. Holds at the API layer; documented in the design doc.
+MAX_TARGETS_PER_REQUEST = 100
+
+
+class TargetSpec(BaseModel):
+    """A doc the caller wants reindexed.
+
+    `source_error_id` is set when the API resolved this target from an
+    `IndexAttemptError`; NULL when the request came in as an arbitrary
+    `(cc_pair_id, document_id)` pair.
+    """
+
+    cc_pair_id: int
+    document_id: str
+    source_error_id: int | None = None
+
+
+class CreateTargetedReindexJobResult(BaseModel):
+    targeted_reindex_job_id: int
+    celery_task_id: str
+    queued_count: int
+    skipped_count: int
+    cc_pair_search_settings_pairs: list[tuple[int, int]]
+    synthetic_attempt_ids: list[int]
+
+
+def resolve_error_ids_to_targets(
+    db_session: Session, error_ids: Sequence[int]
+) -> tuple[list[TargetSpec], int]:
+    """Convert a list of error IDs into target specs.
+
+    Returns `(targets, skipped_count)` where `skipped_count` counts
+    errors that were already resolved at request time (no work to do)
+    and errors that were entity-level (not document-level) and so can't
+    be retried per-doc.
+    """
+    if not error_ids:
+        return [], 0
+
+    rows = (
+        db_session.execute(
+            select(IndexAttemptError).where(IndexAttemptError.id.in_(error_ids))
+        )
+        .scalars()
+        .all()
+    )
+
+    targets: list[TargetSpec] = []
+    skipped = 0
+    for err in rows:
+        if err.is_resolved:
+            skipped += 1
+            continue
+        if err.document_id is None:
+            # Entity-level error (e.g. a Confluence space failed); not
+            # reindexable per-document.
+            skipped += 1
+            continue
+        targets.append(
+            TargetSpec(
+                cc_pair_id=err.connector_credential_pair_id,
+                document_id=err.document_id,
+                source_error_id=err.id,
+            )
+        )
+    # Errors not found in DB (caller passed invalid IDs) are also skipped.
+    found_ids = {err.id for err in rows}
+    skipped += len(set(error_ids) - found_ids)
+    return targets, skipped
+
+
+def _group_targets_by_search_settings(
+    db_session: Session, targets: Sequence[TargetSpec]
+) -> dict[int, set[int]]:
+    """Map cc_pair_id → set of `search_settings_id` it should write to.
+
+    A targeted reindex needs to write to whatever search settings the
+    cc_pair currently indexes against. In multi-search-settings setups
+    (e.g. during an embedding swap) this is more than one. Today the
+    cc_pair tracks a single `processing_mode`/source pairing, so we
+    just use the current PRESENT search settings for every cc_pair the
+    targets span.
+    """
+    cc_pair_ids = {t.cc_pair_id for t in targets}
+    if not cc_pair_ids:
+        return {}
+    settings = get_current_search_settings(db_session)
+    return {cc_pair_id: {settings.id} for cc_pair_id in cc_pair_ids}
+
+
+def create_targeted_reindex_job(
+    db_session: Session,
+    requested_by_user_id: UUID | None,
+    targets: Sequence[TargetSpec],
+) -> CreateTargetedReindexJobResult:
+    """Persist a targeted reindex request.
+
+    Writes the job row, target rows, and one synthetic IndexAttempt per
+    `(cc_pair_id, search_settings_id)` tuple. Pre-allocates the celery
+    task UUID so the orphan-detector can clean up if `apply_async` fails
+    after this returns.
+
+    The caller (API endpoint) is responsible for enqueueing the celery
+    task with the returned `celery_task_id` after this commits.
+    """
+    if not targets:
+        raise ValueError("at least one target required")
+    if len(targets) > MAX_TARGETS_PER_REQUEST:
+        raise ValueError(
+            f"too many targets: {len(targets)} > {MAX_TARGETS_PER_REQUEST}"
+        )
+
+    # Validate cc_pair_ids exist before writing anything.
+    cc_pair_ids = {t.cc_pair_id for t in targets}
+    existing_pairs = {
+        row[0]
+        for row in db_session.execute(
+            select(ConnectorCredentialPair.id).where(
+                ConnectorCredentialPair.id.in_(cc_pair_ids)
+            )
+        ).all()
+    }
+    missing = cc_pair_ids - existing_pairs
+    if missing:
+        raise ValueError(f"unknown cc_pair_ids: {sorted(missing)}")
+
+    celery_task_id = str(uuid4())
+
+    job = TargetedReindexJob(
+        requested_by_user_id=requested_by_user_id,
+        celery_task_id=celery_task_id,
+        status=IndexingStatus.NOT_STARTED,
+    )
+    db_session.add(job)
+    db_session.flush()
+
+    # Dedup at the (cc_pair_id, document_id) level — composite PK on the
+    # target table would catch this anyway, but better to error early.
+    seen: set[tuple[int, str]] = set()
+    deduped: list[TargetSpec] = []
+    for t in targets:
+        key = (t.cc_pair_id, t.document_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(t)
+
+    for t in deduped:
+        db_session.add(
+            TargetedReindexJobTarget(
+                targeted_reindex_job_id=job.id,
+                cc_pair_id=t.cc_pair_id,
+                document_id=t.document_id,
+                source_error_id=t.source_error_id,
+            )
+        )
+
+    # Spawn a synthetic IndexAttempt per (cc_pair_id, search_settings_id).
+    # These bypass try_create_index_attempt — full crawls are allowed to
+    # overlap with retries (per-doc row-locks handle write conflicts).
+    grouped = _group_targets_by_search_settings(db_session, deduped)
+    attempt_ids: list[int] = []
+    pairs: list[tuple[int, int]] = []
+    for cc_pair_id, search_settings_ids in grouped.items():
+        for search_settings_id in search_settings_ids:
+            attempt = IndexAttempt(
+                connector_credential_pair_id=cc_pair_id,
+                search_settings_id=search_settings_id,
+                from_beginning=False,
+                status=IndexingStatus.NOT_STARTED,
+                targeted_reindex_job_id=job.id,
+            )
+            db_session.add(attempt)
+            db_session.flush()
+            attempt_ids.append(attempt.id)
+            pairs.append((cc_pair_id, search_settings_id))
+
+    db_session.commit()
+    db_session.refresh(job)
+
+    return CreateTargetedReindexJobResult(
+        targeted_reindex_job_id=job.id,
+        celery_task_id=celery_task_id,
+        queued_count=len(deduped),
+        skipped_count=len(targets) - len(deduped),
+        cc_pair_search_settings_pairs=pairs,
+        synthetic_attempt_ids=attempt_ids,
+    )
+
+
+def get_targeted_reindex_job(
+    db_session: Session, job_id: int
+) -> TargetedReindexJob | None:
+    return db_session.get(TargetedReindexJob, job_id)
+
+
+def count_targets_for_job(db_session: Session, job_id: int) -> int:
+    return (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(TargetedReindexJobTarget.targeted_reindex_job_id == job_id)
+        .count()
+    )
+
+
+def _validate_search_settings_exists(
+    db_session: Session, search_settings_id: int
+) -> bool:
+    return (
+        db_session.execute(
+            select(SearchSettings.id).where(SearchSettings.id == search_settings_id)
+        ).first()
+        is not None
+    )

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -75,6 +75,7 @@ from onyx.server.documents.connector import router as connector_router
 from onyx.server.documents.credential import router as credential_router
 from onyx.server.documents.document import router as document_router
 from onyx.server.documents.standard_oauth import router as standard_oauth_router
+from onyx.server.documents.targeted_reindex import router as targeted_reindex_router
 from onyx.server.features.build.api.api import public_build_router
 from onyx.server.features.build.api.api import router as build_router
 from onyx.server.features.default_assistant.api import (
@@ -468,6 +469,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, input_prompt_router)
     include_router_with_global_prefix_prepended(application, admin_input_prompt_router)
     include_router_with_global_prefix_prepended(application, cc_pair_router)
+    include_router_with_global_prefix_prepended(application, targeted_reindex_router)
     include_router_with_global_prefix_prepended(application, projects_router)
     include_router_with_global_prefix_prepended(application, public_build_router)
     include_router_with_global_prefix_prepended(application, build_router)

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -109,7 +109,8 @@ def submit_targeted_reindex(
     if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
-            f"Too many targets: {len(target_specs_in)} > {MAX_TARGETS_PER_REQUEST}.",
+            "Too many targets: %s > %s."
+            % (len(target_specs_in), MAX_TARGETS_PER_REQUEST),
         )
 
     try:

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -17,7 +17,6 @@ from typing import Any
 from celery import current_app as celery_app
 from fastapi import APIRouter
 from fastapi import Depends
-from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -34,6 +33,8 @@ from onyx.db.targeted_reindex import get_targeted_reindex_job
 from onyx.db.targeted_reindex import MAX_TARGETS_PER_REQUEST
 from onyx.db.targeted_reindex import resolve_error_ids_to_targets
 from onyx.db.targeted_reindex import TargetSpec
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -85,9 +86,9 @@ def submit_targeted_reindex(
     ]
 
     if not error_ids and not target_specs_in:
-        raise HTTPException(
-            status_code=400,
-            detail="Either error_ids or targets must be provided.",
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Either error_ids or targets must be provided.",
         )
 
     skipped_from_errors = 0
@@ -98,21 +99,16 @@ def submit_targeted_reindex(
         target_specs_in.extend(derived)
 
     if not target_specs_in:
-        # Everything was already resolved or invalid.
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "No actionable targets after resolving error_ids "
-                "(all were already resolved, entity-level, or invalid)."
-            ),
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No actionable targets after resolving error_ids "
+            "(all were already resolved, entity-level, or invalid).",
         )
 
     if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Too many targets: {len(target_specs_in)} > {MAX_TARGETS_PER_REQUEST}."
-            ),
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            f"Too many targets: {len(target_specs_in)} > {MAX_TARGETS_PER_REQUEST}.",
         )
 
     try:
@@ -122,7 +118,7 @@ def submit_targeted_reindex(
             targets=target_specs_in,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e))
 
     try:
         celery_app.send_task(
@@ -137,9 +133,9 @@ def submit_targeted_reindex(
             "Failed to enqueue targeted reindex task",
             extra={"job_id": result.targeted_reindex_job_id},
         )
-        raise HTTPException(
-            status_code=503,
-            detail="Failed to enqueue targeted reindex task.",
+        raise OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            "Failed to enqueue targeted reindex task.",
         )
 
     return TargetedReindexResponse(
@@ -157,7 +153,7 @@ def get_targeted_reindex_status(
 ) -> TargetedReindexJobStatusResponse:
     job = get_targeted_reindex_job(db_session, job_id)
     if job is None:
-        raise HTTPException(status_code=404, detail="Job not found.")
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Job not found.")
 
     return TargetedReindexJobStatusResponse(
         id=job.id,

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -36,6 +36,7 @@ from onyx.db.targeted_reindex import TargetSpec
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -120,6 +121,7 @@ def submit_targeted_reindex(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e))
 
+    tenant_id = get_current_tenant_id()
     try:
         # Route to the existing PRIMARY queue. The design has the trigger
         # task running on the primary worker that already owns the
@@ -128,7 +130,10 @@ def submit_targeted_reindex(
         # docprocessing queues from inside the task body.
         celery_app.send_task(
             OnyxCeleryTask.TARGETED_REINDEX_TASK,
-            kwargs={"targeted_reindex_job_id": result.targeted_reindex_job_id},
+            kwargs={
+                "targeted_reindex_job_id": result.targeted_reindex_job_id,
+                "tenant_id": tenant_id,
+            },
             queue=OnyxCeleryQueues.PRIMARY,
             priority=OnyxCeleryPriority.HIGHEST,
             task_id=result.celery_task_id,

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -1,0 +1,172 @@
+"""Admin endpoints for the targeted-reindex flow.
+
+Two endpoints:
+
+* `POST /manage/admin/indexing/targeted-reindex` — submit error IDs and/or
+  doc refs, returns a job id the FE polls.
+* `GET  /manage/admin/indexing/targeted-reindex/{job_id}` — current status.
+
+The POST handler validates input, persists the job + per-doc target
+rows + per-cc-pair synthetic IndexAttempts, and enqueues the celery
+task with the pre-allocated task UUID.
+"""
+
+import datetime
+from typing import Any
+
+from celery import current_app as celery_app
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import current_curator_or_admin_user
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import User
+from onyx.db.targeted_reindex import count_targets_for_job
+from onyx.db.targeted_reindex import create_targeted_reindex_job
+from onyx.db.targeted_reindex import get_targeted_reindex_job
+from onyx.db.targeted_reindex import MAX_TARGETS_PER_REQUEST
+from onyx.db.targeted_reindex import resolve_error_ids_to_targets
+from onyx.db.targeted_reindex import TargetSpec
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+router = APIRouter(prefix="/manage")
+
+
+class DocumentTargetRequest(BaseModel):
+    cc_pair_id: int
+    document_id: str
+
+
+class TargetedReindexRequest(BaseModel):
+    """Either `error_ids` (failure-driven retry) or `targets` (arbitrary
+    doc reindex). At least one must be non-empty."""
+
+    error_ids: list[int] | None = None
+    targets: list[DocumentTargetRequest] | None = None
+
+
+class TargetedReindexResponse(BaseModel):
+    targeted_reindex_job_id: int
+    queued_count: int
+    skipped_count: int
+
+
+class TargetedReindexJobStatusResponse(BaseModel):
+    id: int
+    status: IndexingStatus
+    requested_at: datetime.datetime
+    completed_at: datetime.datetime | None
+    target_count: int
+    resolved_count: int
+    still_failing_count: int
+    skipped_count: int
+    resolved_summary: list[dict[str, Any]]
+
+
+@router.post("/admin/indexing/targeted-reindex")
+def submit_targeted_reindex(
+    request: TargetedReindexRequest,
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TargetedReindexResponse:
+    error_ids = request.error_ids or []
+    target_specs_in: list[TargetSpec] = [
+        TargetSpec(cc_pair_id=t.cc_pair_id, document_id=t.document_id)
+        for t in (request.targets or [])
+    ]
+
+    if not error_ids and not target_specs_in:
+        raise HTTPException(
+            status_code=400,
+            detail="Either error_ids or targets must be provided.",
+        )
+
+    skipped_from_errors = 0
+    if error_ids:
+        derived, skipped_from_errors = resolve_error_ids_to_targets(
+            db_session, error_ids
+        )
+        target_specs_in.extend(derived)
+
+    if not target_specs_in:
+        # Everything was already resolved or invalid.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No actionable targets after resolving error_ids "
+                "(all were already resolved, entity-level, or invalid)."
+            ),
+        )
+
+    if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Too many targets: {len(target_specs_in)} > {MAX_TARGETS_PER_REQUEST}."
+            ),
+        )
+
+    try:
+        result = create_targeted_reindex_job(
+            db_session=db_session,
+            requested_by_user_id=user.id if user else None,
+            targets=target_specs_in,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    try:
+        celery_app.send_task(
+            OnyxCeleryTask.TARGETED_REINDEX_TASK,
+            kwargs={"targeted_reindex_job_id": result.targeted_reindex_job_id},
+            queue=OnyxCeleryQueues.TARGETED_REINDEX,
+            priority=OnyxCeleryPriority.HIGHEST,
+            task_id=result.celery_task_id,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to enqueue targeted reindex task",
+            extra={"job_id": result.targeted_reindex_job_id},
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Failed to enqueue targeted reindex task.",
+        )
+
+    return TargetedReindexResponse(
+        targeted_reindex_job_id=result.targeted_reindex_job_id,
+        queued_count=result.queued_count,
+        skipped_count=result.skipped_count + skipped_from_errors,
+    )
+
+
+@router.get("/admin/indexing/targeted-reindex/{job_id}")
+def get_targeted_reindex_status(
+    job_id: int,
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> TargetedReindexJobStatusResponse:
+    job = get_targeted_reindex_job(db_session, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found.")
+
+    return TargetedReindexJobStatusResponse(
+        id=job.id,
+        status=job.status,
+        requested_at=job.requested_at,
+        completed_at=job.completed_at,
+        target_count=count_targets_for_job(db_session, job.id),
+        resolved_count=job.resolved_count,
+        still_failing_count=job.still_failing_count,
+        skipped_count=job.skipped_count,
+        resolved_summary=job.resolved_summary,
+    )

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -117,6 +117,7 @@ def submit_targeted_reindex(
             db_session=db_session,
             requested_by_user_id=user.id if user else None,
             targets=target_specs_in,
+            upstream_skipped_count=skipped_from_errors,
         )
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e))
@@ -151,7 +152,7 @@ def submit_targeted_reindex(
     return TargetedReindexResponse(
         targeted_reindex_job_id=result.targeted_reindex_job_id,
         queued_count=result.queued_count,
-        skipped_count=result.skipped_count + skipped_from_errors,
+        skipped_count=result.skipped_count,
     )
 
 

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -121,10 +121,15 @@ def submit_targeted_reindex(
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e))
 
     try:
+        # Route to the existing PRIMARY queue. The design has the trigger
+        # task running on the primary worker that already owns the
+        # indexing scheduler. Per-cc-pair fan-out (connector fetch +
+        # docprocessing) hands off to the existing docfetching/
+        # docprocessing queues from inside the task body.
         celery_app.send_task(
             OnyxCeleryTask.TARGETED_REINDEX_TASK,
             kwargs={"targeted_reindex_job_id": result.targeted_reindex_job_id},
-            queue=OnyxCeleryQueues.TARGETED_REINDEX,
+            queue=OnyxCeleryQueues.PRIMARY,
             priority=OnyxCeleryPriority.HIGHEST,
             task_id=result.celery_task_id,
         )

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -81,31 +81,23 @@ def submit_targeted_reindex(
     db_session: Session = Depends(get_session),
 ) -> TargetedReindexResponse:
     error_ids = request.error_ids or []
-    manual_specs: list[TargetSpec] = [
+    target_specs_in: list[TargetSpec] = [
         TargetSpec(cc_pair_id=t.cc_pair_id, document_id=t.document_id)
         for t in (request.targets or [])
     ]
 
-    if not error_ids and not manual_specs:
+    if not error_ids and not target_specs_in:
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
             "Either error_ids or targets must be provided.",
         )
 
     skipped_from_errors = 0
-    derived: list[TargetSpec] = []
     if error_ids:
         derived, skipped_from_errors = resolve_error_ids_to_targets(
             db_session, error_ids
         )
-
-    # Order matters: dedup in create_targeted_reindex_job keeps the first
-    # occurrence of each (cc_pair_id, document_id). Error-derived specs
-    # carry `source_error_id` and the manual ones don't, so derived must
-    # come first — otherwise the dedup drops the error linkage and the
-    # task's resolution-tracking step never marks the source error
-    # `is_resolved=True`.
-    target_specs_in: list[TargetSpec] = derived + manual_specs
+        target_specs_in.extend(derived)
 
     if not target_specs_in:
         raise OnyxError(

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -81,23 +81,31 @@ def submit_targeted_reindex(
     db_session: Session = Depends(get_session),
 ) -> TargetedReindexResponse:
     error_ids = request.error_ids or []
-    target_specs_in: list[TargetSpec] = [
+    manual_specs: list[TargetSpec] = [
         TargetSpec(cc_pair_id=t.cc_pair_id, document_id=t.document_id)
         for t in (request.targets or [])
     ]
 
-    if not error_ids and not target_specs_in:
+    if not error_ids and not manual_specs:
         raise OnyxError(
             OnyxErrorCode.VALIDATION_ERROR,
             "Either error_ids or targets must be provided.",
         )
 
     skipped_from_errors = 0
+    derived: list[TargetSpec] = []
     if error_ids:
         derived, skipped_from_errors = resolve_error_ids_to_targets(
             db_session, error_ids
         )
-        target_specs_in.extend(derived)
+
+    # Order matters: dedup in create_targeted_reindex_job keeps the first
+    # occurrence of each (cc_pair_id, document_id). Error-derived specs
+    # carry `source_error_id` and the manual ones don't, so derived must
+    # come first — otherwise the dedup drops the error linkage and the
+    # task's resolution-tracking step never marks the source error
+    # `is_resolved=True`.
+    target_specs_in: list[TargetSpec] = derived + manual_specs
 
     if not target_specs_in:
         raise OnyxError(

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -1,0 +1,243 @@
+"""External dependency unit tests for `create_targeted_reindex_job`.
+
+Validates that submitting a targeted reindex request:
+- writes the job row + target rows + per-cc-pair synthetic IndexAttempts
+- pre-allocates a celery task UUID
+- dedupes (cc_pair, document_id) pairs
+- enforces the MAX_TARGETS_PER_REQUEST cap
+- raises on unknown cc_pair_id
+- correctly resolves error IDs into targets, skipping already-resolved
+  and entity-level rows
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import TargetedReindexJob
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.targeted_reindex import create_targeted_reindex_job
+from onyx.db.targeted_reindex import get_targeted_reindex_job
+from onyx.db.targeted_reindex import MAX_TARGETS_PER_REQUEST
+from onyx.db.targeted_reindex import resolve_error_ids_to_targets
+from onyx.db.targeted_reindex import TargetSpec
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        # FK order: targets → errors → attempts → job
+        db_session.query(TargetedReindexJobTarget).delete(synchronize_session="fetch")
+        db_session.query(IndexAttemptError).delete(synchronize_session="fetch")
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(TargetedReindexJob).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_create_job_writes_rows_and_synthetic_attempt(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    targets = [
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1"),
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-2"),
+    ]
+
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    assert result.queued_count == 2
+    assert result.skipped_count == 0
+    assert result.celery_task_id  # non-empty UUID
+    assert len(result.synthetic_attempt_ids) == 1  # one cc_pair → one attempt
+
+    job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.celery_task_id == result.celery_task_id
+    assert job.status == IndexingStatus.NOT_STARTED
+
+    target_rows = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id
+            == result.targeted_reindex_job_id
+        )
+        .all()
+    )
+    assert {t.document_id for t in target_rows} == {"doc-1", "doc-2"}
+    assert all(t.source_error_id is None for t in target_rows)
+
+    attempts = (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
+        .all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].connector_credential_pair_id == cc_pair.id
+    assert attempts[0].status == IndexingStatus.NOT_STARTED
+
+
+def test_create_job_dedups_duplicate_targets(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    targets = [
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1"),
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1"),
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-2"),
+    ]
+
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    assert result.queued_count == 2
+    assert result.skipped_count == 1
+
+
+def test_create_job_rejects_too_many_targets(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    too_many = [
+        TargetSpec(cc_pair_id=cc_pair.id, document_id=f"doc-{i}")
+        for i in range(MAX_TARGETS_PER_REQUEST + 1)
+    ]
+
+    with pytest.raises(ValueError, match="too many targets"):
+        create_targeted_reindex_job(
+            db_session=db_session, requested_by_user_id=None, targets=too_many
+        )
+
+
+def test_create_job_rejects_unknown_cc_pair(db_session: Session) -> None:
+    targets = [TargetSpec(cc_pair_id=999_999_999, document_id="doc-1")]
+
+    with pytest.raises(ValueError, match="unknown cc_pair_ids"):
+        create_targeted_reindex_job(
+            db_session=db_session, requested_by_user_id=None, targets=targets
+        )
+
+
+def test_create_job_rejects_empty_targets(db_session: Session) -> None:
+    with pytest.raises(ValueError, match="at least one target"):
+        create_targeted_reindex_job(
+            db_session=db_session, requested_by_user_id=None, targets=[]
+        )
+
+
+def test_resolve_error_ids_to_targets(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Failure-driven retry: the API accepts error IDs and resolves them
+    to targets. Already-resolved errors and entity-level errors are skipped."""
+    settings = get_current_search_settings(db_session)
+    parent_attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent_attempt)
+    db_session.commit()
+    db_session.refresh(parent_attempt)
+
+    actionable = IndexAttemptError(
+        index_attempt_id=parent_attempt.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="actionable-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    already_resolved = IndexAttemptError(
+        index_attempt_id=parent_attempt.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="resolved-doc",
+        failure_message="boom",
+        is_resolved=True,
+    )
+    entity_level = IndexAttemptError(
+        index_attempt_id=parent_attempt.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id=None,  # entity-level, no doc_id
+        entity_id="some-entity",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add_all([actionable, already_resolved, entity_level])
+    db_session.commit()
+    db_session.refresh(actionable)
+    db_session.refresh(already_resolved)
+    db_session.refresh(entity_level)
+
+    targets, skipped = resolve_error_ids_to_targets(
+        db_session,
+        [actionable.id, already_resolved.id, entity_level.id, 999_999_999],
+    )
+
+    assert len(targets) == 1
+    assert targets[0].document_id == "actionable-doc"
+    assert targets[0].source_error_id == actionable.id
+    # 1 already-resolved + 1 entity-level + 1 invalid id = 3 skipped
+    assert skipped == 3
+
+
+def test_create_job_preserves_source_error_id_on_target_row(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Failure-derived targets carry source_error_id through to the
+    target row so the celery task can resolve the error at completion."""
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="failed-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    derived, skipped = resolve_error_ids_to_targets(db_session, [err.id])
+    assert skipped == 0
+    assert len(derived) == 1
+
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=derived
+    )
+
+    target_row = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id
+            == result.targeted_reindex_job_id
+        )
+        .one()
+    )
+    assert target_row.source_error_id == err.id

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -118,6 +118,38 @@ def test_create_job_dedups_duplicate_targets(
     assert result.queued_count == 2
     assert result.skipped_count == 1
 
+    # GET endpoint reads from job row, so the create-time skip count must
+    # be persisted there too.
+    job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.skipped_count == 1
+
+
+def test_create_job_persists_upstream_skipped_count(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """API layer counts errors that resolved to no-op (already resolved,
+    entity-level, invalid id) as skipped. That count is `upstream_skipped_count`
+    and must end up on the job row so GET returns it before the task runs."""
+    targets = [
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1"),
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1"),  # 1 dedup skip
+    ]
+
+    result = create_targeted_reindex_job(
+        db_session=db_session,
+        requested_by_user_id=None,
+        targets=targets,
+        upstream_skipped_count=3,  # e.g. 3 unresolvable error_ids
+    )
+
+    # 1 dedup + 3 upstream
+    assert result.skipped_count == 4
+
+    job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.skipped_count == 4
+
 
 def test_create_job_rejects_too_many_targets(
     db_session: Session, cc_pair: ConnectorCredentialPair

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -281,3 +281,32 @@ def test_create_job_preserves_source_error_id_on_target_row(
         .one()
     )
     assert target_row.source_error_id == err.id
+
+
+def test_create_job_dedup_keeps_source_error_id_when_overlapping(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """If the same (cc_pair, doc) appears in both the error-derived and
+    arbitrary buckets, the error-derived one (carrying source_error_id)
+    must win the dedup so the task can mark the error resolved."""
+    error_derived = TargetSpec(
+        cc_pair_id=cc_pair.id, document_id="dup-doc", source_error_id=42
+    )
+    manual_dup = TargetSpec(cc_pair_id=cc_pair.id, document_id="dup-doc")
+
+    # Pass derived first (matches API endpoint ordering after the fix).
+    result = create_targeted_reindex_job(
+        db_session=db_session,
+        requested_by_user_id=None,
+        targets=[error_derived, manual_dup],
+    )
+
+    target_row = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id
+            == result.targeted_reindex_job_id
+        )
+        .one()
+    )
+    assert target_row.source_error_id == 42

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -66,7 +66,15 @@ def test_create_job_writes_rows_and_synthetic_attempt(
     assert result.queued_count == 2
     assert result.skipped_count == 0
     assert result.celery_task_id  # non-empty UUID
-    assert len(result.synthetic_attempt_ids) == 1  # one cc_pair → one attempt
+    # One synthetic attempt per (cc_pair × active search settings). Test env
+    # may have PRESENT only or PRESENT+FUTURE, so just assert all attempts
+    # belong to our cc_pair and the (cc_pair, search_settings) tuples are
+    # unique.
+    assert len(result.synthetic_attempt_ids) >= 1
+    assert {p[0] for p in result.cc_pair_search_settings_pairs} == {cc_pair.id}
+    assert len(set(result.cc_pair_search_settings_pairs)) == len(
+        result.cc_pair_search_settings_pairs
+    )
 
     job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
     assert job is not None
@@ -89,9 +97,9 @@ def test_create_job_writes_rows_and_synthetic_attempt(
         .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
         .all()
     )
-    assert len(attempts) == 1
-    assert attempts[0].connector_credential_pair_id == cc_pair.id
-    assert attempts[0].status == IndexingStatus.NOT_STARTED
+    assert len(attempts) == len(result.synthetic_attempt_ids)
+    assert {a.connector_credential_pair_id for a in attempts} == {cc_pair.id}
+    assert all(a.status == IndexingStatus.NOT_STARTED for a in attempts)
 
 
 def test_create_job_dedups_duplicate_targets(

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -289,8 +289,30 @@ def test_create_job_dedup_keeps_source_error_id_when_overlapping(
     """If the same (cc_pair, doc) appears in both the error-derived and
     arbitrary buckets, the error-derived one (carrying source_error_id)
     must win the dedup so the task can mark the error resolved."""
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="dup-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
     error_derived = TargetSpec(
-        cc_pair_id=cc_pair.id, document_id="dup-doc", source_error_id=42
+        cc_pair_id=cc_pair.id, document_id="dup-doc", source_error_id=err.id
     )
     manual_dup = TargetSpec(cc_pair_id=cc_pair.id, document_id="dup-doc")
 
@@ -309,4 +331,4 @@ def test_create_job_dedup_keeps_source_error_id_when_overlapping(
         )
         .one()
     )
-    assert target_row.source_error_id == 42
+    assert target_row.source_error_id == err.id

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -316,11 +316,64 @@ def test_create_job_dedup_keeps_source_error_id_when_overlapping(
     )
     manual_dup = TargetSpec(cc_pair_id=cc_pair.id, document_id="dup-doc")
 
-    # Pass derived first (matches API endpoint ordering after the fix).
+    # Pass derived first.
     result = create_targeted_reindex_job(
         db_session=db_session,
         requested_by_user_id=None,
         targets=[error_derived, manual_dup],
+    )
+
+    target_row = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id
+            == result.targeted_reindex_job_id
+        )
+        .one()
+    )
+    assert target_row.source_error_id == err.id
+
+
+def test_create_job_dedup_prefers_source_error_id_regardless_of_order(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """The dedup must pick the linkage-bearing spec independent of
+    input order. Same scenario as the previous test, but manual is
+    passed FIRST. Without the prefer-linkage rule, last-in or
+    first-in semantics would drop source_error_id depending on which
+    side ordered the list."""
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="dup-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    manual_dup = TargetSpec(cc_pair_id=cc_pair.id, document_id="dup-doc")
+    error_derived = TargetSpec(
+        cc_pair_id=cc_pair.id, document_id="dup-doc", source_error_id=err.id
+    )
+
+    # Manual first this time. Linkage-bearing spec must still win.
+    result = create_targeted_reindex_job(
+        db_session=db_session,
+        requested_by_user_id=None,
+        targets=[manual_dup, error_derived],
     )
 
     target_row = (


### PR DESCRIPTION
## Description

Adds the request-receiving half of the targeted-reindex flow.

`POST /manage/admin/indexing/targeted-reindex`
- Accepts `error_ids` (failure-driven retry) and/or arbitrary `(cc_pair_id, document_id)` pairs.
- Validates, dedups, caps at 100, rejects entity-level errors and already-resolved errors.
- Writes the job row + per-doc target rows + one synthetic `IndexAttempt` per `(cc_pair_id, search_settings_id)` the targets span (so PRESENT+FUTURE indexes both get the reindex during a model swap).
- Enqueues the celery task with the pre-allocated UUID at `OnyxCeleryPriority.HIGHEST` on the existing `PRIMARY` queue. The trigger task itself owns the indexing scheduler; per-cc-pair fan-out hands off to the existing docfetching/docprocessing queues from inside the task body.
- Propagates `tenant_id` through `kwargs` so `TenantAwareTask` runs against the right schema.

`GET /manage/admin/indexing/targeted-reindex/{job_id}`
- Returns current status + counts for the FE to poll.

The celery task is a **stub** for now: transitions the job to `IN_PROGRESS` then `SUCCESS` without doing real reindex work. The real lifecycle + resolution tracking land in #10829; connector + pipeline plumbing lands in a follow-up. The stub exists so the task name resolves at the worker and the API path's `apply_async` doesn't fail with "unknown task."

The flow bypasses `try_create_index_attempt` — full crawls are allowed to overlap with retries by design (per-doc row-locks handle write conflicts; consumer queries already filter retry attempts via `ignore_targeted_reindex=True`).

Builds on the merged schema PR (#10747) and consumer-filters PR (#10764).

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

7 tests in \`backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py\` against real Postgres:
- Row creation: job + targets + synthetic IndexAttempt(s)
- Dedup of duplicate \`(cc_pair_id, document_id)\` pairs
- Max-targets cap enforcement
- Unknown cc_pair rejection
- Empty-input rejection
- Error-id resolution (already-resolved + entity-level rows skipped)
- \`source_error_id\` propagation to target rows

All green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
