### PR TITLE
feat(targeted-reindex): celery task lifecycle + resolution tracking

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -28,74 +28,21 @@ loop and pipes yielded `Document` objects through
 import datetime
 import logging
 from collections import defaultdict
-from typing import Any
 
 from celery import shared_task
 from celery import Task
-from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
-from onyx.db.models import IndexAttempt
-from onyx.db.models import IndexAttemptError
-from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.targeted_reindex import get_index_attempts_for_targeted_reindex_job
 from onyx.db.targeted_reindex import get_targeted_reindex_job
+from onyx.db.targeted_reindex import get_targets_for_job
+from onyx.db.targeted_reindex import resolve_failure_derived_targets
 
 _TARGETED_REINDEX_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
 _TARGETED_REINDEX_TIME_LIMIT = _TARGETED_REINDEX_SOFT_TIME_LIMIT + 60
-
-
-def _resolve_failure_derived_targets(
-    db_session: Session, job_id: int
-) -> tuple[int, list[dict[str, Any]]]:
-    """Mark `IndexAttemptError` rows resolved for every target whose
-    `source_error_id` is set. Returns `(resolved_count, summary)`.
-
-    `summary` is a snapshot of the cleared error rows captured before
-    we update them, so it survives the eventual retention cleanup of
-    `index_attempt_errors`.
-    """
-    target_rows = (
-        db_session.query(TargetedReindexJobTarget)
-        .filter(
-            TargetedReindexJobTarget.targeted_reindex_job_id == job_id,
-            TargetedReindexJobTarget.source_error_id.isnot(None),
-        )
-        .all()
-    )
-    if not target_rows:
-        return 0, []
-
-    error_ids = [
-        t.source_error_id for t in target_rows if t.source_error_id is not None
-    ]
-    error_rows = (
-        db_session.query(IndexAttemptError)
-        .filter(
-            IndexAttemptError.id.in_(error_ids),
-            IndexAttemptError.is_resolved.is_(False),
-        )
-        .all()
-    )
-
-    summary = [
-        {
-            "id": e.id,
-            "document_id": e.document_id,
-            "failure_message": e.failure_message,
-            "error_type": e.error_type,
-            "connector_credential_pair_id": e.connector_credential_pair_id,
-            "index_attempt_id": e.index_attempt_id,
-        }
-        for e in error_rows
-    ]
-
-    for e in error_rows:
-        e.is_resolved = True
-
-    return len(error_rows), summary
 
 
 def run_targeted_reindex(
@@ -123,10 +70,8 @@ def run_targeted_reindex(
             return
 
         # 1. transition synthetic IndexAttempts + job to IN_PROGRESS.
-        attempts = (
-            db_session.query(IndexAttempt)
-            .filter(IndexAttempt.targeted_reindex_job_id == targeted_reindex_job_id)
-            .all()
+        attempts = get_index_attempts_for_targeted_reindex_job(
+            db_session, targeted_reindex_job_id
         )
         for attempt in attempts:
             attempt.status = IndexingStatus.IN_PROGRESS
@@ -139,15 +84,8 @@ def run_targeted_reindex(
         runtime_skipped = 0
         try:
             # 2. group targets by cc_pair (the unit of connector invocation).
-            target_rows = (
-                db_session.query(TargetedReindexJobTarget)
-                .filter(
-                    TargetedReindexJobTarget.targeted_reindex_job_id
-                    == targeted_reindex_job_id
-                )
-                .all()
-            )
-            by_cc_pair: dict[int, list[TargetedReindexJobTarget]] = defaultdict(list)
+            target_rows = get_targets_for_job(db_session, targeted_reindex_job_id)
+            by_cc_pair: dict[int, list] = defaultdict(list)
             for t in target_rows:
                 by_cc_pair[t.cc_pair_id].append(t)
 
@@ -164,7 +102,7 @@ def run_targeted_reindex(
 
             # 4. resolution tracking: walk failure-derived targets and clear
             #    their error rows.
-            resolved_count, summary = _resolve_failure_derived_targets(
+            resolved_count, summary = resolve_failure_derived_targets(
                 db_session, targeted_reindex_job_id
             )
 
@@ -207,13 +145,8 @@ def run_targeted_reindex(
                 db_session.rollback()
                 job = get_targeted_reindex_job(db_session, targeted_reindex_job_id)
                 if job is not None and not job.status.is_terminal():
-                    attempts = (
-                        db_session.query(IndexAttempt)
-                        .filter(
-                            IndexAttempt.targeted_reindex_job_id
-                            == targeted_reindex_job_id
-                        )
-                        .all()
+                    attempts = get_index_attempts_for_targeted_reindex_job(
+                        db_session, targeted_reindex_job_id
                     )
                     now = datetime.datetime.now(datetime.timezone.utc)
                     for attempt in attempts:

--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -1,32 +1,241 @@
 """Celery task for executing a targeted reindex.
 
-Stub for now: transitions the job to IN_PROGRESS, then to a terminal
-state without doing any actual reindex work. The real implementation
-(connector.reindex(), pipeline plumbing, error resolution, stale-write
-mitigation) lands in the follow-up PR.
+This task wires the job-and-target rows persisted by the API to the
+synthetic IndexAttempt(s) that drive per-cc-pair execution. It handles
+lifecycle transitions, batches per-cc-pair execution, and updates
+resolution tracking on `index_attempt_errors` for targets that came
+in as failure-derived retries.
 
-Lives here so the task name is registered with the celery app and the
-API path's `apply_async` resolves. Without this stub, the task name
-would route to a non-existent handler and the worker would log
-`unknown task` errors on every retry submission.
+The actual connector invocation and indexing pipeline call still
+need to be plumbed — that's the follow-up. This task currently:
+
+  - loads the job + targets, groups them by cc_pair
+  - transitions each linked synthetic IndexAttempt through
+    NOT_STARTED → IN_PROGRESS → SUCCESS
+  - marks every `IndexAttemptError` referenced by a target's
+    `source_error_id` as resolved at completion (preserves the
+    contract the FE polls)
+  - snapshots `resolved_summary` for audit
+  - updates `resolved_count` / `still_failing_count` / `skipped_count`
+    on the job row
+  - transitions the job to a terminal state
+
+The follow-up adds the `connector.reindex()` call inside the per-cc-pair
+loop and pipes yielded `Document` objects through
+`index_doc_batch_with_handler`.
 """
 
 import datetime
 import logging
+from collections import defaultdict
+from typing import Any
 
 from celery import shared_task
 from celery import Task
+from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import TargetedReindexJobTarget
 from onyx.db.targeted_reindex import get_targeted_reindex_job
 
-# Soft and hard time limits scoped generously for the eventual real
-# implementation; stub completes in milliseconds.
 _TARGETED_REINDEX_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
 _TARGETED_REINDEX_TIME_LIMIT = _TARGETED_REINDEX_SOFT_TIME_LIMIT + 60
+
+
+def _resolve_failure_derived_targets(
+    db_session: Session, job_id: int
+) -> tuple[int, list[dict[str, Any]]]:
+    """Mark `IndexAttemptError` rows resolved for every target whose
+    `source_error_id` is set. Returns `(resolved_count, summary)`.
+
+    `summary` is a snapshot of the cleared error rows captured before
+    we update them, so it survives the eventual retention cleanup of
+    `index_attempt_errors`.
+    """
+    target_rows = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id == job_id,
+            TargetedReindexJobTarget.source_error_id.isnot(None),
+        )
+        .all()
+    )
+    if not target_rows:
+        return 0, []
+
+    error_ids = [
+        t.source_error_id for t in target_rows if t.source_error_id is not None
+    ]
+    error_rows = (
+        db_session.query(IndexAttemptError)
+        .filter(
+            IndexAttemptError.id.in_(error_ids),
+            IndexAttemptError.is_resolved.is_(False),
+        )
+        .all()
+    )
+
+    summary = [
+        {
+            "id": e.id,
+            "document_id": e.document_id,
+            "failure_message": e.failure_message,
+            "error_type": e.error_type,
+            "connector_credential_pair_id": e.connector_credential_pair_id,
+            "index_attempt_id": e.index_attempt_id,
+        }
+        for e in error_rows
+    ]
+
+    for e in error_rows:
+        e.is_resolved = True
+
+    return len(error_rows), summary
+
+
+def run_targeted_reindex(
+    targeted_reindex_job_id: int,
+    celery_task_id: str | None = None,
+) -> None:
+    """Body of the targeted-reindex task. Lifted out of the @shared_task
+    decorator so tests can call it directly without going through
+    celery's binding machinery."""
+    log = logging.LoggerAdapter(
+        task_logger,
+        extra={
+            "targeted_reindex_job_id": targeted_reindex_job_id,
+            "celery_task_id": celery_task_id,
+        },
+    )
+
+    with get_session_with_current_tenant() as db_session:
+        job = get_targeted_reindex_job(db_session, targeted_reindex_job_id)
+        if job is None:
+            log.warning("Job not found, dropping task")
+            return
+        if job.status.is_terminal():
+            log.info("Job already terminal, dropping task")
+            return
+
+        # 1. transition synthetic IndexAttempts + job to IN_PROGRESS.
+        attempts = (
+            db_session.query(IndexAttempt)
+            .filter(IndexAttempt.targeted_reindex_job_id == targeted_reindex_job_id)
+            .all()
+        )
+        for attempt in attempts:
+            attempt.status = IndexingStatus.IN_PROGRESS
+            attempt.time_started = datetime.datetime.now(datetime.timezone.utc)
+        job.status = IndexingStatus.IN_PROGRESS
+        db_session.commit()
+
+        resolved_count = 0
+        still_failing_count = 0
+        runtime_skipped = 0
+        try:
+            # 2. group targets by cc_pair (the unit of connector invocation).
+            target_rows = (
+                db_session.query(TargetedReindexJobTarget)
+                .filter(
+                    TargetedReindexJobTarget.targeted_reindex_job_id
+                    == targeted_reindex_job_id
+                )
+                .all()
+            )
+            by_cc_pair: dict[int, list[TargetedReindexJobTarget]] = defaultdict(list)
+            for t in target_rows:
+                by_cc_pair[t.cc_pair_id].append(t)
+
+            log.info(
+                "Targeted reindex starting: %d cc_pair(s), %d target(s)",
+                len(by_cc_pair),
+                len(target_rows),
+            )
+
+            # 3. per-cc-pair work. Connector.reindex() and pipeline integration
+            #    are the follow-up; for now we simply count what was requested
+            #    and let the lifecycle code below mark the job complete.
+            total_attempted = len(target_rows)
+
+            # 4. resolution tracking: walk failure-derived targets and clear
+            #    their error rows.
+            resolved_count, summary = _resolve_failure_derived_targets(
+                db_session, targeted_reindex_job_id
+            )
+
+            # 5. terminal state on synthetic IndexAttempts.
+            for attempt in attempts:
+                attempt.status = IndexingStatus.SUCCESS
+                attempt.time_updated = datetime.datetime.now(datetime.timezone.utc)
+
+            # 6. terminal state on the job + counters + summary snapshot.
+            # `still_failing_count` stays 0 here; the connector-invocation
+            # follow-up bumps it when the connector yields ConnectorFailure.
+            # `runtime_skipped` is whatever fell through the per-target
+            # loop without resolving or still-failing. It is added on top
+            # of the create-time skipped_count (dedup + upstream errors
+            # the API already counted) so the three counters always reflect
+            # the total skip universe across both phases.
+            runtime_skipped = max(
+                0, total_attempted - resolved_count - still_failing_count
+            )
+            job.resolved_count = resolved_count
+            job.still_failing_count = still_failing_count
+            job.skipped_count = (job.skipped_count or 0) + runtime_skipped
+            job.resolved_summary = summary
+            job.completed_at = datetime.datetime.now(datetime.timezone.utc)
+            job.status = IndexingStatus.SUCCESS
+
+            db_session.commit()
+        except Exception:
+            # Recover from any mid-task failure: roll back uncommitted
+            # work, then mark the job + synthetic IndexAttempts FAILED so
+            # the FE poll surfaces the failure instead of waiting on a
+            # row stuck in IN_PROGRESS forever.
+            #
+            # The cleanup itself is wrapped so a secondary failure (e.g.
+            # connection reset during the FAILED-state commit) does not
+            # mask the original exception: we always re-raise the root
+            # cause so celery records the right error.
+            log.exception("Targeted reindex task failed; marking job FAILED")
+            try:
+                db_session.rollback()
+                job = get_targeted_reindex_job(db_session, targeted_reindex_job_id)
+                if job is not None and not job.status.is_terminal():
+                    attempts = (
+                        db_session.query(IndexAttempt)
+                        .filter(
+                            IndexAttempt.targeted_reindex_job_id
+                            == targeted_reindex_job_id
+                        )
+                        .all()
+                    )
+                    now = datetime.datetime.now(datetime.timezone.utc)
+                    for attempt in attempts:
+                        if not attempt.status.is_terminal():
+                            attempt.status = IndexingStatus.FAILED
+                            attempt.time_updated = now
+                    job.status = IndexingStatus.FAILED
+                    job.completed_at = now
+                    db_session.commit()
+            except Exception:
+                log.exception(
+                    "Failed to mark job FAILED during error recovery; "
+                    "row may remain IN_PROGRESS until the celery retry"
+                )
+            raise
+
+    log.info(
+        "Targeted reindex done: resolved=%d runtime_skipped=%d still_failing=%d",
+        resolved_count,
+        runtime_skipped,
+        still_failing_count,
+    )
 
 
 @shared_task(
@@ -41,42 +250,7 @@ def targeted_reindex_task(
     targeted_reindex_job_id: int,
     tenant_id: str,  # noqa: ARG001  # consumed by TenantAwareTask wrapper
 ) -> None:
-    """Stub: mark the job IN_PROGRESS and immediately COMPLETED.
-
-    Real implementation in a follow-up PR will:
-      - load targets, group by cc_pair
-      - build connector for each cc_pair, call `connector.reindex(refs)`
-      - pipe Documents through `index_doc_batch_with_handler`
-      - mark `index_attempt_errors.is_resolved=True` for targets with
-        a non-null `source_error_id` whose docs successfully landed
-      - track `resolved_count` / `still_failing_count` on the job row
-      - snapshot `resolved_summary` at completion
-    """
-    log = logging.LoggerAdapter(
-        task_logger,
-        extra={
-            "targeted_reindex_job_id": targeted_reindex_job_id,
-            "celery_task_id": self.request.id,
-        },
+    run_targeted_reindex(
+        targeted_reindex_job_id=targeted_reindex_job_id,
+        celery_task_id=self.request.id,
     )
-    log.info("Targeted reindex task picked up job (stub implementation)")
-
-    with get_session_with_current_tenant() as db_session:
-        job = get_targeted_reindex_job(db_session, targeted_reindex_job_id)
-        if job is None:
-            log.warning("Job not found, dropping task")
-            return
-
-        if job.status.is_terminal():
-            log.info("Job already terminal, dropping task")
-            return
-
-        job.status = IndexingStatus.IN_PROGRESS
-        db_session.commit()
-
-        # Stub: nothing else to do yet. Mark complete.
-        job.status = IndexingStatus.SUCCESS
-        job.completed_at = datetime.datetime.now(datetime.timezone.utc)
-        db_session.commit()
-
-    log.info("Stub targeted reindex task done")

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -17,6 +17,7 @@ return the job_id + per-request counts for the API response.
 """
 
 from collections.abc import Sequence
+from typing import Any
 from uuid import UUID
 from uuid import uuid4
 
@@ -258,3 +259,77 @@ def count_targets_for_job(db_session: Session, job_id: int) -> int:
         .filter(TargetedReindexJobTarget.targeted_reindex_job_id == job_id)
         .count()
     )
+
+
+def get_targets_for_job(
+    db_session: Session, job_id: int
+) -> list[TargetedReindexJobTarget]:
+    """All target rows for a targeted-reindex job, in insertion order."""
+    return (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(TargetedReindexJobTarget.targeted_reindex_job_id == job_id)
+        .all()
+    )
+
+
+def get_index_attempts_for_targeted_reindex_job(
+    db_session: Session, job_id: int
+) -> list[IndexAttempt]:
+    """All synthetic IndexAttempts spawned for a targeted-reindex job."""
+    return (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == job_id)
+        .all()
+    )
+
+
+def resolve_failure_derived_targets(
+    db_session: Session,
+    job_id: int,
+) -> tuple[int, list[dict[str, Any]]]:
+    """Mark `IndexAttemptError` rows resolved for every target whose
+    `source_error_id` is set. Returns `(resolved_count, summary)`.
+
+    `summary` is a snapshot of the cleared error rows captured before
+    we update them, so it survives the eventual retention cleanup of
+    `index_attempt_errors`.
+    """
+    target_rows = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id == job_id,
+            TargetedReindexJobTarget.source_error_id.isnot(None),
+        )
+        .all()
+    )
+    if not target_rows:
+        return 0, []
+
+    error_ids = [
+        t.source_error_id for t in target_rows if t.source_error_id is not None
+    ]
+    error_rows = (
+        db_session.query(IndexAttemptError)
+        .filter(
+            IndexAttemptError.id.in_(error_ids),
+            IndexAttemptError.is_resolved.is_(False),
+        )
+        .all()
+    )
+
+    summary = [
+        {
+            "id": e.id,
+            "document_id": e.document_id,
+            "failure_message": e.failure_message,
+            "error_type": e.error_type,
+            "connector_credential_pair_id": e.connector_credential_pair_id,
+            "index_attempt_id": e.index_attempt_id,
+        }
+        for e in error_rows
+    ]
+
+    for e in error_rows:
+        e.is_resolved = True
+
+    return len(error_rows), summary

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
@@ -251,10 +251,13 @@ def test_task_marks_job_failed_on_mid_task_exception(
     )
 
     # Force the resolution-tracking helper to blow up after the
-    # IN_PROGRESS commit but before the SUCCESS commit.
+    # IN_PROGRESS commit but before the SUCCESS commit. Patch where
+    # the symbol is *imported* (the celery task module), not where it
+    # lives (onyx.db.targeted_reindex), so the local binding is the
+    # one replaced.
     with patch(
         "onyx.background.celery.tasks.docprocessing."
-        "targeted_reindex_task._resolve_failure_derived_targets",
+        "targeted_reindex_task.resolve_failure_derived_targets",
         side_effect=RuntimeError("simulated mid-task crash"),
     ):
         with pytest.raises(RuntimeError, match="simulated mid-task crash"):

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
@@ -1,0 +1,274 @@
+"""External dependency unit tests for the targeted reindex celery task.
+
+Covers the lifecycle and resolution-tracking layers of the task:
+- Job + synthetic IndexAttempt lifecycle transitions
+- Resolution tracking on `IndexAttemptError` rows referenced by targets
+  with `source_error_id`
+- Idempotent re-run (job already terminal → drop)
+- Resolved-summary snapshot
+
+Connector invocation + pipeline integration land in the follow-up
+PR; that path is intentionally out of scope here.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.docprocessing.targeted_reindex_task import (
+    run_targeted_reindex,
+)
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import TargetedReindexJob
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.targeted_reindex import create_targeted_reindex_job
+from onyx.db.targeted_reindex import resolve_error_ids_to_targets
+from onyx.db.targeted_reindex import TargetSpec
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.query(TargetedReindexJobTarget).delete(synchronize_session="fetch")
+        db_session.query(IndexAttemptError).delete(synchronize_session="fetch")
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(TargetedReindexJob).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _run_task(job_id: int) -> None:
+    """Invoke the task body synchronously, bypassing celery binding."""
+    run_targeted_reindex(
+        targeted_reindex_job_id=job_id, celery_task_id="test-celery-id"
+    )
+
+
+def test_task_transitions_job_to_terminal(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    targets = [TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1")]
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.status == IndexingStatus.SUCCESS
+    assert job.completed_at is not None
+
+
+def test_task_transitions_synthetic_attempts_to_success(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    targets = [TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1")]
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    attempts = (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
+        .all()
+    )
+    # One synthetic attempt per (cc_pair × active SearchSettings); CI may
+    # run with PRESENT+FUTURE active. Assert all of them transitioned.
+    assert len(attempts) >= 1
+    assert all(a.status == IndexingStatus.SUCCESS for a in attempts)
+
+
+def test_task_marks_failure_derived_errors_resolved(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="failed-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    derived, _ = resolve_error_ids_to_targets(db_session, [err.id])
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=derived
+    )
+
+    _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    err_after = db_session.get(IndexAttemptError, err.id)
+    assert err_after is not None
+    assert err_after.is_resolved is True
+
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.resolved_count == 1
+    assert job.still_failing_count == 0
+    assert len(job.resolved_summary) == 1
+    assert job.resolved_summary[0]["id"] == err.id
+    assert job.resolved_summary[0]["document_id"] == "failed-doc"
+
+
+def test_task_does_not_touch_arbitrary_targets(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Targets without `source_error_id` are arbitrary reindexes; they
+    have no error row to mark resolved, and the task must not crash on
+    their absence."""
+    targets = [
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="arb-1"),
+        TargetSpec(cc_pair_id=cc_pair.id, document_id="arb-2"),
+    ]
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.status == IndexingStatus.SUCCESS
+    assert job.resolved_count == 0
+    assert job.resolved_summary == []
+
+
+def test_task_skips_already_terminal_job(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """If the task is somehow re-delivered after the job already ran,
+    it must not attempt to re-run the work."""
+    targets = [TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1")]
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    job.status = IndexingStatus.SUCCESS
+    db_session.commit()
+
+    _run_task(result.targeted_reindex_job_id)
+
+    # synthetic attempt should NOT have been transitioned, since we
+    # bailed early.
+    db_session.expire_all()
+    attempts = (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
+        .all()
+    )
+    assert all(a.status == IndexingStatus.NOT_STARTED for a in attempts)
+
+
+def test_task_handles_mix_of_failure_derived_and_arbitrary(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A single job can carry both flavors of target. Failure-derived
+    ones get resolved; arbitrary ones contribute to skipped_count."""
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="failed-doc",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    derived, _ = resolve_error_ids_to_targets(db_session, [err.id])
+    arbitrary = [TargetSpec(cc_pair_id=cc_pair.id, document_id="arb-1")]
+    result = create_targeted_reindex_job(
+        db_session=db_session,
+        requested_by_user_id=None,
+        targets=[*derived, *arbitrary],
+    )
+
+    _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.resolved_count == 1
+    assert job.skipped_count == 1  # the arbitrary target had no error to clear
+
+
+def test_task_marks_job_failed_on_mid_task_exception(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Mid-task failure must transition the job + synthetic attempts to
+    FAILED rather than wedging in IN_PROGRESS forever."""
+    targets = [TargetSpec(cc_pair_id=cc_pair.id, document_id="doc-1")]
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+
+    # Force the resolution-tracking helper to blow up after the
+    # IN_PROGRESS commit but before the SUCCESS commit.
+    with patch(
+        "onyx.background.celery.tasks.docprocessing."
+        "targeted_reindex_task._resolve_failure_derived_targets",
+        side_effect=RuntimeError("simulated mid-task crash"),
+    ):
+        with pytest.raises(RuntimeError, match="simulated mid-task crash"):
+            _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.status == IndexingStatus.FAILED
+    assert job.completed_at is not None
+
+    attempts = (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
+        .all()
+    )
+    assert all(a.status == IndexingStatus.FAILED for a in attempts)


### PR DESCRIPTION
## Description

Stacks on #10828 (API + DB writes). Replaces the no-op stub task body with a real implementation that handles the lifecycle and resolution-tracking layers.

What this task does now:
- transitions the job + every linked synthetic \`IndexAttempt\` \`NOT_STARTED\` → \`IN_PROGRESS\` → \`SUCCESS\`
- marks \`IndexAttemptError.is_resolved=True\` for every target whose \`source_error_id\` is set
- snapshots \`resolved_summary\` so the audit survives later retention cleanup of \`index_attempt_errors\`
- updates \`resolved_count\` / \`skipped_count\` / \`still_failing_count\` on the job row
- on mid-task exception, marks job + non-terminal synthetic attempts \`FAILED\`, then re-raises so celery records the root cause; cleanup commit is wrapped so a secondary commit failure cannot mask the original exception

The task body is a plain function (\`run_targeted_reindex\`) wrapped by \`@shared_task\` to keep tests free of celery binding machinery.

What's still missing (next PR):
- the \`connector.reindex(refs, include_permissions=True)\` call inside the per-cc-pair loop
- piping yielded \`Document\` objects through \`index_doc_batch_with_handler\`
- \`still_failing_count\` increment when the connector yields \`ConnectorFailure\` instead of \`Document\`
- stale-write mitigation under \`prepare_to_modify_documents\`

The lifecycle and resolution-tracking layer landing here is what the FE polls and what the design's resolution-tracking contract depends on. Wiring the connector + pipeline is purely additive on top.

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

7 tests in \`backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py\` against real Postgres:
- Job transitions to terminal state
- Synthetic IndexAttempts transition to terminal state
- Failure-derived targets mark the matching \`IndexAttemptError\` rows as resolved
- Arbitrary targets are no-ops on the error path
- Already-terminal job is idempotent (task drops early on re-delivery)
- Mixed jobs: failure-derived + arbitrary in the same request
- Mid-task exception → job + synthetic attempts transition to \`FAILED\` (not stuck \`IN_PROGRESS\`)

All green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check