### PR TITLE
chore(format): apply black formatting to playwright_fetch.py

### DIFF
--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -122,8 +122,7 @@ def start_playwright() -> tuple[Playwright, BrowserContext]:
     )
 
     # Hide common automation tells used by bot-detection scripts.
-    context.add_init_script(
-        """
+    context.add_init_script("""
         Object.defineProperty(navigator, 'webdriver', {
             get: () => undefined
         });
@@ -133,8 +132,7 @@ def start_playwright() -> tuple[Playwright, BrowserContext]:
         Object.defineProperty(navigator, 'languages', {
             get: () => ['en-US', 'en']
         });
-    """
-    )
+    """)
 
     if (
         WEB_CONNECTOR_OAUTH_CLIENT_ID


### PR DESCRIPTION
## Summary
- Apply `black` formatting fix to `backend/onyx/utils/playwright_fetch.py` so it matches the pinned `black==26.3.1` style.
- Only change is the multi-line string passed to `context.add_init_script(...)` collapsing to the inline form `add_init_script("""...""")`.

## Test plan
- [x] `uvx black==26.3.1 --check backend/onyx/utils/playwright_fetch.py` passes.
- [x] `uvx ruff@0.12.0 check backend/onyx/utils/playwright_fetch.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied `black` formatting to `backend/onyx/utils/playwright_fetch.py` to match `black==26.3.1`. The multi-line script in `context.add_init_script` is now an inline triple-quoted string; no behavior change.

<sup>Written for commit c14e7d0e295aef20d4ac66a10fe43698d917e4a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

