### PR TITLE
fix(chat): kill scroll jitter and clean branch-arrow cancel

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -12,6 +12,7 @@ import { Button } from "@opal/components";
 import { SvgEdit } from "@opal/icons";
 import { Hoverable } from "@opal/core";
 import FileDisplay from "./FileDisplay";
+import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 
 interface MessageEditingProps {
   content: string;
@@ -132,6 +133,11 @@ const HumanMessage = React.memo(function HumanMessage({
   stopGenerating = () => null,
   disableSwitchingForStreaming = false,
 }: HumanMessageProps) {
+  const clearCurrentQueuedMessages = useChatSessionStore(
+    (state) => state.clearCurrentQueuedMessages
+  );
+  const abortSession = useChatSessionStore((state) => state.abortSession);
+
   // TODO (@raunakab):
   //
   // This is some duplicated state that is patching a memoization issue with `HumanMessage`.
@@ -261,6 +267,15 @@ const HumanMessage = React.memo(function HumanMessage({
                 currentPage={currentMessageInd + 1}
                 totalPages={otherMessagesCanSwitchTo.length}
                 handlePrevious={() => {
+                  // Branch switch — silently abandon the current turn and
+                  // any queued follow-ups so they don't auto-flush after
+                  // chatState transitions back to "input". Abort the local
+                  // stream consumer so its in-flight upserts can't
+                  // overwrite the branch flip we're about to apply.
+                  clearCurrentQueuedMessages();
+                  const sessionId =
+                    useChatSessionStore.getState().currentSessionId;
+                  if (sessionId) abortSession(sessionId);
                   stopGenerating();
                   const prevMessage = getPreviousMessage();
                   if (prevMessage !== undefined) {
@@ -268,6 +283,10 @@ const HumanMessage = React.memo(function HumanMessage({
                   }
                 }}
                 handleNext={() => {
+                  clearCurrentQueuedMessages();
+                  const sessionId =
+                    useChatSessionStore.getState().currentSessionId;
+                  if (sessionId) abortSession(sessionId);
                   stopGenerating();
                   const nextMessage = getNextMessage();
                   if (nextMessage !== undefined) {

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -140,8 +140,10 @@ interface ChatSessionStore {
   // Actions - Queued Messages
   enqueueMessage: (sessionId: string, message: string) => void;
   removeQueuedMessage: (sessionId: string, index: number) => void;
+  clearQueuedMessages: (sessionId: string) => void;
   enqueueCurrentMessage: (message: string) => void;
   removeCurrentQueuedMessage: (index: number) => void;
+  clearCurrentQueuedMessages: () => void;
 
   // Actions - Abort Controllers
   setAbortController: (sessionId: string, controller: AbortController) => void;
@@ -539,6 +541,29 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
     const { currentSessionId } = get();
     if (currentSessionId) {
       get().removeQueuedMessage(currentSessionId, index);
+    }
+  },
+
+  clearQueuedMessages: (sessionId: string) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session || session.queuedMessages.length === 0) {
+        return state;
+      }
+      const updatedSession = {
+        ...session,
+        queuedMessages: [],
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  clearCurrentQueuedMessages: () => {
+    const { currentSessionId } = get();
+    if (currentSessionId) {
+      get().clearQueuedMessages(currentSessionId);
     }
   },
 

--- a/web/src/components/chat/DynamicBottomSpacer.tsx
+++ b/web/src/components/chat/DynamicBottomSpacer.tsx
@@ -34,8 +34,12 @@ const DynamicBottomSpacer = React.memo(
     const isStreaming = chatState === "streaming" || chatState === "loading";
 
     // Get scroll container refs from context (provided by ChatScrollContainer)
-    const { scrollContainerRef, contentWrapperRef, spacerHeightRef } =
-      useScrollContainer();
+    const {
+      scrollContainerRef,
+      contentWrapperRef,
+      spacerHeightRef,
+      userScrolledUpRef,
+    } = useScrollContainer();
 
     // Track state with refs to avoid re-renders
     const isActiveRef = useRef(false);
@@ -169,6 +173,13 @@ const DynamicBottomSpacer = React.memo(
 
       const scrollContainer = getScrollContainer();
       if (!scrollContainer) return;
+
+      // Don't yank the user back if they've manually scrolled up.
+      // userScrolledUpRef is only set by handleScroll's scrolled-up branch,
+      // so it's not subject to flaky layout math.
+      if (userScrolledUpRef.current) {
+        return;
+      }
 
       // Get measurements first (before modifying spacer)
       const viewportHeight = scrollContainer.clientHeight;

--- a/web/src/components/chat/ScrollContainerContext.tsx
+++ b/web/src/components/chat/ScrollContainerContext.tsx
@@ -13,6 +13,10 @@ interface ScrollContainerContextType {
   contentWrapperRef: RefObject<HTMLDivElement | null>;
   /** Shared ref for the DynamicBottomSpacer's current height (written by spacer, read by scroll container). */
   spacerHeightRef: MutableRefObject<number>;
+  /** Shared ref tracking whether the user is at the bottom (written by ChatScrollContainer's scroll handler, read by descendants like DynamicBottomSpacer). Reflects the position BEFORE the most recent content mutation. */
+  isAtBottomRef: MutableRefObject<boolean>;
+  /** True iff the user has manually scrolled up since the last bottom-anchored scroll. Updated only by handleScroll's scrolled-up detection (no flaky layout math). Consumers (anchor effect, DynamicBottomSpacer) read this to gate hoist behavior. */
+  userScrolledUpRef: MutableRefObject<boolean>;
 }
 
 const ScrollContainerContext = createContext<
@@ -24,18 +28,34 @@ export function ScrollContainerProvider({
   scrollContainerRef,
   contentWrapperRef,
   spacerHeightRef,
+  isAtBottomRef,
+  userScrolledUpRef,
 }: {
   children: React.ReactNode;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   contentWrapperRef: RefObject<HTMLDivElement | null>;
   spacerHeightRef: MutableRefObject<number>;
+  isAtBottomRef: MutableRefObject<boolean>;
+  userScrolledUpRef: MutableRefObject<boolean>;
 }) {
   // Memoize context value to prevent unnecessary re-renders of consumers.
   // The refs themselves are stable, but without memoization, a new object
   // would be created on every parent re-render.
   const value = useMemo(
-    () => ({ scrollContainerRef, contentWrapperRef, spacerHeightRef }),
-    [scrollContainerRef, contentWrapperRef, spacerHeightRef]
+    () => ({
+      scrollContainerRef,
+      contentWrapperRef,
+      spacerHeightRef,
+      isAtBottomRef,
+      userScrolledUpRef,
+    }),
+    [
+      scrollContainerRef,
+      contentWrapperRef,
+      spacerHeightRef,
+      isAtBottomRef,
+      userScrolledUpRef,
+    ]
   );
 
   return (

--- a/web/src/components/chat/ScrollContainerContext.tsx
+++ b/web/src/components/chat/ScrollContainerContext.tsx
@@ -13,9 +13,7 @@ interface ScrollContainerContextType {
   contentWrapperRef: RefObject<HTMLDivElement | null>;
   /** Shared ref for the DynamicBottomSpacer's current height (written by spacer, read by scroll container). */
   spacerHeightRef: MutableRefObject<number>;
-  /** Shared ref tracking whether the user is at the bottom (written by ChatScrollContainer's scroll handler, read by descendants like DynamicBottomSpacer). Reflects the position BEFORE the most recent content mutation. */
-  isAtBottomRef: MutableRefObject<boolean>;
-  /** True iff the user has manually scrolled up since the last bottom-anchored scroll. Updated only by handleScroll's scrolled-up detection (no flaky layout math). Consumers (anchor effect, DynamicBottomSpacer) read this to gate hoist behavior. */
+  /** True iff the user has manually scrolled up since the last bottom-anchored scroll. Updated only by handleScroll's scrolled-up detection (no flaky layout math). Read by DynamicBottomSpacer to gate hoist behavior. */
   userScrolledUpRef: MutableRefObject<boolean>;
 }
 
@@ -28,14 +26,12 @@ export function ScrollContainerProvider({
   scrollContainerRef,
   contentWrapperRef,
   spacerHeightRef,
-  isAtBottomRef,
   userScrolledUpRef,
 }: {
   children: React.ReactNode;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   contentWrapperRef: RefObject<HTMLDivElement | null>;
   spacerHeightRef: MutableRefObject<number>;
-  isAtBottomRef: MutableRefObject<boolean>;
   userScrolledUpRef: MutableRefObject<boolean>;
 }) {
   // Memoize context value to prevent unnecessary re-renders of consumers.
@@ -46,16 +42,9 @@ export function ScrollContainerProvider({
       scrollContainerRef,
       contentWrapperRef,
       spacerHeightRef,
-      isAtBottomRef,
       userScrolledUpRef,
     }),
-    [
-      scrollContainerRef,
-      contentWrapperRef,
-      spacerHeightRef,
-      isAtBottomRef,
-      userScrolledUpRef,
-    ]
+    [scrollContainerRef, contentWrapperRef, spacerHeightRef, userScrolledUpRef]
   );
 
   return (

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -950,7 +950,10 @@ export default function useChatController({
         };
 
         await delay(50);
-        while (!stack.isComplete || !stack.isEmpty()) {
+        while (
+          (!stack.isComplete || !stack.isEmpty()) &&
+          !controller.signal.aborted
+        ) {
           if (stack.isEmpty()) {
             // Flush the burst on the next paint, or idle briefly.
             if (pendingFlush) {
@@ -1292,6 +1295,52 @@ export default function useChatController({
           completeMessageTreeOverride: currentMessageTreeLocal,
           chatSessionId: frozenSessionId!,
         });
+      }
+
+      // If the drain loop exited because the controller was aborted (e.g. user
+      // clicked a branch arrow mid-stream), the streaming consumer never gets
+      // a natural stop packet. Inject one into the orphan assistant message(s)
+      // so usePacketProcessor sees stopPacketSeen=true and the typewriter
+      // cursor stops blinking.
+      //
+      // Read the LIVE store tree (not the local snapshot) so the user's
+      // branch arrow click — which already wrote `parent.latestChildNodeId`
+      // to the store before triggering the abort — isn't overwritten when
+      // we upsert the stop packet.
+      if (controller.signal.aborted) {
+        const orphanNodes: Message[] = isMultiModel
+          ? initialAssistantNodes
+          : [initialAgentNode];
+        const liveTree =
+          useChatSessionStore.getState().sessions.get(frozenSessionId)
+            ?.messageTree ?? null;
+        const messagesToStop = orphanNodes
+          .map((node) => {
+            const existing = liveTree?.get(node.nodeId) ?? node;
+            if (existing.packets.some((p) => p.obj.type === "stop")) {
+              return null;
+            }
+            return {
+              ...existing,
+              packets: [
+                ...existing.packets,
+                {
+                  placement: { turn_index: 0 },
+                  obj: { type: "stop" as const, stop_reason: "user_cancelled" },
+                },
+              ],
+              packetCount:
+                (existing.packetCount ?? existing.packets.length) + 1,
+            } as Message;
+          })
+          .filter((m): m is Message => m !== null);
+        if (messagesToStop.length > 0) {
+          upsertToCompleteMessageTree({
+            messages: messagesToStop,
+            completeMessageTreeOverride: liveTree,
+            chatSessionId: frozenSessionId!,
+          });
+        }
       }
 
       resetRegenerationState(frozenSessionId);

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -800,6 +800,9 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       autoScroll={autoScrollEnabled}
                       isStreaming={isStreaming}
                       onScrollButtonVisibilityChange={setShowScrollButton}
+                      // Defer initial scroll until the model selector
+                      // (sibling that affects viewport height) has loaded.
+                      parentLayoutReady={!llmManager.isLoadingProviders}
                     >
                       <ChatUI
                         liveAgent={liveAgent!}

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -53,6 +53,15 @@ export interface ChatScrollContainerProps {
 
   /** Hide the scrollbar (scroll still works, just invisible) */
   hideScrollbar?: boolean;
+
+  /**
+   * Set to false while sibling layout that affects this container's
+   * viewport height (e.g. the model selector waiting on
+   * `llmManager.isLoadingProviders`) hasn't settled yet. The initial
+   * scroll-to-bottom is deferred until this is true so we don't land
+   * against a partial layout that shifts moments later.
+   */
+  parentLayoutReady?: boolean;
 }
 
 // Build a CSS mask that fades content opacity at top/bottom edges
@@ -74,6 +83,7 @@ const ChatScrollContainer = React.memo(
         onScrollButtonVisibilityChange,
         sessionId,
         hideScrollbar = false,
+        parentLayoutReady = true,
       }: ChatScrollContainerProps,
       ref: ForwardedRef<ChatScrollContainerHandle>
     ) => {
@@ -91,6 +101,12 @@ const ChatScrollContainer = React.memo(
       const [hasContentBelow, setHasContentBelow] = useState(false);
       const [isAtBottom, setIsAtBottom] = useState(true);
       const isAtBottomRef = useRef(true); // Ref for use in callbacks
+      // True iff the user has manually scrolled up since the last
+      // bottom-anchored scroll. Updated only by handleScroll's scrolled-up
+      // detection (no flaky layout math). Used by the anchor effect and
+      // DynamicBottomSpacer to avoid yanking the user back during streams /
+      // queued auto-flushes when they've intentionally moved away.
+      const userScrolledUpRef = useRef(false);
       const isAutoScrollingRef = useRef(false); // Prevent handleScroll from interfering during auto-scroll
       const prevScrollTopRef = useRef(0); // Track scroll position to detect scroll direction
       const [isScrollReady, setIsScrollReady] = useState(false);
@@ -109,7 +125,7 @@ const ChatScrollContainer = React.memo(
       // Get current scroll state
       const getScrollState = useCallback((): ScrollState => {
         const container = scrollContainerRef.current;
-        if (!container || !endDivRef.current) {
+        if (!container) {
           return {
             isAtBottom: true,
             hasContentAbove: false,
@@ -117,10 +133,15 @@ const ChatScrollContainer = React.memo(
           };
         }
 
+        // Use the container's scrollHeight (same coordinate system as
+        // scrollTop / clientHeight) instead of `endDivRef.offsetTop`, which
+        // resolves against the nearest positioned ancestor and can land in
+        // a different coordinate system entirely — producing wrong
+        // contentBelowViewport values when sibling layout (e.g. the model
+        // selector loading after the initial scroll) shifts things around.
         // Exclude the dynamic spacer — it's cosmetic (push-up effect) and
         // shouldn't make the system think there's real content below the viewport.
-        const contentEnd =
-          endDivRef.current.offsetTop - spacerHeightRef.current;
+        const contentEnd = container.scrollHeight - spacerHeightRef.current;
         const viewportBottom = container.scrollTop + container.clientHeight;
         const contentBelowViewport = contentEnd - viewportBottom;
 
@@ -160,6 +181,8 @@ const ChatScrollContainer = React.memo(
           // Update tracking refs
           prevScrollTopRef.current = targetScrollTop;
           isAtBottomRef.current = true;
+          // Bottom-anchored scroll resets the "user scrolled up" intent
+          userScrolledUpRef.current = false;
 
           // For smooth scrolling, keep isAutoScrollingRef true longer
           if (behavior === "smooth") {
@@ -202,6 +225,7 @@ const ChatScrollContainer = React.memo(
         // Only update isAtBottomRef when user explicitly scrolls UP
         // This prevents content growth or programmatic scrolls from disabling auto-scroll
         if (scrolledUp) {
+          userScrolledUpRef.current = true;
           updateScrollState();
         } else {
           // Still update fade overlays, but preserve isAtBottomRef
@@ -282,6 +306,7 @@ const ChatScrollContainer = React.memo(
           setIsScrollReady(false);
           prevScrollTopRef.current = 0;
           isAtBottomRef.current = true;
+          userScrolledUpRef.current = false;
         }
 
         const shouldScroll =
@@ -290,6 +315,16 @@ const ChatScrollContainer = React.memo(
 
         if (!shouldScroll) {
           prevAnchorSelectorRef.current = anchorSelector ?? null;
+          return;
+        }
+
+        // Hold off the initial scroll until sibling layout that affects
+        // viewport height has finished loading. Otherwise we'd land
+        // against a partial layout (e.g. before ModelSelector appears)
+        // and end up above the true bottom once it shifts.
+        const isLoadingExistingContent =
+          isNewSession || scrolledForSessionRef.current === null;
+        if (isLoadingExistingContent && !parentLayoutReady) {
           return;
         }
 
@@ -305,8 +340,6 @@ const ChatScrollContainer = React.memo(
 
         // Determine scroll behavior
         // New session with existing content = instant, new anchor = smooth
-        const isLoadingExistingContent =
-          isNewSession || scrolledForSessionRef.current === null;
         const behavior: ScrollBehavior = isLoadingExistingContent
           ? "instant"
           : "smooth";
@@ -344,7 +377,13 @@ const ChatScrollContainer = React.memo(
         }, 0);
 
         return () => clearTimeout(timeoutId);
-      }, [sessionId, anchorSelector, anchorOffsetPx, updateScrollState]);
+      }, [
+        sessionId,
+        anchorSelector,
+        anchorOffsetPx,
+        updateScrollState,
+        parentLayoutReady,
+      ]);
 
       // Build mask to fade content opacity at edges
       const contentMask = buildContentMask();
@@ -380,6 +419,8 @@ const ChatScrollContainer = React.memo(
                 scrollContainerRef={scrollContainerRef}
                 contentWrapperRef={contentWrapperRef}
                 spacerHeightRef={spacerHeightRef}
+                isAtBottomRef={isAtBottomRef}
+                userScrolledUpRef={userScrolledUpRef}
               >
                 {children}
               </ScrollContainerProvider>

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -419,7 +419,6 @@ const ChatScrollContainer = React.memo(
                 scrollContainerRef={scrollContainerRef}
                 contentWrapperRef={contentWrapperRef}
                 spacerHeightRef={spacerHeightRef}
-                isAtBottomRef={isAtBottomRef}
                 userScrolledUpRef={userScrolledUpRef}
               >
                 {children}


### PR DESCRIPTION
## Description

**Bug**: Clicking a branch arrow on a parent message during a stream froze the page, queued messages flushed onto the wrong branch, and the orphaned message kept a blinking typewriter cursor forever.

**Why**:
- Drain loop in `useChatController` busy-spun when `signal.aborted` was true with packets still buffered in the FIFO.
- `clearCurrentQueuedMessages` didn't exist — auto-flush still fired after `chatState` returned to `"input"`.
- Stream consumer never got a natural stop packet on abort, so `usePacketProcessor` never set `stopPacketSeen=true`.

**Fix**:
- Branch arrow handler: `clearQueue → abortSession → stopGenerating → onMessageSelection`.
- Drain loop exits on `signal.aborted`.
- Post-abort, inject synthetic `stop` packet into orphan assistant message(s), reading the LIVE store tree as the upsert base so the user's branch flip isn't clobbered.
- New `clearQueuedMessages` / `clearCurrentQueuedMessages` actions.
- DynamicBottomSpacer's hoist gate now checks `userScrolledUpRef` so the auto-scroll doesn't yank a scrolled-up user during stream / queued auto-flush.

## How Has This Been Tested?

<!-- Filled in by reviewer -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check