### PR TITLE
docs: instruct agents to follow PR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,12 @@ status code is dynamic (comes from the upstream response), use `status_code_over
 raise OnyxError(OnyxErrorCode.BAD_GATEWAY, detail, status_code_override=e.response.status_code)
 ```
 
+## Pull Requests
+
+When creating a pull request, follow the template at `.github/pull_request_template.md`.
+Fill out the `Description` and `How Has This Been Tested?` sections, and include the
+`Additional Options` checklist as-is.
+
 ## Best Practices
 
 In addition to the other content in this file, best practices for contributing


### PR DESCRIPTION
## Description

Adds a Pull Requests section to `AGENTS.md` (which `CLAUDE.md` symlinks to) directing AI agents to follow the template at `.github/pull_request_template.md` when opening PRs. Keeps agent-authored PR descriptions consistent with the rest of the repo.

## How Has This Been Tested?

Docs-only change — no automated tests. Verified the new section renders correctly and that `CLAUDE.md` still resolves to the updated `AGENTS.md` via the existing symlink.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Pull Requests section to `AGENTS.md` (symlinked by `CLAUDE.md`) instructing agents to use `.github/pull_request_template.md` and complete the required sections. Keeps PR descriptions consistent across the repo; docs-only change with symlink verified.

<sup>Written for commit 173d4b7b739ca8ab6d3069bd6dfeaf4050f69fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

