### PR TITLE
chore(docprocessing): use batch counters in heartbeat monitor for faster invalidation

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -250,6 +250,8 @@ def validate_active_indexing_attempts(
             # If total_batches is not set yet, docfetching is still running;
             # fall through to immediate invalidation (base timeout elapsed).
             if fresh_attempt.total_batches is not None:
+                in_flight = 0
+                pending = 0
                 try:
                     r = get_redis_client()
                     rd = RedisDocprocessing(fresh_attempt.id, r)
@@ -260,8 +262,6 @@ def validate_active_indexing_attempts(
                         f"Failed to read batch counters for attempt {fresh_attempt.id}, "
                         f"falling back to invalidation"
                     )
-                    in_flight = 0
-                    pending = 0
 
                 task_logger.warning(
                     f"Stale heartbeat for attempt {fresh_attempt.id}: "

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -108,6 +108,7 @@ from onyx.indexing.indexing_pipeline import run_indexing_pipeline
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.natural_language_processing.search_nlp_models import warm_up_bi_encoder
 from onyx.redis.redis_connector import RedisConnector
+from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_pool import get_redis_replica_client
 from onyx.redis.redis_pool import redis_lock_dump
@@ -133,9 +134,8 @@ from shared_configs.contextvars import INDEX_ATTEMPT_INFO_CONTEXTVAR
 logger = setup_logger()
 
 DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER = 4
-DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER = 48
-# Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead
-# This should be much longer than INDEXING_WORKER_HEARTBEAT_INTERVAL (30s)
+# Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead.
+# This should be much longer than INDEXING_WORKER_HEARTBEAT_INTERVAL (30s).
 HEARTBEAT_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 INDEX_ATTEMPT_BATCH_SIZE = 500
 
@@ -229,14 +229,6 @@ def validate_active_indexing_attempts(
                 )
                 continue
 
-            if (
-                fresh_attempt.total_batches
-                and fresh_attempt.completed_batches < fresh_attempt.total_batches
-            ):
-                heartbeat_timeout_seconds = (
-                    HEARTBEAT_TIMEOUT_SECONDS
-                    * DOCPROCESSING_HEARTBEAT_TIMEOUT_MULTIPLIER
-                )
             cutoff_time = datetime.now(timezone.utc) - timedelta(
                 seconds=heartbeat_timeout_seconds
             )
@@ -248,13 +240,66 @@ def validate_active_indexing_attempts(
                 )
                 continue
 
-            # No heartbeat for too long - mark as failed
-            failure_reason = (
-                f"No heartbeat received for {heartbeat_timeout_seconds} seconds"
-            )
+            # Heartbeat is stale. If docfetching has finished (total_batches is
+            # set), use the Redis counters to decide whether to invalidate:
+            #
+            #   in_flight > 0               → workers crashed holding batches → invalidate
+            #   in_flight = 0, pending > 0  → batches in queue, no crash → wait
+            #   in_flight = 0, pending = 0  → no work anywhere, stuck → invalidate
+            #
+            # If total_batches is not set yet, docfetching is still running;
+            # fall through to immediate invalidation (base timeout elapsed).
+            if fresh_attempt.total_batches is not None:
+                try:
+                    r = get_redis_client()
+                    rd = RedisDocprocessing(fresh_attempt.id, r)
+                    in_flight = rd.in_flight()
+                    pending = rd.pending()
+                except Exception:
+                    task_logger.exception(
+                        f"Failed to read batch counters for attempt {fresh_attempt.id}, "
+                        f"falling back to invalidation"
+                    )
+                    in_flight = 0
+                    pending = 0
+
+                task_logger.warning(
+                    f"Stale heartbeat for attempt {fresh_attempt.id}: "
+                    f"in_flight={in_flight} pending={pending} "
+                    f"completed={fresh_attempt.completed_batches}/{fresh_attempt.total_batches}"
+                )
+
+                if in_flight == 0 and pending > 0:
+                    # Batches are sitting in the queue waiting for workers —
+                    # no crash, just backlog. Do not invalidate.
+                    task_logger.info(
+                        f"Attempt {fresh_attempt.id} has {pending} batches in queue, "
+                        f"no workers crashed — waiting for workers to free up"
+                    )
+                    continue
+
+                if in_flight > 0:
+                    failure_reason = (
+                        f"Heartbeat stale for {heartbeat_timeout_seconds}s with "
+                        f"{in_flight} in-flight batches — workers crashed holding batches"
+                    )
+                else:
+                    # in_flight == 0, pending == 0: no work anywhere, no forward
+                    # progress possible — all batches either failed or were lost.
+                    failure_reason = (
+                        f"Heartbeat stale for {heartbeat_timeout_seconds}s with "
+                        f"no pending or in-flight batches — all batches failed or lost"
+                    )
+            else:
+                # total_batches is None: docfetching is still running but the
+                # worker process died. The heartbeat thread runs independently
+                # of rate limiting, so a stale heartbeat here means a real crash.
+                failure_reason = (
+                    f"No heartbeat received for {heartbeat_timeout_seconds} seconds"
+                )
 
             task_logger.warning(
-                f"Heartbeat timeout for attempt {fresh_attempt.id}: "
+                f"Invalidating attempt {fresh_attempt.id}: "
                 f"last_heartbeat_time={last_check_time} "
                 f"cutoff_time={cutoff_time} "
                 f"counter={current_counter}"

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -288,8 +288,8 @@ def mark_attempt_succeeded(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
-        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
-        # stale counters in case cleanup() failed and left them behind.
+        # Stale counter keys left by a failed cleanup() are harmless: the monitor
+        # skips attempts that are already in a terminal state before reading Redis.
         try:
             RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
         except Exception:
@@ -328,8 +328,8 @@ def mark_attempt_partially_succeeded(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
-        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
-        # stale counters in case cleanup() failed and left them behind.
+        # Stale counter keys left by a failed cleanup() are harmless: the monitor
+        # skips attempts that are already in a terminal state before reading Redis.
         try:
             RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
         except Exception:
@@ -371,8 +371,8 @@ def mark_attempt_canceled(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
-        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
-        # stale counters in case cleanup() failed and left them behind.
+        # Stale counter keys left by a failed cleanup() are harmless: the monitor
+        # skips attempts that are already in a terminal state before reading Redis.
         try:
             RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
         except Exception:
@@ -416,8 +416,8 @@ def mark_attempt_failed(
                 "cc_pair_id": attempt.connector_credential_pair_id,
             },
         )
-        # TODO(@bo): in PR 2, cross-check DB terminal status before acting on
-        # stale counters in case cleanup() failed and left them behind.
+        # Stale counter keys left by a failed cleanup() are harmless: the monitor
+        # skips attempts that are already in a terminal state before reading Redis.
         try:
             RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
         except Exception:


### PR DESCRIPTION
## Description

Replaces the blunt 24-hour heartbeat timeout multiplier with a counter-based decision table using the `pending`/`in_flight` Redis counters introduced in #10768. When the heartbeat goes stale and `total_batches` is set, the monitor now reads both counters to determine the correct action: invalidate immediately if workers crashed (`in_flight > 0`) or all batches are lost (`in_flight = 0, pending = 0`), and wait if batches are simply queued with no worker crash (`in_flight = 0, pending > 0`). Also resolves deferred TODOs in `mark_attempt_*` functions — stale counter keys after a failed `cleanup()` are already harmless since the monitor skips terminal attempts before reading Redis.

https://docs.google.com/document/d/1uhL54rzkwJVW3ZBFZlw3_v00-pPZAZ1AeUWP4GobmCE/edit?tab=t.0
https://linear.app/onyx-app/issue/ENG-4092/improve-the-doc-processing-robustness

## How Has This Been Tested?

Verified counter lifecycle end-to-end locally with a Google Drive connector: keys created on first dispatch, `pending`/`in_flight` tracked correctly through concurrent batch processing, and both keys deleted on successful attempt completion.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Redis batch counters in the heartbeat monitor to decide when to invalidate attempts. This speeds up crash detection and prevents canceling healthy queued work (supports Linear ENG-4092).

- **Refactors**
  - Read `in_flight`/`pending` via `RedisDocprocessing` when `total_batches` is set; invalidate on `in_flight > 0` or both zero; wait if `pending > 0` with `in_flight = 0`. If Redis read fails, or `total_batches` is None, invalidate.
  - Remove the long heartbeat timeout multiplier; always use the 30-minute base timeout, then apply counter-based decisions when applicable.
  - Clarify `mark_attempt_*` comments: stale counters after failed cleanup are harmless; still call cleanup and log failures.

<sup>Written for commit 730321fd4ebe68a278db7eaeab52365f15aacd75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



