### PR TITLE
fix(openrouter): enable auto-update mode (#10718) to release v3.3

### DIFF
--- a/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
+++ b/web/src/sections/modals/llmConfig/OpenRouterModal.tsx
@@ -85,7 +85,7 @@ function OpenRouterModalInternals({
 
       <InputDivider />
       <ModelSelectionField
-        shouldShowAutoUpdateToggle={false}
+        shouldShowAutoUpdateToggle={true}
         onRefetch={isFetchDisabled ? undefined : handleFetchModels}
       />
 


### PR DESCRIPTION
Cherry-pick of commit e4196f4225cec0e03916940306087ae627afd6d2 to release/v3.3 branch.

Original PR: #10718

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the auto-update toggle in the OpenRouter model settings so users can opt into automatic model updates. Restores the intended behavior for v3.3 in the OpenRouter modal.

<sup>Written for commit aee4efa55db6cca107b8320b7b8aa03a354676d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

