### PR TITLE
chore(devcontainer): cache frontend build artifacts on named volumes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig,type=bind,readonly",
     "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
-    "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume"
+    "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume",
+    "source=onyx-devcontainer-web-node-modules,target=/workspace/web/node_modules,type=volume",
+    "source=onyx-devcontainer-web-next,target=/workspace/web/.next,type=volume"
   ],
   "containerEnv": {
     "COLORTERM": "truecolor",

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -65,6 +65,18 @@ if [ "$ACTIVE_HOME" != "$MOUNT_HOME" ]; then
     fi
 fi
 
+# ── Phase 1.5: workspace volume ownership ──────────────────────────
+# Named volumes mounted into /workspace (build caches) start root-owned.
+# Chown the mountpoint to match the workspace owner so the dev user can
+# write into them. Non-recursive: contents are created by the dev user
+# (e.g. via `npm ci`) and don't need re-chown on every start.
+for vol in /workspace/web/node_modules /workspace/web/.next; do
+    [ -d "$vol" ] || continue
+    if ! chown "$WS_UID":"$WS_GID" "$vol" 2>&1; then
+        echo "warning: failed to chown $vol" >&2
+    fi
+done
+
 # ── Phase 2: workspace access ───────────────────────────────────────
 
 # Root always has workspace access; Phase 1 handled home setup.

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -19,7 +19,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "tsBuildInfoFile": "./node_modules/.cache/typescript/tsconfig.tsbuildinfo",
     "plugins": [
       {
         "name": "next"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -19,6 +19,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/typescript/tsconfig.tsbuildinfo",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
I ran,

```
git clean -fdx web && ods dev rebuild && ods dev into
cd web
time (npm i && ods web dev)
```

with and without this change. With this change, the time reduced from ~30s to about ~5s.

## Summary
- Move `web/node_modules` and `web/.next` off the workspace bind mount and onto dedicated named Docker volumes (`onyx-devcontainer-web-node-modules`, `onyx-devcontainer-web-next`). Build artifacts now live on container-local storage instead of going through the host bind mount, speeding up `npm ci`, `next build`/`next dev`, and any tooling that scans `node_modules`.
- Point TypeScript's `tsBuildInfoFile` at `./node_modules/.cache/typescript/tsconfig.tsbuildinfo` so the incremental type-check cache piggybacks on the `node_modules` volume — no extra volume needed.
- Add a Phase 1.5 step in `.devcontainer/init-dev-user.sh` that chowns the new volume mountpoints to the workspace owner. Named volumes start root-owned, so this is needed once on first start; non-recursive, runs every start, idempotent.

## Test plan
- [ ] Rebuild the devcontainer from scratch and confirm `npm ci` in `web/` succeeds as the `dev` user (i.e. the chown actually took effect).
- [ ] Confirm `next dev` and `next build` work and write into `/workspace/web/.next` (the volume) rather than the bind mount.
- [ ] Run `npx tsc --noEmit` once cold, then again — second run should be near-instant and produce `node_modules/.cache/typescript/tsconfig.tsbuildinfo`.
- [ ] Stop and restart the container; verify `node_modules` and `.next` survive across container restarts.
- [ ] Verify the rootless-Docker code path (`DEVCONTAINER_REMOTE_USER=root`) still works — the chown-to-`WS_UID` is a no-op when WS_UID is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up frontend installs and builds in the devcontainer by moving `web/node_modules` and `web/.next` to named Docker volumes. Caches now persist across rebuilds and avoid slow host bind-mount I/O, improving `npm ci`, `next dev`, `next build`, and tools that scan `node_modules`.

- **Refactors**
  - Mount `web/node_modules` and `web/.next` as named volumes: `onyx-devcontainer-web-node-modules`, `onyx-devcontainer-web-next`.
  - Chown volume mountpoints on start so the `dev` user can write; idempotent, no-op when `WS_UID=0`.
  - Removed `tsBuildInfoFile` redirect; rely on Next’s cache in `.next/cache` on the volume.

- **Migration**
  - Rebuild the devcontainer to populate the new volumes.

<sup>Written for commit dcb22e9e467ec9d39695f4323d2a8455cea2be8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

