### PR TITLE
fix(freshdesk): handle null due by (#10801) to release v2.12

### DIFF
--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -79,6 +79,20 @@ def _rate_limited_freshdesk_get(
     return rl_requests.get(url, auth=auth, params=params)
 
 
+def _parse_freshdesk_datetime(raw: str | None) -> datetime | None:
+    """Freshdesk timestamps are ISO-8601 with a trailing 'Z'.
+
+    The API documents that fields like ``due_by``/``fr_due_by`` may be returned
+    as ``null`` — see https://developers.freshdesk.com/api/. This is also
+    significantly more frequent on accounts created after 25 Aug 2025, where
+    the new SLA engine recalculates ``due_by`` for a few seconds after every
+    ticket update.
+    """
+    if not raw:
+        return None
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
 def _create_metadata_from_ticket(ticket: dict) -> dict:
     metadata: dict[str, str | list[str]] = {}
     # Combine all emails into a list so there are no repeated emails
@@ -129,8 +143,9 @@ def _create_metadata_from_ticket(ticket: dict) -> dict:
             status_number, "Unknown Status"
         )
 
-    due_by = datetime.fromisoformat(ticket["due_by"].replace("Z", "+00:00"))
-    metadata["overdue"] = str(datetime.now(timezone.utc) > due_by)
+    due_by = _parse_freshdesk_datetime(ticket.get("due_by"))
+    if due_by is not None:
+        metadata["overdue"] = str(datetime.now(timezone.utc) > due_by)
 
     return metadata
 
@@ -154,9 +169,7 @@ def _create_doc_from_ticket(ticket: dict, domain: str) -> Document:
         source=DocumentSource.FRESHDESK,
         semantic_identifier=ticket["subject"],
         metadata=metadata,
-        doc_updated_at=datetime.fromisoformat(
-            ticket["updated_at"].replace("Z", "+00:00")
-        ),
+        doc_updated_at=_parse_freshdesk_datetime(ticket.get("updated_at")),
     )
 
 

--- a/backend/tests/unit/onyx/connectors/freshdesk/test_freshdesk_due_by.py
+++ b/backend/tests/unit/onyx/connectors/freshdesk/test_freshdesk_due_by.py
@@ -1,0 +1,63 @@
+"""Unit tests for Freshdesk connector handling of nullable timestamp fields.
+
+Reproduces the production traceback:
+
+    File "/app/onyx/connectors/freshdesk/connector.py", line 131
+        due_by = datetime.fromisoformat(ticket["due_by"].replace("Z", "+00:00"))
+    AttributeError: 'NoneType' object has no attribute 'replace'
+
+The Freshdesk API explicitly documents ``due_by`` (and ``fr_due_by``) as
+nullable. This is dramatically more frequent on accounts created after
+25 Aug 2025, where the new SLA engine recalculates ``due_by`` for a few
+seconds after every ticket update — and our connector polls by
+``updated_since``, so it specifically targets the tickets most likely to be
+in that recalculation window.
+"""
+
+from typing import Any
+
+from onyx.connectors.freshdesk.connector import _create_doc_from_ticket
+from onyx.connectors.freshdesk.connector import _create_metadata_from_ticket
+
+
+def _ticket(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": 42,
+        "subject": "Website unresponsive",
+        "description_text": "Some details on the issue ...",
+        "status": 2,
+        "priority": 1,
+        "source": 2,
+        "due_by": "2024-01-15T11:30:00Z",
+        "updated_at": "2024-01-10T11:30:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNullDueBy:
+    def test_metadata_omits_overdue_when_due_by_is_null(self) -> None:
+        metadata = _create_metadata_from_ticket(_ticket(due_by=None))
+        assert "overdue" not in metadata
+
+    def test_metadata_omits_overdue_when_due_by_is_missing(self) -> None:
+        ticket = _ticket()
+        del ticket["due_by"]
+        metadata = _create_metadata_from_ticket(ticket)
+        assert "overdue" not in metadata
+
+    def test_metadata_includes_overdue_when_due_by_is_present(self) -> None:
+        metadata = _create_metadata_from_ticket(_ticket(due_by="2024-01-15T11:30:00Z"))
+        # 2024-01-15 is in the past, so the ticket is overdue
+        assert metadata["overdue"] == "True"
+
+    def test_doc_creation_does_not_crash_on_null_due_by(self) -> None:
+        doc = _create_doc_from_ticket(_ticket(due_by=None), domain="example")
+        assert doc.semantic_identifier == "Website unresponsive"
+        assert "overdue" not in doc.metadata
+
+
+class TestNullUpdatedAt:
+    def test_doc_creation_does_not_crash_on_null_updated_at(self) -> None:
+        doc = _create_doc_from_ticket(_ticket(updated_at=None), domain="example")
+        assert doc.doc_updated_at is None


### PR DESCRIPTION
Cherry-pick of commit caf662ac5500d6956fd8817ca8d9824a535e6259 to release/v2.12 branch.

Original PR: #10801

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in the Freshdesk connector when `due_by` or `updated_at` are null. Safely parses timestamps and only sets `overdue` when a due date is present.

- **Bug Fixes**
  - Added `_parse_freshdesk_datetime` to handle `null` and trailing `Z` ISO timestamps; used for `due_by` and `updated_at`.
  - Skip `overdue` metadata when `due_by` is missing and allow `doc_updated_at` to be `None`; added unit tests for null/missing cases.

<sup>Written for commit 06e711a67ad80001edfc99a8b16156d1a76b0a76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

