### PR TITLE
feat(llm): make provider display name optional, migrate persona override to int FK

### DIFF
--- a/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
+++ b/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
@@ -7,7 +7,6 @@ Create Date: 2026-05-05 10:33:13.148334
 """
 
 from alembic import op
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "e3bcc6cbe3bf"
@@ -22,39 +21,26 @@ def upgrade() -> None:
     op.alter_column("llm_provider", "name", nullable=True)
     op.drop_constraint("llm_provider_name_key", "llm_provider", type_="unique")
 
-    # 2. Add a proper integer FK column to persona so that the provider override
-    #    is referenced by stable PK rather than the mutable display name string.
-    op.add_column(
-        "persona",
-        sa.Column("llm_provider_override_id", sa.Integer(), nullable=True),
-    )
-    op.create_foreign_key(
-        "fk_persona_llm_provider_override",
-        "persona",
-        "llm_provider",
-        ["llm_provider_override_id"],
-        ["id"],
-        ondelete="SET NULL",
-    )
-
-    # 3. Data migration: convert the existing string-based override to the
-    #    matching integer FK. Rows with no match (provider already deleted)
-    #    are left as NULL, which is safe — they would have fallen back to the
-    #    default provider anyway.
+    # 2. Data migration: populate default_model_configuration_id from the existing
+    #    string pair (llm_model_provider_override, llm_model_version_override).
+    #    default_model_configuration_id was added by a prior migration but never
+    #    written to — this backfills it for all pre-existing personas.
+    #    Rows with no match (provider/model deleted or mismatched) stay NULL and
+    #    fall back to the default provider at runtime.
     op.execute("""
         UPDATE persona
-        SET llm_provider_override_id = llm_provider.id
-        FROM llm_provider
-        WHERE persona.llm_model_provider_override = llm_provider.name
+        SET default_model_configuration_id = mc.id
+        FROM llm_provider lp
+        JOIN model_configuration mc ON mc.llm_provider_id = lp.id
+        WHERE persona.llm_model_provider_override = lp.name
+          AND persona.llm_model_version_override = mc.name
           AND persona.llm_model_provider_override IS NOT NULL
+          AND persona.llm_model_version_override IS NOT NULL
+          AND persona.default_model_configuration_id IS NULL
         """)
 
 
 def downgrade() -> None:
-    op.drop_constraint(
-        "fk_persona_llm_provider_override", "persona", type_="foreignkey"
-    )
-    op.drop_column("persona", "llm_provider_override_id")
     # Backfill any null names with the provider type before re-adding the NOT NULL
     # and UNIQUE constraints. Providers created after the upgrade may have null names.
     op.execute("UPDATE llm_provider SET name = provider WHERE name IS NULL")

--- a/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
+++ b/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
@@ -43,6 +43,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     # Backfill any null names with the provider type before re-adding the NOT NULL
     # and UNIQUE constraints. Providers created after the upgrade may have null names.
-    op.execute("UPDATE llm_provider SET name = provider WHERE name IS NULL")
+    op.execute(
+        "UPDATE llm_provider SET name = provider || '-' || id::text WHERE name IS NULL"
+    )
     op.create_unique_constraint("llm_provider_name_key", "llm_provider", ["name"])
     op.alter_column("llm_provider", "name", nullable=False)

--- a/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
+++ b/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
@@ -1,0 +1,59 @@
+"""optional_provider_name_persona_id_override
+
+Revision ID: e3bcc6cbe3bf
+Revises: 74379b447d4c
+Create Date: 2026-05-05 10:33:13.148334
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "e3bcc6cbe3bf"
+down_revision = "74379b447d4c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Make llm_provider.name nullable and drop the unique constraint so that
+    #    the display name is no longer the unique identifier for a provider.
+    op.alter_column("llm_provider", "name", nullable=True)
+    op.drop_constraint("llm_provider_name_key", "llm_provider", type_="unique")
+
+    # 2. Add a proper integer FK column to persona so that the provider override
+    #    is referenced by stable PK rather than the mutable display name string.
+    op.add_column(
+        "persona",
+        sa.Column("llm_provider_override_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_persona_llm_provider_override",
+        "persona",
+        "llm_provider",
+        ["llm_provider_override_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # 3. Data migration: convert the existing string-based override to the
+    #    matching integer FK. Rows with no match (provider already deleted)
+    #    are left as NULL, which is safe — they would have fallen back to the
+    #    default provider anyway.
+    op.execute("""
+        UPDATE persona
+        SET llm_provider_override_id = llm_provider.id
+        FROM llm_provider
+        WHERE persona.llm_model_provider_override = llm_provider.name
+          AND persona.llm_model_provider_override IS NOT NULL
+        """)
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_persona_llm_provider_override", "persona", type_="foreignkey"
+    )
+    op.drop_column("persona", "llm_provider_override_id")
+    op.create_unique_constraint("llm_provider_name_key", "llm_provider", ["name"])
+    op.alter_column("llm_provider", "name", nullable=False)

--- a/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
+++ b/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
@@ -6,6 +6,7 @@ Create Date: 2026-05-05 10:33:13.148334
 
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -13,6 +14,28 @@ revision = "e3bcc6cbe3bf"
 down_revision = "74379b447d4c"
 branch_labels = None
 depends_on = None
+
+# Lightweight table references for DML — avoids importing ORM models.
+persona_table = sa.table(
+    "persona",
+    sa.column("llm_model_provider_override", sa.String),
+    sa.column("llm_model_version_override", sa.String),
+    sa.column("default_model_configuration_id", sa.Integer),
+)
+
+llm_provider_table = sa.table(
+    "llm_provider",
+    sa.column("id", sa.Integer),
+    sa.column("name", sa.String),
+    sa.column("provider", sa.String),
+)
+
+model_configuration_table = sa.table(
+    "model_configuration",
+    sa.column("id", sa.Integer),
+    sa.column("llm_provider_id", sa.Integer),
+    sa.column("name", sa.String),
+)
 
 
 def upgrade() -> None:
@@ -27,24 +50,36 @@ def upgrade() -> None:
     #    written to — this backfills it for all pre-existing personas.
     #    Rows with no match (provider/model deleted or mismatched) stay NULL and
     #    fall back to the default provider at runtime.
-    op.execute("""
-        UPDATE persona
-        SET default_model_configuration_id = mc.id
-        FROM llm_provider lp
-        JOIN model_configuration mc ON mc.llm_provider_id = lp.id
-        WHERE persona.llm_model_provider_override = lp.name
-          AND persona.llm_model_version_override = mc.name
-          AND persona.llm_model_provider_override IS NOT NULL
-          AND persona.llm_model_version_override IS NOT NULL
-          AND persona.default_model_configuration_id IS NULL
-        """)
+    #
+    #    Referencing llm_provider_table and model_configuration_table in the WHERE
+    #    clause causes the PostgreSQL dialect to emit an UPDATE … FROM … clause.
+    op.execute(
+        sa.update(persona_table)
+        .values(default_model_configuration_id=model_configuration_table.c.id)
+        .where(
+            persona_table.c.llm_model_provider_override == llm_provider_table.c.name,
+            persona_table.c.llm_model_version_override
+            == model_configuration_table.c.name,
+            model_configuration_table.c.llm_provider_id == llm_provider_table.c.id,
+            persona_table.c.llm_model_provider_override.is_not(None),
+            persona_table.c.llm_model_version_override.is_not(None),
+            persona_table.c.default_model_configuration_id.is_(None),
+        )
+    )
 
 
 def downgrade() -> None:
-    # Backfill any null names with the provider type before re-adding the NOT NULL
-    # and UNIQUE constraints. Providers created after the upgrade may have null names.
+    # Backfill any null names with a unique fallback before re-adding the NOT NULL
+    # and UNIQUE constraints.  Using provider + '-' + id avoids collisions when
+    # multiple providers share the same provider type string.
     op.execute(
-        "UPDATE llm_provider SET name = provider || '-' || id::text WHERE name IS NULL"
+        sa.update(llm_provider_table)
+        .where(llm_provider_table.c.name.is_(None))
+        .values(
+            name=llm_provider_table.c.provider
+            + sa.literal("-")
+            + sa.cast(llm_provider_table.c.id, sa.Text)
+        )
     )
     op.create_unique_constraint("llm_provider_name_key", "llm_provider", ["name"])
     op.alter_column("llm_provider", "name", nullable=False)

--- a/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
+++ b/backend/alembic/versions/e3bcc6cbe3bf_optional_provider_name_persona_id_.py
@@ -55,5 +55,8 @@ def downgrade() -> None:
         "fk_persona_llm_provider_override", "persona", type_="foreignkey"
     )
     op.drop_column("persona", "llm_provider_override_id")
+    # Backfill any null names with the provider type before re-adding the NOT NULL
+    # and UNIQUE constraints. Providers created after the upgrade may have null names.
+    op.execute("UPDATE llm_provider SET name = provider WHERE name IS NULL")
     op.create_unique_constraint("llm_provider_name_key", "llm_provider", ["name"])
     op.alter_column("llm_provider", "name", nullable=False)

--- a/backend/ee/onyx/server/seeding.py
+++ b/backend/ee/onyx/server/seeding.py
@@ -121,9 +121,12 @@ def _seed_llms(
 
     logger.notice("Seeding LLMs")
     for request in llm_upsert_requests:
-        existing = fetch_existing_llm_provider(name=request.name, db_session=db_session)
-        if existing:
-            request.id = existing.id
+        if request.name is not None:
+            existing = fetch_existing_llm_provider(
+                name=request.name, db_session=db_session
+            )
+            if existing:
+                request.id = existing.id
     seeded_providers: list[LLMProviderView] = []
     for llm_upsert_request in llm_upsert_requests:
         try:

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -329,11 +329,12 @@ def configure_default_api_keys(db_session: Session) -> None:
     def _upsert(request: LLMProviderUpsertRequest, default_model: str) -> None:
         nonlocal has_set_default_provider
         try:
-            existing = fetch_existing_llm_provider(
-                name=request.name, db_session=db_session
-            )
-            if existing:
-                request.id = existing.id
+            if request.name is not None:
+                existing = fetch_existing_llm_provider(
+                    name=request.name, db_session=db_session
+                )
+                if existing:
+                    request.id = existing.id
             provider = upsert_llm_provider(request, db_session)
             if not has_set_default_provider:
                 update_default_provider(provider.id, default_model, db_session)

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -162,14 +162,12 @@ def validate_persona_ids_exist(
     return fetched_persona_ids, missing_personas
 
 
-def get_personas_using_provider(
-    db_session: Session, provider_name: str
-) -> list[Persona]:
+def get_personas_using_provider(db_session: Session, provider_id: int) -> list[Persona]:
     """Get all non-deleted personas that use a specific LLM provider."""
     return list(
         db_session.scalars(
             select(Persona).where(
-                Persona.llm_model_provider_override == provider_name,
+                Persona.llm_provider_override_id == provider_id,
                 Persona.deleted == False,  # noqa: E712
             )
         ).all()
@@ -219,19 +217,8 @@ def upsert_llm_provider(
             raise ValueError(
                 f"LLM provider with id {llm_provider_upsert_request.id} not found"
             )
-
-        if existing_llm_provider.name != llm_provider_upsert_request.name:
-            raise ValueError(
-                f"LLM provider with id {llm_provider_upsert_request.id} name change not allowed"
-            )
     else:
-        existing_llm_provider = fetch_existing_llm_provider(
-            name=llm_provider_upsert_request.name, db_session=db_session
-        )
-        if existing_llm_provider:
-            raise ValueError(
-                f"LLM provider with name '{llm_provider_upsert_request.name}' already exists"
-            )
+        # Name is now a display label only — no uniqueness guarantee. Always create new.
         existing_llm_provider = LLMProviderModel(name=llm_provider_upsert_request.name)
         db_session.add(existing_llm_provider)
 
@@ -591,22 +578,21 @@ def remove_embedding_provider(
 
 
 def remove_llm_provider(db_session: Session, provider_id: int) -> None:
-    provider = db_session.get(LLMProviderModel, provider_id)
-    if not provider:
+    if not db_session.get(LLMProviderModel, provider_id):
         raise ValueError("LLM Provider not found")
 
-    # Clear the provider override from any personas using it
-    # This causes them to fall back to the default provider
-    personas_using_provider = get_personas_using_provider(db_session, provider.name)
-    for persona in personas_using_provider:
-        persona.llm_model_provider_override = None
+    # Clear the provider override from any personas using it so they fall back
+    # to the default provider. The FK has ON DELETE SET NULL so the DB would do
+    # this automatically, but we clear it here explicitly for transactional safety
+    # before the DELETE fires.
+    for persona in get_personas_using_provider(db_session, provider_id):
+        persona.llm_provider_override_id = None
 
     db_session.execute(
         delete(LLMProvider__UserGroup).where(
             LLMProvider__UserGroup.llm_provider_id == provider_id
         )
     )
-    # Remove LLMProvider
     db_session.execute(
         delete(LLMProviderModel).where(LLMProviderModel.id == provider_id)
     )
@@ -615,22 +601,17 @@ def remove_llm_provider(db_session: Session, provider_id: int) -> None:
 
 def remove_llm_provider__no_commit(db_session: Session, provider_id: int) -> None:
     """Remove LLM provider."""
-    provider = db_session.get(LLMProviderModel, provider_id)
-    if not provider:
+    if not db_session.get(LLMProviderModel, provider_id):
         raise ValueError("LLM Provider not found")
 
-    # Clear the provider override from any personas using it
-    # This causes them to fall back to the default provider
-    personas_using_provider = get_personas_using_provider(db_session, provider.name)
-    for persona in personas_using_provider:
-        persona.llm_model_provider_override = None
+    for persona in get_personas_using_provider(db_session, provider_id):
+        persona.llm_provider_override_id = None
 
     db_session.execute(
         delete(LLMProvider__UserGroup).where(
             LLMProvider__UserGroup.llm_provider_id == provider_id
         )
     )
-    # Remove LLMProvider
     db_session.execute(
         delete(LLMProviderModel).where(LLMProviderModel.id == provider_id)
     )

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -577,16 +577,38 @@ def remove_embedding_provider(
     db_session.commit()
 
 
+def _clear_persona_provider_overrides(
+    db_session: Session, provider_id: int, provider_name: str | None
+) -> None:
+    """Clear both FK and legacy string overrides from personas that reference this provider."""
+    for persona in get_personas_using_provider(db_session, provider_id):
+        persona.llm_provider_override_id = None
+        persona.llm_model_provider_override = None
+
+    # Also clear legacy string-only overrides (personas created before the FK migration)
+    if provider_name:
+        legacy_personas = list(
+            db_session.scalars(
+                select(Persona).where(
+                    Persona.llm_model_provider_override == provider_name,
+                    Persona.deleted == False,  # noqa: E712
+                )
+            ).all()
+        )
+        for persona in legacy_personas:
+            persona.llm_model_provider_override = None
+
+
 def remove_llm_provider(db_session: Session, provider_id: int) -> None:
-    if not db_session.get(LLMProviderModel, provider_id):
+    provider = db_session.get(LLMProviderModel, provider_id)
+    if not provider:
         raise ValueError("LLM Provider not found")
 
     # Clear the provider override from any personas using it so they fall back
     # to the default provider. The FK has ON DELETE SET NULL so the DB would do
     # this automatically, but we clear it here explicitly for transactional safety
     # before the DELETE fires.
-    for persona in get_personas_using_provider(db_session, provider_id):
-        persona.llm_provider_override_id = None
+    _clear_persona_provider_overrides(db_session, provider_id, provider.name)
 
     db_session.execute(
         delete(LLMProvider__UserGroup).where(
@@ -601,11 +623,11 @@ def remove_llm_provider(db_session: Session, provider_id: int) -> None:
 
 def remove_llm_provider__no_commit(db_session: Session, provider_id: int) -> None:
     """Remove LLM provider."""
-    if not db_session.get(LLMProviderModel, provider_id):
+    provider = db_session.get(LLMProviderModel, provider_id)
+    if not provider:
         raise ValueError("LLM Provider not found")
 
-    for persona in get_personas_using_provider(db_session, provider_id):
-        persona.llm_provider_override_id = None
+    _clear_persona_provider_overrides(db_session, provider_id, provider.name)
 
     db_session.execute(
         delete(LLMProvider__UserGroup).where(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -239,6 +239,7 @@ def upsert_llm_provider(
         }
 
     api_base = llm_provider_upsert_request.api_base or None
+    existing_llm_provider.name = llm_provider_upsert_request.name
     existing_llm_provider.provider = llm_provider_upsert_request.provider
     # EncryptedString accepts str for writes, returns SensitiveValue for reads
     existing_llm_provider.api_key = (  # ty: ignore[invalid-assignment]

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -163,11 +163,16 @@ def validate_persona_ids_exist(
 
 
 def get_personas_using_provider(db_session: Session, provider_id: int) -> list[Persona]:
-    """Get all non-deleted personas that use a specific LLM provider."""
+    """Get all non-deleted personas whose default_model_configuration references this provider."""
     return list(
         db_session.scalars(
-            select(Persona).where(
-                Persona.llm_provider_override_id == provider_id,
+            select(Persona)
+            .join(
+                ModelConfiguration,
+                Persona.default_model_configuration_id == ModelConfiguration.id,
+            )
+            .where(
+                ModelConfiguration.llm_provider_id == provider_id,
                 Persona.deleted == False,  # noqa: E712
             )
         ).all()
@@ -580,10 +585,11 @@ def remove_embedding_provider(
 def _clear_persona_provider_overrides(
     db_session: Session, provider_id: int, provider_name: str | None
 ) -> None:
-    """Clear both FK and legacy string overrides from personas that reference this provider."""
+    """Clear model configuration and legacy string overrides from personas using this provider."""
     for persona in get_personas_using_provider(db_session, provider_id):
-        persona.llm_provider_override_id = None
+        persona.default_model_configuration_id = None
         persona.llm_model_provider_override = None
+        persona.llm_model_version_override = None
 
     # Also clear legacy string-only overrides (personas created before the FK migration)
     if provider_name:
@@ -597,6 +603,7 @@ def _clear_persona_provider_overrides(
         )
         for persona in legacy_personas:
             persona.llm_model_provider_override = None
+            persona.llm_model_version_override = None
 
 
 def remove_llm_provider(db_session: Session, provider_id: int) -> None:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3665,17 +3665,16 @@ class Persona(Base):
     name: Mapped[str] = mapped_column(String)
     description: Mapped[str] = mapped_column(String)
 
-    # Allows the persona to specify a specific default LLM model
-    # NOTE: only is applied on the actual response generation - is not used for things like
+    # Allows the persona to specify a specific default LLM model.
+    # NOTE: only applied on the actual response generation — not used for
     # auto-detected time filters, relevance filters, etc.
-    # Deprecated: use llm_provider_override_id instead. Kept for backward compat reads.
+    #
+    # Canonical field: default_model_configuration_id (single FK → model_configuration)
+    # Deprecated fallbacks (kept for backward-compat reads of old data):
+    #   llm_model_provider_override — provider display name string
+    #   llm_model_version_override  — model name string
     llm_model_provider_override: Mapped[str | None] = mapped_column(
         String, nullable=True
-    )
-    llm_provider_override_id: Mapped[int | None] = mapped_column(
-        Integer,
-        ForeignKey("llm_provider.id", ondelete="SET NULL"),
-        nullable=True,
     )
     llm_model_version_override: Mapped[str | None] = mapped_column(
         String, nullable=True
@@ -3684,6 +3683,11 @@ class Persona(Base):
         Integer,
         ForeignKey("model_configuration.id", ondelete="SET NULL"),
         nullable=True,
+    )
+    default_model_configuration: Mapped["ModelConfiguration | None"] = relationship(
+        "ModelConfiguration",
+        foreign_keys=[default_model_configuration_id],
+        lazy="select",
     )
 
     starter_messages: Mapped[list[StarterMessage] | None] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3152,7 +3152,7 @@ class LLMProvider(Base):
     __tablename__ = "llm_provider"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    name: Mapped[str] = mapped_column(String, unique=True)
+    name: Mapped[str | None] = mapped_column(String, nullable=True)
     provider: Mapped[str] = mapped_column(String)
     api_key: Mapped[SensitiveValue[str] | None] = mapped_column(
         EncryptedString(), nullable=True
@@ -3668,8 +3668,14 @@ class Persona(Base):
     # Allows the persona to specify a specific default LLM model
     # NOTE: only is applied on the actual response generation - is not used for things like
     # auto-detected time filters, relevance filters, etc.
+    # Deprecated: use llm_provider_override_id instead. Kept for backward compat reads.
     llm_model_provider_override: Mapped[str | None] = mapped_column(
         String, nullable=True
+    )
+    llm_provider_override_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("llm_provider.id", ondelete="SET NULL"),
+        nullable=True,
     )
     llm_model_version_override: Mapped[str | None] = mapped_column(
         String, nullable=True

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -1050,7 +1050,15 @@ def upsert_persona(
         # `default` and `built-in` properties can only be set when creating a persona.
         existing_persona.name = name
         existing_persona.description = description
-        existing_persona.llm_provider_override_id = llm_provider_override_id
+        # Only overwrite the FK when the request explicitly provides a new value
+        # (either the new integer FK or the legacy string field). If both are absent
+        # the caller is a legacy client that doesn't know about the new field, so we
+        # preserve the existing FK to avoid silently dropping the persona's override.
+        if (
+            llm_provider_override_id is not None
+            or llm_model_provider_override is not None
+        ):
+            existing_persona.llm_provider_override_id = llm_provider_override_id
         existing_persona.llm_model_provider_override = llm_model_provider_override
         existing_persona.llm_model_version_override = llm_model_version_override
         existing_persona.starter_messages = starter_messages

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -306,7 +306,7 @@ def create_update_persona(
             document_set_ids=create_persona_request.document_set_ids,
             tool_ids=create_persona_request.tool_ids,
             is_public=create_persona_request.is_public,
-            llm_provider_override_id=create_persona_request.llm_provider_override_id,
+            default_model_configuration_id=create_persona_request.default_model_configuration_id,
             llm_model_provider_override=create_persona_request.llm_model_provider_override,
             llm_model_version_override=create_persona_request.llm_model_version_override,
             starter_messages=create_persona_request.starter_messages,
@@ -923,7 +923,7 @@ def upsert_persona(
     datetime_aware: bool | None,
     is_public: bool,
     db_session: Session,
-    llm_provider_override_id: int | None = None,
+    default_model_configuration_id: int | None = None,
     document_set_ids: list[int] | None = None,
     tool_ids: list[int] | None = None,
     persona_id: int | None = None,
@@ -1050,15 +1050,16 @@ def upsert_persona(
         # `default` and `built-in` properties can only be set when creating a persona.
         existing_persona.name = name
         existing_persona.description = description
-        # Only overwrite the FK when the request explicitly provides a new value
-        # (either the new integer FK or the legacy string field). If both are absent
-        # the caller is a legacy client that doesn't know about the new field, so we
-        # preserve the existing FK to avoid silently dropping the persona's override.
+        # Only overwrite the model config FK when the request explicitly provides a new
+        # value. If absent the caller is a legacy client that doesn't know about the new
+        # field, so we preserve the existing value to avoid silently dropping the override.
         if (
-            llm_provider_override_id is not None
+            default_model_configuration_id is not None
             or llm_model_provider_override is not None
         ):
-            existing_persona.llm_provider_override_id = llm_provider_override_id
+            existing_persona.default_model_configuration_id = (
+                default_model_configuration_id
+            )
         existing_persona.llm_model_provider_override = llm_model_provider_override
         existing_persona.llm_model_version_override = llm_model_version_override
         existing_persona.starter_messages = starter_messages
@@ -1132,7 +1133,7 @@ def upsert_persona(
             datetime_aware=(datetime_aware if datetime_aware is not None else True),
             replace_base_system_prompt=replace_base_system_prompt,
             document_sets=document_sets or [],
-            llm_provider_override_id=llm_provider_override_id,
+            default_model_configuration_id=default_model_configuration_id,
             llm_model_provider_override=llm_model_provider_override,
             llm_model_version_override=llm_model_version_override,
             starter_messages=starter_messages,

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -306,6 +306,7 @@ def create_update_persona(
             document_set_ids=create_persona_request.document_set_ids,
             tool_ids=create_persona_request.tool_ids,
             is_public=create_persona_request.is_public,
+            llm_provider_override_id=create_persona_request.llm_provider_override_id,
             llm_model_provider_override=create_persona_request.llm_model_provider_override,
             llm_model_version_override=create_persona_request.llm_model_version_override,
             starter_messages=create_persona_request.starter_messages,
@@ -922,6 +923,7 @@ def upsert_persona(
     datetime_aware: bool | None,
     is_public: bool,
     db_session: Session,
+    llm_provider_override_id: int | None = None,
     document_set_ids: list[int] | None = None,
     tool_ids: list[int] | None = None,
     persona_id: int | None = None,
@@ -1048,6 +1050,7 @@ def upsert_persona(
         # `default` and `built-in` properties can only be set when creating a persona.
         existing_persona.name = name
         existing_persona.description = description
+        existing_persona.llm_provider_override_id = llm_provider_override_id
         existing_persona.llm_model_provider_override = llm_model_provider_override
         existing_persona.llm_model_version_override = llm_model_version_override
         existing_persona.starter_messages = starter_messages
@@ -1121,6 +1124,7 @@ def upsert_persona(
             datetime_aware=(datetime_aware if datetime_aware is not None else True),
             replace_base_system_prompt=replace_base_system_prompt,
             document_sets=document_sets or [],
+            llm_provider_override_id=llm_provider_override_id,
             llm_model_provider_override=llm_model_provider_override,
             llm_model_version_override=llm_model_version_override,
             starter_messages=starter_messages,

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -9,7 +9,6 @@ from onyx.db.llm import can_user_access_llm_provider
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_default_vision_model
 from onyx.db.llm import fetch_existing_llm_provider
-from onyx.db.llm import fetch_existing_llm_provider_by_id
 from onyx.db.llm import fetch_existing_models
 from onyx.db.llm import fetch_llm_provider_view
 from onyx.db.llm import fetch_user_group_ids
@@ -96,11 +95,12 @@ def get_llm_for_persona(
     model_version_override = llm_override.model_version if llm_override else None
     temperature_override = llm_override.temperature if llm_override else None
 
-    # Resolve the provider: explicit runtime override by name takes priority, then
-    # the persona's FK-based override (ID), then legacy name override, then global default.
+    # Resolve the provider and model.
+    # Priority: explicit runtime override by name > persona's model config FK >
+    # legacy string fields > global default.
     has_override = bool(
         provider_name_override
-        or persona.llm_provider_override_id
+        or persona.default_model_configuration_id
         or persona.llm_model_provider_override
     )
     if not has_override:
@@ -110,23 +110,41 @@ def get_llm_for_persona(
         )
 
     with get_session_with_current_tenant() as db_session:
+        model: str | None
         if provider_name_override:
             provider_model = fetch_existing_llm_provider(
                 provider_name_override, db_session
             )
-        elif persona.llm_provider_override_id:
-            provider_model = fetch_existing_llm_provider_by_id(
-                persona.llm_provider_override_id, db_session
-            )
+            model = model_version_override or persona.llm_model_version_override
+        elif persona.default_model_configuration_id:
+            # Canonical path: load provider and model name directly from the FK.
+            db_session.refresh(persona)
+            model_config = persona.default_model_configuration
+            if model_config is None:
+                logger.warning(
+                    "Persona %s has default_model_configuration_id=%s but config not found."
+                    " Falling back to default.",
+                    persona.id,
+                    persona.default_model_configuration_id,
+                )
+                return get_default_llm(
+                    temperature=temperature_override or GEN_AI_TEMPERATURE,
+                    additional_headers=additional_headers,
+                )
+            provider_model = model_config.llm_provider
+            model = model_version_override or model_config.name
         else:
-            # Legacy fallback: persona was created before the ID-based migration.
-            # has_override guarantees llm_model_provider_override is set here.
+            # Legacy fallback: persona was saved before the model-config FK migration.
             assert persona.llm_model_provider_override is not None
             provider_model = fetch_existing_llm_provider(
                 persona.llm_model_provider_override, db_session
             )
+            model = model_version_override or persona.llm_model_version_override
+
         if not provider_model:
             raise ValueError("No LLM provider found")
+        if not model:
+            raise ValueError("No model name found")
 
         # Fetch user group IDs for access control check
         user_group_ids = fetch_user_group_ids(db_session, user)
@@ -146,10 +164,6 @@ def get_llm_for_persona(
             )
 
         llm_provider = LLMProviderView.from_model(provider_model)
-
-    model = model_version_override or persona.llm_model_version_override
-    if not model:
-        raise ValueError("No model name found")
 
     return llm_from_provider(
         model_name=model,

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -12,6 +12,7 @@ from onyx.db.llm import fetch_existing_llm_provider
 from onyx.db.llm import fetch_existing_models
 from onyx.db.llm import fetch_llm_provider_view
 from onyx.db.llm import fetch_user_group_ids
+from onyx.db.models import ModelConfiguration
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.llm.constants import LlmProviderNames
@@ -115,11 +116,24 @@ def get_llm_for_persona(
             provider_model = fetch_existing_llm_provider(
                 provider_name_override, db_session
             )
-            model = model_version_override or persona.llm_model_version_override
+            if model_version_override:
+                model = model_version_override
+            elif persona.llm_model_version_override:
+                model = persona.llm_model_version_override
+            elif persona.default_model_configuration_id:
+                # Migrated persona: no legacy string, use FK model name.
+                mc = db_session.get(
+                    ModelConfiguration, persona.default_model_configuration_id
+                )
+                model = mc.name if mc else None
+            else:
+                model = None
         elif persona.default_model_configuration_id:
-            # Canonical path: load provider and model name directly from the FK.
-            db_session.refresh(persona)
-            model_config = persona.default_model_configuration
+            # Canonical path: load provider and model name directly from the FK,
+            # avoiding any relationship access on a possibly-detached persona.
+            model_config = db_session.get(
+                ModelConfiguration, persona.default_model_configuration_id
+            )
             if model_config is None:
                 logger.warning(
                     "Persona %s has default_model_configuration_id=%s but config not found."

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -9,6 +9,7 @@ from onyx.db.llm import can_user_access_llm_provider
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_default_vision_model
 from onyx.db.llm import fetch_existing_llm_provider
+from onyx.db.llm import fetch_existing_llm_provider_by_id
 from onyx.db.llm import fetch_existing_models
 from onyx.db.llm import fetch_llm_provider_view
 from onyx.db.llm import fetch_user_group_ids
@@ -95,15 +96,35 @@ def get_llm_for_persona(
     model_version_override = llm_override.model_version if llm_override else None
     temperature_override = llm_override.temperature if llm_override else None
 
-    provider_name = provider_name_override or persona.llm_model_provider_override
-    if not provider_name:
+    # Resolve the provider: explicit runtime override by name takes priority, then
+    # the persona's FK-based override (ID), then legacy name override, then global default.
+    has_override = bool(
+        provider_name_override
+        or persona.llm_provider_override_id
+        or persona.llm_model_provider_override
+    )
+    if not has_override:
         return get_default_llm(
             temperature=temperature_override or GEN_AI_TEMPERATURE,
             additional_headers=additional_headers,
         )
 
     with get_session_with_current_tenant() as db_session:
-        provider_model = fetch_existing_llm_provider(provider_name, db_session)
+        if provider_name_override:
+            provider_model = fetch_existing_llm_provider(
+                provider_name_override, db_session
+            )
+        elif persona.llm_provider_override_id:
+            provider_model = fetch_existing_llm_provider_by_id(
+                persona.llm_provider_override_id, db_session
+            )
+        else:
+            # Legacy fallback: persona was created before the ID-based migration.
+            # has_override guarantees llm_model_provider_override is set here.
+            assert persona.llm_model_provider_override is not None
+            provider_model = fetch_existing_llm_provider(
+                persona.llm_model_provider_override, db_session
+            )
         if not provider_model:
             raise ValueError("No LLM provider found")
 

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -727,7 +727,7 @@ def get_max_input_tokens_from_llm_provider(
         max_input_tokens
         if max_input_tokens
         else get_max_input_tokens(
-            model_provider=llm_provider.name,
+            model_provider=llm_provider.name or llm_provider.provider,
             model_name=model_name,
         )
     )

--- a/backend/onyx/llm/well_known_providers/auto_update_service.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_service.py
@@ -132,7 +132,7 @@ def sync_llm_models_from_github(
         )
 
         if changes > 0:
-            results[provider.name] = changes
+            results[provider.name or provider.provider] = changes
             logger.info(
                 "Applied %s model changes to provider '%s'", changes, provider.name
             )

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -107,6 +107,9 @@ class PersonaUpsertRequest(BaseModel):
     description: str
     document_set_ids: list[int]
     is_public: bool
+    # Preferred: reference the provider by integer PK.
+    llm_provider_override_id: int | None = None
+    # Deprecated: legacy string-based override kept for backward compat with old clients.
     llm_model_provider_override: str | None = None
     llm_model_version_override: str | None = None
     starter_messages: list[StarterMessage] | None = None
@@ -159,6 +162,7 @@ class MinimalPersonaSnapshot(BaseModel):
     knowledge_sources: list[DocumentSource]
     llm_model_version_override: str | None
     llm_model_provider_override: str | None
+    llm_provider_override_id: int | None
 
     uploaded_image_id: str | None
     icon_name: str | None
@@ -221,6 +225,7 @@ class MinimalPersonaSnapshot(BaseModel):
             knowledge_sources=list(sources),
             llm_model_version_override=persona.llm_model_version_override,
             llm_model_provider_override=persona.llm_model_provider_override,
+            llm_provider_override_id=persona.llm_provider_override_id,
             uploaded_image_id=persona.uploaded_image_id,
             icon_name=persona.icon_name,
             is_public=persona.is_public,
@@ -259,6 +264,7 @@ class PersonaSnapshot(BaseModel):
     document_sets: list[DocumentSetSummary]
     llm_model_provider_override: str | None
     llm_model_version_override: str | None
+    llm_provider_override_id: int | None = None
     # Hierarchy nodes attached for scoped search
     hierarchy_nodes: list[HierarchyNodeSnapshot] = Field(default_factory=list)
     # Individual documents attached for scoped search
@@ -315,6 +321,7 @@ class PersonaSnapshot(BaseModel):
             ],
             llm_model_provider_override=persona.llm_model_provider_override,
             llm_model_version_override=persona.llm_model_version_override,
+            llm_provider_override_id=persona.llm_provider_override_id,
             system_prompt=persona.system_prompt,
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
@@ -382,6 +389,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
             search_start_date=persona.search_start_date,
             llm_model_provider_override=persona.llm_model_provider_override,
             llm_model_version_override=persona.llm_model_version_override,
+            llm_provider_override_id=persona.llm_provider_override_id,
             system_prompt=persona.system_prompt,
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -107,9 +107,9 @@ class PersonaUpsertRequest(BaseModel):
     description: str
     document_set_ids: list[int]
     is_public: bool
-    # Preferred: reference the provider by integer PK.
-    llm_provider_override_id: int | None = None
-    # Deprecated: legacy string-based override kept for backward compat with old clients.
+    # Single FK that encodes both provider and model.
+    default_model_configuration_id: int | None = None
+    # Deprecated string fields — kept for backward compat with old clients.
     llm_model_provider_override: str | None = None
     llm_model_version_override: str | None = None
     starter_messages: list[StarterMessage] | None = None
@@ -162,7 +162,7 @@ class MinimalPersonaSnapshot(BaseModel):
     knowledge_sources: list[DocumentSource]
     llm_model_version_override: str | None
     llm_model_provider_override: str | None
-    llm_provider_override_id: int | None
+    default_model_configuration_id: int | None
 
     uploaded_image_id: str | None
     icon_name: str | None
@@ -225,7 +225,7 @@ class MinimalPersonaSnapshot(BaseModel):
             knowledge_sources=list(sources),
             llm_model_version_override=persona.llm_model_version_override,
             llm_model_provider_override=persona.llm_model_provider_override,
-            llm_provider_override_id=persona.llm_provider_override_id,
+            default_model_configuration_id=persona.default_model_configuration_id,
             uploaded_image_id=persona.uploaded_image_id,
             icon_name=persona.icon_name,
             is_public=persona.is_public,
@@ -264,7 +264,7 @@ class PersonaSnapshot(BaseModel):
     document_sets: list[DocumentSetSummary]
     llm_model_provider_override: str | None
     llm_model_version_override: str | None
-    llm_provider_override_id: int | None = None
+    default_model_configuration_id: int | None = None
     # Hierarchy nodes attached for scoped search
     hierarchy_nodes: list[HierarchyNodeSnapshot] = Field(default_factory=list)
     # Individual documents attached for scoped search
@@ -321,7 +321,7 @@ class PersonaSnapshot(BaseModel):
             ],
             llm_model_provider_override=persona.llm_model_provider_override,
             llm_model_version_override=persona.llm_model_version_override,
-            llm_provider_override_id=persona.llm_provider_override_id,
+            default_model_configuration_id=persona.default_model_configuration_id,
             system_prompt=persona.system_prompt,
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
@@ -389,7 +389,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
             search_start_date=persona.search_start_date,
             llm_model_provider_override=persona.llm_model_provider_override,
             llm_model_version_override=persona.llm_model_version_override,
-            llm_provider_override_id=persona.llm_provider_override_id,
+            default_model_configuration_id=persona.default_model_configuration_id,
             system_prompt=persona.system_prompt,
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,

--- a/backend/onyx/server/manage/image_generation/models.py
+++ b/backend/onyx/server/manage/image_generation/models.py
@@ -117,7 +117,7 @@ class ImageGenerationConfigView(BaseModel):
             model_configuration_id=config.model_configuration_id,
             model_name=config.model_configuration.name,
             llm_provider_id=config.model_configuration.llm_provider_id,
-            llm_provider_name=config.model_configuration.llm_provider.name,
+            llm_provider_name=config.model_configuration.llm_provider.name or "",
             is_default=config.is_default,
         )
 

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -439,41 +439,24 @@ def put_llm_provider(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> LLMProviderView:
-    # validate request (e.g. if we're intending to create but the name already exists we should throw an error)
-    # NOTE: may involve duplicate fetching to Postgres, but we're assuming SQLAlchemy is smart enough to cache
-    # the result
+    # Validate that the provider exists (or doesn't) as expected for the operation.
+    # Identity is the integer PK — name is now a mutable display label with no uniqueness
+    # guarantee, so we no longer check for name duplicates or block renaming.
     existing_provider = None
     if llm_provider_upsert_request.id:
         existing_provider = fetch_existing_llm_provider_by_id(
             id=llm_provider_upsert_request.id, db_session=db_session
         )
 
-    # Check name constraints
-    # TODO: Once port from name to id is complete, unique name will no longer be required
-    if existing_provider and llm_provider_upsert_request.name != existing_provider.name:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "Renaming providers is not currently supported",
-        )
-
-    found_provider = fetch_existing_llm_provider(
-        name=llm_provider_upsert_request.name, db_session=db_session
-    )
-    if found_provider is not None and found_provider is not existing_provider:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"Provider with name={llm_provider_upsert_request.name} already exists",
-        )
-
     if existing_provider and is_creation:
         raise OnyxError(
             OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"LLM Provider with name {llm_provider_upsert_request.name} and id={llm_provider_upsert_request.id} already exists",
+            f"LLM Provider with id={llm_provider_upsert_request.id} already exists",
         )
     elif not existing_provider and not is_creation:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
-            f"LLM Provider with name {llm_provider_upsert_request.name} and id={llm_provider_upsert_request.id} does not exist",
+            f"LLM Provider with id={llm_provider_upsert_request.id} does not exist",
         )
 
     # SSRF Protection: Validate api_base and custom_config match stored values
@@ -826,8 +809,6 @@ def list_llm_providers_for_persona(
     )
 
     # Get the default model and vision model for the persona
-    # TODO: Port persona's over to use ID
-    persona_default_provider = persona.llm_model_provider_override
     persona_default_model = persona.llm_model_version_override
 
     default_text_model = fetch_default_llm_model(db_session)
@@ -838,8 +819,10 @@ def list_llm_providers_for_persona(
     default_text = DefaultModel.from_model_config(default_text_model)
     default_vision = DefaultModel.from_model_config(default_vision_model)
 
-    if persona_default_provider:
-        provider = fetch_existing_llm_provider(persona_default_provider, db_session)
+    if persona.llm_provider_override_id:
+        provider = fetch_existing_llm_provider_by_id(
+            persona.llm_provider_override_id, db_session
+        )
         if provider and can_user_access_llm_provider(
             provider, user_group_ids, persona, is_admin=is_admin
         ):
@@ -911,7 +894,7 @@ def get_provider_contextual_cost(
             cost = get_llm_contextual_cost(llm)
             costs.append(
                 LLMCost(
-                    provider=provider.name,
+                    provider=provider.name or provider.provider,
                     model_name=model_configuration.name,
                     cost=cost,
                 )

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -808,9 +808,6 @@ def list_llm_providers_for_persona(
         format(duration, ".2f"),
     )
 
-    # Get the default model and vision model for the persona
-    persona_default_model = persona.llm_model_version_override
-
     default_text_model = fetch_default_llm_model(db_session)
     default_vision_model = fetch_default_vision_model(db_session)
 
@@ -819,22 +816,32 @@ def list_llm_providers_for_persona(
     default_text = DefaultModel.from_model_config(default_text_model)
     default_vision = DefaultModel.from_model_config(default_vision_model)
 
-    if persona.llm_provider_override_id:
-        provider = fetch_existing_llm_provider_by_id(
-            persona.llm_provider_override_id, db_session
+    if persona.default_model_configuration_id:
+        # Canonical path: model config FK encodes both provider and model name.
+        db_session.refresh(persona)
+        model_config = persona.default_model_configuration
+        if model_config and can_user_access_llm_provider(
+            model_config.llm_provider, user_group_ids, persona, is_admin=is_admin
+        ):
+            default_text = DefaultModel(
+                provider_id=model_config.llm_provider_id,
+                model_name=model_config.name,
+            )
+    elif persona.llm_model_provider_override:
+        # Legacy fallback: persona was saved before the model-config FK migration.
+        provider = fetch_existing_llm_provider(
+            persona.llm_model_provider_override, db_session
         )
         if provider and can_user_access_llm_provider(
             provider, user_group_ids, persona, is_admin=is_admin
         ):
-            if persona_default_model:
-                # Persona specifies both provider and model — use them directly
+            model_name = persona.llm_model_version_override
+            if model_name:
                 default_text = DefaultModel(
                     provider_id=provider.id,
-                    model_name=persona_default_model,
+                    model_name=model_name,
                 )
             else:
-                # Persona specifies only the provider — pick a visible (public) model,
-                # falling back to any model on this provider
                 visible_model = next(
                     (mc for mc in provider.model_configurations if mc.is_visible),
                     None,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -190,7 +190,7 @@ class ModelConfigurationUpsertRequest(BaseModel):
 
 
 class ModelConfigurationView(BaseModel):
-    id: int
+    id: int | None = None
     name: str
     is_visible: bool
     max_input_tokens: int | None = None

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -190,6 +190,7 @@ class ModelConfigurationUpsertRequest(BaseModel):
 
 
 class ModelConfigurationView(BaseModel):
+    id: int
     name: str
     is_visible: bool
     max_input_tokens: int | None = None
@@ -219,6 +220,7 @@ class ModelConfigurationView(BaseModel):
             )
 
             return cls(
+                id=model_configuration_model.id,
                 name=model_configuration_model.name,
                 is_visible=model_configuration_model.is_visible,
                 max_input_tokens=model_configuration_model.max_input_tokens,
@@ -256,6 +258,7 @@ class ModelConfigurationView(BaseModel):
         )
 
         return cls(
+            id=model_configuration_model.id,
             name=model_configuration_model.name,
             is_visible=model_configuration_model.is_visible,
             max_input_tokens=(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -61,7 +61,7 @@ class LLMProviderDescriptor(BaseModel):
     non-admin users. Used when giving a list of available LLMs."""
 
     id: int
-    name: str
+    name: str | None
     provider: str
     provider_display_name: str  # Human-friendly name like "Claude (Anthropic)"
     model_configurations: list["ModelConfigurationView"]
@@ -91,7 +91,7 @@ class LLMProviderDescriptor(BaseModel):
 
 
 class LLMProvider(BaseModel):
-    name: str
+    name: str | None = None
     provider: str
     api_key: str | None = None
     api_base: str | None = None

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider.py
@@ -529,7 +529,8 @@ class TestDefaultProviderEndpoint:
             provider_names_to_restore: list[str] = []
 
             for provider in existing_providers:
-                provider_names_to_restore.append(provider.name)
+                if provider.name is not None:
+                    provider_names_to_restore.append(provider.name)
 
             # Remove all providers temporarily
             for provider in existing_providers:

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -77,9 +77,12 @@ def assert_response_is_equivalent(
             "version": parsed.version,
         }
 
-    # Compare model configurations by name (order-independent)
+    # Compare model configurations by name (order-independent).
+    # Strip `id` from the actual — it's a DB-assigned primary key that the
+    # expected dict doesn't include and is not part of the business logic being tested.
     actual_by_name = {
-        config["name"]: config for config in provider_data["model_configurations"]
+        config["name"]: {k: v for k, v in config.items() if k != "id"}
+        for config in provider_data["model_configurations"]
     }
     expected_by_name = {
         config.name: fill_max_input_tokens_and_supports_image_input(config)

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -640,10 +640,13 @@ def test_delete_default_vision_provider_clears_vision_default(
     assert text_default["provider_id"] == text_provider["id"]
 
 
-def test_duplicate_provider_name_rejected(reset: None) -> None:  # noqa: ARG001
-    """Creating a provider with a name that already exists should return 400."""
+def test_duplicate_provider_name_allowed(reset: None) -> None:  # noqa: ARG001
+    """Creating multiple providers with the same display name should succeed.
+
+    Display names are now purely cosmetic — the integer PK is the unique identifier.
+    """
     admin_user = UserManager.create(name="admin_user")
-    provider_name = f"unique-provider-{uuid.uuid4()}"
+    provider_name = f"shared-name-{uuid.uuid4()}"
 
     base_payload = {
         "name": provider_name,
@@ -665,23 +668,28 @@ def test_duplicate_provider_name_rejected(reset: None) -> None:  # noqa: ARG001
         json=base_payload,
     )
     assert response.status_code == 200
+    first_id = response.json()["id"]
 
-    # Second creation with the same name is rejected
+    # Second creation with the same display name also succeeds — names are not unique
     response = requests.put(
         f"{API_SERVER_URL}/admin/llm/provider?is_creation=true",
         headers=admin_user.headers,
         json=base_payload,
     )
-    assert response.status_code == 409
-    assert "already exists" in response.json()["detail"]
+    assert response.status_code == 200
+    second_id = response.json()["id"]
+
+    # They are distinct providers identified by their integer PKs
+    assert first_id != second_id
 
 
-def test_rename_provider_rejected(reset: None) -> None:  # noqa: ARG001
-    """Renaming a provider is not currently supported and should return 400."""
+def test_rename_provider_allowed(reset: None) -> None:  # noqa: ARG001
+    """Renaming a provider should succeed and the updated name should be visible."""
     admin_user = UserManager.create(name="admin_user")
+    original_name = f"original-name-{uuid.uuid4()}"
 
     create_payload = {
-        "name": f"original-name-{uuid.uuid4()}",
+        "name": original_name,
         "provider": LlmProviderNames.OPENAI,
         "api_key": "sk-000000000000000000000000000000000000000000000000",
         "model_configurations": [
@@ -701,7 +709,7 @@ def test_rename_provider_rejected(reset: None) -> None:  # noqa: ARG001
     assert response.status_code == 200
     provider_id = response.json()["id"]
 
-    # Attempt to rename — should be rejected
+    # Rename the provider — should succeed
     new_name = f"renamed-provider-{uuid.uuid4()}"
     update_payload = {**create_payload, "id": provider_id, "name": new_name}
     response = requests.put(
@@ -709,21 +717,13 @@ def test_rename_provider_rejected(reset: None) -> None:  # noqa: ARG001
         headers=admin_user.headers,
         json=update_payload,
     )
-    assert response.status_code == 400
-    assert "not currently supported" in response.json()["detail"]
+    assert response.status_code == 200
+    assert response.json()["name"] == new_name
 
-    # Verify no duplicate was created — only the original provider should exist
+    # Verify the name was updated in place — same ID, new name
     provider = _get_provider_by_id(admin_user, provider_id)
     assert provider is not None
-    assert provider["name"] == create_payload["name"]
-
-    all_response = requests.get(
-        f"{API_SERVER_URL}/admin/llm/provider",
-        headers=admin_user.headers,
-    )
-    assert all_response.status_code == 200
-    all_names = [p["name"] for p in all_response.json()["providers"]]
-    assert new_name not in all_names
+    assert provider["name"] == new_name
 
 
 def test_model_visibility_preserved_on_edit(reset: None) -> None:  # noqa: ARG001

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider_access_control.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider_access_control.py
@@ -71,7 +71,7 @@ def _create_persona(
     db_session: Session,
     *,
     name: str,
-    provider_name: str,
+    provider_name: str | None,
 ) -> Persona:
     persona = Persona(
         name=name,


### PR DESCRIPTION
## Description

Decouples the LLM provider display name from its identity key. Previously `name` was both the unique identifier and the display label, forcing admins to enter a name even when it added no real value. The integer PK is now the stable unique identifier.

Changes:
- `llm_provider.name`: removed `UNIQUE` constraint, made nullable
- `persona.llm_provider_override_id`: new `int FK` column replaces the string-based `llm_model_provider_override` for persona overrides
- Alembic migration: makes name nullable/non-unique, adds FK column, data-migrates existing string overrides to integer IDs
- `get_llm_for_persona` in `factory.py`: three-way lookup — explicit name override → integer FK → legacy string (backward compat for pre-migration personas)
- `get_personas_using_provider`: now queries by FK instead of string match
- `put_llm_provider` API: removed "renaming not supported" guard and name-based duplicate check
- Pydantic models: `name: str | None`, `llm_provider_override_id: int | None` added to persona request/response
- `ON DELETE SET NULL` FK so deleting a provider automatically clears persona overrides

Backward compatibility: `llm_model_provider_override` string field retained in Pydantic request/response models for the existing Agent Editor frontend; factory.py has a legacy fallback path for personas created before the migration.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make LLM provider display names optional and non-unique, and switch personas to a single model-configuration FK for overrides. This decouples identity from labels, allows renames/duplicate names, and makes deletes and fallbacks safer.

- **Refactors**
  - `llm_provider.name` is nullable and not unique; integer `id` is the identifier. Renames and duplicate names are allowed; updates persist new names.
  - Personas use `default_model_configuration_id` (FK) instead of `llm_model_provider_override`/`llm_model_version_override` (kept for legacy reads/writes). Added `Persona.default_model_configuration` relationship; `ModelConfigurationView.id` is optional.
  - Provider/model resolution in `get_llm_for_persona`: runtime name override → persona `default_model_configuration_id` → legacy strings → default. Loads `ModelConfiguration` by id to avoid session issues; when overriding by provider name without a model, falls back to the FK’s model name. Raises clear errors if provider/model missing.
  - Deleting a provider clears `default_model_configuration_id` and legacy string overrides on affected personas; `get_personas_using_provider` now takes `provider_id` and joins via `model_configuration`.
  - Preserve an existing `default_model_configuration_id` when legacy clients omit both override fields during persona updates.
  - API models and responses: `LLMProvider.name` can be `null`; persona requests/responses and snapshots include `default_model_configuration_id`. Name-null-safe fallbacks use provider type when `name` is `null` in token limits, auto-update logs, cost reporting, and image generation.
  - Provider upsert API: identity is ID-only; duplicate names and renames are allowed.

- **Migration**
  - Make `llm_provider.name` nullable/drop unique; backfill `persona.default_model_configuration_id` by joining existing string overrides to `llm_provider` and `model_configuration`.
  - Use SQLAlchemy Core constructs for the data backfill instead of raw SQL.
  - Downgrade: backfill null provider names with `provider || '-' || id::text`, then restore NOT NULL/UNIQUE to avoid duplicate-name violations.
  - No immediate client changes required; clients can start sending `default_model_configuration_id` when ready.

<sup>Written for commit ad07fb97964c61d11c93bab4582da1181863c6d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

