### PR TITLE
fix(indexing): surface oversized document errors and raise MAX_DOCUMENT_CHARS limit

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -882,8 +882,10 @@ INDEXING_EMBEDDING_MODEL_NUM_THREADS = int(
     os.environ.get("INDEXING_EMBEDDING_MODEL_NUM_THREADS") or 8
 )
 
-# Maximum file size in a document to be indexed
-MAX_DOCUMENT_CHARS = int(os.environ.get("MAX_DOCUMENT_CHARS") or 5_000_000)
+# Maximum number of characters in a single document before it is skipped during indexing.
+# Documents exceeding this limit will surface a visible error rather than being silently dropped.
+# Default is 512MB worth of characters (536,870,912). Configurable via MAX_DOCUMENT_CHARS env var.
+MAX_DOCUMENT_CHARS = int(os.environ.get("MAX_DOCUMENT_CHARS") or 536_870_912)
 MAX_FILE_SIZE_BYTES = int(
     os.environ.get("MAX_FILE_SIZE_BYTES") or 2 * 1024 * 1024 * 1024
 )  # 2GB in bytes

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -531,8 +531,11 @@ def index_doc_batch_prepare(
     )
 
 
-def filter_documents(document_batch: list[Document]) -> list[Document]:
+def filter_documents(
+    document_batch: list[Document],
+) -> tuple[list[Document], list[ConnectorFailure]]:
     documents: list[Document] = []
+    failures: list[ConnectorFailure] = []
     total_chars_in_batch = 0
     skipped_too_long = []
 
@@ -591,6 +594,23 @@ def filter_documents(document_batch: list[Document]) -> list[Document]:
                 format(MAX_DOCUMENT_CHARS, ","),
             )
             skipped_too_long.append((document.id, doc_total_chars))
+            failures.append(
+                ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=document.id,
+                        document_link=(
+                            document.sections[0].link if document.sections else None
+                        ),
+                    ),
+                    failure_message=(
+                        f"Document '{document.semantic_identifier}' is too large to index "
+                        f"({format(doc_total_chars, ',')} chars). "
+                        f"The limit is {format(MAX_DOCUMENT_CHARS, ',')} chars "
+                        f"(set by MAX_DOCUMENT_CHARS). "
+                        "Split the document into smaller parts to index it."
+                    ),
+                )
+            )
             continue
 
         total_chars_in_batch += doc_total_chars
@@ -614,7 +634,7 @@ def filter_documents(document_batch: list[Document]) -> list[Document]:
                 "Skipped oversized documents [%s]: %s", source, skipped_too_long[:5]
             )  # Log first 5
 
-    return documents
+    return documents, failures
 
 
 def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
@@ -1083,7 +1103,9 @@ def index_doc_batch(
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
     ignore_time_skip: bool = False,
-    filter_fnc: Callable[[list[Document]], list[Document]] = filter_documents,
+    filter_fnc: Callable[
+        [list[Document]], tuple[list[Document], list[ConnectorFailure]]
+    ] = filter_documents,
 ) -> IndexingPipelineResult:
     """End-to-end indexing for a pre-batched set of documents."""
     """Takes different pieces of the indexing pipeline and applies it to a batch of documents
@@ -1114,12 +1136,14 @@ def index_doc_batch(
         _attempt_metadata.attempt_id if _attempt_metadata is not None else None
     )
 
-    filtered_documents = filter_fnc(document_batch)
+    filtered_documents, filter_failures = filter_fnc(document_batch)
     filtered_documents = _apply_document_ingestion_hook(filtered_documents, db_session)
     with time_stage_if_set(IndexAttemptStage.DOC_DB_PREPARE, attempt_id):
         context = adapter.prepare(filtered_documents, ignore_time_skip)
     if not context:
-        return IndexingPipelineResult.empty(len(filtered_documents))
+        result = IndexingPipelineResult.empty(len(filtered_documents))
+        result.failures.extend(filter_failures)
+        return result
 
     # Convert documents to IndexingDocument objects with processed section.
     # Only record IMAGE_PROCESSING when there's actually image work to do --
@@ -1282,7 +1306,8 @@ def index_doc_batch(
         total_docs=len(filtered_documents),
         total_chunks=len(embedding_result.successful_chunk_ids),
         failures=primary_doc_idx_vector_db_write_failures
-        + embedding_result.connector_failures,
+        + embedding_result.connector_failures
+        + filter_failures,
     )
 
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import pytest
 
-from onyx.configs.app_configs import MAX_DOCUMENT_CHARS
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentSource
 from onyx.connectors.models import ImageSection
@@ -54,35 +53,43 @@ def test_filter_documents_empty_title_and_content() -> None:
     doc = create_test_document(
         title="", semantic_id="", sections=[TextSection(text="", link="test_link")]
     )
-    result = filter_documents([doc])
-    assert len(result) == 0
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 0
+    assert len(failures) == 0
 
 
 def test_filter_documents_empty_title_with_content() -> None:
     doc = create_test_document(
         title="", sections=[TextSection(text="Valid content", link="test_link")]
     )
-    result = filter_documents([doc])
-    assert len(result) == 1
-    assert result[0].id == "test_id"
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 1
+    assert docs[0].id == "test_id"
+    assert len(failures) == 0
 
 
 def test_filter_documents_empty_content_with_title() -> None:
     doc = create_test_document(
         title="Valid Title", sections=[TextSection(text="", link="test_link")]
     )
-    result = filter_documents([doc])
-    assert len(result) == 1
-    assert result[0].id == "test_id"
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 1
+    assert docs[0].id == "test_id"
+    assert len(failures) == 0
 
 
 def test_filter_documents_exceeding_max_chars() -> None:
-    if not MAX_DOCUMENT_CHARS:  # Skip if no max chars configured
-        return
-    long_text = "a" * (MAX_DOCUMENT_CHARS + 1)
+    limit = 100
+    long_text = "a" * (limit + 1)
     doc = create_test_document(sections=[TextSection(text=long_text, link="test_link")])
-    result = filter_documents([doc])
-    assert len(result) == 0
+    with patch("onyx.indexing.indexing_pipeline.MAX_DOCUMENT_CHARS", limit):
+        docs, failures = filter_documents([doc])
+    assert len(docs) == 0
+    assert len(failures) == 1
+    assert failures[0].failed_document is not None
+    assert failures[0].failed_document.document_id == "test_id"
+    assert "too large to index" in failures[0].failure_message
+    assert "MAX_DOCUMENT_CHARS" in failures[0].failure_message
 
 
 def test_filter_documents_valid_document() -> None:
@@ -90,10 +97,11 @@ def test_filter_documents_valid_document() -> None:
         title="Valid Title",
         sections=[TextSection(text="Valid content", link="test_link")],
     )
-    result = filter_documents([doc])
-    assert len(result) == 1
-    assert result[0].id == "test_id"
-    assert result[0].title == "Valid Title"
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 1
+    assert docs[0].id == "test_id"
+    assert docs[0].title == "Valid Title"
+    assert len(failures) == 0
 
 
 def test_filter_documents_whitespace_only() -> None:
@@ -102,8 +110,9 @@ def test_filter_documents_whitespace_only() -> None:
         semantic_id="  ",
         sections=[TextSection(text="   ", link="test_link")],
     )
-    result = filter_documents([doc])
-    assert len(result) == 0
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 0
+    assert len(failures) == 0
 
 
 def test_filter_documents_semantic_id_no_title() -> None:
@@ -112,9 +121,10 @@ def test_filter_documents_semantic_id_no_title() -> None:
         semantic_id="Valid Semantic ID",
         sections=[TextSection(text="Valid content", link="test_link")],
     )
-    result = filter_documents([doc])
-    assert len(result) == 1
-    assert result[0].semantic_identifier == "Valid Semantic ID"
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 1
+    assert docs[0].semantic_identifier == "Valid Semantic ID"
+    assert len(failures) == 0
 
 
 def test_filter_documents_multiple_sections() -> None:
@@ -125,27 +135,30 @@ def test_filter_documents_multiple_sections() -> None:
             TextSection(text="Content 3", link="test_link"),
         ]
     )
-    result = filter_documents([doc])
-    assert len(result) == 1
-    assert len(result[0].sections) == 3
+    docs, failures = filter_documents([doc])
+    assert len(docs) == 1
+    assert len(docs[0].sections) == 3
+    assert len(failures) == 0
 
 
 def test_filter_documents_multiple_documents() -> None:
-    docs = [
+    docs_input = [
         create_test_document(doc_id="1", title="Title 1"),
         create_test_document(
             doc_id="2", title="", sections=[TextSection(text="", link="test_link")]
-        ),  # Should be filtered
+        ),  # Should be filtered (empty, no failure)
         create_test_document(doc_id="3", title="Title 3"),
     ]
-    result = filter_documents(docs)
-    assert len(result) == 2
-    assert {doc.id for doc in result} == {"1", "3"}
+    docs, failures = filter_documents(docs_input)
+    assert len(docs) == 2
+    assert {doc.id for doc in docs} == {"1", "3"}
+    assert len(failures) == 0
 
 
 def test_filter_documents_empty_batch() -> None:
-    result = filter_documents([])
-    assert len(result) == 0
+    docs, failures = filter_documents([])
+    assert len(docs) == 0
+    assert len(failures) == 0
 
 
 @patch("onyx.llm.utils.GEN_AI_MAX_TOKENS", 4096)


### PR DESCRIPTION
## Description

Documents exceeding `MAX_DOCUMENT_CHARS` were silently dropped during indexing, causing connectors to show "Succeeded / No additional docs processed" with no explanation. This PR surfaces oversized documents as explicit `ConnectorFailure` records (visible in the connector errors modal) and raises the default limit from 5M chars (~5MB) to 536,870,912 chars (~512MB).

https://linear.app/onyx-app/issue/ENG-4104/indexing-improving-handling-of-large-files

## How Has This Been Tested?

Unit tests in `test_indexing_pipeline.py` updated to cover the new `filter_documents` return type, including a new assertion that oversized documents produce a `ConnectorFailure` with an actionable error message.

local test

- [x] test with a small threshold observing failures
- [x] test with large threshold no failures
<img width="1239" height="893" alt="Screenshot 2026-05-05 at 2 58 21 PM" src="https://github.com/user-attachments/assets/9ea9268d-6e3e-4b78-8a6b-8097f7892ae2" />
<img width="1576" height="808" alt="Screenshot 2026-05-05 at 2 58 18 PM" src="https://github.com/user-attachments/assets/26622ebf-dd14-41b4-94cc-7fcc
<img width="1475" height="221" alt="Screenshot 2026-05-05 at 3 02 44 PM" src="https://github.com/user-attachments/assets/a0c9f134-d86f-48ad-ab75-e16713711207" />
b8170350" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface oversized document errors during indexing instead of silently dropping them, and raise the default character limit to 512MB. This makes connector runs show clear failures in the connector errors modal and addresses ENG-4104.

- **Bug Fixes**
  - Oversized documents now create `ConnectorFailure` records with an actionable message (includes char count, limit, `MAX_DOCUMENT_CHARS`, and a split suggestion; adds doc link when available).
  - Increased `MAX_DOCUMENT_CHARS` default from 5,000,000 to 536,870,912 (512MB); still configurable via `MAX_DOCUMENT_CHARS`.
  - `filter_documents` now returns `(documents, failures)`; failures are propagated in `index_doc_batch` results, including when no documents are indexed; unit tests updated.

<sup>Written for commit 363c15188d328e29fe64ea75ba43c55e07d088d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



