### PR TITLE
chore(devcontainer): add release workflow to publish multi-arch image

### DIFF
--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -12,6 +12,9 @@ jobs:
       - runs-on
       - runner=2cpu-linux-x64
       - run-id=${{ github.run_id }}-devcontainer-amd64
+    environment: deploy
+    permissions:
+      id-token: write
     timeout-minutes: 60
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
@@ -23,14 +26,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
+        with:
+          secret-ids: |
+            DOCKER_USERNAME, deploy/docker-username
+            DOCKER_TOKEN, deploy/docker-token
+          parse-json-secrets: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Build and push AMD64
         id: build
@@ -53,6 +70,9 @@ jobs:
       - runs-on
       - runner=2cpu-linux-arm64
       - run-id=${{ github.run_id }}-devcontainer-arm64
+    environment: deploy
+    permissions:
+      id-token: write
     timeout-minutes: 60
     outputs:
       digest: ${{ steps.digest.outputs.digest }}
@@ -64,14 +84,28 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
+        with:
+          secret-ids: |
+            DOCKER_USERNAME, deploy/docker-username
+            DOCKER_TOKEN, deploy/docker-token
+          parse-json-secrets: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Build and push ARM64
         id: build
@@ -97,18 +131,35 @@ jobs:
       - runs-on
       - runner=2cpu-linux-x64
       - run-id=${{ github.run_id }}-devcontainer-merge
+    environment: deploy
+    permissions:
+      id-token: write
     timeout-minutes: 10
     env:
       REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
+        with:
+          secret-ids: |
+            DOCKER_USERNAME, deploy/docker-username
+            DOCKER_TOKEN, deploy/docker-token
+          parse-json-secrets: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Create and push manifest
         env:

--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -1,0 +1,121 @@
+name: Release Devcontainer
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-amd64:
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - run-id=${{ github.run_id }}-devcontainer-amd64
+    timeout-minutes: 60
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push AMD64
+        id: build
+        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # ratchet:docker/bake-action@v7.0.0
+        with:
+          targets: devcontainer
+          set: |
+            devcontainer.platform=linux/amd64
+            devcontainer.output=type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Extract digest
+        id: digest
+        env:
+          METADATA: ${{ steps.build.outputs.metadata }}
+        run: |
+          echo "digest=$(echo "$METADATA" | jq -r '.devcontainer."containerimage.digest"')" >> "$GITHUB_OUTPUT"
+
+  docker-arm64:
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - run-id=${{ github.run_id }}-devcontainer-arm64
+    timeout-minutes: 60
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+    env:
+      REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push ARM64
+        id: build
+        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # ratchet:docker/bake-action@v7.0.0
+        with:
+          targets: devcontainer
+          set: |
+            devcontainer.platform=linux/arm64
+            devcontainer.output=type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Extract digest
+        id: digest
+        env:
+          METADATA: ${{ steps.build.outputs.metadata }}
+        run: |
+          echo "digest=$(echo "$METADATA" | jq -r '.devcontainer."containerimage.digest"')" >> "$GITHUB_OUTPUT"
+
+  merge-docker:
+    needs:
+      - docker-amd64
+      - docker-arm64
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-x64
+      - run-id=${{ github.run_id }}-devcontainer-merge
+    timeout-minutes: 10
+    env:
+      REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Create and push manifest
+        env:
+          AMD64_DIGEST: ${{ needs.docker-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.docker-arm64.outputs.digest }}
+        run: |
+          docker buildx imagetools create \
+            -t "${REGISTRY_IMAGE}:latest" \
+            "${REGISTRY_IMAGE}@${AMD64_DIGEST}" \
+            "${REGISTRY_IMAGE}@${ARM64_DIGEST}"

--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -19,12 +19,12 @@ jobs:
       REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build and push AMD64
         id: build
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # ratchet:docker/bake-action@v7.0.0
+        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7
         with:
           targets: devcontainer
           set: |
@@ -60,12 +60,12 @@ jobs:
       REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build and push ARM64
         id: build
-        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7 # ratchet:docker/bake-action@v7.0.0
+        uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7
         with:
           targets: devcontainer
           set: |
@@ -102,7 +102,7 @@ jobs:
       REGISTRY_IMAGE: onyxdotapp/onyx-devcontainer
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ plans/
 
 # Added context for LLMs
 .claude/CLAUDE.md
+.claude/settings.local.json

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -19,7 +19,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "tsBuildInfoFile": "./node_modules/.cache/typescript/tsconfig.tsbuildinfo",
     "plugins": [
       {
         "name": "next"

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -19,6 +19,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/typescript/tsconfig.tsbuildinfo",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-devcontainer.yml`, a manually-triggered (`workflow_dispatch`) workflow that builds and pushes `onyxdotapp/onyx-devcontainer:latest` as a multi-arch image.
- Builds happen on native `runs-on` runners (`2cpu-linux-x64` and `2cpu-linux-arm64`) via `docker/bake-action` against the `devcontainer` target in `docker-bake.hcl`, then a `merge-docker` job stitches the two digests into a single `:latest` manifest. Pattern mirrors `release-cli.yml`.
- Auths to Docker Hub via `secrets.DOCKER_USERNAME` / `secrets.DOCKER_TOKEN` (same as `docker-tag-latest.yml`); registry cache reuses the `cache-from` refs already in `docker-bake.hcl`.

## Test plan
- [ ] Trigger the workflow from the Actions tab and confirm the `docker-amd64` and `docker-arm64` jobs both build and push by digest.
- [ ] Confirm `merge-docker` creates `onyxdotapp/onyx-devcontainer:latest` as a multi-arch manifest containing both `linux/amd64` and `linux/arm64`.
- [ ] `docker pull onyxdotapp/onyx-devcontainer:latest` on an arm64 host (e.g. Apple Silicon) pulls the arm64 variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual workflow to build and publish `onyxdotapp/onyx-devcontainer:latest` as a multi-arch image. Also tweaks the devcontainer to speed frontend builds with persistent caches.

- **New Features**
  - Adds `.github/workflows/release-devcontainer.yml` (`workflow_dispatch`) to release the devcontainer.
  - Builds the `devcontainer` target from `docker-bake.hcl` on native `2cpu-linux-x64` and `2cpu-linux-arm64` runners via `docker/bake-action`, then merges digests into a single `:latest` manifest with `docker buildx imagetools`.
  - Authenticates to Docker Hub by assuming the deploy AWS role via OIDC and pulling creds from AWS Secrets Manager.

- **Refactors**
  - Moves `web/node_modules` and `web/.next` to named Docker volumes for faster installs/builds; drops the `tsBuildInfoFile` redirect.

<sup>Written for commit 4f9802ef14089a3e33eacf9816f76f3779b311fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

