### PR TITLE
fix(ui): correct indexing errors modal pagination

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -15,13 +15,11 @@ import { PageSelector } from "@/components/PageSelector";
 import { useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
 
-const ITEMS_PER_PAGE = 10;
-
 export interface IndexAttemptErrorsModalProps {
   errors: {
     items: IndexAttemptError[];
-    total_items: number;
   };
+  totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
   onClose: () => void;
@@ -31,17 +29,13 @@ export interface IndexAttemptErrorsModalProps {
 
 export default function IndexAttemptErrorsModal({
   errors,
+  totalPages,
   currentPage,
   onPageChange,
   onClose,
   onResolveAll,
   isResolvingErrors = false,
 }: IndexAttemptErrorsModalProps) {
-  const totalPages = useMemo(
-    () => Math.ceil(errors.total_items / ITEMS_PER_PAGE),
-    [errors.total_items]
-  );
-
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,77 +12,35 @@ import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
+
+const ITEMS_PER_PAGE = 10;
+
 export interface IndexAttemptErrorsModalProps {
   errors: {
     items: IndexAttemptError[];
     total_items: number;
   };
+  currentPage: number;
+  onPageChange: (page: number) => void;
   onClose: () => void;
   onResolveAll: () => void;
   isResolvingErrors?: boolean;
 }
 
-const ROW_HEIGHT = 65; // 4rem + 1px for border
-
 export default function IndexAttemptErrorsModal({
   errors,
+  currentPage,
+  onPageChange,
   onClose,
   onResolveAll,
   isResolvingErrors = false,
 }: IndexAttemptErrorsModalProps) {
-  const observerRef = useRef<ResizeObserver | null>(null);
-  const [pageSize, setPageSize] = useState(10);
-  const [currentPage, setCurrentPage] = useState(1);
-
-  const tableContainerRef = useCallback((container: HTMLDivElement | null) => {
-    if (observerRef.current) {
-      observerRef.current.disconnect();
-      observerRef.current = null;
-    }
-
-    if (!container) return;
-
-    const observer = new ResizeObserver(() => {
-      const thead = container.querySelector("thead");
-      const theadHeight = thead?.getBoundingClientRect().height ?? 0;
-      const availableHeight = container.clientHeight - theadHeight;
-      const newPageSize = Math.max(3, Math.floor(availableHeight / ROW_HEIGHT));
-      setPageSize(newPageSize);
-    });
-
-    observer.observe(container);
-    observerRef.current = observer;
-  }, []);
-
-  // When data changes, reset to page 1.
-  // When page size changes (resize), preserve the user's position by
-  // finding which new page contains the first item they were looking at.
-  const prevPageSizeRef = useRef(pageSize);
-  useEffect(() => {
-    if (pageSize !== prevPageSizeRef.current) {
-      setCurrentPage((prev) => {
-        const firstVisibleIndex = (prev - 1) * prevPageSizeRef.current;
-        const newPage = Math.floor(firstVisibleIndex / pageSize) + 1;
-        const totalPages = Math.ceil(errors.items.length / pageSize);
-        return Math.min(newPage, totalPages);
-      });
-      prevPageSizeRef.current = pageSize;
-    } else {
-      setCurrentPage(1);
-    }
-  }, [errors.items.length, pageSize]);
-
-  const paginationData = useMemo(() => {
-    const totalPages = Math.ceil(errors.items.length / pageSize);
-    const startIndex = (currentPage - 1) * pageSize;
-    const currentPageItems = errors.items.slice(
-      startIndex,
-      startIndex + pageSize
-    );
-    return { totalPages, currentPageItems };
-  }, [errors.items, pageSize, currentPage]);
+  const totalPages = useMemo(
+    () => Math.ceil(errors.total_items / ITEMS_PER_PAGE),
+    [errors.total_items]
+  );
 
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
@@ -90,9 +48,8 @@ export default function IndexAttemptErrorsModal({
   );
 
   const handlePageChange = (page: number) => {
-    // Ensure we don't go to an invalid page
-    if (page >= 1 && page <= paginationData.totalPages) {
-      setCurrentPage(page);
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
     }
   };
 
@@ -125,10 +82,7 @@ export default function IndexAttemptErrorsModal({
             </div>
           )}
 
-          <div
-            ref={tableContainerRef}
-            className="flex-1 w-full overflow-hidden min-h-0"
-          >
+          <div className="flex-1 w-full overflow-hidden min-h-0">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -139,8 +93,8 @@ export default function IndexAttemptErrorsModal({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {paginationData.currentPageItems.length > 0 ? (
-                  paginationData.currentPageItems.map((error) => (
+                {errors.items.length > 0 ? (
+                  errors.items.map((error) => (
                     <TableRow key={error.id} className="h-[4rem]">
                       <TableCell>
                         {localizeAndPrettify(error.time_created)}
@@ -168,8 +122,8 @@ export default function IndexAttemptErrorsModal({
                         <span
                           className={`px-2 py-1 rounded text-xs ${
                             error.is_resolved
-                              ? "bg-green-100 text-green-800"
-                              : "bg-red-100 text-red-800"
+                              ? "bg-status-success-02 text-status-success-05"
+                              : "bg-status-error-02 text-status-error-05"
                           }`}
                         >
                           {error.is_resolved ? "Resolved" : "Unresolved"}
@@ -181,7 +135,7 @@ export default function IndexAttemptErrorsModal({
                   <TableRow className="h-[4rem]">
                     <TableCell
                       colSpan={4}
-                      className="text-center py-8 text-gray-500"
+                      className="text-center py-8 text-text-03"
                     >
                       No errors found on this page
                     </TableCell>
@@ -191,10 +145,10 @@ export default function IndexAttemptErrorsModal({
             </Table>
           </div>
 
-          {paginationData.totalPages > 1 && (
+          {totalPages > 1 && (
             <div className="flex w-full justify-center">
               <PageSelector
-                totalPages={paginationData.totalPages}
+                totalPages={totalPages}
                 currentPage={currentPage}
                 onPageChange={handlePageChange}
               />

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -127,6 +127,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     itemsPerPage: 10,
     pagesPerBatch: 1,
     endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
+    disableUrlSync: true,
   });
 
   // Initialize hooks at top level to avoid conditional hook calls

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -119,6 +119,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const {
     currentPageData: indexAttemptErrorsPage,
+    totalPages: indexAttemptErrorsTotalPages,
     totalItems: indexAttemptErrorsTotalItems,
     currentPage: indexAttemptErrorsCurrentPage,
     goToPage: goToIndexAttemptErrorsPage,
@@ -142,10 +143,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   } = useStatusChange(ccPair || null);
 
   const indexAttemptErrors = indexAttemptErrorsPage
-    ? {
-        items: indexAttemptErrorsPage,
-        total_items: indexAttemptErrorsTotalItems,
-      }
+    ? { items: indexAttemptErrorsPage }
     : null;
 
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
@@ -417,6 +415,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {showIndexAttemptErrors && indexAttemptErrors && (
         <IndexAttemptErrorsModal
           errors={indexAttemptErrors}
+          totalPages={indexAttemptErrorsTotalPages}
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
           onClose={() => setShowIndexAttemptErrors(false)}
@@ -561,7 +560,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
         </div>
       )}
 
-      {indexAttemptErrors && indexAttemptErrors.total_items > 0 && (
+      {indexAttemptErrors && indexAttemptErrorsTotalItems > 0 && (
         <Alert className="border-alert bg-yellow-50 dark:bg-yellow-800 my-2 mt-6">
           <AlertCircle className="h-4 w-4 text-yellow-700 dark:text-yellow-500" />
           <AlertTitle className="text-yellow-950 dark:text-yellow-200 font-semibold">

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -117,12 +117,16 @@ function Main({ ccPairId }: { ccPairId: number }) {
     endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
   });
 
-  const { currentPageData: indexAttemptErrorsPage } =
-    usePaginatedFetch<IndexAttemptError>({
-      itemsPerPage: 10,
-      pagesPerBatch: 1,
-      endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
-    });
+  const {
+    currentPageData: indexAttemptErrorsPage,
+    totalItems: indexAttemptErrorsTotalItems,
+    currentPage: indexAttemptErrorsCurrentPage,
+    goToPage: goToIndexAttemptErrorsPage,
+  } = usePaginatedFetch<IndexAttemptError>({
+    itemsPerPage: 10,
+    pagesPerBatch: 1,
+    endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
+  });
 
   // Initialize hooks at top level to avoid conditional hook calls
   const { showReIndexModal, ReIndexModal } = useReIndexModal(
@@ -140,7 +144,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   const indexAttemptErrors = indexAttemptErrorsPage
     ? {
         items: indexAttemptErrorsPage,
-        total_items: indexAttemptErrorsPage.length,
+        total_items: indexAttemptErrorsTotalItems,
       }
     : null;
 
@@ -413,6 +417,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {showIndexAttemptErrors && indexAttemptErrors && (
         <IndexAttemptErrorsModal
           errors={indexAttemptErrors}
+          currentPage={indexAttemptErrorsCurrentPage}
+          onPageChange={goToIndexAttemptErrorsPage}
           onClose={() => setShowIndexAttemptErrors(false)}
           onResolveAll={async () => {
             setShowIndexAttemptErrors(false);

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -24,6 +24,7 @@ interface PaginationConfig {
   query?: string;
   filter?: Record<string, string | boolean | number | string[] | Date>;
   refreshIntervalInMs?: number;
+  disableUrlSync?: boolean;
 }
 
 interface PaginatedHookReturnData<T extends PaginatedType> {
@@ -44,6 +45,7 @@ function usePaginatedFetch<T extends PaginatedType>({
   query,
   filter,
   refreshIntervalInMs = 5000,
+  disableUrlSync = false,
 }: PaginationConfig): PaginatedHookReturnData<T> {
   const router = useRouter();
   const currentPath = usePathname();
@@ -146,15 +148,14 @@ function usePaginatedFetch<T extends PaginatedType>({
   // Updates the URL with the current page number
   const updatePageUrl = useCallback(
     (page: number) => {
-      if (currentPath && searchParams) {
-        const params = new URLSearchParams(searchParams);
-        params.set("page", page.toString());
-        router.replace(`${currentPath}?${params.toString()}` as Route, {
-          scroll: false,
-        });
-      }
+      if (disableUrlSync || !currentPath || !searchParams) return;
+      const params = new URLSearchParams(searchParams);
+      params.set("page", page.toString());
+      router.replace(`${currentPath}?${params.toString()}` as Route, {
+        scroll: false,
+      });
     },
-    [currentPath, router, searchParams]
+    [disableUrlSync, currentPath, router, searchParams]
   );
 
   // Updates the current page


### PR DESCRIPTION
## Description

The Indexing Errors modal was only showing ~10-20 errors regardless of how many existed. The bug was that `total_items` was set to `indexAttemptErrorsPage.length` (the current page slice, ≤10) instead of the real total from the server. The modal then did client-side pagination over those ≤10 items, so users only ever saw 1–2 pages.

Fix: thread `totalItems`, `currentPage`, and `goToPage` from `usePaginatedFetch` into the modal so pagination is driven by server-side data. The modal's internal ResizeObserver + local page state were removed since page management now happens at the parent level.

https://linear.app/onyx-app/issue/ENG-4105/google-drive-for-savvy-wealth

## How Has This Been Tested?

Manually verified against a connector with 415 unresolved errors — the modal now correctly shows all pages.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Indexing Errors modal so pagination uses server data from `usePaginatedFetch` with parent-managed page state. Users can now navigate all error pages, and the modal no longer overwrites the index-attempts table `?page`. Addresses Linear ENG-4105.

- **Bug Fixes**
  - Passed `totalPages`, `currentPage`, and `goToPage` from `usePaginatedFetch` into `IndexAttemptErrorsModal`; `PageSelector` reads `totalPages` directly (removes `ITEMS_PER_PAGE` duplication).
  - Removed the modal’s `ResizeObserver` and local page state; the modal now renders the parent’s current page items.
  - In `page.tsx`, dropped `errors.total_items`, used `usePaginatedFetch.totalItems` for the alert, and passed pagination props to the modal; updated status badge/empty-state colors to design tokens.
  - Added `disableUrlSync` to `usePaginatedFetch` and enabled it for the errors fetch to prevent the modal from stomping the table’s `?page` in the URL.

<sup>Written for commit 02d69e2746eb5166e2b1aacd2440dfb8ac71a68e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



