### PR TITLE
fix(ui): correct indexing errors modal pagination

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -15,13 +15,11 @@ import { PageSelector } from "@/components/PageSelector";
 import { useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
 
-const ITEMS_PER_PAGE = 10;
-
 export interface IndexAttemptErrorsModalProps {
   errors: {
     items: IndexAttemptError[];
-    total_items: number;
   };
+  totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
   onClose: () => void;
@@ -31,17 +29,13 @@ export interface IndexAttemptErrorsModalProps {
 
 export default function IndexAttemptErrorsModal({
   errors,
+  totalPages,
   currentPage,
   onPageChange,
   onClose,
   onResolveAll,
   isResolvingErrors = false,
 }: IndexAttemptErrorsModalProps) {
-  const totalPages = useMemo(
-    () => Math.ceil(errors.total_items / ITEMS_PER_PAGE),
-    [errors.total_items]
-  );
-
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -1,83 +1,21 @@
-"use client";
-
-import { useCallback, useMemo, useRef } from "react";
-import { createTableColumns, Pagination, Table, Text } from "@opal/components";
-import { Section } from "@/layouts/general-layouts";
 import Modal from "@/refresh-components/Modal";
-import Button from "@/refresh-components/buttons/Button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { IndexAttemptError } from "./types";
 import { localizeAndPrettify } from "@/lib/time";
+import Button from "@/refresh-components/buttons/Button";
+import Text from "@/refresh-components/texts/Text";
+import { PageSelector } from "@/components/PageSelector";
+import { useCallback, useMemo, useRef } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
 
 const ROW_HEIGHT = 65; // 4rem + 1px for border
-
-const tc = createTableColumns<IndexAttemptError>();
-
-const columns = [
-  tc.column("time_created", {
-    header: "Time",
-    weight: 18,
-    enableSorting: false,
-    cell: (value) => (
-      <Text as="span" font="main-ui-body" color="text-04">
-        {localizeAndPrettify(value)}
-      </Text>
-    ),
-  }),
-  tc.column("document_id", {
-    header: "Document ID",
-    weight: 25,
-    enableSorting: false,
-    cell: (value, row) => {
-      const label = value ?? row.entity_id ?? "Unknown";
-      if (row.document_link) {
-        return (
-          <a
-            href={row.document_link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-link hover:underline"
-          >
-            <Text as="span" font="main-ui-body" color="text-04">
-              {label}
-            </Text>
-          </a>
-        );
-      }
-      return (
-        <Text as="span" font="main-ui-body" color="text-04">
-          {label}
-        </Text>
-      );
-    },
-  }),
-  tc.column("failure_message", {
-    header: "Error Message",
-    weight: 42,
-    enableSorting: false,
-    cell: (value) => (
-      <Text as="span" font="main-ui-body" color="text-04">
-        {value}
-      </Text>
-    ),
-  }),
-  tc.column("is_resolved", {
-    header: "Status",
-    weight: 15,
-    enableSorting: false,
-    cell: (value) => (
-      <span
-        className={`px-2 py-1 rounded text-xs ${
-          value
-            ? "bg-status-success-02 text-status-success-05"
-            : "bg-status-error-02 text-status-error-05"
-        }`}
-      >
-        {value ? "Resolved" : "Unresolved"}
-      </span>
-    ),
-  }),
-];
 
 export interface IndexAttemptErrorsModalProps {
   errors: {
@@ -138,6 +76,12 @@ export default function IndexAttemptErrorsModal({
     [errors.items]
   );
 
+  const handlePageChange = (page: number) => {
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
+    }
+  };
+
   return (
     <Modal open onOpenChange={onClose}>
       <Modal.Content width="full" height="full">
@@ -154,36 +98,93 @@ export default function IndexAttemptErrorsModal({
         />
         <Modal.Body height="full">
           {!isResolvingErrors && (
-            <Section flexDirection="column" height="fit" gap={0.5}>
-              <Text as="p" font="main-ui-body" color="text-03">
+            <div className="flex flex-col gap-2 flex-shrink-0">
+              <Text as="p">
                 Below are the errors encountered during indexing. Each row
                 represents a failed document or entity.
               </Text>
-              <Text as="p" font="main-ui-body" color="text-03">
+              <Text as="p">
                 Click the button below to kick off a full re-index to try and
                 resolve these errors. This full re-index may take much longer
                 than a normal update.
               </Text>
-            </Section>
+            </div>
           )}
 
-          <Section ref={tableContainerRef} alignItems="stretch" height="full">
-            <Table
-              data={errors.items}
-              columns={columns}
-              getRowId={(row) => String(row.id)}
-            />
-          </Section>
+          <div
+            ref={tableContainerRef}
+            className="flex-1 w-full overflow-hidden min-h-0"
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Document ID</TableHead>
+                  <TableHead className="w-1/2">Error Message</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {errors.items.length > 0 ? (
+                  errors.items.map((error) => (
+                    <TableRow key={error.id} className="h-[4rem]">
+                      <TableCell>
+                        {localizeAndPrettify(error.time_created)}
+                      </TableCell>
+                      <TableCell>
+                        {error.document_link ? (
+                          <a
+                            href={error.document_link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-link hover:underline"
+                          >
+                            {error.document_id || error.entity_id || "Unknown"}
+                          </a>
+                        ) : (
+                          error.document_id || error.entity_id || "Unknown"
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center h-[2rem] overflow-y-auto whitespace-normal">
+                          {error.failure_message}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <span
+                          className={`px-2 py-1 rounded text-xs ${
+                            error.is_resolved
+                              ? "bg-status-success-02 text-status-success-05"
+                              : "bg-status-error-02 text-status-error-05"
+                          }`}
+                        >
+                          {error.is_resolved ? "Resolved" : "Unresolved"}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow className="h-[4rem]">
+                    <TableCell
+                      colSpan={4}
+                      className="text-center py-8 text-text-03"
+                    >
+                      No errors found on this page
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
 
           {totalPages > 1 && (
-            <Section flexDirection="row" height="fit">
-              <Pagination
-                variant="list"
-                currentPage={currentPage}
+            <div className="flex w-full justify-center">
+              <PageSelector
                 totalPages={totalPages}
-                onChange={onPageChange}
+                currentPage={currentPage}
+                onPageChange={handlePageChange}
               />
-            </Section>
+            </div>
           )}
         </Modal.Body>
         <Modal.Footer>

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,8 +12,10 @@ import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
+
+const ROW_HEIGHT = 65; // 4rem + 1px for border
 
 export interface IndexAttemptErrorsModalProps {
   errors: {
@@ -22,6 +24,7 @@ export interface IndexAttemptErrorsModalProps {
   totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
   onClose: () => void;
   onResolveAll: () => void;
   isResolvingErrors?: boolean;
@@ -32,10 +35,42 @@ export default function IndexAttemptErrorsModal({
   totalPages,
   currentPage,
   onPageChange,
+  onPageSizeChange,
   onClose,
   onResolveAll,
   isResolvingErrors = false,
 }: IndexAttemptErrorsModalProps) {
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const tableContainerRef = useCallback(
+    (container: HTMLDivElement | null) => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+      if (!container) return;
+
+      const observer = new ResizeObserver(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+          const thead = container.querySelector("thead");
+          const theadHeight = thead?.getBoundingClientRect().height ?? 0;
+          const availableHeight = container.clientHeight - theadHeight;
+          const newPageSize = Math.max(
+            3,
+            Math.floor(availableHeight / ROW_HEIGHT)
+          );
+          onPageSizeChange(newPageSize);
+        }, 150);
+      });
+
+      observer.observe(container);
+      observerRef.current = observer;
+    },
+    [onPageSizeChange]
+  );
+
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]
@@ -76,7 +111,10 @@ export default function IndexAttemptErrorsModal({
             </div>
           )}
 
-          <div className="flex-1 w-full overflow-hidden min-h-0">
+          <div
+            ref={tableContainerRef}
+            className="flex-1 w-full overflow-hidden min-h-0"
+          >
             <Table>
               <TableHeader>
                 <TableRow>

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -1,21 +1,83 @@
+"use client";
+
+import { useCallback, useMemo, useRef } from "react";
+import { createTableColumns, Pagination, Table, Text } from "@opal/components";
+import { Section } from "@/layouts/general-layouts";
 import Modal from "@/refresh-components/Modal";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+import Button from "@/refresh-components/buttons/Button";
 import { IndexAttemptError } from "./types";
 import { localizeAndPrettify } from "@/lib/time";
-import Button from "@/refresh-components/buttons/Button";
-import Text from "@/refresh-components/texts/Text";
-import { PageSelector } from "@/components/PageSelector";
-import { useCallback, useMemo, useRef } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
 
 const ROW_HEIGHT = 65; // 4rem + 1px for border
+
+const tc = createTableColumns<IndexAttemptError>();
+
+const columns = [
+  tc.column("time_created", {
+    header: "Time",
+    weight: 18,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {localizeAndPrettify(value)}
+      </Text>
+    ),
+  }),
+  tc.column("document_id", {
+    header: "Document ID",
+    weight: 25,
+    enableSorting: false,
+    cell: (value, row) => {
+      const label = value ?? row.entity_id ?? "Unknown";
+      if (row.document_link) {
+        return (
+          <a
+            href={row.document_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-link hover:underline"
+          >
+            <Text as="span" font="main-ui-body" color="text-04">
+              {label}
+            </Text>
+          </a>
+        );
+      }
+      return (
+        <Text as="span" font="main-ui-body" color="text-04">
+          {label}
+        </Text>
+      );
+    },
+  }),
+  tc.column("failure_message", {
+    header: "Error Message",
+    weight: 42,
+    enableSorting: false,
+    cell: (value) => (
+      <Text as="span" font="main-ui-body" color="text-04">
+        {value}
+      </Text>
+    ),
+  }),
+  tc.column("is_resolved", {
+    header: "Status",
+    weight: 15,
+    enableSorting: false,
+    cell: (value) => (
+      <span
+        className={`px-2 py-1 rounded text-xs ${
+          value
+            ? "bg-status-success-02 text-status-success-05"
+            : "bg-status-error-02 text-status-error-05"
+        }`}
+      >
+        {value ? "Resolved" : "Unresolved"}
+      </span>
+    ),
+  }),
+];
 
 export interface IndexAttemptErrorsModalProps {
   errors: {
@@ -76,12 +138,6 @@ export default function IndexAttemptErrorsModal({
     [errors.items]
   );
 
-  const handlePageChange = (page: number) => {
-    if (page >= 1 && page <= totalPages) {
-      onPageChange(page);
-    }
-  };
-
   return (
     <Modal open onOpenChange={onClose}>
       <Modal.Content width="full" height="full">
@@ -98,93 +154,36 @@ export default function IndexAttemptErrorsModal({
         />
         <Modal.Body height="full">
           {!isResolvingErrors && (
-            <div className="flex flex-col gap-2 flex-shrink-0">
-              <Text as="p">
+            <Section flexDirection="column" height="fit" gap={0.5}>
+              <Text as="p" font="main-ui-body" color="text-03">
                 Below are the errors encountered during indexing. Each row
                 represents a failed document or entity.
               </Text>
-              <Text as="p">
+              <Text as="p" font="main-ui-body" color="text-03">
                 Click the button below to kick off a full re-index to try and
                 resolve these errors. This full re-index may take much longer
                 than a normal update.
               </Text>
-            </div>
+            </Section>
           )}
 
-          <div
-            ref={tableContainerRef}
-            className="flex-1 w-full overflow-hidden min-h-0"
-          >
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Time</TableHead>
-                  <TableHead>Document ID</TableHead>
-                  <TableHead className="w-1/2">Error Message</TableHead>
-                  <TableHead>Status</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {errors.items.length > 0 ? (
-                  errors.items.map((error) => (
-                    <TableRow key={error.id} className="h-[4rem]">
-                      <TableCell>
-                        {localizeAndPrettify(error.time_created)}
-                      </TableCell>
-                      <TableCell>
-                        {error.document_link ? (
-                          <a
-                            href={error.document_link}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-link hover:underline"
-                          >
-                            {error.document_id || error.entity_id || "Unknown"}
-                          </a>
-                        ) : (
-                          error.document_id || error.entity_id || "Unknown"
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center h-[2rem] overflow-y-auto whitespace-normal">
-                          {error.failure_message}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <span
-                          className={`px-2 py-1 rounded text-xs ${
-                            error.is_resolved
-                              ? "bg-status-success-02 text-status-success-05"
-                              : "bg-status-error-02 text-status-error-05"
-                          }`}
-                        >
-                          {error.is_resolved ? "Resolved" : "Unresolved"}
-                        </span>
-                      </TableCell>
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow className="h-[4rem]">
-                    <TableCell
-                      colSpan={4}
-                      className="text-center py-8 text-text-03"
-                    >
-                      No errors found on this page
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <Section ref={tableContainerRef} alignItems="stretch" height="full">
+            <Table
+              data={errors.items}
+              columns={columns}
+              getRowId={(row) => String(row.id)}
+            />
+          </Section>
 
           {totalPages > 1 && (
-            <div className="flex w-full justify-center">
-              <PageSelector
-                totalPages={totalPages}
+            <Section flexDirection="row" height="fit">
+              <Pagination
+                variant="list"
                 currentPage={currentPage}
-                onPageChange={handlePageChange}
+                totalPages={totalPages}
+                onChange={onPageChange}
               />
-            </div>
+            </Section>
           )}
         </Modal.Body>
         <Modal.Footer>

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,77 +12,35 @@ import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
+
+const ITEMS_PER_PAGE = 10;
+
 export interface IndexAttemptErrorsModalProps {
   errors: {
     items: IndexAttemptError[];
     total_items: number;
   };
+  currentPage: number;
+  onPageChange: (page: number) => void;
   onClose: () => void;
   onResolveAll: () => void;
   isResolvingErrors?: boolean;
 }
 
-const ROW_HEIGHT = 65; // 4rem + 1px for border
-
 export default function IndexAttemptErrorsModal({
   errors,
+  currentPage,
+  onPageChange,
   onClose,
   onResolveAll,
   isResolvingErrors = false,
 }: IndexAttemptErrorsModalProps) {
-  const observerRef = useRef<ResizeObserver | null>(null);
-  const [pageSize, setPageSize] = useState(10);
-  const [currentPage, setCurrentPage] = useState(1);
-
-  const tableContainerRef = useCallback((container: HTMLDivElement | null) => {
-    if (observerRef.current) {
-      observerRef.current.disconnect();
-      observerRef.current = null;
-    }
-
-    if (!container) return;
-
-    const observer = new ResizeObserver(() => {
-      const thead = container.querySelector("thead");
-      const theadHeight = thead?.getBoundingClientRect().height ?? 0;
-      const availableHeight = container.clientHeight - theadHeight;
-      const newPageSize = Math.max(3, Math.floor(availableHeight / ROW_HEIGHT));
-      setPageSize(newPageSize);
-    });
-
-    observer.observe(container);
-    observerRef.current = observer;
-  }, []);
-
-  // When data changes, reset to page 1.
-  // When page size changes (resize), preserve the user's position by
-  // finding which new page contains the first item they were looking at.
-  const prevPageSizeRef = useRef(pageSize);
-  useEffect(() => {
-    if (pageSize !== prevPageSizeRef.current) {
-      setCurrentPage((prev) => {
-        const firstVisibleIndex = (prev - 1) * prevPageSizeRef.current;
-        const newPage = Math.floor(firstVisibleIndex / pageSize) + 1;
-        const totalPages = Math.ceil(errors.items.length / pageSize);
-        return Math.min(newPage, totalPages);
-      });
-      prevPageSizeRef.current = pageSize;
-    } else {
-      setCurrentPage(1);
-    }
-  }, [errors.items.length, pageSize]);
-
-  const paginationData = useMemo(() => {
-    const totalPages = Math.ceil(errors.items.length / pageSize);
-    const startIndex = (currentPage - 1) * pageSize;
-    const currentPageItems = errors.items.slice(
-      startIndex,
-      startIndex + pageSize
-    );
-    return { totalPages, currentPageItems };
-  }, [errors.items, pageSize, currentPage]);
+  const totalPages = useMemo(
+    () => Math.ceil(errors.total_items / ITEMS_PER_PAGE),
+    [errors.total_items]
+  );
 
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
@@ -90,9 +48,8 @@ export default function IndexAttemptErrorsModal({
   );
 
   const handlePageChange = (page: number) => {
-    // Ensure we don't go to an invalid page
-    if (page >= 1 && page <= paginationData.totalPages) {
-      setCurrentPage(page);
+    if (page >= 1 && page <= totalPages) {
+      onPageChange(page);
     }
   };
 
@@ -125,10 +82,7 @@ export default function IndexAttemptErrorsModal({
             </div>
           )}
 
-          <div
-            ref={tableContainerRef}
-            className="flex-1 w-full overflow-hidden min-h-0"
-          >
+          <div className="flex-1 w-full overflow-hidden min-h-0">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -139,8 +93,8 @@ export default function IndexAttemptErrorsModal({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {paginationData.currentPageItems.length > 0 ? (
-                  paginationData.currentPageItems.map((error) => (
+                {errors.items.length > 0 ? (
+                  errors.items.map((error) => (
                     <TableRow key={error.id} className="h-[4rem]">
                       <TableCell>
                         {localizeAndPrettify(error.time_created)}
@@ -168,8 +122,8 @@ export default function IndexAttemptErrorsModal({
                         <span
                           className={`px-2 py-1 rounded text-xs ${
                             error.is_resolved
-                              ? "bg-green-100 text-green-800"
-                              : "bg-red-100 text-red-800"
+                              ? "bg-status-success-02 text-status-success-05"
+                              : "bg-status-error-02 text-status-error-05"
                           }`}
                         >
                           {error.is_resolved ? "Resolved" : "Unresolved"}
@@ -181,7 +135,7 @@ export default function IndexAttemptErrorsModal({
                   <TableRow className="h-[4rem]">
                     <TableCell
                       colSpan={4}
-                      className="text-center py-8 text-gray-500"
+                      className="text-center py-8 text-text-03"
                     >
                       No errors found on this page
                     </TableCell>
@@ -191,10 +145,10 @@ export default function IndexAttemptErrorsModal({
             </Table>
           </div>
 
-          {paginationData.totalPages > 1 && (
+          {totalPages > 1 && (
             <div className="flex w-full justify-center">
               <PageSelector
-                totalPages={paginationData.totalPages}
+                totalPages={totalPages}
                 currentPage={currentPage}
                 onPageChange={handlePageChange}
               />

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -117,6 +117,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
     endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
   });
 
+  const [errorsItemsPerPage, setErrorsItemsPerPage] = useState(10);
+
   const {
     currentPageData: indexAttemptErrorsPage,
     totalPages: indexAttemptErrorsTotalPages,
@@ -124,7 +126,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     currentPage: indexAttemptErrorsCurrentPage,
     goToPage: goToIndexAttemptErrorsPage,
   } = usePaginatedFetch<IndexAttemptError>({
-    itemsPerPage: 10,
+    itemsPerPage: errorsItemsPerPage,
     pagesPerBatch: 1,
     endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
     disableUrlSync: true,
@@ -419,6 +421,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
           totalPages={indexAttemptErrorsTotalPages}
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
+          onPageSizeChange={setErrorsItemsPerPage}
           onClose={() => setShowIndexAttemptErrors(false)}
           onResolveAll={async () => {
             setShowIndexAttemptErrors(false);

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -127,6 +127,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     itemsPerPage: 10,
     pagesPerBatch: 1,
     endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
+    disableUrlSync: true,
   });
 
   // Initialize hooks at top level to avoid conditional hook calls

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -119,6 +119,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const {
     currentPageData: indexAttemptErrorsPage,
+    totalPages: indexAttemptErrorsTotalPages,
     totalItems: indexAttemptErrorsTotalItems,
     currentPage: indexAttemptErrorsCurrentPage,
     goToPage: goToIndexAttemptErrorsPage,
@@ -142,10 +143,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   } = useStatusChange(ccPair || null);
 
   const indexAttemptErrors = indexAttemptErrorsPage
-    ? {
-        items: indexAttemptErrorsPage,
-        total_items: indexAttemptErrorsTotalItems,
-      }
+    ? { items: indexAttemptErrorsPage }
     : null;
 
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
@@ -417,6 +415,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {showIndexAttemptErrors && indexAttemptErrors && (
         <IndexAttemptErrorsModal
           errors={indexAttemptErrors}
+          totalPages={indexAttemptErrorsTotalPages}
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
           onClose={() => setShowIndexAttemptErrors(false)}
@@ -561,7 +560,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
         </div>
       )}
 
-      {indexAttemptErrors && indexAttemptErrors.total_items > 0 && (
+      {indexAttemptErrors && indexAttemptErrorsTotalItems > 0 && (
         <Alert className="border-alert bg-yellow-50 dark:bg-yellow-800 my-2 mt-6">
           <AlertCircle className="h-4 w-4 text-yellow-700 dark:text-yellow-500" />
           <AlertTitle className="text-yellow-950 dark:text-yellow-200 font-semibold">

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -117,12 +117,16 @@ function Main({ ccPairId }: { ccPairId: number }) {
     endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
   });
 
-  const { currentPageData: indexAttemptErrorsPage } =
-    usePaginatedFetch<IndexAttemptError>({
-      itemsPerPage: 10,
-      pagesPerBatch: 1,
-      endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
-    });
+  const {
+    currentPageData: indexAttemptErrorsPage,
+    totalItems: indexAttemptErrorsTotalItems,
+    currentPage: indexAttemptErrorsCurrentPage,
+    goToPage: goToIndexAttemptErrorsPage,
+  } = usePaginatedFetch<IndexAttemptError>({
+    itemsPerPage: 10,
+    pagesPerBatch: 1,
+    endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
+  });
 
   // Initialize hooks at top level to avoid conditional hook calls
   const { showReIndexModal, ReIndexModal } = useReIndexModal(
@@ -140,7 +144,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   const indexAttemptErrors = indexAttemptErrorsPage
     ? {
         items: indexAttemptErrorsPage,
-        total_items: indexAttemptErrorsPage.length,
+        total_items: indexAttemptErrorsTotalItems,
       }
     : null;
 
@@ -413,6 +417,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
       {showIndexAttemptErrors && indexAttemptErrors && (
         <IndexAttemptErrorsModal
           errors={indexAttemptErrors}
+          currentPage={indexAttemptErrorsCurrentPage}
+          onPageChange={goToIndexAttemptErrorsPage}
           onClose={() => setShowIndexAttemptErrors(false)}
           onResolveAll={async () => {
             setShowIndexAttemptErrors(false);

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -53,7 +53,7 @@ function usePaginatedFetch<T extends PaginatedType>({
 
   // State to initialize and hold the current page number
   const [currentPage, setCurrentPage] = useState(() =>
-    parseInt(searchParams?.get("page") || "1", 10)
+    disableUrlSync ? 1 : parseInt(searchParams?.get("page") || "1", 10)
   );
   const [currentPageData, setCurrentPageData] = useState<T[] | null>(null);
   const [error, setError] = useState<Error | null>(null);

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -236,9 +236,9 @@ function usePaginatedFetch<T extends PaginatedType>({
   useEffect(() => {
     setCachedBatches({});
     setTotalItems(0);
-    goToPage(1);
+    setCurrentPage(1);
     setError(null);
-  }, [currentPath, query, filter]);
+  }, [currentPath, query, filter, itemsPerPage]);
 
   return {
     currentPage,

--- a/web/src/hooks/usePaginatedFetch.ts
+++ b/web/src/hooks/usePaginatedFetch.ts
@@ -24,6 +24,7 @@ interface PaginationConfig {
   query?: string;
   filter?: Record<string, string | boolean | number | string[] | Date>;
   refreshIntervalInMs?: number;
+  disableUrlSync?: boolean;
 }
 
 interface PaginatedHookReturnData<T extends PaginatedType> {
@@ -44,6 +45,7 @@ function usePaginatedFetch<T extends PaginatedType>({
   query,
   filter,
   refreshIntervalInMs = 5000,
+  disableUrlSync = false,
 }: PaginationConfig): PaginatedHookReturnData<T> {
   const router = useRouter();
   const currentPath = usePathname();
@@ -146,15 +148,14 @@ function usePaginatedFetch<T extends PaginatedType>({
   // Updates the URL with the current page number
   const updatePageUrl = useCallback(
     (page: number) => {
-      if (currentPath && searchParams) {
-        const params = new URLSearchParams(searchParams);
-        params.set("page", page.toString());
-        router.replace(`${currentPath}?${params.toString()}` as Route, {
-          scroll: false,
-        });
-      }
+      if (disableUrlSync || !currentPath || !searchParams) return;
+      const params = new URLSearchParams(searchParams);
+      params.set("page", page.toString());
+      router.replace(`${currentPath}?${params.toString()}` as Route, {
+        scroll: false,
+      });
     },
-    [currentPath, router, searchParams]
+    [disableUrlSync, currentPath, router, searchParams]
   );
 
   // Updates the current page


### PR DESCRIPTION
## Description

The Indexing Errors modal was only showing ~10-20 errors regardless of how many existed. The bug was that `total_items` was set to `indexAttemptErrorsPage.length` (the current page slice, ≤10) instead of the real total from the server. The modal then did client-side pagination over those ≤10 items, so users only ever saw 1–2 pages.

Fix: thread `totalItems`, `currentPage`, and `goToPage` from `usePaginatedFetch` into the modal so pagination is driven by server-side data. The modal's internal ResizeObserver + local page state were removed since page management now happens at the parent level.

https://linear.app/onyx-app/issue/ENG-4105/google-drive-for-savvy-wealth

## How Has This Been Tested?

Manually verified against a connector with more than 10 errors.

Before the change
<img width="1561" height="788" alt="Screenshot 2026-05-05 at 6 21 50 PM" src="https://github.com/user-attachments/assets/d6eca104-0fbc-46cf-b3e7-86ff8c1f5661" />


After the change
<img width="1579" height="806" alt="Screenshot 2026-05-05 at 6 46 32 PM" src="https://github.com/user-attachments/assets/d6f9ab85-ad25-4bf3-bd39-8da0756368fd" />



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Indexing Errors modal so it paginates across all server-side errors and stops reading/writing the `?page` URL param. Supports Linear ENG-4105.

- **Bug Fixes**
  - Drive pagination from `usePaginatedFetch` (`totalPages`, `totalItems`, `currentPage`, `goToPage`); remove local pagination and the `ITEMS_PER_PAGE` constant.
  - Restore dynamic page sizing: measure table height and call `onPageSizeChange` so the hook fetches the right page size.
  - Add and respect `disableUrlSync` in `usePaginatedFetch` (including on init) so modal page changes don’t read/write the index-attempts table `?page`.

<sup>Written for commit 7660a5ee80aa6b3206d654d8095a5c5264601eab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



