### PR TITLE
fix(ci): clear devcontainer tags when pushing by digest

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:e663b2bfed88cfc9fd7c86cae25885816692a1e19d9e88110a97ff8d4f700a25",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:b5b6e7a3c66085b65dc3aec5af7da879ab4dd6e5c36cfccb7f3b4e9b1e970d5a",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -56,6 +56,7 @@ jobs:
           targets: devcontainer
           set: |
             devcontainer.platform=linux/amd64
+            devcontainer.tags=
             devcontainer.output=type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Extract digest
@@ -114,6 +115,7 @@ jobs:
           targets: devcontainer
           set: |
             devcontainer.platform=linux/arm64
+            devcontainer.tags=
             devcontainer.output=type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Extract digest


### PR DESCRIPTION

## Description

Per Claude:

> The devcontainer bake target sets `tags=[onyxdotapp/onyx-devcontainer:latest]`, which conflicts with `push-by-digest=true` in the Release Devcontainer workflow: buildx refuses to push a tagged ref by digest. Override the target's tags to empty in both per-arch build steps so the digest-only push succeeds; the multi-arch `:latest` tag is still assembled later by `merge-docker`.

Also upgrades the devcontainer to a version that supports arm64.

## How Has This Been Tested?

```
ods dev rebuild
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears per-arch devcontainer tags in the release workflow so digest-only pushes work; the multi-arch `:latest` is still assembled later via `merge-docker`. Also updates the devcontainer image digest to an arm64-capable build.

<sup>Written for commit ffd3afd4c4cac3ba14c8a8fa40aef18538aac1ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



