### PR TITLE
fix: use rest space perms confluence dc 9.1

### DIFF
--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -7,7 +7,15 @@ from onyx.connectors.sharepoint.connector import SharepointConnector
 def validate_confluence_perm_sync(connector: ConfluenceConnector) -> None:
     """
     Validate that the connector is configured correctly for permissions syncing.
+
+    For Confluence Data Center 9.1+, the REST space-permissions endpoint
+    returns HTTP 500 (rather than 403) for non-admin callers
+    (CONFSERVER-99908). Probe it once during validation so a missing-admin
+    misconfiguration surfaces at connector creation time -- with an
+    actionable InsufficientPermissionsError -- instead of as a
+    per-space-per-sync HTTP 500 with no clear remediation.
     """
+    connector.probe_rest_space_permissions_admin_access()
 
 
 def validate_drive_perm_sync(connector: GoogleDriveConnector) -> None:

--- a/backend/ee/onyx/external_permissions/confluence/constants.py
+++ b/backend/ee/onyx/external_permissions/confluence/constants.py
@@ -3,5 +3,18 @@
 # is only accessible to users who have confluence accounts.
 ALL_CONF_EMAILS_GROUP_NAME = "All_Confluence_Users_Found_By_Onyx"
 
+# JSON-RPC permission category that maps to "view this space" on
+# Confluence Server / DC < 9.1.
 VIEWSPACE_PERMISSION_TYPE = "VIEWSPACE"
+
+# Field values from the Confluence DC 9.1+ space-permissions REST API.
+# Response shape: list of {operation: {targetType, operationKey},
+#                          subject:   {type, name|userKey},
+#                          spaceKey, spaceId}
+# Documented in CONFSERVER-78176 and the Confluence DC 9.1 release notes.
+SPACE_PERMISSION_TARGET_TYPE_SPACE = "space"
+SPACE_PERMISSION_OPERATION_READ = "read"
+SPACE_PERMISSION_SUBJECT_TYPE_USER = "user"
+SPACE_PERMISSION_SUBJECT_TYPE_GROUP = "group"
+
 REQUEST_PAGINATION_LIMIT = 5000

--- a/backend/ee/onyx/external_permissions/confluence/space_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/space_access.py
@@ -27,6 +27,7 @@ from onyx.connectors.confluence.onyx_confluence import (
     get_user_email_from_username__server,
 )
 from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -54,7 +55,9 @@ def _has_anonymous_read_permission(anonymous_permissions: list[dict]) -> bool:
             candidates.append(entry[_OPERATION])
 
     return any(
-        op.get("operationKey") == SPACE_PERMISSION_OPERATION_READ for op in candidates
+        op.get("operationKey") == SPACE_PERMISSION_OPERATION_READ
+        and op.get("targetType") == SPACE_PERMISSION_TARGET_TYPE_SPACE
+        for op in candidates
     )
 
 
@@ -75,6 +78,14 @@ def _resolve_anonymous_access(
                 space_key=space_key,
             )
         )
+    except InsufficientPermissionsError:
+        # CONFSERVER-99908: HTTP 500 from the anonymous endpoint means the
+        # bot lacks Confluence/space-admin rights. The main probe in
+        # validate_confluence_perm_sync only checks the bulk endpoint, so
+        # this can pass validation but fail here on every sync. Surface it
+        # loudly instead of silently flagging every space as "no anonymous
+        # access" -- otherwise public spaces would be hidden from users.
+        raise
     except Exception as e:
         # Don't fail the whole sync over an anonymous-permissions hiccup.
         # The bulk-permissions response covers explicit grants; we only

--- a/backend/ee/onyx/external_permissions/confluence/space_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/space_access.py
@@ -1,10 +1,28 @@
 from ee.onyx.configs.app_configs import CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC
 from ee.onyx.external_permissions.confluence.constants import ALL_CONF_EMAILS_GROUP_NAME
 from ee.onyx.external_permissions.confluence.constants import REQUEST_PAGINATION_LIMIT
+from ee.onyx.external_permissions.confluence.constants import (
+    SPACE_PERMISSION_OPERATION_READ,
+)
+from ee.onyx.external_permissions.confluence.constants import (
+    SPACE_PERMISSION_SUBJECT_TYPE_GROUP,
+)
+from ee.onyx.external_permissions.confluence.constants import (
+    SPACE_PERMISSION_SUBJECT_TYPE_USER,
+)
+from ee.onyx.external_permissions.confluence.constants import (
+    SPACE_PERMISSION_TARGET_TYPE_SPACE,
+)
 from ee.onyx.external_permissions.confluence.constants import VIEWSPACE_PERMISSION_TYPE
 from onyx.access.models import ExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.confluence.onyx_confluence import (
+    ConfluenceRestSpacePermissionsNotAvailableError,
+)
+from onyx.connectors.confluence.onyx_confluence import (
+    get_user_email_from_userkey__server,
+)
 from onyx.connectors.confluence.onyx_confluence import (
     get_user_email_from_username__server,
 )
@@ -13,10 +31,138 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+_OPERATION = "operation"
+_OPERATIONS = "operations"
 
-def _get_server_space_permissions(
+
+def _has_anonymous_read_permission(anonymous_permissions: list[dict]) -> bool:
+    """Whether the anonymous role has 'read' on a given space.
+
+    The DC 9.1+ anonymous-permissions endpoint can return either a flat
+    list of {operation: {operationKey, targetType}} entries OR a nested
+    {operations: [...]} envelope, depending on patch version. Accept both
+    so a transient endpoint shape change doesn't silently disable
+    anonymous-access detection.
+    """
+    candidates: list[dict] = []
+    for entry in anonymous_permissions:
+        if not isinstance(entry, dict):
+            continue
+        if _OPERATIONS in entry and isinstance(entry[_OPERATIONS], list):
+            candidates.extend(op for op in entry[_OPERATIONS] if isinstance(op, dict))
+        if _OPERATION in entry and isinstance(entry[_OPERATION], dict):
+            candidates.append(entry[_OPERATION])
+
+    return any(
+        op.get("operationKey") == SPACE_PERMISSION_OPERATION_READ for op in candidates
+    )
+
+
+def _resolve_anonymous_access(
+    confluence_client: OnyxConfluence, space_key: str
+) -> tuple[bool, set[str]]:
+    """Decide is_public + extra group_names contributed by anonymous access.
+
+    Returns (is_public, extra_group_names). Mirrors the legacy JSON-RPC
+    behavior: if anonymous read is enabled and
+    CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC is set, mark the space public;
+    otherwise add ALL_CONF_EMAILS_GROUP_NAME so authenticated Confluence
+    users still see the content but external/anon users don't.
+    """
+    try:
+        anonymous_permissions = (
+            confluence_client.get_anonymous_space_permissions_server_rest(
+                space_key=space_key,
+            )
+        )
+    except Exception as e:
+        # Don't fail the whole sync over an anonymous-permissions hiccup.
+        # The bulk-permissions response covers explicit grants; we only
+        # lose anonymous-access detection on this one space.
+        logger.warning(
+            "Failed to fetch anonymous space permissions for %s: %s. "
+            "Treating as 'no anonymous access' for this run.",
+            space_key,
+            e,
+        )
+        return False, set()
+
+    if not _has_anonymous_read_permission(anonymous_permissions):
+        return False, set()
+
+    if CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC:
+        return True, set()
+    return False, {ALL_CONF_EMAILS_GROUP_NAME}
+
+
+def _get_server_space_permissions_rest(
     confluence_client: OnyxConfluence, space_key: str
 ) -> ExternalAccess:
+    """Confluence DC 9.1+ REST-API path for space permissions.
+
+    Differences from the JSON-RPC shape (CONFSERVER-78176, CONFSERVER-100505):
+      - flat list of {operation, subject, spaceKey, spaceId} entries.
+      - groups expose subject.name directly.
+      - users expose subject.userKey only -- email must be resolved
+        separately via /rest/api/user?key={userKey}.
+      - anonymous access is its own endpoint, not an inline row.
+    """
+    raw_permissions = confluence_client.get_all_space_permissions_server_rest(
+        space_key=space_key
+    )
+
+    user_keys: set[str] = set()
+    group_names: set[str] = set()
+    for permission in raw_permissions:
+        operation = permission.get("operation") or {}
+        if operation.get("targetType") != SPACE_PERMISSION_TARGET_TYPE_SPACE:
+            continue
+        if operation.get("operationKey") != SPACE_PERMISSION_OPERATION_READ:
+            continue
+
+        subject = permission.get("subject") or {}
+        subject_type = subject.get("type")
+        if subject_type == SPACE_PERMISSION_SUBJECT_TYPE_USER:
+            if user_key := subject.get("userKey"):
+                user_keys.add(user_key)
+        elif subject_type == SPACE_PERMISSION_SUBJECT_TYPE_GROUP:
+            if name := subject.get("name"):
+                group_names.add(name)
+
+    is_public, extra_groups = _resolve_anonymous_access(confluence_client, space_key)
+    group_names.update(extra_groups)
+
+    user_emails: set[str] = set()
+    for user_key in user_keys:
+        email = get_user_email_from_userkey__server(confluence_client, user_key)
+        if email:
+            user_emails.add(email)
+            continue
+        logger.warning("Email for userKey %s not found in Confluence", user_key)
+
+    if not user_emails and not group_names and not is_public:
+        logger.warning(
+            "No user emails or group names found in Confluence space "
+            "permissions (REST path)\nSpace key: %s\nSpace permissions: %s",
+            space_key,
+            raw_permissions,
+        )
+
+    return ExternalAccess(
+        external_user_emails=user_emails,
+        external_user_group_ids=group_names,
+        is_public=is_public,
+    )
+
+
+def _get_server_space_permissions_jsonrpc(
+    confluence_client: OnyxConfluence, space_key: str
+) -> ExternalAccess:
+    """Legacy JSON-RPC path; kept for Confluence DC < 9.1.0.
+
+    See get_all_space_permissions_server in onyx_confluence.py for the
+    failure-mode notes and WebSudo escape hatch.
+    """
     space_permissions = confluence_client.get_all_space_permissions_server(
         space_key=space_key
     )
@@ -74,6 +220,32 @@ def _get_server_space_permissions(
         external_user_group_ids=group_names,
         is_public=is_public,
     )
+
+
+def _get_server_space_permissions(
+    confluence_client: OnyxConfluence, space_key: str
+) -> ExternalAccess:
+    """Dispatch between the DC 9.1+ REST path and the legacy JSON-RPC path.
+
+    The JSON-RPC path is fragile on modern Confluence (Secure Administrator
+    Sessions / WebSudo intercepts admin JSON-RPC calls -- see the
+    get_all_space_permissions_server docstring). Wherever the REST API
+    is available we prefer it.
+    """
+    if confluence_client.supports_rest_space_permissions():
+        try:
+            return _get_server_space_permissions_rest(confluence_client, space_key)
+        except ConfluenceRestSpacePermissionsNotAvailableError as e:
+            # serverInfo lied / custom build / plugin disabled; fall back.
+            logger.info(
+                "Confluence reports a version that should support REST "
+                "space-permissions, but the endpoint is unavailable for "
+                "space %s (%s); falling back to JSON-RPC.",
+                space_key,
+                e,
+            )
+
+    return _get_server_space_permissions_jsonrpc(confluence_client, space_key)
 
 
 def _get_cloud_space_permissions(

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -1055,6 +1055,66 @@ class ConfluenceConnector(
                     "Invalid Confluence space key provided"
                 ) from e
 
+    def probe_rest_space_permissions_admin_access(self) -> None:
+        """For Confluence DC 9.1+, probe the REST space-permissions endpoint
+        to surface "bot account is not a Confluence/space admin" at perm-sync
+        validation time rather than mid-sync per-space.
+
+        The motivating quirk is CONFSERVER-99908: that endpoint returns 500
+        (instead of 403) for non-admin callers, so a regular permission-sync
+        run produces an unactionable 500-bubble-up instead of a clear
+        "you need admin rights" signal. This probe intentionally lives in
+        validate_perm_sync (not validate_connector_settings) so that
+        connectors without permission sync don't have admin rights forced
+        on them.
+
+        No-ops for Cloud (different API surface) and for DC < 9.1.0 (no
+        REST endpoint -- the legacy JSON-RPC path is on a different
+        permission model and is validated via its own failure modes
+        during sync).
+        """
+        client = self.low_timeout_confluence_client
+        if not client.supports_rest_space_permissions():
+            return
+
+        # Pick any visible space; the 500-vs-200 distinction is global to
+        # the credential, not per-space, so the cheapest visible space works.
+        try:
+            spaces_iter = client.retrieve_confluence_spaces(limit=1)
+            first_space = next(spaces_iter, None)
+        except Exception as e:
+            logger.warning(
+                "Skipping REST space-permissions admin probe; could not "
+                "list any space to probe against: %s",
+                e,
+            )
+            return
+        if not first_space:
+            return
+        first_space_key = first_space.get("key")
+        if not first_space_key:
+            return
+
+        try:
+            # InsufficientPermissionsError on 500 (CONFSERVER-99908); we
+            # let it propagate -- that *is* the validation failure we want.
+            client.get_all_space_permissions_server_rest(
+                space_key=first_space_key,
+            )
+        except InsufficientPermissionsError:
+            raise
+        except Exception as e:
+            # Any other failure here is unexpected but not necessarily a
+            # blocker for setup. Log it and let the sync surface the real
+            # error if there is one; we don't want a flaky network call to
+            # block connector creation.
+            logger.warning(
+                "REST space-permissions admin probe against space %s "
+                "failed with non-permission error: %s. Skipping.",
+                first_space_key,
+                e,
+            )
+
 
 if __name__ == "__main__":
     import os

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -44,6 +44,7 @@ from onyx.connectors.confluence.utils import get_start_param_from_url
 from onyx.connectors.confluence.utils import update_param_in_path
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import scoped_url
 from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.interfaces import CredentialsProviderInterface
 from onyx.file_processing.html_utils import format_document_soup
 from onyx.redis.redis_pool import get_redis_client
@@ -62,6 +63,10 @@ _REPLACEMENT_EXPANSIONS = "body.view.value"
 _USER_NOT_FOUND = "Unknown Confluence User"
 _USER_ID_TO_DISPLAY_NAME_CACHE: dict[str, str | None] = {}
 _USER_EMAIL_CACHE: dict[str, str | None] = {}
+# Separate cache from _USER_EMAIL_CACHE: the DC 9.1+ REST space-permissions
+# response only includes a user's userKey (CONFSERVER-100505), not their
+# username, so we have to resolve email by a different identifier.
+_USER_KEY_TO_EMAIL_CACHE: dict[str, str | None] = {}
 _DEFAULT_PAGINATION_LIMIT = 1000
 _MINIMUM_PAGINATION_LIMIT = 5
 
@@ -83,9 +88,23 @@ _WEBSUDO_KB_URL = (
 # in our logs and validation surface.
 _JSONRPC_ERROR_BODY_SNIPPET_CHARS = 1000
 
+# DC 9.1.0 is the first DC release with the REST API for space permissions
+# (CONFSERVER-78176). Older DC versions still need the legacy JSON-RPC
+# fallback. Server / Data Center only -- Cloud has its own permissions API
+# and is branched on `is_cloud` upstream of any version check.
+_MIN_DC_VERSION_FOR_REST_SPACE_PERMISSIONS: tuple[int, int] = (9, 1)
+
 
 class ConfluenceRateLimitError(Exception):
     pass
+
+
+class ConfluenceRestSpacePermissionsNotAvailableError(Exception):
+    """Raised by REST-API space-permissions calls when the endpoint is missing
+    on the upstream Confluence DC instance (e.g. DC < 9.1.0 returning 404).
+
+    Callers use this as a signal to fall back to the legacy JSON-RPC path.
+    """
 
 
 class OnyxConfluence:
@@ -152,6 +171,13 @@ class OnyxConfluence:
             if confluence_user_profiles_override
             else None
         )
+
+        # Cached result of /rest/api/serverInfo, populated on first
+        # `get_server_version()` call. _server_version_probed=True with
+        # _server_version=None means "we tried and the probe failed", so
+        # we don't keep retrying every space-permissions sync.
+        self._server_version: tuple[int, int] | None = None
+        self._server_version_probed: bool = False
 
     def _renew_credentials(self) -> tuple[dict[str, Any], bool]:
         """credential_json - the current json credentials
@@ -1037,6 +1063,157 @@ class OnyxConfluence:
 
         return payload.get("result", [])
 
+    def get_server_version(self) -> tuple[int, int] | None:
+        """Returns the (major, minor) version of the upstream Confluence
+        Data Center instance, or None for Cloud or when the probe fails.
+
+        Probed once per OnyxConfluence instance via /rest/api/serverInfo
+        (the result is cached on the instance, including the negative
+        result, so a one-off network blip doesn't cause us to re-probe on
+        every space-permissions sync).
+
+        Used to gate features that only exist on newer DC versions, such
+        as the REST space-permissions API introduced in DC 9.1.0
+        (CONFSERVER-78176). Most callers should prefer the higher-level
+        feature predicates (e.g. supports_rest_space_permissions) over
+        comparing the version tuple directly.
+        """
+        if self._is_cloud:
+            return None
+        if self._server_version_probed:
+            return self._server_version
+
+        self._server_version = self._probe_server_version()
+        self._server_version_probed = True
+        if self._server_version is not None:
+            logger.info(
+                "Detected Confluence Data Center version %s.%s",
+                self._server_version[0],
+                self._server_version[1],
+            )
+        return self._server_version
+
+    def _probe_server_version(self) -> tuple[int, int] | None:
+        try:
+            info = self.get("rest/api/serverInfo")
+        except Exception as e:
+            logger.warning("Failed to probe Confluence server version: %s", e)
+            return None
+        if not isinstance(info, dict):
+            return None
+        version_str = info.get("version") or ""
+        return _parse_dc_version(version_str)
+
+    def supports_rest_space_permissions(self) -> bool:
+        """Whether the upstream instance has the DC 9.1+ space-permissions
+        REST API (CONFSERVER-78176). Always False for Cloud (different API
+        surface, branched on `is_cloud` upstream of any version check) and
+        for DC instances older than 9.1.0 or where the version probe fails.
+        """
+        version = self.get_server_version()
+        return (
+            version is not None
+            and version >= _MIN_DC_VERSION_FOR_REST_SPACE_PERMISSIONS
+        )
+
+    def get_all_space_permissions_server_rest(
+        self,
+        space_key: str,
+    ) -> list[dict[str, Any]]:
+        """Confluence DC 9.1+ REST API for space permissions.
+
+        GET /rest/api/space/{spaceKey}/permissions returns a flat list of
+        {operation, subject, spaceKey, spaceId} entries (CONFSERVER-78176).
+
+        Failure modes:
+
+        - 401: handled identically to the JSON-RPC path (token missing /
+          expired).
+        - 404: the endpoint isn't available on this Confluence DC version
+          (i.e. < 9.1.0). Surfaced as
+          ConfluenceRestSpacePermissionsNotAvailableError so the caller
+          can fall back to the legacy JSON-RPC path.
+        - 500: per CONFSERVER-99908, callers without
+          Confluence-admin/space-admin rights receive HTTP 500 (rather
+          than the more correct 403). Surfaced as
+          InsufficientPermissionsError with that ticket referenced so
+          the operator knows the actual remediation is "grant the bot
+          account admin", not "investigate a server-side bug".
+        """
+        path = f"rest/api/space/{quote(space_key, safe='')}/permissions"
+        response: requests.Response = self.get(path, advanced_mode=True)
+
+        if response.status_code == 404:
+            raise ConfluenceRestSpacePermissionsNotAvailableError(
+                f"REST space-permissions endpoint not available on this "
+                f"Confluence instance (HTTP 404 for space '{space_key}'). "
+                "The endpoint requires Confluence Data Center 9.1.0+."
+            )
+        if response.status_code == 401:
+            raise HTTPError(
+                "Unauthorized (401) when calling REST space-permissions API. "
+                "The credential is missing or expired.",
+                response=response,
+            )
+        if response.status_code == 500:
+            raise InsufficientPermissionsError(
+                f"Confluence returned HTTP 500 for "
+                f"GET /rest/api/space/{space_key}/permissions. Per "
+                "CONFSERVER-99908 this endpoint returns 500 (rather than "
+                "403) when the calling account lacks Confluence-admin or "
+                "space-admin rights. Grant the bot account admin "
+                "permissions on this space (or globally) and retry."
+            )
+        response.raise_for_status()
+
+        payload = response.json()
+        if not isinstance(payload, list):
+            logger.warning(
+                "Unexpected REST space-permissions payload shape for space "
+                "%s: expected list, got %s",
+                space_key,
+                type(payload).__name__,
+            )
+            return []
+        return payload
+
+    def get_anonymous_space_permissions_server_rest(
+        self,
+        space_key: str,
+    ) -> list[dict[str, Any]]:
+        """Confluence DC 9.1+ anonymous space-permissions endpoint.
+
+        GET /rest/api/space/{spaceKey}/permissions/anonymous returns the
+        operations the anonymous role has on the space. Distinct from the
+        bulk endpoint, which on the JSON-RPC path used to return an
+        anonymous "row" inline.
+
+        404 is treated as "no anonymous access" rather than fatal; some
+        9.x patch versions had this endpoint missing or moved before it
+        stabilized, and "missing endpoint" should not be louder than
+        "no anonymous access" for our use case.
+        """
+        path = f"rest/api/space/{quote(space_key, safe='')}/permissions/anonymous"
+        response: requests.Response = self.get(path, advanced_mode=True)
+
+        if response.status_code == 404:
+            return []
+        if response.status_code == 500:
+            # CONFSERVER-99908 again -- same remediation, different endpoint.
+            raise InsufficientPermissionsError(
+                f"Confluence returned HTTP 500 for "
+                f"GET /rest/api/space/{space_key}/permissions/anonymous. "
+                "Per CONFSERVER-99908 this endpoint returns 500 (rather "
+                "than 403) when the calling account lacks "
+                "Confluence-admin or space-admin rights."
+            )
+        response.raise_for_status()
+
+        payload = response.json()
+        if not isinstance(payload, list):
+            return []
+        return payload
+
     def get_current_user(self, expand: str | None = None) -> Any:
         """
         Implements a method that isn't in the third party client.
@@ -1093,6 +1270,58 @@ def get_user_email_from_username__server(
             email = None
         _USER_EMAIL_CACHE[user_name] = email
     return _USER_EMAIL_CACHE[user_name]
+
+
+def get_user_email_from_userkey__server(
+    confluence_client: OnyxConfluence, user_key: str
+) -> str | None:
+    """userKey -> email resolver for Confluence Data Center.
+
+    Parallels get_user_email_from_username__server but keyed on userKey
+    instead of username, because the DC 9.1+ space-permissions REST API
+    only exposes userKey on user subjects (CONFSERVER-100505 -- still
+    unresolved as of the 10.x line).
+
+    Cached separately from _USER_EMAIL_CACHE because the keyspaces are
+    different (userKey is opaque hex, username is human-readable).
+    """
+    global _USER_KEY_TO_EMAIL_CACHE
+    if user_key not in _USER_KEY_TO_EMAIL_CACHE:
+        try:
+            response = confluence_client.get_user_details_by_userkey(user_key)
+            email = response.get("email") if isinstance(response, dict) else None
+        except HTTPError as e:
+            status_code = e.response.status_code if e.response is not None else "N/A"
+            logger.warning(
+                "Failed to get confluence email for userKey %s: HTTP %s - %s",
+                user_key,
+                status_code,
+                e,
+            )
+            email = None
+        except Exception as e:
+            logger.warning(
+                "Failed to get confluence email for userKey %s: %s - %s",
+                user_key,
+                type(e).__name__,
+                e,
+            )
+            email = None
+        _USER_KEY_TO_EMAIL_CACHE[user_key] = email
+    return _USER_KEY_TO_EMAIL_CACHE[user_key]
+
+
+def _parse_dc_version(version_str: str) -> tuple[int, int] | None:
+    """Parse 'X.Y.Z[...]' into (X, Y); returns None on malformed input."""
+    if not version_str:
+        return None
+    parts = version_str.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except ValueError:
+        return None
 
 
 def _get_user(confluence_client: OnyxConfluence, user_id: str) -> str:

--- a/backend/tests/unit/ee/onyx/external_permissions/confluence/test_space_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/confluence/test_space_access.py
@@ -1,0 +1,305 @@
+"""Dispatcher-level tests for Confluence space permission sync.
+
+The companion file `backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py`
+covers the OnyxConfluence client methods (REST 404/500 handling, version
+probe, userKey-email cache). Tests here cover the EE-side dispatcher in
+`ee/onyx/external_permissions/confluence/space_access.py` -- which path
+gets picked, how the REST response shape is translated into ExternalAccess,
+and how the anonymous endpoint plays into is_public.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from ee.onyx.external_permissions.confluence import space_access
+from ee.onyx.external_permissions.confluence.constants import ALL_CONF_EMAILS_GROUP_NAME
+from onyx.connectors.confluence.onyx_confluence import (
+    ConfluenceRestSpacePermissionsNotAvailableError,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_permission_for_group(group_name: str, space_key: str = "ENG") -> dict:
+    return {
+        "operation": {"targetType": "space", "operationKey": "read"},
+        "subject": {"type": "group", "name": group_name},
+        "spaceKey": space_key,
+        "spaceId": 131083,
+    }
+
+
+def _read_permission_for_user(user_key: str, space_key: str = "ENG") -> dict:
+    return {
+        "operation": {"targetType": "space", "operationKey": "read"},
+        "subject": {"type": "user", "userKey": user_key},
+        "spaceKey": space_key,
+        "spaceId": 131083,
+    }
+
+
+def _anonymous_read_permission() -> dict:
+    return {"operation": {"targetType": "space", "operationKey": "read"}}
+
+
+def _make_client(
+    *,
+    supports_rest: bool,
+    rest_permissions: list[dict[str, Any]] | Exception | None = None,
+    anonymous_permissions: list[dict[str, Any]] | None = None,
+    jsonrpc_permissions: list[dict[str, Any]] | None = None,
+) -> mock.Mock:
+    client = mock.Mock()
+    client.supports_rest_space_permissions.return_value = supports_rest
+
+    if isinstance(rest_permissions, Exception):
+        client.get_all_space_permissions_server_rest.side_effect = rest_permissions
+    else:
+        client.get_all_space_permissions_server_rest.return_value = (
+            rest_permissions or []
+        )
+
+    client.get_anonymous_space_permissions_server_rest.return_value = (
+        anonymous_permissions or []
+    )
+    client.get_all_space_permissions_server.return_value = jsonrpc_permissions or []
+    return client
+
+
+@pytest.fixture
+def patched_userkey_resolver() -> Generator[dict[str, str | None], None, None]:
+    """Make get_user_email_from_userkey__server return whatever the test
+    sets in the returned dict, with no real network involvement.
+    """
+    fake_db: dict[str, str | None] = {}
+
+    def fake_resolver(_client: object, user_key: str) -> str | None:
+        return fake_db.get(user_key)
+
+    with mock.patch.object(
+        space_access,
+        "get_user_email_from_userkey__server",
+        side_effect=fake_resolver,
+    ):
+        yield fake_db
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher: REST vs JSON-RPC
+# ---------------------------------------------------------------------------
+
+
+def test_dispatcher_uses_rest_for_dc_91_plus(
+    patched_userkey_resolver: dict[str, str | None],
+) -> None:
+    """DC 9.1+ should use the REST API, never touching the legacy JSON-RPC
+    method. This is the actual production fix for cc_pair=44 / cc_pair=50.
+    """
+    patched_userkey_resolver["userkey-alice"] = "alice@example.com"
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=[
+            _read_permission_for_group("confluence-users"),
+            _read_permission_for_user("userkey-alice"),
+        ],
+    )
+
+    access = space_access._get_server_space_permissions(
+        confluence_client=client, space_key="ENG"
+    )
+
+    assert access.is_public is False
+    assert access.external_user_emails == {"alice@example.com"}
+    assert access.external_user_group_ids == {"confluence-users"}
+    client.get_all_space_permissions_server_rest.assert_called_once_with(
+        space_key="ENG"
+    )
+    client.get_all_space_permissions_server.assert_not_called()
+
+
+def test_dispatcher_falls_back_to_jsonrpc_for_pre_91() -> None:
+    """DC < 9.1 has no REST endpoint; the dispatcher must fall back to the
+    legacy JSON-RPC path (and produce identical-shape ExternalAccess).
+    """
+    client = _make_client(
+        supports_rest=False,
+        jsonrpc_permissions=[
+            {
+                "type": "VIEWSPACE",
+                "spacePermissions": [
+                    {"groupName": "confluence-users", "userName": None},
+                ],
+            }
+        ],
+    )
+
+    access = space_access._get_server_space_permissions(
+        confluence_client=client, space_key="ENG"
+    )
+
+    assert access.external_user_group_ids == {"confluence-users"}
+    client.get_all_space_permissions_server.assert_called_once_with(space_key="ENG")
+    client.get_all_space_permissions_server_rest.assert_not_called()
+
+
+def test_dispatcher_falls_back_to_jsonrpc_when_rest_signals_unavailable() -> None:
+    """If serverInfo lies (or a custom build doesn't have the REST plugin),
+    the REST call raises the typed unavailability signal and the dispatcher
+    must fall back rather than blow up.
+    """
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=ConfluenceRestSpacePermissionsNotAvailableError(
+            "404 from upstream"
+        ),
+        jsonrpc_permissions=[
+            {
+                "type": "VIEWSPACE",
+                "spacePermissions": [{"groupName": "fallback-group", "userName": None}],
+            }
+        ],
+    )
+
+    access = space_access._get_server_space_permissions(
+        confluence_client=client, space_key="ENG"
+    )
+
+    assert access.external_user_group_ids == {"fallback-group"}
+    client.get_all_space_permissions_server_rest.assert_called_once()
+    client.get_all_space_permissions_server.assert_called_once_with(space_key="ENG")
+
+
+# ---------------------------------------------------------------------------
+# REST response shape: anonymous endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_rest_anonymous_endpoint_marks_public_when_env_var_set() -> None:
+    """When the anonymous endpoint reports a 'read' grant AND
+    CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC is set, the space surfaces as
+    is_public=True. (No surrogate group is added.)
+
+    Doesn't need patched_userkey_resolver because rest_permissions is
+    empty -- there are no userKeys to resolve.
+    """
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=[],
+        anonymous_permissions=[_anonymous_read_permission()],
+    )
+
+    with mock.patch.object(space_access, "CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC", True):
+        access = space_access._get_server_space_permissions(
+            confluence_client=client, space_key="ENG"
+        )
+
+    assert access.is_public is True
+    assert access.external_user_emails == set()
+    assert access.external_user_group_ids == set()
+
+
+def test_rest_anonymous_endpoint_falls_back_to_all_users_group_when_env_unset() -> None:
+    """Without the env var, the legacy behavior is to add the
+    ALL_CONF_EMAILS group so authenticated Confluence users still see the
+    space, but the surface isn't marked truly public. Mirror this on the
+    REST path.
+
+    Doesn't need patched_userkey_resolver because rest_permissions is
+    empty -- there are no userKeys to resolve.
+    """
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=[],
+        anonymous_permissions=[_anonymous_read_permission()],
+    )
+
+    with mock.patch.object(
+        space_access, "CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC", False
+    ):
+        access = space_access._get_server_space_permissions(
+            confluence_client=client, space_key="ENG"
+        )
+
+    assert access.is_public is False
+    assert access.external_user_group_ids == {ALL_CONF_EMAILS_GROUP_NAME}
+
+
+def test_rest_anonymous_endpoint_failure_does_not_break_explicit_grants(
+    patched_userkey_resolver: dict[str, str | None],
+) -> None:
+    """If the anonymous endpoint blows up on a single space, that should
+    not nuke the explicit user/group grants we already collected from the
+    bulk endpoint -- we'd rather lose anonymous detection than lose the
+    whole permission set.
+    """
+    patched_userkey_resolver["userkey-alice"] = "alice@example.com"
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=[
+            _read_permission_for_group("confluence-users"),
+            _read_permission_for_user("userkey-alice"),
+        ],
+    )
+    client.get_anonymous_space_permissions_server_rest.side_effect = RuntimeError(
+        "anonymous endpoint flaked"
+    )
+
+    access = space_access._get_server_space_permissions(
+        confluence_client=client, space_key="ENG"
+    )
+
+    assert access.is_public is False
+    assert access.external_user_emails == {"alice@example.com"}
+    assert access.external_user_group_ids == {"confluence-users"}
+
+
+# ---------------------------------------------------------------------------
+# REST response shape: ignored entries
+# ---------------------------------------------------------------------------
+
+
+def test_rest_path_ignores_non_read_and_non_space_permissions(
+    patched_userkey_resolver: dict[str, str | None],
+) -> None:
+    """The REST endpoint returns *all* operations for the space (read,
+    update, delete, etc., across multiple targetTypes). Only space-level
+    READ entries should contribute to permission sync.
+    """
+    patched_userkey_resolver["userkey-alice"] = "alice@example.com"
+    client = _make_client(
+        supports_rest=True,
+        rest_permissions=[
+            # Should be picked up:
+            _read_permission_for_group("confluence-users"),
+            _read_permission_for_user("userkey-alice"),
+            # Should be ignored: write permission
+            {
+                "operation": {
+                    "targetType": "space",
+                    "operationKey": "create",
+                },
+                "subject": {"type": "group", "name": "writers"},
+                "spaceKey": "ENG",
+                "spaceId": 131083,
+            },
+            # Should be ignored: not a space-level operation
+            {
+                "operation": {"targetType": "page", "operationKey": "read"},
+                "subject": {"type": "group", "name": "page-readers"},
+                "spaceKey": "ENG",
+                "spaceId": 131083,
+            },
+        ],
+    )
+
+    access = space_access._get_server_space_permissions(
+        confluence_client=client, space_key="ENG"
+    )
+
+    assert access.external_user_emails == {"alice@example.com"}
+    assert access.external_user_group_ids == {"confluence-users"}

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -6,10 +6,18 @@ import pytest
 import requests
 from requests import HTTPError
 
+from onyx.connectors.confluence import onyx_confluence as onyx_confluence_module
 from onyx.connectors.confluence.onyx_confluence import _DEFAULT_PAGINATION_LIMIT
 from onyx.connectors.confluence.onyx_confluence import _MINIMUM_PAGINATION_LIMIT
+from onyx.connectors.confluence.onyx_confluence import (
+    ConfluenceRestSpacePermissionsNotAvailableError,
+)
+from onyx.connectors.confluence.onyx_confluence import (
+    get_user_email_from_userkey__server,
+)
 from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
 from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.interfaces import CredentialsProviderInterface
 
 
@@ -1073,3 +1081,217 @@ def test_jsonrpc_websudo_html_response_raises_validation_error(
     # we're looking at really is WebSudo (vs e.g. a reverse-proxy error
     # page that happens to also be HTML).
     assert "WebSudoRequiredException" in msg
+
+
+# ---------------------------------------------------------------------------
+# DC 9.1+ REST space-permissions API: version detection, REST call, and
+# userKey -> email helper. See plans/confluence-dc-space-permissions-rest.md
+# for the broader rationale.
+# ---------------------------------------------------------------------------
+
+
+def _serverinfo_payload(version: str) -> dict[str, Any]:
+    """Minimal /rest/api/serverInfo payload; we only consume `version`."""
+    return {"version": version, "buildNumber": "0"}
+
+
+def test_supports_rest_space_permissions_true_for_dc_91_plus(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """DC 10.2.10 (the customer's actual deployed version) should report
+    support for the REST API. Cached after first probe, so a subsequent
+    call must not hit /rest/api/serverInfo a second time.
+    """
+    serverinfo_mock = mock.Mock(return_value=_serverinfo_payload("10.2.10"))
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        serverinfo_mock
+    )
+
+    assert confluence_server_client.supports_rest_space_permissions() is True
+    assert confluence_server_client.get_server_version() == (10, 2)
+    assert confluence_server_client.supports_rest_space_permissions() is True
+    assert serverinfo_mock.call_count == 1
+
+
+def test_supports_rest_space_permissions_false_for_dc_pre_91(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    serverinfo_mock = mock.Mock(return_value=_serverinfo_payload("8.9.1"))
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        serverinfo_mock
+    )
+
+    assert confluence_server_client.supports_rest_space_permissions() is False
+    assert confluence_server_client.get_server_version() == (8, 9)
+
+
+def test_supports_rest_space_permissions_false_when_probe_fails(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """Negative probe is cached: a flaky serverInfo call doesn't make us
+    re-probe on every space-permissions sync.
+    """
+    serverinfo_mock = mock.Mock(side_effect=requests.ConnectionError("boom"))
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        serverinfo_mock
+    )
+
+    assert confluence_server_client.supports_rest_space_permissions() is False
+    assert confluence_server_client.get_server_version() is None
+    confluence_server_client.supports_rest_space_permissions()
+    assert serverinfo_mock.call_count == 1
+
+
+def test_get_all_space_permissions_server_rest_404_raises_unavailable(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """A 404 from the REST endpoint means the upstream DC version is too
+    old for this API; surface as the typed signal so the dispatcher can
+    fall back to JSON-RPC instead of bubbling up an opaque HTTPError.
+    """
+    response = _create_mock_response(404, json_data={}, url="x")
+    get_mock = mock.Mock(return_value=response)
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        get_mock
+    )
+
+    with pytest.raises(ConfluenceRestSpacePermissionsNotAvailableError) as exc_info:
+        confluence_server_client.get_all_space_permissions_server_rest(space_key="ENG")
+
+    msg = str(exc_info.value)
+    assert "ENG" in msg
+    assert "9.1" in msg
+
+
+def test_get_all_space_permissions_server_rest_500_raises_insufficient_permissions(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """CONFSERVER-99908: the REST endpoint returns 500 (not 403) when the
+    bot account lacks Confluence/space-admin rights. Make sure we surface
+    this as InsufficientPermissionsError with the ticket reference rather
+    than a raw 5xx.
+    """
+    response = _create_mock_response(500, json_data={}, url="x")
+    get_mock = mock.Mock(return_value=response)
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        get_mock
+    )
+
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        confluence_server_client.get_all_space_permissions_server_rest(space_key="ENG")
+
+    msg = str(exc_info.value)
+    assert "ENG" in msg
+    assert "CONFSERVER-99908" in msg
+    assert "admin" in msg.lower()
+
+
+def test_get_all_space_permissions_server_rest_happy_path(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """Verifies advanced_mode is on (so non-200s reach our handlers) and
+    that the raw list shape from CONFSERVER-78176 is returned unchanged
+    so the dispatcher can do its own filtering.
+    """
+    permissions_payload: list[dict[str, Any]] = [
+        {
+            "operation": {"targetType": "space", "operationKey": "read"},
+            "subject": {"type": "group", "name": "confluence-users"},
+            "spaceKey": "ENG",
+            "spaceId": 131083,
+        },
+        {
+            "operation": {"targetType": "space", "operationKey": "read"},
+            "subject": {
+                "type": "user",
+                # Format is opaque hex in production; keep it human-readable
+                # here so secret-scanners don't flag it as a real credential.
+                "userKey": "fake-test-userkey-alice",
+            },
+            "spaceKey": "ENG",
+            "spaceId": 131083,
+        },
+    ]
+    # The REST endpoint returns a list, not a dict, so we hand-roll the
+    # mock response (the shared _create_mock_response helper is
+    # dict-only).
+    response = requests.Response()
+    response.status_code = 200
+    response.url = "x"
+    json_mock = mock.Mock(return_value=permissions_payload)
+    response.json = json_mock  # ty: ignore[invalid-assignment]
+    get_mock = mock.Mock(return_value=response)
+    confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
+        get_mock
+    )
+
+    result = confluence_server_client.get_all_space_permissions_server_rest(
+        space_key="ENG"
+    )
+
+    assert result == permissions_payload
+    _, kwargs = get_mock.call_args
+    assert kwargs.get("advanced_mode") is True
+
+
+def test_get_user_email_from_userkey_caches_lookups(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """Cache hit-rate is the only thing keeping per-space user resolution
+    from being O(N_users * N_spaces) network calls. Regression-guard the
+    cache.
+    """
+    user_key = "test_userkey_unique_to_this_case"
+    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.pop(user_key, None)
+
+    user_details_mock = mock.Mock(
+        return_value={
+            "userKey": user_key,
+            "username": "alice",
+            "email": "alice@example.com",
+            "displayName": "Alice",
+        }
+    )
+    confluence_server_client._confluence.get_user_details_by_userkey = (  # ty: ignore[invalid-assignment]
+        user_details_mock
+    )
+
+    first = get_user_email_from_userkey__server(
+        confluence_server_client, user_key=user_key
+    )
+    second = get_user_email_from_userkey__server(
+        confluence_server_client, user_key=user_key
+    )
+
+    assert first == "alice@example.com"
+    assert second == "alice@example.com"
+    assert user_details_mock.call_count == 1
+
+
+def test_get_user_email_from_userkey_caches_negative_result(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """A user we couldn't resolve (HTTPError, no email field, etc.) should
+    cache as None so we don't keep retrying every sync. This both saves
+    HTTP load and keeps the warning log from spamming.
+    """
+    user_key = "missing_userkey_unique_to_this_case"
+    onyx_confluence_module._USER_KEY_TO_EMAIL_CACHE.pop(user_key, None)
+
+    user_details_mock = mock.Mock(
+        side_effect=HTTPError(response=_create_mock_response(404, {}, "x"))
+    )
+    confluence_server_client._confluence.get_user_details_by_userkey = (  # ty: ignore[invalid-assignment]
+        user_details_mock
+    )
+
+    first = get_user_email_from_userkey__server(
+        confluence_server_client, user_key=user_key
+    )
+    second = get_user_email_from_userkey__server(
+        confluence_server_client, user_key=user_key
+    )
+
+    assert first is None
+    assert second is None
+    assert user_details_mock.call_count == 1

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1024,8 +1024,7 @@ def test_jsonrpc_websudo_html_response_raises_validation_error(
     confluence_server_client: OnyxConfluence,
 ) -> None:
     """
-    Regression test for the production failure on cc_pair=44 / cc_pair=50
-    against Confluence DC 10.2.10.
+    Regression test for the production failure against Confluence DC 10.2.10.
 
     When 'Secure Administrator Sessions' (WebSudo) intercepts a JSON-RPC
     call, the response body is HTML (login page / WebSudoRequiredException)


### PR DESCRIPTION
## Description

use the rest api to fetch space permissions for confluence data center v9.1+
there are other associated changes to handle along with this, I'll let AI do the summary

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix/confluence-dc-websudo","parentHead":"d34d076b0056f6d71066ef5962e5b257acecbce3","parentPull":10853,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Confluence Data Center permission sync to the DC 9.1+ REST space-permissions API with a safe JSON-RPC fallback. This reduces WebSudo issues and makes anonymous access handling more reliable.

- New Features
  - Use REST space-permissions on DC 9.1+; include only space-level read grants; resolve and cache user emails via `userKey` -> email.
  - Handle anonymous access via `/permissions/anonymous`; accept flat or nested shapes; if `CONFLUENCE_ANONYMOUS_ACCESS_IS_PUBLIC` is true mark the space public, else add `All_Confluence_Users_Found_By_Onyx`.
  - Detect and cache server version via `/rest/api/serverInfo`; expose `supports_rest_space_permissions()` and `ConfluenceRestSpacePermissionsNotAvailableError`; probe admin access once via `probe_rest_space_permissions_admin_access()` during perm-sync validation.

- Bug Fixes
  - Map REST 500s from non-admin callers (bulk and anonymous endpoints; CONFSERVER-99908) to `InsufficientPermissionsError` with clear remediation.
  - Fall back to JSON-RPC when REST is missing (404) or reported available but unavailable at runtime; treat 404 from the anonymous endpoint as “no anonymous access”; don’t fail a sync if the anonymous-permissions call flakes for a space.
  - Prefer REST over JSON-RPC to avoid WebSudo on modern DC; no behavior change for Cloud.

<sup>Written for commit 3dc42b8d33102e667b38fe01c2b0190935c75f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

