### PR TITLE
fix: handle already-deleted batch files in cleanup_all_batches

### DIFF
--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -207,7 +207,7 @@ class FileStoreDocumentBatchStorage(DocumentBatchStorage):
 
     def delete_batch_by_name(self, batch_file_name: str) -> None:
         """Delete a specific batch from FileStore."""
-        self.file_store.delete_file(batch_file_name)
+        self.file_store.delete_file(batch_file_name, error_on_missing=False)
         logger.debug("Deleted batch %s from FileStore", batch_file_name)
 
     def delete_batch_by_num(self, batch_num: int) -> None:

--- a/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
+++ b/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
@@ -1,0 +1,41 @@
+"""Tests for FileStoreDocumentBatchStorage."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.file_store.document_batch_storage import FileStoreDocumentBatchStorage
+from onyx.file_store.file_store import S3BackedFileStore
+
+_S3_MODULE = "onyx.file_store.file_store"
+
+
+def _mock_db_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+@patch(f"{_S3_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_S3_MODULE}.get_filerecord_by_file_id_optional", return_value=None)
+@patch(f"{_S3_MODULE}.get_filerecord_by_prefix")
+def test_cleanup_all_batches_completes_when_files_already_deleted(
+    mock_list: MagicMock,
+    _mock_get_record: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    """cleanup_all_batches must complete without raising even if every batch
+    file is already gone — e.g. from a partial cleanup or a batch that was
+    never written due to an earlier failure."""
+    mock_ctx.return_value = _mock_db_session()
+    mock_list.return_value = [
+        MagicMock(file_id="iab/1/42/0.json"),
+        MagicMock(file_id="iab/1/42/1.json"),
+        MagicMock(file_id="iab/1/42/2.json"),
+    ]
+
+    file_store = S3BackedFileStore(bucket_name="test-bucket")
+    storage = FileStoreDocumentBatchStorage(
+        cc_pair_id=1, index_attempt_id=42, file_store=file_store
+    )
+    storage.cleanup_all_batches()  # must not raise


### PR DESCRIPTION
## Summary

`cleanup_all_batches` iterates over batch files and calls `delete_batch_by_name` for each. If a file is already gone — either from a partial cleanup that previously ran, or because it was never written due to an earlier failure in the same indexing attempt — `delete_file` raises a `RuntimeError` (the default `error_on_missing=True`), aborting the entire cleanup loop.

The fix passes `error_on_missing=False` so cleanup is idempotent and tolerates files that no longer exist.

## Reproducing

Observed during Jira connector indexing: a batch file was deleted or never written, then `cleanup_all_batches` raised:

```
RuntimeError: File by id iab/3/116/14353.json does not exist or was deleted
```

## Fix

One-line change in `delete_batch_by_name`:

```python
# Before
self.file_store.delete_file(batch_file_name)

# After
self.file_store.delete_file(batch_file_name, error_on_missing=False)
```

`FileStore.delete_file` already accepts `error_on_missing: bool = True` — this just opts in to the tolerant behaviour that cleanup should have.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make batch cleanup idempotent by tolerating missing batch files. `delete_batch_by_name` now calls `file_store.delete_file(..., error_on_missing=False)`, so `cleanup_all_batches` completes even if files were already deleted or never written; added a unit test to cover this case.

<sup>Written for commit 7bd7356c36ad6265debd9f5acfeb9cd0b686a756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

