### PR TITLE
fix(indexing): tabular chunker crash on Google Sheets with multi-line cells

### DIFF
--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -1,3 +1,4 @@
+import csv
 from collections.abc import Iterable
 
 from pydantic import BaseModel
@@ -236,8 +237,22 @@ class TabularChunker(SectionChunker):
         payloads = accumulator.flush_to_list()
 
         text = section.text or ""
-        parsed_rows = list(parse_csv_string(text))
-        headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
+        try:
+            parsed_rows = list(parse_csv_string(text))
+        except csv.Error as e:
+            logger.warning(
+                "TabularChunker: failed to parse CSV for section (link=%s): %s",
+                section.link,
+                e,
+            )
+            parsed_rows = []
+        if parsed_rows:
+            headers = parsed_rows[0].header
+        else:
+            try:
+                headers = read_csv_header(text)
+            except csv.Error:
+                headers = []
         heading = section.heading or ""
 
         chunk_texts: list[str] = []

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -251,7 +251,12 @@ class TabularChunker(SectionChunker):
         else:
             try:
                 headers = read_csv_header(text)
-            except csv.Error:
+            except csv.Error as e:
+                logger.warning(
+                    "TabularChunker: failed to read CSV header for section (link=%s): %s",
+                    section.link,
+                    e,
+                )
                 headers = []
         heading = section.heading or ""
 

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -1,4 +1,3 @@
-import csv
 from collections.abc import Iterable
 
 from pydantic import BaseModel
@@ -18,7 +17,6 @@ from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
-from onyx.utils.csv_utils import normalize_csv_newlines
 from onyx.utils.csv_utils import parse_csv_string
 from onyx.utils.csv_utils import ParsedRow
 from onyx.utils.csv_utils import read_csv_header
@@ -238,35 +236,8 @@ class TabularChunker(SectionChunker):
         payloads = accumulator.flush_to_list()
 
         text = section.text or ""
-        # csv_text may be replaced with a normalized copy on first parse error
-        csv_text = text
-        parse_error = False
-        try:
-            parsed_rows = list(parse_csv_string(csv_text))
-        except csv.Error:
-            csv_text = normalize_csv_newlines(text)
-            try:
-                parsed_rows = list(parse_csv_string(csv_text))
-            except csv.Error as e:
-                logger.error(
-                    "TabularChunker: failed to parse CSV for section (link=%s): %s",
-                    section.link,
-                    e,
-                )
-                parsed_rows = []
-                parse_error = True
-        if parsed_rows:
-            headers = parsed_rows[0].header
-        else:
-            try:
-                headers = read_csv_header(csv_text)
-            except csv.Error as e:
-                logger.error(
-                    "TabularChunker: failed to read CSV header for section (link=%s): %s",
-                    section.link,
-                    e,
-                )
-                headers = []
+        parsed_rows = list(parse_csv_string(text))
+        headers = parsed_rows[0].header if parsed_rows else read_csv_header(text)
         heading = section.heading or ""
 
         chunk_texts: list[str] = []
@@ -302,19 +273,12 @@ class TabularChunker(SectionChunker):
             )
 
         if not chunk_texts:
-            if csv_text.strip():
-                if parse_error:
-                    logger.error(
-                        "TabularChunker: CSV parse failed, falling back to plain text (link=%s)",
-                        section.link,
-                    )
-                chunk_texts = split_text_by_tokens(
-                    csv_text, self.tokenizer, content_token_limit
-                )
-            else:
-                return SectionChunkerOutput(
-                    payloads=payloads, accumulator=AccumulatorState()
-                )
+            logger.warning(
+                "TabularChunker: skipping unparseable section (link=%s)", section.link
+            )
+            return SectionChunkerOutput(
+                payloads=payloads, accumulator=AccumulatorState()
+            )
 
         for i, text in enumerate(chunk_texts):
             payloads.append(

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -18,6 +18,7 @@ from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.natural_language_processing.utils import count_tokens
 from onyx.natural_language_processing.utils import split_text_by_tokens
+from onyx.utils.csv_utils import normalize_csv_newlines
 from onyx.utils.csv_utils import parse_csv_string
 from onyx.utils.csv_utils import ParsedRow
 from onyx.utils.csv_utils import read_csv_header
@@ -237,22 +238,30 @@ class TabularChunker(SectionChunker):
         payloads = accumulator.flush_to_list()
 
         text = section.text or ""
+        # csv_text may be replaced with a normalized copy on first parse error
+        csv_text = text
+        parse_error = False
         try:
-            parsed_rows = list(parse_csv_string(text))
-        except csv.Error as e:
-            logger.warning(
-                "TabularChunker: failed to parse CSV for section (link=%s): %s",
-                section.link,
-                e,
-            )
-            parsed_rows = []
+            parsed_rows = list(parse_csv_string(csv_text))
+        except csv.Error:
+            csv_text = normalize_csv_newlines(text)
+            try:
+                parsed_rows = list(parse_csv_string(csv_text))
+            except csv.Error as e:
+                logger.error(
+                    "TabularChunker: failed to parse CSV for section (link=%s): %s",
+                    section.link,
+                    e,
+                )
+                parsed_rows = []
+                parse_error = True
         if parsed_rows:
             headers = parsed_rows[0].header
         else:
             try:
-                headers = read_csv_header(text)
+                headers = read_csv_header(csv_text)
             except csv.Error as e:
-                logger.warning(
+                logger.error(
                     "TabularChunker: failed to read CSV header for section (link=%s): %s",
                     section.link,
                     e,
@@ -293,12 +302,19 @@ class TabularChunker(SectionChunker):
             )
 
         if not chunk_texts:
-            logger.warning(
-                "TabularChunker: skipping unparseable section (link=%s)", section.link
-            )
-            return SectionChunkerOutput(
-                payloads=payloads, accumulator=AccumulatorState()
-            )
+            if csv_text.strip():
+                if parse_error:
+                    logger.error(
+                        "TabularChunker: CSV parse failed, falling back to plain text (link=%s)",
+                        section.link,
+                    )
+                chunk_texts = split_text_by_tokens(
+                    csv_text, self.tokenizer, content_token_limit
+                )
+            else:
+                return SectionChunkerOutput(
+                    payloads=payloads, accumulator=AccumulatorState()
+                )
 
         for i, text in enumerate(chunk_texts):
             payloads.append(

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -10,6 +10,17 @@ class ParsedRow(BaseModel):
     row: list[str]
 
 
+def normalize_csv_newlines(text: str) -> str:
+    """Normalize Windows (\\r\\n) and old-Mac (\\r) line endings to Unix (\\n).
+
+    io.StringIO does not split on bare \\r, so csv.reader raises
+    "new-line character seen in unquoted field" for files that use \\r as
+    the row separator (e.g. old Mac-format CSVs from Google Drive).
+    Call this as a fallback when csv.reader raises csv.Error.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def read_csv_header(csv_text: str) -> list[str]:
     """Return the first non-blank row (the header) of a CSV string, or
     [] if the text has no usable header.

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -4,6 +4,8 @@ from collections.abc import Generator
 
 from pydantic import BaseModel
 
+_NEWLINE_CSV_ERROR = "new-line character seen in unquoted field"
+
 
 class ParsedRow(BaseModel):
     header: list[str]
@@ -16,7 +18,6 @@ def normalize_csv_newlines(text: str) -> str:
     io.StringIO does not split on bare \\r, so csv.reader raises
     "new-line character seen in unquoted field" for files that use \\r as
     the row separator (e.g. old Mac-format CSVs from Google Drive).
-    Call this as a fallback when csv.reader raises csv.Error.
     """
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
@@ -24,29 +25,59 @@ def normalize_csv_newlines(text: str) -> str:
 def read_csv_header(csv_text: str) -> list[str]:
     """Return the first non-blank row (the header) of a CSV string, or
     [] if the text has no usable header.
+
+    Falls back to normalized line endings when csv.reader raises the
+    specific "new-line character" error.
     """
+
+    def _read(text: str) -> list[str]:
+        for row in csv.reader(io.StringIO(text)):
+            if any(c.strip() for c in row):
+                return row
+        return []
+
     if not csv_text.strip():
         return []
-    for row in csv.reader(io.StringIO(csv_text)):
-        if any(c.strip() for c in row):
-            return row
-    return []
+    try:
+        return _read(csv_text)
+    except csv.Error as e:
+        if _NEWLINE_CSV_ERROR not in str(e):
+            raise csv.Error(f"read_csv_header failed: {e}") from e
+    try:
+        return _read(normalize_csv_newlines(csv_text))
+    except csv.Error as e:
+        raise csv.Error(f"read_csv_header failed: {e}") from e
 
 
 def parse_csv_string(csv_text: str) -> Generator[ParsedRow, None, None]:
+    """Yield each data row paired with its header from a CSV string.
+
+    Falls back to normalized line endings when csv.reader raises the
+    specific "new-line character" error (e.g. old Mac-format CSVs).
     """
-    Takes in a string in the form of a CSV and yields back
-    each row + header in the csv.
-    """
+
+    def _parse(text: str) -> list[ParsedRow]:
+        reader = csv.reader(io.StringIO(text))
+        header: list[str] | None = None
+        rows: list[ParsedRow] = []
+        for row in reader:
+            if not any(cell.strip() for cell in row):
+                continue
+            if header is None:
+                header = row
+                continue
+            rows.append(ParsedRow(header=header, row=row))
+        return rows
+
     if not csv_text.strip():
         return
-
-    reader = csv.reader(io.StringIO(csv_text))
-    header: list[str] | None = None
-    for row in reader:
-        if not any(cell.strip() for cell in row):
-            continue
-        if header is None:
-            header = row
-            continue
-        yield ParsedRow(header=header, row=row)
+    try:
+        rows = _parse(csv_text)
+    except csv.Error as e:
+        if _NEWLINE_CSV_ERROR not in str(e):
+            raise csv.Error(f"parse_csv_string failed: {e}") from e
+        try:
+            rows = _parse(normalize_csv_newlines(csv_text))
+        except csv.Error as e2:
+            raise csv.Error(f"parse_csv_string failed: {e2}") from e2
+    yield from rows

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -630,6 +630,22 @@ class TestTabularChunkerChunkSection:
         assert [p.is_continuation for p in out.payloads] == [False, True, True]
 
 
+class TestTabularChunkerMalformedCsv:
+    def test_unquoted_newline_does_not_raise(self) -> None:
+        """Google Sheets exports cells with embedded newlines without quoting them,
+        causing csv.reader to raise csv.Error. The chunker should handle this
+        gracefully rather than propagating the exception."""
+        # Simulates a Google Sheet CSV export where a cell value contains a
+        # newline that was not quoted: "col1,col2\nvalue1,line1\nline2"
+        malformed_csv = "col1,col2\nvalue1,line1\nline2"
+        section = _tabular_section(malformed_csv)
+        chunker = _make_chunker_no_metadata()
+        result = chunker.chunk_section(
+            section, AccumulatorState(), content_token_limit=500
+        )
+        assert result is not None
+
+
 class TestBuildSheetDescriptorChunks:
     """Direct tests of `build_sheet_descriptor_chunks` — the per-section
     descriptor builder that backs the metadata chunks emitted by

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -632,8 +632,9 @@ class TestTabularChunkerChunkSection:
 
 class TestTabularChunkerMalformedCsv:
     def test_bare_cr_normalized_and_parsed(self) -> None:
-        """A bare \\r (old Mac line ending) is normalized to \\n before
-        parsing, so the rows are recovered instead of dropped."""
+        """A bare \\r (old Mac line ending) is normalized inside
+        parse_csv_string, so rows are recovered and the chunker never
+        sees an error."""
         # "value1,line1\rline2" normalizes to two rows:
         #   row 2: col1=value1, col2=line1
         #   row 3: col1=line2  (short row — col2 absent, skipped by zip)
@@ -659,19 +660,6 @@ class TestTabularChunkerMalformedCsv:
         assert len(result.payloads) > 0
         texts = [p.text for p in result.payloads]
         assert any("col1" in t for t in texts)
-
-    def test_header_only_csv_falls_back_to_plain_text(self) -> None:
-        """A header-only CSV (no data rows) with ignore_metadata_chunks=True
-        produces no tabular chunks. The section falls back to plain text so
-        the content is still indexed rather than silently dropped."""
-        header_only = "col1,col2,col3"
-        section = _tabular_section(header_only)
-        chunker = _make_chunker_no_metadata()
-        result = chunker.chunk_section(
-            section, AccumulatorState(), content_token_limit=500
-        )
-        assert len(result.payloads) > 0
-        assert any("col1" in p.text for p in result.payloads)
 
 
 class TestBuildSheetDescriptorChunks:

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -632,18 +632,35 @@ class TestTabularChunkerChunkSection:
 
 class TestTabularChunkerMalformedCsv:
     def test_unquoted_newline_does_not_raise(self) -> None:
-        """Google Sheets exports cells with embedded newlines without quoting them,
-        causing csv.reader to raise csv.Error. The chunker should handle this
-        gracefully rather than propagating the exception."""
-        # Simulates a Google Sheet CSV export where a cell value contains a
-        # newline that was not quoted: "col1,col2\nvalue1,line1\nline2"
-        malformed_csv = "col1,col2\nvalue1,line1\nline2"
+        """Google Sheets exports cells with embedded carriage returns without
+        quoting them, causing csv.reader to raise csv.Error. The chunker
+        should handle this gracefully rather than propagating the exception."""
+        # A bare \r inside a field (not followed by \n) causes
+        # csv.Error: "new-line character seen in unquoted field".
+        malformed_csv = "col1,col2\nvalue1,line1\rline2"
         section = _tabular_section(malformed_csv)
         chunker = _make_chunker_no_metadata()
         result = chunker.chunk_section(
             section, AccumulatorState(), content_token_limit=500
         )
-        assert result is not None
+        assert result.payloads == []
+
+    def test_unquoted_newline_with_metadata_chunker(self) -> None:
+        """When parse_csv_string fails but read_csv_header succeeds, the
+        metadata-chunker path (ignore_metadata_chunks=False) should still
+        produce descriptor chunks for the valid header without raising."""
+        # The header line is valid CSV; only the data rows trigger csv.Error.
+        malformed_csv = "col1,col2\nvalue1,line1\rline2"
+        section = _tabular_section(malformed_csv)
+        chunker = _make_chunker_with_metadata()
+        result = chunker.chunk_section(
+            section, AccumulatorState(), content_token_limit=500
+        )
+        # No row chunks (parse_csv_string failed), but descriptor chunks from
+        # the valid header should be present.
+        assert len(result.payloads) > 0
+        texts = [p.text for p in result.payloads]
+        assert any("col1" in t for t in texts)
 
 
 class TestBuildSheetDescriptorChunks:

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -631,36 +631,47 @@ class TestTabularChunkerChunkSection:
 
 
 class TestTabularChunkerMalformedCsv:
-    def test_unquoted_newline_does_not_raise(self) -> None:
-        """Google Sheets exports cells with embedded carriage returns without
-        quoting them, causing csv.reader to raise csv.Error. The chunker
-        should handle this gracefully rather than propagating the exception."""
-        # A bare \r inside a field (not followed by \n) causes
-        # csv.Error: "new-line character seen in unquoted field".
-        malformed_csv = "col1,col2\nvalue1,line1\rline2"
-        section = _tabular_section(malformed_csv)
+    def test_bare_cr_normalized_and_parsed(self) -> None:
+        """A bare \\r (old Mac line ending) is normalized to \\n before
+        parsing, so the rows are recovered instead of dropped."""
+        # "value1,line1\rline2" normalizes to two rows:
+        #   row 2: col1=value1, col2=line1
+        #   row 3: col1=line2  (short row — col2 absent, skipped by zip)
+        csv_with_bare_cr = "col1,col2\nvalue1,line1\rline2"
+        section = _tabular_section(csv_with_bare_cr)
         chunker = _make_chunker_no_metadata()
         result = chunker.chunk_section(
             section, AccumulatorState(), content_token_limit=500
         )
-        assert result.payloads == []
+        assert len(result.payloads) > 0
+        texts = [p.text for p in result.payloads]
+        assert any("col1=value1" in t for t in texts)
 
-    def test_unquoted_newline_with_metadata_chunker(self) -> None:
-        """When parse_csv_string fails but read_csv_header succeeds, the
-        metadata-chunker path (ignore_metadata_chunks=False) should still
-        produce descriptor chunks for the valid header without raising."""
-        # The header line is valid CSV; only the data rows trigger csv.Error.
-        malformed_csv = "col1,col2\nvalue1,line1\rline2"
-        section = _tabular_section(malformed_csv)
+    def test_bare_cr_with_metadata_chunker(self) -> None:
+        """With ignore_metadata_chunks=False, bare-\\r CSVs produce both
+        row chunks and descriptor chunks after normalization."""
+        csv_with_bare_cr = "col1,col2\nvalue1,line1\rline2"
+        section = _tabular_section(csv_with_bare_cr)
         chunker = _make_chunker_with_metadata()
         result = chunker.chunk_section(
             section, AccumulatorState(), content_token_limit=500
         )
-        # No row chunks (parse_csv_string failed), but descriptor chunks from
-        # the valid header should be present.
         assert len(result.payloads) > 0
         texts = [p.text for p in result.payloads]
         assert any("col1" in t for t in texts)
+
+    def test_header_only_csv_falls_back_to_plain_text(self) -> None:
+        """A header-only CSV (no data rows) with ignore_metadata_chunks=True
+        produces no tabular chunks. The section falls back to plain text so
+        the content is still indexed rather than silently dropped."""
+        header_only = "col1,col2,col3"
+        section = _tabular_section(header_only)
+        chunker = _make_chunker_no_metadata()
+        result = chunker.chunk_section(
+            section, AccumulatorState(), content_token_limit=500
+        )
+        assert len(result.payloads) > 0
+        assert any("col1" in p.text for p in result.payloads)
 
 
 class TestBuildSheetDescriptorChunks:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Google Drive CSV files with old Mac-style (\r-only) line endings caused csv.reader to raise csv.Error: new-line character seen in unquoted field on every row after the header, resulting in 240 document indexing failures for a customer.

parse_csv_string and read_csv_header in csv_utils.py now transparently retry with normalized line endings when they encounter this specific error. Normalization (\r\n → \n, \r → \n) only triggers as a fallback — well-formed CSVs are untouched. All other csv.Error types are re-raised with the originating function name for easier diagnosis. tabular_section_chunker.py is unchanged.
## How Has This Been Tested?
unit test
local test
before fix
<img width="1609" height="609" alt="Screenshot 2026-05-06 at 11 59 11 AM" src="https://github.com/user-attachments/assets/61744ee5-8a8b-47d8-9e89-1ea267720e0a" />


after fix
<img width="856" height="123" alt="Screenshot 2026-05-06 at 12 14 31 PM" src="https://github.com/user-attachments/assets/440bdde0-8031-4e73-a053-321156b6df97" />



https://linear.app/onyx-app/issue/ENG-4105/google-drive-for-savvy-wealth
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tabular chunker crashes on Google Sheets/Drive CSVs with multi‑line cells by detecting the “new-line character…” error, normalizing CRLF/CR to LF, and retrying header and row parsing. When parsing still fails, clearer errors help callers fall back to plain‑text indexing; Sheets with multi‑line cells now index reliably with structured rows (ENG-4105).

- **Bug Fixes**
  - Normalize Windows and old‑Mac line endings only when `csv.reader` raises the specific error; retry in `read_csv_header` and `parse_csv_string`.
  - Prefix other `csv.Error`s with function names for easier diagnosis; callers can fall back to plain‑text indexing.
  - Tests cover bare‑CR CSVs producing row and descriptor chunks (with and without metadata).

<sup>Written for commit 9e4b46d05aaa70cf03281a6c8609345d3937b864. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





