### PR TITLE
chore: remove kg_processing worker from vscode launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -272,35 +272,6 @@
       "justMyCode": false
     },
     {
-      "name": "Celery kg_processing",
-      "type": "debugpy",
-      "request": "launch",
-      "module": "celery",
-      "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
-      "env": {
-        "LOG_LEVEL": "INFO",
-        "PYTHONUNBUFFERED": "1",
-        "PYTHONPATH": "."
-      },
-      "args": [
-        "-A",
-        "onyx.background.celery.versioned_apps.kg_processing",
-        "worker",
-        "--pool=threads",
-        "--concurrency=2",
-        "--prefetch-multiplier=1",
-        "--loglevel=INFO",
-        "--hostname=kg_processing@%n",
-        "-Q",
-        "kg_processing"
-      ],
-      "presentation": {
-        "group": "2"
-      },
-      "consoleTitle": "Celery kg_processing Console"
-    },
-    {
       "name": "Celery monitoring",
       "type": "debugpy",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,7 +45,6 @@
         "Celery primary",
         "Celery light",
         "Celery heavy",
-        "Celery kg_processing",
         "Celery monitoring",
         "Celery user_file_processing",
         "Celery docfetching",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,27 +62,20 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
    - Tasks: connector pruning, document permissions sync, external group sync, CSV generation
    - Runs with 4 threads concurrency
 
-6. **KG Processing Worker** (`kg_processing`)
-
-   - Handles Knowledge Graph processing and clustering
-   - Builds relationships between documents
-   - Runs clustering algorithms
-   - Configurable concurrency
-
-7. **Monitoring Worker** (`monitoring`)
+6. **Monitoring Worker** (`monitoring`)
 
    - System health monitoring and metrics collection
    - Monitors Celery queues, process memory, and system status
    - Single thread (monitoring doesn't need parallelism)
    - Cloud-specific monitoring tasks
 
-8. **User File Processing Worker** (`user_file_processing`)
+7. **User File Processing Worker** (`user_file_processing`)
 
    - Processes user-uploaded files
    - Handles user file indexing and project synchronization
    - Configurable concurrency
 
-9. **Beat Worker** (`beat`)
+8. **Beat Worker** (`beat`)
    - Celery's scheduler for periodic tasks
    - Uses DynamicTenantScheduler for multi-tenant support
    - Schedules tasks like:
@@ -90,7 +83,6 @@ Onyx uses Celery for asynchronous task processing with multiple specialized work
      - Connector deletion checks (every 20 seconds)
      - Vespa sync checks (every 20 seconds)
      - Pruning checks (every 20 seconds)
-     - KG processing (every 60 seconds)
      - Monitoring tasks (every 5 minutes)
      - Cleanup tasks (hourly)
 


### PR DESCRIPTION
## Description

This worker launches with the compound `Celery` config in the .vscode/launch.json

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed deprecated `kg_processing` Celery worker from `.vscode/launch.json` by deleting the standalone launch target and its entry in the `Celery` compound, and updated `AGENTS.md` to remove the worker and its beat schedule. This keeps dev launch targets and docs aligned and avoids invalid entries.

<sup>Written for commit a93c45d8c224c1cad31c43e9368ff4264ac552df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



