### PR TITLE
feat(targeted-reindex): connector.reindex + indexing pipeline wiring

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -1,38 +1,21 @@
 """Celery task for executing a targeted reindex.
 
 This task wires the job-and-target rows persisted by the API to the
-synthetic IndexAttempt(s) that drive per-cc-pair execution. It handles
-lifecycle transitions, batches per-cc-pair execution, and updates
-resolution tracking on `index_attempt_errors` for targets that came
-in as failure-derived retries.
-
-The actual connector invocation and indexing pipeline call still
-need to be plumbed — that's the follow-up. This task currently:
-
-  - loads the job + targets, groups them by cc_pair
-  - transitions each linked synthetic IndexAttempt through
-    NOT_STARTED → IN_PROGRESS → SUCCESS
-  - marks every `IndexAttemptError` referenced by a target's
-    `source_error_id` as resolved at completion (preserves the
-    contract the FE polls)
-  - snapshots `resolved_summary` for audit
-  - updates `resolved_count` / `still_failing_count` / `skipped_count`
-    on the job row
-  - transitions the job to a terminal state
-
-The follow-up adds the `connector.reindex()` call inside the per-cc-pair
-loop and pipes yielded `Document` objects through
-`index_doc_batch_with_handler`.
+synthetic IndexAttempt(s) that drive per-cc-pair execution. Lifecycle
++ counter aggregation + resolution-tracking gating live here; per-cc-pair
+connector invocation + indexing pipeline plumbing live in
+`onyx.background.indexing.run_targeted_reindex`.
 """
 
 import datetime
 import logging
-from collections import defaultdict
 
 from celery import shared_task
 from celery import Task
 
 from onyx.background.celery.apps.app_base import task_logger
+from onyx.background.indexing.run_targeted_reindex import group_targets_by_cc_pair
+from onyx.background.indexing.run_targeted_reindex import process_targets_for_cc_pair
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
@@ -40,6 +23,7 @@ from onyx.db.targeted_reindex import get_index_attempts_for_targeted_reindex_job
 from onyx.db.targeted_reindex import get_targeted_reindex_job
 from onyx.db.targeted_reindex import get_targets_for_job
 from onyx.db.targeted_reindex import resolve_failure_derived_targets
+from shared_configs.contextvars import get_current_tenant_id
 
 _TARGETED_REINDEX_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
 _TARGETED_REINDEX_TIME_LIMIT = _TARGETED_REINDEX_SOFT_TIME_LIMIT + 60
@@ -83,11 +67,11 @@ def run_targeted_reindex(
         still_failing_count = 0
         runtime_skipped = 0
         try:
+            tenant_id = get_current_tenant_id()
+
             # 2. group targets by cc_pair (the unit of connector invocation).
             target_rows = get_targets_for_job(db_session, targeted_reindex_job_id)
-            by_cc_pair: dict[int, list] = defaultdict(list)
-            for t in target_rows:
-                by_cc_pair[t.cc_pair_id].append(t)
+            by_cc_pair = group_targets_by_cc_pair(target_rows)
 
             log.info(
                 "Targeted reindex starting: %d cc_pair(s), %d target(s)",
@@ -95,16 +79,54 @@ def run_targeted_reindex(
                 len(target_rows),
             )
 
-            # 3. per-cc-pair work. Connector.reindex() and pipeline integration
-            #    are the follow-up; for now we simply count what was requested
-            #    and let the lifecycle code below mark the job complete.
-            total_attempted = len(target_rows)
+            # 3. per-cc-pair connector fetch + pipeline run. Track
+            # outcomes at (cc_pair_id, document_id) granularity — the
+            # same doc can be a target across multiple cc_pairs and
+            # landing it for one must not clear an error filed against
+            # another.
+            landed_keys: set[tuple[int, str]] = set()
+            failed_keys: set[tuple[int, str]] = set()
+            for cc_pair_id, cc_targets in by_cc_pair.items():
+                try:
+                    result = process_targets_for_cc_pair(
+                        cc_pair_id=cc_pair_id,
+                        targets=cc_targets,
+                        attempts=attempts,
+                        tenant_id=tenant_id,
+                        db_session=db_session,
+                    )
+                except Exception:
+                    # One bad cc_pair must not poison the rest of the
+                    # job — log, mark its targets still_failing, and
+                    # carry on to the next cc_pair.
+                    log.exception(
+                        "process_targets_for_cc_pair raised for cc_pair_id=%s",
+                        cc_pair_id,
+                    )
+                    failed_keys.update((cc_pair_id, t.document_id) for t in cc_targets)
+                    continue
+                landed_keys.update(
+                    (cc_pair_id, doc_id) for doc_id in result.landed_doc_ids
+                )
+                failed_keys.update(
+                    (cc_pair_id, doc_id) for doc_id in result.failed_doc_ids
+                )
+                if result.unsupported:
+                    log.info(
+                        "cc_pair_id=%s connector does not support targeted reindex",
+                        cc_pair_id,
+                    )
 
-            # 4. resolution tracking: walk failure-derived targets and clear
-            #    their error rows.
+            # 4. resolution tracking: clear error rows only for the
+            #    (cc_pair, doc) pairs that actually landed. Errors
+            #    whose target failed to land stay open so the admin can
+            #    retry.
             resolved_count, summary = resolve_failure_derived_targets(
-                db_session, targeted_reindex_job_id
+                db_session, targeted_reindex_job_id, landed_keys
             )
+
+            still_failing_count = len(failed_keys)
+            total_attempted = len(target_rows)
 
             # 5. terminal state on synthetic IndexAttempts.
             for attempt in attempts:
@@ -112,13 +134,11 @@ def run_targeted_reindex(
                 attempt.time_updated = datetime.datetime.now(datetime.timezone.utc)
 
             # 6. terminal state on the job + counters + summary snapshot.
-            # `still_failing_count` stays 0 here; the connector-invocation
-            # follow-up bumps it when the connector yields ConnectorFailure.
-            # `runtime_skipped` is whatever fell through the per-target
-            # loop without resolving or still-failing. It is added on top
-            # of the create-time skipped_count (dedup + upstream errors
-            # the API already counted) so the three counters always reflect
-            # the total skip universe across both phases.
+            # `runtime_skipped` covers the residual: targets that neither
+            # resolved (landed + had a source error) nor failed (connector/
+            # pipeline rejected). Added on top of the create-time
+            # skipped_count (dedup + upstream errors the API already
+            # counted) so counters reflect total skip universe.
             runtime_skipped = max(
                 0, total_attempted - resolved_count - still_failing_count
             )

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -1,0 +1,283 @@
+"""Per-cc-pair fetch + index for the targeted-reindex flow.
+
+The targeted-reindex celery task delegates the actual connector
+invocation + pipeline plumbing to this module so the task body stays
+focused on lifecycle and resolution-tracking. One call to
+`process_targets_for_cc_pair` covers a single cc_pair: it instantiates
+the connector, converts the per-doc target rows into
+`ConnectorFailure` inputs that the `Resolver.reindex` interface
+expects, and streams yielded `Document` objects through the standard
+indexing pipeline once per active search_settings (so PRESENT and
+FUTURE indexes both receive the reindex during a model swap).
+
+Connectors that don't subclass `Resolver` short-circuit: their targets
+are reported as still-failing so the admin sees clearly that targeted
+reindex isn't supported yet for that source.
+"""
+
+from collections import defaultdict
+from collections.abc import Iterable
+from collections.abc import Sequence
+
+from more_itertools import chunked
+from sqlalchemy.orm import Session
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.connectors.factory import instantiate_connector
+from onyx.connectors.interfaces import Resolver
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import IndexAttemptMetadata
+from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
+from onyx.db.enums import AccessType
+from onyx.db.models import IndexAttempt
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.targeted_reindex import targets_to_connector_failures
+from onyx.document_index.factory import get_all_document_indices
+from onyx.httpx.httpx_pool import HttpxPool
+from onyx.indexing.adapters.document_indexing_adapter import (
+    DocumentIndexingBatchAdapter,
+)
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.indexing_pipeline import run_indexing_pipeline
+from onyx.utils.logger import setup_logger
+from onyx.utils.middleware import make_randomized_onyx_request_id
+
+logger = setup_logger()
+
+
+class CCPairReindexResult:
+    """Per-cc-pair outcome.
+
+    `landed_doc_ids` are the doc_ids that successfully made it through
+    the pipeline. The task's resolution-tracking step only marks an
+    `IndexAttemptError` resolved if the corresponding target's doc is
+    in this set.
+
+    `failed_doc_ids` covers connector-side failures (connector yielded
+    `ConnectorFailure`) plus pipeline-side failures (handler caught an
+    exception during chunk/embed/write). They drive the per-job
+    `still_failing_count`.
+
+    `unsupported` is True iff the connector class does not implement
+    `Resolver`. All targets for that cc_pair are bucketed into
+    `failed_doc_ids` in that case so the admin sees a clear signal.
+    """
+
+    def __init__(
+        self,
+        landed_doc_ids: set[str],
+        failed_doc_ids: set[str],
+        unsupported: bool,
+    ) -> None:
+        self.landed_doc_ids = landed_doc_ids
+        self.failed_doc_ids = failed_doc_ids
+        self.unsupported = unsupported
+
+
+def _flush_batch(
+    *,
+    documents: list[Document],
+    attempt: IndexAttempt,
+    tenant_id: str,
+    db_session: Session,
+    batch_num: int,
+) -> tuple[set[str], set[str]]:
+    """Run a single `Document` batch through the indexing pipeline for
+    one synthetic IndexAttempt's search_settings.
+
+    `batch_num` is the 0-indexed position of this batch within the
+    attempt's overall reindex run; it propagates into tracing /
+    `IndexAttemptMetadata.structured_id` so each batch is
+    distinguishable in logs and sentry breadcrumbs.
+
+    Returns `(landed_doc_ids, failed_doc_ids)`. The pipeline's adapter
+    already wraps writes in `prepare_to_modify_documents`, so concurrent
+    full-crawl writes on the same docs are safely serialized.
+    """
+    if not documents:
+        return set(), set()
+
+    search_settings = attempt.search_settings
+    if search_settings is None:
+        # Synthetic attempt should always have search_settings linked; if
+        # the row is missing, treat all docs as failed for this attempt
+        # rather than crash the whole job.
+        logger.warning(
+            "synthetic IndexAttempt id=%s missing search_settings; "
+            "skipping pipeline run",
+            attempt.id,
+        )
+        return set(), {d.id for d in documents}
+
+    embedder = DefaultIndexingEmbedder.from_db_search_settings(
+        search_settings=search_settings,
+        callback=None,
+    )
+    document_indices = get_all_document_indices(
+        search_settings,
+        None,
+        httpx_client=HttpxPool.get("vespa"),
+    )
+    metadata = IndexAttemptMetadata(
+        attempt_id=attempt.id,
+        connector_id=attempt.connector_credential_pair.connector.id,
+        credential_id=attempt.connector_credential_pair.credential.id,
+        request_id=make_randomized_onyx_request_id("TRX"),
+        structured_id="%s:%s:%s:targeted:%s"
+        % (tenant_id, attempt.connector_credential_pair_id, attempt.id, batch_num),
+        batch_num=batch_num,
+    )
+    adapter = DocumentIndexingBatchAdapter(
+        db_session=db_session,
+        connector_id=attempt.connector_credential_pair.connector.id,
+        credential_id=attempt.connector_credential_pair.credential.id,
+        tenant_id=tenant_id,
+        index_attempt_metadata=metadata,
+    )
+
+    result = run_indexing_pipeline(
+        embedder=embedder,
+        document_indices=document_indices,
+        ignore_time_skip=True,
+        db_session=db_session,
+        tenant_id=tenant_id,
+        document_batch=documents,
+        request_id=metadata.request_id,
+        adapter=adapter,
+    )
+
+    failed_ids: set[str] = set()
+    for f in result.failures or []:
+        if f.failed_document is not None:
+            failed_ids.add(f.failed_document.document_id)
+
+    landed_ids = {d.id for d in documents} - failed_ids
+    return landed_ids, failed_ids
+
+
+def process_targets_for_cc_pair(
+    *,
+    cc_pair_id: int,
+    targets: Sequence[TargetedReindexJobTarget],
+    attempts: Iterable[IndexAttempt],
+    tenant_id: str,
+    db_session: Session,
+) -> CCPairReindexResult:
+    """Fetch + index every target for one cc_pair.
+
+    `attempts` is the set of synthetic IndexAttempts the create step
+    spawned for this cc_pair (one per active search_settings). The
+    connector is instantiated once and its `reindex` output is fed
+    into the pipeline once per attempt so all active indexes receive
+    the same Documents.
+    """
+    target_doc_ids = {t.document_id for t in targets}
+    cc_pair_attempts = [
+        a for a in attempts if a.connector_credential_pair_id == cc_pair_id
+    ]
+    if not cc_pair_attempts:
+        # Shouldn't happen — create_targeted_reindex_job spawns one
+        # synthetic attempt per active search_settings — but be
+        # defensive so we don't crash the whole job.
+        logger.warning(
+            "no synthetic IndexAttempt for cc_pair_id=%s; skipping", cc_pair_id
+        )
+        return CCPairReindexResult(set(), target_doc_ids, unsupported=False)
+
+    cc_pair = get_connector_credential_pair_from_id(
+        db_session=db_session, cc_pair_id=cc_pair_id
+    )
+    if cc_pair is None:
+        logger.warning(
+            "cc_pair_id=%s no longer exists; marking targets still_failing",
+            cc_pair_id,
+        )
+        return CCPairReindexResult(set(), target_doc_ids, unsupported=False)
+
+    connector = instantiate_connector(
+        db_session=db_session,
+        source=cc_pair.connector.source,
+        input_type=cc_pair.connector.input_type,
+        connector_specific_config=cc_pair.connector.connector_specific_config,
+        credential=cc_pair.credential,
+    )
+    if not isinstance(connector, Resolver):
+        logger.info(
+            "connector source=%s does not implement Resolver; targets "
+            "marked still_failing",
+            cc_pair.connector.source,
+        )
+        return CCPairReindexResult(set(), target_doc_ids, unsupported=True)
+
+    include_permissions = cc_pair.access_type == AccessType.SYNC
+    failures = targets_to_connector_failures(targets, db_session)
+
+    # Materialize the connector output once. MAX_TARGETS_PER_REQUEST caps
+    # the universe at 100 docs total per job, so this is bounded.
+    docs: list[Document] = []
+    failed_from_connector: set[str] = set()
+    for item in connector.reindex(
+        errors=failures, include_permissions=include_permissions
+    ):
+        if isinstance(item, ConnectorFailure):
+            if item.failed_document is not None:
+                failed_from_connector.add(item.failed_document.document_id)
+            continue
+        if isinstance(item, Document):
+            docs.append(item)
+            continue
+        # TODO(targeted-reindex follow-up): plumb HierarchyNode yields
+        # through the same path the indexing pipeline uses for full
+        # crawls. Skipping is safe today (a missing ancestor folder
+        # node falls back to "source-type root" in KG selection), but
+        # for cases like "admin restored a folder's permissions and
+        # reindexed its docs" the new ancestor relationship would
+        # otherwise stay missing until the next full crawl.
+
+    # Per-attempt pipeline run. Each attempt commits to its own
+    # search_settings's document_indices.
+    landed_overall: set[str] = set()
+    failed_pipeline_overall: set[str] = set()
+    for attempt in cc_pair_attempts:
+        for batch_num, batch in enumerate(chunked(docs, INDEX_BATCH_SIZE)):
+            landed, failed = _flush_batch(
+                documents=list(batch),
+                attempt=attempt,
+                tenant_id=tenant_id,
+                db_session=db_session,
+                batch_num=batch_num,
+            )
+            landed_overall |= landed
+            failed_pipeline_overall |= failed
+
+    # Conservative landing: a doc is only "landed" if some attempt
+    # accepted it AND no attempt or upstream phase failed it. The set
+    # math is (landed_overall - failed_*), which means if PRESENT
+    # accepts doc X but FUTURE fails it during a model swap, doc X is
+    # NOT counted as landed and its source error stays open. This is
+    # the right call for resolution tracking — partial dual-index
+    # landing should not auto-resolve the failure. If the strictness
+    # ever causes too many false-still-failing on transient infra
+    # blips, switch to per-attempt landing tracking and require all
+    # attempts to land independently.
+    docs_never_yielded = target_doc_ids - {d.id for d in docs} - failed_from_connector
+    failed_doc_ids = (
+        failed_from_connector | failed_pipeline_overall | docs_never_yielded
+    )
+    landed_doc_ids = landed_overall - failed_doc_ids
+
+    return CCPairReindexResult(
+        landed_doc_ids=landed_doc_ids,
+        failed_doc_ids=failed_doc_ids,
+        unsupported=False,
+    )
+
+
+def group_targets_by_cc_pair(
+    targets: Sequence[TargetedReindexJobTarget],
+) -> dict[int, list[TargetedReindexJobTarget]]:
+    by_cc_pair: dict[int, list[TargetedReindexJobTarget]] = defaultdict(list)
+    for t in targets:
+        by_cc_pair[t.cc_pair_id].append(t)
+    return by_cc_pair

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -23,8 +23,11 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy import tuple_
 from sqlalchemy.orm import Session
 
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import DocumentFailure
 from onyx.db.enums import IndexingStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
@@ -286,22 +289,39 @@ def get_index_attempts_for_targeted_reindex_job(
 def resolve_failure_derived_targets(
     db_session: Session,
     job_id: int,
+    landed_keys: set[tuple[int, str]] | None = None,
 ) -> tuple[int, list[dict[str, Any]]]:
-    """Mark `IndexAttemptError` rows resolved for every target whose
-    `source_error_id` is set. Returns `(resolved_count, summary)`.
+    """Mark `IndexAttemptError` rows resolved for every failure-derived
+    target. Returns `(resolved_count, summary)`.
+
+    `landed_keys` gates the resolution set as `(cc_pair_id, document_id)`
+    tuples. The pair is required (not just `document_id`) because the
+    same Drive doc can be a target across multiple cc_pairs — landing
+    it on cc_pair A does NOT clear an error filed against cc_pair B
+    where the doc is still failing. When `landed_keys` is None (caller
+    has no per-doc outcome) every failure-derived target resolves —
+    that matches the stub-task behavior the C PR shipped before the
+    connector wiring landed.
 
     `summary` is a snapshot of the cleared error rows captured before
     we update them, so it survives the eventual retention cleanup of
     `index_attempt_errors`.
     """
-    target_rows = (
-        db_session.query(TargetedReindexJobTarget)
-        .filter(
-            TargetedReindexJobTarget.targeted_reindex_job_id == job_id,
-            TargetedReindexJobTarget.source_error_id.isnot(None),
+    base_filters = [
+        TargetedReindexJobTarget.targeted_reindex_job_id == job_id,
+        TargetedReindexJobTarget.source_error_id.isnot(None),
+    ]
+    if landed_keys is not None:
+        if not landed_keys:
+            return 0, []
+        base_filters.append(
+            tuple_(
+                TargetedReindexJobTarget.cc_pair_id,
+                TargetedReindexJobTarget.document_id,
+            ).in_(landed_keys)
         )
-        .all()
-    )
+
+    target_rows = db_session.query(TargetedReindexJobTarget).filter(*base_filters).all()
     if not target_rows:
         return 0, []
 
@@ -333,3 +353,47 @@ def resolve_failure_derived_targets(
         e.is_resolved = True
 
     return len(error_rows), summary
+
+
+def targets_to_connector_failures(
+    targets: Sequence[TargetedReindexJobTarget],
+    db_session: Session,
+) -> list[ConnectorFailure]:
+    """Build the `ConnectorFailure` list `Resolver.reindex` expects.
+
+    Targets carrying a `source_error_id` are rehydrated from the
+    original `IndexAttemptError` so the connector sees the same
+    failure context (message, link) it failed on. Arbitrary targets
+    (no source error) are synthesized with a generic
+    `failure_message` — `Resolver.reindex` only consumes
+    `failed_document.document_id`, so the message body is informational.
+    """
+    error_ids = [t.source_error_id for t in targets if t.source_error_id is not None]
+    error_rows: dict[int, IndexAttemptError] = {}
+    if error_ids:
+        rows = (
+            db_session.query(IndexAttemptError)
+            .filter(IndexAttemptError.id.in_(error_ids))
+            .all()
+        )
+        error_rows = {r.id: r for r in rows}
+
+    failures: list[ConnectorFailure] = []
+    for t in targets:
+        err = (
+            error_rows.get(t.source_error_id) if t.source_error_id is not None else None
+        )
+        failures.append(
+            ConnectorFailure(
+                failed_document=DocumentFailure(
+                    document_id=t.document_id,
+                    document_link=err.document_link if err else None,
+                ),
+                failure_message=(
+                    err.failure_message
+                    if err
+                    else "Targeted reindex requested by admin (no prior failure)"
+                ),
+            )
+        )
+    return failures

--- a/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
+++ b/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
@@ -1,0 +1,334 @@
+"""External dependency unit tests for the per-cc-pair processor.
+
+The processor `process_targets_for_cc_pair` owns the path between
+target rows and the indexing pipeline: instantiate connector → check
+Resolver capability → convert targets to ConnectorFailure inputs →
+stream Documents → run pipeline once per (cc_pair × search_settings)
+synthetic IndexAttempt.
+
+`instantiate_connector` and the pipeline call are mocked here so the
+test stays focused on the processor's own decisions (capability gate,
+ConnectorFailure rehydration, landed/failed bucketing). The full
+end-to-end path lands when the integration test suite covers a real
+Drive connector reindex run.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.indexing.run_targeted_reindex import process_targets_for_cc_pair
+from onyx.connectors.interfaces import Resolver
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import DocumentSource
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import TextSection
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import TargetedReindexJob
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.targeted_reindex import create_targeted_reindex_job
+from onyx.db.targeted_reindex import resolve_error_ids_to_targets
+from onyx.db.targeted_reindex import targets_to_connector_failures
+from onyx.db.targeted_reindex import TargetSpec
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.query(TargetedReindexJobTarget).delete(synchronize_session="fetch")
+        db_session.query(IndexAttemptError).delete(synchronize_session="fetch")
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(TargetedReindexJob).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _doc(doc_id: str) -> Document:
+    return Document(
+        id=doc_id,
+        sections=[TextSection(text="content for %s" % doc_id, link=None)],
+        source=DocumentSource.NOT_APPLICABLE,
+        semantic_identifier=doc_id,
+        metadata={},
+    )
+
+
+class _StubResolver(Resolver):
+    """Minimal Resolver used in tests. Yields whatever the test setup hands it."""
+
+    def __init__(self, yields: list[Document | ConnectorFailure]) -> None:
+        self._yields = yields
+
+    def reindex(
+        self,
+        errors: list[ConnectorFailure],
+        include_permissions: bool = False,
+    ) -> Generator[Document | ConnectorFailure | HierarchyNode, None, None]:
+        del errors, include_permissions
+        yield from self._yields
+
+    # Required by BaseConnector but not exercised by the processor.
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        del credentials
+        return None
+
+    def validate_connector_settings(self) -> None:
+        return None
+
+
+class _StubBaseConnector:
+    """Stand-in for a connector that does NOT implement Resolver, used to
+    test the unsupported-source short-circuit."""
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        del credentials
+        return None
+
+
+def _job_with_targets(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,  # noqa: ARG001  # documents test wiring
+    targets: list[TargetSpec],
+) -> tuple[list[TargetedReindexJobTarget], list[IndexAttempt]]:
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=targets
+    )
+    target_rows = (
+        db_session.query(TargetedReindexJobTarget)
+        .filter(
+            TargetedReindexJobTarget.targeted_reindex_job_id
+            == result.targeted_reindex_job_id
+        )
+        .all()
+    )
+    attempts = (
+        db_session.query(IndexAttempt)
+        .filter(IndexAttempt.targeted_reindex_job_id == result.targeted_reindex_job_id)
+        .all()
+    )
+    return target_rows, attempts
+
+
+def test_unsupported_connector_marks_all_targets_failed(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    target_rows, attempts = _job_with_targets(
+        db_session,
+        cc_pair,
+        [
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d1"),
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d2"),
+        ],
+    )
+
+    with patch(
+        "onyx.background.indexing.run_targeted_reindex.instantiate_connector",
+        return_value=_StubBaseConnector(),
+    ):
+        result = process_targets_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            targets=target_rows,
+            attempts=attempts,
+            tenant_id=TEST_TENANT_ID,
+            db_session=db_session,
+        )
+
+    assert result.unsupported is True
+    assert result.landed_doc_ids == set()
+    assert result.failed_doc_ids == {"d1", "d2"}
+
+
+def test_resolver_yields_all_docs_lands_them_all(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    target_rows, attempts = _job_with_targets(
+        db_session,
+        cc_pair,
+        [
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d1"),
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d2"),
+        ],
+    )
+    stub = _StubResolver(yields=[_doc("d1"), _doc("d2")])
+
+    fake_pipeline_result = MagicMock(failures=[])
+
+    with (
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.instantiate_connector",
+            return_value=stub,
+        ),
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.run_indexing_pipeline",
+            return_value=fake_pipeline_result,
+        ),
+    ):
+        result = process_targets_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            targets=target_rows,
+            attempts=attempts,
+            tenant_id=TEST_TENANT_ID,
+            db_session=db_session,
+        )
+
+    assert result.unsupported is False
+    assert result.landed_doc_ids == {"d1", "d2"}
+    assert result.failed_doc_ids == set()
+
+
+def test_connector_failure_yields_route_to_failed_doc_ids(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    target_rows, attempts = _job_with_targets(
+        db_session,
+        cc_pair,
+        [
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d1"),
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d2"),
+        ],
+    )
+    stub = _StubResolver(
+        yields=[
+            _doc("d1"),
+            ConnectorFailure(
+                failed_document=DocumentFailure(document_id="d2"),
+                failure_message="still 403",
+            ),
+        ],
+    )
+    fake_pipeline_result = MagicMock(failures=[])
+
+    with (
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.instantiate_connector",
+            return_value=stub,
+        ),
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.run_indexing_pipeline",
+            return_value=fake_pipeline_result,
+        ),
+    ):
+        result = process_targets_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            targets=target_rows,
+            attempts=attempts,
+            tenant_id=TEST_TENANT_ID,
+            db_session=db_session,
+        )
+
+    assert result.landed_doc_ids == {"d1"}
+    assert result.failed_doc_ids == {"d2"}
+
+
+def test_doc_never_yielded_is_marked_failed(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """If the connector silently drops a doc (yields neither Document
+    nor ConnectorFailure for it), the processor must still treat it as
+    failed so still_failing_count reflects reality."""
+    target_rows, attempts = _job_with_targets(
+        db_session,
+        cc_pair,
+        [
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d1"),
+            TargetSpec(cc_pair_id=cc_pair.id, document_id="d2"),
+        ],
+    )
+    # Stub yields only d1.
+    stub = _StubResolver(yields=[_doc("d1")])
+    fake_pipeline_result = MagicMock(failures=[])
+
+    with (
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.instantiate_connector",
+            return_value=stub,
+        ),
+        patch(
+            "onyx.background.indexing.run_targeted_reindex.run_indexing_pipeline",
+            return_value=fake_pipeline_result,
+        ),
+    ):
+        result = process_targets_for_cc_pair(
+            cc_pair_id=cc_pair.id,
+            targets=target_rows,
+            attempts=attempts,
+            tenant_id=TEST_TENANT_ID,
+            db_session=db_session,
+        )
+
+    assert result.landed_doc_ids == {"d1"}
+    assert result.failed_doc_ids == {"d2"}
+
+
+def test_targets_to_connector_failures_rehydrates_error_context(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="from-error",
+        document_link="https://example/x",
+        failure_message="403 forbidden",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    derived, _ = resolve_error_ids_to_targets(db_session, [err.id])
+    arbitrary = [TargetSpec(cc_pair_id=cc_pair.id, document_id="arbitrary")]
+    target_rows, _ = _job_with_targets(db_session, cc_pair, [*derived, *arbitrary])
+
+    failures = targets_to_connector_failures(target_rows, db_session)
+
+    by_doc = {
+        f.failed_document.document_id: f
+        for f in failures
+        if f.failed_document is not None
+    }
+    # Failure-derived target carries the original error's link + message.
+    rehydrated = by_doc["from-error"]
+    assert rehydrated.failure_message == "403 forbidden"
+    assert (
+        rehydrated.failed_document is not None
+        and rehydrated.failed_document.document_link == "https://example/x"
+    )
+    # Arbitrary target gets a synthesized message; no link.
+    synth = by_doc["arbitrary"]
+    assert "Targeted reindex requested by admin" in synth.failure_message
+    assert (
+        synth.failed_document is not None
+        and synth.failed_document.document_link is None
+    )

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
@@ -3,12 +3,15 @@
 Covers the lifecycle and resolution-tracking layers of the task:
 - Job + synthetic IndexAttempt lifecycle transitions
 - Resolution tracking on `IndexAttemptError` rows referenced by targets
-  with `source_error_id`
+  with `source_error_id` (gated on landed_doc_ids)
 - Idempotent re-run (job already terminal → drop)
 - Resolved-summary snapshot
+- Mid-task exception → FAILED recovery
 
-Connector invocation + pipeline integration land in the follow-up
-PR; that path is intentionally out of scope here.
+The per-cc-pair connector + pipeline path is mocked out via
+`process_targets_for_cc_pair`; its own coverage lives in
+`test_run_targeted_reindex.py`. That separation keeps these tests
+fast and lets us exercise lifecycle without spinning up a connector.
 """
 
 from collections.abc import Generator
@@ -20,6 +23,7 @@ from sqlalchemy.orm import Session
 from onyx.background.celery.tasks.docprocessing.targeted_reindex_task import (
     run_targeted_reindex,
 )
+from onyx.background.indexing.run_targeted_reindex import CCPairReindexResult
 from onyx.db.enums import IndexingStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
@@ -32,6 +36,33 @@ from onyx.db.targeted_reindex import resolve_error_ids_to_targets
 from onyx.db.targeted_reindex import TargetSpec
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+_PROCESSOR_PATH = (
+    "onyx.background.celery.tasks.docprocessing."
+    "targeted_reindex_task.process_targets_for_cc_pair"
+)
+
+
+def _patch_processor(
+    landed_doc_ids: set[str] | None = None,
+    failed_doc_ids: set[str] | None = None,
+    unsupported: bool = False,
+):  # type: ignore[no-untyped-def]
+    """Patch the per-cc-pair processor with a fixed result.
+
+    Defaults to landing nothing / failing nothing (no-op) so the
+    existing lifecycle tests don't need to know about doc semantics.
+    Pass `landed_doc_ids` to simulate successful reindex of specific
+    docs.
+    """
+    return patch(
+        _PROCESSOR_PATH,
+        return_value=CCPairReindexResult(
+            landed_doc_ids=landed_doc_ids or set(),
+            failed_doc_ids=failed_doc_ids or set(),
+            unsupported=unsupported,
+        ),
+    )
 
 
 @pytest.fixture
@@ -68,7 +99,8 @@ def test_task_transitions_job_to_terminal(
         db_session=db_session, requested_by_user_id=None, targets=targets
     )
 
-    _run_task(result.targeted_reindex_job_id)
+    with _patch_processor(landed_doc_ids={"doc-1"}):
+        _run_task(result.targeted_reindex_job_id)
 
     db_session.expire_all()
     job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
@@ -85,7 +117,8 @@ def test_task_transitions_synthetic_attempts_to_success(
         db_session=db_session, requested_by_user_id=None, targets=targets
     )
 
-    _run_task(result.targeted_reindex_job_id)
+    with _patch_processor(landed_doc_ids={"doc-1"}):
+        _run_task(result.targeted_reindex_job_id)
 
     db_session.expire_all()
     attempts = (
@@ -129,7 +162,8 @@ def test_task_marks_failure_derived_errors_resolved(
         db_session=db_session, requested_by_user_id=None, targets=derived
     )
 
-    _run_task(result.targeted_reindex_job_id)
+    with _patch_processor(landed_doc_ids={"failed-doc"}):
+        _run_task(result.targeted_reindex_job_id)
 
     db_session.expire_all()
     err_after = db_session.get(IndexAttemptError, err.id)
@@ -159,7 +193,8 @@ def test_task_does_not_touch_arbitrary_targets(
         db_session=db_session, requested_by_user_id=None, targets=targets
     )
 
-    _run_task(result.targeted_reindex_job_id)
+    with _patch_processor(landed_doc_ids={"arb-1", "arb-2"}):
+        _run_task(result.targeted_reindex_job_id)
 
     db_session.expire_all()
     job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
@@ -167,6 +202,134 @@ def test_task_does_not_touch_arbitrary_targets(
     assert job.status == IndexingStatus.SUCCESS
     assert job.resolved_count == 0
     assert job.resolved_summary == []
+
+
+def test_task_does_not_resolve_errors_when_doc_failed_to_land(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Resolution-tracking gate: an IndexAttemptError stays open if the
+    targeted reindex couldn't actually re-fetch + re-index its doc."""
+    settings = get_current_search_settings(db_session)
+    parent = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(parent)
+    db_session.commit()
+    db_session.refresh(parent)
+
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=cc_pair.id,
+        document_id="still-broken",
+        failure_message="boom",
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+
+    derived, _ = resolve_error_ids_to_targets(db_session, [err.id])
+    result = create_targeted_reindex_job(
+        db_session=db_session, requested_by_user_id=None, targets=derived
+    )
+
+    # Doc didn't land — connector or pipeline failed.
+    with _patch_processor(failed_doc_ids={"still-broken"}):
+        _run_task(result.targeted_reindex_job_id)
+
+    db_session.expire_all()
+    err_after = db_session.get(IndexAttemptError, err.id)
+    assert err_after is not None
+    assert err_after.is_resolved is False  # NOT resolved; doc still failing
+
+    job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
+    assert job is not None
+    assert job.resolved_count == 0
+    assert job.still_failing_count == 1
+    assert job.resolved_summary == []
+
+
+def test_task_does_not_resolve_error_when_doc_landed_for_other_cc_pair(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Cross-cc_pair safety: the same doc id can be a target across two
+    cc_pairs. If it lands for cc_pair A but fails for cc_pair B, the
+    error filed against cc_pair B must stay open. Resolution is gated
+    on the (cc_pair_id, document_id) pair, not on bare document_id."""
+    second = make_cc_pair(db_session)
+    settings = get_current_search_settings(db_session)
+    try:
+        # Failure-derived target on cc_pair B (the one that won't land)
+        parent_b = IndexAttempt(
+            connector_credential_pair_id=second.id,
+            search_settings_id=settings.id,
+            from_beginning=False,
+            status=IndexingStatus.FAILED,
+        )
+        db_session.add(parent_b)
+        db_session.commit()
+        db_session.refresh(parent_b)
+
+        err_b = IndexAttemptError(
+            index_attempt_id=parent_b.id,
+            connector_credential_pair_id=second.id,
+            document_id="shared-doc",
+            failure_message="still failing for cc_pair B",
+            is_resolved=False,
+        )
+        db_session.add(err_b)
+        db_session.commit()
+        db_session.refresh(err_b)
+
+        # Same shared-doc on cc_pair A as an arbitrary target
+        # (no source_error_id; landing it should not affect cc_pair B's err).
+        derived_b, _ = resolve_error_ids_to_targets(db_session, [err_b.id])
+        arbitrary_a = [TargetSpec(cc_pair_id=cc_pair.id, document_id="shared-doc")]
+        result = create_targeted_reindex_job(
+            db_session=db_session,
+            requested_by_user_id=None,
+            targets=[*derived_b, *arbitrary_a],
+        )
+
+        # Processor lands shared-doc for cc_pair A, fails it for cc_pair B.
+        def _by_cc_pair(*_args, **kwargs):  # type: ignore[no-untyped-def]
+            from onyx.background.indexing.run_targeted_reindex import (
+                CCPairReindexResult,
+            )
+
+            cc_id = kwargs["cc_pair_id"]
+            if cc_id == cc_pair.id:
+                return CCPairReindexResult(
+                    landed_doc_ids={"shared-doc"},
+                    failed_doc_ids=set(),
+                    unsupported=False,
+                )
+            return CCPairReindexResult(
+                landed_doc_ids=set(),
+                failed_doc_ids={"shared-doc"},
+                unsupported=False,
+            )
+
+        with patch(_PROCESSOR_PATH, side_effect=_by_cc_pair):
+            _run_task(result.targeted_reindex_job_id)
+
+        db_session.expire_all()
+        err_after = db_session.get(IndexAttemptError, err_b.id)
+        assert err_after is not None
+        assert err_after.is_resolved is False  # NOT resolved — failed for B
+    finally:
+        # Per-test cleanup of the second cc_pair's rows.
+        db_session.query(TargetedReindexJobTarget).delete(synchronize_session="fetch")
+        db_session.query(IndexAttemptError).delete(synchronize_session="fetch")
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == second.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(TargetedReindexJob).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, second)
 
 
 def test_task_skips_already_terminal_job(
@@ -231,7 +394,10 @@ def test_task_handles_mix_of_failure_derived_and_arbitrary(
         targets=[*derived, *arbitrary],
     )
 
-    _run_task(result.targeted_reindex_job_id)
+    # Both docs land. Failure-derived → resolved; arbitrary contributes
+    # to runtime_skipped (no error linkage to record against).
+    with _patch_processor(landed_doc_ids={"failed-doc", "arb-1"}):
+        _run_task(result.targeted_reindex_job_id)
 
     db_session.expire_all()
     job = db_session.get(TargetedReindexJob, result.targeted_reindex_job_id)
@@ -251,14 +417,14 @@ def test_task_marks_job_failed_on_mid_task_exception(
     )
 
     # Force the resolution-tracking helper to blow up after the
-    # IN_PROGRESS commit but before the SUCCESS commit. Patch where
-    # the symbol is *imported* (the celery task module), not where it
-    # lives (onyx.db.targeted_reindex), so the local binding is the
-    # one replaced.
-    with patch(
-        "onyx.background.celery.tasks.docprocessing."
-        "targeted_reindex_task.resolve_failure_derived_targets",
-        side_effect=RuntimeError("simulated mid-task crash"),
+    # IN_PROGRESS commit but before the SUCCESS commit.
+    with (
+        _patch_processor(landed_doc_ids={"doc-1"}),
+        patch(
+            "onyx.background.celery.tasks.docprocessing."
+            "targeted_reindex_task.resolve_failure_derived_targets",
+            side_effect=RuntimeError("simulated mid-task crash"),
+        ),
     ):
         with pytest.raises(RuntimeError, match="simulated mid-task crash"):
             _run_task(result.targeted_reindex_job_id)


### PR DESCRIPTION
## Description

PR D in the targeted-reindex series. Stacks on #10829 (celery task lifecycle + resolution tracking).

Replaces the per-cc-pair stub with a real fetch + index path:

- Per-cc-pair processor (\`onyx/background/indexing/run_targeted_reindex.py\`) instantiates the connector via the standard factory, checks \`Resolver\` capability, converts target rows into \`ConnectorFailure\` inputs (rehydrating original failure context for failure-derived targets, synthesizing for arbitrary ones), and streams \`connector.reindex()\` output through the standard indexing pipeline once per active search_settings.
- Connectors that don't subclass \`Resolver\` short-circuit: their targets are marked \`still_failing\` so the admin sees a clear signal that targeted reindex isn't supported yet for that source. Today only Google Drive implements \`Resolver\` — adding it to other sources is a follow-up.
- Pipeline failures (handler caught) and connector-side \`ConnectorFailure\` yields both flow into \`still_failing_count\`.
- Resolution tracking is now gated on \`landed_doc_ids\`: an \`IndexAttemptError\` is marked resolved only if its target's doc actually made it through the pipeline. Errors whose docs failed to land stay open so the admin can retry.
- Stale-write mitigation rides for free — \`DocumentIndexingBatchAdapter\` already wraps writes in \`prepare_to_modify_documents\`, serializing concurrent full-crawl writes on the same docs.
- Module split keeps the celery task focused on lifecycle + counter aggregation; the heavy lifting lives in a helper module that mirrors \`run_docfetching.py\`.

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

\`backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py\` — existing lifecycle tests now mock \`process_targets_for_cc_pair\`; added one new test (\`test_task_does_not_resolve_errors_when_doc_failed_to_land\`) covering the resolution-tracking gate.

\`backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py\` — new file, 5 tests against the processor itself: unsupported connector short-circuit, full landing, \`ConnectorFailure\` routing, silent drop, \`ConnectorFailure\` rehydration from \`IndexAttemptError\`.

End-to-end against a real Drive cc_pair will land in the integration test suite as a follow-up.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check