### PR TITLE
feat(code-interpreter): Add version to health endpoint

### DIFF
--- a/backend/onyx/server/manage/code_interpreter/api.py
+++ b/backend/onyx/server/manage/code_interpreter/api.py
@@ -23,7 +23,7 @@ def get_code_interpreter_health(
 ) -> CodeInterpreterServerHealth:
     try:
         client = CodeInterpreterClient()
-        return CodeInterpreterServerHealth(healthy=client.health())
+        return CodeInterpreterServerHealth(healthy=client.health().healthy)
     except ValueError:
         return CodeInterpreterServerHealth(healthy=False)
 

--- a/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
+++ b/backend/onyx/tools/tool_implementations/python/code_interpreter_client.py
@@ -17,7 +17,15 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 _HEALTH_CACHE_TTL_SECONDS = 30
-_health_cache: dict[str, tuple[float, bool]] = {}
+_DEFAULT_SERVER_VERSION = "0.0.0"
+_health_cache: dict[str, tuple[float, "HealthResponse"]] = {}
+
+
+class HealthResponse(BaseModel):
+    """Result of a Code Interpreter health check"""
+
+    healthy: bool
+    version: str = _DEFAULT_SERVER_VERSION
 
 
 class FileInput(TypedDict):
@@ -136,8 +144,13 @@ class CodeInterpreterClient:
             payload["files"] = files
         return payload
 
-    def health(self, use_cache: bool = False) -> bool:
+    def health(self, use_cache: bool = False) -> HealthResponse:
         """Check if the Code Interpreter service is healthy
+
+        Returns a ``HealthResponse`` containing both the health status and the
+        server version (defaults to ``"0.0.0"`` when the server is unhealthy
+        or the response does not include a version field — e.g. older
+        code-interpreter releases that pre-date version reporting).
 
         Args:
             use_cache: When True, return a cached result if available and
@@ -155,10 +168,13 @@ class CodeInterpreterClient:
         try:
             response = self.session.get(url, timeout=5)
             response.raise_for_status()
-            result = response.json().get("status") == "ok"
+            body = response.json()
+            healthy = body.get("status") == "ok"
+            version = body.get("version") or _DEFAULT_SERVER_VERSION
+            result = HealthResponse(healthy=healthy, version=version)
         except Exception as e:
             logger.warning("Exception caught when checking health, e=%s", e)
-            result = False
+            result = HealthResponse(healthy=False, version=_DEFAULT_SERVER_VERSION)
 
         _health_cache[self.base_url] = (time.monotonic(), result)
         return result

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -118,7 +118,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
             return False
 
         with CodeInterpreterClient() as client:
-            return client.health(use_cache=True)
+            return client.health(use_cache=True).healthy
 
     def tool_definition(self) -> dict:
         return {

--- a/backend/tests/unit/onyx/tools/test_python_tool_availability.py
+++ b/backend/tests/unit/onyx/tools/test_python_tool_availability.py
@@ -85,8 +85,12 @@ def test_python_tool_available_when_health_check_passes(
     mock_server.server_enabled = True
     mock_fetch.return_value = mock_server
 
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        HealthResponse,
+    )
+
     mock_client = MagicMock()
-    mock_client.health.return_value = True
+    mock_client.health.return_value = HealthResponse(healthy=True, version="1.0.0")
     mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
     mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -108,8 +112,12 @@ def test_python_tool_unavailable_when_health_check_fails(
     mock_server.server_enabled = True
     mock_fetch.return_value = mock_server
 
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        HealthResponse,
+    )
+
     mock_client = MagicMock()
-    mock_client.health.return_value = False
+    mock_client.health.return_value = HealthResponse(healthy=False)
     mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
     mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -156,8 +164,8 @@ def test_health_check_cached_on_second_call() -> None:
     mock_response.json.return_value = {"status": "ok"}
 
     with patch.object(client.session, "get", return_value=mock_response) as mock_get:
-        assert client.health(use_cache=True) is True
-        assert client.health(use_cache=True) is True
+        assert client.health(use_cache=True).healthy is True
+        assert client.health(use_cache=True).healthy is True
         # Only one HTTP call — the second used the cache
         mock_get.assert_called_once()
 
@@ -178,17 +186,17 @@ def test_health_check_refreshed_after_ttl_expires(mock_time: MagicMock) -> None:
     with patch.object(client.session, "get", return_value=mock_response) as mock_get:
         # First call at t=0 — cache miss
         mock_time.monotonic.return_value = 0.0
-        assert client.health(use_cache=True) is True
+        assert client.health(use_cache=True).healthy is True
         assert mock_get.call_count == 1
 
         # Second call within TTL — cache hit
         mock_time.monotonic.return_value = float(_HEALTH_CACHE_TTL_SECONDS - 1)
-        assert client.health(use_cache=True) is True
+        assert client.health(use_cache=True).healthy is True
         assert mock_get.call_count == 1
 
         # Third call after TTL — cache miss, fresh request
         mock_time.monotonic.return_value = float(_HEALTH_CACHE_TTL_SECONDS + 1)
-        assert client.health(use_cache=True) is True
+        assert client.health(use_cache=True).healthy is True
         assert mock_get.call_count == 2
 
 
@@ -202,7 +210,58 @@ def test_health_check_no_cache_by_default() -> None:
     mock_response.json.return_value = {"status": "ok"}
 
     with patch.object(client.session, "get", return_value=mock_response) as mock_get:
-        assert client.health() is True
-        assert client.health() is True
+        assert client.health().healthy is True
+        assert client.health().healthy is True
         # Both calls hit the network when use_cache=False (default)
         assert mock_get.call_count == 2
+
+
+def test_health_check_returns_version_when_present() -> None:
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        CodeInterpreterClient,
+    )
+
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"status": "ok", "version": "1.4.2"}
+
+    with patch.object(client.session, "get", return_value=mock_response):
+        result = client.health()
+
+    assert result.healthy is True
+    assert result.version == "1.4.2"
+
+
+def test_health_check_defaults_version_when_missing() -> None:
+    """Older code-interpreter versions don't return a version field — the
+    client must default to '0.0.0' rather than raising."""
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        CodeInterpreterClient,
+    )
+
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"status": "ok"}
+
+    with patch.object(client.session, "get", return_value=mock_response):
+        result = client.health()
+
+    assert result.healthy is True
+    assert result.version == "0.0.0"
+
+
+def test_health_check_defaults_version_on_request_failure() -> None:
+    """When the request itself fails, healthy=False and version='0.0.0'."""
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        CodeInterpreterClient,
+    )
+
+    client = CodeInterpreterClient(base_url="http://fake:9000")
+
+    with patch.object(
+        client.session, "get", side_effect=RuntimeError("connection refused")
+    ):
+        result = client.health()
+
+    assert result.healthy is False
+    assert result.version == "0.0.0"


### PR DESCRIPTION
## Description
A change to the code interpreter server is being introduced such that it now responds with it's version in the health check. This pipes this through

## How Has This Been Tested?
Unit + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds version reporting to the code interpreter health check and returns it from the client. Server and Python tool now read `.healthy`, enabling consumers to access both health and server version.

- **New Features**
  - Introduced `HealthResponse` with `healthy` and `version` (defaults to "0.0.0" when missing or on failure).
  - Updated `CodeInterpreterClient.health()` to return `HealthResponse` and keep caching behavior; compatible with older servers without a version field.
  - Updated `get_code_interpreter_health` and the Python tool availability check to use `.healthy`; added tests for version presence/missing, failures, and cache TTL.

- **Migration**
  - If you call `CodeInterpreterClient.health()`, update usage to `client.health().healthy` and read `client.health().version` if needed.

<sup>Written for commit cbd7cdb00d033ad5760feba475625ae32d9adbb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

