### PR TITLE
fix(auth): make /auth/verify tenant-aware in multi-tenant cloud

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -437,6 +437,64 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         return user
 
+    async def verify(self, token: str, request: Optional[Request] = None) -> User:
+        # The injected `self.user_db` session is bound to the default schema
+        # because the verify request has no auth cookie yet. Re-resolve the
+        # tenant from the JWT email and run the update against a tenant-bound
+        # session, mirroring oauth_callback / get_by_email.
+        try:
+            data = decode_jwt(
+                token,
+                self.verification_token_secret,
+                [self.verification_token_audience],
+            )
+        except jwt.PyJWTError:
+            raise exceptions.InvalidVerifyToken()
+
+        try:
+            user_id = data["sub"]
+            email = data["email"]
+        except KeyError:
+            raise exceptions.InvalidVerifyToken()
+
+        try:
+            tenant_id = fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.user_mapping",
+                "get_tenant_id_for_email",
+                None,
+            )(email)
+        except exceptions.UserNotExists:
+            raise exceptions.InvalidVerifyToken()
+
+        contextvar_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+        try:
+            async with get_async_session_context_manager(tenant_id) as db_session:
+                tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
+                    db_session, User, OAuthAccount
+                )
+
+                user = await tenant_user_db.get_by_email(email)
+                if user is None:
+                    raise exceptions.InvalidVerifyToken()
+
+                try:
+                    parsed_id = self.parse_id(user_id)
+                except exceptions.InvalidID:
+                    raise exceptions.InvalidVerifyToken()
+
+                if parsed_id != user.id:
+                    raise exceptions.InvalidVerifyToken()
+
+                if user.is_verified:
+                    raise exceptions.UserAlreadyVerified()
+
+                verified_user = await tenant_user_db.update(user, {"is_verified": True})
+
+            await self.on_after_verify(verified_user, request)
+            return verified_user
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(contextvar_token)
+
     async def create(
         self,
         user_create: schemas.UC | UserCreate,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -495,8 +495,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
                 verified_user = await tenant_user_db.update(user, {"is_verified": True})
 
-            await self.on_after_verify(verified_user, request)
-            return verified_user
+                await self.on_after_verify(verified_user, request)
+                return verified_user
         finally:
             CURRENT_TENANT_ID_CONTEXTVAR.reset(contextvar_token)
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -438,8 +438,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         return user
 
     async def verify(self, token: str, request: Optional[Request] = None) -> User:
-        # The injected `self.user_db` session is bound to the default schema
-        # because the verify request has no auth cookie yet. Re-resolve the
+        # Single-tenant: inherit fastapi-users default; the injected
+        # self.user_db is already bound to the correct schema.
+        if not MULTI_TENANT:
+            return await super().verify(token, request)
+
+        # Multi-tenant: the verify request has no auth cookie yet, so the
+        # tenant middleware fell back to the default schema. Re-resolve the
         # tenant from the JWT email and run the update against a tenant-bound
         # session, mirroring oauth_callback / get_by_email.
         try:


### PR DESCRIPTION
## Description

**Bug.** `POST /auth/verify` returns 500 in multi-tenant cloud. Reproduces today (free-trial org adding a second user). Error surfaces as `asyncpg.UndefinedTableError: relation "public.user" does not exist` from `UPDATE public."user" SET is_verified=...`.

**Root cause.** The verify request carries no auth cookie yet, so the tenant middleware (`ee/onyx/server/middleware/tenant_tracking.py`) falls back to `POSTGRES_DEFAULT_SCHEMA`. The fastapi-users default `UserManager.verify()` runs its UPDATE against the schema-translated session, which in MT cloud resolves to `public.user` — a table that does not exist. (`public.user` only exists in single-tenant deployments; MT cloud puts the table per-tenant in `tenant_<uuid>` schemas.)

**Fix.** Override `UserManager.verify()` to:
1. Decode the verification JWT (`sub`, `email`).
2. In MULTI_TENANT, resolve the tenant from the email via `get_tenant_id_for_email`, set `CURRENT_TENANT_ID_CONTEXTVAR`, and run all queries against a tenant-bound session.
3. In single-tenant, short-circuit to `super().verify(token, request)` — the injected `self.user_db` is already correct.

Mirrors the existing `oauth_callback` / `get_by_email` pattern in the same class.

### Commits

- `81eb8cdfa3` — original override (resolve tenant from JWT email, tenant-bound UPDATE).
- `6d4389aea2` — Greptile-response: guard MT-only path; defer to `super().verify` in single-tenant to avoid an unnecessary new session.
- `f72b5584cf` — Codex-response: move `on_after_verify` and `return` inside the `async with` so the user object is still session-attached when hooks fire (matches `BaseUserManager.verify` semantics).

## How Has This Been Tested?

- `pytest -xv backend/tests/unit/onyx/auth/test_verify_email_*.py backend/tests/unit/onyx/auth/test_verify_auth_setting.py` → 20/20 passed.
- `ruff format --check backend/onyx/auth/users.py` → already formatted.
- `ty check` → no new diagnostics on `backend/onyx/auth/users.py` (4 pre-existing diagnostics remain in `tests/integration/common_utils/` — unrelated, untouched).
- Manual live test of the verify flow against MT cloud will be performed once this lands on the next release tag — staging cluster will be unblocked first.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check