### PR TITLE
fix(indexing): fix generator didn't stop after throw() in prepare_to_modify_documents

### DIFF
--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -1110,22 +1110,33 @@ def prepare_to_modify_documents(
 
     lock_acquired = False
     for i in range(_NUM_LOCK_ATTEMPTS):
+        yielded = False
         try:
             with db_session.begin() as transaction:
                 lock_acquired = acquire_document_locks(
                     db_session=db_session, document_ids=document_ids
                 )
                 if lock_acquired:
+                    yielded = True
                     yield transaction
-                    break
-        except OperationalError as e:
+                    return
+        except Exception as e:
+            if yielded:
+                # Exception came from the caller's body (after yield), not from
+                # lock acquisition. Re-raise regardless of type so the generator
+                # terminates — looping would cause a second yield and
+                # "RuntimeError: generator didn't stop after throw()".
+                raise
+            if not isinstance(e, OperationalError):
+                raise
             logger.warning(
                 "Failed to acquire locks for documents on attempt %s, retrying. Error: %s",
                 i,
                 e,
             )
 
-        time.sleep(retry_delay)
+        if i < _NUM_LOCK_ATTEMPTS - 1:
+            time.sleep(retry_delay)
 
     if not lock_acquired:
         raise RuntimeError(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
<img width="486" height="254" alt="Screenshot 2026-05-06 at 1 11 23 PM" src="https://github.com/user-attachments/assets/006075c7-7e3e-4df2-9346-6afc1ef9cb49" />

Root cause: prepare_to_modify_documents is a @contextmanager that yields inside a retry loop wrapped by except OperationalError. When the caller's with block body raised an OperationalError, Python injected it into the generator via throw(). The exception was caught by the except OperationalError handler (intended only for lock acquisition failures), the loop continued, and the generator yielded a second time — causing RuntimeError: generator didn't stop after throw() and masking the real error.

```
The hidden errors were SQLAlchemy OperationalErrors raised during the document modification work itself — i.e., inside the body of the with prepare_to_modify_documents(...) as transaction: block. Examples:

  - Lock timeout — a different query inside the body hits a lock_timeout or statement_timeout
  - Connection lost — the DB connection drops mid-transaction during a write
  - Deadlock — two transactions deadlock on different rows during the update
  - Out of shared memory — Postgres runs out of resources mid-operation

All of these are OperationalError subclasses in SQLAlchemy. Instead of surfacing as e.g. OperationalError: deadlock detected, they were swallowed by the retry loop, which re-yielded and produced the opaque RuntimeError: generator didn't stop after throw() — with no trace of what the actual DB error
   was.
```


Fix: Added a yielded flag set immediately before yield. In the except block, if yielded is True the exception originated from the caller's body — re-raise immediately regardless of type. Also broadened except OperationalError to except Exception to prevent unexpected exception types from acquire_document_locks() from being silently ignored, and skipped the time.sleep on the final retry attempt.
https://linear.app/onyx-app/issue/ENG-4105/google-drive-for-savvy-wealth
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Existing unit tests pass. 
Local test
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug in the document lock context manager that could yield twice after an exception, causing "generator didn't stop after throw()" and hiding the real error. Addresses Linear ENG-4105 and prevents stuck Google Drive indexing runs.

- **Bug Fixes**
  - Track if we already yielded; if an exception comes from the caller after the yield, re-raise immediately so the generator terminates.
  - Broaden handling to `except Exception`; only retry on `OperationalError`, re-raise others.
  - Skip the sleep on the final retry attempt.

<sup>Written for commit 9584aeff8ea34cf83f1e056be051c5c30a710d50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

