### PR TITLE
fix(db): asyncpg statement_cache_size=0

### DIFF
--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -3,7 +3,6 @@ from contextlib import asynccontextmanager
 from typing import Any
 from typing import AsyncContextManager
 
-import asyncpg
 from fastapi import HTTPException
 from sqlalchemy import event
 from sqlalchemy import pool
@@ -14,7 +13,6 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
-from onyx.configs.app_configs import POSTGRES_DB
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_POOL_PRE_PING
 from onyx.configs.app_configs import POSTGRES_POOL_RECYCLE
@@ -34,22 +32,6 @@ from shared_configs.contextvars import get_current_tenant_id
 
 # Global so we don't create more than one engine per process
 _ASYNC_ENGINE: AsyncEngine | None = None
-
-
-async def get_async_connection() -> Any:
-    """
-    Custom connection function for async engine when using IAM auth.
-    """
-    host = POSTGRES_HOST
-    port = POSTGRES_PORT
-    user = POSTGRES_USER
-    db = POSTGRES_DB
-    token = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
-
-    # asyncpg requires 'ssl="require"' if SSL needed
-    return await asyncpg.connect(
-        user=user, password=token, host=host, port=int(port), database=db, ssl="require"
-    )
 
 
 def get_sqlalchemy_async_engine() -> AsyncEngine:

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -67,6 +67,13 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
 
         connect_args["ssl"] = create_ssl_context_if_iam()
 
+        # Disable asyncpg's prepared-statement cache. Required when running
+        # against pgbouncer in transaction pool mode: the server connection
+        # rotates between transactions (with `DISCARD ALL`), so cached named
+        # prepared statements get wiped, leading to intermittent
+        # `prepared statement does not exist` / `MissingGreenlet` errors.
+        connect_args["statement_cache_size"] = 0
+
         engine_kwargs = {
             "connect_args": connect_args,
             "pool_pre_ping": POSTGRES_POOL_PRE_PING,


### PR DESCRIPTION
## Description

**Bug:** Intermittent login failures showing `MissingGreenlet`, `greenlet_spawn has not been called`, `InterfaceError: underlying connection is closed`, and `prepared statement does not exist`. Often resolves on retry/refresh.

<img width="499" height="504" alt="image" src="https://github.com/user-attachments/assets/57fd93f7-209a-4c04-936a-6a8b75bcf3c9" />

**Cause:** asyncpg's default `statement_cache_size=100` caches **named** prepared statements client-side. That cache is fragile across the SQLAlchemy async greenlet bridge and breaks in multiple deployment topologies:

- **Cloud (pgbouncer transaction mode):** api-server points at pgbouncer with `server_reset_query = DISCARD ALL` and `server_lifetime = 120`. Cached named prepared statements get wiped by `DISCARD ALL` or rotated out from under us. Next `EXECUTE` fails; SQLAlchemy's async teardown then can't rollback cleanly → surfaces as `MissingGreenlet`.
- **Self-hosted (direct postgres, no pooler):** Onyx defaults to `POSTGRES_USE_NULL_POOL=true`, so each checkout creates a fresh asyncpg connection. Every cold connect re-runs asyncpg's init protocol (type/codec introspection via prepared statements) inside the greenlet wrapper, which races on first request — produces the same `greenlet_spawn has not been called` symptom. Matches the "everyone hits this on first login, goes away on refresh" report.
- **Any deployment after schema change:** Alembic migrations / DDL can invalidate plans cached against the pre-migration schema.

**Fix:** Set `statement_cache_size=0` in asyncpg `connect_args`. Queries use **unnamed** prepared statements (auto-destroyed at end of statement) — the documented SQLAlchemy + asyncpg recipe for both pgbouncer transaction mode and general async-engine reliability.

**Also:** drop the unused `get_async_connection()` helper in the same file — orphaned since #3479, would silently bypass `connect_args` and reintroduce this bug if ever wired up.

## Implications (heads-up for reviewer)

- **Perf:** ~1-3% extra parse/plan per query worst case. Effectively zero in practice — Onyx already uses `POSTGRES_USE_NULL_POOL=true` so the cache rarely hit anyway.
- **Scope:** Async engine only. Sync engine (psycopg2, used by Celery + most Onyx code) untouched.
- **Watch post-deploy:** RDS CPU on Datadog/CW for ~30 min. Should see noise-level change. If it spikes >15%, likely PG14+ JIT re-compiling per execution on heavy queries — tunable via `jit_above_cost` if so.
- **Reversible:** one-line revert.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check