### PR TITLE
refactor(web): extract providerDisplayName helper + fix LLMOption.name nullability

### DIFF
--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -63,7 +63,7 @@ export default function useMultiModelChat(
     );
     if (!match) return null;
     return {
-      name: match.name,
+      name: match.name ?? "",
       provider: match.provider,
       modelName: match.modelName,
       displayName: match.displayName,
@@ -175,7 +175,7 @@ export default function useMultiModelChat(
         );
         if (match) {
           restored.push({
-            name: match.name,
+            name: match.name ?? "",
             provider: match.provider,
             modelName: match.modelName,
             displayName: match.displayName,
@@ -201,7 +201,7 @@ export default function useMultiModelChat(
       if (match) {
         setSelectedModels([
           {
-            name: match.name,
+            name: match.name ?? "",
             provider: match.provider,
             modelName: match.modelName,
             displayName: match.displayName,

--- a/web/src/lib/languageModels/utils.ts
+++ b/web/src/lib/languageModels/utils.ts
@@ -2,9 +2,15 @@ import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import {
   DefaultModel,
   LLMProviderDescriptor,
+  LLMProviderView,
   ModelConfiguration,
 } from "@/interfaces/llm";
 import { LlmDescriptor } from "@/lib/hooks";
+import { getProvider } from "@/lib/languageModels";
+
+export function providerDisplayName(provider: LLMProviderView): string {
+  return provider.name || getProvider(provider.provider, provider).productName;
+}
 
 export function getFinalLLM(
   llmProviders: LLMProviderDescriptor[],
@@ -72,11 +78,11 @@ export function getProviderOverrideForPersona(
 }
 
 export const structureValue = (
-  name: string,
+  name: string | null,
   provider: string,
   modelName: string
 ) => {
-  return `${name}__${provider}__${modelName}`;
+  return `${name ?? ""}__${provider}__${modelName}`;
 };
 
 export const parseLlmDescriptor = (value: string): LlmDescriptor => {

--- a/web/src/refresh-components/popovers/LLMPopover.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.tsx
@@ -127,7 +127,7 @@ export default function LLMPopover({
       llmManager.updateCurrentLlm({
         modelName: option.modelName,
         provider: option.provider,
-        name: option.name,
+        name: option.name ?? "",
       } as LlmDescriptor);
       onSelect?.(
         structureValue(option.name, option.provider, option.modelName)

--- a/web/src/refresh-components/popovers/ModelSelector.tsx
+++ b/web/src/refresh-components/popovers/ModelSelector.tsx
@@ -88,7 +88,7 @@ export default function ModelSelector({
 
   const handleSelect = (option: LLMOption) => {
     const model: SelectedModel = {
-      name: option.name,
+      name: option.name ?? "",
       provider: option.provider,
       modelName: option.modelName,
       displayName: option.displayName,

--- a/web/src/refresh-components/popovers/interfaces.ts
+++ b/web/src/refresh-components/popovers/interfaces.ts
@@ -2,7 +2,7 @@ import type { IconProps } from "@opal/types";
 import { FunctionComponent } from "react";
 
 export interface LLMOption {
-  name: string;
+  name: string | null;
   provider: string;
   providerDisplayName: string;
   modelName: string;

--- a/web/src/refresh-components/popovers/llmUtils.ts
+++ b/web/src/refresh-components/popovers/llmUtils.ts
@@ -35,7 +35,7 @@ export function buildLlmOptions(
         seenKeys.add(key);
 
         options.push({
-          name: llmProvider.name ?? "",
+          name: llmProvider.name ?? null,
           provider: llmProvider.provider,
           providerDisplayName:
             llmProvider.provider_display_name || llmProvider.provider,

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -212,7 +212,10 @@ function LlmPicker({
 
   const handleSelect = useCallback(
     (option: LLMOption) => {
-      onChange({ modelName: option.modelName, providerName: option.name });
+      onChange({
+        modelName: option.modelName,
+        providerName: option.name ?? "",
+      });
       setOpen(false);
     },
     [onChange]

--- a/web/src/refresh-pages/admin/LanguageModelsPage.tsx
+++ b/web/src/refresh-pages/admin/LanguageModelsPage.tsx
@@ -25,6 +25,7 @@ import {
   deleteLlmProvider,
   setDefaultLlmModel,
 } from "@/lib/languageModels/svc";
+import { providerDisplayName } from "@/lib/languageModels/utils";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { useCreateModal } from "@/refresh-components/contexts/ModalContext";
@@ -33,10 +34,6 @@ import { Section } from "@/layouts/general-layouts";
 import { markdown } from "@opal/utils";
 
 const route = ADMIN_ROUTES.LLM_MODELS;
-
-function providerDisplayName(provider: LLMProviderView): string {
-  return provider.name || getProvider(provider.provider, provider).productName;
-}
 
 // ============================================================================
 // Provider form mapping (keyed by provider name from the API)


### PR DESCRIPTION
## Description

**1. Extract `providerDisplayName()` into `lib/languageModels/utils`**

The helper was defined as a module-private function inside `LanguageModelsPage.tsx`. Moving it to `utils.ts` makes it available to any future component that needs to display a provider's label.

**2. Fix `LLMOption.name: string | null`**

`buildLlmOptions()` in `llmUtils.ts` was coercing a null provider name to `""` via `?? ""`. This leaked an empty string into form state and composite keys. Changed to `?? null` and updated `LLMOption.name` to `string | null`. All six call sites that assign this into `string`-typed fields (`LlmDescriptor.name`, `SelectedModel.name`, `structureValue()`) are updated to coerce with `?? ""` explicitly — making the semantics visible at each use.

## Screenshots + Videos

Small logical change; no UI changes. Screenshots / videos not required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted `providerDisplayName()` to `lib/languageModels/utils` and made `LLMOption.name` nullable to prevent empty strings in form state and composite keys.

- **Refactors**
  - Moved `providerDisplayName()` from `LanguageModelsPage.tsx` to `lib/languageModels/utils` and updated imports.
  - Updated `structureValue(name, provider, modelName)` to accept `string | null` and coerce with `?? ""`.

- **Bug Fixes**
  - Changed `LLMOption.name` to `string | null`. Set `null` in `buildLlmOptions()` and explicitly coerce with `?? ""` in selectors, popovers, multi-model chat, and index settings.

<sup>Written for commit 0d91ab21f3fa491c1ba5df60e279fc9ceff02fbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

