### PR TITLE
test(targeted-reindex): daily integration suite against real Drive

### DIFF
--- a/backend/tests/daily/targeted_reindex/conftest.py
+++ b/backend/tests/daily/targeted_reindex/conftest.py
@@ -1,0 +1,49 @@
+"""Daily-suite conftest for targeted-reindex integration tests.
+
+These tests need:
+- Real Postgres (cc_pair, IndexAttempt, IndexAttemptError, TargetedReindexJob rows)
+- Real OpenSearch (verify documents actually land in the index)
+- Real Drive credentials (via the shared `test_secrets` fixture)
+
+The parent `tests/daily/conftest.py` already opts into the
+`@pytest.mark.secrets` infrastructure; we add Postgres + tenant context
+on top so the targeted-reindex flow can write its rows the same way
+production does.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.engine.sql_engine import SqlEngine
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _init_sql_engine() -> None:
+    """Initialise the connection pool exactly once per test session so we
+    don't re-enter `SqlEngine.init_engine` on every test function. The
+    init itself is internally guarded (early-return if already set), but
+    keeping the call out of the per-function fixture avoids accidental
+    pool churn if that guard ever changes."""
+    SqlEngine.init_engine(pool_size=10, max_overflow=5)
+
+
+@pytest.fixture(scope="function")
+def db_session() -> Generator[Session, None, None]:
+    """Real Postgres session. Mirrors `tests/external_dependency_unit/conftest.py`
+    so the same write paths are exercised, just from the daily suite."""
+    with get_session_with_current_tenant() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+def tenant_context() -> Generator[None, None, None]:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
+    try:
+        yield
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)

--- a/backend/tests/daily/targeted_reindex/helpers.py
+++ b/backend/tests/daily/targeted_reindex/helpers.py
@@ -1,0 +1,195 @@
+"""Helpers for daily targeted-reindex integration tests.
+
+Each helper writes the minimum DB state needed to drive the targeted-
+reindex flow against a real Drive cc_pair: a connector + credential +
+cc_pair tied to the Drive service account, a parent IndexAttempt to
+hang errors off of, and an IndexAttemptError pointing at a known doc.
+"""
+
+import json
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.google_utils.shared_constants import (
+    DB_CREDENTIALS_AUTHENTICATION_METHOD,
+)
+from onyx.connectors.google_utils.shared_constants import (
+    DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY,
+)
+from onyx.connectors.google_utils.shared_constants import (
+    DB_CREDENTIALS_PRIMARY_ADMIN_KEY,
+)
+from onyx.connectors.google_utils.shared_constants import (
+    GoogleOAuthAuthenticationMethod,
+)
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
+from onyx.db.models import TargetedReindexJob
+from onyx.db.models import TargetedReindexJobTarget
+from onyx.db.search_settings import get_current_search_settings
+
+_ADMIN_EMAIL = "admin@onyx-test.com"
+
+
+def _parse_credentials(env_str: str) -> dict[str, Any]:
+    """Service account JSON arrives from AWS secrets either as a plain
+    JSON string or as a double-escaped one (depending on how the secret
+    was stored). Try the plain form first, fall back to unescaping only
+    on a JSON parse failure so any other exception (e.g. missing secret
+    surfacing as a TypeError) propagates cleanly."""
+    try:
+        return json.loads(env_str)
+    except json.JSONDecodeError:
+        unescaped = env_str.replace('\\"', '"').strip('"')
+        return json.loads(unescaped)
+
+
+def make_drive_cc_pair(
+    db_session: Session, service_account_json_str: str
+) -> ConnectorCredentialPair:
+    """Persist a Drive cc_pair using the service account credential.
+
+    Connector config is intentionally minimal — `Resolver.reindex` only
+    needs valid auth and a primary admin email; it doesn't crawl.
+    """
+    refried = json.dumps(_parse_credentials(service_account_json_str))
+    credential_json: dict[str, Any] = {
+        DB_CREDENTIALS_DICT_SERVICE_ACCOUNT_KEY: refried,
+        DB_CREDENTIALS_PRIMARY_ADMIN_KEY: _ADMIN_EMAIL,
+        DB_CREDENTIALS_AUTHENTICATION_METHOD: (
+            GoogleOAuthAuthenticationMethod.UPLOADED.value
+        ),
+    }
+
+    connector = Connector(
+        name="targeted-reindex-integration-drive-%s" % uuid4().hex[:8],
+        source=DocumentSource.GOOGLE_DRIVE,
+        input_type=InputType.POLL,
+        connector_specific_config={"include_files_shared_with_me": True},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.GOOGLE_DRIVE,
+        credential_json=credential_json,
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name="targeted-reindex-integration-cc-%s" % uuid4().hex[:8],
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+        auto_sync_options=None,
+    )
+    db_session.add(pair)
+    db_session.commit()
+    db_session.refresh(pair)
+    return pair
+
+
+def make_failed_index_attempt(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> IndexAttempt:
+    """Parent IndexAttempt for IndexAttemptError rows to FK against.
+    Status FAILED is required because IndexAttemptError can only attach
+    to non-success attempts in production."""
+    settings = get_current_search_settings(db_session)
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=settings.id,
+        from_beginning=False,
+        status=IndexingStatus.FAILED,
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    return attempt
+
+
+def make_index_attempt_error(
+    db_session: Session,
+    parent: IndexAttempt,
+    document_id: str,
+    failure_message: str = "synthetic test failure",
+) -> IndexAttemptError:
+    err = IndexAttemptError(
+        index_attempt_id=parent.id,
+        connector_credential_pair_id=parent.connector_credential_pair_id,
+        document_id=document_id,
+        document_link=document_id if document_id.startswith("http") else None,
+        failure_message=failure_message,
+        is_resolved=False,
+    )
+    db_session.add(err)
+    db_session.commit()
+    db_session.refresh(err)
+    return err
+
+
+def cleanup_targeted_reindex_state(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Tear down everything created during one integration test.
+
+    Scoped to this cc_pair only so the cleanup is safe in a shared test
+    DB. We discover the job ids touched by this run via the
+    `targeted_reindex_job_target` table (each row carries `cc_pair_id`),
+    then delete in FK-safe order:
+    targeted_reindex_job_target → targeted_reindex_job →
+    index_attempt_errors → index_attempt → cc_pair → connector +
+    credential.
+    """
+    db_session.expire_all()
+
+    job_ids: list[int] = [
+        row[0]
+        for row in db_session.query(TargetedReindexJobTarget.targeted_reindex_job_id)
+        .filter(TargetedReindexJobTarget.cc_pair_id == cc_pair.id)
+        .distinct()
+        .all()
+    ]
+
+    db_session.query(TargetedReindexJobTarget).filter(
+        TargetedReindexJobTarget.cc_pair_id == cc_pair.id
+    ).delete(synchronize_session="fetch")
+    if job_ids:
+        db_session.query(TargetedReindexJob).filter(
+            TargetedReindexJob.id.in_(job_ids)
+        ).delete(synchronize_session="fetch")
+    db_session.query(IndexAttemptError).filter(
+        IndexAttemptError.connector_credential_pair_id == cc_pair.id
+    ).delete(synchronize_session="fetch")
+    db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == cc_pair.id
+    ).delete(synchronize_session="fetch")
+
+    connector_id = cc_pair.connector_id
+    credential_id = cc_pair.credential_id
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.id == cc_pair.id
+    ).delete(synchronize_session="fetch")
+    db_session.query(Connector).filter(Connector.id == connector_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.query(Credential).filter(Credential.id == credential_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()

--- a/backend/tests/daily/targeted_reindex/test_drive_targeted_reindex_integration.py
+++ b/backend/tests/daily/targeted_reindex/test_drive_targeted_reindex_integration.py
@@ -1,0 +1,230 @@
+"""Integration coverage for targeted-reindex against real Google Drive.
+
+Exercises the task body, connector instantiation, `Resolver.reindex`
+invocation against the real Drive API, indexing pipeline run,
+OpenSearch write, and resolution tracking on `IndexAttemptError` —
+using the same Drive service account that the existing connector daily
+tests run under.
+
+Not full end-to-end: HTTP API + celery dispatch + FE polling are not
+exercised here. `run_targeted_reindex` is invoked directly. A separate
+e2e test that goes through the API endpoint and the celery worker can
+land later if the integration coverage proves insufficient.
+
+Three scenarios:
+1. real existing Drive doc → resolves cleanly, error closes, doc lands
+2. nonexistent Drive doc → resolution stays open, still_failing > 0
+3. mixed batch (real + fake) → only the real one resolves
+
+Connector-level reindex coverage already lives in
+`tests/daily/connectors/google_drive/test_resolver.py`; this file is
+the feature-level companion.
+"""
+
+import json
+import os
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.docprocessing.targeted_reindex_task import (
+    run_targeted_reindex,
+)
+from onyx.db.enums import IndexingStatus
+from onyx.db.models import Document as DBDocument
+from onyx.db.models import IndexAttemptError
+from onyx.db.targeted_reindex import create_targeted_reindex_job
+from onyx.db.targeted_reindex import get_targeted_reindex_job
+from onyx.db.targeted_reindex import resolve_error_ids_to_targets
+from tests.daily.targeted_reindex.helpers import cleanup_targeted_reindex_state
+from tests.daily.targeted_reindex.helpers import make_drive_cc_pair
+from tests.daily.targeted_reindex.helpers import make_failed_index_attempt
+from tests.daily.targeted_reindex.helpers import make_index_attempt_error
+from tests.utils.secret_names import TestSecret
+
+_DRIVE_ID_MAPPING_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "connectors",
+    "google_drive",
+    "drive_id_mapping.json",
+)
+
+
+def _web_view_link_for(file_id: int) -> str:
+    """Resolve a stable Drive test-doc reference into the web view link
+    that the resolver consumes as `failed_document.document_id`."""
+    with open(_DRIVE_ID_MAPPING_PATH) as f:
+        mapping: dict[str, str] = json.load(f)
+    return mapping[str(file_id)]
+
+
+def _run(job_id: int) -> None:
+    """Invoke the task body synchronously, bypassing celery binding."""
+    run_targeted_reindex(
+        targeted_reindex_job_id=job_id, celery_task_id="daily-integration"
+    )
+
+
+@pytest.mark.secrets(TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR)
+def test_targeted_reindex_resolves_real_drive_doc(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Happy path: error references a real Drive doc, reindex re-fetches,
+    pipeline writes, error closes, summary populates, doc row exists."""
+    cc_pair = make_drive_cc_pair(
+        db_session,
+        test_secrets[TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR],
+    )
+    try:
+        target_link = _web_view_link_for(0)
+        parent = make_failed_index_attempt(db_session, cc_pair)
+        err = make_index_attempt_error(
+            db_session,
+            parent,
+            document_id=target_link,
+            failure_message="synthetic 403 boom",
+        )
+
+        derived, skipped = resolve_error_ids_to_targets(db_session, [err.id])
+        assert skipped == 0
+        result = create_targeted_reindex_job(
+            db_session=db_session,
+            requested_by_user_id=None,
+            targets=derived,
+        )
+
+        _run(result.targeted_reindex_job_id)
+
+        db_session.expire_all()
+        err_after = db_session.get(IndexAttemptError, err.id)
+        assert err_after is not None
+        assert err_after.is_resolved is True
+
+        job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+        assert job is not None
+        assert job.status == IndexingStatus.SUCCESS
+        assert job.resolved_count == 1
+        assert job.still_failing_count == 0
+        assert len(job.resolved_summary) == 1
+        assert job.resolved_summary[0]["id"] == err.id
+
+        # Document row exists, signaling the pipeline reached the upsert
+        # stage. We don't assert on chunks directly — that's covered by
+        # the indexing pipeline's own tests.
+        doc_row = (
+            db_session.query(DBDocument).filter(DBDocument.id == target_link).first()
+        )
+        assert doc_row is not None
+    finally:
+        cleanup_targeted_reindex_state(db_session, cc_pair)
+
+
+@pytest.mark.secrets(TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR)
+def test_targeted_reindex_marks_still_failing_for_nonexistent_doc(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Resolution gate: an error pointing at a nonexistent Drive doc
+    must not auto-resolve. The doc never lands, so the error stays open
+    and still_failing_count goes up by one."""
+    cc_pair = make_drive_cc_pair(
+        db_session,
+        test_secrets[TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR],
+    )
+    try:
+        bogus_link = "https://drive.google.com/file/d/0doesnotexist00000000000000000000"
+        parent = make_failed_index_attempt(db_session, cc_pair)
+        err = make_index_attempt_error(
+            db_session,
+            parent,
+            document_id=bogus_link,
+            failure_message="synthetic 404 boom",
+        )
+
+        derived, _ = resolve_error_ids_to_targets(db_session, [err.id])
+        result = create_targeted_reindex_job(
+            db_session=db_session,
+            requested_by_user_id=None,
+            targets=derived,
+        )
+
+        _run(result.targeted_reindex_job_id)
+
+        db_session.expire_all()
+        err_after = db_session.get(IndexAttemptError, err.id)
+        assert err_after is not None
+        assert err_after.is_resolved is False
+
+        job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+        assert job is not None
+        assert job.status == IndexingStatus.SUCCESS
+        assert job.resolved_count == 0
+        assert job.still_failing_count == 1
+        assert job.resolved_summary == []
+
+        # No DB document row should have been written for the bogus link.
+        doc_row = (
+            db_session.query(DBDocument).filter(DBDocument.id == bogus_link).first()
+        )
+        assert doc_row is None
+    finally:
+        cleanup_targeted_reindex_state(db_session, cc_pair)
+
+
+@pytest.mark.secrets(TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR)
+def test_targeted_reindex_mixed_real_and_fake(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Mixed batch: one real doc, one fake. The real one closes its
+    error; the fake one stays open. Counters reflect both buckets."""
+    cc_pair = make_drive_cc_pair(
+        db_session,
+        test_secrets[TestSecret.GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON_STR],
+    )
+    try:
+        real_link = _web_view_link_for(2)
+        fake_link = "https://drive.google.com/file/d/0fakefakefakefakefakefakefakefakea"
+
+        parent = make_failed_index_attempt(db_session, cc_pair)
+        real_err = make_index_attempt_error(
+            db_session, parent, document_id=real_link, failure_message="real boom"
+        )
+        fake_err = make_index_attempt_error(
+            db_session, parent, document_id=fake_link, failure_message="fake boom"
+        )
+
+        derived, _ = resolve_error_ids_to_targets(
+            db_session, [real_err.id, fake_err.id]
+        )
+        assert len(derived) == 2
+
+        result = create_targeted_reindex_job(
+            db_session=db_session,
+            requested_by_user_id=None,
+            targets=derived,
+        )
+
+        _run(result.targeted_reindex_job_id)
+
+        db_session.expire_all()
+        real_after = db_session.get(IndexAttemptError, real_err.id)
+        fake_after = db_session.get(IndexAttemptError, fake_err.id)
+        assert real_after is not None and real_after.is_resolved is True
+        assert fake_after is not None and fake_after.is_resolved is False
+
+        job = get_targeted_reindex_job(db_session, result.targeted_reindex_job_id)
+        assert job is not None
+        assert job.status == IndexingStatus.SUCCESS
+        assert job.resolved_count == 1
+        assert job.still_failing_count == 1
+        # Only the real doc made it to summary.
+        assert len(job.resolved_summary) == 1
+        assert job.resolved_summary[0]["id"] == real_err.id
+    finally:
+        cleanup_targeted_reindex_state(db_session, cc_pair)


### PR DESCRIPTION
## Description

Integration coverage for the targeted-reindex feature against real Google Drive. Stacks on #10864 (connector wiring) since that's the layer being exercised.

\`backend/tests/daily/targeted_reindex/\` runs the task body, connector instantiation, \`Resolver.reindex\` invocation against the real Drive API, indexing pipeline run, OpenSearch write, and resolution tracking on \`IndexAttemptError\` — using the same Drive service account that the existing connector daily tests run under.

Not full end-to-end: HTTP API + celery dispatch + FE polling are not exercised here. \`run_targeted_reindex\` is invoked directly. A separate e2e test that goes through the API endpoint and the celery worker can land later if integration coverage proves insufficient.

- \`make_drive_cc_pair\` persists a Drive cc_pair using the same service account JSON the existing \`tests/daily/connectors/google_drive/\` suite uses.
- \`make_failed_index_attempt\` + \`make_index_attempt_error\` seed the parent \`IndexAttempt\` and \`IndexAttemptError\` rows the targeted-reindex flow expects.

Three scenarios:
- **Real existing Drive doc** — error closes, doc lands in DB, \`resolved_summary\` populates, \`resolved_count=1\`.
- **Nonexistent doc** — \`still_failing_count\` goes up, error stays open, no DB document row written.
- **Mixed batch** — real resolves; fake stays open; counters reflect both buckets.

Connector-level \`reindex()\` coverage already lives in \`tests/daily/connectors/google_drive/test_resolver.py\`; this is the feature-level companion.

Design: https://linear.app/onyx-app/document/targeted-doc-re-indexing-design-4f9f9080760e

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

Three new tests in \`backend/tests/daily/targeted_reindex/test_drive_targeted_reindex_integration.py\` against real Drive + real Postgres + real OpenSearch via the daily test secret infrastructure.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check