### PR TITLE
feat(tools): Add bash tool

### DIFF
--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -55,6 +55,9 @@ class StreamingType(Enum):
     INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta"
     INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs"
 
+    BASH_TOOL_START = "bash_tool_start"
+    BASH_TOOL_DELTA = "bash_tool_delta"
+
 
 class BaseObj(BaseModel):
     type: str = ""
@@ -368,6 +371,22 @@ class IntermediateReportCitedDocs(BaseObj):
 
 
 ################################################
+# Bash Tool Packets
+################################################
+class BashToolStart(BaseObj):
+    type: Literal["bash_tool_start"] = StreamingType.BASH_TOOL_START.value
+    cmd: str
+
+
+class BashToolDelta(BaseObj):
+    type: Literal["bash_tool_delta"] = StreamingType.BASH_TOOL_DELTA.value
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: int | None = None
+    timed_out: bool = False
+
+
+################################################
 # Packet Object
 ################################################
 # Discriminated union of all possible packet object types
@@ -415,6 +434,9 @@ PacketObj = Union[
     IntermediateReportStart,
     IntermediateReportDelta,
     IntermediateReportCitedDocs,
+    # Bash Tool Packets
+    BashToolStart,
+    BashToolDelta,
 ]
 
 

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -47,8 +47,7 @@ class BashTool(Tool[BashToolOverrideKwargs]):
     NAME = "bash"
     DISPLAY_NAME = "Bash"
     DESCRIPTION = (
-        "Execute a bash command inside an isolated, network-restricted "
-        "session. Filesystem state persists across calls within the session."
+        "Execute a bash command inside an isolated, network-restricted " "session."
     )
 
     def __init__(self, tool_id: int, session_id: str, emitter: Emitter) -> None:

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -21,6 +21,7 @@ from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
     CodeInterpreterClient,
 )
+from onyx.tools.tool_implementations.utils import truncate_output as _truncate_output
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -38,16 +39,6 @@ class LlmBashExecutionResult(BaseModel):
     exit_code: int | None
     timed_out: bool
     error: str | None = None
-
-
-def _truncate_output(output: str, max_length: int, label: str = "output") -> str:
-    truncated = output[:max_length]
-    if len(output) > max_length:
-        truncated += (
-            f"\n... [output truncated, {len(output) - max_length} characters omitted]"
-        )
-        logger.debug("Truncated %s: %s", label, truncated)
-    return truncated
 
 
 class BashTool(Tool[BashToolOverrideKwargs]):

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -3,11 +3,14 @@ from typing import cast
 
 from pydantic import BaseModel
 from pydantic import TypeAdapter
+from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from onyx.chat.emitter import Emitter
+from onyx.configs.app_configs import CODE_INTERPRETER_BASE_URL
 from onyx.configs.app_configs import CODE_INTERPRETER_DEFAULT_TIMEOUT_MS
 from onyx.configs.app_configs import CODE_INTERPRETER_MAX_OUTPUT_LENGTH
+from onyx.db.code_interpreter import fetch_code_interpreter_server
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import BashToolDelta
 from onyx.server.query_and_chat.streaming_models import BashToolStart
@@ -81,6 +84,32 @@ class BashTool(Tool[BashToolOverrideKwargs]):
     @property
     def session_id(self) -> str:
         return self._session_id
+
+    @override
+    @classmethod
+    def is_available(cls, db_session: Session) -> bool:
+        """Available only when the code-interpreter is configured, healthy,
+        AND the deployed service version supports the session/bash routes.
+
+        Mirrors ``PythonTool.is_available`` for the env / DB / health checks,
+        plus a ``client.supports(...)`` capability gate so an outdated
+        code-interpreter deployment doesn't make this tool appear available
+        when its underlying calls would be rejected by the version guard.
+        """
+        if not CODE_INTERPRETER_BASE_URL:
+            return False
+        server = fetch_code_interpreter_server(db_session)
+        if not server.server_enabled:
+            return False
+
+        with CodeInterpreterClient() as client:
+            if not client.health(use_cache=True).healthy:
+                return False
+            return client.supports(
+                CodeInterpreterClient.create_session,
+                CodeInterpreterClient.execute_bash_in_session,
+                CodeInterpreterClient.delete_session,
+            )
 
     def tool_definition(self) -> dict:
         return {

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -149,39 +149,39 @@ class BashTool(Tool[BashToolOverrideKwargs]):
 
         adapter = TypeAdapter(LlmBashExecutionResult)
 
-        with CodeInterpreterClient() as client:
-            try:
+        try:
+            with CodeInterpreterClient() as client:
                 logger.debug("Executing bash in session %s: %s", self._session_id, cmd)
                 response = client.execute_bash_in_session(
                     session_id=self._session_id,
                     cmd=cmd,
                     timeout_ms=CODE_INTERPRETER_DEFAULT_TIMEOUT_MS,
                 )
-            except Exception as e:
-                logger.error("Bash execution failed: %s", e)
-                error_msg = str(e)
-                error_result = LlmBashExecutionResult(
-                    stdout="",
-                    stderr=error_msg,
-                    exit_code=-1,
-                    timed_out=False,
-                    error=error_msg,
-                )
-                self.emitter.emit(
-                    Packet(
-                        placement=placement,
-                        obj=BashToolDelta(
-                            stdout="",
-                            stderr=error_msg,
-                            exit_code=-1,
-                            timed_out=False,
-                        ),
+        except Exception as e:
+            logger.error("Bash execution failed: %s", e)
+            error_msg = str(e)
+            error_result = LlmBashExecutionResult(
+                stdout="",
+                stderr=error_msg,
+                exit_code=-1,
+                timed_out=False,
+                error=error_msg,
+            )
+            self.emitter.emit(
+                Packet(
+                    placement=placement,
+                    obj=BashToolDelta(
+                        stdout="",
+                        stderr=error_msg,
+                        exit_code=-1,
+                        timed_out=False,
                     ),
-                )
-                return ToolResponse(
-                    rich_response=None,
-                    llm_facing_response=adapter.dump_json(error_result).decode(),
-                )
+                ),
+            )
+            return ToolResponse(
+                rich_response=None,
+                llm_facing_response=adapter.dump_json(error_result).decode(),
+            )
 
         truncated_stdout = _truncate_output(
             response.stdout, CODE_INTERPRETER_MAX_OUTPUT_LENGTH, "stdout"

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -1,5 +1,4 @@
 from typing import Any
-from typing import cast
 
 from pydantic import BaseModel
 from pydantic import TypeAdapter
@@ -140,7 +139,19 @@ class BashTool(Tool[BashToolOverrideKwargs]):
                     f'{{"cmd": "ls -la"}}'
                 ),
             )
-        cmd = cast(str, llm_kwargs[CMD_FIELD])
+        cmd = llm_kwargs[CMD_FIELD]
+        if not isinstance(cmd, str):
+            raise ToolCallException(
+                message=(
+                    f"'{CMD_FIELD}' must be a string in bash tool call, "
+                    f"got {type(cmd).__name__}"
+                ),
+                llm_facing_message=(
+                    f"The bash tool requires '{CMD_FIELD}' to be a string "
+                    f"(got {type(cmd).__name__}). Pass a single shell "
+                    f'command, e.g. {{"cmd": "ls -la"}}.'
+                ),
+            )
 
         self.emitter.emit(
             Packet(placement=placement, obj=BashToolStart(cmd=cmd)),

--- a/backend/onyx/tools/tool_implementations/bash/bash_tool.py
+++ b/backend/onyx/tools/tool_implementations/bash/bash_tool.py
@@ -1,0 +1,201 @@
+from typing import Any
+from typing import cast
+
+from pydantic import BaseModel
+from pydantic import TypeAdapter
+from typing_extensions import override
+
+from onyx.chat.emitter import Emitter
+from onyx.configs.app_configs import CODE_INTERPRETER_DEFAULT_TIMEOUT_MS
+from onyx.configs.app_configs import CODE_INTERPRETER_MAX_OUTPUT_LENGTH
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import BashToolDelta
+from onyx.server.query_and_chat.streaming_models import BashToolStart
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.interface import Tool
+from onyx.tools.models import ToolCallException
+from onyx.tools.models import ToolResponse
+from onyx.tools.tool_implementations.python.code_interpreter_client import (
+    CodeInterpreterClient,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+CMD_FIELD = "cmd"
+
+
+class BashToolOverrideKwargs(BaseModel):
+    pass
+
+
+class LlmBashExecutionResult(BaseModel):
+    stdout: str
+    stderr: str
+    exit_code: int | None
+    timed_out: bool
+    error: str | None = None
+
+
+def _truncate_output(output: str, max_length: int, label: str = "output") -> str:
+    truncated = output[:max_length]
+    if len(output) > max_length:
+        truncated += (
+            f"\n... [output truncated, {len(output) - max_length} characters omitted]"
+        )
+        logger.debug("Truncated %s: %s", label, truncated)
+    return truncated
+
+
+class BashTool(Tool[BashToolOverrideKwargs]):
+    """Bash command execution tool backed by a Code Interpreter session."""
+
+    NAME = "bash"
+    DISPLAY_NAME = "Bash"
+    DESCRIPTION = (
+        "Execute a bash command inside an isolated, network-restricted "
+        "session. Filesystem state persists across calls within the session."
+    )
+
+    def __init__(self, tool_id: int, session_id: str, emitter: Emitter) -> None:
+        super().__init__(emitter=emitter)
+        self._id = tool_id
+        self._session_id = session_id
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def name(self) -> str:
+        return self.NAME
+
+    @property
+    def description(self) -> str:
+        return self.DESCRIPTION
+
+    @property
+    def display_name(self) -> str:
+        return self.DISPLAY_NAME
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def tool_definition(self) -> dict:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        CMD_FIELD: {
+                            "type": "string",
+                            "description": "Bash command to execute in the session.",
+                        },
+                    },
+                    "required": [CMD_FIELD],
+                },
+            },
+        }
+
+    def emit_start(self, placement: Placement) -> None:
+        """Emit start packet for this tool. Code will be emitted in run() method."""
+        # cmd isn't available until run(); BashToolStart is emitted there,
+        # mirroring PythonTool's pattern.
+
+    def run(
+        self,
+        placement: Placement,
+        override_kwargs: BashToolOverrideKwargs,  # noqa: ARG002
+        **llm_kwargs: Any,
+    ) -> ToolResponse:
+        if CMD_FIELD not in llm_kwargs:
+            raise ToolCallException(
+                message=f"Missing required '{CMD_FIELD}' parameter in bash tool call",
+                llm_facing_message=(
+                    f"The bash tool requires a '{CMD_FIELD}' parameter containing "
+                    f"the bash command to execute. Please provide like: "
+                    f'{{"cmd": "ls -la"}}'
+                ),
+            )
+        cmd = cast(str, llm_kwargs[CMD_FIELD])
+
+        self.emitter.emit(
+            Packet(placement=placement, obj=BashToolStart(cmd=cmd)),
+        )
+
+        adapter = TypeAdapter(LlmBashExecutionResult)
+
+        with CodeInterpreterClient() as client:
+            try:
+                logger.debug("Executing bash in session %s: %s", self._session_id, cmd)
+                response = client.execute_bash_in_session(
+                    session_id=self._session_id,
+                    cmd=cmd,
+                    timeout_ms=CODE_INTERPRETER_DEFAULT_TIMEOUT_MS,
+                )
+            except Exception as e:
+                logger.error("Bash execution failed: %s", e)
+                error_msg = str(e)
+                error_result = LlmBashExecutionResult(
+                    stdout="",
+                    stderr=error_msg,
+                    exit_code=-1,
+                    timed_out=False,
+                    error=error_msg,
+                )
+                self.emitter.emit(
+                    Packet(
+                        placement=placement,
+                        obj=BashToolDelta(
+                            stdout="",
+                            stderr=error_msg,
+                            exit_code=-1,
+                            timed_out=False,
+                        ),
+                    ),
+                )
+                return ToolResponse(
+                    rich_response=None,
+                    llm_facing_response=adapter.dump_json(error_result).decode(),
+                )
+
+        truncated_stdout = _truncate_output(
+            response.stdout, CODE_INTERPRETER_MAX_OUTPUT_LENGTH, "stdout"
+        )
+        truncated_stderr = _truncate_output(
+            response.stderr, CODE_INTERPRETER_MAX_OUTPUT_LENGTH, "stderr"
+        )
+
+        result = LlmBashExecutionResult(
+            stdout=truncated_stdout,
+            stderr=truncated_stderr,
+            exit_code=response.exit_code,
+            timed_out=response.timed_out,
+            error=(None if response.exit_code == 0 else truncated_stderr),
+        )
+
+        self.emitter.emit(
+            Packet(
+                placement=placement,
+                obj=BashToolDelta(
+                    stdout=truncated_stdout,
+                    stderr=truncated_stderr,
+                    exit_code=response.exit_code,
+                    timed_out=response.timed_out,
+                ),
+            ),
+        )
+
+        return ToolResponse(
+            rich_response=None,
+            llm_facing_response=adapter.dump_json(result).decode(),
+        )
+
+    @classmethod
+    @override
+    def should_emit_argument_deltas(cls) -> bool:
+        return True

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -40,32 +40,12 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
     StreamResultEvent,
 )
+from onyx.tools.tool_implementations.utils import truncate_output as _truncate_output
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 CODE_FIELD = "code"
-
-
-def _truncate_output(output: str, max_length: int, label: str = "output") -> str:
-    """
-    Truncate output string to max_length and append truncation message if needed.
-
-    Args:
-        output: The original output string to truncate
-        max_length: Maximum length before truncation
-        label: Label for logging (e.g., "stdout", "stderr")
-
-    Returns:
-        Truncated string with truncation message appended if truncated
-    """
-    truncated = output[:max_length]
-    if len(output) > max_length:
-        truncated += (
-            f"\n... [output truncated, {len(output) - max_length} characters omitted]"
-        )
-        logger.debug("Truncated %s: %s", label, truncated)
-    return truncated
 
 
 class PythonTool(Tool[PythonToolOverrideKwargs]):

--- a/backend/onyx/tools/tool_implementations/utils.py
+++ b/backend/onyx/tools/tool_implementations/utils.py
@@ -2,6 +2,21 @@ import json
 
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.utils import sandbox_filename_for_document
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def truncate_output(output: str, max_length: int, label: str = "output") -> str:
+    """Truncate to ``max_length`` and append a footer noting how many chars were elided. ``label`` is only used in the debug log."""
+    truncated = output[:max_length]
+    if len(output) > max_length:
+        truncated += (
+            f"\n... [output truncated, {len(output) - max_length} characters omitted]"
+        )
+        logger.debug("Truncated %s: %s", label, truncated)
+    return truncated
+
 
 FILE_ASSOCIATED_GUIDANCE = (
     "Only a short excerpt from this document is shown below. The complete "

--- a/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
@@ -1,0 +1,447 @@
+"""Unit tests for BashTool.
+
+Covers:
+- Happy path: response shape, emitted start + delta packets.
+- Missing required ``cmd`` parameter raises ToolCallException.
+- Exception during execute is caught and surfaces as an error result + delta.
+- stdout/stderr are truncated at CODE_INTERPRETER_MAX_OUTPUT_LENGTH.
+- Non-zero exit code populates the result's ``error`` field.
+- Tool definition exposes the expected schema.
+- Properties return the values set in __init__.
+- ``is_available`` correctly gates on env / DB / health / supports().
+"""
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.app_configs import CODE_INTERPRETER_DEFAULT_TIMEOUT_MS
+from onyx.configs.app_configs import CODE_INTERPRETER_MAX_OUTPUT_LENGTH
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import BashToolDelta
+from onyx.server.query_and_chat.streaming_models import BashToolStart
+from onyx.tools.models import ToolCallException
+from onyx.tools.tool_implementations.bash.bash_tool import BashTool
+from onyx.tools.tool_implementations.bash.bash_tool import BashToolOverrideKwargs
+from onyx.tools.tool_implementations.bash.bash_tool import CMD_FIELD
+from onyx.tools.tool_implementations.python.code_interpreter_client import (
+    BashExecResponse,
+)
+
+TOOL_MODULE = "onyx.tools.tool_implementations.bash.bash_tool"
+
+
+def _make_response(
+    stdout: str = "",
+    stderr: str = "",
+    exit_code: int | None = 0,
+    timed_out: bool = False,
+    duration_ms: int = 10,
+) -> BashExecResponse:
+    return BashExecResponse(
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=exit_code,
+        timed_out=timed_out,
+        duration_ms=duration_ms,
+    )
+
+
+def _make_tool() -> tuple[BashTool, MagicMock]:
+    emitter = MagicMock()
+    tool = BashTool(tool_id=42, session_id="session-abc", emitter=emitter)
+    return tool, emitter
+
+
+def _patched_client(client: MagicMock) -> MagicMock:
+    """Wrap a MagicMock as a context manager and patch CodeInterpreterClient."""
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=client)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def _placement() -> Placement:
+    return Placement(turn_index=0, tab_index=0)
+
+
+# ---------------------------------------------------------------------------
+# Properties + tool definition
+# ---------------------------------------------------------------------------
+
+
+def test_properties_match_constructor_args() -> None:
+    tool, _ = _make_tool()
+    assert tool.id == 42
+    assert tool.name == "bash"
+    assert tool.display_name == "Bash"
+    assert tool.session_id == "session-abc"
+    assert tool.description  # non-empty
+
+
+def test_tool_definition_shape() -> None:
+    tool, _ = _make_tool()
+    definition = tool.tool_definition()
+
+    assert definition["type"] == "function"
+    fn = definition["function"]
+    assert fn["name"] == "bash"
+    params = fn["parameters"]
+    assert params["type"] == "object"
+    assert CMD_FIELD in params["properties"]
+    assert params["properties"][CMD_FIELD]["type"] == "string"
+    assert params["required"] == [CMD_FIELD]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_returns_serialized_result_and_emits_packets() -> None:
+    tool, emitter = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout="hello\n", stderr="", exit_code=0
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="echo hello",
+        )
+
+    # Client called with the right args
+    client.execute_bash_in_session.assert_called_once_with(
+        session_id="session-abc",
+        cmd="echo hello",
+        timeout_ms=CODE_INTERPRETER_DEFAULT_TIMEOUT_MS,
+    )
+
+    # Response shape
+    payload = json.loads(response.llm_facing_response)
+    assert payload["stdout"] == "hello\n"
+    assert payload["stderr"] == ""
+    assert payload["exit_code"] == 0
+    assert payload["timed_out"] is False
+    assert payload["error"] is None  # exit_code == 0
+    assert response.rich_response is None
+
+    # Two packets emitted: start (with cmd) then delta (with stdout/stderr)
+    assert emitter.emit.call_count == 2
+    start_packet = emitter.emit.call_args_list[0].args[0]
+    delta_packet = emitter.emit.call_args_list[1].args[0]
+    assert isinstance(start_packet.obj, BashToolStart)
+    assert start_packet.obj.cmd == "echo hello"
+    assert isinstance(delta_packet.obj, BashToolDelta)
+    assert delta_packet.obj.stdout == "hello\n"
+    assert delta_packet.obj.exit_code == 0
+    assert delta_packet.obj.timed_out is False
+
+
+# ---------------------------------------------------------------------------
+# Missing cmd parameter
+# ---------------------------------------------------------------------------
+
+
+def test_missing_cmd_raises_tool_call_exception() -> None:
+    tool, emitter = _make_tool()
+
+    with pytest.raises(ToolCallException) as excinfo:
+        tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+        )
+
+    # Internal message + llm-facing message both present and mention the field
+    assert CMD_FIELD in str(excinfo.value)
+    assert CMD_FIELD in excinfo.value.llm_facing_message
+
+    # Nothing should have been emitted before the exception
+    emitter.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exception during execute is caught and surfaced
+# ---------------------------------------------------------------------------
+
+
+def test_client_exception_returns_error_result_and_emits_error_delta() -> None:
+    tool, emitter = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.side_effect = RuntimeError("connection refused")
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="ls",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert payload["stdout"] == ""
+    assert "connection refused" in payload["stderr"]
+    assert payload["exit_code"] == -1
+    assert payload["timed_out"] is False
+    assert "connection refused" in payload["error"]
+
+    # Start + error-delta both emitted (still two packets)
+    assert emitter.emit.call_count == 2
+    delta_packet = emitter.emit.call_args_list[1].args[0]
+    assert isinstance(delta_packet.obj, BashToolDelta)
+    assert delta_packet.obj.exit_code == -1
+    assert "connection refused" in delta_packet.obj.stderr
+
+
+# ---------------------------------------------------------------------------
+# Output truncation
+# ---------------------------------------------------------------------------
+
+
+def test_long_stdout_is_truncated() -> None:
+    tool, _ = _make_tool()
+    client = MagicMock()
+    long_output = "x" * (CODE_INTERPRETER_MAX_OUTPUT_LENGTH + 5_000)
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout=long_output, stderr="", exit_code=0
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="cat huge.txt",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert "[output truncated" in payload["stdout"]
+    # Truncated to MAX + truncation footer; should be much shorter than original
+    assert len(payload["stdout"]) < len(long_output)
+
+
+def test_short_stdout_is_not_truncated() -> None:
+    tool, _ = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout="short", stderr="", exit_code=0
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="echo short",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert payload["stdout"] == "short"
+    assert "[output truncated" not in payload["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# Non-zero exit code populates error field
+# ---------------------------------------------------------------------------
+
+
+def test_nonzero_exit_code_sets_error_field_to_stderr() -> None:
+    tool, _ = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout="", stderr="cat: missing.txt: No such file", exit_code=1
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="cat missing.txt",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert payload["exit_code"] == 1
+    assert payload["error"] == "cat: missing.txt: No such file"
+    assert payload["stderr"] == "cat: missing.txt: No such file"
+
+
+def test_zero_exit_code_with_stderr_does_not_set_error() -> None:
+    """A command can write to stderr while still exiting cleanly (e.g. progress
+    bars). We only treat it as an error when exit_code != 0."""
+    tool, _ = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout="ok", stderr="warning: deprecated", exit_code=0
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="legacy-cmd",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert payload["exit_code"] == 0
+    assert payload["stderr"] == "warning: deprecated"
+    assert payload["error"] is None
+
+
+# ---------------------------------------------------------------------------
+# emit_start is a deliberate no-op
+# ---------------------------------------------------------------------------
+
+
+def test_emit_start_is_a_noop() -> None:
+    tool, emitter = _make_tool()
+    tool.emit_start(_placement())
+    emitter.emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Timed-out command surfaces as timed_out=True
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# is_available — gates on env, DB, health, and capability/supports check
+# ---------------------------------------------------------------------------
+
+
+def _make_db_session() -> MagicMock:
+    """Build a MagicMock db_session. The session itself is opaque —
+    ``fetch_code_interpreter_server`` is patched, so only that mock's
+    return value matters for is_available tests."""
+    return MagicMock()
+
+
+@contextmanager
+def _is_available_env(
+    *,
+    base_url: str = "http://fake:8000",
+    server_enabled: bool = True,
+    healthy: bool = True,
+    server_version: str = "1.0.0",
+    supports_return: bool = True,
+) -> Iterator[MagicMock]:
+    """Patch the four moving parts ``BashTool.is_available`` consults
+    (``CODE_INTERPRETER_BASE_URL``, ``fetch_code_interpreter_server``, the
+    ``CodeInterpreterClient`` class, and the client's ``health`` /
+    ``supports`` return values), yielding the inner mock client so tests
+    can assert on which methods were called.
+    """
+    from onyx.tools.tool_implementations.python.code_interpreter_client import (
+        HealthResponse,
+    )
+
+    with (
+        patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", base_url),
+        patch(f"{TOOL_MODULE}.fetch_code_interpreter_server") as mock_fetch,
+        patch(f"{TOOL_MODULE}.CodeInterpreterClient") as mock_client_cls,
+    ):
+        mock_server = MagicMock()
+        mock_server.server_enabled = server_enabled
+        mock_fetch.return_value = mock_server
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = HealthResponse(
+            healthy=healthy, version=server_version
+        )
+        mock_client.supports.return_value = supports_return
+
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        yield mock_client
+
+
+def test_is_available_true_when_all_checks_pass() -> None:
+    with _is_available_env(
+        healthy=True, server_version="0.4.0", supports_return=True
+    ) as mock_client:
+        assert BashTool.is_available(_make_db_session()) is True
+        # supports() should have been called once with the three session
+        # methods BashTool transitively depends on. The method identities
+        # come from the patched CodeInterpreterClient (so they're child
+        # mocks at runtime); assert by name rather than by identity.
+        mock_client.supports.assert_called_once()
+        called_args, _ = mock_client.supports.call_args
+        called_names = {getattr(arg, "_mock_name", "") for arg in called_args}
+        assert called_names == {
+            "create_session",
+            "execute_bash_in_session",
+            "delete_session",
+        }
+
+
+def test_is_available_false_when_base_url_missing() -> None:
+    with _is_available_env(base_url="") as mock_client:
+        assert BashTool.is_available(_make_db_session()) is False
+        # Short-circuit: never even hit the DB or the client
+        mock_client.health.assert_not_called()
+        mock_client.supports.assert_not_called()
+
+
+def test_is_available_false_when_server_disabled_in_db() -> None:
+    with _is_available_env(server_enabled=False) as mock_client:
+        assert BashTool.is_available(_make_db_session()) is False
+        # Short-circuit before the network probe
+        mock_client.health.assert_not_called()
+        mock_client.supports.assert_not_called()
+
+
+def test_is_available_false_when_unhealthy() -> None:
+    with _is_available_env(healthy=False) as mock_client:
+        assert BashTool.is_available(_make_db_session()) is False
+        # Short-circuit before the version-gate probe
+        mock_client.supports.assert_not_called()
+
+
+def test_is_available_false_when_server_too_old() -> None:
+    """Healthy + reachable but the deployed code-interpreter version doesn't
+    expose the session/bash routes that BashTool depends on."""
+    with _is_available_env(
+        healthy=True, server_version="0.3.9", supports_return=False
+    ) as mock_client:
+        assert BashTool.is_available(_make_db_session()) is False
+        # supports() must have been called — that's how we detected the gap
+        mock_client.supports.assert_called_once()
+
+
+def test_timed_out_response_is_propagated() -> None:
+    tool, emitter = _make_tool()
+    client = MagicMock()
+    client.execute_bash_in_session.return_value = _make_response(
+        stdout="partial", stderr="", exit_code=None, timed_out=True
+    )
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient", return_value=_patched_client(client)
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="sleep 99999",
+        )
+
+    payload = json.loads(response.llm_facing_response)
+    assert payload["timed_out"] is True
+    assert payload["exit_code"] is None
+    delta_packet = emitter.emit.call_args_list[1].args[0]
+    assert isinstance(delta_packet.obj, BashToolDelta)
+    assert delta_packet.obj.timed_out is True

--- a/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
@@ -202,6 +202,38 @@ def test_client_exception_returns_error_result_and_emits_error_delta() -> None:
     assert "connection refused" in delta_packet.obj.stderr
 
 
+def test_client_constructor_failure_still_emits_closing_delta() -> None:
+    """Regression: a ``CodeInterpreterClient()`` constructor failure (e.g.
+    ``CODE_INTERPRETER_BASE_URL`` unset, raising ``ValueError`` in __init__)
+    must NOT escape past the try/except. Without the fix, ``BashToolStart``
+    would already be on the wire and no closing ``BashToolDelta`` would
+    follow — leaving the frontend timeline stuck."""
+    tool, emitter = _make_tool()
+
+    with patch(
+        f"{TOOL_MODULE}.CodeInterpreterClient",
+        side_effect=ValueError("CODE_INTERPRETER_BASE_URL not configured"),
+    ):
+        response = tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd="ls",
+        )
+
+    # Error path: error result returned, no exception bubbled out
+    payload = json.loads(response.llm_facing_response)
+    assert payload["exit_code"] == -1
+    assert "CODE_INTERPRETER_BASE_URL" in payload["error"]
+
+    # Critically: both Start AND closing Delta were emitted, in that order
+    assert emitter.emit.call_count == 2
+    start_packet = emitter.emit.call_args_list[0].args[0]
+    delta_packet = emitter.emit.call_args_list[1].args[0]
+    assert isinstance(start_packet.obj, BashToolStart)
+    assert isinstance(delta_packet.obj, BashToolDelta)
+    assert delta_packet.obj.exit_code == -1
+
+
 # ---------------------------------------------------------------------------
 # Output truncation
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
@@ -168,6 +168,40 @@ def test_missing_cmd_raises_tool_call_exception() -> None:
     emitter.emit.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "bad_cmd",
+    [
+        None,
+        42,
+        ["ls", "-la"],
+        {"cmd": "ls"},
+        b"ls -la",
+    ],
+)
+def test_non_string_cmd_raises_tool_call_exception(bad_cmd: object) -> None:
+    """Regression: ``cast(str, ...)`` is a no-op at runtime, so a non-string
+    ``cmd`` from the LLM (e.g. a list, None, an int) used to flow through
+    and surface as either an opaque Pydantic validation error (from
+    ``BashToolStart``) or a 422 from the upstream service. We now fail fast
+    with a clear ``ToolCallException`` before any packet is emitted."""
+    tool, emitter = _make_tool()
+
+    with pytest.raises(ToolCallException) as excinfo:
+        tool.run(
+            placement=_placement(),
+            override_kwargs=BashToolOverrideKwargs(),
+            cmd=bad_cmd,
+        )
+
+    # llm-facing message names the field and the actual type so the model
+    # can self-correct on the next try
+    assert CMD_FIELD in excinfo.value.llm_facing_message
+    assert type(bad_cmd).__name__ in excinfo.value.llm_facing_message
+
+    # No packets emitted — failure is at validation, before BashToolStart
+    emitter.emit.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Exception during execute is caught and surfaced
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
@@ -20,9 +20,6 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
     BashExecResponse,
 )
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
-    BashExecResponse,
-)
-from onyx.tools.tool_implementations.python.code_interpreter_client import (
     CodeInterpreterClient,
 )
 from onyx.tools.tool_implementations.python.code_interpreter_client import (

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_code_interpreter_client.py
@@ -20,6 +20,9 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
     BashExecResponse,
 )
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
+    BashExecResponse,
+)
+from onyx.tools.tool_implementations.python.code_interpreter_client import (
     CodeInterpreterClient,
 )
 from onyx.tools.tool_implementations.python.code_interpreter_client import (


### PR DESCRIPTION
## Description
This PR adds a bash tool. The implementation is reliant on the code-interpreter server

## How Has This Been Tested?
Unit + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `bash` tool that runs shell commands in an isolated code-interpreter session with start/delta streaming and shared output truncation. Also adds new streaming packet types and updates the `python` tool to reuse truncation.

- **New Features**
  - New `bash` tool runs commands in a network-restricted, per-session filesystem.
  - Streams `bash_tool_start` (cmd) and `bash_tool_delta` (stdout, stderr, exit_code, timed_out); emits a final delta even on errors.
  - Validates and type-checks `cmd`; raises `ToolCallException` when missing or not a string; non-zero exits set `error`.
  - Centralized `truncate_output` in `utils`, reused by both `bash` and `python`.
  - Availability gated by interpreter health and capabilities via `CodeInterpreterClient.supports()`.

- **Migration**
  - Requires code-interpreter server >= `0.4.0` (session/bash routes); otherwise the tool stays unavailable.
  - Streaming consumers must handle `bash_tool_start` and `bash_tool_delta`.

<sup>Written for commit ecf5f1e31fb4029a88635c61ba5a3afbb8248111. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

