### PR TITLE
fix: confluence data center websudo (#10853) to release v3.3

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -26,6 +26,7 @@ from typing import TypeVar
 from urllib.parse import quote
 
 import bs4
+import requests
 from atlassian import Confluence
 from redis import Redis
 from requests import HTTPError
@@ -42,6 +43,7 @@ from onyx.connectors.confluence.utils import confluence_refresh_tokens
 from onyx.connectors.confluence.utils import get_start_param_from_url
 from onyx.connectors.confluence.utils import update_param_in_path
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import scoped_url
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import CredentialsProviderInterface
 from onyx.file_processing.html_utils import format_document_soup
 from onyx.redis.redis_pool import get_redis_client
@@ -67,6 +69,19 @@ _SERVER_ERROR_CODES = {500, 502, 503, 504}
 
 _CONFLUENCE_SPACES_API_V1 = "rest/api/space"
 _CONFLUENCE_SPACES_API_V2 = "wiki/api/v2/spaces"
+
+# Atlassian KB documenting how Secure Administrator Sessions (WebSudo) breaks
+# admin JSON-RPC calls. Surfaced in the validation error so admins can act on
+# it without our help.
+_WEBSUDO_KB_URL = (
+    "https://support.atlassian.com/confluence/kb/"
+    "json-rpc-api-request-returns-websudorequiredexception-on-confluence/"
+)
+# Cap how much of an unparseable JSON-RPC response body we put in the error
+# message. WebSudo / login HTML pages are well under this; the cap is a
+# defense against a runaway response (e.g. a multi-MB error page) ending up
+# in our logs and validation surface.
+_JSONRPC_ERROR_BODY_SNIPPET_CHARS = 1000
 
 
 class ConfluenceRateLimitError(Exception):
@@ -923,16 +938,35 @@ class OnyxConfluence:
         space_key: str,
     ) -> list[dict[str, Any]]:
         """
-        This is a confluence server/data center specific method that can be used to
-        fetch the permissions of a space.
+        Fetches a space's permissions via the legacy JSON-RPC API.
 
-        NOTE: This uses the JSON-RPC API which is the ONLY way to get space permissions
-        on Confluence Server/Data Center. The REST API equivalent (expand=permissions)
-        is Cloud-only and not available on Data Center as of version 8.9.x.
+        This is the only space-permissions API available on Confluence Data
+        Center < 9.1.0. DC 9.1.0+ ships a proper REST API at
+        /rest/api/space/{spaceKey}/permissions (CONFSERVER-78176) which is
+        preferred wherever available; this method is the fallback for older
+        Server / Data Center deployments.
 
-        If this fails with 401 Unauthorized, the customer needs to enable JSON-RPC:
-        Confluence Admin -> General Configuration -> Further Configuration
-        -> Enable "Remote API (XML-RPC & SOAP)"
+        Failure modes handled here:
+
+        - HTTP 401: the JSON-RPC plugin is disabled. Confluence Admin ->
+          General Configuration -> Further Configuration -> Enable
+          "Remote API (XML-RPC & SOAP)".
+        - HTTP 200 with a non-JSON body (Confluence 7.7+): "Secure
+          Administrator Sessions" / WebSudo is intercepting admin JSON-RPC
+          calls and serving the login HTML or a WebSudoRequiredException
+          page instead of a JSON-RPC envelope. We surface the actual HTTP
+          status, Content-Type, and a body snippet so the admin can confirm
+          which of the documented failure modes they're hitting (rather
+          than guessing) and act on it.
+
+        We use atlassian-python-api's `advanced_mode=True` to get the raw
+        requests.Response back. Without it, the library's _response_handler
+        catches the JSON parse error and silently coerces the body to None,
+        which throws away every signal we'd need to debug the failure.
+        Trade-off: the library no longer raises HTTPError on 4xx/5xx in
+        advanced mode, so this call no longer benefits from the
+        __getattr__ wrapper's retry-on-5xx; we call raise_for_status
+        ourselves to preserve the "blow up on server error" behavior.
         """
         url = "rpc/json-rpc/confluenceservice-v2"
         data = {
@@ -941,25 +975,47 @@ class OnyxConfluence:
             "id": 7,
             "params": [space_key],
         }
+        response: requests.Response = self.post(url, data=data, advanced_mode=True)
+
+        if response.status_code == 401:
+            raise HTTPError(
+                "Unauthorized (401) when calling JSON-RPC API for space permissions. "
+                "This is likely because the Remote API is disabled. "
+                "To fix: Confluence Admin -> General Configuration -> Further Configuration "
+                "-> Enable 'Remote API (XML-RPC & SOAP)'",
+                response=response,
+            )
+        response.raise_for_status()
+
         try:
-            response = self.post(url, data=data)
-        except HTTPError as e:
-            if e.response is not None and e.response.status_code == 401:
-                raise HTTPError(
-                    "Unauthorized (401) when calling JSON-RPC API for space permissions. "
-                    "This is likely because the Remote API is disabled. "
-                    "To fix: Confluence Admin -> General Configuration -> Further Configuration "
-                    "-> Enable 'Remote API (XML-RPC & SOAP)'",
-                    response=e.response,
-                ) from e
-            raise
-        logger.debug(f"jsonrpc response: {response}")
-        if not response.get("result"):
-            logger.warning(
-                f"No jsonrpc response for space permissions for space {space_key}\nResponse: {response}"
+            payload = response.json()
+        except ValueError:
+            content_type = response.headers.get("Content-Type", "<unset>")
+            body_snippet = response.text[:_JSONRPC_ERROR_BODY_SNIPPET_CHARS]
+            raise ConnectorValidationError(
+                f"Confluence JSON-RPC returned a non-JSON response for space "
+                f"'{space_key}' (HTTP {response.status_code}, "
+                f"Content-Type={content_type}). This typically happens on "
+                "Confluence Server / Data Center 7.7+ when 'Secure "
+                "Administrator Sessions' (WebSudo) intercepts admin JSON-RPC "
+                "calls. To fix, either (1) disable Secure Administrator "
+                "Sessions in General Configuration -> Security Configuration, "
+                "or (2) upgrade to Confluence Data Center 9.1+ where the REST "
+                f"space-permissions API replaces JSON-RPC. See "
+                f"{_WEBSUDO_KB_URL}\n"
+                f"Response body (first {_JSONRPC_ERROR_BODY_SNIPPET_CHARS} "
+                f"chars): {body_snippet!r}"
             )
 
-        return response.get("result", [])
+        logger.debug("jsonrpc response: %s", payload)
+        if not payload.get("result"):
+            logger.warning(
+                "No jsonrpc response for space permissions for space %s\nResponse: %s",
+                space_key,
+                payload,
+            )
+
+        return payload.get("result", [])
 
     def get_current_user(self, expand: str | None = None) -> Any:
         """

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -9,6 +9,7 @@ from requests import HTTPError
 from onyx.connectors.confluence.onyx_confluence import _DEFAULT_PAGINATION_LIMIT
 from onyx.connectors.confluence.onyx_confluence import _MINIMUM_PAGINATION_LIMIT
 from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import CredentialsProviderInterface
 
 
@@ -1009,3 +1010,66 @@ def test_paginate_url_504_halves_multiple_times(
     assert "limit=20" in mock_get_call_paths[1]
     assert "limit=10" in mock_get_call_paths[2]
     assert "limit=5" in mock_get_call_paths[3]
+
+
+def test_jsonrpc_websudo_html_response_raises_validation_error(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """
+    Regression test for the production failure on cc_pair=44 / cc_pair=50
+    against Confluence DC 10.2.10.
+
+    When 'Secure Administrator Sessions' (WebSudo) intercepts a JSON-RPC
+    call, the response body is HTML (login page / WebSudoRequiredException)
+    rather than a JSON-RPC envelope. atlassian-python-api's _response_handler
+    swallows the ValueError from response.json() and returns None, and the
+    pre-fix implementation then did `response.get("result")` and blew up
+    with `AttributeError: 'NoneType' object has no attribute 'get'` --
+    leaking up through permission sync as an unactionable error.
+
+    After the fix, this surfaces as a ConnectorValidationError that:
+      - Names the WebSudo failure mode and points at the Atlassian KB.
+      - Includes the actual HTTP status, Content-Type, and body snippet so
+        the admin can confirm WebSudo (rather than guessing) and act on it.
+    """
+    websudo_html = (
+        "<!DOCTYPE html>\n"
+        "<html><head><title>Confluence</title></head>\n"
+        "<body><h1>WebSudoRequiredException</h1>"
+        "<p>You need to confirm your password to access this resource. "
+        "(Secure Administrator Sessions are enabled.)</p></body></html>"
+    )
+    fake_response = requests.Response()
+    fake_response.status_code = 200
+    fake_response.url = "http://fake-confluence.com/rpc/json-rpc/confluenceservice-v2"
+    fake_response.headers["Content-Type"] = "text/html;charset=UTF-8"
+    fake_response._content = websudo_html.encode("utf-8")
+
+    post_mock = mock.Mock(return_value=fake_response)
+    confluence_server_client._confluence.post = (  # ty: ignore[invalid-assignment]
+        post_mock
+    )
+
+    with pytest.raises(ConnectorValidationError) as exc_info:
+        confluence_server_client.get_all_space_permissions_server(space_key="TST")
+
+    # Verify atlassian-python-api was invoked in advanced mode -- otherwise
+    # the library swallows the parse failure and we lose the response body.
+    _, kwargs = post_mock.call_args
+    assert kwargs.get("advanced_mode") is True
+
+    msg = str(exc_info.value)
+    # Names the failure mode in language a Confluence admin will recognize.
+    assert "Secure Administrator Sessions" in msg
+    # Includes the bad space key so it correlates with sync logs.
+    assert "TST" in msg
+    # Includes the canonical Atlassian KB so the admin can act without us.
+    assert "support.atlassian.com" in msg
+    # Includes the actual HTTP status and Content-Type from the upstream
+    # response, so a developer reading the error doesn't have to guess.
+    assert "HTTP 200" in msg
+    assert "text/html" in msg
+    # And critically, surfaces the actual body so we can confirm that what
+    # we're looking at really is WebSudo (vs e.g. a reverse-proxy error
+    # page that happens to also be HTML).
+    assert "WebSudoRequiredException" in msg


### PR DESCRIPTION
Cherry-pick of commit 54b9be9909d1504a1b34c31b119a828512bd669f to release/v3.3 branch.

Original PR: #10853

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Confluence Data Center space-permissions sync when WebSudo intercepts JSON-RPC calls. We now surface a clear, actionable error instead of crashing.

- **Bug Fixes**
  - Detect non-JSON JSON-RPC responses caused by WebSudo and raise `ConnectorValidationError` with HTTP status, Content-Type, a capped body snippet, and a link to the Atlassian KB.
  - Use `advanced_mode=True` in `atlassian-python-api` to access the raw `requests` response and call `raise_for_status()` to preserve 5xx handling.
  - Keep explicit 401 handling for disabled Remote API and add a unit test covering the WebSudo HTML response.

<sup>Written for commit 5fdc640c7987e4c94c4059f25b0b9864d727bf34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

