### PR TITLE
feat(github): Download github util function

### DIFF
--- a/backend/onyx/utils/github.py
+++ b/backend/onyx/utils/github.py
@@ -1,0 +1,87 @@
+import re
+
+import requests
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+GITHUB_TARBALL_URL = "https://api.github.com/repos/{owner}/{repo}/tarball"
+GITHUB_DOWNLOAD_CONNECT_TIMEOUT_SECONDS = 30
+GITHUB_DOWNLOAD_READ_TIMEOUT_SECONDS = 300
+GITHUB_DOWNLOAD_CHUNK_SIZE_BYTES = 1024 * 1024  # 1 MiB
+DEFAULT_MAX_TARBALL_SIZE_BYTES = 500 * 1024 * 1024  # 500 MiB
+
+
+def parse_github_repo(repo: str) -> tuple[str, str]:
+    """Parse a GitHub repo identifier into (owner, name).
+
+    Accepts forms:
+        - https://github.com/owner/repo[.git][/...]
+        - http://github.com/owner/repo[.git]
+        - git@github.com:owner/repo[.git]
+        - owner/repo
+    """
+    repo = repo.strip()
+
+    https_match = re.match(
+        r"^https?://github\.com/([^/]+)/([^/?#\s]+?)(?:\.git)?(?:[/?#].*)?$", repo
+    )
+    if https_match:
+        return https_match.group(1), https_match.group(2)
+
+    ssh_match = re.match(r"^git@github\.com:([^/]+)/([^/\s]+?)(?:\.git)?$", repo)
+    if ssh_match:
+        return ssh_match.group(1), ssh_match.group(2)
+
+    short_match = re.match(r"^([^/\s]+)/([^/\s]+?)(?:\.git)?$", repo)
+    if short_match:
+        return short_match.group(1), short_match.group(2)
+
+    raise ValueError(f"Could not parse GitHub repo identifier: {repo!r}")
+
+
+def download_github_repo(
+    repo: str,
+    github_token: str | None = None,
+    max_size_bytes: int = DEFAULT_MAX_TARBALL_SIZE_BYTES,
+) -> bytes:
+    """Download a GitHub repo as a gzipped tarball of its default branch.
+
+    ``repo`` accepts any form supported by :func:`parse_github_repo`. The
+    response body is streamed and aborted with ``ValueError`` once it exceeds
+    ``max_size_bytes`` so a runaway repo cannot exhaust memory.
+    """
+    owner, name = parse_github_repo(repo)
+    url = GITHUB_TARBALL_URL.format(owner=owner, repo=name)
+    headers = {"Accept": "application/vnd.github+json"}
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    logger.info("Downloading GitHub tarball: %s/%s", owner, name)
+    with requests.get(
+        url,
+        headers=headers,
+        timeout=(
+            GITHUB_DOWNLOAD_CONNECT_TIMEOUT_SECONDS,
+            GITHUB_DOWNLOAD_READ_TIMEOUT_SECONDS,
+        ),
+        allow_redirects=True,
+        stream=True,
+    ) as response:
+        response.raise_for_status()
+
+        chunks: list[bytes] = []
+        total_bytes = 0
+        for chunk in response.iter_content(chunk_size=GITHUB_DOWNLOAD_CHUNK_SIZE_BYTES):
+            if not chunk:
+                continue
+            total_bytes += len(chunk)
+            if total_bytes > max_size_bytes:
+                raise ValueError(
+                    f"GitHub tarball for {owner}/{name} exceeded "
+                    f"max_size_bytes={max_size_bytes}"
+                )
+            chunks.append(chunk)
+
+    return b"".join(chunks)

--- a/backend/tests/unit/onyx/utils/test_github.py
+++ b/backend/tests/unit/onyx/utils/test_github.py
@@ -1,0 +1,178 @@
+"""Unit tests for onyx.utils.github."""
+
+from collections.abc import Iterable
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from onyx.utils.github import download_github_repo
+from onyx.utils.github import GITHUB_TARBALL_URL
+from onyx.utils.github import parse_github_repo
+
+
+class TestParseGithubRepo:
+    def test_https_plain(self) -> None:
+        assert parse_github_repo("https://github.com/onyx-dot-app/onyx") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_https_with_dot_git(self) -> None:
+        assert parse_github_repo("https://github.com/onyx-dot-app/onyx.git") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_https_with_trailing_path(self) -> None:
+        assert parse_github_repo(
+            "https://github.com/onyx-dot-app/onyx/tree/main/backend"
+        ) == ("onyx-dot-app", "onyx")
+
+    def test_https_with_query_and_fragment(self) -> None:
+        assert parse_github_repo("https://github.com/onyx-dot-app/onyx?foo=bar") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+        assert parse_github_repo("https://github.com/onyx-dot-app/onyx#readme") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_http_scheme(self) -> None:
+        assert parse_github_repo("http://github.com/onyx-dot-app/onyx") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_ssh_plain(self) -> None:
+        assert parse_github_repo("git@github.com:onyx-dot-app/onyx") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_ssh_with_dot_git(self) -> None:
+        assert parse_github_repo("git@github.com:onyx-dot-app/onyx.git") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_short_form(self) -> None:
+        assert parse_github_repo("onyx-dot-app/onyx") == ("onyx-dot-app", "onyx")
+
+    def test_short_form_with_dot_git(self) -> None:
+        assert parse_github_repo("onyx-dot-app/onyx.git") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    def test_strips_whitespace(self) -> None:
+        assert parse_github_repo("  onyx-dot-app/onyx  ") == (
+            "onyx-dot-app",
+            "onyx",
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "   ",
+            "not a repo",
+            "https://gitlab.com/owner/repo",
+            "https://github.com/onlyowner",
+            "owner/",
+            "/repo",
+        ],
+    )
+    def test_invalid_raises(self, bad: str) -> None:
+        with pytest.raises(ValueError):
+            parse_github_repo(bad)
+
+
+def _mock_response(chunks: Iterable[bytes], status_code: int = 200) -> MagicMock:
+    """Build a MagicMock that quacks like a streamed ``requests.Response``."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.iter_content.return_value = iter(list(chunks))
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"HTTP {status_code}"
+        )
+    else:
+        response.raise_for_status.return_value = None
+    response.__enter__.return_value = response
+    response.__exit__.return_value = False
+    return response
+
+
+class TestDownloadGithubRepo:
+    def test_returns_concatenated_body(self) -> None:
+        response = _mock_response([b"foo", b"bar", b"baz"])
+        with patch("onyx.utils.github.requests.get", return_value=response) as mock_get:
+            result = download_github_repo("onyx-dot-app/onyx")
+
+        assert result == b"foobarbaz"
+        mock_get.assert_called_once()
+
+    def test_skips_empty_keepalive_chunks(self) -> None:
+        response = _mock_response([b"foo", b"", b"bar"])
+        with patch("onyx.utils.github.requests.get", return_value=response):
+            assert download_github_repo("onyx-dot-app/onyx") == b"foobar"
+
+    def test_builds_tarball_url_from_owner_and_name(self) -> None:
+        response = _mock_response([b""])
+        with patch("onyx.utils.github.requests.get", return_value=response) as mock_get:
+            download_github_repo("https://github.com/onyx-dot-app/onyx.git")
+
+        called_url = mock_get.call_args.args[0]
+        assert called_url == GITHUB_TARBALL_URL.format(
+            owner="onyx-dot-app", repo="onyx"
+        )
+
+    def test_sets_authorization_header_when_token_provided(self) -> None:
+        response = _mock_response([b""])
+        with patch("onyx.utils.github.requests.get", return_value=response) as mock_get:
+            download_github_repo("onyx-dot-app/onyx", github_token="ghp_secret")
+
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer ghp_secret"
+        assert headers["Accept"] == "application/vnd.github+json"
+
+    def test_omits_authorization_header_when_no_token(self) -> None:
+        response = _mock_response([b""])
+        with patch("onyx.utils.github.requests.get", return_value=response) as mock_get:
+            download_github_repo("onyx-dot-app/onyx")
+
+        headers = mock_get.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    def test_uses_streaming_with_split_timeout(self) -> None:
+        response = _mock_response([b""])
+        with patch("onyx.utils.github.requests.get", return_value=response) as mock_get:
+            download_github_repo("onyx-dot-app/onyx")
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["allow_redirects"] is True
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, tuple)
+        assert len(timeout) == 2
+
+    def test_raises_when_exceeds_max_size(self) -> None:
+        response = _mock_response([b"x" * 10, b"x" * 10])
+        with patch("onyx.utils.github.requests.get", return_value=response):
+            with pytest.raises(ValueError, match="exceeded max_size_bytes"):
+                download_github_repo("onyx-dot-app/onyx", max_size_bytes=15)
+
+    def test_propagates_http_errors(self) -> None:
+        response = _mock_response([], status_code=404)
+        with patch("onyx.utils.github.requests.get", return_value=response):
+            with pytest.raises(requests.HTTPError):
+                download_github_repo("onyx-dot-app/onyx")
+
+    def test_invalid_repo_raises_before_request(self) -> None:
+        with patch("onyx.utils.github.requests.get") as mock_get:
+            with pytest.raises(ValueError):
+                download_github_repo("not a repo")
+        mock_get.assert_not_called()


### PR DESCRIPTION
## Description
This PR provides a function that can download github repos. The repo name can be any of these forms:
 - https://github.com/owner/repo[.git][/...]
 - http://github.com/owner/repo[.git]
 - git@github.com:owner/repo[.git]
 - owner/repo

This will be used in the coding agent

## How Has This Been Tested?
Manual + Unit Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `onyx.utils.github` with `download_github_repo` to fetch a repo’s default-branch tarball and `parse_github_repo` to normalize repo identifiers. This powers the coding agent with safe, streamed downloads and a configurable size cap.

- **New Features**
  - Accepts repo forms: https/http URLs, `git@github.com:owner/repo`, and `owner/repo` (with optional `.git` and extra path/query).
  - Streams the tarball with timeouts (30s connect, 300s read) and 1 MiB chunks; aborts if over the max size (default 500 MiB).
  - Optional `github_token` adds `Authorization: Bearer` and sets `Accept: application/vnd.github+json`.
  - Validates repo input before network calls and propagates HTTP errors. Unit tests cover parsing, headers, URL building, streaming, limits, and errors.

<sup>Written for commit cc7d9cce00accc898928bf69981ff47fe5064568. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

