### PR TITLE
feat(users): re-add invite-only toggle

### DIFF
--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -164,6 +164,7 @@ module.exports = {
         "**/src/lib/**/*.test.tsx",
         "**/src/providers/**/*.test.tsx",
         "**/src/refresh-components/**/*.test.tsx",
+        "**/src/refresh-pages/**/*.test.tsx",
         "**/src/hooks/**/*.test.tsx",
         "**/src/sections/**/*.test.tsx",
         // Add more patterns here as you add more integration tests

--- a/web/src/lib/settings/svc.ts
+++ b/web/src/lib/settings/svc.ts
@@ -1,0 +1,24 @@
+import { Settings } from "@/interfaces/settings";
+
+async function parseErrorDetail(
+  res: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const body = await res.json();
+    return body?.detail ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function updateAdminSettings(settings: Settings): Promise<void> {
+  const res = await fetch("/api/admin/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!res.ok) {
+    throw new Error(await parseErrorDetail(res, "Failed to update settings"));
+  }
+}

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render, screen, waitFor, userEvent } from "@tests/setup/test-utils";
+import InviteOnlyCard from "./InviteOnlyCard";
+import { Settings } from "@/interfaces/settings";
+
+const baseSettings: Partial<Settings> = {
+  invite_only_enabled: false,
+};
+
+const mockUseSettingsContext = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+const mockMutate = jest.fn();
+
+jest.mock("@/providers/SettingsProvider", () => ({
+  useSettingsContext: () => mockUseSettingsContext(),
+}));
+
+jest.mock("@/hooks/useToast", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  mutate: (...args: unknown[]) => mockMutate(...args),
+}));
+
+describe("InviteOnlyCard", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, "fetch");
+    mockUseSettingsContext.mockReturnValue({ settings: baseSettings });
+    mockMutate.mockImplementation(async (_key, fn) => {
+      if (typeof fn === "function") return fn();
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  test("renders with copy and reflects current invite_only_enabled state", () => {
+    render(<InviteOnlyCard />);
+    expect(screen.getByText("Restrict Open Sign-Up")).toBeInTheDocument();
+    expect(
+      screen.getByText("New users must be invited to join this workspace.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  test("reflects checked state when invite_only_enabled is true", () => {
+    mockUseSettingsContext.mockReturnValue({
+      settings: { ...baseSettings, invite_only_enabled: true },
+    });
+    render(<InviteOnlyCard />);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("clicking switch PUTs /api/admin/settings with invite_only_enabled toggled", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    const user = userEvent.setup();
+    render(<InviteOnlyCard />);
+
+    await user.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/admin/settings",
+        expect.objectContaining({
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    });
+
+    const callArgs = fetchSpy.mock.calls[0];
+    const body = JSON.parse(callArgs[1].body as string);
+    expect(body.invite_only_enabled).toBe(true);
+    expect(mockToastSuccess).toHaveBeenCalledWith("Settings updated");
+  });
+
+  test("shows error toast when PUT fails", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ detail: "boom" }),
+    } as Response);
+
+    const user = userEvent.setup();
+    render(<InviteOnlyCard />);
+
+    await user.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Failed to update settings");
+    });
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
@@ -11,6 +11,7 @@ const mockUseSettingsContext = jest.fn();
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 const mockMutate = jest.fn();
+const mockUpdateAdminSettings = jest.fn();
 
 jest.mock("@/providers/SettingsProvider", () => ({
   useSettingsContext: () => mockUseSettingsContext(),
@@ -29,11 +30,12 @@ jest.mock("swr", () => ({
   mutate: (...args: unknown[]) => mockMutate(...args),
 }));
 
-describe("InviteOnlyCard", () => {
-  let fetchSpy: jest.SpyInstance;
+jest.mock("@/lib/settings/svc", () => ({
+  updateAdminSettings: (...args: unknown[]) => mockUpdateAdminSettings(...args),
+}));
 
+describe("InviteOnlyCard", () => {
   beforeEach(() => {
-    fetchSpy = jest.spyOn(global, "fetch");
     mockUseSettingsContext.mockReturnValue({ settings: baseSettings });
     mockMutate.mockImplementation(async (_key, fn) => {
       if (typeof fn === "function") return fn();
@@ -41,7 +43,6 @@ describe("InviteOnlyCard", () => {
   });
 
   afterEach(() => {
-    fetchSpy.mockRestore();
     jest.clearAllMocks();
   });
 
@@ -62,11 +63,8 @@ describe("InviteOnlyCard", () => {
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   });
 
-  test("clicking switch PUTs /api/admin/settings with invite_only_enabled toggled", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({}),
-    } as Response);
+  test("clicking switch calls updateAdminSettings with the merged payload", async () => {
+    mockUpdateAdminSettings.mockResolvedValueOnce(undefined);
 
     const user = userEvent.setup();
     render(<InviteOnlyCard />);
@@ -74,30 +72,19 @@ describe("InviteOnlyCard", () => {
     await user.click(screen.getByRole("switch"));
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(
-        "/api/admin/settings",
-        expect.objectContaining({
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-        })
+      expect(mockUpdateAdminSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ invite_only_enabled: true })
       );
     });
-
-    const callArgs = fetchSpy.mock.calls[0];
-    const body = JSON.parse(callArgs[1].body as string);
-    expect(body.invite_only_enabled).toBe(true);
     expect(mockToastSuccess).toHaveBeenCalledWith("Settings updated");
   });
 
-  test("shows error toast when PUT fails", async () => {
+  test("surfaces error message in toast when service throws", async () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ detail: "boom" }),
-    } as Response);
+    mockUpdateAdminSettings.mockRejectedValueOnce(new Error("boom"));
 
     const user = userEvent.setup();
     render(<InviteOnlyCard />);
@@ -111,15 +98,12 @@ describe("InviteOnlyCard", () => {
     consoleErrorSpy.mockRestore();
   });
 
-  test("falls back to generic message when error has no detail", async () => {
+  test("falls back to generic message when error has no message", async () => {
     const consoleErrorSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => {});
 
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({}),
-    } as Response);
+    mockUpdateAdminSettings.mockRejectedValueOnce(new Error(""));
 
     const user = userEvent.setup();
     render(<InviteOnlyCard />);
@@ -127,7 +111,7 @@ describe("InviteOnlyCard", () => {
     await user.click(screen.getByRole("switch"));
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith("Request failed");
+      expect(mockToastError).toHaveBeenCalledWith("Failed to update settings");
     });
     consoleErrorSpy.mockRestore();
   });

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.test.tsx
@@ -105,9 +105,30 @@ describe("InviteOnlyCard", () => {
     await user.click(screen.getByRole("switch"));
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith("Failed to update settings");
+      expect(mockToastError).toHaveBeenCalledWith("boom");
     });
     expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("falls back to generic message when error has no detail", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    const user = userEvent.setup();
+    render(<InviteOnlyCard />);
+
+    await user.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Request failed");
+    });
     consoleErrorSpy.mockRestore();
   });
 });

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
@@ -40,7 +40,11 @@ export default function InviteOnlyCard() {
         toast.success("Settings updated");
       } catch (err) {
         console.error("Failed to update invite_only_enabled", err);
-        toast.error("Failed to update settings");
+        const message =
+          err instanceof Error && err.message
+            ? err.message
+            : "Failed to update settings";
+        toast.error(message);
       }
     },
     [settings]

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
@@ -9,6 +9,7 @@ import { useSettingsContext } from "@/providers/SettingsProvider";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { toast } from "@/hooks/useToast";
 import { Settings } from "@/interfaces/settings";
+import { updateAdminSettings } from "@/lib/settings/svc";
 
 export default function InviteOnlyCard() {
   const { settings } = useSettingsContext();
@@ -20,15 +21,7 @@ export default function InviteOnlyCard() {
         await mutate(
           SWR_KEYS.settings,
           async () => {
-            const response = await fetch("/api/admin/settings", {
-              method: "PUT",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(newSettings),
-            });
-            if (!response.ok) {
-              const body = (await response.json()) as { detail?: string };
-              throw new Error(body.detail ?? "Request failed");
-            }
+            await updateAdminSettings(newSettings);
             return newSettings;
           },
           {

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback } from "react";
+import { mutate } from "swr";
+import { ContentAction } from "@opal/layouts";
+import Card from "@/refresh-components/cards/Card";
+import Switch from "@/refresh-components/inputs/Switch";
+import { useSettingsContext } from "@/providers/SettingsProvider";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { toast } from "@/hooks/useToast";
+import { Settings } from "@/interfaces/settings";
+
+export default function InviteOnlyCard() {
+  const settingsContext = useSettingsContext();
+  const settings = settingsContext.settings;
+
+  const saveSettings = useCallback(
+    async (updates: Partial<Settings>) => {
+      const newSettings = { ...settings, ...updates };
+      try {
+        const response = await fetch("/api/admin/settings", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newSettings),
+        });
+        if (!response.ok) {
+          const errorMsg = (await response.json()).detail;
+          throw new Error(errorMsg);
+        }
+        await mutate(SWR_KEYS.settings);
+        toast.success("Settings updated");
+      } catch {
+        toast.error("Failed to update settings");
+      }
+    },
+    [settings]
+  );
+
+  return (
+    <Card gap={0.5} padding={0.75}>
+      <ContentAction
+        title="Restrict Open Sign-Up"
+        description="New users must be invited to join this workspace."
+        sizePreset="main-ui"
+        variant="section"
+        padding="fit"
+        rightChildren={
+          <Switch
+            checked={settings.invite_only_enabled ?? false}
+            onCheckedChange={(checked) =>
+              void saveSettings({ invite_only_enabled: checked })
+            }
+          />
+        }
+      />
+    </Card>
+  );
+}

--- a/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteOnlyCard.tsx
@@ -11,25 +11,35 @@ import { toast } from "@/hooks/useToast";
 import { Settings } from "@/interfaces/settings";
 
 export default function InviteOnlyCard() {
-  const settingsContext = useSettingsContext();
-  const settings = settingsContext.settings;
+  const { settings } = useSettingsContext();
 
   const saveSettings = useCallback(
     async (updates: Partial<Settings>) => {
-      const newSettings = { ...settings, ...updates };
+      const newSettings: Settings = { ...settings, ...updates };
       try {
-        const response = await fetch("/api/admin/settings", {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(newSettings),
-        });
-        if (!response.ok) {
-          const errorMsg = (await response.json()).detail;
-          throw new Error(errorMsg);
-        }
-        await mutate(SWR_KEYS.settings);
+        await mutate(
+          SWR_KEYS.settings,
+          async () => {
+            const response = await fetch("/api/admin/settings", {
+              method: "PUT",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(newSettings),
+            });
+            if (!response.ok) {
+              const body = (await response.json()) as { detail?: string };
+              throw new Error(body.detail ?? "Request failed");
+            }
+            return newSettings;
+          },
+          {
+            optimisticData: newSettings,
+            revalidate: true,
+            rollbackOnError: true,
+          }
+        );
         toast.success("Settings updated");
-      } catch {
+      } catch (err) {
+        console.error("Failed to update invite_only_enabled", err);
         toast.error("Failed to update settings");
       }
     },

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -8,7 +8,7 @@ import IconButton from "@/refresh-components/buttons/IconButton";
 import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
-import { useAuthType } from "@/lib/hooks";
+import { useAuthTypeMetadata } from "@/hooks/useAuthTypeMetadata";
 import { AuthType } from "@/lib/constants";
 import InviteOnlyCard from "./InviteOnlyCard";
 
@@ -109,10 +109,11 @@ export default function UsersSummary({
   onFilterInvites,
   onFilterRequests,
 }: UsersSummaryProps) {
-  const authType = useAuthType();
+  const { authTypeMetadata } = useAuthTypeMetadata();
   const showInviteOnly =
     !showScim &&
-    (authType === AuthType.BASIC || authType === AuthType.GOOGLE_OAUTH);
+    (authTypeMetadata.authType === AuthType.BASIC ||
+      authTypeMetadata.authType === AuthType.GOOGLE_OAUTH);
   const showRequests = requests !== null && requests > 0;
 
   const statsCard = (

--- a/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/UsersSummary.tsx
@@ -8,6 +8,9 @@ import IconButton from "@/refresh-components/buttons/IconButton";
 import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { useAuthType } from "@/lib/hooks";
+import { AuthType } from "@/lib/constants";
+import InviteOnlyCard from "./InviteOnlyCard";
 
 // ---------------------------------------------------------------------------
 // Stats cell — number + label + hover filter icon
@@ -84,7 +87,7 @@ function ScimCard() {
 }
 
 // ---------------------------------------------------------------------------
-// Stats bar — layout varies by SCIM status
+// Stats bar — layout varies by SCIM / invite-only status
 // ---------------------------------------------------------------------------
 
 type UsersSummaryProps = {
@@ -106,6 +109,10 @@ export default function UsersSummary({
   onFilterInvites,
   onFilterRequests,
 }: UsersSummaryProps) {
+  const authType = useAuthType();
+  const showInviteOnly =
+    !showScim &&
+    (authType === AuthType.BASIC || authType === AuthType.GOOGLE_OAUTH);
   const showRequests = requests !== null && requests > 0;
 
   const statsCard = (
@@ -132,7 +139,13 @@ export default function UsersSummary({
     </Card>
   );
 
-  if (showScim) {
+  const rightCard = showScim ? (
+    <ScimCard />
+  ) : showInviteOnly ? (
+    <InviteOnlyCard />
+  ) : null;
+
+  if (rightCard) {
     return (
       <Section
         flexDirection="row"
@@ -141,37 +154,10 @@ export default function UsersSummary({
         gap={0.5}
       >
         {statsCard}
-        <ScimCard />
+        {rightCard}
       </Section>
     );
   }
 
-  // No SCIM — each stat gets its own card
-  return (
-    <Section flexDirection="row" gap={0.5}>
-      <Card padding={0.5}>
-        <StatCell
-          value={activeUsers}
-          label="active users"
-          onFilter={onFilterActive}
-        />
-      </Card>
-      <Card padding={0.5}>
-        <StatCell
-          value={pendingInvites}
-          label="pending invites"
-          onFilter={onFilterInvites}
-        />
-      </Card>
-      {showRequests && (
-        <Card padding={0.5}>
-          <StatCell
-            value={requests}
-            label="requests to join"
-            onFilter={onFilterRequests}
-          />
-        </Card>
-      )}
-    </Section>
-  );
+  return statsCard;
 }


### PR DESCRIPTION
## Description

Restores the workspace-level invite-only switch dropped during the admin Users page revamp. Backend (`invite_only_enabled`) was unchanged.

- New `InviteOnlyCard` with copy `"Restrict Open Sign-Up"` / `"New users must be invited to join this workspace."`
- Right slot of stats row: SCIM | InviteOnly | nothing
- Hidden on SAML, OIDC, CLOUD (backend bypasses the flag for SSO; CLOUD uses a different flow)
- Stats card always combined; drops the per-stat split branch

**Linear:** [ENG-4102](https://linear.app/onyx-app/issue/ENG-4102/add-invite-only-switch)

## How Has This Been Tested?

<img width="2206" height="1088" alt="2026-05-12 16 22 23" src="https://github.com/user-attachments/assets/2d84631d-f35b-4f5d-85f7-27fb47a8a8d4" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check