### PR TITLE
fix(litellm): Opus 4.7 no longer accepts `temperature` param, litellm is not dropping it (#10878) to release v3.2

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -75,6 +75,19 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 # + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
 _ANTHROPIC_ADAPTIVE_THINKING_MODELS = ("claude-opus-4-7",)
 
+# Anthropic models that reject any non-default sampling parameter (temperature,
+# top_p, top_k). For these models we must omit these params entirely from the
+# request payload — passing them returns a 400 invalid_request_error. LiteLLM's
+# drop_params is unreliable here because AnthropicConfig still lists temperature
+# as supported. Match on substring to cover proxy/Vertex naming variants (e.g.
+# "claude-4.7-opus" via litellm_proxy).
+_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
+    "claude-opus-4-7",
+    "claude-opus-4.7",
+    "claude-4-7-opus",
+    "claude-4.7-opus",
+)
+
 
 class LLMTimeoutError(Exception):
     """
@@ -241,6 +254,14 @@ def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
     return any(
         adaptive_model in normalized_model_name
         for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
+    )
+
+
+def _anthropic_omits_sampling_params(model_name: str) -> bool:
+    normalized_model_name = model_name.lower()
+    return any(
+        no_sampling_model in normalized_model_name
+        for no_sampling_model in _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS
     )
 
 
@@ -499,7 +520,17 @@ class LitellmLLM(LLM):
             tool_choice = None
 
         # Temperature
-        temperature = 1 if is_reasoning else self._temperature
+        # Some models reject any non-default sampling parameter (e.g. Claude
+        # Opus 4.7 returns a 400 invalid_request_error if temperature is set to
+        # anything). For those models we must omit the param entirely —
+        # LiteLLM's drop_params is not reliable here because the upstream
+        # provider config can still claim the param is supported.
+        # https://github.com/BerriAI/litellm/issues/26444
+        # TODO(litellm): Consider removing this once the above is resolved,
+        # although this assumes users have upgraded their litellm if relevant.
+        omits_sampling_params = _anthropic_omits_sampling_params(self.config.model_name)
+        if not omits_sampling_params:
+            optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
 
         if stream and not is_vertex_model_rejecting_output_config:
             optional_kwargs["stream_options"] = {"include_usage": True}
@@ -658,7 +689,6 @@ class LitellmLLM(LLM):
                     messages=messages,
                     tools=tools,
                     stream=stream,
-                    temperature=temperature,
                     timeout=timeout_override or self._timeout,
                     max_tokens=max_tokens,
                     client=client,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -425,6 +425,49 @@ def test_multiple_tool_calls_streaming(default_multi_llm: LitellmLLM) -> None:
         )
 
 
+ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
+    "claude-opus-4-7",
+    "claude-opus-4-7@20260101",
+    "claude-opus-4.7",
+    "claude-4-7-opus",
+    "claude-4.7-opus",
+]
+
+
+@pytest.mark.parametrize("model_name", ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS)
+def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> None:
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name=model_name,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name=model_name,
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
+def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> None:
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(default_multi_llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["temperature"] == 0.0
+
+
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)
 def test_vertex_stream_omits_stream_options(model_name: str) -> None:
     llm = LitellmLLM(


### PR DESCRIPTION
Cherry-pick of commit 969f71f46a29673208b512ea6fc13e25083514be to release/v3.2 branch.

Original PR: #10878

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending `temperature` to Anthropic Claude Opus 4.7 variants via `litellm` to prevent 400 invalid_request errors. Adds a model-name check so we omit sampling params for these models without affecting others.

- **Bug Fixes**
  - Detect Opus 4.7 variants (e.g., "claude-opus-4-7", "claude-4.7-opus") and omit `temperature` in `litellm.completion` calls.
  - Bypass `litellm`’s `drop_params` and handle omission explicitly to match Anthropic’s current API behavior.
  - Add tests to ensure `temperature` is not sent for these models and is preserved for others.

<sup>Written for commit 3aa6b8514136c7735c43b0994187fd61191b0fda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

