### PR TITLE
fix(celery): gate cleanup tasks to active tenants only

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -81,6 +81,7 @@ beat_task_templates: list[dict] = [
             "expires": BEAT_EXPIRES_DEFAULT,
             # Run on gated tenants too — they may still have stale checkpoints to clean.
             "skip_gated": False,
+            "work_gated": True,
         },
     },
     {
@@ -92,6 +93,7 @@ beat_task_templates: list[dict] = [
             "expires": BEAT_EXPIRES_DEFAULT,
             # Run on gated tenants too — they may still have stale index attempts.
             "skip_gated": False,
+            "work_gated": True,
         },
     },
     {


### PR DESCRIPTION
## Description

`check-for-checkpoint-cleanup` and `check-for-index-attempt-cleanup` were missing `work_gated: True`, so they fanned out to all ~23k tenant schemas every cycle. Peer cleanup tasks already had the flag.

In cloud the 8x beat multiplier stretches the index-attempt cleanup to ~4h cycles. Each fanout slammed bloated `index_attempt` tables, saturated `IO:DataFileRead`, spiked DBLoad to 200-454 AAS, and queued user requests (notably `/me`) behind the storm.

Adding `work_gated: True` restricts regular cycles to the ~88 active tenants. The existing full-fanout-cycle bypass still catches dormant tenants periodically.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check