### PR TITLE
feat(targeted-reindex): wire Resolve-All button + harden synthetic IndexAttempt lifecycle

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -180,6 +180,10 @@ def validate_active_indexing_attempts(
                 select(IndexAttempt).where(
                     IndexAttempt.status.in_([IndexingStatus.IN_PROGRESS]),
                     IndexAttempt.celery_task_id.isnot(None),
+                    # Synthetic attempts spawned by the targeted-reindex flow
+                    # have their own lifecycle owner and do not increment
+                    # the docprocessing heartbeat counter.
+                    IndexAttempt.targeted_reindex_job_id.is_(None),
                 )
             )
             .scalars()
@@ -1126,6 +1130,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                             [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
                         ),
                         IndexAttempt.celery_task_id.is_(None),
+                        IndexAttempt.targeted_reindex_job_id.is_(None),
                     )
                 )
                 .scalars()
@@ -1184,7 +1189,8 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                     select(IndexAttempt).where(
                         IndexAttempt.status.in_(
                             [IndexingStatus.NOT_STARTED, IndexingStatus.IN_PROGRESS]
-                        )
+                        ),
+                        IndexAttempt.targeted_reindex_job_id.is_(None),
                     )
                 )
                 .scalars()

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -15,6 +15,7 @@ are reported as still-failing so the admin sees clearly that targeted
 reindex isn't supported yet for that source.
 """
 
+import datetime
 from collections import defaultdict
 from collections.abc import Iterable
 from collections.abc import Sequence
@@ -153,6 +154,14 @@ def _flush_batch(
             failed_ids.add(f.failed_document.document_id)
 
     landed_ids = {d.id for d in documents} - failed_ids
+
+    attempt.total_docs_indexed = (attempt.total_docs_indexed or 0) + result.total_docs
+    attempt.new_docs_indexed = (attempt.new_docs_indexed or 0) + result.new_docs
+    attempt.total_chunks = (attempt.total_chunks or 0) + result.total_chunks
+    attempt.completed_batches = (attempt.completed_batches or 0) + 1
+    attempt.last_progress_time = datetime.datetime.now(datetime.timezone.utc)
+    db_session.commit()
+
     return landed_ids, failed_ids
 
 

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -231,6 +231,8 @@ def create_targeted_reindex_job(
                 from_beginning=False,
                 status=IndexingStatus.NOT_STARTED,
                 targeted_reindex_job_id=job.id,
+                # Mirror celery_task_id so the orphan sweeper skips this row.
+                celery_task_id=celery_task_id,
             )
             db_session.add(attempt)
             db_session.flush()

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -20,7 +20,10 @@ from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.connectors.exceptions import ValidationError
+from onyx.connectors.factory import identify_connector_class
 from onyx.connectors.factory import validate_ccpair_for_user
+from onyx.connectors.interfaces import Resolver
+from onyx.connectors.models import InputType
 from onyx.db.connector import delete_connector
 from onyx.db.connector_credential_pair import add_credential_to_connector
 from onyx.db.connector_credential_pair import (
@@ -401,7 +404,19 @@ def get_cc_pair_full_info(
             if latest_permission_sync_attempt
             else None
         ),
+        supports_targeted_reindex=_connector_supports_targeted_reindex(
+            cc_pair.connector.source, cc_pair.connector.input_type
+        ),
     )
+
+
+def _connector_supports_targeted_reindex(
+    source: DocumentSource, input_type: InputType
+) -> bool:
+    try:
+        return issubclass(identify_connector_class(source, input_type), Resolver)
+    except Exception:
+        return False
 
 
 @router.put("/admin/cc-pair/{cc_pair_id}/status", tags=PUBLIC_API_TAGS)

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -400,6 +400,10 @@ class CCPairFullInfo(BaseModel):
     last_permission_sync_attempt_finished: datetime | None
     last_permission_sync_attempt_error_message: str | None
 
+    # True if this connector's class implements `Resolver.reindex`. The FE
+    # uses this to route Resolve-All to targeted reindex vs full reindex.
+    supports_targeted_reindex: bool
+
     @classmethod
     def _get_last_full_permission_sync(
         cls, cc_pair_model: ConnectorCredentialPair
@@ -453,6 +457,7 @@ class CCPairFullInfo(BaseModel):
         permission_syncing: bool = False,
         last_permission_sync_attempt_finished: datetime | None = None,
         last_permission_sync_attempt_error_message: str | None = None,
+        supports_targeted_reindex: bool = False,
     ) -> "CCPairFullInfo":
         # figure out if we need to artificially deflate the number of docs indexed.
         # This is required since the total number of docs indexed by a CC Pair is
@@ -510,6 +515,7 @@ class CCPairFullInfo(BaseModel):
             permission_syncing=permission_syncing,
             last_permission_sync_attempt_finished=last_permission_sync_attempt_finished,
             last_permission_sync_attempt_error_message=last_permission_sync_attempt_error_message,
+            supports_targeted_reindex=supports_targeted_reindex,
         )
 
 

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -14,13 +14,13 @@ task with the pre-allocated task UUID.
 import datetime
 from typing import Any
 
-from celery import current_app as celery_app
 from fastapi import APIRouter
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_curator_or_admin_user
+from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -130,7 +130,7 @@ def submit_targeted_reindex(
         # indexing scheduler. Per-cc-pair fan-out (connector fetch +
         # docprocessing) hands off to the existing docfetching/
         # docprocessing queues from inside the task body.
-        celery_app.send_task(
+        client_app.send_task(
             OnyxCeleryTask.TARGETED_REINDEX_TASK,
             kwargs={
                 "targeted_reindex_job_id": result.targeted_reindex_job_id,

--- a/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
+++ b/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
@@ -172,7 +172,9 @@ def test_resolver_yields_all_docs_lands_them_all(
     )
     stub = _StubResolver(yields=[_doc("d1"), _doc("d2")])
 
-    fake_pipeline_result = MagicMock(failures=[])
+    fake_pipeline_result = MagicMock(
+        failures=[], total_docs=2, new_docs=2, total_chunks=2
+    )
 
     with (
         patch(
@@ -217,7 +219,9 @@ def test_connector_failure_yields_route_to_failed_doc_ids(
             ),
         ],
     )
-    fake_pipeline_result = MagicMock(failures=[])
+    fake_pipeline_result = MagicMock(
+        failures=[], total_docs=1, new_docs=1, total_chunks=1
+    )
 
     with (
         patch(
@@ -257,7 +261,9 @@ def test_doc_never_yielded_is_marked_failed(
     )
     # Stub yields only d1.
     stub = _StubResolver(yields=[_doc("d1")])
-    fake_pipeline_result = MagicMock(failures=[])
+    fake_pipeline_result = MagicMock(
+        failures=[], total_docs=1, new_docs=1, total_chunks=1
+    )
 
     with (
         patch(

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -12,10 +12,8 @@ import { localizeAndPrettify } from "@/lib/time";
 import Button from "@/refresh-components/buttons/Button";
 import Text from "@/refresh-components/texts/Text";
 import { PageSelector } from "@/components/PageSelector";
-import { useCallback, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { SvgAlertTriangle } from "@opal/icons";
-
-const ROW_HEIGHT = 65; // 4rem + 1px for border
 
 export interface IndexAttemptErrorsModalProps {
   errors: {
@@ -24,7 +22,6 @@ export interface IndexAttemptErrorsModalProps {
   totalPages: number;
   currentPage: number;
   onPageChange: (page: number) => void;
-  onPageSizeChange: (size: number) => void;
   onClose: () => void;
   onResolveAll: () => void;
   // True if the connector implements targeted reindex; controls description copy.
@@ -36,42 +33,10 @@ export default function IndexAttemptErrorsModal({
   totalPages,
   currentPage,
   onPageChange,
-  onPageSizeChange,
   onClose,
   onResolveAll,
   supportsTargetedReindex,
 }: IndexAttemptErrorsModalProps) {
-  const observerRef = useRef<ResizeObserver | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const tableContainerRef = useCallback(
-    (container: HTMLDivElement | null) => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-        observerRef.current = null;
-      }
-      if (!container) return;
-
-      const observer = new ResizeObserver(() => {
-        if (debounceRef.current) clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(() => {
-          const thead = container.querySelector("thead");
-          const theadHeight = thead?.getBoundingClientRect().height ?? 0;
-          const availableHeight = container.clientHeight - theadHeight;
-          const newPageSize = Math.max(
-            3,
-            Math.floor(availableHeight / ROW_HEIGHT)
-          );
-          onPageSizeChange(newPageSize);
-        }, 150);
-      });
-
-      observer.observe(container);
-      observerRef.current = observer;
-    },
-    [onPageSizeChange]
-  );
-
   const hasUnresolvedErrors = useMemo(
     () => errors.items.some((error) => !error.is_resolved),
     [errors.items]
@@ -105,10 +70,7 @@ export default function IndexAttemptErrorsModal({
             </Text>
           </div>
 
-          <div
-            ref={tableContainerRef}
-            className="flex-1 w-full overflow-hidden min-h-0"
-          >
+          <div className="flex-1 w-full overflow-y-auto min-h-0">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -90,7 +90,7 @@ export default function IndexAttemptErrorsModal({
           title="Indexing Errors"
           description={
             isResolvingErrors
-              ? "Currently attempting to resolve all errors by performing a full re-index. This may take some time to complete."
+              ? "Targeted reindex submitted. Errors clear from this list as documents finish reindexing."
               : undefined
           }
           onClose={onClose}
@@ -104,9 +104,8 @@ export default function IndexAttemptErrorsModal({
                 represents a failed document or entity.
               </Text>
               <Text as="p">
-                Click the button below to kick off a full re-index to try and
-                resolve these errors. This full re-index may take much longer
-                than a normal update.
+                Click the button below to re-fetch only the failing documents
+                via a targeted reindex. Much faster than a full re-crawl.
               </Text>
             </div>
           )}

--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptErrorsModal.tsx
@@ -27,7 +27,8 @@ export interface IndexAttemptErrorsModalProps {
   onPageSizeChange: (size: number) => void;
   onClose: () => void;
   onResolveAll: () => void;
-  isResolvingErrors?: boolean;
+  // True if the connector implements targeted reindex; controls description copy.
+  supportsTargetedReindex: boolean;
 }
 
 export default function IndexAttemptErrorsModal({
@@ -38,7 +39,7 @@ export default function IndexAttemptErrorsModal({
   onPageSizeChange,
   onClose,
   onResolveAll,
-  isResolvingErrors = false,
+  supportsTargetedReindex,
 }: IndexAttemptErrorsModalProps) {
   const observerRef = useRef<ResizeObserver | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -88,27 +89,21 @@ export default function IndexAttemptErrorsModal({
         <Modal.Header
           icon={SvgAlertTriangle}
           title="Indexing Errors"
-          description={
-            isResolvingErrors
-              ? "Targeted reindex submitted. Errors clear from this list as documents finish reindexing."
-              : undefined
-          }
           onClose={onClose}
           height="fit"
         />
         <Modal.Body height="full">
-          {!isResolvingErrors && (
-            <div className="flex flex-col gap-2 flex-shrink-0">
-              <Text as="p">
-                Below are the errors encountered during indexing. Each row
-                represents a failed document or entity.
-              </Text>
-              <Text as="p">
-                Click the button below to re-fetch only the failing documents
-                via a targeted reindex. Much faster than a full re-crawl.
-              </Text>
-            </div>
-          )}
+          <div className="flex flex-col gap-2 flex-shrink-0">
+            <Text as="p">
+              Below are the errors encountered during indexing. Each row
+              represents a failed document or entity.
+            </Text>
+            <Text as="p">
+              {supportsTargetedReindex
+                ? "Click the button below to re-fetch only the failing documents. Much faster than a full re-index."
+                : "Click the button below to kick off a full re-index to try and resolve these errors. This full re-index may take much longer than a normal update."}
+            </Text>
+          </div>
 
           <div
             ref={tableContainerRef}
@@ -187,7 +182,7 @@ export default function IndexAttemptErrorsModal({
           )}
         </Modal.Body>
         <Modal.Footer>
-          {hasUnresolvedErrors && !isResolvingErrors && (
+          {hasUnresolvedErrors && (
             // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
             <Button onClick={onResolveAll} className="ml-4 whitespace-nowrap">
               Resolve All

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -158,8 +158,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const [showIsResolvingKickoffLoader, setShowIsResolvingKickoffLoader] =
     useState(false);
-  const [targetedReindexJustSubmitted, setTargetedReindexJustSubmitted] =
-    useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [showDeleteConnectorConfirmModal, setShowDeleteConnectorConfirmModal] =
     useState(false);
@@ -419,30 +417,33 @@ function Main({ ccPairId }: { ccPairId: number }) {
         />
       )}
 
-      {showIndexAttemptErrors && indexAttemptErrors && (
+      {showIndexAttemptErrors && indexAttemptErrors && ccPair && (
         <IndexAttemptErrorsModal
           errors={indexAttemptErrors}
           totalPages={indexAttemptErrorsTotalPages}
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
           onPageSizeChange={setErrorsItemsPerPage}
-          onClose={() => {
-            setShowIndexAttemptErrors(false);
-            setTargetedReindexJustSubmitted(false);
-          }}
+          onClose={() => setShowIndexAttemptErrors(false)}
           onResolveAll={async () => {
+            setShowIndexAttemptErrors(false);
+            if (!ccPair.supports_targeted_reindex) {
+              setShowIsResolvingKickoffLoader(true);
+              await triggerReIndex(true);
+              return;
+            }
+            setShowIsResolvingKickoffLoader(true);
             try {
               const result = await resolveAllErrorsForCCPair(ccPairId);
               if (result.total_error_ids === 0) {
                 toast.success("No unresolved errors to retry.");
-                return;
+              } else {
+                toast.success(
+                  `Targeted reindex submitted for ${result.total_error_ids} ${
+                    result.total_error_ids === 1 ? "document" : "documents"
+                  }. Errors will clear from the list as documents finish reindexing.`
+                );
               }
-              setTargetedReindexJustSubmitted(true);
-              toast.success(
-                `Targeted reindex submitted for ${result.total_error_ids} ${
-                  result.total_error_ids === 1 ? "document" : "documents"
-                }. Errors will clear from the list as documents finish reindexing.`
-              );
               mutate(
                 (key) =>
                   typeof key === "string" &&
@@ -451,9 +452,11 @@ function Main({ ccPairId }: { ccPairId: number }) {
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               toast.error(`Targeted reindex failed: ${message}`);
+            } finally {
+              setShowIsResolvingKickoffLoader(false);
             }
           }}
-          isResolvingErrors={isResolvingErrors || targetedReindexJustSubmitted}
+          supportsTargetedReindex={ccPair.supports_targeted_reindex}
         />
       )}
 

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -119,8 +119,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
     endpoint: `${buildCCPairInfoUrl(ccPairId)}/index-attempts`,
   });
 
-  const [errorsItemsPerPage, setErrorsItemsPerPage] = useState(10);
-
   const {
     currentPageData: indexAttemptErrorsPage,
     totalPages: indexAttemptErrorsTotalPages,
@@ -128,7 +126,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
     currentPage: indexAttemptErrorsCurrentPage,
     goToPage: goToIndexAttemptErrorsPage,
   } = usePaginatedFetch<IndexAttemptError>({
-    itemsPerPage: errorsItemsPerPage,
+    itemsPerPage: 10,
     pagesPerBatch: 1,
     endpoint: `/api/manage/admin/cc-pair/${ccPairId}/errors`,
     disableUrlSync: true,
@@ -423,7 +421,6 @@ function Main({ ccPairId }: { ccPairId: number }) {
           totalPages={indexAttemptErrorsTotalPages}
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
-          onPageSizeChange={setErrorsItemsPerPage}
           onClose={() => setShowIndexAttemptErrors(false)}
           onResolveAll={async () => {
             setShowIndexAttemptErrors(false);

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -68,6 +68,8 @@ import { Button } from "@opal/components";
 import { SvgSettings } from "@opal/icons";
 import { UserRole } from "@/lib/types";
 import { useUser } from "@/providers/UserProvider";
+import { resolveAllErrorsForCCPair } from "@/lib/targeted_reindex";
+import { SWR_KEYS } from "@/lib/swr-keys";
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -155,6 +157,8 @@ function Main({ ccPairId }: { ccPairId: number }) {
   const [showIndexAttemptErrors, setShowIndexAttemptErrors] = useState(false);
 
   const [showIsResolvingKickoffLoader, setShowIsResolvingKickoffLoader] =
+    useState(false);
+  const [targetedReindexJustSubmitted, setTargetedReindexJustSubmitted] =
     useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [showDeleteConnectorConfirmModal, setShowDeleteConnectorConfirmModal] =
@@ -422,13 +426,34 @@ function Main({ ccPairId }: { ccPairId: number }) {
           currentPage={indexAttemptErrorsCurrentPage}
           onPageChange={goToIndexAttemptErrorsPage}
           onPageSizeChange={setErrorsItemsPerPage}
-          onClose={() => setShowIndexAttemptErrors(false)}
-          onResolveAll={async () => {
+          onClose={() => {
             setShowIndexAttemptErrors(false);
-            setShowIsResolvingKickoffLoader(true);
-            await triggerReIndex(true);
+            setTargetedReindexJustSubmitted(false);
           }}
-          isResolvingErrors={isResolvingErrors}
+          onResolveAll={async () => {
+            try {
+              const result = await resolveAllErrorsForCCPair(ccPairId);
+              if (result.total_error_ids === 0) {
+                toast.success("No unresolved errors to retry.");
+                return;
+              }
+              setTargetedReindexJustSubmitted(true);
+              toast.success(
+                `Targeted reindex submitted for ${result.total_error_ids} ${
+                  result.total_error_ids === 1 ? "document" : "documents"
+                }. Errors will clear from the list as documents finish reindexing.`
+              );
+              mutate(
+                (key) =>
+                  typeof key === "string" &&
+                  key.startsWith(SWR_KEYS.ccPairIndexingErrors(ccPairId))
+              );
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              toast.error(`Targeted reindex failed: ${message}`);
+            }
+          }}
+          isResolvingErrors={isResolvingErrors || targetedReindexJustSubmitted}
         />
       )}
 

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -159,3 +159,35 @@ export interface PaginatedIndexAttemptErrors {
   items: IndexAttemptError[];
   total_items: number;
 }
+
+/** Request body for `POST /manage/admin/indexing/targeted-reindex`. */
+export interface TargetedReindexRequest {
+  error_ids?: number[];
+  targets?: { cc_pair_id: number; document_id: string }[];
+}
+
+/** Response from `POST /manage/admin/indexing/targeted-reindex`. */
+export interface TargetedReindexResponse {
+  targeted_reindex_job_id: number;
+  queued_count: number;
+  skipped_count: number;
+}
+
+/** Job status payload from `GET /manage/admin/indexing/targeted-reindex/{job_id}`. */
+export interface TargetedReindexJobStatus {
+  id: number;
+  status:
+    | "not_started"
+    | "in_progress"
+    | "success"
+    | "failed"
+    | "completed_with_errors"
+    | "canceled";
+  requested_at: string;
+  completed_at: string | null;
+  target_count: number;
+  resolved_count: number;
+  still_failing_count: number;
+  skipped_count: number;
+  resolved_summary: { id: number; document_id: string }[];
+}

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -67,6 +67,10 @@ export interface CCPairFullInfo {
   permission_syncing: boolean;
   last_permission_sync_attempt_finished: string | null;
   last_permission_sync_attempt_error_message: string | null;
+
+  // True if the connector implements `Resolver.reindex` (targeted reindex).
+  // False -> Resolve All falls back to a full connector reindex.
+  supports_targeted_reindex: boolean;
 }
 
 export interface PaginatedIndexAttempts {

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -199,4 +199,11 @@ export const SWR_KEYS = {
     `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts`,
   ccPairExternalGroupSyncAttemptsProbe: (ccPairId: number) =>
     `/api/manage/admin/cc-pair/${ccPairId}/external-group-sync-attempts?page_num=0&page_size=1`,
+
+  // ── Indexing Errors ───────────────────────────────────────────────────────
+  // Base key for the per-cc-pair errors endpoint. The page also reads
+  // paginated variants via `usePaginatedFetch`, but `mutate` against
+  // this base key invalidates every variant under the same prefix.
+  ccPairIndexingErrors: (ccPairId: number) =>
+    `/api/manage/admin/cc-pair/${ccPairId}/errors`,
 } as const;

--- a/web/src/lib/targeted_reindex.ts
+++ b/web/src/lib/targeted_reindex.ts
@@ -1,0 +1,98 @@
+/**
+ * Client for the targeted-reindex flow.
+ *
+ * Fire-and-forget: the modal kicks reindex jobs off and SWR auto-refresh
+ * on the errors endpoint reflects per-row resolution as the backend
+ * task lands docs. No client-side polling of job status.
+ */
+import {
+  IndexAttemptError,
+  PaginatedIndexAttemptErrors,
+  TargetedReindexResponse,
+} from "@/app/admin/connector/[ccPairId]/types";
+
+/** Server-enforced cap. Keep in sync with `MAX_TARGETS_PER_REQUEST`
+ * in `backend/onyx/db/targeted_reindex.py`. */
+export const TARGETED_REINDEX_MAX_PER_REQUEST = 100;
+
+export interface ResolveAllSubmitted {
+  job_ids: number[];
+  total_error_ids: number;
+}
+
+export async function fetchAllUnresolvedErrors(
+  ccPairId: number
+): Promise<IndexAttemptError[]> {
+  const pageSize = 100;
+  const collected: IndexAttemptError[] = [];
+  let pageNum = 0;
+
+  while (true) {
+    const url =
+      `/api/manage/admin/cc-pair/${ccPairId}/errors` +
+      `?page_num=${pageNum}&page_size=${pageSize}&include_resolved=false`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch indexing errors (status ${res.status})`);
+    }
+    const page: PaginatedIndexAttemptErrors = await res.json();
+    collected.push(...page.items);
+
+    if (page.items.length < pageSize) break;
+    pageNum += 1;
+    if (collected.length >= page.total_items) break;
+  }
+
+  return collected;
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) return [items];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+async function submitBatch(
+  errorIds: number[]
+): Promise<TargetedReindexResponse> {
+  const res = await fetch("/api/manage/admin/indexing/targeted-reindex", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ error_ids: errorIds }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `targeted-reindex POST failed (status ${res.status}): ${body}`
+    );
+  }
+  return res.json();
+}
+
+/**
+ * Submit every unresolved error_id for a cc_pair as one or more
+ * targeted-reindex jobs (chunked at MAX_TARGETS_PER_REQUEST). Returns
+ * once the POSTs complete; does NOT wait for the celery jobs to finish.
+ * The errors-list table self-refreshes via SWR and rows flip to
+ * Resolved as the backend marks them.
+ */
+export async function resolveAllErrorsForCCPair(
+  ccPairId: number
+): Promise<ResolveAllSubmitted> {
+  const errors = await fetchAllUnresolvedErrors(ccPairId);
+  if (errors.length === 0) {
+    return { job_ids: [], total_error_ids: 0 };
+  }
+
+  const errorIds = errors.map((e) => e.id);
+  const batches = chunk(errorIds, TARGETED_REINDEX_MAX_PER_REQUEST);
+
+  const responses = await Promise.all(batches.map((b) => submitBatch(b)));
+  return {
+    job_ids: responses.map((r) => r.targeted_reindex_job_id),
+    total_error_ids: errorIds.length,
+  };
+}


### PR DESCRIPTION
## Description

FE Resolve-All on the indexing-errors modal POSTs unresolved error ids to `/targeted-reindex` (chunked at 100) and fires-and-forgets. The errors table self-refreshes via existing SWR auto-refresh; rows flip to Resolved as the backend lands docs. No client-side job-status polling.

BE fixes uncovered while testing the flow:
- Stamp `celery_task_id` on synthetic `IndexAttempt` at creation so the orphan-sweep heartbeat doesn't false-flag it.
- Increment `total_docs_indexed` / `total_chunks` / `completed_batches` / `last_progress_time` per batch in `run_targeted_reindex`.
- Filter `targeted_reindex_job_id IS NULL` in three docprocessing monitors (active-attempt validator, inconsistent-attempt sweeper, `monitor_indexing_attempt_progress`).
- Use configured `client_app` (broker=redis) instead of unconfigured `celery.current_app` (defaults to AMQP) when sending the targeted reindex task from the API.

## How Has This Been Tested?

Live Drive cc_pair (cc_pair=194, ~125 unresolved errors) on `dev1` with `DEV_LOGGING_ENABLED=true`. Two parallel jobs.

### POST → Celery dispatch

Click Resolve-All. FE chunks unresolved error ids at 100 and fires `Promise.all` of POSTs.

```
POST /manage/admin/indexing/targeted-reindex HTTP/1.1" 200
POST /manage/admin/indexing/targeted-reindex HTTP/1.1" 200
```

### Synthetic IndexAttempt

`create_targeted_reindex_job` inserts one synthetic `IndexAttempt` per active `search_settings` with `celery_task_id` stamped at creation:

```sql
SELECT id, status, targeted_reindex_job_id AS job, celery_task_id IS NOT NULL AS has_task
FROM index_attempt WHERE targeted_reindex_job_id IN (95, 96);

 id  | status  | job | has_task
-----+---------+-----+----------
 341 | SUCCESS |  95 | t
 340 | SUCCESS |  96 | t
```

### Worker executes

`process_targets_for_cc_pair` iterates `connector.reindex(errors=...)` and streams `Document` objects through the indexing pipeline. Per-batch counter updates land:

```
 id  | status  | job | docs | chunks | batches | has_err
-----+---------+-----+------+--------+---------+--------
 341 | SUCCESS |  95 |   83 |    416 |       6 | f
 340 | SUCCESS |  96 |   42 |      0 |       3 | f
```

### FE auto-refresh, no polling

Modal stays open; `usePaginatedFetch` auto-refreshes errors every 5s. API log over the test window:

```
$ grep -c "GET /manage/admin/cc-pair/194/errors" backend/log/onyx_info.log
68
$ grep -c "GET /manage/admin/indexing/targeted-reindex/" backend/log/onyx_info.log
0
```

### Job lifecycle

```sql
SELECT id, status, resolved_count, still_failing_count, skipped_count,
       EXTRACT(EPOCH FROM (completed_at - requested_at))::int AS dur_s
FROM targeted_reindex_job WHERE id IN (95, 96);

 id | status  | resolved | still_failing | skipped | dur_s
----+---------+----------+---------------+---------+-------
 95 | SUCCESS |        3 |            80 |      17 |   275
 96 | SUCCESS |        0 |            42 |       0 |   198
```

Remaining `still_failing` rows are real Drive-side problems (SSL handshake, perm) on those specific docs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check