### PR TITLE
chore(mypy): Disable mypy cache for release/v3.2

### DIFF
--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -54,15 +54,19 @@ jobs:
         run: |
           ods openapi all
 
-      - name: Cache mypy cache
-        if: ${{ vars.DISABLE_MYPY_CACHE != 'true' }}
-        uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # ratchet:runs-on/cache@v4
-        with:
-          path: .mypy_cache
-          key: mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-${{ hashFiles('**/*.py', '**/*.pyi', 'pyproject.toml') }}
-          restore-keys: |
-            mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-
-            mypy-${{ runner.os }}-
+      # We've disabled the mypy cache because we saw that the cache was poisoned
+      # for release/v3.2, but we no longer use mypy as of v3.3, so just don't
+      # rely on the cache at the expense of CI time for cherry-picks to this
+      # release branch.
+      # - name: Cache mypy cache
+      #   if: ${{ vars.DISABLE_MYPY_CACHE != 'true' }}
+      #   uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # ratchet:runs-on/cache@v4
+      #   with:
+      #     path: .mypy_cache
+      #     key: mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-${{ hashFiles('**/*.py', '**/*.pyi', 'pyproject.toml') }}
+      #     restore-keys: |
+      #       mypy-${{ runner.os }}-${{ github.base_ref || github.event.merge_group.base_ref || 'main' }}-
+      #       mypy-${{ runner.os }}-
 
       - name: Run MyPy
         env:


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the mypy cache in CI for `release/v3.2` to avoid poisoned artifacts, and brought in stability, security, and observability updates across chat, connectors, and metrics.

- **New Features**
  - Converted Gong connector to a checkpointed model for reliable, resumable syncs.
  - Slack search now includes full thread replies and can fetch threads directly from pasted Slack URLs.
  - Added connector health and deletion lifecycle Prometheus metrics; tracked Celery task queue wait time; exposed metrics on `light` and `primary` workers.
  - Usage export now records the LLM model per assistant reply.
  - Announced upcoming group-based permissions via notifications.
  - Opted out of Datadog admission on sandbox pods with a label.

- **Bug Fixes**
  - CI: disabled mypy cache; added S3 env to integration tests.
  - Security: enforced ownership on stop-chat-session; hardened `/chat/file` downloads with per-user and connector ACL checks.
  - Image handling: capped embedded images per file/upload and guarded PDF image extraction; added inline file_id tags for user-attached images; improved OpenAI image model routing.
  - Connectors: Gmail date parsing fallback; Jira bulk fetch respects API limits and bisects on bad payloads; Google KV accepts legacy JSON strings.
  - Licensing/SCIM: excluded `SERVICE_ACCOUNT` from seat counts; added per-tenant advisory lock to prevent seat allocation races.
  - Personas/UI: user-uploaded files appear as a knowledge source; improved LLM provider model fetch by resolving masked API keys.

<sup>Written for commit 6dfcf24da1201f98b3a1cfc67304e4cdcfcfff75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

