### PR TITLE
chore(gha): add repro command to nightly external dependency tests Slack notification

### DIFF
--- a/.github/workflows/nightly-external-dependency-unit-tests.yml
+++ b/.github/workflows/nightly-external-dependency-unit-tests.yml
@@ -69,6 +69,11 @@ jobs:
         uses: ./.github/actions/slack-notify
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          failed-jobs: nightly-external-dependency-unit-tests
+          details: |
+            *Failed jobs:*
+            nightly-external-dependency-unit-tests
+
+            *To reproduce locally:*
+            `uv run pytest -m nightly backend/tests/external_dependency_unit`
           title: "🚨 Nightly External Dependency Unit Tests failed!"
           ref-name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Switch `nightly-external-dependency-unit-tests.yml` from the deprecated `failed-jobs` input to `details`, and include the local repro command (`uv run pytest -m nightly backend/tests/external_dependency_unit`) so on-call can copy/paste from the Slack alert.

## Test plan
- [ ] Trigger a failing run via `workflow_dispatch` (or wait for a scheduled failure) and confirm the Slack message renders the failed job name and the repro command in a code span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the nightly external dependency unit tests Slack alert to use the `details` input and include a local repro command: `uv run pytest -m nightly backend/tests/external_dependency_unit`. This replaces the deprecated `failed-jobs` input and makes on-call copy/paste easier.

<sup>Written for commit 6401813cee17b3d4ebfcdd27762ea78df08f2be5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

