### PR TITLE
feat: capture perm sync exception trace

### DIFF
--- a/backend/alembic/versions/1c36b3dc2f4e_add_full_exception_trace_to_permission_.py
+++ b/backend/alembic/versions/1c36b3dc2f4e_add_full_exception_trace_to_permission_.py
@@ -1,0 +1,32 @@
+"""add full_exception_trace to permission sync attempts
+
+Revision ID: 1c36b3dc2f4e
+Revises: f0db5f1c6370
+Create Date: 2026-05-06 16:18:40.855449
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "1c36b3dc2f4e"
+down_revision = "f0db5f1c6370"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "doc_permission_sync_attempt",
+        sa.Column("full_exception_trace", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "external_group_permission_sync_attempt",
+        sa.Column("full_exception_trace", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("external_group_permission_sync_attempt", "full_exception_trace")
+    op.drop_column("doc_permission_sync_attempt", "full_exception_trace")

--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -629,6 +630,7 @@ def connector_permission_sync_generator_task(
 
     except Exception as e:
         error_msg = format_error_for_logging(e)
+        full_exception_trace = traceback.format_exc()
 
         task_logger.warning(
             f"Permission sync exceptioned: cc_pair={cc_pair_id} payload_id={payload_id} {error_msg}"
@@ -639,7 +641,10 @@ def connector_permission_sync_generator_task(
 
         with get_session_with_current_tenant() as db_session:
             mark_doc_permission_sync_attempt_failed(
-                attempt_id, db_session, error_message=error_msg
+                attempt_id,
+                db_session,
+                error_message=error_msg,
+                full_exception_trace=full_exception_trace,
             )
 
         redis_connector.permissions.generator_clear()

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -1,4 +1,5 @@
 import time
+import traceback
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -613,7 +614,10 @@ def _timed_perform_external_group_sync(
 
             # Mark as failed (this also updates progress to show partial progress)
             mark_external_group_sync_attempt_failed(
-                attempt_id, db_session, error_message=str(e)
+                attempt_id,
+                db_session,
+                error_message=str(e),
+                full_exception_trace=traceback.format_exc(),
             )
 
             # TODO: add some notification to the admins here

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4973,8 +4973,9 @@ class DocPermissionSyncAttempt(Base):
     total_docs_synced: Mapped[int | None] = mapped_column(Integer, default=0)
     docs_with_permission_errors: Mapped[int | None] = mapped_column(Integer, default=0)
 
-    # Error message if sync fails
+    # Error information if sync fails
     error_message: Mapped[str | None] = mapped_column(Text, default=None)
+    full_exception_trace: Mapped[str | None] = mapped_column(Text, default=None)
 
     # Timestamps
     time_created: Mapped[datetime.datetime] = mapped_column(
@@ -5042,8 +5043,9 @@ class ExternalGroupPermissionSyncAttempt(Base):
         Integer, default=0
     )
 
-    # Error message if sync fails
+    # Error information if sync fails
     error_message: Mapped[str | None] = mapped_column(Text, default=None)
+    full_exception_trace: Mapped[str | None] = mapped_column(Text, default=None)
 
     # Timestamps
     time_created: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -150,8 +150,17 @@ def mark_doc_permission_sync_attempt_failed(
     attempt_id: int,
     db_session: Session,
     error_message: str,
+    full_exception_trace: str | None = None,
 ) -> None:
-    """Mark a doc permission sync attempt as failed."""
+    """Mark a doc permission sync attempt as failed.
+
+    ``full_exception_trace`` is optional so call sites that fail with a
+    synthesized error message (e.g. fence missing, payload invalid) and
+    have no live exception in scope can omit it. When the failure
+    originates from an ``except`` block, callers should pass
+    ``traceback.format_exc()`` so the full stack is persisted alongside
+    the short ``error_message``.
+    """
     try:
         attempt = db_session.execute(
             select(DocPermissionSyncAttempt)
@@ -164,6 +173,7 @@ def mark_doc_permission_sync_attempt_failed(
         attempt.status = PermissionSyncStatus.FAILED
         attempt.time_finished = func.now()
         attempt.error_message = error_message
+        attempt.full_exception_trace = full_exception_trace
         db_session.commit()
 
         # Add telemetry for permission sync attempt status change
@@ -416,8 +426,17 @@ def mark_external_group_sync_attempt_failed(
     attempt_id: int,
     db_session: Session,
     error_message: str,
+    full_exception_trace: str | None = None,
 ) -> None:
-    """Mark an external group sync attempt as failed."""
+    """Mark an external group sync attempt as failed.
+
+    ``full_exception_trace`` is optional so call sites that fail with a
+    synthesized error message (e.g. missing sync config) and have no
+    live exception in scope can omit it. When the failure originates
+    from an ``except`` block, callers should pass
+    ``traceback.format_exc()`` so the full stack is persisted alongside
+    the short ``error_message``.
+    """
     try:
         attempt = db_session.execute(
             select(ExternalGroupPermissionSyncAttempt)
@@ -430,6 +449,7 @@ def mark_external_group_sync_attempt_failed(
         attempt.status = PermissionSyncStatus.FAILED
         attempt.time_finished = func.now()
         attempt.error_message = error_message
+        attempt.full_exception_trace = full_exception_trace
         db_session.commit()
 
         # Add telemetry for permission sync attempt status change

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -288,6 +288,7 @@ class DocPermissionSyncAttemptSnapshot(BaseModel):
     id: int
     status: PermissionSyncStatus
     error_message: str | None
+    full_exception_trace: str | None
     total_docs_synced: int
     docs_with_permission_errors: int
     time_created: str
@@ -302,6 +303,7 @@ class DocPermissionSyncAttemptSnapshot(BaseModel):
             id=attempt.id,
             status=attempt.status,
             error_message=attempt.error_message,
+            full_exception_trace=attempt.full_exception_trace,
             total_docs_synced=attempt.total_docs_synced or 0,
             docs_with_permission_errors=attempt.docs_with_permission_errors or 0,
             time_created=attempt.time_created.isoformat(),
@@ -318,6 +320,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
     id: int
     status: PermissionSyncStatus
     error_message: str | None
+    full_exception_trace: str | None
     total_users_processed: int
     total_groups_processed: int
     total_group_memberships_synced: int
@@ -333,6 +336,7 @@ class ExternalGroupSyncAttemptSnapshot(BaseModel):
             id=attempt.id,
             status=attempt.status,
             error_message=attempt.error_message,
+            full_exception_trace=attempt.full_exception_trace,
             total_users_processed=attempt.total_users_processed or 0,
             total_groups_processed=attempt.total_groups_processed or 0,
             total_group_memberships_synced=attempt.total_group_memberships_synced or 0,

--- a/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_doc_permission_sync_attempt.py
@@ -155,6 +155,40 @@ class TestDocPermissionSyncAttempt:
         assert attempt.time_started is not None
         assert attempt.time_finished is not None
         assert attempt.error_message == error_msg
+        # Default-omitted full_exception_trace should be None — guards
+        # the optional-kwarg signature so synthesized-string callers
+        # (e.g. ``_fail_doc_permission_sync_attempt``) keep working.
+        assert attempt.full_exception_trace is None
+
+    def test_mark_doc_permission_sync_attempt_failed_persists_traceback(
+        self, db_session: Session
+    ) -> None:
+        """Tracebacks captured in ``except`` blocks must round-trip
+        through the failure helper so the connector-detail UI can
+        surface the full Python stack instead of just a single-line
+        summary."""
+        cc_pair = _create_test_connector_credential_pair(db_session)
+        attempt_id = create_doc_permission_sync_attempt(cc_pair.id, db_session)
+
+        error_msg = "Sync process crashed unexpectedly"
+        full_trace = (
+            "Traceback (most recent call last):\n"
+            '  File "tasks.py", line 123, in connector_permission_sync_generator_task\n'
+            "    do_sync()\n"
+            "RuntimeError: simulated failure\n"
+        )
+        mark_doc_permission_sync_attempt_failed(
+            attempt_id,
+            db_session,
+            error_message=error_msg,
+            full_exception_trace=full_trace,
+        )
+
+        attempt = get_doc_permission_sync_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PermissionSyncStatus.FAILED
+        assert attempt.error_message == error_msg
+        assert attempt.full_exception_trace == full_trace
 
     def test_get_recent_doc_permission_sync_attempts_for_cc_pair(
         self, db_session: Session

--- a/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
+++ b/backend/tests/external_dependency_unit/permission_sync/test_external_group_permission_sync_attempt.py
@@ -187,6 +187,10 @@ class TestExternalGroupPermissionSyncAttempt:
         assert attempt.time_started is not None  # Should be set if not already set
         assert attempt.time_finished is not None
         assert attempt.error_message == error_msg_1
+        # Default-omitted full_exception_trace should be None — guards
+        # the optional-kwarg signature so synthesized-string callers
+        # (e.g. ``_fail_external_group_sync_attempt``) keep working.
+        assert attempt.full_exception_trace is None
 
         # Test with error message
         attempt_id_2 = create_external_group_sync_attempt(cc_pair.id, db_session)
@@ -200,6 +204,36 @@ class TestExternalGroupPermissionSyncAttempt:
         assert attempt_2 is not None
         assert attempt_2.status == PermissionSyncStatus.FAILED
         assert attempt_2.error_message == error_msg
+
+    def test_mark_external_group_sync_attempt_failed_persists_traceback(
+        self, db_session: Session
+    ) -> None:
+        """Tracebacks captured in ``except`` blocks must round-trip
+        through the failure helper so the connector-detail UI can
+        surface the full Python stack instead of just a single-line
+        summary."""
+        cc_pair = _create_test_connector_credential_pair(db_session)
+        attempt_id = create_external_group_sync_attempt(cc_pair.id, db_session)
+
+        error_msg = "External group sync service unavailable"
+        full_trace = (
+            "Traceback (most recent call last):\n"
+            '  File "tasks.py", line 456, in connector_external_group_sync_generator_task\n'
+            "    sync_groups()\n"
+            "RuntimeError: simulated failure\n"
+        )
+        mark_external_group_sync_attempt_failed(
+            attempt_id,
+            db_session,
+            error_message=error_msg,
+            full_exception_trace=full_trace,
+        )
+
+        attempt = get_external_group_sync_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PermissionSyncStatus.FAILED
+        assert attempt.error_message == error_msg
+        assert attempt.full_exception_trace == full_trace
 
     def test_get_recent_external_group_sync_attempts_for_cc_pair(
         self, db_session: Session

--- a/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/DocPermissionSyncAttemptsTable.tsx
@@ -86,8 +86,12 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       header: "Error Message",
       weight: 28,
       enableSorting: false,
-      cell: (value) => (
-        <ErrorMessageCell errorMessage={value} onErrorClick={onErrorClick} />
+      cell: (value, row) => (
+        <ErrorMessageCell
+          errorMessage={value}
+          modalContent={row.full_exception_trace ?? value}
+          onErrorClick={onErrorClick}
+        />
       ),
     }),
   ];
@@ -95,6 +99,14 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
 
 interface ErrorMessageCellProps {
   errorMessage: string | null;
+  /**
+   * Full content shown in `ExceptionTraceModal` on click — prefers the
+   * traceback when present, otherwise falls back to the short
+   * ``error_message``. Older attempts (pre-traceback-capture migration)
+   * have ``full_exception_trace = null`` and gracefully degrade to the
+   * single-line summary, matching `IndexAttemptsTable`'s behavior.
+   */
+  modalContent: string | null;
   onErrorClick: (errorMessage: string) => void;
 }
 
@@ -107,6 +119,7 @@ interface ErrorMessageCellProps {
  */
 function ErrorMessageCell({
   errorMessage,
+  modalContent,
   onErrorClick,
 }: ErrorMessageCellProps) {
   if (!errorMessage) {
@@ -119,7 +132,7 @@ function ErrorMessageCell({
   return (
     <button
       type="button"
-      onClick={() => onErrorClick(errorMessage)}
+      onClick={() => onErrorClick(modalContent ?? errorMessage)}
       aria-label="View full error message"
       className="text-left w-full cursor-pointer hover:underline"
     >

--- a/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/ExternalGroupSyncAttemptsTable.tsx
@@ -112,8 +112,12 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
       header: "Error Message",
       weight: 28,
       enableSorting: false,
-      cell: (value) => (
-        <ErrorMessageCell errorMessage={value} onErrorClick={onErrorClick} />
+      cell: (value, row) => (
+        <ErrorMessageCell
+          errorMessage={value}
+          modalContent={row.full_exception_trace ?? value}
+          onErrorClick={onErrorClick}
+        />
       ),
     }),
   ];
@@ -121,6 +125,14 @@ function buildColumns(onErrorClick: (errorMessage: string) => void) {
 
 interface ErrorMessageCellProps {
   errorMessage: string | null;
+  /**
+   * Full content shown in `ExceptionTraceModal` on click — prefers the
+   * traceback when present, otherwise falls back to the short
+   * ``error_message``. Older attempts (pre-traceback-capture migration)
+   * have ``full_exception_trace = null`` and gracefully degrade to the
+   * single-line summary, matching `IndexAttemptsTable`'s behavior.
+   */
+  modalContent: string | null;
   onErrorClick: (errorMessage: string) => void;
 }
 
@@ -133,6 +145,7 @@ interface ErrorMessageCellProps {
  */
 function ErrorMessageCell({
   errorMessage,
+  modalContent,
   onErrorClick,
 }: ErrorMessageCellProps) {
   if (!errorMessage) {
@@ -145,7 +158,7 @@ function ErrorMessageCell({
   return (
     <button
       type="button"
-      onClick={() => onErrorClick(errorMessage)}
+      onClick={() => onErrorClick(modalContent ?? errorMessage)}
       aria-label="View full error message"
       className="text-left w-full cursor-pointer hover:underline"
     >

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -88,6 +88,7 @@ export interface DocPermissionSyncAttemptSnapshot {
   id: number;
   status: PermissionSyncStatusEnum;
   error_message: string | null;
+  full_exception_trace: string | null;
   total_docs_synced: number;
   docs_with_permission_errors: number;
   time_created: string;
@@ -106,6 +107,7 @@ export interface ExternalGroupSyncAttemptSnapshot {
   id: number;
   status: PermissionSyncStatusEnum;
   error_message: string | null;
+  full_exception_trace: string | null;
   total_users_processed: number;
   total_groups_processed: number;
   total_group_memberships_synced: number;


### PR DESCRIPTION
## Description

Save perm sync exception traces

## How Has This Been Tested?

tests and will check manually too

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture and persist full exception traces for document and external group permission sync attempts, and show the full stack in the admin UI for easier debugging.

- **New Features**
  - Added `full_exception_trace` to `doc_permission_sync_attempt` and `external_group_permission_sync_attempt` and populate it on failures from Celery tasks.
  - Exposed `full_exception_trace` in API snapshots and updated TS types.
  - Admin tables now open the traceback in the modal when present, falling back to the short error message.

- **Migration**
  - Run DB migrations to add the new `full_exception_trace` columns.

<sup>Written for commit 2e0eadb9a90eceb8a08fec73fddd1acfc16cb87e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

