### PR TITLE
chore: [Running GitHub actions for #10856]

### DIFF
--- a/backend/onyx/file_store/document_batch_storage.py
+++ b/backend/onyx/file_store/document_batch_storage.py
@@ -207,7 +207,7 @@ class FileStoreDocumentBatchStorage(DocumentBatchStorage):
 
     def delete_batch_by_name(self, batch_file_name: str) -> None:
         """Delete a specific batch from FileStore."""
-        self.file_store.delete_file(batch_file_name)
+        self.file_store.delete_file(batch_file_name, error_on_missing=False)
         logger.debug("Deleted batch %s from FileStore", batch_file_name)
 
     def delete_batch_by_num(self, batch_num: int) -> None:

--- a/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
+++ b/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
@@ -16,6 +16,7 @@ def _mock_db_session() -> MagicMock:
     return session
 
 
+@patch(f"{_S3_MODULE}.get_session_with_current_tenant")
 @patch(f"{_S3_MODULE}.get_session_with_current_tenant_if_none")
 @patch(f"{_S3_MODULE}.get_filerecord_by_file_id_optional", return_value=None)
 @patch(f"{_S3_MODULE}.get_filerecord_by_prefix")
@@ -23,11 +24,13 @@ def test_cleanup_all_batches_completes_when_files_already_deleted(
     mock_list: MagicMock,
     _mock_get_record: MagicMock,
     mock_ctx: MagicMock,
+    mock_session_ctx: MagicMock,
 ) -> None:
     """cleanup_all_batches must complete without raising even if every batch
     file is already gone — e.g. from a partial cleanup or a batch that was
     never written due to an earlier failure."""
     mock_ctx.return_value = _mock_db_session()
+    mock_session_ctx.return_value = _mock_db_session()
     mock_list.return_value = [
         MagicMock(file_id="iab/1/42/0.json"),
         MagicMock(file_id="iab/1/42/1.json"),

--- a/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
+++ b/backend/tests/unit/onyx/file_store/test_document_batch_storage.py
@@ -1,0 +1,41 @@
+"""Tests for FileStoreDocumentBatchStorage."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.file_store.document_batch_storage import FileStoreDocumentBatchStorage
+from onyx.file_store.file_store import S3BackedFileStore
+
+_S3_MODULE = "onyx.file_store.file_store"
+
+
+def _mock_db_session() -> MagicMock:
+    session = MagicMock()
+    session.__enter__ = MagicMock(return_value=session)
+    session.__exit__ = MagicMock(return_value=False)
+    return session
+
+
+@patch(f"{_S3_MODULE}.get_session_with_current_tenant_if_none")
+@patch(f"{_S3_MODULE}.get_filerecord_by_file_id_optional", return_value=None)
+@patch(f"{_S3_MODULE}.get_filerecord_by_prefix")
+def test_cleanup_all_batches_completes_when_files_already_deleted(
+    mock_list: MagicMock,
+    _mock_get_record: MagicMock,
+    mock_ctx: MagicMock,
+) -> None:
+    """cleanup_all_batches must complete without raising even if every batch
+    file is already gone — e.g. from a partial cleanup or a batch that was
+    never written due to an earlier failure."""
+    mock_ctx.return_value = _mock_db_session()
+    mock_list.return_value = [
+        MagicMock(file_id="iab/1/42/0.json"),
+        MagicMock(file_id="iab/1/42/1.json"),
+        MagicMock(file_id="iab/1/42/2.json"),
+    ]
+
+    file_store = S3BackedFileStore(bucket_name="test-bucket")
+    storage = FileStoreDocumentBatchStorage(
+        cc_pair_id=1, index_attempt_id=42, file_store=file_store
+    )
+    storage.cleanup_all_batches()  # must not raise


### PR DESCRIPTION
This PR runs GitHub Actions CI for #10856.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make document batch cleanup idempotent by skipping missing files during deletion so `cleanup_all_batches` completes instead of aborting. Add a unit test that verifies completion when batch files are already gone.

- **Bug Fixes**
  - In `onyx.file_store.document_batch_storage.FileStoreDocumentBatchStorage.delete_batch_by_name`, call `self.file_store.delete_file(..., error_on_missing=False)` to tolerate missing files.

<sup>Written for commit 68ee0f3498d593e213b54884ac49fa8475c721e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

