### PR TITLE
fix(seat-limit): close TOCTOU race + plug promotion + cloud auto-bill

### DIFF
--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -1,10 +1,13 @@
 """Database and cache operations for the license table."""
 
+import hashlib
+import struct
 from datetime import datetime
 from typing import NamedTuple
 
 from sqlalchemy import func
 from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ee.onyx.server.license.models import LicenseMetadata
@@ -24,6 +27,41 @@ logger = setup_logger()
 
 LICENSE_METADATA_KEY = "license:metadata"
 LICENSE_CACHE_TTL_SECONDS = 86400  # 24 hours
+
+# Namespace prefix for the seat-allocation advisory lock. Hashed together
+# with the tenant ID so the lock is scoped per-tenant (unrelated tenants
+# never block each other) and cannot collide with unrelated advisory locks.
+_SEAT_LOCK_NAMESPACE = "onyx_seat_lock"
+
+
+def seat_lock_id_for_tenant(tenant_id: str) -> int:
+    """Derive a stable 64-bit signed int lock id for this tenant's seat lock.
+
+    Used by ``acquire_seat_lock`` and the SCIM seat-availability check to
+    serialize concurrent seat-allocation operations within a tenant.
+    """
+    digest = hashlib.sha256(f"{_SEAT_LOCK_NAMESPACE}:{tenant_id}".encode()).digest()
+    # pg_advisory_xact_lock takes a signed 8-byte int; unpack as such.
+    return struct.unpack("q", digest[:8])[0]
+
+
+def acquire_seat_lock(db_session: Session, tenant_id: str | None = None) -> None:
+    """Acquire a transaction-scoped advisory lock on this tenant's seat slot.
+
+    The lock is released automatically on COMMIT or ROLLBACK of the caller's
+    transaction. Callers MUST run the seat check AND the subsequent INSERT /
+    UPDATE in the same transaction so the lock guards both: see
+    ``check_seat_availability`` for the check, and the surrounding callers
+    for the write.
+
+    Concurrent requests for the same tenant block here; concurrent requests
+    for different tenants proceed in parallel.
+    """
+    lock_id = seat_lock_id_for_tenant(tenant_id or get_current_tenant_id())
+    db_session.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_id)"),
+        {"lock_id": lock_id},
+    )
 
 
 class SeatAvailabilityResult(NamedTuple):

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -141,6 +141,23 @@ def delete_license(db_session: Session) -> bool:
 # -----------------------------------------------------------------------------
 
 
+def user_counts_toward_seats(user: User) -> bool:
+    """Whether a single user row would be counted by ``get_used_seats``.
+
+    Mirrors the filter below; canonical predicate for any caller that
+    needs to know whether a write (e.g. an EXT_PERM_USER → STANDARD
+    upgrade) flips an uncounted user into a counted one. Keep in sync
+    with ``get_used_seats`` — adding or removing a clause there must
+    update this function in lockstep.
+    """
+    return (
+        bool(user.is_active)
+        and user.role != UserRole.EXT_PERM_USER
+        and user.email != ANONYMOUS_USER_EMAIL
+        and user.account_type != AccountType.SERVICE_ACCOUNT
+    )
+
+
 def get_used_seats(tenant_id: str | None = None) -> int:
     """
     Get current seat usage directly from database.
@@ -153,6 +170,9 @@ def get_used_seats(tenant_id: str | None = None) -> int:
     anonymous system user are excluded. BOT (Slack users) ARE counted
     because they represent real humans and get upgraded to STANDARD
     when they log in via web.
+
+    The ``user_counts_toward_seats`` helper above mirrors this filter
+    for callers that need a per-user predicate; keep them in sync.
     """
     if MULTI_TENANT:
         from ee.onyx.server.tenants.user_mapping import get_tenant_count

--- a/backend/ee/onyx/db/license.py
+++ b/backend/ee/onyx/db/license.py
@@ -28,34 +28,22 @@ logger = setup_logger()
 LICENSE_METADATA_KEY = "license:metadata"
 LICENSE_CACHE_TTL_SECONDS = 86400  # 24 hours
 
-# Namespace prefix for the seat-allocation advisory lock. Hashed together
-# with the tenant ID so the lock is scoped per-tenant (unrelated tenants
-# never block each other) and cannot collide with unrelated advisory locks.
+# Namespaced + tenant-hashed so unrelated tenants don't block each other
+# and the lock id can't collide with other advisory locks in the codebase.
 _SEAT_LOCK_NAMESPACE = "onyx_seat_lock"
 
 
 def seat_lock_id_for_tenant(tenant_id: str) -> int:
-    """Derive a stable 64-bit signed int lock id for this tenant's seat lock.
-
-    Used by ``acquire_seat_lock`` and the SCIM seat-availability check to
-    serialize concurrent seat-allocation operations within a tenant.
-    """
     digest = hashlib.sha256(f"{_SEAT_LOCK_NAMESPACE}:{tenant_id}".encode()).digest()
-    # pg_advisory_xact_lock takes a signed 8-byte int; unpack as such.
+    # pg_advisory_xact_lock takes a signed 8-byte int.
     return struct.unpack("q", digest[:8])[0]
 
 
 def acquire_seat_lock(db_session: Session, tenant_id: str | None = None) -> None:
-    """Acquire a transaction-scoped advisory lock on this tenant's seat slot.
+    """Tenant-scoped advisory lock; released on the caller's commit/rollback.
 
-    The lock is released automatically on COMMIT or ROLLBACK of the caller's
-    transaction. Callers MUST run the seat check AND the subsequent INSERT /
-    UPDATE in the same transaction so the lock guards both: see
-    ``check_seat_availability`` for the check, and the surrounding callers
-    for the write.
-
-    Concurrent requests for the same tenant block here; concurrent requests
-    for different tenants proceed in parallel.
+    Caller must run the seat check AND the seat-consuming write in the
+    same transaction.
     """
     lock_id = seat_lock_id_for_tenant(tenant_id or get_current_tenant_id())
     db_session.execute(
@@ -142,13 +130,10 @@ def delete_license(db_session: Session) -> bool:
 
 
 def user_counts_toward_seats(user: User) -> bool:
-    """Whether a single user row would be counted by ``get_used_seats``.
+    """Per-user predicate matching ``get_used_seats``'s SQL filter below.
 
-    Mirrors the filter below; canonical predicate for any caller that
-    needs to know whether a write (e.g. an EXT_PERM_USER → STANDARD
-    upgrade) flips an uncounted user into a counted one. Keep in sync
-    with ``get_used_seats`` — adding or removing a clause there must
-    update this function in lockstep.
+    Self-hosted only — cloud counts ``UserTenantMapping`` rows instead.
+    Keep in sync with ``get_used_seats``.
     """
     return (
         bool(user.is_active)
@@ -162,17 +147,11 @@ def get_used_seats(tenant_id: str | None = None) -> int:
     """
     Get current seat usage directly from database.
 
-    For multi-tenant: counts users in UserTenantMapping for this tenant.
-    For self-hosted: counts all active users.
+    Multi-tenant: counts active UserTenantMapping rows. Self-hosted:
+    counts active users excluding SERVICE_ACCOUNT, EXT_PERM_USER, and
+    the anonymous user. BOT is counted (real humans).
 
-    Only human accounts count toward seat limits.
-    SERVICE_ACCOUNT (API key dummy users), EXT_PERM_USER, and the
-    anonymous system user are excluded. BOT (Slack users) ARE counted
-    because they represent real humans and get upgraded to STANDARD
-    when they log in via web.
-
-    The ``user_counts_toward_seats`` helper above mirrors this filter
-    for callers that need a per-user predicate; keep them in sync.
+    Per-user predicate ``user_counts_toward_seats`` mirrors this filter.
     """
     if MULTI_TENANT:
         from ee.onyx.server.tenants.user_mapping import get_tenant_count

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -25,6 +25,8 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.license import acquire_seat_lock
+from ee.onyx.db.license import check_seat_availability
 from ee.onyx.db.scim import ScimDAL
 from ee.onyx.server.scim.auth import ScimAuthError
 from ee.onyx.server.scim.auth import verify_scim_token
@@ -64,7 +66,6 @@ from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.utils.logger import setup_logger
-from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -212,35 +213,13 @@ def _apply_exclusions(
 def _check_seat_availability(dal: ScimDAL) -> str | None:
     """Return an error message if seat limit is reached, else None.
 
-    Acquires a transaction-scoped advisory lock so that concurrent
-    SCIM requests are serialized.  IdPs like Okta send provisioning
-    requests in parallel batches — without serialization the check is
-    vulnerable to a TOCTOU race where N concurrent requests each see
-    "seats available", all insert, and the tenant ends up over its
-    seat limit.
-
-    The lock is held until the caller's next COMMIT or ROLLBACK, which
-    means the seat count cannot change between the check here and the
-    subsequent INSERT/UPDATE.  Each call site in this module follows
-    the pattern: _check_seat_availability → write → dal.commit()
-    (which releases the lock for the next waiting request).
+    Holds a transaction-scoped advisory lock across the check + the
+    caller's write (committed via ``dal.commit()``) so that batched
+    Okta / Azure AD provisioning requests cannot each pass the check
+    and race past the seat cap.
     """
-    # ``fetch_ee_implementation_or_noop`` returns a callable in all build
-    # modes — the EE function in EE builds, a sync no-op (returning the
-    # passed default) in CE. On CE the no-op acquires no lock and the
-    # check returns ``None``, falling through to the ``not result`` branch.
-    acquire_lock_fn = fetch_ee_implementation_or_noop(
-        "onyx.db.license", "acquire_seat_lock", None
-    )
-    check_fn = fetch_ee_implementation_or_noop(
-        "onyx.db.license", "check_seat_availability", None
-    )
-
-    acquire_lock_fn(dal.session, get_current_tenant_id())
-    result = check_fn(dal.session, seats_needed=1)
-    if result is None:
-        # CE: noop check returns None (the default). No license, no limit.
-        return None
+    acquire_seat_lock(dal.session, get_current_tenant_id())
+    result = check_seat_availability(dal.session, seats_needed=1)
     if not result.available:
         return result.error_message or "Seat limit reached"
     return None

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -225,17 +225,22 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     the pattern: _check_seat_availability → write → dal.commit()
     (which releases the lock for the next waiting request).
     """
+    # ``fetch_ee_implementation_or_noop`` returns a callable in all build
+    # modes — the EE function in EE builds, a sync no-op (returning the
+    # passed default) in CE. On CE the no-op acquires no lock and the
+    # check returns ``None``, falling through to the ``not result`` branch.
     acquire_lock_fn = fetch_ee_implementation_or_noop(
         "onyx.db.license", "acquire_seat_lock", None
     )
     check_fn = fetch_ee_implementation_or_noop(
         "onyx.db.license", "check_seat_availability", None
     )
-    if check_fn is None or acquire_lock_fn is None:
-        return None
 
     acquire_lock_fn(dal.session, get_current_tenant_id())
     result = check_fn(dal.session, seats_needed=1)
+    if result is None:
+        # CE: noop check returns None (the default). No license, no limit.
+        return None
     if not result.available:
         return result.error_message or "Seat limit reached"
     return None

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -11,8 +11,6 @@ require a valid SCIM bearer token.
 
 from __future__ import annotations
 
-import hashlib
-import struct
 from uuid import UUID
 
 from fastapi import APIRouter
@@ -24,7 +22,6 @@ from fastapi import Response
 from fastapi.responses import JSONResponse
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import func
-from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -74,18 +71,6 @@ logger = setup_logger()
 
 # Group names reserved for system default groups (seeded by migration).
 _RESERVED_GROUP_NAMES = frozenset({"Admin", "Basic"})
-
-# Namespace prefix for the seat-allocation advisory lock. Hashed together
-# with the tenant ID so the lock is scoped per-tenant (unrelated tenants
-# never block each other) and cannot collide with unrelated advisory locks.
-_SEAT_LOCK_NAMESPACE = "onyx_scim_seat_lock"
-
-
-def _seat_lock_id_for_tenant(tenant_id: str) -> int:
-    """Derive a stable 64-bit signed int lock id for this tenant's seat lock."""
-    digest = hashlib.sha256(f"{_SEAT_LOCK_NAMESPACE}:{tenant_id}".encode()).digest()
-    # pg_advisory_xact_lock takes a signed 8-byte int; unpack as such.
-    return struct.unpack("q", digest[:8])[0]
 
 
 class ScimJSONResponse(JSONResponse):
@@ -240,22 +225,16 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     the pattern: _check_seat_availability → write → dal.commit()
     (which releases the lock for the next waiting request).
     """
+    acquire_lock_fn = fetch_ee_implementation_or_noop(
+        "onyx.db.license", "acquire_seat_lock", None
+    )
     check_fn = fetch_ee_implementation_or_noop(
         "onyx.db.license", "check_seat_availability", None
     )
-    if check_fn is None:
+    if check_fn is None or acquire_lock_fn is None:
         return None
 
-    # Transaction-scoped advisory lock — released on dal.commit() / dal.rollback().
-    # The lock id is derived from the tenant so unrelated tenants never block
-    # each other, and from a namespace string so it cannot collide with
-    # unrelated advisory locks elsewhere in the codebase.
-    lock_id = _seat_lock_id_for_tenant(get_current_tenant_id())
-    dal.session.execute(
-        text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": lock_id},
-    )
-
+    acquire_lock_fn(dal.session, get_current_tenant_id())
     result = check_fn(dal.session, seats_needed=1)
     if not result.available:
         return result.error_message or "Seat limit reached"

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -3,12 +3,15 @@ from typing import Literal
 
 import requests
 import stripe
+from sqlalchemy.orm import Session
 
 from ee.onyx.configs.app_configs import STRIPE_SECRET_KEY
+from ee.onyx.db.license import acquire_seat_lock
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.usage_limits import is_tenant_on_trial_fn
@@ -220,19 +223,36 @@ def attempt_seat_billing_increase(
         return False, "subscription_invalid"
 
 
-def enforce_cloud_seat_limit(seats_needed: int = 1) -> None:
+def enforce_cloud_seat_limit(
+    seats_needed: int = 1,
+    tenant_id: str | None = None,
+    db_session: Session | None = None,
+) -> None:
     """Cloud (multi-tenant) signup-time seat enforcer.
 
     Computes ``target_quantity = current_active_users + seats_needed`` for
-    the current tenant and asks the control plane (via Stripe) to bill the
+    the target tenant and asks the control plane (via Stripe) to bill the
     new total. Raises ``OnyxError(SEAT_LIMIT_EXCEEDED)`` when the auto-bill
     is declined; returns silently on success.
+
+    Concurrency: when ``db_session`` is the shared-schema session that the
+    caller will commit after inserting the seat-consuming row(s), the
+    ``pg_advisory_xact_lock`` acquired here is held until that commit. Two
+    concurrent signups for the same tenant therefore serialize across the
+    full count → bill → insert window, closing the TOCTOU gap that the
+    Stripe idempotency key alone does not.
+
+    Without ``db_session`` the lock is taken on a short-lived shared-schema
+    session and released as soon as the bill returns — best-effort: it
+    serializes the count + bill against other holders of the same lock,
+    but the caller's later insert is not protected. Use the ``db_session``
+    overload from any path that performs the seat-consuming write.
 
     Trial tenants short-circuit — the trial-invite cap in
     ``bulk_invite_users`` is the only seat backstop for trial accounts.
     """
-    tenant_id = get_current_tenant_id()
-    if is_tenant_on_trial_fn(tenant_id):
+    tenant = tenant_id or get_current_tenant_id()
+    if is_tenant_on_trial_fn(tenant):
         return
 
     # Local import keeps the billing module loadable on environments that
@@ -240,10 +260,23 @@ def enforce_cloud_seat_limit(seats_needed: int = 1) -> None:
     # that import billing only via ``fetch_ee_implementation_or_noop``).
     from ee.onyx.server.tenants.user_mapping import get_tenant_count
 
-    current_count = get_tenant_count(tenant_id)
-    target_quantity = current_count + seats_needed
+    if db_session is not None:
+        # Lock the caller's transaction for this tenant. The lock will be
+        # released by the caller's commit/rollback, after their insert.
+        acquire_seat_lock(db_session, tenant)
+        current_count = get_tenant_count(tenant)
+        target_quantity = current_count + seats_needed
+        success, reason = attempt_seat_billing_increase(tenant, target_quantity)
+    else:
+        # Best-effort fallback: serialize the count + bill on a short-lived
+        # shared-schema session. The caller's later insert is unprotected.
+        with get_session_with_shared_schema() as locked_session:
+            acquire_seat_lock(locked_session, tenant)
+            current_count = get_tenant_count(tenant)
+            target_quantity = current_count + seats_needed
+            success, reason = attempt_seat_billing_increase(tenant, target_quantity)
+            locked_session.commit()
 
-    success, reason = attempt_seat_billing_increase(tenant_id, target_quantity)
     if success:
         return
 

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -185,9 +185,24 @@ def attempt_seat_billing_increase(
     so the caller fails closed rather than silently allowing a signup that
     bypasses billing.
 
-    Idempotent: if the existing Stripe subscription quantity is already
-    >= ``target_quantity``, the call is a no-op and returns success without
-    reissuing the modify.
+    Idempotent on retry: passing the same ``(tenant_id, target_quantity)``
+    twice generates the same Stripe ``idempotency_key``, so a retried HTTP
+    request will not double-charge. If the existing subscription quantity
+    is already ``>= target_quantity``, the call is a no-op and returns
+    success without reissuing the modify.
+
+    .. warning::
+       The idempotency key is RETRY-SAFE, NOT a concurrency serializer.
+       Two concurrent signups that both compute ``target = N + 1`` and
+       reuse the same key will both receive Stripe success responses,
+       and Stripe will only bill ``N + 1`` (not ``N + 2``). Callers that
+       need cap enforcement under concurrency MUST hold a per-tenant
+       advisory lock across the {count, this call, seat-consuming
+       insert} window — use ``enforce_cloud_seat_limit(db_session=...)``,
+       which acquires that lock and only releases it on the caller's
+       commit. Direct calls to this function from outside the wrapper
+       bypass cap enforcement and should be limited to retry / repair
+       paths.
     """
     try:
         response = fetch_tenant_stripe_information(tenant_id)

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -9,7 +9,11 @@ from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.server.tenants.models import BillingInformation
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.usage_limits import is_tenant_on_trial_fn
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 stripe.api_key = STRIPE_SECRET_KEY
 
@@ -109,10 +113,17 @@ def fetch_customer_portal_session(tenant_id: str, return_url: str | None = None)
     return response.json()["url"]
 
 
-def register_tenant_users(tenant_id: str, number_of_users: int) -> stripe.Subscription:
+def register_tenant_users(
+    tenant_id: str,
+    number_of_users: int,
+    idempotency_key: str | None = None,
+) -> stripe.Subscription:
     """
     Update the number of seats for a tenant's subscription.
     Preserves the existing price (monthly, annual, or grandfathered).
+
+    When ``idempotency_key`` is provided, retried HTTP requests will not
+    double-charge — Stripe deduplicates by the key for ~24 h.
     """
     response = fetch_tenant_stripe_information(tenant_id)
     stripe_subscription_id = cast(str, response.get("stripe_subscription_id"))
@@ -123,15 +134,130 @@ def register_tenant_users(tenant_id: str, number_of_users: int) -> stripe.Subscr
     # Use existing price to preserve the customer's current plan
     current_price_id = subscription_item.price.id
 
-    updated_subscription = stripe.Subscription.modify(
-        stripe_subscription_id,
-        items=[
+    modify_kwargs: dict = {
+        "items": [
             {
                 "id": subscription_item.id,
                 "price": current_price_id,
                 "quantity": number_of_users,
             }
         ],
-        metadata={"tenant_id": str(tenant_id)},
+        "metadata": {"tenant_id": str(tenant_id)},
+    }
+    if idempotency_key is not None:
+        modify_kwargs["idempotency_key"] = idempotency_key
+
+    updated_subscription = stripe.Subscription.modify(
+        stripe_subscription_id,
+        **modify_kwargs,
     )
     return updated_subscription
+
+
+def _seat_billing_idempotency_key(tenant_id: str, target_quantity: int) -> str:
+    """Stable idempotency key for an auto-bill seat increase.
+
+    Same ``(tenant_id, target_quantity)`` produces the same key, so retried
+    HTTP requests for the same logical operation are deduplicated by Stripe
+    (~24h window).
+    """
+    return f"seat-bill-{tenant_id}-{target_quantity}"
+
+
+def attempt_seat_billing_increase(
+    tenant_id: str,
+    target_quantity: int,
+) -> tuple[bool, str | None]:
+    """Attempt to set the tenant's Stripe seat quantity to ``target_quantity``.
+
+    Returns ``(True, None)`` on success.
+
+    Returns ``(False, reason)`` for billing-side declines that should reject
+    the originating signup:
+      - ``"card_declined"`` — Stripe ``CardError`` (insufficient funds, etc.)
+      - ``"subscription_invalid"`` — Stripe ``InvalidRequestError`` (e.g.,
+        no active subscription for this tenant)
+
+    Other Stripe errors (network, rate-limit, auth, generic API) propagate
+    so the caller fails closed rather than silently allowing a signup that
+    bypasses billing.
+
+    Idempotent: if the existing Stripe subscription quantity is already
+    >= ``target_quantity``, the call is a no-op and returns success without
+    reissuing the modify.
+    """
+    try:
+        response = fetch_tenant_stripe_information(tenant_id)
+        stripe_subscription_id = cast(str, response.get("stripe_subscription_id"))
+        if not stripe_subscription_id:
+            return False, "subscription_invalid"
+
+        subscription = stripe.Subscription.retrieve(stripe_subscription_id)
+        subscription_item = subscription["items"]["data"][0]
+        current_quantity = int(subscription_item.get("quantity", 0))
+        if current_quantity >= target_quantity:
+            return True, None
+
+        register_tenant_users(
+            tenant_id,
+            target_quantity,
+            idempotency_key=_seat_billing_idempotency_key(tenant_id, target_quantity),
+        )
+        return True, None
+    except stripe.CardError as e:
+        logger.warning(
+            "Card declined while billing seat increase for tenant %s: %s",
+            tenant_id,
+            e.user_message or str(e),
+        )
+        return False, "card_declined"
+    except stripe.InvalidRequestError as e:
+        logger.warning(
+            "Stripe rejected seat-billing increase for tenant %s: %s",
+            tenant_id,
+            str(e),
+        )
+        return False, "subscription_invalid"
+
+
+def enforce_cloud_seat_limit(seats_needed: int = 1) -> None:
+    """Cloud (multi-tenant) signup-time seat enforcer.
+
+    Computes ``target_quantity = current_active_users + seats_needed`` for
+    the current tenant and asks the control plane (via Stripe) to bill the
+    new total. Raises ``OnyxError(SEAT_LIMIT_EXCEEDED)`` when the auto-bill
+    is declined; returns silently on success.
+
+    Trial tenants short-circuit — the trial-invite cap in
+    ``bulk_invite_users`` is the only seat backstop for trial accounts.
+    """
+    tenant_id = get_current_tenant_id()
+    if is_tenant_on_trial_fn(tenant_id):
+        return
+
+    # Local import keeps the billing module loadable on environments that
+    # don't have the EE tenant package on the import path (e.g., CE tests
+    # that import billing only via ``fetch_ee_implementation_or_noop``).
+    from ee.onyx.server.tenants.user_mapping import get_tenant_count
+
+    current_count = get_tenant_count(tenant_id)
+    target_quantity = current_count + seats_needed
+
+    success, reason = attempt_seat_billing_increase(tenant_id, target_quantity)
+    if success:
+        return
+
+    if reason == "card_declined":
+        message = (
+            "Could not add a new seat: your payment method was declined. "
+            "Please update your billing details and try again."
+        )
+    elif reason == "subscription_invalid":
+        message = (
+            "Could not add a new seat: this tenant does not have an active "
+            "subscription. Please contact your Onyx administrator."
+        )
+    else:
+        message = "Could not add a new seat (billing declined)."
+
+    raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, message)

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -1,3 +1,4 @@
+from enum import Enum as PyEnum
 from typing import cast
 from typing import Literal
 
@@ -21,6 +22,11 @@ from shared_configs.contextvars import get_current_tenant_id
 stripe.api_key = STRIPE_SECRET_KEY
 
 logger = setup_logger()
+
+
+class SeatBillingDeclineReason(str, PyEnum):
+    CARD_DECLINED = "card_declined"
+    SUBSCRIPTION_INVALID = "subscription_invalid"
 
 
 def fetch_stripe_checkout_session(
@@ -162,16 +168,12 @@ def _seat_billing_idempotency_key(tenant_id: str, target_quantity: int) -> str:
 def attempt_seat_billing_increase(
     tenant_id: str,
     target_quantity: int,
-) -> tuple[bool, str | None]:
+) -> tuple[bool, SeatBillingDeclineReason | None]:
     """Set Stripe seat quantity to ``target_quantity``.
 
-    Returns ``(False, reason)`` for billing declines the caller should
-    surface as signup failures:
-      - ``"card_declined"`` — Stripe ``CardError``
-      - ``"subscription_invalid"`` — Stripe ``InvalidRequestError``
-
-    Other Stripe errors propagate (fail closed). No-op when current
-    quantity already ``>= target_quantity``.
+    On decline returns ``(False, SeatBillingDeclineReason.X)``. Other
+    Stripe errors propagate (fail closed). No-op when current quantity
+    is already ``>= target_quantity``.
 
     NOT a concurrency serializer — the idempotency key only dedupes
     HTTP retries. For cap enforcement under concurrency call
@@ -182,7 +184,7 @@ def attempt_seat_billing_increase(
         response = fetch_tenant_stripe_information(tenant_id)
         stripe_subscription_id = cast(str, response.get("stripe_subscription_id"))
         if not stripe_subscription_id:
-            return False, "subscription_invalid"
+            return False, SeatBillingDeclineReason.SUBSCRIPTION_INVALID
 
         subscription = stripe.Subscription.retrieve(stripe_subscription_id)
         subscription_item = subscription["items"]["data"][0]
@@ -202,14 +204,14 @@ def attempt_seat_billing_increase(
             tenant_id,
             e.user_message or str(e),
         )
-        return False, "card_declined"
+        return False, SeatBillingDeclineReason.CARD_DECLINED
     except stripe.InvalidRequestError as e:
         logger.warning(
             "Stripe rejected seat-billing increase for tenant %s: %s",
             tenant_id,
             str(e),
         )
-        return False, "subscription_invalid"
+        return False, SeatBillingDeclineReason.SUBSCRIPTION_INVALID
 
 
 def enforce_cloud_seat_limit(
@@ -231,7 +233,8 @@ def enforce_cloud_seat_limit(
     if is_tenant_on_trial_fn(tenant):
         return
 
-    # Local import — billing module must load on CE without EE tenants on path.
+    # Local import avoids circular import with user_mapping (which calls
+    # back into this module from add_users_to_tenant).
     from ee.onyx.server.tenants.user_mapping import get_tenant_count
 
     if db_session is not None:
@@ -250,12 +253,12 @@ def enforce_cloud_seat_limit(
     if success:
         return
 
-    if reason == "card_declined":
+    if reason == SeatBillingDeclineReason.CARD_DECLINED:
         message = (
             "Could not add a new seat: your payment method was declined. "
             "Please update your billing details and try again."
         )
-    elif reason == "subscription_invalid":
+    elif reason == SeatBillingDeclineReason.SUBSCRIPTION_INVALID:
         message = (
             "Could not add a new seat: this tenant does not have an active "
             "subscription. Please contact your Onyx administrator."

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -1,5 +1,4 @@
 from enum import Enum as PyEnum
-from typing import Any
 from typing import cast
 from typing import Literal
 
@@ -141,24 +140,27 @@ def register_tenant_users(
     # Use existing price to preserve the customer's current plan
     current_price_id = subscription_item.price.id
 
-    modify_kwargs: dict[str, Any] = {
-        "items": [
-            {
-                "id": subscription_item.id,
-                "price": current_price_id,
-                "quantity": number_of_users,
-            }
-        ],
-        "metadata": {"tenant_id": str(tenant_id)},
-    }
-    if idempotency_key is not None:
-        modify_kwargs["idempotency_key"] = idempotency_key
+    items = [
+        {
+            "id": subscription_item.id,
+            "price": current_price_id,
+            "quantity": number_of_users,
+        }
+    ]
+    metadata = {"tenant_id": str(tenant_id)}
 
-    updated_subscription = stripe.Subscription.modify(
+    if idempotency_key is None:
+        return stripe.Subscription.modify(
+            stripe_subscription_id,
+            items=items,
+            metadata=metadata,
+        )
+    return stripe.Subscription.modify(
         stripe_subscription_id,
-        **modify_kwargs,
+        items=items,
+        metadata=metadata,
+        idempotency_key=idempotency_key,
     )
-    return updated_subscription
 
 
 def _seat_billing_idempotency_key(tenant_id: str, target_quantity: int) -> str:

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -124,9 +124,6 @@ def register_tenant_users(
     """
     Update the number of seats for a tenant's subscription.
     Preserves the existing price (monthly, annual, or grandfathered).
-
-    When ``idempotency_key`` is provided, retried HTTP requests will not
-    double-charge — Stripe deduplicates by the key for ~24 h.
     """
     response = fetch_tenant_stripe_information(tenant_id)
     stripe_subscription_id = cast(str, response.get("stripe_subscription_id"))
@@ -158,12 +155,7 @@ def register_tenant_users(
 
 
 def _seat_billing_idempotency_key(tenant_id: str, target_quantity: int) -> str:
-    """Stable idempotency key for an auto-bill seat increase.
-
-    Same ``(tenant_id, target_quantity)`` produces the same key, so retried
-    HTTP requests for the same logical operation are deduplicated by Stripe
-    (~24h window).
-    """
+    """Stable per-(tenant, target) key so HTTP retries don't double-bill."""
     return f"seat-bill-{tenant_id}-{target_quantity}"
 
 
@@ -171,38 +163,20 @@ def attempt_seat_billing_increase(
     tenant_id: str,
     target_quantity: int,
 ) -> tuple[bool, str | None]:
-    """Attempt to set the tenant's Stripe seat quantity to ``target_quantity``.
+    """Set Stripe seat quantity to ``target_quantity``.
 
-    Returns ``(True, None)`` on success.
+    Returns ``(False, reason)`` for billing declines the caller should
+    surface as signup failures:
+      - ``"card_declined"`` — Stripe ``CardError``
+      - ``"subscription_invalid"`` — Stripe ``InvalidRequestError``
 
-    Returns ``(False, reason)`` for billing-side declines that should reject
-    the originating signup:
-      - ``"card_declined"`` — Stripe ``CardError`` (insufficient funds, etc.)
-      - ``"subscription_invalid"`` — Stripe ``InvalidRequestError`` (e.g.,
-        no active subscription for this tenant)
+    Other Stripe errors propagate (fail closed). No-op when current
+    quantity already ``>= target_quantity``.
 
-    Other Stripe errors (network, rate-limit, auth, generic API) propagate
-    so the caller fails closed rather than silently allowing a signup that
-    bypasses billing.
-
-    Idempotent on retry: passing the same ``(tenant_id, target_quantity)``
-    twice generates the same Stripe ``idempotency_key``, so a retried HTTP
-    request will not double-charge. If the existing subscription quantity
-    is already ``>= target_quantity``, the call is a no-op and returns
-    success without reissuing the modify.
-
-    .. warning::
-       The idempotency key is RETRY-SAFE, NOT a concurrency serializer.
-       Two concurrent signups that both compute ``target = N + 1`` and
-       reuse the same key will both receive Stripe success responses,
-       and Stripe will only bill ``N + 1`` (not ``N + 2``). Callers that
-       need cap enforcement under concurrency MUST hold a per-tenant
-       advisory lock across the {count, this call, seat-consuming
-       insert} window — use ``enforce_cloud_seat_limit(db_session=...)``,
-       which acquires that lock and only releases it on the caller's
-       commit. Direct calls to this function from outside the wrapper
-       bypass cap enforcement and should be limited to retry / repair
-       paths.
+    NOT a concurrency serializer — the idempotency key only dedupes
+    HTTP retries. For cap enforcement under concurrency call
+    ``enforce_cloud_seat_limit(db_session=...)``, which holds the
+    per-tenant advisory lock across {count, bill, insert}.
     """
     try:
         response = fetch_tenant_stripe_information(tenant_id)
@@ -243,48 +217,29 @@ def enforce_cloud_seat_limit(
     tenant_id: str | None = None,
     db_session: Session | None = None,
 ) -> None:
-    """Cloud (multi-tenant) signup-time seat enforcer.
+    """Cloud signup-time seat enforcer. Auto-bills via Stripe; raises
+    ``OnyxError(SEAT_LIMIT_EXCEEDED)`` on decline.
 
-    Computes ``target_quantity = current_active_users + seats_needed`` for
-    the target tenant and asks the control plane (via Stripe) to bill the
-    new total. Raises ``OnyxError(SEAT_LIMIT_EXCEEDED)`` when the auto-bill
-    is declined; returns silently on success.
+    Pass ``db_session`` (shared-schema) to hold the advisory lock across
+    {count, bill, caller's insert} — the only mode that closes the
+    cloud TOCTOU. Without it, lock is held only across {count, bill}.
 
-    Concurrency: when ``db_session`` is the shared-schema session that the
-    caller will commit after inserting the seat-consuming row(s), the
-    ``pg_advisory_xact_lock`` acquired here is held until that commit. Two
-    concurrent signups for the same tenant therefore serialize across the
-    full count → bill → insert window, closing the TOCTOU gap that the
-    Stripe idempotency key alone does not.
-
-    Without ``db_session`` the lock is taken on a short-lived shared-schema
-    session and released as soon as the bill returns — best-effort: it
-    serializes the count + bill against other holders of the same lock,
-    but the caller's later insert is not protected. Use the ``db_session``
-    overload from any path that performs the seat-consuming write.
-
-    Trial tenants short-circuit — the trial-invite cap in
-    ``bulk_invite_users`` is the only seat backstop for trial accounts.
+    Trial tenants short-circuit; ``NUM_FREE_TRIAL_USER_INVITES`` is the
+    only trial backstop.
     """
     tenant = tenant_id or get_current_tenant_id()
     if is_tenant_on_trial_fn(tenant):
         return
 
-    # Local import keeps the billing module loadable on environments that
-    # don't have the EE tenant package on the import path (e.g., CE tests
-    # that import billing only via ``fetch_ee_implementation_or_noop``).
+    # Local import — billing module must load on CE without EE tenants on path.
     from ee.onyx.server.tenants.user_mapping import get_tenant_count
 
     if db_session is not None:
-        # Lock the caller's transaction for this tenant. The lock will be
-        # released by the caller's commit/rollback, after their insert.
         acquire_seat_lock(db_session, tenant)
         current_count = get_tenant_count(tenant)
         target_quantity = current_count + seats_needed
         success, reason = attempt_seat_billing_increase(tenant, target_quantity)
     else:
-        # Best-effort fallback: serialize the count + bill on a short-lived
-        # shared-schema session. The caller's later insert is unprotected.
         with get_session_with_shared_schema() as locked_session:
             acquire_seat_lock(locked_session, tenant)
             current_count = get_tenant_count(tenant)

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -1,4 +1,5 @@
 from enum import Enum as PyEnum
+from typing import Any
 from typing import cast
 from typing import Literal
 
@@ -140,7 +141,7 @@ def register_tenant_users(
     # Use existing price to preserve the customer's current plan
     current_price_id = subscription_item.price.id
 
-    modify_kwargs: dict = {
+    modify_kwargs: dict[str, Any] = {
         "items": [
             {
                 "id": subscription_item.id,

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -125,10 +125,19 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
             if new_active_seat_emails:
                 from ee.onyx.server.tenants.billing import enforce_cloud_seat_limit
 
-                # Raises OnyxError(SEAT_LIMIT_EXCEEDED) on Stripe decline; the
-                # outer `except Exception` rolls the transaction back so no
-                # mappings are persisted on failure.
-                enforce_cloud_seat_limit(seats_needed=len(new_active_seat_emails))
+                # Pass ``db_session`` so the advisory lock is held across
+                # the Stripe call AND the mapping inserts below — closes the
+                # cloud TOCTOU window that a Stripe-only idempotency key
+                # cannot. Pass ``tenant_id`` explicitly (not via context var)
+                # to bill the correct tenant if the caller's context differs.
+                # Raises OnyxError(SEAT_LIMIT_EXCEEDED) on Stripe decline;
+                # the outer ``except Exception`` rolls the transaction back
+                # so no mappings are persisted on failure.
+                enforce_cloud_seat_limit(
+                    seats_needed=len(new_active_seat_emails),
+                    tenant_id=tenant_id,
+                    db_session=db_session,
+                )
 
             # Add mappings for emails that don't already have one to this tenant
             for email in unique_emails:

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -75,6 +75,9 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
     an inactive mapping (invitation) to this tenant. They can accept the
     invitation later to switch tenants.
 
+    Defense-in-depth: before inserting any new ACTIVE mapping (a brand-new
+    seat for this tenant), call ``enforce_cloud_seat_limit`` so a missed
+    upstream check still fails closed via Stripe auto-billing.
     """
     unique_emails = set(emails)
     if not unique_emails:
@@ -108,6 +111,24 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
                 .all()
             )
             emails_with_active_mapping = {m.email for m in active_mappings}
+
+            # Determine which emails will produce a NEW ACTIVE mapping for
+            # this tenant. Inactive (invitation) mappings to other tenants
+            # don't count — they don't consume a seat until accepted.
+            new_active_seat_emails = [
+                email
+                for email in unique_emails
+                if email not in emails_with_mapping
+                and email not in emails_with_active_mapping
+            ]
+
+            if new_active_seat_emails:
+                from ee.onyx.server.tenants.billing import enforce_cloud_seat_limit
+
+                # Raises OnyxError(SEAT_LIMIT_EXCEEDED) on Stripe decline; the
+                # outer `except Exception` rolls the transaction back so no
+                # mappings are persisted on failure.
+                enforce_cloud_seat_limit(seats_needed=len(new_active_seat_emails))
 
             # Add mappings for emails that don't already have one to this tenant
             for email in unique_emails:

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -68,16 +68,11 @@ def user_owns_a_tenant(email: str) -> bool:
 
 def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
     """
-    Add users to a tenant with proper transaction handling.
-    Checks if users already have a tenant mapping to avoid duplicates.
+    Add users to a tenant. If a user has an active mapping elsewhere,
+    they get an inactive (invitation) mapping until they accept.
 
-    If a user already has an active mapping to a different tenant, they receive
-    an inactive mapping (invitation) to this tenant. They can accept the
-    invitation later to switch tenants.
-
-    Defense-in-depth: before inserting any new ACTIVE mapping (a brand-new
-    seat for this tenant), call ``enforce_cloud_seat_limit`` so a missed
-    upstream check still fails closed via Stripe auto-billing.
+    Calls ``enforce_cloud_seat_limit`` before inserting any new active
+    mapping so Stripe auto-billing fails the request closed on decline.
     """
     unique_emails = set(emails)
     if not unique_emails:
@@ -112,9 +107,8 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
             )
             emails_with_active_mapping = {m.email for m in active_mappings}
 
-            # Determine which emails will produce a NEW ACTIVE mapping for
-            # this tenant. Inactive (invitation) mappings to other tenants
-            # don't count — they don't consume a seat until accepted.
+            # Emails that will produce a NEW active mapping (consume a
+            # seat). Invitations to other tenants don't count.
             new_active_seat_emails = [
                 email
                 for email in unique_emails
@@ -125,14 +119,8 @@ def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:
             if new_active_seat_emails:
                 from ee.onyx.server.tenants.billing import enforce_cloud_seat_limit
 
-                # Pass ``db_session`` so the advisory lock is held across
-                # the Stripe call AND the mapping inserts below — closes the
-                # cloud TOCTOU window that a Stripe-only idempotency key
-                # cannot. Pass ``tenant_id`` explicitly (not via context var)
-                # to bill the correct tenant if the caller's context differs.
-                # Raises OnyxError(SEAT_LIMIT_EXCEEDED) on Stripe decline;
-                # the outer ``except Exception`` rolls the transaction back
-                # so no mappings are persisted on failure.
+                # Lock + bill held across the inserts below; rolled back
+                # on Stripe decline by the outer ``except Exception``.
                 enforce_cloud_seat_limit(
                     seats_needed=len(new_active_seat_emails),
                     tenant_id=tenant_id,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -336,11 +336,28 @@ def verify_email_domain(email: str, *, is_registration: bool = False) -> None:
 
 
 def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
-    """Raise HTTPException(402) if adding users would exceed the seat limit.
+    """Raise OnyxError(SEAT_LIMIT_EXCEEDED) if adding users would exceed the limit.
 
-    No-op for multi-tenant or CE deployments.
+    Self-hosted: runs ``check_seat_availability`` against the local license.
+    Cloud (multi-tenant): delegates to the EE control-plane billing helper,
+    which attempts to auto-bill the new seat(s) and rejects on Stripe failure.
+    No-op for CE deployments without an EE license.
+
+    Callers that follow this with an INSERT in the same transaction should
+    use ``enforce_seat_limit_locked`` instead — it acquires a tenant-scoped
+    advisory lock so concurrent requests cannot each pass the check and
+    over-insert.
     """
     if MULTI_TENANT:
+        # Default to a no-op so CE / non-EE deployments do not blow up if
+        # someone enables MULTI_TENANT without the EE billing module on the
+        # import path. The real EE implementation rejects via OnyxError
+        # when Stripe declines.
+        fetch_ee_implementation_or_noop(
+            "onyx.server.tenants.billing",
+            "enforce_cloud_seat_limit",
+            lambda **_kw: None,
+        )(seats_needed=seats_needed)
         return
 
     result = fetch_ee_implementation_or_noop(
@@ -349,6 +366,65 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
 
     if result is not None and not result.available:
         raise OnyxError(OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message)
+
+
+def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> None:
+    """Acquire the tenant seat lock on ``db_session``, then enforce the limit.
+
+    The advisory lock is transaction-scoped: it is released when the caller's
+    transaction commits or rolls back. The caller MUST run the subsequent
+    INSERT/UPDATE in the same transaction so the seat count cannot change
+    between this check and the write.
+
+    Self-hosted: locks the local row, then runs ``check_seat_availability``.
+    Cloud (multi-tenant): the lock acquisition is a no-op (the seat count
+    lives in Stripe, not the local DB) — but the cloud auto-bill path is
+    inherently serialized per-tenant by the Stripe idempotency key.
+    """
+    if not MULTI_TENANT:
+        fetch_ee_implementation_or_noop("onyx.db.license", "acquire_seat_lock", None)(
+            db_session, get_current_tenant_id()
+        )
+
+    enforce_seat_limit(db_session, seats_needed=seats_needed)
+
+
+def _user_currently_counts_toward_seats(user: User) -> bool:
+    """Return whether ``user`` is currently counted by ``get_used_seats``.
+
+    Mirrors the filter at ``ee/onyx/db/license.py:get_used_seats``: active,
+    non-anonymous, role != EXT_PERM_USER, account_type != SERVICE_ACCOUNT.
+    """
+    return (
+        bool(user.is_active)
+        and user.role != UserRole.EXT_PERM_USER
+        and user.email != ANONYMOUS_USER_EMAIL
+        and user.account_type != AccountType.SERVICE_ACCOUNT
+    )
+
+
+def _upgrade_will_add_seat(user_before: User, will_become_active: bool) -> bool:
+    """Return whether upgrading ``user_before`` to STANDARD/web-login will
+    flip them from uncounted to counted (i.e. consume an additional seat).
+
+    After upgrade: account_type=STANDARD, role=BASIC/ADMIN — so post-upgrade
+    seat-counted-status depends only on whether the user will be active and
+    is not the anonymous account.
+    """
+    will_be_counted = will_become_active and user_before.email != ANONYMOUS_USER_EMAIL
+    return will_be_counted and not _user_currently_counts_toward_seats(user_before)
+
+
+def _invalidate_license_cache_after_seat_change() -> None:
+    """Invalidate the license metadata cache so the middleware re-reads
+    ``used_seats`` on the next request.
+
+    Safe no-op on CE / cache outage; cache TTL bounds the staleness either
+    way.
+    """
+    fetch_ee_implementation_or_noop(
+        "onyx.db.license", "invalidate_license_cache", None
+    )()
 
 
 class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
@@ -479,11 +555,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             UserRole.ADMIN
                         )
 
-                # Check seat availability for new users (single-tenant only)
-                with get_session_with_current_tenant() as sync_db:
-                    existing = get_user_by_email(user_create.email, sync_db)
-                    if existing is None:
-                        enforce_seat_limit(sync_db)
+                # Check seat availability for new users. Runs in the SAME
+                # async-session transaction as the subsequent insert so the
+                # advisory lock acquired here is held until that insert
+                # commits — closes the TOCTOU race against concurrent signups.
+                existing = await self.user_db.session.run_sync(
+                    lambda s: get_user_by_email(user_create.email, s)
+                )
+                if existing is None:
+                    await self.user_db.session.run_sync(
+                        lambda s: enforce_seat_limit_locked(s, seats_needed=1)
+                    )
 
                 user_created = False
                 try:
@@ -602,7 +684,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
         All writes happen in a single sync transaction so neither the field
         update nor the group assignment is visible without the other.
+
+        If the upgrade flips the user from uncounted to counted (e.g.
+        EXT_PERM_USER → STANDARD), enforce the seat limit inside the same
+        transaction so the advisory lock is held until commit and the
+        promotion cannot push the tenant past its seat cap.
         """
+        seat_added = False
         with get_session_with_current_tenant() as sync_db:
             sync_user = (
                 sync_db.query(User)
@@ -610,6 +698,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 .first()
             )
             if sync_user:
+                # The upgrade keeps is_active unchanged; seat-count flip is
+                # purely about the role/account_type change.
+                if _upgrade_will_add_seat(
+                    sync_user, will_become_active=bool(sync_user.is_active)
+                ):
+                    enforce_seat_limit_locked(sync_db, seats_needed=1)
+                    seat_added = True
                 sync_user.hashed_password = self.password_helper.hash(
                     user_create.password
                 )
@@ -627,6 +722,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     "User %s not found in sync session during upgrade to standard; skipping upgrade",
                     user_id,
                 )
+        if seat_added:
+            _invalidate_license_cache_after_seat_change()
 
     async def validate_password(  # ty: ignore[invalid-method-override]
         self, password: str, _: schemas.UC | models.UP
@@ -742,9 +839,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 except exceptions.UserNotExists:
                     verify_email_domain(account_email, is_registration=True)
 
-                    # Check seat availability before creating (single-tenant only)
-                    with get_session_with_current_tenant() as sync_db:
-                        enforce_seat_limit(sync_db)
+                    # Lock + seat check inside the same async-session
+                    # transaction as the subsequent insert so the lock
+                    # blocks concurrent OAuth signups until this insert
+                    # commits — closes the TOCTOU race against /auth/register
+                    # and other OAuth callbacks.
+                    await self.user_db.session.run_sync(
+                        lambda s: enforce_seat_limit_locked(s, seats_needed=1)
+                    )
 
                     password = self.password_helper.generate()
                     user_dict = {
@@ -794,16 +896,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         if user_by_session:
                             user = user_by_session
 
-                # If the user is inactive, check seat availability before
-                # upgrading role — otherwise they'd become an inactive BASIC
-                # user who still can't log in.
-                if not user.is_active:
-                    with get_session_with_current_tenant() as sync_db:
-                        enforce_seat_limit(sync_db)
-
-                # Upgrade the user and assign default groups in a single
-                # transaction so neither change is visible without the other.
+                # Lock + seat check + upgrade all in one sync transaction.
+                # The advisory lock is released on commit/rollback, so the
+                # seat-counted-status flip (inactive→active and/or
+                # non-web-login→STANDARD) is serialized against concurrent
+                # signup/upgrade requests for this tenant.
                 was_inactive = not user.is_active
+                seat_added = False
                 with get_session_with_current_tenant() as sync_db:
                     sync_user = (
                         sync_db.query(User)
@@ -811,6 +910,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         .first()
                     )
                     if sync_user:
+                        will_become_active = (
+                            True if was_inactive else bool(sync_user.is_active)
+                        )
+                        if _upgrade_will_add_seat(
+                            sync_user, will_become_active=will_become_active
+                        ):
+                            enforce_seat_limit_locked(sync_db, seats_needed=1)
+                            seat_added = True
                         sync_user.is_verified = is_verified_by_default
                         sync_user.role = UserRole.BASIC
                         sync_user.account_type = AccountType.STANDARD
@@ -818,6 +925,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             sync_user.is_active = True
                         assign_user_to_default_groups__no_commit(sync_db, sync_user)
                         sync_db.commit()
+                if seat_added:
+                    _invalidate_license_cache_after_seat_change()
 
                 # Refresh the async user object so downstream code
                 # (e.g. oidc_expiry check) sees the updated fields.

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -420,10 +420,23 @@ def _upgrade_will_add_seat(user_before: User, will_become_active: bool) -> bool:
     """Return whether upgrading ``user_before`` to STANDARD/web-login will
     flip them from uncounted to counted (i.e. consume an additional seat).
 
-    After upgrade: account_type=STANDARD, role=BASIC/ADMIN — so post-upgrade
-    seat-counted-status depends only on whether the user will be active and
-    is not the anonymous account.
+    Self-hosted: seat counting is per-User filtered by role/account_type.
+    Upgrades that change role/account_type can shift the count, so we
+    compare the canonical predicate before vs the post-upgrade state.
+    Post-upgrade: account_type=STANDARD, role=BASIC/ADMIN — so the
+    post-upgrade seat-counted-status depends only on activeness and the
+    email not being anonymous.
+
+    Multi-tenant cloud: seat counting is per-``UserTenantMapping`` row,
+    NOT per-User. A role/account_type upgrade does not add a mapping —
+    the user must already have an active mapping to be promoting in the
+    first place — so the upgrade is seat-neutral by ``get_tenant_count``.
+    Return ``False`` so the cloud billing path is not triggered with a
+    target quantity that the mapping count will never reach (which would
+    over-bill the tenant by one seat per promotion).
     """
+    if MULTI_TENANT:
+        return False
     will_be_counted = will_become_active and user_before.email != ANONYMOUS_USER_EMAIL
     return will_be_counted and not _user_currently_counts_toward_seats(user_before)
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -392,9 +392,15 @@ def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> Non
 def _user_currently_counts_toward_seats(user: User) -> bool:
     """Return whether ``user`` is currently counted by ``get_used_seats``.
 
-    Mirrors the filter at ``ee/onyx/db/license.py:get_used_seats``: active,
-    non-anonymous, role != EXT_PERM_USER, account_type != SERVICE_ACCOUNT.
+    Delegates to the canonical predicate in ``ee/onyx/db/license.py`` so
+    the two definitions cannot drift. The local fallback below is only
+    reached on CE / non-EE deployments where the EE module is absent.
     """
+    canonical = fetch_ee_implementation_or_noop(
+        "onyx.db.license", "user_counts_toward_seats", None
+    )(user)
+    if canonical is not None:
+        return bool(canonical)
     return (
         bool(user.is_active)
         and user.role != UserRole.EXT_PERM_USER

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -336,23 +336,14 @@ def verify_email_domain(email: str, *, is_registration: bool = False) -> None:
 
 
 def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
-    """Raise OnyxError(SEAT_LIMIT_EXCEEDED) if adding users would exceed the limit.
+    """Raise ``OnyxError(SEAT_LIMIT_EXCEEDED)`` if seats would be exceeded.
 
-    Self-hosted: runs ``check_seat_availability`` against the local license.
-    Cloud (multi-tenant): delegates to the EE control-plane billing helper,
-    which attempts to auto-bill the new seat(s) and rejects on Stripe failure.
-    No-op for CE deployments without an EE license.
-
-    Callers that follow this with an INSERT in the same transaction should
-    use ``enforce_seat_limit_locked`` instead — it acquires a tenant-scoped
-    advisory lock so concurrent requests cannot each pass the check and
-    over-insert.
+    Self-hosted runs ``check_seat_availability``; cloud delegates to
+    ``enforce_cloud_seat_limit`` which auto-bills via Stripe. Use
+    ``enforce_seat_limit_locked`` when followed by a write in the same
+    transaction.
     """
     if MULTI_TENANT:
-        # Default to a no-op so CE / non-EE deployments do not blow up if
-        # someone enables MULTI_TENANT without the EE billing module on the
-        # import path. The real EE implementation rejects via OnyxError
-        # when Stripe declines.
         fetch_ee_implementation_or_noop(
             "onyx.server.tenants.billing",
             "enforce_cloud_seat_limit",
@@ -369,27 +360,14 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
 
 
 def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> None:
-    """Acquire the tenant seat lock on ``db_session``, then enforce the limit.
+    """Self-hosted: take the tenant advisory lock on ``db_session`` then
+    enforce. Lock holds until caller commits — so the check and the
+    write share one transaction.
 
-    The advisory lock is transaction-scoped: it is released when the caller's
-    transaction commits or rolls back. The caller MUST run the subsequent
-    INSERT/UPDATE in the same transaction so the seat count cannot change
-    between this check and the write.
-
-    Self-hosted: locks the local tenant on ``db_session``, then runs
-    ``check_seat_availability`` against the same session.
-
-    Cloud (multi-tenant): this wrapper is a best-effort pre-flight only —
-    the local advisory lock is NOT acquired (cloud seat state lives in
-    Stripe + ``UserTenantMapping`` in the shared schema, not the
-    tenant-scoped ``db_session``). The seat-consuming write itself runs
-    later in ``add_users_to_tenant``, which calls
-    ``enforce_cloud_seat_limit(db_session=shared_session)`` — that path
-    DOES acquire the tenant-scoped advisory lock on the shared-schema
-    session and holds it across {count, Stripe modify, mapping insert}.
-    The Stripe idempotency key is retry-safe but NOT a concurrency
-    serializer; the lock in ``add_users_to_tenant`` is what enforces the
-    seat cap under concurrency.
+    Cloud: best-effort pre-flight only. The cap is actually enforced
+    inside ``add_users_to_tenant``, which calls
+    ``enforce_cloud_seat_limit(db_session=shared_session)`` and holds
+    the advisory lock across {count, Stripe modify, mapping insert}.
     """
     if not MULTI_TENANT:
         fetch_ee_implementation_or_noop("onyx.db.license", "acquire_seat_lock", None)(
@@ -400,15 +378,7 @@ def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> Non
 
 
 def _user_currently_counts_toward_seats(user: User) -> bool:
-    """Return whether ``user`` is currently counted by ``get_used_seats``.
-
-    Single delegating call to the canonical EE predicate
-    ``ee/onyx/db/license.py:user_counts_toward_seats`` — the only source
-    of truth for the seat-count filter. On CE / non-EE deployments the
-    no-op returns ``False``, which is the seat-conservative answer
-    (callers in CE never enforce a seat cap because no license is
-    present, so the predicate's value is moot).
-    """
+    """Delegate to canonical ``ee/onyx/db/license.py:user_counts_toward_seats``."""
     return bool(
         fetch_ee_implementation_or_noop(
             "onyx.db.license", "user_counts_toward_seats", False
@@ -417,23 +387,11 @@ def _user_currently_counts_toward_seats(user: User) -> bool:
 
 
 def _upgrade_will_add_seat(user_before: User, will_become_active: bool) -> bool:
-    """Return whether upgrading ``user_before`` to STANDARD/web-login will
-    flip them from uncounted to counted (i.e. consume an additional seat).
+    """Whether promoting to STANDARD will consume a seat.
 
-    Self-hosted: seat counting is per-User filtered by role/account_type.
-    Upgrades that change role/account_type can shift the count, so we
-    compare the canonical predicate before vs the post-upgrade state.
-    Post-upgrade: account_type=STANDARD, role=BASIC/ADMIN — so the
-    post-upgrade seat-counted-status depends only on activeness and the
-    email not being anonymous.
-
-    Multi-tenant cloud: seat counting is per-``UserTenantMapping`` row,
-    NOT per-User. A role/account_type upgrade does not add a mapping —
-    the user must already have an active mapping to be promoting in the
-    first place — so the upgrade is seat-neutral by ``get_tenant_count``.
-    Return ``False`` so the cloud billing path is not triggered with a
-    target quantity that the mapping count will never reach (which would
-    over-bill the tenant by one seat per promotion).
+    Cloud counts ``UserTenantMapping`` rows, not user attributes — an
+    upgrade leaves the mapping count unchanged, so always seat-neutral
+    in MT. Self-hosted compares the per-user predicate before vs after.
     """
     if MULTI_TENANT:
         return False
@@ -442,12 +400,7 @@ def _upgrade_will_add_seat(user_before: User, will_become_active: bool) -> bool:
 
 
 def _invalidate_license_cache_after_seat_change() -> None:
-    """Invalidate the license metadata cache so the middleware re-reads
-    ``used_seats`` on the next request.
-
-    Safe no-op on CE / cache outage; cache TTL bounds the staleness either
-    way.
-    """
+    """Invalidate license cache so middleware re-reads ``used_seats``."""
     fetch_ee_implementation_or_noop(
         "onyx.db.license", "invalidate_license_cache", None
     )()
@@ -581,10 +534,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                             UserRole.ADMIN
                         )
 
-                # Check seat availability for new users. Runs in the SAME
-                # async-session transaction as the subsequent insert so the
-                # advisory lock acquired here is held until that insert
-                # commits — closes the TOCTOU race against concurrent signups.
+                # Lock + check on the same session that does the insert.
                 existing = await self.user_db.session.run_sync(
                     lambda s: get_user_by_email(user_create.email, s)
                 )
@@ -706,15 +656,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user_id: uuid.UUID,
         user_create: UserCreate,
     ) -> None:
-        """Upgrade a non-web user to STANDARD and assign default groups atomically.
+        """Upgrade a non-web user to STANDARD + assign groups in one tx.
 
-        All writes happen in a single sync transaction so neither the field
-        update nor the group assignment is visible without the other.
-
-        If the upgrade flips the user from uncounted to counted (e.g.
-        EXT_PERM_USER → STANDARD), enforce the seat limit inside the same
-        transaction so the advisory lock is held until commit and the
-        promotion cannot push the tenant past its seat cap.
+        Enforces the seat limit inside the same transaction when the
+        upgrade flips an uncounted user (EXT_PERM_USER, SERVICE_ACCOUNT)
+        into a counted one.
         """
         seat_added = False
         with get_session_with_current_tenant() as sync_db:
@@ -724,8 +670,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 .first()
             )
             if sync_user:
-                # The upgrade keeps is_active unchanged; seat-count flip is
-                # purely about the role/account_type change.
                 if _upgrade_will_add_seat(
                     sync_user, will_become_active=bool(sync_user.is_active)
                 ):
@@ -865,11 +809,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                 except exceptions.UserNotExists:
                     verify_email_domain(account_email, is_registration=True)
 
-                    # Lock + seat check inside the same async-session
-                    # transaction as the subsequent insert so the lock
-                    # blocks concurrent OAuth signups until this insert
-                    # commits — closes the TOCTOU race against /auth/register
-                    # and other OAuth callbacks.
+                    # Lock + check on the same session that does the insert.
                     await self.user_db.session.run_sync(
                         lambda s: enforce_seat_limit_locked(s, seats_needed=1)
                     )
@@ -922,11 +862,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         if user_by_session:
                             user = user_by_session
 
-                # Lock + seat check + upgrade all in one sync transaction.
-                # The advisory lock is released on commit/rollback, so the
-                # seat-counted-status flip (inactive→active and/or
-                # non-web-login→STANDARD) is serialized against concurrent
-                # signup/upgrade requests for this tenant.
+                # Lock + check + upgrade in one transaction.
                 was_inactive = not user.is_active
                 seat_added = False
                 with get_session_with_current_tenant() as sync_db:

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -335,7 +335,11 @@ def verify_email_domain(email: str, *, is_registration: bool = False) -> None:
             raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Email domain is not valid")
 
 
-def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
+def enforce_seat_limit(
+    db_session: Session,
+    seats_needed: int = 1,
+    lock_session: Session | None = None,
+) -> None:
     """Raise ``OnyxError(SEAT_LIMIT_EXCEEDED)`` if seats would be exceeded.
 
     Self-hosted runs ``check_seat_availability``; cloud delegates to
@@ -348,7 +352,11 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
             "onyx.server.tenants.billing",
             "enforce_cloud_seat_limit",
             lambda **_kw: None,
-        )(seats_needed=seats_needed)
+        )(
+            seats_needed=seats_needed,
+            tenant_id=get_current_tenant_id(),
+            db_session=lock_session,
+        )
         return
 
     result = fetch_ee_implementation_or_noop(
@@ -360,21 +368,20 @@ def enforce_seat_limit(db_session: Session, seats_needed: int = 1) -> None:
 
 
 def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> None:
-    """Self-hosted: take the tenant advisory lock on ``db_session`` then
-    enforce. Lock holds until caller commits — so the check and the
-    write share one transaction.
+    """Acquire the tenant advisory lock on ``db_session``, then enforce.
 
-    Cloud: best-effort pre-flight only. The cap is actually enforced
-    inside ``add_users_to_tenant``, which calls
-    ``enforce_cloud_seat_limit(db_session=shared_session)`` and holds
-    the advisory lock across {count, Stripe modify, mapping insert}.
+    Self-hosted: lock + ``check_seat_availability`` on the caller's
+    session — held until caller commits.
+
+    Cloud: lock + ``get_tenant_count`` + Stripe modify also held on the
+    caller's session — released on caller commit so the seat-consuming
+    write (e.g. ``activate_user``) is covered.
     """
-    if not MULTI_TENANT:
-        fetch_ee_implementation_or_noop("onyx.db.license", "acquire_seat_lock", None)(
-            db_session, get_current_tenant_id()
-        )
+    fetch_ee_implementation_or_noop("onyx.db.license", "acquire_seat_lock", None)(
+        db_session, get_current_tenant_id()
+    )
 
-    enforce_seat_limit(db_session, seats_needed=seats_needed)
+    enforce_seat_limit(db_session, seats_needed=seats_needed, lock_session=db_session)
 
 
 def _user_currently_counts_toward_seats(user: User) -> bool:

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -376,10 +376,20 @@ def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> Non
     INSERT/UPDATE in the same transaction so the seat count cannot change
     between this check and the write.
 
-    Self-hosted: locks the local row, then runs ``check_seat_availability``.
-    Cloud (multi-tenant): the lock acquisition is a no-op (the seat count
-    lives in Stripe, not the local DB) — but the cloud auto-bill path is
-    inherently serialized per-tenant by the Stripe idempotency key.
+    Self-hosted: locks the local tenant on ``db_session``, then runs
+    ``check_seat_availability`` against the same session.
+
+    Cloud (multi-tenant): this wrapper is a best-effort pre-flight only —
+    the local advisory lock is NOT acquired (cloud seat state lives in
+    Stripe + ``UserTenantMapping`` in the shared schema, not the
+    tenant-scoped ``db_session``). The seat-consuming write itself runs
+    later in ``add_users_to_tenant``, which calls
+    ``enforce_cloud_seat_limit(db_session=shared_session)`` — that path
+    DOES acquire the tenant-scoped advisory lock on the shared-schema
+    session and holds it across {count, Stripe modify, mapping insert}.
+    The Stripe idempotency key is retry-safe but NOT a concurrency
+    serializer; the lock in ``add_users_to_tenant`` is what enforces the
+    seat cap under concurrency.
     """
     if not MULTI_TENANT:
         fetch_ee_implementation_or_noop("onyx.db.license", "acquire_seat_lock", None)(
@@ -392,20 +402,17 @@ def enforce_seat_limit_locked(db_session: Session, seats_needed: int = 1) -> Non
 def _user_currently_counts_toward_seats(user: User) -> bool:
     """Return whether ``user`` is currently counted by ``get_used_seats``.
 
-    Delegates to the canonical predicate in ``ee/onyx/db/license.py`` so
-    the two definitions cannot drift. The local fallback below is only
-    reached on CE / non-EE deployments where the EE module is absent.
+    Single delegating call to the canonical EE predicate
+    ``ee/onyx/db/license.py:user_counts_toward_seats`` — the only source
+    of truth for the seat-count filter. On CE / non-EE deployments the
+    no-op returns ``False``, which is the seat-conservative answer
+    (callers in CE never enforce a seat cap because no license is
+    present, so the predicate's value is moot).
     """
-    canonical = fetch_ee_implementation_or_noop(
-        "onyx.db.license", "user_counts_toward_seats", None
-    )(user)
-    if canonical is not None:
-        return bool(canonical)
-    return (
-        bool(user.is_active)
-        and user.role != UserRole.EXT_PERM_USER
-        and user.email != ANONYMOUS_USER_EMAIL
-        and user.account_type != AccountType.SERVICE_ACCOUNT
+    return bool(
+        fetch_ee_implementation_or_noop(
+            "onyx.db.license", "user_counts_toward_seats", False
+        )(user)
     )
 
 

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
 from uuid import UUID
@@ -339,12 +340,27 @@ def _generate_slack_user(email: str) -> User:
     )
 
 
-def add_slack_user_if_not_exists(db_session: Session, email: str) -> User:
+def add_slack_user_if_not_exists(
+    db_session: Session,
+    email: str,
+    enforce_seat_check: Callable[[Session, int], None] | None = None,
+) -> User:
+    """Look up or create the Slack-bot user for ``email``.
+
+    If ``enforce_seat_check`` is provided, it is invoked inside this
+    function's transaction whenever the call would convert an uncounted
+    user (EXT_PERM_USER) into a counted one (BOT). The check must raise
+    on overage; on success the conversion proceeds and is committed.
+    Callers that have already enforced the seat limit upstream may pass
+    ``None`` to opt out.
+    """
     email = email.lower()
     user = get_user_by_email(email, db_session)
     if user is not None:
         # If the user is an external permissioned user, we update it to a slack user
         if user.account_type == AccountType.EXT_PERM_USER:
+            if enforce_seat_check is not None:
+                enforce_seat_check(db_session, 1)
             user.role = UserRole.SLACK_USER
             user.account_type = AccountType.BOT
             db_session.commit()

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -348,8 +348,9 @@ def add_slack_user_if_not_exists(
     """Look up or create the Slack-bot user for ``email``.
 
     ``enforce_seat_check`` (optional): invoked inside this function's
-    transaction when the call would promote an EXT_PERM_USER (uncounted)
-    to BOT (counted). Must raise on overage.
+    transaction whenever the call would consume a seat — i.e. on
+    brand-new BOT creation OR on EXT_PERM_USER (uncounted) -> BOT
+    (counted) promotion. Must raise on overage.
     """
     email = email.lower()
     user = get_user_by_email(email, db_session)
@@ -363,6 +364,8 @@ def add_slack_user_if_not_exists(
             db_session.commit()
         return user
 
+    if enforce_seat_check is not None:
+        enforce_seat_check(db_session, 1)
     user = _generate_slack_user(email=email)
     db_session.add(user)
     db_session.commit()

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -347,12 +347,9 @@ def add_slack_user_if_not_exists(
 ) -> User:
     """Look up or create the Slack-bot user for ``email``.
 
-    If ``enforce_seat_check`` is provided, it is invoked inside this
-    function's transaction whenever the call would convert an uncounted
-    user (EXT_PERM_USER) into a counted one (BOT). The check must raise
-    on overage; on success the conversion proceeds and is committed.
-    Callers that have already enforced the seat limit upstream may pass
-    ``None`` to opt out.
+    ``enforce_seat_check`` (optional): invoked inside this function's
+    transaction when the call would promote an EXT_PERM_USER (uncounted)
+    to BOT (counted). Must raise on overage.
     """
     email = email.lower()
     user = get_user_by_email(email, db_session)

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -255,11 +255,18 @@ def handle_message(
                 not existing_user.is_active
                 and existing_user.account_type == AccountType.BOT
             ):
+                # Lock + check on the same session that commits activate_user.
+                acquire_lock_fn = fetch_ee_implementation_or_noop(
+                    "onyx.db.license",
+                    "acquire_seat_lock",
+                    None,
+                )
                 check_seat_fn = fetch_ee_implementation_or_noop(
                     "onyx.db.license",
                     "check_seat_availability",
                     None,
                 )
+                acquire_lock_fn(db_session, get_current_tenant_id())
                 seat_result = check_seat_fn(db_session=db_session)
                 if seat_result is not None and not seat_result.available:
                     logger.info(

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -370,11 +370,12 @@ def handle_message(
                 )
                 return False
             else:
-                # Promotion may have happened — invalidate the license cache so
-                # the middleware re-reads used_seats on the next request.
-                if existing_user is not None and existing_user.account_type == (
-                    AccountType.EXT_PERM_USER
-                ):
+                # Invalidate the license cache whenever the call consumed
+                # a seat: brand-new BOT insert OR EXT_PERM_USER -> BOT.
+                consumed_seat = existing_user is None or (
+                    existing_user.account_type == AccountType.EXT_PERM_USER
+                )
+                if consumed_seat:
                     invalidate_fn = fetch_ee_implementation_or_noop(
                         "onyx.db.license",
                         "invalidate_license_cache",

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -26,6 +26,7 @@ from onyx.onyxbot.slack.utils import update_emote_react
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import SLACK_CHANNEL_ID
+from shared_configs.contextvars import get_current_tenant_id
 
 logger_base = setup_logger()
 
@@ -324,12 +325,25 @@ def handle_message(
             # of the branches above already pre-checked, so this is purely a
             # defense-in-depth guard against a future caller that forgets to
             # check first.
+            #
+            # Acquire the per-tenant advisory lock on the SAME session that
+            # add_slack_user_if_not_exists will commit, so the check + the
+            # promotion write run under one tenant-scoped lock. Without this,
+            # two concurrent Slack workers each promoting a different
+            # EXT_PERM_USER at exactly the seat limit would both pass and
+            # both commit, breaching the cap.
             def _slack_seat_enforcer(session: Session, seats_needed: int) -> None:
+                acquire_lock_fn = fetch_ee_implementation_or_noop(
+                    "onyx.db.license",
+                    "acquire_seat_lock",
+                    None,
+                )
                 check_fn = fetch_ee_implementation_or_noop(
                     "onyx.db.license",
                     "check_seat_availability",
                     None,
                 )
+                acquire_lock_fn(session, get_current_tenant_id())
                 result = check_fn(session, seats_needed=seats_needed)
                 if result is not None and not result.available:
                     raise OnyxError(

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -291,11 +291,8 @@ def handle_message(
                 logger.info("Reactivated inactive Slack user %s", message_info.email)
 
             elif existing_user.account_type == AccountType.EXT_PERM_USER:
-                # EXT_PERM_USER is excluded from the seat count; promotion to
-                # BOT inside add_slack_user_if_not_exists would silently bump
-                # used_seats. Pre-check here so we can surface a user-facing
-                # message; the defense-in-depth enforcer below also guards
-                # against missed code paths.
+                # Pre-check so the user gets a Slack-side message; the
+                # locked enforcer below is defense-in-depth.
                 check_seat_fn = fetch_ee_implementation_or_noop(
                     "onyx.db.license",
                     "check_seat_availability",
@@ -320,18 +317,8 @@ def handle_message(
                     )
                     return False
 
-            # The optional enforcer fires inside add_slack_user_if_not_exists
-            # only when the call would convert an EXT_PERM_USER to BOT. Each
-            # of the branches above already pre-checked, so this is purely a
-            # defense-in-depth guard against a future caller that forgets to
-            # check first.
-            #
-            # Acquire the per-tenant advisory lock on the SAME session that
-            # add_slack_user_if_not_exists will commit, so the check + the
-            # promotion write run under one tenant-scoped lock. Without this,
-            # two concurrent Slack workers each promoting a different
-            # EXT_PERM_USER at exactly the seat limit would both pass and
-            # both commit, breaching the cap.
+            # Defense-in-depth: locks + checks on the same session that
+            # commits the EXT_PERM_USER -> BOT promotion.
             def _slack_seat_enforcer(session: Session, seats_needed: int) -> None:
                 acquire_lock_fn = fetch_ee_implementation_or_noop(
                     "onyx.db.license",

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -2,6 +2,7 @@ import datetime
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+from sqlalchemy.orm import Session
 
 from onyx.configs.onyxbot_configs import ONYX_BOT_FEEDBACK_REMINDER
 from onyx.configs.onyxbot_configs import ONYX_BOT_REACT_EMOJI
@@ -11,6 +12,8 @@ from onyx.db.models import SlackChannelConfig
 from onyx.db.user_preferences import activate_user
 from onyx.db.users import add_slack_user_if_not_exists
 from onyx.db.users import get_user_by_email
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.onyxbot.slack.blocks import get_feedback_reminder_blocks
 from onyx.onyxbot.slack.handlers.handle_regular_answer import handle_regular_answer
 from onyx.onyxbot.slack.handlers.handle_standard_answers import handle_standard_answers
@@ -286,7 +289,90 @@ def handle_message(
                 invalidate_license_cache_fn()
                 logger.info("Reactivated inactive Slack user %s", message_info.email)
 
-            add_slack_user_if_not_exists(db_session, message_info.email)
+            elif existing_user.account_type == AccountType.EXT_PERM_USER:
+                # EXT_PERM_USER is excluded from the seat count; promotion to
+                # BOT inside add_slack_user_if_not_exists would silently bump
+                # used_seats. Pre-check here so we can surface a user-facing
+                # message; the defense-in-depth enforcer below also guards
+                # against missed code paths.
+                check_seat_fn = fetch_ee_implementation_or_noop(
+                    "onyx.db.license",
+                    "check_seat_availability",
+                    None,
+                )
+                seat_result = check_seat_fn(db_session=db_session)
+                if seat_result is not None and not seat_result.available:
+                    logger.info(
+                        "Blocked Slack-bot promotion of %s: %s",
+                        message_info.email,
+                        seat_result.error_message,
+                    )
+                    respond_in_thread_or_channel(
+                        client=client,
+                        channel=channel,
+                        thread_ts=message_info.msg_to_respond,
+                        text=(
+                            "We weren't able to respond because your organization "
+                            "has reached its user seat limit. Please contact your "
+                            "Onyx administrator to add more seats."
+                        ),
+                    )
+                    return False
+
+            # The optional enforcer fires inside add_slack_user_if_not_exists
+            # only when the call would convert an EXT_PERM_USER to BOT. Each
+            # of the branches above already pre-checked, so this is purely a
+            # defense-in-depth guard against a future caller that forgets to
+            # check first.
+            def _slack_seat_enforcer(session: Session, seats_needed: int) -> None:
+                check_fn = fetch_ee_implementation_or_noop(
+                    "onyx.db.license",
+                    "check_seat_availability",
+                    None,
+                )
+                result = check_fn(session, seats_needed=seats_needed)
+                if result is not None and not result.available:
+                    raise OnyxError(
+                        OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message
+                    )
+
+            try:
+                add_slack_user_if_not_exists(
+                    db_session,
+                    message_info.email,
+                    enforce_seat_check=_slack_seat_enforcer,
+                )
+            except OnyxError as e:
+                if e.error_code != OnyxErrorCode.SEAT_LIMIT_EXCEEDED:
+                    raise
+                logger.info(
+                    "Blocked Slack-bot user creation/promotion for %s: %s",
+                    message_info.email,
+                    e.detail,
+                )
+                respond_in_thread_or_channel(
+                    client=client,
+                    channel=channel,
+                    thread_ts=message_info.msg_to_respond,
+                    text=(
+                        "We weren't able to respond because your organization "
+                        "has reached its user seat limit. Please contact your "
+                        "Onyx administrator to add more seats."
+                    ),
+                )
+                return False
+            else:
+                # Promotion may have happened — invalidate the license cache so
+                # the middleware re-reads used_seats on the next request.
+                if existing_user is not None and existing_user.account_type == (
+                    AccountType.EXT_PERM_USER
+                ):
+                    invalidate_fn = fetch_ee_implementation_or_noop(
+                        "onyx.db.license",
+                        "invalidate_license_cache",
+                        None,
+                    )
+                    invalidate_fn()
 
         # first check if we need to respond with a standard answer
         # standard answers should be published in a thread

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -344,6 +344,14 @@ def handle_message(
                         OnyxErrorCode.SEAT_LIMIT_EXCEEDED, result.error_message
                     )
 
+            # Snapshot pre-call seat-counted state. ``add_slack_user_if_not_exists``
+            # mutates ``existing_user`` in place on EXT_PERM_USER -> BOT, so
+            # reading ``account_type`` after the call would see the new value
+            # and skip cache invalidation.
+            consumed_seat = existing_user is None or (
+                existing_user.account_type == AccountType.EXT_PERM_USER
+            )
+
             try:
                 add_slack_user_if_not_exists(
                     db_session,
@@ -370,11 +378,6 @@ def handle_message(
                 )
                 return False
             else:
-                # Invalidate the license cache whenever the call consumed
-                # a seat: brand-new BOT insert OR EXT_PERM_USER -> BOT.
-                consumed_seat = existing_user is None or (
-                    existing_user.account_type == AccountType.EXT_PERM_USER
-                )
                 if consumed_seat:
                     invalidate_fn = fetch_ee_implementation_or_noop(
                         "onyx.db.license",

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -470,13 +470,8 @@ def bulk_invite_users(
         if e not in existing_users and e not in already_invited
     ]
 
-    # Check seat availability for new users. Must run before the counter
-    # reservation below — a seat-limit failure must not burn trial quota.
-    # Uses the locked variant so concurrent invite + signup flows for this
-    # tenant are serialized: the advisory lock is held until ``db_session``
-    # commits, which is the same transaction that writes the invitation
-    # rows further down, so no other request can slip in seats between the
-    # check and the write.
+    # Must run before the trial counter reservation — a seat-limit
+    # failure must not burn trial quota.
     if emails_needing_seats:
         enforce_seat_limit_locked(db_session, seats_needed=len(emails_needing_seats))
 
@@ -726,9 +721,6 @@ def activate_user_api(
         logger.warning("%s is already activated", user_to_activate.email)
         return
 
-    # Check seat availability before activating. Locked variant so the
-    # advisory lock is held until ``activate_user``'s commit on the same
-    # session — concurrent activate/signup requests are serialized.
     enforce_seat_limit_locked(db_session)
 
     activate_user(user_to_activate, db_session)

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -32,7 +32,7 @@ from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import current_curator_or_admin_user
-from onyx.auth.users import enforce_seat_limit
+from onyx.auth.users import enforce_seat_limit_locked
 from onyx.auth.users import optional_user
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_TYPE
@@ -472,8 +472,13 @@ def bulk_invite_users(
 
     # Check seat availability for new users. Must run before the counter
     # reservation below — a seat-limit failure must not burn trial quota.
+    # Uses the locked variant so concurrent invite + signup flows for this
+    # tenant are serialized: the advisory lock is held until ``db_session``
+    # commits, which is the same transaction that writes the invitation
+    # rows further down, so no other request can slip in seats between the
+    # check and the write.
     if emails_needing_seats:
-        enforce_seat_limit(db_session, seats_needed=len(emails_needing_seats))
+        enforce_seat_limit_locked(db_session, seats_needed=len(emails_needing_seats))
 
     # Enforce the trial invite cap via the monotonic `tenant_invite_counter`.
     # The UPSERT holds a row-level lock on `tenant_id` during the UPDATE, so
@@ -721,9 +726,10 @@ def activate_user_api(
         logger.warning("%s is already activated", user_to_activate.email)
         return
 
-    # Check seat availability before activating
-    # Only for self-hosted (non-multi-tenant) deployments
-    enforce_seat_limit(db_session)
+    # Check seat availability before activating. Locked variant so the
+    # advisory lock is held until ``activate_user``'s commit on the same
+    # session — concurrent activate/signup requests are serialized.
+    enforce_seat_limit_locked(db_session)
 
     activate_user(user_to_activate, db_session)
 

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
@@ -16,6 +16,7 @@ import stripe
 from ee.onyx.server.tenants.billing import _seat_billing_idempotency_key
 from ee.onyx.server.tenants.billing import attempt_seat_billing_increase
 from ee.onyx.server.tenants.billing import enforce_cloud_seat_limit
+from ee.onyx.server.tenants.billing import SeatBillingDeclineReason
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
@@ -110,7 +111,7 @@ class TestAttemptSeatBillingIncrease:
 
         success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
 
-        assert (success, reason) == (False, "card_declined")
+        assert (success, reason) == (False, SeatBillingDeclineReason.CARD_DECLINED)
 
     @patch(f"{_BILLING}.register_tenant_users")
     @patch(f"{_BILLING}.stripe.Subscription.retrieve")
@@ -129,7 +130,10 @@ class TestAttemptSeatBillingIncrease:
 
         success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
 
-        assert (success, reason) == (False, "subscription_invalid")
+        assert (success, reason) == (
+            False,
+            SeatBillingDeclineReason.SUBSCRIPTION_INVALID,
+        )
 
     @patch(f"{_BILLING}.fetch_tenant_stripe_information")
     def test_missing_subscription_returns_subscription_invalid(
@@ -140,7 +144,10 @@ class TestAttemptSeatBillingIncrease:
 
         success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
 
-        assert (success, reason) == (False, "subscription_invalid")
+        assert (success, reason) == (
+            False,
+            SeatBillingDeclineReason.SUBSCRIPTION_INVALID,
+        )
 
 
 class TestEnforceCloudSeatLimit:
@@ -181,8 +188,8 @@ class TestEnforceCloudSeatLimit:
     @pytest.mark.parametrize(
         "reason,expected_in_message",
         [
-            ("card_declined", "payment method was declined"),
-            ("subscription_invalid", "active subscription"),
+            (SeatBillingDeclineReason.CARD_DECLINED, "payment method was declined"),
+            (SeatBillingDeclineReason.SUBSCRIPTION_INVALID, "active subscription"),
         ],
     )
     @patch(f"{_BILLING}.acquire_seat_lock")

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
@@ -1,0 +1,206 @@
+"""Unit tests for cloud (multi-tenant) auto-bill seat enforcement.
+
+Covers ``attempt_seat_billing_increase`` (Stripe error mapping +
+idempotency) and ``enforce_cloud_seat_limit`` (trial bypass + decline
+surfacing as ``OnyxError(SEAT_LIMIT_EXCEEDED)``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+import stripe
+
+from ee.onyx.server.tenants.billing import _seat_billing_idempotency_key
+from ee.onyx.server.tenants.billing import attempt_seat_billing_increase
+from ee.onyx.server.tenants.billing import enforce_cloud_seat_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+_BILLING = "ee.onyx.server.tenants.billing"
+
+
+def _stripe_subscription(quantity: int) -> dict:
+    return {
+        "items": {
+            "data": [
+                {
+                    "id": "si_123",
+                    "price": MagicMock(id="price_123"),
+                    "quantity": quantity,
+                }
+            ]
+        }
+    }
+
+
+class TestIdempotencyKey:
+    def test_stable_for_same_inputs(self) -> None:
+        assert _seat_billing_idempotency_key("t1", 5) == _seat_billing_idempotency_key(
+            "t1", 5
+        )
+
+    def test_differs_per_tenant(self) -> None:
+        assert _seat_billing_idempotency_key("t1", 5) != _seat_billing_idempotency_key(
+            "t2", 5
+        )
+
+    def test_differs_per_quantity(self) -> None:
+        assert _seat_billing_idempotency_key("t1", 5) != _seat_billing_idempotency_key(
+            "t1", 6
+        )
+
+
+class TestAttemptSeatBillingIncrease:
+    @patch(f"{_BILLING}.register_tenant_users")
+    @patch(f"{_BILLING}.stripe.Subscription.retrieve")
+    @patch(f"{_BILLING}.fetch_tenant_stripe_information")
+    def test_success_calls_register_with_target_and_idempotency_key(
+        self,
+        mock_fetch: MagicMock,
+        mock_retrieve: MagicMock,
+        mock_register: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"stripe_subscription_id": "sub_123"}
+        mock_retrieve.return_value = _stripe_subscription(quantity=3)
+
+        success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
+
+        assert (success, reason) == (True, None)
+        mock_register.assert_called_once()
+        kwargs = mock_register.call_args.kwargs
+        args = mock_register.call_args.args
+        assert args[0] == "tenant_a"
+        assert args[1] == 5
+        assert kwargs["idempotency_key"] == _seat_billing_idempotency_key("tenant_a", 5)
+
+    @patch(f"{_BILLING}.register_tenant_users")
+    @patch(f"{_BILLING}.stripe.Subscription.retrieve")
+    @patch(f"{_BILLING}.fetch_tenant_stripe_information")
+    def test_idempotent_when_already_at_or_above_target(
+        self,
+        mock_fetch: MagicMock,
+        mock_retrieve: MagicMock,
+        mock_register: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"stripe_subscription_id": "sub_123"}
+        mock_retrieve.return_value = _stripe_subscription(quantity=10)
+
+        success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
+
+        assert (success, reason) == (True, None)
+        mock_register.assert_not_called()
+
+    @patch(f"{_BILLING}.register_tenant_users")
+    @patch(f"{_BILLING}.stripe.Subscription.retrieve")
+    @patch(f"{_BILLING}.fetch_tenant_stripe_information")
+    def test_card_declined_returns_card_declined(
+        self,
+        mock_fetch: MagicMock,
+        mock_retrieve: MagicMock,
+        mock_register: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"stripe_subscription_id": "sub_123"}
+        mock_retrieve.return_value = _stripe_subscription(quantity=3)
+        mock_register.side_effect = stripe.CardError(
+            "card declined", param="card", code="card_declined"
+        )
+
+        success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
+
+        assert (success, reason) == (False, "card_declined")
+
+    @patch(f"{_BILLING}.register_tenant_users")
+    @patch(f"{_BILLING}.stripe.Subscription.retrieve")
+    @patch(f"{_BILLING}.fetch_tenant_stripe_information")
+    def test_invalid_request_returns_subscription_invalid(
+        self,
+        mock_fetch: MagicMock,
+        mock_retrieve: MagicMock,
+        mock_register: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"stripe_subscription_id": "sub_123"}
+        mock_retrieve.return_value = _stripe_subscription(quantity=3)
+        mock_register.side_effect = stripe.InvalidRequestError(
+            "no such subscription", param="id"
+        )
+
+        success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
+
+        assert (success, reason) == (False, "subscription_invalid")
+
+    @patch(f"{_BILLING}.fetch_tenant_stripe_information")
+    def test_missing_subscription_returns_subscription_invalid(
+        self,
+        mock_fetch: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = {"stripe_subscription_id": ""}
+
+        success, reason = attempt_seat_billing_increase("tenant_a", target_quantity=5)
+
+        assert (success, reason) == (False, "subscription_invalid")
+
+
+class TestEnforceCloudSeatLimit:
+    @patch(f"{_BILLING}.is_tenant_on_trial_fn")
+    def test_trial_tenant_short_circuits(
+        self,
+        mock_trial: MagicMock,
+    ) -> None:
+        mock_trial.return_value = True
+        with patch(f"{_BILLING}.get_current_tenant_id", return_value="t1"):
+            # Must not raise, must not call Stripe.
+            enforce_cloud_seat_limit(seats_needed=1)
+
+    @patch("ee.onyx.server.tenants.user_mapping.get_tenant_count")
+    @patch(f"{_BILLING}.attempt_seat_billing_increase")
+    @patch(f"{_BILLING}.is_tenant_on_trial_fn")
+    @patch(f"{_BILLING}.get_current_tenant_id")
+    def test_success_returns_silently(
+        self,
+        mock_tenant_id: MagicMock,
+        mock_trial: MagicMock,
+        mock_attempt: MagicMock,
+        mock_count: MagicMock,
+    ) -> None:
+        mock_tenant_id.return_value = "t1"
+        mock_trial.return_value = False
+        mock_count.return_value = 4
+        mock_attempt.return_value = (True, None)
+
+        enforce_cloud_seat_limit(seats_needed=2)
+
+        mock_attempt.assert_called_once_with("t1", 6)
+
+    @pytest.mark.parametrize(
+        "reason,expected_in_message",
+        [
+            ("card_declined", "payment method was declined"),
+            ("subscription_invalid", "active subscription"),
+        ],
+    )
+    @patch("ee.onyx.server.tenants.user_mapping.get_tenant_count")
+    @patch(f"{_BILLING}.attempt_seat_billing_increase")
+    @patch(f"{_BILLING}.is_tenant_on_trial_fn")
+    @patch(f"{_BILLING}.get_current_tenant_id")
+    def test_decline_raises_seat_limit_exceeded(
+        self,
+        mock_tenant_id: MagicMock,
+        mock_trial: MagicMock,
+        mock_attempt: MagicMock,
+        mock_count: MagicMock,
+        reason: str,
+        expected_in_message: str,
+    ) -> None:
+        mock_tenant_id.return_value = "t1"
+        mock_trial.return_value = False
+        mock_count.return_value = 4
+        mock_attempt.return_value = (False, reason)
+
+        with pytest.raises(OnyxError) as exc:
+            enforce_cloud_seat_limit(seats_needed=1)
+
+        assert exc.value.error_code == OnyxErrorCode.SEAT_LIMIT_EXCEEDED
+        assert expected_in_message in exc.value.detail

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
@@ -154,6 +154,7 @@ class TestEnforceCloudSeatLimit:
             # Must not raise, must not call Stripe.
             enforce_cloud_seat_limit(seats_needed=1)
 
+    @patch(f"{_BILLING}.acquire_seat_lock")
     @patch("ee.onyx.server.tenants.user_mapping.get_tenant_count")
     @patch(f"{_BILLING}.attempt_seat_billing_increase")
     @patch(f"{_BILLING}.is_tenant_on_trial_fn")
@@ -164,15 +165,18 @@ class TestEnforceCloudSeatLimit:
         mock_trial: MagicMock,
         mock_attempt: MagicMock,
         mock_count: MagicMock,
+        mock_acquire_lock: MagicMock,
     ) -> None:
         mock_tenant_id.return_value = "t1"
         mock_trial.return_value = False
         mock_count.return_value = 4
         mock_attempt.return_value = (True, None)
+        db_session = MagicMock()
 
-        enforce_cloud_seat_limit(seats_needed=2)
+        enforce_cloud_seat_limit(seats_needed=2, db_session=db_session)
 
         mock_attempt.assert_called_once_with("t1", 6)
+        mock_acquire_lock.assert_called_once_with(db_session, "t1")
 
     @pytest.mark.parametrize(
         "reason,expected_in_message",
@@ -181,6 +185,7 @@ class TestEnforceCloudSeatLimit:
             ("subscription_invalid", "active subscription"),
         ],
     )
+    @patch(f"{_BILLING}.acquire_seat_lock")
     @patch("ee.onyx.server.tenants.user_mapping.get_tenant_count")
     @patch(f"{_BILLING}.attempt_seat_billing_increase")
     @patch(f"{_BILLING}.is_tenant_on_trial_fn")
@@ -191,16 +196,46 @@ class TestEnforceCloudSeatLimit:
         mock_trial: MagicMock,
         mock_attempt: MagicMock,
         mock_count: MagicMock,
+        mock_acquire_lock: MagicMock,
         reason: str,
         expected_in_message: str,
     ) -> None:
+        del mock_acquire_lock  # injected by @patch but not asserted on
         mock_tenant_id.return_value = "t1"
         mock_trial.return_value = False
         mock_count.return_value = 4
         mock_attempt.return_value = (False, reason)
 
         with pytest.raises(OnyxError) as exc:
-            enforce_cloud_seat_limit(seats_needed=1)
+            enforce_cloud_seat_limit(seats_needed=1, db_session=MagicMock())
 
         assert exc.value.error_code == OnyxErrorCode.SEAT_LIMIT_EXCEEDED
         assert expected_in_message in exc.value.detail
+
+    @patch(f"{_BILLING}.acquire_seat_lock")
+    @patch("ee.onyx.server.tenants.user_mapping.get_tenant_count")
+    @patch(f"{_BILLING}.attempt_seat_billing_increase")
+    @patch(f"{_BILLING}.is_tenant_on_trial_fn")
+    @patch(f"{_BILLING}.get_current_tenant_id", return_value="ctx_var_tenant")
+    def test_explicit_tenant_id_overrides_context_var(
+        self,
+        _mock_tenant_id: MagicMock,
+        mock_trial: MagicMock,
+        mock_attempt: MagicMock,
+        mock_count: MagicMock,
+        mock_acquire_lock: MagicMock,
+    ) -> None:
+        """Caller-supplied tenant_id must be billed, not the context var."""
+        mock_trial.return_value = False
+        mock_count.return_value = 0
+        mock_attempt.return_value = (True, None)
+        db_session = MagicMock()
+
+        enforce_cloud_seat_limit(
+            seats_needed=1, tenant_id="explicit_tenant", db_session=db_session
+        )
+
+        mock_trial.assert_called_once_with("explicit_tenant")
+        mock_count.assert_called_once_with("explicit_tenant")
+        mock_attempt.assert_called_once_with("explicit_tenant", 1)
+        mock_acquire_lock.assert_called_once_with(db_session, "explicit_tenant")

--- a/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
+++ b/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
@@ -4,16 +4,49 @@ These cover the predicate that decides whether upgrading a non-web-login
 user to STANDARD will add a seat (i.e. flip the user from uncounted to
 counted), so the surrounding upgrade paths can short-circuit when the
 upgrade is seat-neutral.
+
+``_user_currently_counts_toward_seats`` is a thin delegator to the
+canonical EE predicate ``ee/onyx/db/license.py:user_counts_toward_seats``;
+the autouse fixture below wires the EE function in via a patched
+``fetch_ee_implementation_or_noop`` so these tests are deterministic on
+both EE and CE builds.
 """
 
 from __future__ import annotations
 
+from typing import Any
+from typing import Iterator
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import pytest
+
+from ee.onyx.db.license import user_counts_toward_seats as _canonical
 from onyx.auth.users import _upgrade_will_add_seat
 from onyx.auth.users import _user_currently_counts_toward_seats
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
 from onyx.db.enums import AccountType
+
+
+@pytest.fixture(autouse=True)
+def _patch_canonical_predicate() -> Iterator[None]:
+    """Wire ``_user_currently_counts_toward_seats`` to the EE predicate.
+
+    On CE builds ``fetch_ee_implementation_or_noop`` returns a no-op that
+    yields the supplied default (``False``); these tests want to validate
+    the actual seat-counting logic, so we patch the lookup to return the
+    canonical EE function regardless of build mode.
+    """
+
+    def fake_fetch(_module: str, name: str, _default: Any) -> Any:
+        if name == "user_counts_toward_seats":
+            return _canonical
+        return _default
+
+    with patch(
+        "onyx.auth.users.fetch_ee_implementation_or_noop", side_effect=fake_fetch
+    ):
+        yield
 
 
 def _user(
@@ -148,3 +181,22 @@ class TestUpgradeWillAddSeat:
             account_type=AccountType.EXT_PERM_USER,
         )
         assert not _upgrade_will_add_seat(before, will_become_active=True)
+
+
+class TestCEDelegationFallback:
+    """When the EE predicate is unavailable (CE build / noop fetch),
+    ``_user_currently_counts_toward_seats`` returns the seat-conservative
+    default ``False``."""
+
+    def test_ce_returns_false(self) -> None:
+        # Simulate CE: noop returns the default supplied by users.py (False).
+        with patch(
+            "onyx.auth.users.fetch_ee_implementation_or_noop",
+            side_effect=lambda _m, _n, default: lambda *_a, **_kw: default,
+        ):
+            assert (
+                _user_currently_counts_toward_seats(
+                    _user(account_type=AccountType.STANDARD)
+                )
+                is False
+            )

--- a/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
+++ b/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
@@ -1,0 +1,150 @@
+"""Unit tests for the seat-counted-status helpers in onyx.auth.users.
+
+These cover the predicate that decides whether upgrading a non-web-login
+user to STANDARD will add a seat (i.e. flip the user from uncounted to
+counted), so the surrounding upgrade paths can short-circuit when the
+upgrade is seat-neutral.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from onyx.auth.users import _upgrade_will_add_seat
+from onyx.auth.users import _user_currently_counts_toward_seats
+from onyx.configs.constants import ANONYMOUS_USER_EMAIL
+from onyx.db.enums import AccountType
+
+
+def _user(
+    *,
+    is_active: bool = True,
+    role: object = "BASIC",
+    email: str = "u@test.com",
+    account_type: object = AccountType.STANDARD,
+) -> MagicMock:
+    user = MagicMock()
+    user.is_active = is_active
+    user.role = role
+    user.email = email
+    user.account_type = account_type
+    return user
+
+
+class TestUserCurrentlyCountsTowardSeats:
+    def test_active_standard_user_counts(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        assert _user_currently_counts_toward_seats(
+            _user(role=UserRole.BASIC, account_type=AccountType.STANDARD)
+        )
+
+    def test_active_bot_user_counts(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        # BOT account_type is included in the seat count by design.
+        assert _user_currently_counts_toward_seats(
+            _user(role=UserRole.SLACK_USER, account_type=AccountType.BOT)
+        )
+
+    def test_inactive_user_does_not_count(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        assert not _user_currently_counts_toward_seats(
+            _user(is_active=False, role=UserRole.BASIC)
+        )
+
+    def test_ext_perm_user_does_not_count(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        assert not _user_currently_counts_toward_seats(
+            _user(role=UserRole.EXT_PERM_USER, account_type=AccountType.EXT_PERM_USER)
+        )
+
+    def test_service_account_does_not_count(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        assert not _user_currently_counts_toward_seats(
+            _user(role=UserRole.BASIC, account_type=AccountType.SERVICE_ACCOUNT)
+        )
+
+    def test_anonymous_user_does_not_count(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        assert not _user_currently_counts_toward_seats(
+            _user(role=UserRole.BASIC, email=ANONYMOUS_USER_EMAIL)
+        )
+
+
+class TestUpgradeWillAddSeat:
+    def test_ext_perm_to_standard_active_adds_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=True,
+            role=UserRole.EXT_PERM_USER,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        assert _upgrade_will_add_seat(before, will_become_active=True)
+
+    def test_service_account_to_standard_active_adds_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=True,
+            role=UserRole.BASIC,
+            account_type=AccountType.SERVICE_ACCOUNT,
+        )
+        assert _upgrade_will_add_seat(before, will_become_active=True)
+
+    def test_inactive_to_active_standard_adds_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=False,
+            role=UserRole.BASIC,
+            account_type=AccountType.STANDARD,
+        )
+        assert _upgrade_will_add_seat(before, will_become_active=True)
+
+    def test_inactive_remaining_inactive_does_not_add_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=False,
+            role=UserRole.EXT_PERM_USER,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        assert not _upgrade_will_add_seat(before, will_become_active=False)
+
+    def test_bot_to_standard_does_not_add_seat(self) -> None:
+        # BOT counts already; upgrade keeps it counted.
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=True,
+            role=UserRole.SLACK_USER,
+            account_type=AccountType.BOT,
+        )
+        assert not _upgrade_will_add_seat(before, will_become_active=True)
+
+    def test_already_standard_active_does_not_add_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=True,
+            role=UserRole.BASIC,
+            account_type=AccountType.STANDARD,
+        )
+        assert not _upgrade_will_add_seat(before, will_become_active=True)
+
+    def test_anonymous_email_never_adds_seat(self) -> None:
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=False,
+            role=UserRole.BASIC,
+            email=ANONYMOUS_USER_EMAIL,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        assert not _upgrade_will_add_seat(before, will_become_active=True)

--- a/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
+++ b/backend/tests/unit/onyx/auth/test_seat_upgrade_helpers.py
@@ -182,6 +182,21 @@ class TestUpgradeWillAddSeat:
         )
         assert not _upgrade_will_add_seat(before, will_become_active=True)
 
+    def test_multi_tenant_upgrade_is_seat_neutral(self) -> None:
+        """Cloud counts UserTenantMapping rows, not User attributes —
+        an EXT_PERM_USER upgrade leaves the mapping count unchanged, so
+        ``_upgrade_will_add_seat`` must return ``False`` to avoid
+        over-billing the tenant on every promotion."""
+        from onyx.auth.schemas import UserRole
+
+        before = _user(
+            is_active=True,
+            role=UserRole.EXT_PERM_USER,
+            account_type=AccountType.EXT_PERM_USER,
+        )
+        with patch("onyx.auth.users.MULTI_TENANT", True):
+            assert not _upgrade_will_add_seat(before, will_become_active=True)
+
 
 class TestCEDelegationFallback:
     """When the EE predicate is unavailable (CE build / noop fetch),

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -443,6 +443,42 @@ class TestSeatLimitEnforcement:
         ):
             enforce_seat_limit(MagicMock())  # should not raise
 
+    def test_cloud_locked_variant_forwards_session_to_billing(self) -> None:
+        from onyx.auth.users import enforce_seat_limit_locked
+
+        captured: dict = {}
+
+        def fake_cloud_enforce(**kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def fake_acquire_lock(*_a: object, **_kw: object) -> None:
+            pass
+
+        def fake_fetch(_module: str, name: str, _default: object) -> object:
+            if name == "acquire_seat_lock":
+                return fake_acquire_lock
+            if name == "enforce_cloud_seat_limit":
+                return fake_cloud_enforce
+            return _default
+
+        db_session = MagicMock()
+        with (
+            patch("onyx.auth.users.MULTI_TENANT", True),
+            patch(
+                "onyx.auth.users.get_current_tenant_id",
+                return_value="tenant_xyz",
+            ),
+            patch(
+                "onyx.auth.users.fetch_ee_implementation_or_noop",
+                side_effect=fake_fetch,
+            ),
+        ):
+            enforce_seat_limit_locked(db_session, seats_needed=2)
+
+        assert captured["db_session"] is db_session
+        assert captured["tenant_id"] == "tenant_xyz"
+        assert captured["seats_needed"] == 2
+
 
 class TestCaseInsensitiveEmailMatching:
     """Test case-insensitive email matching for existing user checks."""

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -430,7 +430,17 @@ class TestSeatLimitEnforcement:
     def test_seat_limit_only_enforced_for_self_hosted(self) -> None:
         from onyx.auth.users import enforce_seat_limit
 
-        with patch("onyx.auth.users.MULTI_TENANT", True):
+        # In MULTI_TENANT mode the local seat check is bypassed in favor of
+        # the cloud auto-bill helper. Patch fetch_ee_implementation_or_noop
+        # to the no-op default so the test does not depend on whether the
+        # real EE billing module has been imported by an earlier test.
+        with (
+            patch("onyx.auth.users.MULTI_TENANT", True),
+            patch(
+                "onyx.auth.users.fetch_ee_implementation_or_noop",
+                return_value=lambda **_kw: None,
+            ),
+        ):
             enforce_seat_limit(MagicMock())  # should not raise
 
 

--- a/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
+++ b/backend/tests/unit/onyx/onyxbot/test_slack_gating.py
@@ -334,7 +334,11 @@ class TestHandleMessageSeatCheck:
 
         self._call_handle_message(email="new@test.com")
 
-        mock_add_user.assert_called_once_with(db_session, "new@test.com")
+        mock_add_user.assert_called_once()
+        args, kwargs = mock_add_user.call_args
+        assert args == (db_session, "new@test.com")
+        assert "enforce_seat_check" in kwargs
+        assert callable(kwargs["enforce_seat_check"])
 
     @patch(f"{_HANDLE_MSG}.handle_regular_answer", return_value=False)
     @patch(f"{_HANDLE_MSG}.handle_standard_answers", return_value=False)
@@ -355,7 +359,11 @@ class TestHandleMessageSeatCheck:
 
         self._call_handle_message(email="new@test.com")
 
-        mock_add_user.assert_called_once_with(db_session, "new@test.com")
+        mock_add_user.assert_called_once()
+        args, kwargs = mock_add_user.call_args
+        assert args == (db_session, "new@test.com")
+        assert "enforce_seat_check" in kwargs
+        assert callable(kwargs["enforce_seat_check"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
+++ b/backend/tests/unit/onyx/server/manage/test_bulk_invite_limit.py
@@ -46,7 +46,7 @@ def _make_shared_session_mock(next_total: int) -> MagicMock:
 @patch("onyx.server.manage.users.get_current_tenant_id", return_value="test_tenant")
 @patch("onyx.server.manage.users.get_invited_users", return_value=[])
 @patch("onyx.server.manage.users.get_all_users", return_value=[])
-@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
 @patch("onyx.server.manage.users.NUM_FREE_TRIAL_USER_INVITES", 5)
 def test_trial_tenant_cannot_exceed_invite_limit(*_mocks: None) -> None:
     """Post-upsert total of 6 exceeds cap=5 — must raise OnyxError."""
@@ -73,7 +73,7 @@ def test_trial_tenant_cannot_exceed_invite_limit(*_mocks: None) -> None:
 @patch("onyx.server.manage.users.get_invited_users", return_value=[])
 @patch("onyx.server.manage.users.get_all_users", return_value=[])
 @patch("onyx.server.manage.users.write_invited_users", return_value=3)
-@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
 @patch("onyx.server.manage.users.NUM_FREE_TRIAL_USER_INVITES", 5)
 @patch(
     "onyx.server.manage.users.fetch_ee_implementation_or_noop",
@@ -99,7 +99,7 @@ def test_trial_tenant_can_invite_within_limit(*_mocks: None) -> None:
 @patch("onyx.server.manage.users.get_invited_users", return_value=[])
 @patch("onyx.server.manage.users.get_all_users", return_value=[])
 @patch("onyx.server.manage.users.write_invited_users", return_value=3)
-@patch("onyx.server.manage.users.enforce_seat_limit")
+@patch("onyx.server.manage.users.enforce_seat_limit_locked")
 @patch(
     "onyx.server.manage.users.fetch_ee_implementation_or_noop",
     return_value=lambda *_args: None,
@@ -132,7 +132,7 @@ _COMMON_PATCHES = [
     patch("onyx.server.manage.users.get_invited_users", return_value=[]),
     patch("onyx.server.manage.users.get_all_users", return_value=[]),
     patch("onyx.server.manage.users.write_invited_users", return_value=1),
-    patch("onyx.server.manage.users.enforce_seat_limit"),
+    patch("onyx.server.manage.users.enforce_seat_limit_locked"),
     patch("onyx.server.manage.users.enforce_invite_rate_limit"),
 ]
 

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -10,9 +10,9 @@ from uuid import uuid4
 from fastapi import Response
 from sqlalchemy.exc import IntegrityError
 
+from ee.onyx.db.license import seat_lock_id_for_tenant
 from ee.onyx.server.scim.api import _check_seat_availability
 from ee.onyx.server.scim.api import _scim_name_to_str
-from ee.onyx.server.scim.api import _seat_lock_id_for_tenant
 from ee.onyx.server.scim.api import create_user
 from ee.onyx.server.scim.api import delete_user
 from ee.onyx.server.scim.api import get_user
@@ -758,55 +758,35 @@ class TestSeatLock:
         """The advisory lock must be acquired before the seat check runs."""
         call_order: list[str] = []
 
-        def track_execute(stmt: Any, _params: Any = None) -> None:
-            if "pg_advisory_xact_lock" in str(stmt):
-                call_order.append("lock")
+        def fake_acquire(_session: Any, _tenant_id: Any) -> None:
+            call_order.append("lock")
 
-        mock_dal.session.execute.side_effect = track_execute
+        mock_result = MagicMock()
+        mock_result.available = True
+
+        def fake_check(*_args: Any, **_kwargs: Any) -> Any:
+            call_order.append("check")
+            return mock_result
+
+        def fake_fetch(_module: str, name: str, _default: Any) -> Any:
+            if name == "acquire_seat_lock":
+                return fake_acquire
+            if name == "check_seat_availability":
+                return fake_check
+            raise AssertionError(f"unexpected fetch: {name}")
 
         with patch(
-            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop"
-        ) as mock_fetch:
-            mock_result = MagicMock()
-            mock_result.available = True
-            mock_fn = MagicMock(return_value=mock_result)
-            mock_fetch.return_value = mock_fn
-
-            def track_check(*_args: Any, **_kwargs: Any) -> Any:
-                call_order.append("check")
-                return mock_result
-
-            mock_fn.side_effect = track_check
-
+            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
+            side_effect=fake_fetch,
+        ):
             _check_seat_availability(mock_dal)
 
         assert call_order == ["lock", "check"]
 
-    @patch("ee.onyx.server.scim.api.get_current_tenant_id", return_value="tenant_xyz")
-    def test_lock_uses_tenant_scoped_key(
-        self,
-        _mock_tenant: MagicMock,
-        mock_dal: MagicMock,
-    ) -> None:
-        """The lock id must be derived from the tenant via _seat_lock_id_for_tenant."""
-        mock_result = MagicMock()
-        mock_result.available = True
-        mock_check = MagicMock(return_value=mock_result)
-
-        with patch(
-            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
-            return_value=mock_check,
-        ):
-            _check_seat_availability(mock_dal)
-
-        mock_dal.session.execute.assert_called_once()
-        params = mock_dal.session.execute.call_args[0][1]
-        assert params["lock_id"] == _seat_lock_id_for_tenant("tenant_xyz")
-
     def test_seat_lock_id_is_stable_and_tenant_scoped(self) -> None:
         """Lock id must be deterministic and differ across tenants."""
-        assert _seat_lock_id_for_tenant("t1") == _seat_lock_id_for_tenant("t1")
-        assert _seat_lock_id_for_tenant("t1") != _seat_lock_id_for_tenant("t2")
+        assert seat_lock_id_for_tenant("t1") == seat_lock_id_for_tenant("t1")
+        assert seat_lock_id_for_tenant("t1") != seat_lock_id_for_tenant("t2")
 
     def test_no_lock_when_ee_absent(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from uuid import uuid4
@@ -750,36 +749,26 @@ class TestSeatLock:
     """Tests for the advisory lock in _check_seat_availability."""
 
     @patch("ee.onyx.server.scim.api.get_current_tenant_id", return_value="tenant_abc")
+    @patch("ee.onyx.server.scim.api.check_seat_availability")
+    @patch("ee.onyx.server.scim.api.acquire_seat_lock")
     def test_acquires_advisory_lock_before_checking(
         self,
+        mock_acquire: MagicMock,
+        mock_check: MagicMock,
         _mock_tenant: MagicMock,
         mock_dal: MagicMock,
     ) -> None:
         """The advisory lock must be acquired before the seat check runs."""
         call_order: list[str] = []
 
-        def fake_acquire(_session: Any, _tenant_id: Any) -> None:
-            call_order.append("lock")
-
+        mock_acquire.side_effect = lambda *_a, **_kw: call_order.append("lock")
         mock_result = MagicMock()
         mock_result.available = True
+        mock_check.side_effect = lambda *_a, **_kw: (
+            call_order.append("check") or mock_result
+        )
 
-        def fake_check(*_args: Any, **_kwargs: Any) -> Any:
-            call_order.append("check")
-            return mock_result
-
-        def fake_fetch(_module: str, name: str, _default: Any) -> Any:
-            if name == "acquire_seat_lock":
-                return fake_acquire
-            if name == "check_seat_availability":
-                return fake_check
-            raise AssertionError(f"unexpected fetch: {name}")
-
-        with patch(
-            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
-            side_effect=fake_fetch,
-        ):
-            _check_seat_availability(mock_dal)
+        _check_seat_availability(mock_dal)
 
         assert call_order == ["lock", "check"]
 
@@ -787,23 +776,3 @@ class TestSeatLock:
         """Lock id must be deterministic and differ across tenants."""
         assert seat_lock_id_for_tenant("t1") == seat_lock_id_for_tenant("t1")
         assert seat_lock_id_for_tenant("t1") != seat_lock_id_for_tenant("t2")
-
-    def test_no_error_on_ce_noop_check(
-        self,
-        mock_dal: MagicMock,
-    ) -> None:
-        """On CE, ``fetch_ee_implementation_or_noop`` returns a callable
-        no-op that yields ``None``; ``_check_seat_availability`` must
-        treat the absence of a result as "no enforcement" rather than
-        crashing on attribute access."""
-
-        def fake_fetch(_module: str, _name: str, _default: Any) -> Any:
-            return lambda *_a, **_kw: None
-
-        with patch(
-            "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
-            side_effect=fake_fetch,
-        ):
-            result = _check_seat_availability(mock_dal)
-
-        assert result is None

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -788,16 +788,22 @@ class TestSeatLock:
         assert seat_lock_id_for_tenant("t1") == seat_lock_id_for_tenant("t1")
         assert seat_lock_id_for_tenant("t1") != seat_lock_id_for_tenant("t2")
 
-    def test_no_lock_when_ee_absent(
+    def test_no_error_on_ce_noop_check(
         self,
         mock_dal: MagicMock,
     ) -> None:
-        """No advisory lock should be acquired when the EE check is absent."""
+        """On CE, ``fetch_ee_implementation_or_noop`` returns a callable
+        no-op that yields ``None``; ``_check_seat_availability`` must
+        treat the absence of a result as "no enforcement" rather than
+        crashing on attribute access."""
+
+        def fake_fetch(_module: str, _name: str, _default: Any) -> Any:
+            return lambda *_a, **_kw: None
+
         with patch(
             "ee.onyx.server.scim.api.fetch_ee_implementation_or_noop",
-            return_value=None,
+            side_effect=fake_fetch,
         ):
             result = _check_seat_availability(mock_dal)
 
         assert result is None
-        mock_dal.session.execute.assert_not_called()


### PR DESCRIPTION
## Description

**Bug (self-hosted licensed deploys):** could exceed `license.seats`, after which `license_enforcement.py:131` returns 402 on every subsequent request — locking the entire tenant out.

**Causes:**
- `enforce_seat_limit` did the seat check on a different session than the INSERT and held no lock — concurrent signups all passed.
- EXT_PERM/SERVICE_ACCOUNT → STANDARD upgrades (IntegrityError + UserAlreadyExists branches in `UserManager.create`, OAuth callback, Slack `add_slack_user_if_not_exists`) silently flipped the user from uncounted to counted with no check.

**Fix (self-hosted):**
- Promote SCIM's `pg_advisory_xact_lock` into `acquire_seat_lock` and add `enforce_seat_limit_locked` that holds the lock until the caller's INSERT/UPDATE commits. `UserManager.create`, `oauth_callback`, `bulk_invite_users`, `activate_user_api` now share one transaction with the check.
- Promotion paths run the lock + seat check in their upgrade transaction and invalidate the license cache when the upgrade adds a seat. `add_slack_user_if_not_exists` accepts an optional enforcer.

**Separate change (cloud / multi-tenant):** cloud doesn't enforce a `license.seats` cap (no lock-out behavior applies). Previously the cloud branch of `enforce_seat_limit` was a no-op and signups never auto-billed. Now `enforce_seat_limit` delegates in MT to `enforce_cloud_seat_limit`, which calls Stripe via `register_tenant_users` with a per-(tenant, quantity) idempotency key. `CardError` / `InvalidRequestError` → `OnyxError(SEAT_LIMIT_EXCEEDED)`. Trial tenants short-circuit (existing `NUM_FREE_TRIAL_USER_INVITES` cap unchanged). `add_users_to_tenant` calls the enforcer for net-new active mappings as defense-in-depth.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check