### PR TITLE
chore(embedding): Use `expire` instead of `set` when resetting the TTL for query cache hits

### DIFF
--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -149,12 +149,8 @@ def get_cached_query_embeddings(
             continue
 
         hits += 1
-        # Refresh TTL by re-setting the value. ``backend.expire`` would be a
-        # cheaper round trip but ``TenantRedis`` doesn't currently prefix
-        # ``EXPIRE`` calls, so the EXPIRE would target the wrong key. Re-set is
-        # one byte heavier on the wire and entirely safe.
         try:
-            cache_backend.set(key, raw, ex=ttl_seconds)
+            cache_backend.expire(key, ttl_seconds)
         except CACHE_TRANSIENT_ERRORS:
             logger.debug("Failed to refresh TTL for %s.", key, exc_info=True)
 


### PR DESCRIPTION
## Description
We had to use `set` because #10849 had not existed yet.

## How Has This Been Tested?
Not explicitly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `expire` instead of `set` to refresh TTL on query embedding cache hits. This avoids rewriting values and reduces network overhead now that `TenantRedis` correctly prefixes EXPIRE calls.

<sup>Written for commit c7ca530ebd302408157d36ac70f1f9e8aa1ebf90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

