### PR TITLE
fix(chat): release DB session before LLM stream begins

### DIFF
--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -181,7 +181,16 @@ class AvailableFiles(BaseModel):
 
 @dataclass(frozen=True)
 class ChatTurnSetup:
-    """Immutable context produced by ``build_chat_turn`` and consumed by ``_run_models``."""
+    """Immutable context produced by ``build_chat_turn`` and consumed by ``_run_models``.
+
+    **Detached-safety contract:** instances of this class travel outside the DB
+    session that built them. Every ORM object reachable from this dataclass
+    (``chat_session``, ``persona``, ``user_message``, ``reserved_messages``,
+    ``llms``) is detached after ``build_chat_turn`` returns. Downstream code
+    must only read column attributes that were eager-loaded during setup —
+    do NOT access lazy-loaded relationships (e.g. ``setup.chat_session.messages``,
+    ``setup.persona.tools[i].some_lazy_field``) or SQLAlchemy will raise
+    ``DetachedInstanceError`` at runtime."""
 
     new_msg_req: SendMessageRequest
     chat_session: ChatSession

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1482,6 +1482,9 @@ def _stream_chat_turn(
         if new_msg_req.mock_llm_response is not None:
             mock_response_token = set_llm_mock_response(new_msg_req.mock_llm_response)
 
+        assert (
+            setup is not None
+        ), "build_chat_turn must complete before _run_models is called"
         yield from _run_models(
             setup=setup,
             user=user,
@@ -1678,7 +1681,8 @@ def llm_loop_completion_handle(
     pre_answer_processing_time = state_container.get_pre_answer_processing_time()
 
     completed_normally = is_connected()
-    chat_session_id = assistant_message.chat_session_id
+    chat_session_id: UUID = assistant_message.chat_session_id
+    assistant_message_id: int = assistant_message.id
     if completed_normally:
         if answer_tokens is None:
             raise RuntimeError(
@@ -1695,10 +1699,16 @@ def llm_loop_completion_handle(
             final_answer = "The generation was stopped by the user."
 
     # Open a short-lived session here rather than holding one across the LLM
-    # stream. Re-attach the (possibly detached) ChatMessage so save_chat_turn's
-    # attribute mutations are tracked and persisted on commit.
+    # stream. Re-fetch the ChatMessage so save_chat_turn's mutations are applied
+    # on top of current DB state — using merge() would silently overwrite any
+    # concurrent writes (admin edits, retries) made between build_chat_turn's
+    # commit and this completion handler.
     with get_session_with_current_tenant() as db_session:
-        attached_message = db_session.merge(assistant_message, load=False)
+        attached_message = db_session.get(ChatMessage, assistant_message_id)
+        if attached_message is None:
+            raise RuntimeError(
+                "ChatMessage %d not found during completion" % assistant_message_id
+            )
 
         save_chat_turn(
             message_text=final_answer,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -70,6 +70,7 @@ from onyx.db.chat import get_or_create_root_message
 from onyx.db.chat import reserve_message_id
 from onyx.db.chat import reserve_multi_model_message_ids
 from onyx.db.document_set import filter_document_set_names_by_user_access
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import HookPoint
 from onyx.db.memory import get_memories
 from onyx.db.models import ChatMessage
@@ -1057,15 +1058,17 @@ _CANCEL_POLL_INTERVAL_S: Final[float] = 0.05
 def _run_models(
     setup: ChatTurnSetup,
     user: User,
-    db_session: Session,
     external_state_container: ChatStateContainer | None = None,
 ) -> AnswerStream:
     """Stream packets from one or more LLM loops running in parallel worker threads.
 
-    Each model gets its own worker thread, DB session, and ``Emitter``. Threads write
-    packets to a shared unbounded queue as they are produced; the drain loop yields them
-    in arrival order so the caller receives a single interleaved stream regardless of
-    how many models are running.
+    Each model gets its own worker thread, ``Emitter``, and short-lived DB sessions
+    opened on demand. Threads write packets to a shared unbounded queue as they are
+    produced; the drain loop yields them in arrival order so the caller receives a
+    single interleaved stream regardless of how many models are running.
+
+    No DB connection is held across the LLM stream — completion + error handlers
+    open their own short sessions when persistence is needed.
 
     Single-model (N=1) and multi-model (N>1) use the same execution path. Every
     packet is tagged with ``model_index`` by the model's Emitter — ``0`` for N=1,
@@ -1074,8 +1077,6 @@ def _run_models(
     Args:
         setup: Fully constructed turn context — LLMs, persona, history, tool config.
         user: Authenticated user making the request.
-        db_session: Caller's DB session (used for setup reads; each worker opens its own
-            session because SQLAlchemy sessions are not thread-safe).
         external_state_container: Pre-constructed state container for the first model.
             Used by evals and the non-streaming API path so the caller can inspect
             accumulated state (tool calls, answer tokens, citations) after the stream
@@ -1213,12 +1214,18 @@ def _run_models(
     def _save_errored_message(model_idx: int, context: str) -> None:
         """Save an error message to a reserved ChatMessage that failed during execution."""
         try:
-            msg = db_session.get(ChatMessage, setup.reserved_messages[model_idx].id)
-            if msg is not None:
-                error_text = f"Error from {setup.model_display_names[model_idx]}: model encountered an error during generation."
-                msg.message = error_text
-                msg.error = error_text
-                db_session.commit()
+            with get_session_with_current_tenant() as save_db_session:
+                msg = save_db_session.get(
+                    ChatMessage, setup.reserved_messages[model_idx].id
+                )
+                if msg is not None:
+                    error_text = (
+                        "Error from %s: model encountered an error during generation."
+                        % setup.model_display_names[model_idx]
+                    )
+                    msg.message = error_text
+                    msg.error = error_text
+                    save_db_session.commit()
         except Exception:
             logger.exception(
                 "%s error save failed for model %d (%s)",
@@ -1260,7 +1267,6 @@ def _run_models(
                             llm_loop_completion_handle(
                                 state_container=state_containers[i],
                                 is_connected=lambda: succeeded,
-                                db_session=db_session,
                                 assistant_message=setup.reserved_messages[i],
                                 llm=setup.llms[i],
                                 reserved_tokens=setup.reserved_token_count,
@@ -1314,8 +1320,8 @@ def _run_models(
 
         # ── Completion: save each successful model's response ───────────────
         # All model loops have completed (run_llm_loop returned) — no more writes
-        # to state_containers. Worker threads may still be closing their own DB
-        # sessions, but the main-thread db_session is unshared and safe to use.
+        # to state_containers. Each model's completion runs inside its own
+        # short-lived DB session so no connection is held across the loop.
         for i in range(n_models):
             if not model_succeeded[i]:
                 # Model errored — delete its orphaned reserved message.
@@ -1325,7 +1331,6 @@ def _run_models(
                 llm_loop_completion_handle(
                     state_container=state_containers[i],
                     is_connected=setup.check_is_connected,
-                    db_session=db_session,
                     assistant_message=setup.reserved_messages[i],
                     llm=setup.llms[i],
                     reserved_tokens=setup.reserved_token_count,
@@ -1360,7 +1365,6 @@ def _run_models(
                             state_container=state_containers[i],
                             # Model already finished — persist full response.
                             is_connected=lambda: True,
-                            db_session=db_session,
                             assistant_message=setup.reserved_messages[i],
                             llm=setup.llms[i],
                             reserved_tokens=setup.reserved_token_count,
@@ -1384,7 +1388,6 @@ def _run_models(
 def _stream_chat_turn(
     new_msg_req: SendMessageRequest,
     user: User,
-    db_session: Session,
     llm_overrides: list[LLMOverride] | None = None,
     litellm_additional_headers: dict[str, str] | None = None,
     custom_tool_additional_headers: dict[str, str] | None = None,
@@ -1396,10 +1399,11 @@ def _stream_chat_turn(
 ) -> AnswerStream:
     """Private implementation for single-model and multi-model chat turn streaming.
 
-    Builds the turn context via ``build_chat_turn``, then streams packets from
-    ``_run_models`` back to the caller. Handles setup errors, LLM errors, and
-    cancellation uniformly, saving whatever partial state has been accumulated
-    before re-raising or yielding a terminal error packet.
+    Builds the turn context via ``build_chat_turn`` inside a short-lived DB session,
+    then streams packets from ``_run_models`` back to the caller without holding any
+    DB connection. Handles setup errors, LLM errors, and cancellation uniformly,
+    saving whatever partial state has been accumulated before re-raising or yielding
+    a terminal error packet.
 
     Not called directly — use the public wrappers:
     - ``handle_stream_message_objects`` for single-model (N=1) requests.
@@ -1408,7 +1412,6 @@ def _stream_chat_turn(
     Args:
         new_msg_req: The incoming chat request from the user.
         user: Authenticated user; may be anonymous for public personas.
-        db_session: Database session for this request.
         llm_overrides: ``None`` → single-model (persona default LLM).
             Non-empty list → multi-model (one LLM per override, 2–3 items).
         litellm_additional_headers: Extra headers forwarded to the LLM provider.
@@ -1435,53 +1438,53 @@ def _stream_chat_turn(
     setup: ChatTurnSetup | None = None
 
     try:
-        # Enforce document-set access on any user-supplied filters before setup
-        # or any tool invocation. Running here (rather than inside SearchTool.run())
-        # means the OnyxError propagates to the StreamingError handler below
-        # instead of being swallowed by the tool runner's catch-all.
-        if (
-            not bypass_acl
-            and new_msg_req.internal_search_filters is not None
-            and new_msg_req.internal_search_filters.document_set is not None
-        ):
-            accessible_names = filter_document_set_names_by_user_access(
-                db_session=db_session,
-                document_set_names=new_msg_req.internal_search_filters.document_set,
-                user=user,
-            )
-            unauthorized = sorted(
-                name
-                for name in new_msg_req.internal_search_filters.document_set
-                if name not in accessible_names
-            )
-            if unauthorized:
-                raise OnyxError(
-                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                    f"User does not have access to document sets: {unauthorized}",
+        with get_session_with_current_tenant() as setup_db_session:
+            try:
+                if (
+                    not bypass_acl
+                    and new_msg_req.internal_search_filters is not None
+                    and new_msg_req.internal_search_filters.document_set is not None
+                ):
+                    accessible_names = filter_document_set_names_by_user_access(
+                        db_session=setup_db_session,
+                        document_set_names=new_msg_req.internal_search_filters.document_set,
+                        user=user,
+                    )
+                    unauthorized = sorted(
+                        name
+                        for name in new_msg_req.internal_search_filters.document_set
+                        if name not in accessible_names
+                    )
+                    if unauthorized:
+                        raise OnyxError(
+                            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                            "User does not have access to document sets: %s"
+                            % unauthorized,
+                        )
+
+                setup = yield from build_chat_turn(
+                    new_msg_req=new_msg_req,
+                    user=user,
+                    db_session=setup_db_session,
+                    llm_overrides=llm_overrides,
+                    litellm_additional_headers=litellm_additional_headers,
+                    custom_tool_additional_headers=custom_tool_additional_headers,
+                    mcp_headers=mcp_headers,
+                    bypass_acl=bypass_acl,
+                    slack_context=slack_context,
+                    additional_context=additional_context,
                 )
+                setup_db_session.expunge_all()
+            except Exception:
+                setup_db_session.rollback()
+                raise
 
-        setup = yield from build_chat_turn(
-            new_msg_req=new_msg_req,
-            user=user,
-            db_session=db_session,
-            llm_overrides=llm_overrides,
-            litellm_additional_headers=litellm_additional_headers,
-            custom_tool_additional_headers=custom_tool_additional_headers,
-            mcp_headers=mcp_headers,
-            bypass_acl=bypass_acl,
-            slack_context=slack_context,
-            additional_context=additional_context,
-        )
-
-        # Set mock response token right before the LLM stream begins so that
-        # run_in_background threads inherit the correct context.
         if new_msg_req.mock_llm_response is not None:
             mock_response_token = set_llm_mock_response(new_msg_req.mock_llm_response)
 
         yield from _run_models(
             setup=setup,
             user=user,
-            db_session=db_session,
             external_state_container=external_state_container,
         )
 
@@ -1493,7 +1496,6 @@ def _stream_chat_turn(
             error_code=e.error_code.code,
             is_retryable=e.status_code >= 500,
         )
-        db_session.rollback()
         return
 
     except ValueError as e:
@@ -1503,7 +1505,6 @@ def _stream_chat_turn(
             error_code="VALIDATION_ERROR",
             is_retryable=True,
         )
-        db_session.rollback()
         return
 
     except EmptyLLMResponseError as e:
@@ -1525,7 +1526,6 @@ def _stream_chat_turn(
                 "tool_choice": e.tool_choice.value,
             },
         )
-        db_session.rollback()
 
     except Exception as e:
         logger.exception("Failed to process chat message due to %s", e)
@@ -1560,7 +1560,6 @@ def _stream_chat_turn(
                 error_code="INIT_FAILED",
                 is_retryable=True,
             )
-        db_session.rollback()
 
     finally:
         if mock_response_token is not None:
@@ -1579,7 +1578,6 @@ def _stream_chat_turn(
 def handle_stream_message_objects(
     new_msg_req: SendMessageRequest,
     user: User,
-    db_session: Session,
     litellm_additional_headers: dict[str, str] | None = None,
     custom_tool_additional_headers: dict[str, str] | None = None,
     mcp_headers: dict[str, str] | None = None,
@@ -1592,7 +1590,6 @@ def handle_stream_message_objects(
     yield from _stream_chat_turn(
         new_msg_req=new_msg_req,
         user=user,
-        db_session=db_session,
         llm_overrides=None,
         litellm_additional_headers=litellm_additional_headers,
         custom_tool_additional_headers=custom_tool_additional_headers,
@@ -1614,7 +1611,6 @@ def _build_model_display_name(override: LLMOverride | None) -> str:
 def handle_multi_model_stream(
     new_msg_req: SendMessageRequest,
     user: User,
-    db_session: Session,
     llm_overrides: list[LLMOverride],
     litellm_additional_headers: dict[str, str] | None = None,
     custom_tool_additional_headers: dict[str, str] | None = None,
@@ -1628,7 +1624,6 @@ def handle_multi_model_stream(
     Args:
         new_msg_req: The incoming chat request. ``deep_research`` must be ``False``.
         user: Authenticated user making the request.
-        db_session: Database session for this request.
         llm_overrides: Exactly 2 or 3 ``LLMOverride`` objects — one per model to run.
         litellm_additional_headers: Extra headers forwarded to each LLM provider.
         custom_tool_additional_headers: Extra headers for custom tool HTTP calls.
@@ -1641,7 +1636,7 @@ def handle_multi_model_stream(
     n_models = len(llm_overrides)
     if n_models < 2 or n_models > 3:
         yield StreamingError(
-            error=f"Multi-model requires 2-3 overrides, got {n_models}",
+            error="Multi-model requires 2-3 overrides, got %d" % n_models,
             error_code="VALIDATION_ERROR",
             is_retryable=False,
         )
@@ -1656,7 +1651,6 @@ def handle_multi_model_stream(
     yield from _stream_chat_turn(
         new_msg_req=new_msg_req,
         user=user,
-        db_session=db_session,
         llm_overrides=llm_overrides,
         litellm_additional_headers=litellm_additional_headers,
         custom_tool_additional_headers=custom_tool_additional_headers,
@@ -1667,13 +1661,10 @@ def handle_multi_model_stream(
 def llm_loop_completion_handle(
     state_container: ChatStateContainer,
     is_connected: Callable[[], bool],
-    db_session: Session,
     assistant_message: ChatMessage,
     llm: LLM,
     reserved_tokens: int,
 ) -> None:
-    chat_session_id = assistant_message.chat_session_id
-
     # Snapshot all state under the container's lock before any DB write.
     # Worker threads may still be running (e.g. user-cancellation path), so
     # direct attribute access is not thread-safe — use the provided getters.
@@ -1687,6 +1678,7 @@ def llm_loop_completion_handle(
     pre_answer_processing_time = state_container.get_pre_answer_processing_time()
 
     completed_normally = is_connected()
+    chat_session_id = assistant_message.chat_session_id
     if completed_normally:
         if answer_tokens is None:
             raise RuntimeError(
@@ -1694,7 +1686,6 @@ def llm_loop_completion_handle(
             )
         final_answer = answer_tokens
     else:
-        # Stopped by user - append stop message
         logger.debug("Chat session %s stopped by user", chat_session_id)
         if answer_tokens:
             final_answer = (
@@ -1703,43 +1694,47 @@ def llm_loop_completion_handle(
         else:
             final_answer = "The generation was stopped by the user."
 
-    save_chat_turn(
-        message_text=final_answer,
-        reasoning_tokens=reasoning_tokens,
-        citation_to_doc=citation_to_doc,
-        tool_calls=tool_calls,
-        all_search_docs=all_search_docs,
-        db_session=db_session,
-        assistant_message=assistant_message,
-        is_clarification=is_clarification,
-        emitted_citations=emitted_citations,
-        pre_answer_processing_time=pre_answer_processing_time,
-    )
+    # Open a short-lived session here rather than holding one across the LLM
+    # stream. Re-attach the (possibly detached) ChatMessage so save_chat_turn's
+    # attribute mutations are tracked and persisted on commit.
+    with get_session_with_current_tenant() as db_session:
+        attached_message = db_session.merge(assistant_message, load=False)
 
-    # Check if compression is needed after saving the message
-    updated_chat_history = create_chat_history_chain(
-        chat_session_id=chat_session_id,
-        db_session=db_session,
-    )
-    total_tokens = calculate_total_history_tokens(updated_chat_history)
-
-    compression_params = get_compression_params(
-        max_input_tokens=llm.config.max_input_tokens,
-        current_history_tokens=total_tokens,
-        reserved_tokens=reserved_tokens,
-    )
-    if compression_params.should_compress:
-        # Build tool mapping for formatting messages
-        all_tools = get_tools(db_session)
-        tool_id_to_name = {tool.id: tool.name for tool in all_tools}
-
-        compress_chat_history(
+        save_chat_turn(
+            message_text=final_answer,
+            reasoning_tokens=reasoning_tokens,
+            citation_to_doc=citation_to_doc,
+            tool_calls=tool_calls,
+            all_search_docs=all_search_docs,
             db_session=db_session,
-            chat_history=updated_chat_history,
-            llm=llm,
-            compression_params=compression_params,
-            tool_id_to_name=tool_id_to_name,
+            assistant_message=attached_message,
+            is_clarification=is_clarification,
+            emitted_citations=emitted_citations,
+            pre_answer_processing_time=pre_answer_processing_time,
         )
+
+        updated_chat_history = create_chat_history_chain(
+            chat_session_id=chat_session_id,
+            db_session=db_session,
+        )
+        total_tokens = calculate_total_history_tokens(updated_chat_history)
+
+        compression_params = get_compression_params(
+            max_input_tokens=llm.config.max_input_tokens,
+            current_history_tokens=total_tokens,
+            reserved_tokens=reserved_tokens,
+        )
+        if compression_params.should_compress:
+            all_tools = get_tools(db_session)
+            tool_id_to_name = {tool.id: tool.name for tool in all_tools}
+
+            compress_chat_history(
+                db_session=db_session,
+                chat_history=updated_chat_history,
+                llm=llm,
+                compression_params=compression_params,
+                tool_id_to_name=tool_id_to_name,
+            )
 
 
 _CITATION_LINK_START_PATTERN = re.compile(r"\s*\[\[\d+\]\]\(")

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1264,9 +1264,13 @@ def _run_models(
                             continue
                         try:
                             succeeded = model_succeeded[i]
+
+                            def _stop_button_is_connected(s: bool = succeeded) -> bool:
+                                return s
+
                             llm_loop_completion_handle(
                                 state_container=state_containers[i],
-                                is_connected=lambda: succeeded,
+                                is_connected=_stop_button_is_connected,
                                 assistant_message=setup.reserved_messages[i],
                                 llm=setup.llms[i],
                                 reserved_tokens=setup.reserved_token_count,

--- a/backend/onyx/evals/eval.py
+++ b/backend/onyx/evals/eval.py
@@ -236,7 +236,6 @@ def _get_answer_with_tools(
             packets = handle_stream_message_objects(
                 new_msg_req=request,
                 user=user,
-                db_session=db_session,
                 external_state_container=state_container,
             )
             full = gather_stream_full(packets, state_container)
@@ -249,8 +248,7 @@ def _get_answer_with_tools(
             )
 
             logger.info(
-                "Eval completed. Tools called: %s.\n"
-                "Assertion passed: %s. Details: %s",
+                "Eval completed. Tools called: %s.\nAssertion passed: %s. Details: %s",
                 result.tools_called,
                 assertion_passed,
                 assertion_details,
@@ -396,7 +394,6 @@ def _get_multi_turn_answer_with_tools(
                 packets = handle_stream_message_objects(
                     new_msg_req=request,
                     user=user,
-                    db_session=db_session,
                     external_state_container=state_container,
                 )
                 full = gather_stream_full(packets, state_container)

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -246,16 +246,14 @@ def handle_regular_answer(
         slack_context_str: str | None,
         onyx_user: User,
     ) -> ChatBasicResponse:
-        with get_session_with_current_tenant() as db_session:
-            packets = handle_stream_message_objects(
-                new_msg_req=new_message_request,
-                user=onyx_user,
-                db_session=db_session,
-                bypass_acl=False,
-                additional_context=slack_context_str,
-                slack_context=message_info.slack_context,
-            )
-            answer = gather_stream(packets)
+        packets = handle_stream_message_objects(
+            new_msg_req=new_message_request,
+            user=onyx_user,
+            bypass_acl=False,
+            additional_context=slack_context_str,
+            slack_context=message_info.slack_context,
+        )
+        answer = gather_stream(packets)
 
         if answer.error_msg:
             raise RuntimeError(answer.error_msg)

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -587,21 +587,19 @@ def handle_send_chat_message(
 
         def multi_model_stream_generator() -> Generator[str, None, None]:
             try:
-                with get_session_with_current_tenant() as db_session:
-                    for obj in handle_multi_model_stream(
-                        new_msg_req=chat_message_req,
-                        user=user,
-                        db_session=db_session,
-                        llm_overrides=llm_overrides,
-                        litellm_additional_headers=extract_headers(
-                            request.headers, LITELLM_PASS_THROUGH_HEADERS
-                        ),
-                        custom_tool_additional_headers=get_custom_tool_additional_request_headers(
-                            request.headers
-                        ),
-                        mcp_headers=chat_message_req.mcp_headers,
-                    ):
-                        yield get_json_line(obj.model_dump())
+                for obj in handle_multi_model_stream(
+                    new_msg_req=chat_message_req,
+                    user=user,
+                    llm_overrides=llm_overrides,
+                    litellm_additional_headers=extract_headers(
+                        request.headers, LITELLM_PASS_THROUGH_HEADERS
+                    ),
+                    custom_tool_additional_headers=get_custom_tool_additional_request_headers(
+                        request.headers
+                    ),
+                    mcp_headers=chat_message_req.mcp_headers,
+                ):
+                    yield get_json_line(obj.model_dump())
             except Exception as e:
                 logger.exception("Error in multi-model streaming")
                 yield json.dumps({"error": str(e)})
@@ -618,27 +616,45 @@ def handle_send_chat_message(
 
     # Non-streaming path: consume all packets and return complete response
     if not chat_message_req.stream:
-        with get_session_with_current_tenant() as db_session:
-            # Check and track non-streaming API usage limits
-            if is_usage_limits_enabled():
+        if is_usage_limits_enabled():
+            with get_session_with_current_tenant() as usage_db_session:
                 check_usage_and_raise(
-                    db_session=db_session,
+                    db_session=usage_db_session,
                     usage_type=UsageType.NON_STREAMING_API_CALLS,
                     tenant_id=tenant_id,
                     pending_amount=1,
                 )
                 increment_usage(
-                    db_session=db_session,
+                    db_session=usage_db_session,
                     usage_type=UsageType.NON_STREAMING_API_CALLS,
                     amount=1,
                 )
-                db_session.commit()
+                usage_db_session.commit()
 
-            state_container = ChatStateContainer()
-            packets = handle_stream_message_objects(
+        state_container = ChatStateContainer()
+        packets = handle_stream_message_objects(
+            new_msg_req=chat_message_req,
+            user=user,
+            litellm_additional_headers=extract_headers(
+                request.headers, LITELLM_PASS_THROUGH_HEADERS
+            ),
+            custom_tool_additional_headers=get_custom_tool_additional_request_headers(
+                request.headers
+            ),
+            mcp_headers=chat_message_req.mcp_headers,
+            additional_context=chat_message_req.additional_context,
+            external_state_container=state_container,
+        )
+        result = gather_stream_full(packets, state_container)
+        return result
+
+    # Streaming path, normal Onyx UI behavior
+    def stream_generator() -> Generator[str, None, None]:
+        state_container = ChatStateContainer()
+        try:
+            for obj in handle_stream_message_objects(
                 new_msg_req=chat_message_req,
                 user=user,
-                db_session=db_session,
                 litellm_additional_headers=extract_headers(
                     request.headers, LITELLM_PASS_THROUGH_HEADERS
                 ),
@@ -648,32 +664,8 @@ def handle_send_chat_message(
                 mcp_headers=chat_message_req.mcp_headers,
                 additional_context=chat_message_req.additional_context,
                 external_state_container=state_container,
-            )
-            result = gather_stream_full(packets, state_container)
-            # Note: LLM cost tracking is now handled in multi_llm.py
-            return result
-
-    # Streaming path, normal Onyx UI behavior
-    def stream_generator() -> Generator[str, None, None]:
-        state_container = ChatStateContainer()
-        try:
-            with get_session_with_current_tenant() as db_session:
-                for obj in handle_stream_message_objects(
-                    new_msg_req=chat_message_req,
-                    user=user,
-                    db_session=db_session,
-                    litellm_additional_headers=extract_headers(
-                        request.headers, LITELLM_PASS_THROUGH_HEADERS
-                    ),
-                    custom_tool_additional_headers=get_custom_tool_additional_request_headers(
-                        request.headers
-                    ),
-                    mcp_headers=chat_message_req.mcp_headers,
-                    additional_context=chat_message_req.additional_context,
-                    external_state_container=state_container,
-                ):
-                    yield get_json_line(obj.model_dump())
-                # Note: LLM cost tracking is now handled in multi_llm.py
+            ):
+                yield get_json_line(obj.model_dump())
 
         except Exception as e:
             logger.exception("Error in chat message streaming")
@@ -869,7 +861,6 @@ def fetch_chat_file(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> Response:
-
     # For user files, we need to get the file id from the user file id
     file_id_from_user_file = get_file_id_by_user_file_id(file_id, user.id, db_session)
     if file_id_from_user_file:

--- a/backend/tests/external_dependency_unit/answer/stream_test_utils.py
+++ b/backend/tests/external_dependency_unit/answer/stream_test_utils.py
@@ -40,7 +40,6 @@ def create_placement(
 def submit_query(
     query: str,
     chat_session_id: UUID | None,
-    db_session: Session,
     user: User,
     llm_override: LLMOverride | None = None,
 ) -> Iterator[AnswerStreamPart]:
@@ -57,7 +56,6 @@ def submit_query(
     return handle_stream_message_objects(
         new_msg_req=request,
         user=user,
-        db_session=db_session,
     )
 
 

--- a/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
+++ b/backend/tests/external_dependency_unit/answer/test_answer_without_openai.py
@@ -77,7 +77,6 @@ def test_answer_with_only_anthropic_provider(
         for packet in handle_stream_message_objects(
             new_msg_req=chat_request,
             user=test_user,
-            db_session=db_session,
         ):
             response_stream.append(packet)
 

--- a/backend/tests/external_dependency_unit/answer/test_current_datetime_replacement.py
+++ b/backend/tests/external_dependency_unit/answer/test_current_datetime_replacement.py
@@ -49,7 +49,6 @@ def test_stream_chat_current_date_response(
     gen = handle_stream_message_objects(
         new_msg_req=chat_request,
         user=test_user,
-        db_session=db_session,
     )
 
     raw: list[AnswerStreamPart] = []

--- a/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
+++ b/backend/tests/external_dependency_unit/answer/test_stream_chat_message.py
@@ -91,7 +91,6 @@ def test_stream_chat_with_answer(
         answer_stream = submit_query(
             query=query,
             chat_session_id=chat_session.id,
-            db_session=db_session,
             user=test_user,
         )
 
@@ -135,7 +134,6 @@ def test_stream_chat_with_answer_create_chat(
         answer_stream = submit_query(
             query=query,
             chat_session_id=None,
-            db_session=db_session,
             user=test_user,
         )
 
@@ -222,7 +220,7 @@ def test_stream_chat_with_search_and_openurl_tools(
     ]
 
     REASONING_RESPONSE_3 = (
-        "I now know everything that I need to know. " "I can now answer the question."
+        "I now know everything that I need to know. I can now answer the question."
     )
 
     ANSWER_RESPONSE_1 = (
@@ -243,7 +241,6 @@ def test_stream_chat_with_search_and_openurl_tools(
         answer_stream = submit_query(
             query=QUERY,
             chat_session_id=chat_session.id,
-            db_session=db_session,
             user=test_user,
         )
 
@@ -441,7 +438,6 @@ def test_image_generation_tool_no_reasoning(
         answer_stream = submit_query(
             query=QUERY,
             chat_session_id=chat_session.id,
-            db_session=db_session,
             user=test_user,
         )
 
@@ -767,7 +763,6 @@ def test_parallel_internal_and_web_search_tool_calls(
         answer_stream = submit_query(
             query=QUERY,
             chat_session_id=chat_session.id,
-            db_session=db_session,
             user=test_user,
         )
 

--- a/backend/tests/external_dependency_unit/answer/test_stream_chat_message_objects.py
+++ b/backend/tests/external_dependency_unit/answer/test_stream_chat_message_objects.py
@@ -101,7 +101,6 @@ def test_stream_chat_message_objects_without_web_search(
     response_generator = handle_stream_message_objects(
         new_msg_req=chat_request,
         user=test_user,
-        db_session=db_session,
     )
     # Collect all packets from the response
     raw_answer_stream: list[AnswerStreamPart] = []

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_called.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_called.py
@@ -179,7 +179,6 @@ def test_user_sends_message_to_private_provider(
             answer_stream = submit_query(
                 query="Hello, how are you?",
                 chat_session_id=chat_session_id,
-                db_session=db_session,
                 user=admin_user,
                 llm_override=LLMOverride(
                     model_provider="private-provider",
@@ -211,7 +210,6 @@ def test_user_sends_message_to_private_provider(
             answer_stream = submit_query(
                 query="I'm good, thank you!",
                 chat_session_id=chat_session_id,
-                db_session=db_session,
                 user=admin_user,
                 llm_override=LLMOverride(
                     model_provider="private-provider",

--- a/backend/tests/external_dependency_unit/tools/test_python_tool.py
+++ b/backend/tests/external_dependency_unit/tools/test_python_tool.py
@@ -1210,11 +1210,7 @@ def test_code_interpreter_receives_chat_files(
 
         ci_mod.CodeInterpreterClient.__init__.__defaults__ = (mock_url,)
         try:
-            list(
-                handle_stream_message_objects(
-                    new_msg_req=msg_req, user=user, db_session=db_session
-                )
-            )
+            list(handle_stream_message_objects(new_msg_req=msg_req, user=user))
         finally:
             ci_mod.CodeInterpreterClient.__init__.__defaults__ = original_defaults
 
@@ -1279,9 +1275,7 @@ def test_code_interpreter_replay_packets_include_code_and_output(
         try:
             handler = StreamTestBuilder(llm_controller=mock_llm)
 
-            stream = handle_stream_message_objects(
-                new_msg_req=msg_req, user=user, db_session=db_session
-            )
+            stream = handle_stream_message_objects(new_msg_req=msg_req, user=user)
             # First packet is always MessageResponseIDInfo
             next(stream)
 
@@ -1425,9 +1419,7 @@ def test_code_interpreter_streaming_fallback_to_batch(
         ci_mod.CodeInterpreterClient.__init__.__defaults__ = (mock_url,)
         try:
             packets = list(
-                handle_stream_message_objects(
-                    new_msg_req=msg_req, user=user, db_session=db_session
-                )
+                handle_stream_message_objects(new_msg_req=msg_req, user=user)
             )
         finally:
             ci_mod.CodeInterpreterClient.__init__.__defaults__ = original_defaults

--- a/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_multi_model_streaming.py
@@ -66,9 +66,8 @@ def _first_from_stream(req: SendMessageRequest, overrides: list[LLMOverride]) ->
     user = MagicMock()
     user.is_anonymous = False
     user.email = "test@example.com"
-    db = MagicMock()
 
-    gen = handle_multi_model_stream(req, user, db, overrides)
+    gen = handle_multi_model_stream(req, user, overrides)
     return next(gen)
 
 
@@ -276,7 +275,7 @@ def _run_models_collect(setup: MagicMock) -> list:
     """Drive _run_models to completion and return all yielded items."""
     from onyx.chat.process_message import _run_models
 
-    return list(_run_models(setup, MagicMock(), MagicMock()))
+    return list(_run_models(setup, MagicMock()))
 
 
 class TestRunModels:
@@ -598,7 +597,7 @@ class TestRunModels:
         ):
             from onyx.chat.process_message import _run_models
 
-            gen = cast(Generator, _run_models(setup, MagicMock(), MagicMock()))
+            gen = cast(Generator, _run_models(setup, MagicMock()))
             first = next(gen)
             assert isinstance(first, Packet)
             # Simulate Starlette closing the stream on HTTP client disconnect.
@@ -654,7 +653,7 @@ class TestRunModels:
         ):
             from onyx.chat.process_message import _run_models
 
-            gen = cast(Generator, _run_models(setup, MagicMock(), MagicMock()))
+            gen = cast(Generator, _run_models(setup, MagicMock()))
             first = next(gen)
             assert isinstance(first, Packet)
 
@@ -730,11 +729,7 @@ class TestRunModels:
                 return_value=lambda _: 0,
             ),
         ):
-            list(
-                _run_models(
-                    setup, MagicMock(), MagicMock(), external_state_container=external
-                )
-            )
+            list(_run_models(setup, MagicMock(), external_state_container=external))
 
         # The state_container kwarg passed to run_llm_loop must be the external one
         call_kwargs = mock_llm.call_args.kwargs

--- a/backend/tests/unit/onyx/chat/test_process_message_mock_llm.py
+++ b/backend/tests/unit/onyx/chat/test_process_message_mock_llm.py
@@ -35,7 +35,6 @@ def test_mock_llm_response_requires_integration_mode() -> None:
             process_message.handle_stream_message_objects(
                 new_msg_req=request,
                 user=mock_user,
-                db_session=Mock(),
             )
         )
 


### PR DESCRIPTION
## Description

Removes the request-scoped DB session that wrapped the entire chat streaming generator in `chat_backend.py` (lines 590, 621, 660). The session committed at `build_chat_turn()` then sat idle for the full LLM inference window — load balancers / PgBouncer dropped the connection, surfacing as `OperationalError` on cleanup.

Companion to #10159, which fixed the per-worker-thread session inside `_run_model`. This eliminates the outer session that wrapped both setup and streaming.

- `chat_backend.py`: drop outer `with`-blocks. Non-stream usage check runs in its own short session.
- `_stream_chat_turn`: opens a short session for ACL check + setup, closes it before `_run_models` begins. `expunge_all()` on the way out so `ChatTurnSetup` ORM members are detached but still readable (persona is already eager-loaded per `construct_tools` docstring).
- `_run_models`, `handle_stream_message_objects`, `handle_multi_model_stream`: drop `db_session` parameter.
- `_save_errored_message` + `llm_loop_completion_handle`: open their own short-lived sessions internally; the latter `merge()`s the detached `ChatMessage` so `save_chat_turn`'s mutations are tracked.
- Update existing eval, slack, and test callers to match.

## How Has This Been Tested?

- `mypy` clean on touched files.
- `ruff` clean on touched files.
- `pytest backend/tests/unit/onyx/chat/test_multi_model_streaming.py backend/tests/unit/onyx/chat/test_process_message_mock_llm.py` — 28 passed.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check