### PR TITLE
chore(tf): Ability to pin nodes

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -39,6 +39,10 @@ module "eks" {
       # Only add subnet_ids override for vespa node group if specified
       k == "vespa" && length(var.vespa_node_subnet_ids) > 0 ? {
         subnet_ids = var.vespa_node_subnet_ids
+      } : {},
+      # Only add subnet_ids override for main node group if specified
+      k == "main" && length(var.main_node_subnet_ids) > 0 ? {
+        subnet_ids = var.main_node_subnet_ids
       } : {}
     )
   }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -55,6 +55,12 @@ variable "vespa_node_subnet_ids" {
   default     = []
 }
 
+variable "main_node_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the main node group. If not specified, uses all cluster subnets. Pin to private subnets to keep node egress on the NAT gateway IP across replacements."
+  default     = []
+}
+
 variable "eks_managed_node_groups" {
   type        = map(any)
   description = "EKS managed node groups with EBS volume configuration"

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -74,6 +74,10 @@ module "eks" {
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
 
+  main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
+    var.main_node_private_subnets_only ? local.private_subnets : []
+  )
+
   # Wire RDS IAM connection for the same IRSA service account used by apps
   enable_rds_iam_for_service_account = var.enable_iam_auth
   rds_db_username                    = var.postgres_username

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -91,6 +91,18 @@ variable "cluster_endpoint_public_access_cidrs" {
   default     = []
 }
 
+variable "main_node_subnet_ids" {
+  type        = list(string)
+  description = "Explicit subnet IDs for the main node group. Takes precedence over main_node_private_subnets_only."
+  default     = []
+}
+
+variable "main_node_private_subnets_only" {
+  type        = bool
+  description = "When true, pins the main node group to the VPC's private subnets so node egress always exits via the NAT gateway IP. Ignored if main_node_subnet_ids is set."
+  default     = false
+}
+
 variable "redis_auth_token" {
   type        = string
   description = "Authentication token for the Redis cluster"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Adding the ability the pin specific nodes in specific subnets in order to ensure that the IP stays in a specific range.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Applied to an EKS cluster already

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support to pin the EKS main node group to specific subnets to keep nodes within a desired CIDR and ensure stable egress via the NAT gateway. Defaults keep current behavior unless a new variable is set.

- **New Features**
  - `aws/eks` module: adds `main_node_subnet_ids` to override `subnet_ids` for the `main` node group when provided.
  - `aws/onyx` module: exposes `main_node_subnet_ids` and a convenience flag `main_node_private_subnets_only` that pins the main node group to private subnets when true; explicit `main_node_subnet_ids` takes precedence.

- **Migration**
  - No changes required; existing clusters behave the same.
  - To pin: set `main_node_subnet_ids = ["subnet-..."]` in `aws/onyx`, or set `main_node_private_subnets_only = true` to use the VPC’s private subnets.

<sup>Written for commit 3037c3e0eefc13301ba7ed3b9292804f3425184d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

