### PR TITLE
fix(auth): refresh OIDC access tokens on every authenticated request (follow-up to #10794) (#10806) to release v3.3

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -1,4 +1,7 @@
 import asyncio
+import os
+import time
+import uuid
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -27,9 +30,18 @@ REFRESH_ENDPOINTS: Dict[str, str] = {
 }
 
 # Token endpoint resolved from the configured OIDC discovery document.
-# Populated lazily on first successful fetch and re-used thereafter, so the
-# .well-known/openid-configuration document is only retrieved once per process.
-_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str] = {}
+# Populated lazily on first successful fetch and re-used until the entry's
+# `fetched_at` exceeds OIDC_DISCOVERY_CACHE_TTL_SECONDS, at which point it is
+# re-fetched. The TTL guards against the IdP rotating its `token_endpoint`
+# without us noticing (rare for major IdPs but possible across tenant moves
+# or app-reg migrations).
+_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str | float] = {}
+
+# Default 1 hour: matches Microsoft Entra's default access-token lifetime, so
+# at worst one refresh fails after an endpoint rotation before we self-heal.
+OIDC_DISCOVERY_CACHE_TTL_SECONDS: int = int(
+    os.environ.get("OIDC_DISCOVERY_CACHE_TTL_SECONDS") or 3600
+)
 
 # Lazily-initialized lock guarding concurrent first-time fetches of the OIDC
 # discovery document. Created on first use so it binds to the running event
@@ -45,6 +57,45 @@ def _get_oidc_lock() -> asyncio.Lock:
     return _OIDC_TOKEN_ENDPOINT_LOCK
 
 
+# Per-user locks coalescing concurrent token-refresh attempts. Without this,
+# two requests for the same user near expiry could both POST a refresh, and
+# IdPs that rotate refresh tokens (e.g. Microsoft Entra) would invalidate one
+# of them with `400 invalid_grant`. The lock pairs with a re-read inside
+# `check_and_refresh_oauth_tokens` so the second coroutine skips the redundant
+# request entirely once the first has succeeded.
+_USER_REFRESH_LOCKS: Dict[uuid.UUID, asyncio.Lock] = {}
+_USER_REFRESH_LOCKS_GUARD: Optional[asyncio.Lock] = None
+
+
+def _get_user_refresh_locks_guard() -> asyncio.Lock:
+    """Lazy-init the meta-lock that protects the per-user lock dict itself."""
+    global _USER_REFRESH_LOCKS_GUARD
+    if _USER_REFRESH_LOCKS_GUARD is None:
+        _USER_REFRESH_LOCKS_GUARD = asyncio.Lock()
+    return _USER_REFRESH_LOCKS_GUARD
+
+
+async def _get_user_refresh_lock(user_id: uuid.UUID) -> asyncio.Lock:
+    """Get-or-create a per-user lock keyed by `user.id`."""
+    async with _get_user_refresh_locks_guard():
+        lock = _USER_REFRESH_LOCKS.get(user_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _USER_REFRESH_LOCKS[user_id] = lock
+        return lock
+
+
+def _cached_token_endpoint() -> Optional[str]:
+    """Return the cached endpoint if still within its TTL, else None."""
+    cached_url = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+    fetched_at = _OIDC_TOKEN_ENDPOINT_CACHE.get("fetched_at")
+    if not isinstance(cached_url, str) or not isinstance(fetched_at, float):
+        return None
+    if (time.monotonic() - fetched_at) >= OIDC_DISCOVERY_CACHE_TTL_SECONDS:
+        return None
+    return cached_url
+
+
 async def _get_oidc_token_endpoint() -> Optional[str]:
     """Resolve the OAuth2 token endpoint for the configured OIDC provider.
 
@@ -52,9 +103,10 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
     refresh works for any OIDC provider (Microsoft Entra, Okta, Keycloak,
     Auth0, ...) without hardcoding provider-specific URLs. The lock + double
     check ensures concurrent callers (e.g. multiple tokens expiring at once
-    after a server restart) coalesce into a single discovery request.
+    after a server restart) coalesce into a single discovery request, and the
+    TTL ensures we re-fetch periodically in case the IdP rotates the endpoint.
     """
-    cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+    cached = _cached_token_endpoint()
     if cached:
         return cached
     if not OPENID_CONFIG_URL:
@@ -62,7 +114,7 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
     async with _get_oidc_lock():
         # Re-check inside the lock — another coroutine may have populated
         # the cache while we were waiting to acquire it.
-        cached = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
+        cached = _cached_token_endpoint()
         if cached:
             return cached
         try:
@@ -78,6 +130,7 @@ async def _get_oidc_token_endpoint() -> Optional[str]:
         token_endpoint = config.get("token_endpoint")
         if isinstance(token_endpoint, str) and token_endpoint:
             _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
+            _OIDC_TOKEN_ENDPOINT_CACHE["fetched_at"] = time.monotonic()
             return token_endpoint
         return None
 
@@ -247,15 +300,40 @@ async def check_and_refresh_oauth_tokens(
             oauth_account.expires_at
             and oauth_account.expires_at - now_timestamp < buffer_seconds
         ):
-            logger.info(f"OAuth token for {user.email} is about to expire - refreshing")
-            success = await refresh_oauth_token(
-                user, oauth_account, db_session, user_manager
-            )
+            # Coalesce concurrent refreshes for the same user. Re-read the
+            # account inside the lock so the second coroutine sees the
+            # refreshed `expires_at` (and `refresh_token` for IdPs that
+            # rotate) and skips the redundant POST.
+            user_lock = await _get_user_refresh_lock(user.id)
+            async with user_lock:
+                try:
+                    await db_session.refresh(oauth_account)
+                except Exception:
+                    # `db_session.refresh` can fail when oauth_account is
+                    # detached from this session (e.g. pre-loaded by the
+                    # caller). Fall through and attempt the refresh anyway —
+                    # at worst the second coroutine sees the same stale
+                    # state we'd see without the lock.
+                    pass
 
-            if not success:
-                logger.warning(
-                    "Failed to refresh OAuth token. User may need to re-authenticate."
+                if (
+                    oauth_account.expires_at
+                    and oauth_account.expires_at - now_timestamp >= buffer_seconds
+                ):
+                    # Another coroutine already refreshed this account.
+                    continue
+
+                logger.info(
+                    "OAuth token for %s is about to expire - refreshing", user.email
                 )
+                success = await refresh_oauth_token(
+                    user, oauth_account, db_session, user_manager
+                )
+
+                if not success:
+                    logger.warning(
+                        "Failed to refresh OAuth token. User may need to re-authenticate."
+                    )
 
 
 async def check_oauth_account_has_refresh_token(

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1612,13 +1612,53 @@ async def _check_for_saml_and_jwt(
     return user
 
 
+async def _maybe_refresh_oauth_tokens(
+    user: User,
+    async_db_session: AsyncSession,
+    user_manager: BaseUserManager[User, uuid.UUID],
+) -> None:
+    """Best-effort refresh of any near-expiry OAuth access tokens.
+
+    PT_OAUTH MCP tools and any custom HTTP tool with bearer pass-through
+    forward `user.oauth_accounts[0].access_token` directly to the upstream
+    service. The web client's /auth/refresh ticker is gated off for
+    OIDC/SAML (see `web/src/hooks/useTokenRefresh.ts`), so without this hook
+    the stored access_token would rot at the IdP's lifetime (~1 h on
+    Microsoft Entra default) and downstream calls would 401 until the user
+    signs out and back in.
+
+    Refreshing here on every authenticated request is cheap — the underlying
+    `check_and_refresh_oauth_tokens` short-circuits when no account is
+    within the 5-minute renewal buffer. Failures log and return, so a
+    misconfigured IdP can never break authentication of an otherwise-valid
+    request.
+    """
+    # Local import mirrors the pattern at `get_refresh_router` to keep the
+    # auth module's load order resilient.
+    from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
+
+    try:
+        await check_and_refresh_oauth_tokens(
+            user=user,
+            db_session=async_db_session,
+            user_manager=cast(Any, user_manager),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to opportunistically refresh OAuth tokens for %s",
+            user.email,
+        )
+
+
 async def optional_user(
     request: Request,
     async_db_session: AsyncSession = Depends(get_async_session),
     user: User | None = Depends(optional_fastapi_current_user),
+    user_manager: BaseUserManager[User, uuid.UUID] = Depends(get_user_manager),
 ) -> User | None:
     if user := await _check_for_saml_and_jwt(request, user, async_db_session):
         # If user is already set, _check_for_saml_and_jwt returns the same user object
+        await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
         return user
 
     try:
@@ -1630,6 +1670,8 @@ async def optional_user(
         logger.warning("Issue with validating authentication token")
         return None
 
+    if user is not None:
+        await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)
     return user
 
 

--- a/backend/tests/unit/onyx/auth/conftest.py
+++ b/backend/tests/unit/onyx/auth/conftest.py
@@ -40,4 +40,9 @@ def mock_user_manager() -> MagicMock:
 @pytest.fixture
 def mock_db_session() -> MagicMock:
     """Creates a mock database session for testing."""
-    return MagicMock()
+    session = MagicMock()
+    # `check_and_refresh_oauth_tokens` calls `await db_session.refresh(...)`
+    # inside the per-user lock to re-read the latest expires_at from DB; the
+    # AsyncMock here lets that await resolve without raising.
+    session.refresh = AsyncMock()
+    return session

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -176,6 +176,72 @@ async def test_check_and_refresh_oauth_tokens(
 
 
 @pytest.mark.asyncio
+async def test_check_and_refresh_oauth_tokens_coalesces_concurrent_refresh(
+    mock_user_manager: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent refreshes for the same user trigger only one IdP POST.
+
+    Mirrors the post-refresh in-memory state by having the mocked
+    `refresh_oauth_token` update `account.expires_at` to a fresh value
+    (the way `update_oauth_account` would refresh the SQLAlchemy object on
+    success). The second coroutine must observe the fresh `expires_at`
+    inside the per-user lock and skip its redundant POST.
+    """
+    import asyncio as _asyncio
+
+    monkeypatch.setattr(oauth_refresher, "_USER_REFRESH_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_USER_REFRESH_LOCKS_GUARD", None)
+
+    now_timestamp = datetime.now(timezone.utc).timestamp()
+
+    account = MagicMock(spec=OAuthAccount)
+    account.oauth_name = "openid"
+    account.refresh_token = "rt"
+    account.expires_at = now_timestamp + 60  # within renewal buffer
+
+    user = MagicMock()
+    user.id = "concurrent-test-user"
+    user.email = "concurrent@example.com"
+    user.oauth_accounts = [account]
+
+    db_session = MagicMock()
+    db_session.refresh = AsyncMock()
+
+    refresh_started = _asyncio.Event()
+    release_refresh = _asyncio.Event()
+
+    async def slow_refresh(
+        _u: MagicMock, a: MagicMock, *_args: object, **_kwargs: object
+    ) -> bool:
+        # Park the first caller inside refresh_oauth_token so the second
+        # caller has a chance to reach the lock; the test fails
+        # (call_count > 1) if the lock doesn't coalesce them.
+        refresh_started.set()
+        await release_refresh.wait()
+        a.expires_at = now_timestamp + 3600  # simulate post-refresh state
+        return True
+
+    with patch(
+        "onyx.auth.oauth_refresher.refresh_oauth_token",
+        AsyncMock(side_effect=slow_refresh),
+    ) as mock_refresh:
+        first = _asyncio.create_task(
+            check_and_refresh_oauth_tokens(user, db_session, mock_user_manager)
+        )
+        await refresh_started.wait()
+        second = _asyncio.create_task(
+            check_and_refresh_oauth_tokens(user, db_session, mock_user_manager)
+        )
+        # Yield once so the second task reaches the lock acquisition.
+        await _asyncio.sleep(0)
+        release_refresh.set()
+        await _asyncio.gather(first, second)
+
+    assert mock_refresh.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_get_oauth_accounts_requiring_refresh_token(mock_user: MagicMock) -> None:
     """Test identifying OAuth accounts that need refresh tokens."""
     # Create accounts with and without refresh tokens
@@ -256,6 +322,9 @@ async def test_resolve_token_endpoint_openid_via_discovery(
 ) -> None:
     """For OIDC ("openid"), the token endpoint is read from the discovery doc."""
     monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
+    # Reset the lock so it gets created in the current test's event loop;
+    # without this, a prior test's lock could be bound to a different loop.
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -288,6 +357,50 @@ async def test_resolve_token_endpoint_openid_via_discovery(
     endpoint_cached = await _resolve_token_endpoint("openid")
     assert endpoint_cached == "https://idp.example.com/oauth2/v2.0/token"
     mock_client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_endpoint_openid_cache_ttl_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An expired cache entry triggers a fresh discovery fetch."""
+    import time as _time
+
+    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(
+        oauth_refresher,
+        "OPENID_CONFIG_URL",
+        "https://idp.example.com/.well-known/openid-configuration",
+    )
+    monkeypatch.setattr(oauth_refresher, "OIDC_DISCOVERY_CACHE_TTL_SECONDS", 1)
+    # Pre-populate the cache with an entry that's already past TTL.
+    expired_fetched_at = _time.monotonic() - 60.0
+    monkeypatch.setattr(
+        oauth_refresher,
+        "_OIDC_TOKEN_ENDPOINT_CACHE",
+        {
+            "url": "https://idp.example.com/old-token-endpoint",
+            "fetched_at": expired_fetched_at,
+        },
+    )
+
+    discovery_response = MagicMock()
+    discovery_response.status_code = 200
+    discovery_response.raise_for_status.return_value = None
+    discovery_response.json.return_value = {
+        "token_endpoint": "https://idp.example.com/new-token-endpoint",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = discovery_response
+
+    with patch("onyx.auth.oauth_refresher.httpx.AsyncClient") as client_class_mock:
+        client_class_mock.return_value.__aenter__.return_value = mock_client
+        endpoint = await _resolve_token_endpoint("openid")
+
+    # Must NOT return the stale cached URL; a fresh fetch is required.
+    assert endpoint == "https://idp.example.com/new-token-endpoint"
+    mock_client.get.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -403,12 +516,18 @@ async def test_refresh_oauth_token_openid_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """OIDC ("openid") accounts refresh via the discovery-resolved endpoint."""
+    import time as _time
+
     # Pre-populate the cache so the refresh test does not depend on the
-    # discovery-doc fetch path (covered separately above).
+    # discovery-doc fetch path (covered separately above). Include a fresh
+    # `fetched_at` so the entry is well within the TTL window.
     monkeypatch.setattr(
         oauth_refresher,
         "_OIDC_TOKEN_ENDPOINT_CACHE",
-        {"url": "https://idp.example.com/oauth2/v2.0/token"},
+        {
+            "url": "https://idp.example.com/oauth2/v2.0/token",
+            "fetched_at": _time.monotonic(),
+        },
     )
 
     mock_oauth_account.oauth_name = "openid"

--- a/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
+++ b/backend/tests/unit/onyx/auth/test_optional_user_oauth_refresh.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from onyx.auth.users import _maybe_refresh_oauth_tokens
+from onyx.db.models import User
+
+
+@pytest.mark.asyncio
+async def test_maybe_refresh_oauth_tokens_invokes_check_and_refresh(
+    mock_user: MagicMock,
+    mock_user_manager: MagicMock,
+    mock_db_session: AsyncSession,
+) -> None:
+    """Happy path: the helper delegates to `check_and_refresh_oauth_tokens`.
+
+    `check_and_refresh_oauth_tokens` already short-circuits when no
+    oauth_account is within the 5-minute renewal buffer, so calling it on
+    every authenticated request is the right granularity for this hook.
+    """
+    with patch(
+        "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
+        AsyncMock(return_value=None),
+    ) as mock_refresh:
+        await _maybe_refresh_oauth_tokens(mock_user, mock_db_session, mock_user_manager)
+
+    mock_refresh.assert_awaited_once()
+    await_args = mock_refresh.await_args
+    assert await_args is not None
+    assert await_args.kwargs["user"] is mock_user
+    assert await_args.kwargs["db_session"] is mock_db_session
+    assert await_args.kwargs["user_manager"] is mock_user_manager
+
+
+@pytest.mark.asyncio
+async def test_maybe_refresh_oauth_tokens_swallows_failures(
+    mock_user: MagicMock,
+    mock_user_manager: MagicMock,
+    mock_db_session: AsyncSession,
+) -> None:
+    """A misconfigured IdP must NOT break authentication of a valid request.
+
+    `check_and_refresh_oauth_tokens` raising should be logged and the
+    helper should return None — leaving the caller (`optional_user`) to
+    return the resolved user with whatever access_token is already stored.
+    """
+    with patch(
+        "onyx.auth.oauth_refresher.check_and_refresh_oauth_tokens",
+        AsyncMock(side_effect=RuntimeError("IdP unreachable")),
+    ):
+        result = await _maybe_refresh_oauth_tokens(
+            mock_user, mock_db_session, mock_user_manager
+        )
+
+    # The helper has no return value; the assertion that matters is that
+    # the exception did NOT propagate.
+    assert result is None
+
+
+@pytest.fixture
+def mock_user() -> MagicMock:
+    user = MagicMock(spec=User)
+    user.email = "test@example.com"
+    return user
+
+
+@pytest.fixture
+def mock_user_manager() -> MagicMock:
+    user_manager = MagicMock()
+    user_manager.user_db = MagicMock()
+    user_manager.user_db.update_oauth_account = AsyncMock()
+    user_manager.user_db.update = AsyncMock()
+    return user_manager
+
+
+@pytest.fixture
+def mock_db_session() -> MagicMock:
+    return MagicMock()


### PR DESCRIPTION
Cherry-pick of commit 76e2bfe2eede4309a85ea16c4697f5e6089369ac to release/v3.3 branch.

Original PR: #10794, #10806

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh OIDC access tokens on every authenticated request and prevent concurrent refresh races. This fixes intermittent 401s from expired tokens and stabilizes tools that pass through user access tokens.

- **Bug Fixes**
  - Added `_maybe_refresh_oauth_tokens` and called it from `optional_user` to refresh near-expiry tokens on each authenticated request.
  - Coalesced concurrent refreshes per user with a lock and DB re-read of `expires_at` to avoid duplicate POSTs and `invalid_grant` errors.
  - Introduced TTL-based cache for OIDC discovery `token_endpoint` with `OIDC_DISCOVERY_CACHE_TTL_SECONDS` (default 3600) to self-heal after endpoint rotations.
  - Expanded tests for concurrency, cache TTL expiry, and the optional-user refresh path; adjusted test fixtures to await `db_session.refresh`.

<sup>Written for commit 94f14970052a9d1b7bcc7b5b41a1c73608a79294. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

