### PR TITLE
chore(devtools): VS Code task for frontend with remote backend

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume",
     "source=onyx-devcontainer-web-node-modules,target=/workspace/web/node_modules,type=volume",
-    "source=onyx-devcontainer-web-next,target=/workspace/web/.next,type=volume"
+    "source=onyx-devcontainer-web-next,target=/workspace/web/.next,type=volume",
+    "source=${localEnv:HOME}/.onyx-env,target=/home/dev/.onyx-env,type=bind,readonly"
   ],
   "containerEnv": {
     "COLORTERM": "truecolor",
@@ -31,7 +32,7 @@
   },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",
   "updateRemoteUserUID": false,
-  "initializeCommand": "docker network create onyx_default 2>/dev/null || true",
+  "initializeCommand": "docker network create onyx_default 2>/dev/null || true; touch \"${HOME}/.onyx-env\"",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postStartCommand": "sudo bash /workspace/.devcontainer/init-dev-user.sh && if [ \"${ONYX_DEVCONTAINER_FIREWALL:-}\" = \"1\" ]; then sudo bash /workspace/.devcontainer/init-firewall.sh; else echo 'Devcontainer firewall disabled. Set ONYX_DEVCONTAINER_FIREWALL=1 on the host before starting the container to enable it.'; fi",

--- a/.kanban.toml
+++ b/.kanban.toml
@@ -10,6 +10,10 @@ container_port = 3000
 label = "start frontend (docker backend)"
 container_port = 3001
 
+[[task]]
+label = "start frontend (remote backend)"
+container_port = 3002
+
 [sync]
 allow_rebase = true
 allow_merge = false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,8 +42,8 @@
     {
       "type": "shell",
       "label": "start frontend (remote backend)",
-      "detail": "Loads INTERNAL_URL and DEBUG_AUTH_COOKIE from .vscode/.env. See web/README.md.",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "detail": "Loads INTERNAL_URL and DEBUG_AUTH_COOKIE from ~/.onyx-env on the host (mounted at /home/dev/.onyx-env). See web/README.md.",
+      "envFile": "/home/dev/.onyx-env",
       "options": {
         "cwd": "${workspaceFolder}",
         "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,6 +47,7 @@
       "options": {
         "cwd": "${workspaceFolder}",
         "env": {
+          "PORT": "3002",
           "UV_LINK_MODE": "copy"
         }
       },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,6 +41,20 @@
     },
     {
       "type": "shell",
+      "label": "start frontend (remote backend)",
+      "detail": "Loads INTERNAL_URL and DEBUG_AUTH_COOKIE from .vscode/.env. See web/README.md.",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "options": {
+        "cwd": "${workspaceFolder}",
+        "env": {
+          "UV_LINK_MODE": "copy"
+        }
+      },
+      "command": "uv",
+      "args": ["run", "--with", "onyx-devtools", "ods", "web", "dev"]
+    },
+    {
+      "type": "shell",
       "label": "Generate Onyx OpenAPI Python client",
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.env",


### PR DESCRIPTION
## Summary
- Adds a `start frontend (remote backend)` VS Code task that runs `ods web dev` with env vars loaded from `.vscode/.env`.
- Lets developers target a cloud backend (per `web/README.md`) without editing checked-in files; existing `start frontend` and `start frontend (docker backend)` tasks are unchanged and ignore `.vscode/.env`.

## Test plan
- [ ] Create `.vscode/.env` with `INTERNAL_URL=https://st-dev.onyx.app/api` and `DEBUG_AUTH_COOKIE=<value>`.
- [ ] Run the new task from VS Code's Run Task picker; confirm the dev server starts and proxies API calls to the remote backend.
- [ ] Confirm `start frontend` still uses the local backend (i.e., does not pick up `.vscode/.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new VS Code task, "start frontend (remote backend)," to run the web dev server against a cloud backend using `INTERNAL_URL` and `DEBUG_AUTH_COOKIE` from the host `~/.onyx-env` (mounted at `/home/dev/.onyx-env`). Pins the task to `PORT=3002` with a matching `.kanban.toml` entry and updates the devcontainer to bind-mount the env file read-only and pre-create it to avoid mount errors; existing "start frontend" and "start frontend (docker backend)" tasks are unchanged.

<sup>Written for commit abed735003e58348fa234227efe3fe7dfc4bcb1b. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

