### PR TITLE
fix(targeted-reindex): synthetic IndexAttempt sweeper + counter staleness + broker app

### DIFF
--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -15,6 +15,7 @@ are reported as still-failing so the admin sees clearly that targeted
 reindex isn't supported yet for that source.
 """
 
+import datetime
 from collections import defaultdict
 from collections.abc import Iterable
 from collections.abc import Sequence
@@ -153,6 +154,14 @@ def _flush_batch(
             failed_ids.add(f.failed_document.document_id)
 
     landed_ids = {d.id for d in documents} - failed_ids
+
+    attempt.total_docs_indexed = (attempt.total_docs_indexed or 0) + result.total_docs
+    attempt.new_docs_indexed = (attempt.new_docs_indexed or 0) + result.new_docs
+    attempt.total_chunks = (attempt.total_chunks or 0) + result.total_chunks
+    attempt.completed_batches = (attempt.completed_batches or 0) + 1
+    attempt.last_progress_time = datetime.datetime.now(datetime.timezone.utc)
+    db_session.commit()
+
     return landed_ids, failed_ids
 
 

--- a/backend/onyx/db/targeted_reindex.py
+++ b/backend/onyx/db/targeted_reindex.py
@@ -231,6 +231,8 @@ def create_targeted_reindex_job(
                 from_beginning=False,
                 status=IndexingStatus.NOT_STARTED,
                 targeted_reindex_job_id=job.id,
+                # Mirror celery_task_id so the orphan sweeper skips this row.
+                celery_task_id=celery_task_id,
             )
             db_session.add(attempt)
             db_session.flush()

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -14,13 +14,13 @@ task with the pre-allocated task UUID.
 import datetime
 from typing import Any
 
-from celery import current_app as celery_app
 from fastapi import APIRouter
 from fastapi import Depends
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_curator_or_admin_user
+from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -130,7 +130,7 @@ def submit_targeted_reindex(
         # indexing scheduler. Per-cc-pair fan-out (connector fetch +
         # docprocessing) hands off to the existing docfetching/
         # docprocessing queues from inside the task body.
-        celery_app.send_task(
+        client_app.send_task(
             OnyxCeleryTask.TARGETED_REINDEX_TASK,
             kwargs={
                 "targeted_reindex_job_id": result.targeted_reindex_job_id,


### PR DESCRIPTION
## Description

Two bugs surfaced in dev with the synthetic IndexAttempt rows from #10828 / #10864:

- **`current_app` falls back to AMQP defaults.** The endpoint imported `from celery import current_app` instead of the configured `versioned_apps.client.app`, so `send_task()` defaulted to `amqp://localhost:5672` and 503'd because Onyx uses Redis. Switched to the same client app that `document_set` / `projects` / `build` endpoints use.
- **Sweeper false-positive + missing counter updates.** `check_for_indexing` flags any IN_PROGRESS IndexAttempt with `celery_task_id IS NULL` as orphaned and writes a bogus `error_msg`. Synthetic attempts had NULL because the celery id lived on the parent job row. Mirror the id onto the synthetic attempt. Also update the standard pipeline counters (`total_docs_indexed`, `new_docs_indexed`, `total_chunks`, `completed_batches`, `last_progress_time`) inside `_flush_batch` since we bypass the docprocessing wrapper that normally maintains them.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

Live Drive reindex on dev1: pre-fix `error_msg=Inconsistent..., total_docs_indexed=0`; post-fix `error_msg=NULL, total_docs_indexed=95, total_chunks=2940, completed_batches=6`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check