### PR TITLE
feat(web): drain typewriter faster after stream finishes

### DIFF
--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -261,7 +261,11 @@ export const MessageTextRenderer: MessageRenderer<
 
   const isStreamFinished = isFinalAnswerComplete(packets);
 
-  const displayedContent = useTypewriter(content, isStreamingAnimationEnabled);
+  const displayedContent = useTypewriter(
+    content,
+    isStreamingAnimationEnabled,
+    isStreamFinished
+  );
 
   // One-way signal: stream done AND typewriter caught up. Do NOT derive
   // this from "typewriter currently behind" — it oscillates mid-stream

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -104,6 +104,9 @@ export const MessageTextRenderer: MessageRenderer<
   const setLatestMessageRenderComplete = useChatSessionStore(
     (state) => state.setLatestMessageRenderComplete
   );
+  const setIsStreamDraining = useChatSessionStore(
+    (state) => state.setIsStreamDraining
+  );
 
   const lastStableSyncedContentRef = useRef("");
   const lastVisibleContentRef = useRef("");
@@ -261,7 +264,7 @@ export const MessageTextRenderer: MessageRenderer<
 
   const isStreamFinished = isFinalAnswerComplete(packets);
 
-  const displayedContent = useTypewriter(
+  const { displayed: displayedContent, isDraining } = useTypewriter(
     content,
     isStreamingAnimationEnabled,
     isStreamFinished
@@ -304,6 +307,15 @@ export const MessageTextRenderer: MessageRenderer<
       }
     }
   }, [streamFullyDisplayed, onComplete, setLatestMessageRenderComplete]);
+
+  // Mirror the typewriter's drain state into the chat-session store so
+  // ChatScrollContainer can pause auto-scroll while the drain runs. Only
+  // the actively-animating renderer writes — historical mounts never
+  // enter the drain branch in useTypewriter.
+  useEffect(() => {
+    if (!wasEverAnimatingRef.current || !sessionIdAtMountRef.current) return;
+    setIsStreamDraining(sessionIdAtMountRef.current, isDraining);
+  }, [isDraining, setIsStreamDraining]);
 
   const processedContent = useMemo(
     () => processContent(displayedContent),

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -53,6 +53,12 @@ interface ChatSessionData {
   // Gates queued-message dispatch so a follow-up isn't sent while the
   // previous answer is still drawing on screen.
   latestMessageRenderComplete: boolean;
+
+  // True while the smooth-streaming typewriter is running its post-finish
+  // adaptive drain. Auto-scroll pauses during this window so the page
+  // doesn't yank as the typewriter speeds up — the user is reading at
+  // this point, not watching new content arrive.
+  isStreamDraining: boolean;
 }
 
 interface ChatSessionStore {
@@ -154,6 +160,7 @@ interface ChatSessionStore {
     sessionId: string,
     complete: boolean
   ) => void;
+  setIsStreamDraining: (sessionId: string, draining: boolean) => void;
 
   // Actions - Abort Controllers
   setAbortController: (sessionId: string, controller: AbortController) => void;
@@ -196,6 +203,7 @@ const createInitialSessionData = (
   isLoaded: false,
   queuedMessages: [],
   latestMessageRenderComplete: true,
+  isStreamDraining: false,
   ...initialData,
 });
 
@@ -563,6 +571,12 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
     });
   },
 
+  setIsStreamDraining: (sessionId: string, draining: boolean) => {
+    const session = get().sessions.get(sessionId);
+    if (!session || session.isStreamDraining === draining) return;
+    get().updateSessionData(sessionId, { isStreamDraining: draining });
+  },
+
   // Abort Controller Actions
   setAbortController: (sessionId: string, controller: AbortController) => {
     get().updateSessionData(sessionId, { abortController: controller });
@@ -746,4 +760,13 @@ export const useCurrentLatestMessageRenderComplete = () =>
       ? sessions.get(currentSessionId)
       : null;
     return currentSession?.latestMessageRenderComplete ?? true;
+  });
+
+export const useCurrentIsStreamDraining = () =>
+  useChatSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    const currentSession = currentSessionId
+      ? sessions.get(currentSessionId)
+      : null;
+    return currentSession?.isStreamDraining ?? false;
   });

--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -9,6 +9,15 @@ const CHARS_PER_FRAME = 3;
 // the user is still reading along.
 const CATCHUP_FRAMES = 30;
 
+export interface UseTypewriterResult {
+  displayed: string;
+  /** True while post-finish adaptive drain is running. Callers can use
+   *  this to pause auto-scroll so the page doesn't yank when the
+   *  typewriter speeds up — the user is reading at this point, not
+   *  watching new content arrive. */
+  isDraining: boolean;
+}
+
 /**
  * Reveals `target` one character at a time on each animation frame.
  * When `enabled` is false (historical messages), snaps to full on mount.
@@ -22,7 +31,7 @@ export function useTypewriter(
   target: string,
   enabled: boolean,
   streamFinished: boolean = false
-): string {
+): UseTypewriterResult {
   // Ref so the rAF loop reads latest length without restarting.
   const targetRef = useRef(target);
   targetRef.current = target;
@@ -43,6 +52,10 @@ export function useTypewriter(
   // Dividing the *current* backlog each tick produces geometric decay
   // and overshoots CATCHUP_FRAMES significantly for long tails.
   const drainStepRef = useRef<number | null>(null);
+
+  // Exposed so callers can suppress auto-scroll while the drain runs.
+  const [isDraining, setIsDraining] = useState(false);
+  const isDrainingRef = useRef(false);
 
   // `enabled` controls initial state: animate from 0 vs snap to full for
   // history/voice. Transitions mid-stream are handled via enabledRef in
@@ -84,6 +97,10 @@ export function useTypewriter(
         // restart it when `target` grows.
         runningRef.current = false;
         rafIdRef.current = null;
+        if (isDrainingRef.current) {
+          isDrainingRef.current = false;
+          setIsDraining(false);
+        }
         return;
       }
       let charsThisFrame: number;
@@ -94,6 +111,10 @@ export function useTypewriter(
             CHARS_PER_FRAME,
             Math.ceil(initialBacklog / CATCHUP_FRAMES)
           );
+          if (!isDrainingRef.current) {
+            isDrainingRef.current = true;
+            setIsDraining(true);
+          }
         }
         charsThisFrame = drainStepRef.current;
       } else {
@@ -163,8 +184,10 @@ export function useTypewriter(
       document.removeEventListener("visibilitychange", handleVisibility);
   }, []);
 
-  return useMemo(
+  const displayed = useMemo(
     () => target.slice(0, Math.min(displayedLength, target.length)),
     [target, displayedLength]
   );
+
+  return { displayed, isDraining };
 }

--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -1,15 +1,28 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-// Fixed reveal rate — NOT adaptive. Any ceil(delta/N) formula produces
-// visible chunks on burst packet arrivals. 1 = 60 cps, 2 = 120 cps.
+// Mid-stream reveal rate stays fixed — any ceil(delta/N) formula
+// produces visible chunks on burst packet arrivals. 1 = 60 cps, 2 = 120 cps.
 const CHARS_PER_FRAME = 3;
+// Once the stream is finished, the rate becomes adaptive so a long
+// backlog drains within ~CATCHUP_FRAMES frames. Bursty rendering after
+// the final packet is fine — the visible chunk size only matters while
+// the user is still reading along.
+const CATCHUP_FRAMES = 30;
 
 /**
  * Reveals `target` one character at a time on each animation frame.
  * When `enabled` is false (historical messages), snaps to full on mount.
  * The rAF loop pauses once caught up and resumes when `target` grows.
+ *
+ * `streamFinished` lets the loop drain any remaining backlog faster
+ * once the backend is done, so callers gating on "FE fully displayed"
+ * don't sit on a long tail when packets arrived in a burst.
  */
-export function useTypewriter(target: string, enabled: boolean): string {
+export function useTypewriter(
+  target: string,
+  enabled: boolean,
+  streamFinished: boolean = false
+): string {
   // Ref so the rAF loop reads latest length without restarting.
   const targetRef = useRef(target);
   targetRef.current = target;
@@ -20,6 +33,10 @@ export function useTypewriter(target: string, enabled: boolean): string {
   // animate a jump after audio ends).
   const enabledRef = useRef(enabled);
   enabledRef.current = enabled;
+
+  // Read inside the rAF loop without restarting it.
+  const streamFinishedRef = useRef(streamFinished);
+  streamFinishedRef.current = streamFinished;
 
   // `enabled` controls initial state: animate from 0 vs snap to full for
   // history/voice. Transitions mid-stream are handled via enabledRef in
@@ -63,7 +80,11 @@ export function useTypewriter(target: string, enabled: boolean): string {
         rafIdRef.current = null;
         return;
       }
-      const next = Math.min(prev + CHARS_PER_FRAME, targetLen);
+      const backlog = targetLen - prev;
+      const charsThisFrame = streamFinishedRef.current
+        ? Math.max(CHARS_PER_FRAME, Math.ceil(backlog / CATCHUP_FRAMES))
+        : CHARS_PER_FRAME;
+      const next = Math.min(prev + charsThisFrame, targetLen);
       displayedLengthRef.current = next;
       setDisplayedLength(next);
       rafIdRef.current = requestAnimationFrame(tick);

--- a/web/src/hooks/useTypewriter.ts
+++ b/web/src/hooks/useTypewriter.ts
@@ -38,6 +38,12 @@ export function useTypewriter(
   const streamFinishedRef = useRef(streamFinished);
   streamFinishedRef.current = streamFinished;
 
+  // Captured once when post-finish drain begins, so the per-frame step
+  // size stays constant instead of decaying with the shrinking backlog.
+  // Dividing the *current* backlog each tick produces geometric decay
+  // and overshoots CATCHUP_FRAMES significantly for long tails.
+  const drainStepRef = useRef<number | null>(null);
+
   // `enabled` controls initial state: animate from 0 vs snap to full for
   // history/voice. Transitions mid-stream are handled via enabledRef in
   // the restart effect so a flip to false doesn't dump the buffered tail
@@ -80,10 +86,19 @@ export function useTypewriter(
         rafIdRef.current = null;
         return;
       }
-      const backlog = targetLen - prev;
-      const charsThisFrame = streamFinishedRef.current
-        ? Math.max(CHARS_PER_FRAME, Math.ceil(backlog / CATCHUP_FRAMES))
-        : CHARS_PER_FRAME;
+      let charsThisFrame: number;
+      if (streamFinishedRef.current) {
+        if (drainStepRef.current === null) {
+          const initialBacklog = targetLen - prev;
+          drainStepRef.current = Math.max(
+            CHARS_PER_FRAME,
+            Math.ceil(initialBacklog / CATCHUP_FRAMES)
+          );
+        }
+        charsThisFrame = drainStepRef.current;
+      } else {
+        charsThisFrame = CHARS_PER_FRAME;
+      }
       const next = Math.min(prev + charsThisFrame, targetLen);
       displayedLengthRef.current = next;
       setDisplayedLength(next);

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -49,6 +49,7 @@ import {
   useCurrentChatState,
   useIsReady,
   useDocumentSidebarVisible,
+  useCurrentIsStreamDraining,
 } from "@/app/app/stores/useChatSessionStore";
 import FederatedOAuthModal from "@/components/chat/FederatedOAuthModal";
 import ChatScrollContainer, {
@@ -391,8 +392,13 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const anchorNodeId = anchorMessage?.nodeId;
   const anchorSelector = anchorNodeId ? `#message-${anchorNodeId}` : undefined;
 
-  // Auto-scroll preference from user settings
-  const autoScrollEnabled = user?.preferences?.auto_scroll !== false;
+  // Auto-scroll preference from user settings. Pause while the
+  // typewriter is running its post-finish adaptive drain — the user is
+  // reading at that point and a scroll yank as the typewriter speeds up
+  // is jarring.
+  const autoScrollPreference = user?.preferences?.auto_scroll !== false;
+  const isStreamDraining = useCurrentIsStreamDraining();
+  const autoScrollEnabled = autoScrollPreference && !isStreamDraining;
   const isStreaming = currentChatState === "streaming";
 
   const multiModel = useMultiModelChat(llmManager);


### PR DESCRIPTION
## Description

Once the backend stops streaming, scale the typewriter's per-frame reveal rate to the remaining backlog so a long tail drains within ~30 frames instead of the fixed 3 chars/frame. Mid-stream rate is unchanged (still 3 chars/frame) so live rendering during burst packet arrivals stays smooth — only the post-finish tail is allowed to burst.

This closes the visible gap between "backend done streaming" and "FE done rendering" without changing how content reveals while the user is still reading along.

## How Has This Been Tested?


https://github.com/user-attachments/assets/489fa455-d00e-439b-8a58-c4f57d8b05bb




## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check