### PR TITLE
feat(web): gate queued messages on previous answer fully rendered

### DIFF
--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -269,17 +269,18 @@ export const MessageTextRenderer: MessageRenderer<
   const streamFullyDisplayed =
     isStreamFinished && displayedContent.length >= content.length;
 
-  // Track whether this renderer was ever actively animating during its
-  // lifetime. `animate` flips false the moment the stop packet arrives
-  // (AgentMessage passes `animate={!stopPacketSeen}`), but the typewriter
-  // keeps draining for some time after — so checking `animate` at the
-  // moment `streamFullyDisplayed` fires would always be false for the
-  // active stream. Historical mounts start with animate=false, so this
-  // ref stays false for them.
+  // Capture `animate` at mount. `animate = !stopPacketSeen`, which only
+  // ever goes true→false during a renderer's lifetime, so its mount-time
+  // value distinguishes "actively-streaming renderer" (animate=true) from
+  // "historical mount" (animate=false). Used to gate the queue-release
+  // write below.
   const wasEverAnimatingRef = useRef(animate);
-  if (animate && !wasEverAnimatingRef.current) {
-    wasEverAnimatingRef.current = true;
-  }
+
+  // Bind sessionId at mount so a navigation while the typewriter is still
+  // draining doesn't write the completion flag to the newly-active session.
+  const sessionIdAtMountRef = useRef(
+    useChatSessionStore.getState().currentSessionId
+  );
 
   // Fire onComplete exactly once per mount. `onComplete` is an inline
   // arrow in AgentMessage so its identity changes on every parent render;
@@ -290,13 +291,12 @@ export const MessageTextRenderer: MessageRenderer<
     if (streamFullyDisplayed && !onCompleteFiredRef.current) {
       onCompleteFiredRef.current = true;
       onComplete();
-      // Only the renderer that was actively streaming (ever had
+      // Only the renderer that was actively streaming (mounted with
       // animate=true) flips the chat-session gate back to "rendered".
       // Historical mounts leave the flag alone so they don't release the
       // queue while a newer stream is still in flight.
-      if (wasEverAnimatingRef.current) {
-        const sid = useChatSessionStore.getState().currentSessionId;
-        if (sid) setLatestMessageRenderComplete(sid, true);
+      if (wasEverAnimatingRef.current && sessionIdAtMountRef.current) {
+        setLatestMessageRenderComplete(sessionIdAtMountRef.current, true);
       }
     }
   }, [streamFullyDisplayed, onComplete, setLatestMessageRenderComplete]);

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -269,6 +269,18 @@ export const MessageTextRenderer: MessageRenderer<
   const streamFullyDisplayed =
     isStreamFinished && displayedContent.length >= content.length;
 
+  // Track whether this renderer was ever actively animating during its
+  // lifetime. `animate` flips false the moment the stop packet arrives
+  // (AgentMessage passes `animate={!stopPacketSeen}`), but the typewriter
+  // keeps draining for some time after — so checking `animate` at the
+  // moment `streamFullyDisplayed` fires would always be false for the
+  // active stream. Historical mounts start with animate=false, so this
+  // ref stays false for them.
+  const wasEverAnimatingRef = useRef(animate);
+  if (animate && !wasEverAnimatingRef.current) {
+    wasEverAnimatingRef.current = true;
+  }
+
   // Fire onComplete exactly once per mount. `onComplete` is an inline
   // arrow in AgentMessage so its identity changes on every parent render;
   // without this guard, each new identity would re-fire the effect once
@@ -278,21 +290,16 @@ export const MessageTextRenderer: MessageRenderer<
     if (streamFullyDisplayed && !onCompleteFiredRef.current) {
       onCompleteFiredRef.current = true;
       onComplete();
-      // Only the actively-animating renderer signals "latest message
-      // rendered" to the chat-session gate. Historical mounts have
-      // animate=false and would otherwise flip the flag while a newer
-      // stream is still in flight.
-      if (animate) {
+      // Only the renderer that was actively streaming (ever had
+      // animate=true) flips the chat-session gate back to "rendered".
+      // Historical mounts leave the flag alone so they don't release the
+      // queue while a newer stream is still in flight.
+      if (wasEverAnimatingRef.current) {
         const sid = useChatSessionStore.getState().currentSessionId;
         if (sid) setLatestMessageRenderComplete(sid, true);
       }
     }
-  }, [
-    streamFullyDisplayed,
-    onComplete,
-    animate,
-    setLatestMessageRenderComplete,
-  ]);
+  }, [streamFullyDisplayed, onComplete, setLatestMessageRenderComplete]);
 
   const processedContent = useMemo(
     () => processContent(displayedContent),

--- a/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/renderers/MessageTextRenderer.tsx
@@ -30,6 +30,7 @@ import { extractChatImageFileId } from "@/app/app/components/files/images/utils"
 import { transformLinkUri } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { useSmoothStreaming } from "@/hooks/useSmoothStreaming";
+import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 
 /** Maps a visible-char count to a markdown index (skips formatting chars,
  *  extends to word boundary). Used by the voice-sync reveal path only. */
@@ -100,6 +101,9 @@ export const MessageTextRenderer: MessageRenderer<
   children,
 }) => {
   const { enabled: smoothStreamingEnabled } = useSmoothStreaming();
+  const setLatestMessageRenderComplete = useChatSessionStore(
+    (state) => state.setLatestMessageRenderComplete
+  );
 
   const lastStableSyncedContentRef = useRef("");
   const lastVisibleContentRef = useRef("");
@@ -274,8 +278,21 @@ export const MessageTextRenderer: MessageRenderer<
     if (streamFullyDisplayed && !onCompleteFiredRef.current) {
       onCompleteFiredRef.current = true;
       onComplete();
+      // Only the actively-animating renderer signals "latest message
+      // rendered" to the chat-session gate. Historical mounts have
+      // animate=false and would otherwise flip the flag while a newer
+      // stream is still in flight.
+      if (animate) {
+        const sid = useChatSessionStore.getState().currentSessionId;
+        if (sid) setLatestMessageRenderComplete(sid, true);
+      }
     }
-  }, [streamFullyDisplayed, onComplete]);
+  }, [
+    streamFullyDisplayed,
+    onComplete,
+    animate,
+    setLatestMessageRenderComplete,
+  ]);
 
   const processedContent = useMemo(
     () => processContent(displayedContent),

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -47,6 +47,12 @@ interface ChatSessionData {
 
   // Queued messages
   queuedMessages: QueuedMessage[];
+
+  // True once the latest assistant message has fully rendered to the
+  // user (backend stream done AND smooth-streaming typewriter caught up).
+  // Gates queued-message dispatch so a follow-up isn't sent while the
+  // previous answer is still drawing on screen.
+  latestMessageRenderComplete: boolean;
 }
 
 interface ChatSessionStore {
@@ -143,6 +149,12 @@ interface ChatSessionStore {
   enqueueCurrentMessage: (message: string) => void;
   removeCurrentQueuedMessage: (index: number) => void;
 
+  // Actions - Render completion
+  setLatestMessageRenderComplete: (
+    sessionId: string,
+    complete: boolean
+  ) => void;
+
   // Actions - Abort Controllers
   setAbortController: (sessionId: string, controller: AbortController) => void;
   abortSession: (sessionId: string) => void;
@@ -183,6 +195,7 @@ const createInitialSessionData = (
   lastAccessed: new Date(),
   isLoaded: false,
   queuedMessages: [],
+  latestMessageRenderComplete: true,
   ...initialData,
 });
 
@@ -542,6 +555,14 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
     }
   },
 
+  setLatestMessageRenderComplete: (sessionId: string, complete: boolean) => {
+    const session = get().sessions.get(sessionId);
+    if (!session || session.latestMessageRenderComplete === complete) return;
+    get().updateSessionData(sessionId, {
+      latestMessageRenderComplete: complete,
+    });
+  },
+
   // Abort Controller Actions
   setAbortController: (sessionId: string, controller: AbortController) => {
     get().updateSessionData(sessionId, { abortController: controller });
@@ -716,4 +737,13 @@ export const useCurrentQueuedMessages = () =>
       ? sessions.get(currentSessionId)
       : null;
     return currentSession?.queuedMessages ?? EMPTY_QUEUED_MESSAGES;
+  });
+
+export const useCurrentLatestMessageRenderComplete = () =>
+  useChatSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    const currentSession = currentSessionId
+      ? sessions.get(currentSessionId)
+      : null;
+    return currentSession?.latestMessageRenderComplete ?? true;
   });

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -1301,6 +1301,13 @@ export default function useChatController({
       resetRegenerationState(frozenSessionId);
       setStreamingStartTime(frozenSessionId, null);
       updateChatStateAction(frozenSessionId, "input");
+      // Error paths replace the streaming node with an empty-packets error
+      // node, so MessageTextRenderer never fires streamFullyDisplayed and
+      // never flips the queue gate back to true. Reset it here so queued
+      // follow-ups aren't silently dropped after a stream failure.
+      if (!streamSucceeded) {
+        setLatestMessageRenderComplete(frozenSessionId, true);
+      }
 
       // Name the chat now that we have the first AI response (navigation already happened before streaming)
       if (shouldAutoNameChatSessionAfterResponse) {

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -162,6 +162,9 @@ export default function useChatController({
   const updateChatStateAction = useChatSessionStore(
     (state) => state.updateChatState
   );
+  const setLatestMessageRenderComplete = useChatSessionStore(
+    (state) => state.setLatestMessageRenderComplete
+  );
   const updateRegenerationStateAction = useChatSessionStore(
     (state) => state.updateRegenerationState
   );
@@ -588,6 +591,7 @@ export default function useChatController({
       ];
 
       updateChatStateAction(frozenSessionId, "loading");
+      setLatestMessageRenderComplete(frozenSessionId, false);
 
       // find the parent
       const currMessageHistory =

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -64,6 +64,7 @@ import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import { useVoiceStatus } from "@/hooks/useVoiceStatus";
 import {
   useCurrentQueuedMessages,
+  useCurrentLatestMessageRenderComplete,
   useChatSessionStore,
 } from "@/app/app/stores/useChatSessionStore";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
@@ -133,6 +134,7 @@ const AppInputBar = React.memo(
     );
     const setMutedRef = useRef<((muted: boolean) => void) | null>(null);
     const queuedMessages = useCurrentQueuedMessages();
+    const latestMessageRenderComplete = useCurrentLatestMessageRenderComplete();
     const enqueueCurrentMessage = useChatSessionStore(
       (state) => state.enqueueCurrentMessage
     );
@@ -302,14 +304,25 @@ const AppInputBar = React.memo(
 
     const prevChatStateRef = useRef(chatState);
     const prevAwaitingRef = useRef(awaitingPreferredSelection);
+    const prevRenderCompleteRef = useRef(latestMessageRenderComplete);
 
     useEffect(() => {
+      // "Ready" requires the backend to be idle AND the previous answer
+      // to have finished drawing on screen. Without the render-complete
+      // gate, a queued follow-up fires while the smooth-streaming
+      // typewriter is still flushing the prior answer.
       const wasReady =
-        prevChatStateRef.current === "input" && !prevAwaitingRef.current;
-      const isReady = chatState === "input" && !awaitingPreferredSelection;
+        prevChatStateRef.current === "input" &&
+        !prevAwaitingRef.current &&
+        prevRenderCompleteRef.current;
+      const isReady =
+        chatState === "input" &&
+        !awaitingPreferredSelection &&
+        latestMessageRenderComplete;
 
       prevChatStateRef.current = chatState;
       prevAwaitingRef.current = awaitingPreferredSelection;
+      prevRenderCompleteRef.current = latestMessageRenderComplete;
 
       if (!wasReady && isReady && queuedMessages.length > 0) {
         const nextMessage = queuedMessages[0]!.text;
@@ -322,6 +335,7 @@ const AppInputBar = React.memo(
     }, [
       chatState,
       awaitingPreferredSelection,
+      latestMessageRenderComplete,
       queuedMessages,
       removeCurrentQueuedMessage,
       stopTTS,


### PR DESCRIPTION
## Description

A queued follow-up message currently fires the moment `chatState` flips to `"input"` — i.e. as soon as the backend stops streaming. With smooth streaming on, the typewriter is still flushing the previous answer when this happens, so the next request fires while the user is still watching the previous one finish drawing.

This adds a per-session `latestMessageRenderComplete` flag to the chat-session store:

- `useChatController` flips it to `false` when a new send/regen begins.
- The actively-animating `MessageTextRenderer` flips it to `true` on `streamFullyDisplayed`. Historical mounts (`animate=false`) leave it alone.
- `AppInputBar` ANDs it into the queued-dispatch readiness check.

When smooth streaming is disabled (cookie off), the typewriter snaps to full immediately, so the flag flips to `true` in the same tick the backend finishes — the gate is a no-op for that path.

## How Has This Been Tested?

<img width="1842" height="1852" alt="2026-05-13 15 49 15" src="https://github.com/user-attachments/assets/512f5d37-746e-4b13-a2fd-ef67dbdfdac2" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check