### PR TITLE
fix(db_session): release DB session before embedding in docprocessing task

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1656,6 +1656,8 @@ def _docprocessing_task(
             },
         )
 
+        # Phase 1: fast DB reads to set up the pipeline. Session closes before
+        # the slow embedding + Vespa work begins, returning the connection to the pool.
         with get_session_with_current_tenant() as db_session:
             # matches parts of _run_indexing
             index_attempt = get_index_attempt(
@@ -1714,48 +1716,51 @@ def _docprocessing_task(
                 batch_num=batch_num,
             )
 
-            # Process documents through indexing pipeline
-            connector_source = (
+            # Capture primitives needed after session close
+            connector_source: str = (
                 index_attempt.connector_credential_pair.connector.source.value
             )
-            task_logger.info(
-                f"Processing {len(documents)} documents through indexing pipeline: "
-                f"cc_pair_id={cc_pair_id}, source={connector_source}, "
-                f"batch_num={batch_num}"
-            )
+            search_settings_id: int = index_attempt.search_settings.id
 
-            adapter = DocumentIndexingBatchAdapter(
-                db_session=db_session,
-                connector_id=index_attempt.connector_credential_pair.connector.id,
-                credential_id=index_attempt.connector_credential_pair.credential.id,
-                tenant_id=tenant_id,
-                index_attempt_metadata=index_attempt_metadata,
-            )
+        # Session is now closed; no connection held during embedding.
 
-            # Setup is complete. Record DOCPROCESSING_SETUP (everything from the
-            # top of the task minus BATCH_LOAD, which is tracked separately).
-            # BATCH_TOTAL starts immediately after; it spans run_indexing_pipeline
-            # plus all post-indexing bookkeeping in this try block.
-            setup_total_ms = max(0, int((time.monotonic() - setup_start) * 1000))
-            docprocessing_setup_ms = max(0, setup_total_ms - batch_load_ms)
-            safe_record_single_event(
-                IndexAttemptStage.DOCPROCESSING_SETUP,
-                index_attempt_id,
-                docprocessing_setup_ms,
-            )
-            batch_total_start = time.monotonic()
+        task_logger.info(
+            f"Processing {len(documents)} documents through indexing pipeline: "
+            f"cc_pair_id={cc_pair_id}, source={connector_source}, "
+            f"batch_num={batch_num}"
+        )
 
-            # real work happens here!
-            index_pipeline_result = run_indexing_pipeline(
-                embedder=embedding_model,
-                document_indices=document_indices,
-                ignore_time_skip=True,  # Documents are already filtered during extraction
-                db_session=db_session,
-                tenant_id=tenant_id,
-                document_batch=documents,
-                request_id=index_attempt_metadata.request_id,
-                adapter=adapter,
-            )
+        # The adapter manages its own short-lived sessions per phase.
+        adapter = DocumentIndexingBatchAdapter(
+            connector_id=index_attempt_metadata.connector_id,
+            credential_id=index_attempt_metadata.credential_id,
+            tenant_id=tenant_id,
+            index_attempt_metadata=index_attempt_metadata,
+        )
+
+        # Setup is complete. Record DOCPROCESSING_SETUP (everything from the
+        # top of the task minus BATCH_LOAD, which is tracked separately).
+        # BATCH_TOTAL starts immediately after; it spans run_indexing_pipeline
+        # plus all post-indexing bookkeeping in this try block.
+        setup_total_ms = max(0, int((time.monotonic() - setup_start) * 1000))
+        docprocessing_setup_ms = max(0, setup_total_ms - batch_load_ms)
+        safe_record_single_event(
+            IndexAttemptStage.DOCPROCESSING_SETUP,
+            index_attempt_id,
+            docprocessing_setup_ms,
+        )
+        batch_total_start = time.monotonic()
+
+        # real work happens here!
+        index_pipeline_result = run_indexing_pipeline(
+            embedder=embedding_model,
+            document_indices=document_indices,
+            ignore_time_skip=True,  # Documents are already filtered during extraction
+            tenant_id=tenant_id,
+            document_batch=documents,
+            request_id=index_attempt_metadata.request_id,
+            adapter=adapter,
+        )
 
         # Track chunk indexing usage for cloud usage limits
         if USAGE_LIMITS_ENABLED and index_pipeline_result.total_chunks > 0:
@@ -1830,7 +1835,7 @@ def _docprocessing_task(
                 "cc_pair_id": cc_pair_id,
                 "current_docs_indexed": coordination_status.total_docs,
                 "current_chunks_indexed": coordination_status.total_chunks,
-                "source": index_attempt.connector_credential_pair.connector.source.value,
+                "source": connector_source,
                 "completed_batches": coordination_status.completed_batches,
                 "total_batches": coordination_status.total_batches,
             },
@@ -1874,7 +1879,7 @@ def _docprocessing_task(
             f"Completed document batch processing: "
             f"index_attempt={index_attempt_id} "
             f"cc_pair={cc_pair_id} "
-            f"search_settings={index_attempt.search_settings.id} "
+            f"search_settings={search_settings_id} "
             f"batch_num={batch_num} "
             f"docs={len(index_pipeline_result.failures) + index_pipeline_result.total_docs} "
             f"chunks={index_pipeline_result.total_chunks} "

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -129,7 +129,6 @@ def _flush_batch(
         batch_num=batch_num,
     )
     adapter = DocumentIndexingBatchAdapter(
-        db_session=db_session,
         connector_id=attempt.connector_credential_pair.connector.id,
         credential_id=attempt.connector_credential_pair.credential.id,
         tenant_id=tenant_id,

--- a/backend/onyx/indexing/adapters/document_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/document_indexing_adapter.py
@@ -1,7 +1,6 @@
 import contextlib
 from collections.abc import Generator
 
-from sqlalchemy.engine.util import TransactionalContext
 from sqlalchemy.orm import Session
 
 from onyx.access.access import get_access_for_documents
@@ -17,6 +16,7 @@ from onyx.db.document import update_docs_chunk_count__no_commit
 from onyx.db.document import update_docs_last_modified__no_commit
 from onyx.db.document import update_docs_updated_at__no_commit
 from onyx.db.document_set import fetch_document_sets_for_documents
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.indexing.indexing_pipeline import DocumentBatchPrepareContext
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.indexing.models import ChunkEnrichmentContext
@@ -35,17 +35,17 @@ class DocumentIndexingBatchAdapter:
     """Default adapter: handles DB prep, locking, metadata enrichment, and finalize.
 
     Keeps orchestration logic in the pipeline and side-effects in the adapter.
+    Each phase opens its own short-lived session so no connection is held idle
+    during the long embedding and Vespa-write phases.
     """
 
     def __init__(
         self,
-        db_session: Session,
         connector_id: int,
         credential_id: int,
         tenant_id: str,
         index_attempt_metadata: IndexAttemptMetadata,
     ):
-        self.db_session = db_session
         self.connector_id = connector_id
         self.credential_id = credential_id
         self.tenant_id = tenant_id
@@ -54,43 +54,55 @@ class DocumentIndexingBatchAdapter:
     def prepare(
         self, documents: list[Document], ignore_time_skip: bool
     ) -> DocumentBatchPrepareContext | None:
-        """Upsert docs, map CC pairs, return context or mark as indexed if no-op."""
-        context = index_doc_batch_prepare(
-            documents=documents,
-            index_attempt_metadata=self.index_attempt_metadata,
-            db_session=self.db_session,
-            ignore_time_skip=ignore_time_skip,
-        )
+        """Upsert docs, map CC pairs, return context or mark as indexed if no-op.
 
-        if not context:
-            # even though we didn't actually index anything, we should still
-            # mark them as "completed" for the CC Pair in order to make the
-            # counts match
-            mark_document_as_indexed_for_cc_pair__no_commit(
-                connector_id=self.index_attempt_metadata.connector_id,
-                credential_id=self.index_attempt_metadata.credential_id,
-                document_ids=[doc.id for doc in documents],
-                db_session=self.db_session,
+        Opens and closes its own short-lived session so the caller holds no
+        connection after this method returns.
+        """
+        with get_session_with_current_tenant() as db_session:
+            context = index_doc_batch_prepare(
+                documents=documents,
+                index_attempt_metadata=self.index_attempt_metadata,
+                db_session=db_session,
+                ignore_time_skip=ignore_time_skip,
             )
-            self.db_session.commit()
+
+            if not context:
+                # even though we didn't actually index anything, we should still
+                # mark them as "completed" for the CC Pair in order to make the
+                # counts match
+                mark_document_as_indexed_for_cc_pair__no_commit(
+                    connector_id=self.index_attempt_metadata.connector_id,
+                    credential_id=self.index_attempt_metadata.credential_id,
+                    document_ids=[doc.id for doc in documents],
+                    db_session=db_session,
+                )
+            db_session.commit()
 
         return context
 
     @contextlib.contextmanager
-    def lock_context(
-        self, documents: list[Document]
-    ) -> Generator[TransactionalContext, None, None]:
-        """Acquire transaction/row locks on docs for the critical section."""
-        with prepare_to_modify_documents(
-            db_session=self.db_session, document_ids=[doc.id for doc in documents]
-        ) as transaction:
-            yield transaction
+    def lock_context(self, documents: list[Document]) -> Generator[Session, None, None]:
+        """Acquire transaction/row locks on docs and yield the session.
+
+        Commits once after the caller's body returns (still inside the
+        prepare_to_modify_documents begin() block), then closes the session.
+        The single commit both flushes post_index's writes and releases the lock.
+        """
+        with get_session_with_current_tenant() as db_session:
+            with prepare_to_modify_documents(
+                db_session=db_session,
+                document_ids=[doc.id for doc in documents],
+            ):
+                yield db_session
+                db_session.commit()
 
     def prepare_enrichment(
         self,
         context: DocumentBatchPrepareContext,
         tenant_id: str,
         chunks: list[DocAwareChunk],
+        db_session: Session,
     ) -> "DocumentChunkEnricher":
         """Do all DB lookups once and return a per-chunk enricher."""
         updatable_ids = [doc.id for doc in context.updatable_docs]
@@ -112,23 +124,23 @@ class DocumentIndexingBatchAdapter:
 
         return DocumentChunkEnricher(
             doc_id_to_access_info=get_access_for_documents(
-                document_ids=updatable_ids, db_session=self.db_session
+                document_ids=updatable_ids, db_session=db_session
             ),
             doc_id_to_document_set={
                 document_id: document_sets
                 for document_id, document_sets in fetch_document_sets_for_documents(
-                    document_ids=updatable_ids, db_session=self.db_session
+                    document_ids=updatable_ids, db_session=db_session
                 )
             },
             doc_id_to_ancestor_ids=self._get_ancestor_ids_for_documents(
-                context.updatable_docs, tenant_id
+                context.updatable_docs, tenant_id, db_session
             ),
             id_to_boost_map=context.id_to_boost_map,
             doc_id_to_previous_chunk_cnt={
                 document_id: chunk_count
                 for document_id, chunk_count in fetch_chunk_counts_for_documents(
                     document_ids=updatable_ids,
-                    db_session=self.db_session,
+                    db_session=db_session,
                 )
             },
             doc_id_to_new_chunk_cnt=dict(doc_id_to_new_chunk_cnt),
@@ -140,6 +152,7 @@ class DocumentIndexingBatchAdapter:
         self,
         documents: list[Document],
         tenant_id: str,
+        db_session: Session,
     ) -> dict[str, list[int]]:
         """
         Get ancestor hierarchy node IDs for a batch of documents.
@@ -163,7 +176,7 @@ class DocumentIndexingBatchAdapter:
                 redis_client=redis_client,
                 source=doc.source,
                 parent_hierarchy_raw_node_id=doc.parent_hierarchy_raw_node_id,
-                db_session=self.db_session,
+                db_session=db_session,
             )
             result[doc.id] = ancestors
 
@@ -175,6 +188,7 @@ class DocumentIndexingBatchAdapter:
         updatable_chunk_data: list[UpdatableChunkData],
         filtered_documents: list[Document],
         enrichment: ChunkEnrichmentContext,
+        db_session: Session,
     ) -> None:
         """Finalize DB updates, store plaintext, and mark docs as indexed."""
         updatable_ids = [doc.id for doc in context.updatable_docs]
@@ -189,17 +203,17 @@ class DocumentIndexingBatchAdapter:
             ids_to_new_updated_at[doc.id] = doc.doc_updated_at
 
         update_docs_updated_at__no_commit(
-            ids_to_new_updated_at=ids_to_new_updated_at, db_session=self.db_session
+            ids_to_new_updated_at=ids_to_new_updated_at, db_session=db_session
         )
 
         update_docs_last_modified__no_commit(
-            document_ids=last_modified_ids, db_session=self.db_session
+            document_ids=last_modified_ids, db_session=db_session
         )
 
         update_docs_chunk_count__no_commit(
             document_ids=updatable_ids,
             doc_id_to_chunk_count=enrichment.doc_id_to_new_chunk_cnt,
-            db_session=self.db_session,
+            db_session=db_session,
         )
 
         # these documents can now be counted as part of the CC Pairs
@@ -211,15 +225,13 @@ class DocumentIndexingBatchAdapter:
             connector_id=self.index_attempt_metadata.connector_id,
             credential_id=self.index_attempt_metadata.credential_id,
             document_ids=[doc.id for doc in filtered_documents],
-            db_session=self.db_session,
+            db_session=db_session,
         )
 
         # save the chunk boost components to postgres
         update_chunk_boost_components__no_commit(
-            chunk_data=updatable_chunk_data, db_session=self.db_session
+            chunk_data=updatable_chunk_data, db_session=db_session
         )
-
-        self.db_session.commit()
 
 
 class DocumentChunkEnricher:

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -11,7 +11,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
-from sqlalchemy.orm.session import TransactionalContext
 
 from onyx.access.access import get_access_for_user_files
 from onyx.access.models import DocumentAccess
@@ -79,20 +78,19 @@ class UserFileIndexingAdapter:
         )
 
     @contextlib.contextmanager
-    def lock_context(
-        self, documents: list[Document]
-    ) -> Generator[TransactionalContext, None, None]:
+    def lock_context(self, documents: list[Document]) -> Generator[Session, None, None]:
         self.db_session.commit()  # ensure that we're not in a transaction
         lock_acquired = False
         for i in range(_NUM_LOCK_ATTEMPTS):
             try:
-                with self.db_session.begin() as transaction:
+                with self.db_session.begin():
                     lock_acquired = _acquire_user_file_locks(
                         db_session=self.db_session,
                         user_file_ids=[doc.id for doc in documents],
                     )
                     if lock_acquired:
-                        yield transaction
+                        yield self.db_session
+                        self.db_session.commit()
                         break
             except OperationalError as e:
                 logger.warning(
@@ -113,6 +111,7 @@ class UserFileIndexingAdapter:
         context: DocumentBatchPrepareContext,
         tenant_id: str,
         chunks: list[DocAwareChunk],
+        db_session: Session,
     ) -> UserFileChunkEnricher:
         """Do all DB lookups and pre-compute file metadata from chunks."""
         updatable_ids = [doc.id for doc in context.updatable_docs]
@@ -133,21 +132,21 @@ class UserFileIndexingAdapter:
 
         user_file_id_to_project_ids = fetch_user_project_ids_for_user_files(
             user_file_ids=updatable_ids,
-            db_session=self.db_session,
+            db_session=db_session,
         )
         user_file_id_to_persona_ids = fetch_persona_ids_for_user_files(
             user_file_ids=updatable_ids,
-            db_session=self.db_session,
+            db_session=db_session,
         )
         user_file_id_to_access: dict[str, DocumentAccess] = get_access_for_user_files(
             user_file_ids=updatable_ids,
-            db_session=self.db_session,
+            db_session=db_session,
         )
         user_file_id_to_previous_chunk_cnt: dict[str, int] = {
             user_file_id: chunk_count
             for user_file_id, chunk_count in fetch_chunk_counts_for_user_files(
                 user_file_ids=updatable_ids,
-                db_session=self.db_session,
+                db_session=db_session,
             )
         }
 
@@ -192,7 +191,7 @@ class UserFileIndexingAdapter:
         )
 
     def _notify_assistant_owners_if_files_ready(
-        self, user_files: list[UserFile]
+        self, user_files: list[UserFile], db_session: Session
     ) -> None:
         """
         Check if all files for associated assistants are processed and notify owners.
@@ -217,7 +216,7 @@ class UserFileIndexingAdapter:
                         create_notification(
                             user_id=assistant.user_id,
                             notif_type=NotificationType.ASSISTANT_FILES_READY,
-                            db_session=self.db_session,
+                            db_session=db_session,
                             title="Your files are ready!",
                             description=f"All files for agent {assistant.name} have been processed and are now available.",
                             additional_data={
@@ -233,12 +232,13 @@ class UserFileIndexingAdapter:
         updatable_chunk_data: list[UpdatableChunkData],  # noqa: ARG002
         filtered_documents: list[Document],  # noqa: ARG002
         enrichment: ChunkEnrichmentContext,
+        db_session: Session,
     ) -> None:
         assert isinstance(enrichment, UserFileChunkEnricher)
         user_file_ids = [doc.id for doc in context.updatable_docs]
 
         user_files = (
-            self.db_session.query(UserFile)
+            db_session.query(UserFile)
             .options(selectinload(UserFile.assistants).selectinload(Persona.user_files))
             .filter(UserFile.id.in_(user_file_ids))
             .all()
@@ -258,9 +258,7 @@ class UserFileIndexingAdapter:
             ]
 
         # Notify assistant owners if all their files are now processed
-        self._notify_assistant_owners_if_files_ready(user_files)
-
-        self.db_session.commit()
+        self._notify_assistant_owners_if_files_ready(user_files, db_session)
 
         # Store the plaintext in the file store for faster retrieval
         # NOTE: this creates its own session to avoid committing the overall

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -36,6 +36,7 @@ from onyx.connectors.models import TextSection
 from onyx.db.document import get_documents_by_ids
 from onyx.db.document import upsert_document_by_connector_credential_pair
 from onyx.db.document import upsert_documents
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import HookPoint
 from onyx.db.hierarchy import link_hierarchy_nodes_to_documents
 from onyx.db.index_attempt_metrics import IndexAttemptStage
@@ -338,7 +339,6 @@ def index_doc_batch_with_handler(
     document_batch: list[Document],
     request_id: str | None,
     tenant_id: str,
-    db_session: Session,
     adapter: IndexingBatchAdapter,
     ignore_time_skip: bool = False,
     enable_contextual_rag: bool = False,
@@ -352,7 +352,6 @@ def index_doc_batch_with_handler(
             document_batch=document_batch,
             request_id=request_id,
             tenant_id=tenant_id,
-            db_session=db_session,
             adapter=adapter,
             ignore_time_skip=ignore_time_skip,
             enable_contextual_rag=enable_contextual_rag,
@@ -964,13 +963,15 @@ def _verify_indexing_completeness(
 
 def _apply_document_ingestion_hook(
     documents: list[Document],
-    db_session: Session,
 ) -> list[Document]:
     """Apply the Document Ingestion hook to each document in the batch.
 
     - HookSkipped / HookSoftFailed → document passes through unchanged.
     - Response with sections=None → document is dropped (logged).
     - Response with sections → document sections are replaced with the hook's output.
+
+    Opens its own short-lived session so the caller holds no connection during
+    this call.
     """
 
     def _build_payload(doc: Document) -> DocumentIngestionPayload:
@@ -1056,35 +1057,36 @@ def _apply_document_ingestion_hook(
     if not documents:
         return documents
 
-    # Run the hook for the first document. If it returns HookSkipped the hook
-    # is not configured — skip the remaining N-1 DB lookups.
-    first_doc = documents[0]
-    first_payload = _build_payload(first_doc).model_dump()
-    first_hook_result = execute_hook(
-        db_session=db_session,
-        hook_point=HookPoint.DOCUMENT_INGESTION,
-        payload=first_payload,
-        response_type=DocumentIngestionResponse,
-    )
-    if isinstance(first_hook_result, HookSkipped):
-        return documents
-
-    result: list[Document] = []
-    first_applied = _apply_result(first_doc, first_hook_result)
-    if first_applied is not None:
-        result.append(first_applied)
-
-    for doc in documents[1:]:
-        payload = _build_payload(doc).model_dump()
-        hook_result = execute_hook(
+    with get_session_with_current_tenant() as db_session:
+        # Run the hook for the first document. If it returns HookSkipped the hook
+        # is not configured — skip the remaining N-1 DB lookups.
+        first_doc = documents[0]
+        first_payload = _build_payload(first_doc).model_dump()
+        first_hook_result = execute_hook(
             db_session=db_session,
             hook_point=HookPoint.DOCUMENT_INGESTION,
-            payload=payload,
+            payload=first_payload,
             response_type=DocumentIngestionResponse,
         )
-        applied = _apply_result(doc, hook_result)
-        if applied is not None:
-            result.append(applied)
+        if isinstance(first_hook_result, HookSkipped):
+            return documents
+
+        result: list[Document] = []
+        first_applied = _apply_result(first_doc, first_hook_result)
+        if first_applied is not None:
+            result.append(first_applied)
+
+        for doc in documents[1:]:
+            payload = _build_payload(doc).model_dump()
+            hook_result = execute_hook(
+                db_session=db_session,
+                hook_point=HookPoint.DOCUMENT_INGESTION,
+                payload=payload,
+                response_type=DocumentIngestionResponse,
+            )
+            applied = _apply_result(doc, hook_result)
+            if applied is not None:
+                result.append(applied)
 
     return result
 
@@ -1098,7 +1100,6 @@ def index_doc_batch(
     document_indices: list[DocumentIndex],
     request_id: str | None,
     tenant_id: str,
-    db_session: Session,
     adapter: IndexingBatchAdapter,
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
@@ -1137,7 +1138,7 @@ def index_doc_batch(
     )
 
     filtered_documents, filter_failures = filter_fnc(document_batch)
-    filtered_documents = _apply_document_ingestion_hook(filtered_documents, db_session)
+    filtered_documents = _apply_document_ingestion_hook(filtered_documents)
     with time_stage_if_set(IndexAttemptStage.DOC_DB_PREPARE, attempt_id):
         context = adapter.prepare(filtered_documents, ignore_time_skip)
     if not context:
@@ -1226,11 +1227,12 @@ def index_doc_batch(
         # Acquires a lock on the documents so that no other process can modify
         # them.  Not needed until here, since this is when the actual race
         # condition with vector db can occur.
-        with adapter.lock_context(context.updatable_docs):
+        with adapter.lock_context(context.updatable_docs) as db_session:
             enricher = adapter.prepare_enrichment(
                 context=context,
                 tenant_id=tenant_id,
                 chunks=embedded_chunks,
+                db_session=db_session,
             )
 
             index_batch_params = IndexBatchParams(
@@ -1295,6 +1297,7 @@ def index_doc_batch(
                     updatable_chunk_data=updatable_chunk_data,
                     filtered_documents=filtered_documents,
                     enrichment=enricher,
+                    db_session=db_session,
                 )
 
     assert primary_doc_idx_insertion_records is not None
@@ -1317,14 +1320,18 @@ def run_indexing_pipeline(
     request_id: str | None,
     embedder: IndexingEmbedder,
     document_indices: list[DocumentIndex],
-    db_session: Session,
+    db_session: Session | None = None,
     tenant_id: str,
     adapter: IndexingBatchAdapter,
     chunker: Chunker | None = None,
     ignore_time_skip: bool = False,
 ) -> IndexingPipelineResult:
     """Builds a pipeline which takes in a list (batch) of docs and indexes them."""
-    all_search_settings = get_active_search_settings(db_session)
+    if db_session is not None:
+        all_search_settings = get_active_search_settings(db_session)
+    else:
+        with get_session_with_current_tenant() as _sess:
+            all_search_settings = get_active_search_settings(_sess)
     if (
         all_search_settings.secondary
         and all_search_settings.secondary.status == IndexModelStatus.FUTURE
@@ -1361,7 +1368,6 @@ def run_indexing_pipeline(
         document_batch=document_batch,
         request_id=request_id,
         tenant_id=tenant_id,
-        db_session=db_session,
         adapter=adapter,
         enable_contextual_rag=enable_contextual_rag,
         llm=llm,

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -18,7 +18,7 @@ from shared_configs.model_server_models import Embedding
 
 if TYPE_CHECKING:
     from onyx.indexing.indexing_pipeline import DocumentBatchPrepareContext
-from sqlalchemy.engine.util import TransactionalContext
+from sqlalchemy.orm import Session
 
 if TYPE_CHECKING:
     from onyx.db.models import SearchSettings
@@ -257,16 +257,15 @@ class IndexingBatchAdapter(Protocol):
     ) -> Optional["DocumentBatchPrepareContext"]: ...
 
     @contextlib.contextmanager
-    def lock_context(
-        self, documents: list[Document]
-    ) -> Generator[TransactionalContext, None, None]:
-        """Provide a transaction/row-lock context for critical updates."""
+    def lock_context(self, documents: list[Document]) -> Generator[Session, None, None]:
+        """Acquire row locks and yield the session for the critical section."""
 
     def prepare_enrichment(
         self,
         context: "DocumentBatchPrepareContext",
         tenant_id: str,
         chunks: list[DocAwareChunk],
+        db_session: Session,
     ) -> ChunkEnrichmentContext:
         """Prepare per-chunk enrichment data (access, document sets, boost, etc.).
 
@@ -282,4 +281,5 @@ class IndexingBatchAdapter(Protocol):
         updatable_chunk_data: list[UpdatableChunkData],
         filtered_documents: list[Document],
         enrichment: ChunkEnrichmentContext,
+        db_session: Session,
     ) -> None: ...

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -119,7 +119,6 @@ def upsert_ingestion_doc(
 
     # Build adapter for primary indexing
     adapter = DocumentIndexingBatchAdapter(
-        db_session=db_session,
         connector_id=cc_pair.connector_id,
         credential_id=cc_pair.credential_id,
         tenant_id=tenant_id,

--- a/backend/tests/external_dependency_unit/celery/test_user_file_indexing_adapter.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_indexing_adapter.py
@@ -157,6 +157,7 @@ class TestAdapterWritesBothMetadataFields:
             context=context,
             tenant_id=TEST_TENANT_ID,
             chunks=[chunk],
+            db_session=db_session,
         )
         aware_chunk = enricher.enrich_chunk(chunk, 1.0)
 
@@ -192,6 +193,7 @@ class TestAdapterWritesBothMetadataFields:
             context=context,
             tenant_id=TEST_TENANT_ID,
             chunks=[chunk],
+            db_session=db_session,
         )
         aware_chunk = enricher.enrich_chunk(chunk, 1.0)
 
@@ -229,6 +231,7 @@ class TestAdapterWritesBothMetadataFields:
             context=context,
             tenant_id=TEST_TENANT_ID,
             chunks=[chunk],
+            db_session=db_session,
         )
         aware_chunk = enricher.enrich_chunk(chunk, 1.0)
 
@@ -260,6 +263,7 @@ class TestAdapterWritesBothMetadataFields:
             context=context,
             tenant_id=TEST_TENANT_ID,
             chunks=[chunk],
+            db_session=db_session,
         )
         aware_chunk = enricher.enrich_chunk(chunk, 1.0)
 
@@ -298,6 +302,7 @@ class TestAdapterWritesBothMetadataFields:
             context=context,
             tenant_id=TEST_TENANT_ID,
             chunks=[chunk],
+            db_session=db_session,
         )
         aware_chunk = enricher.enrich_chunk(chunk, 1.0)
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -251,6 +251,7 @@ def test_contextual_rag(
 # ---------------------------------------------------------------------------
 
 _PATCH_EXECUTE_HOOK = "onyx.indexing.indexing_pipeline.execute_hook"
+_PATCH_GET_SESSION = "onyx.indexing.indexing_pipeline.get_session_with_current_tenant"
 
 
 def _make_doc(
@@ -271,60 +272,82 @@ def _make_doc(
 
 def test_document_ingestion_hook_skipped_passes_through() -> None:
     doc = _make_doc()
-    with patch(_PATCH_EXECUTE_HOOK, return_value=HookSkipped()):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+    with (
+        patch(_PATCH_EXECUTE_HOOK, return_value=HookSkipped()),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc])
     assert result == [doc]
 
 
 def test_document_ingestion_hook_soft_failed_passes_through() -> None:
     doc = _make_doc()
-    with patch(_PATCH_EXECUTE_HOOK, return_value=HookSoftFailed()):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+    with (
+        patch(_PATCH_EXECUTE_HOOK, return_value=HookSoftFailed()),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc])
     assert result == [doc]
 
 
 def test_document_ingestion_hook_none_sections_drops_document() -> None:
     doc = _make_doc()
-    with patch(
-        _PATCH_EXECUTE_HOOK,
-        return_value=DocumentIngestionResponse(
-            sections=None, rejection_reason="PII detected"
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=None, rejection_reason="PII detected"
+            ),
         ),
+        patch(_PATCH_GET_SESSION),
     ):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+        result = _apply_document_ingestion_hook([doc])
     assert result == []
 
 
 def test_document_ingestion_hook_all_invalid_sections_drops_document() -> None:
     """A non-empty list where every section has neither text nor image_file_id drops the doc."""
     doc = _make_doc()
-    with patch(
-        _PATCH_EXECUTE_HOOK,
-        return_value=DocumentIngestionResponse(sections=[DocumentIngestionSection()]),
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[DocumentIngestionSection()]
+            ),
+        ),
+        patch(_PATCH_GET_SESSION),
     ):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+        result = _apply_document_ingestion_hook([doc])
     assert result == []
 
 
 def test_document_ingestion_hook_empty_sections_drops_document() -> None:
     doc = _make_doc()
-    with patch(
-        _PATCH_EXECUTE_HOOK,
-        return_value=DocumentIngestionResponse(sections=[]),
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(sections=[]),
+        ),
+        patch(_PATCH_GET_SESSION),
     ):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+        result = _apply_document_ingestion_hook([doc])
     assert result == []
 
 
 def test_document_ingestion_hook_rewrites_text_sections() -> None:
     doc = _make_doc(sections=[TextSection(text="original", link="http://a.com")])
-    with patch(
-        _PATCH_EXECUTE_HOOK,
-        return_value=DocumentIngestionResponse(
-            sections=[DocumentIngestionSection(text="rewritten", link="http://b.com")]
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[
+                    DocumentIngestionSection(text="rewritten", link="http://b.com")
+                ]
+            ),
         ),
+        patch(_PATCH_GET_SESSION),
     ):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+        result = _apply_document_ingestion_hook([doc])
     assert len(result) == 1
     assert len(result[0].sections) == 1
     section = result[0].sections[0]
@@ -340,16 +363,19 @@ def test_document_ingestion_hook_preserves_image_section_order() -> None:
         sections=[TextSection(text="original", link=None), image],
     )
     # Hook moves the image before the text section
-    with patch(
-        _PATCH_EXECUTE_HOOK,
-        return_value=DocumentIngestionResponse(
-            sections=[
-                DocumentIngestionSection(image_file_id="img-1", link=None),
-                DocumentIngestionSection(text="rewritten", link=None),
-            ]
+    with (
+        patch(
+            _PATCH_EXECUTE_HOOK,
+            return_value=DocumentIngestionResponse(
+                sections=[
+                    DocumentIngestionSection(image_file_id="img-1", link=None),
+                    DocumentIngestionSection(text="rewritten", link=None),
+                ]
+            ),
         ),
+        patch(_PATCH_GET_SESSION),
     ):
-        result = _apply_document_ingestion_hook([doc], MagicMock())
+        result = _apply_document_ingestion_hook([doc])
     assert len(result) == 1
     sections = result[0].sections
     assert len(sections) == 2
@@ -375,10 +401,11 @@ def test_document_ingestion_hook_mixed_batch() -> None:
             )
         return HookSkipped()
 
-    with patch(_PATCH_EXECUTE_HOOK, side_effect=_side_effect):
-        result = _apply_document_ingestion_hook(
-            [doc_drop, doc_rewrite, doc_skip], MagicMock()
-        )
+    with (
+        patch(_PATCH_EXECUTE_HOOK, side_effect=_side_effect),
+        patch(_PATCH_GET_SESSION),
+    ):
+        result = _apply_document_ingestion_hook([doc_drop, doc_rewrite, doc_skip])
 
     assert len(result) == 2
     ids = {d.id for d in result}

--- a/backend/tests/unit/onyx/indexing/test_personas_in_chunks.py
+++ b/backend/tests/unit/onyx/indexing/test_personas_in_chunks.py
@@ -159,6 +159,7 @@ def _run_adapter_build(
             context=context,
             tenant_id="test_tenant",
             chunks=[chunk],
+            db_session=MagicMock(),
         )
         return [enricher.enrich_chunk(chunk, 1.0)]
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

  - DocumentIndexingBatchAdapter: Removed db_session from constructor. prepare() opens/closes its own session. lock_context() opens a session for the critical section (lock → enrichment → Vespa writes → post-index), stored as self._lock_session.
  - indexing_pipeline.py: _apply_document_ingestion_hook opens its own session. index_doc_batch / index_doc_batch_with_handler dropped db_session. run_indexing_pipeline makes db_session optional, opening a short session for get_active_search_settings when none is passed.
  - _docprocessing_task: Setup session closes before run_indexing_pipeline is called. Adapter created without db_session.
  - ingestion.py, run_targeted_reindex.py: Removed db_session from adapter constructor calls.


https://docs.google.com/document/d/1mfaYno431ASHZXgnFUaDv5OnALLqCU5czNIH8xpAIUc/edit?tab=t.0
https://linear.app/onyx-app/issue/ENG-4107/improve-on-long-lived-db-sessions
## How Has This Been Tested?
Updated Unit tests
Local tests
<img width="1119" height="290" alt="Screenshot 2026-05-07 at 5 58 24 PM" src="https://github.com/user-attachments/assets/fb70ecce-5c12-4777-b666-2e03dfcd5237" />

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release DB sessions before the long embedding step and switch the indexing pipeline/adapters to short‑lived sessions per phase to avoid idle connections. Addresses ENG-4107 and reduces connection pool pressure.

- **Refactors**
  - `DocumentIndexingBatchAdapter`: removed `db_session` arg; `prepare()` opens/closes its own session; `lock_context()` opens and yields a session and commits on exit; `prepare_enrichment()`/`post_index()` now accept `db_session` (commit happens in `lock_context`); ancestor lookup now uses the passed `db_session`.
  - `indexing_pipeline`: removed `db_session` from `index_doc_batch*`; `_apply_document_ingestion_hook` opens/closes its own session; pass `db_session` from `lock_context` into enrichment and post‑index; `run_indexing_pipeline` takes optional `db_session` and does a short read for `get_active_search_settings`.
  - `docprocessing_task`: run setup reads inside a short `get_session_with_current_tenant()` and close before embedding; capture `connector_source` and `search_settings_id` for logging after session close; adapter created without a session.
  - `user_file_indexing_adapter`: `lock_context()` now yields the session and commits; `prepare_enrichment()`/`post_index()` accept `db_session` and use it for notifications.
  - Updated call sites (`ingestion.py`, `run_targeted_reindex.py`) and tests.

- **Bug Fixes**
  - Prevent holding DB connections during embedding and Vespa writes, reducing timeouts.
  - Ensure ingestion hooks and assistant notifications run with short‑lived sessions.
  - Preserve required metadata for logging/metrics after the session is closed.

<sup>Written for commit a91afe098e26df291de784ba382ff85de1de11e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

