### PR TITLE
fix(imap): replace print() with logger.warning in charset decoding fallback

### DIFF
--- a/backend/onyx/connectors/imap/connector.py
+++ b/backend/onyx/connectors/imap/connector.py
@@ -405,7 +405,7 @@ def _parse_email_body(
             body = raw_payload.decode(charset)
             break
         except (UnicodeDecodeError, LookupError) as e:
-            print(f"Warning: Could not decode part with charset {charset}. Error: {e}")
+            logger.warning("Could not decode part with charset %s: %s", charset, e)
             continue
 
     if not body:


### PR DESCRIPTION
## Description

The IMAP connector used a bare `print(f"Warning: ...")` for charset decode failures instead of the logger already set up in the file. Converts to `logger.warning()` with %-style formatting (ruff G004 compliant).

This was the only production `print()` call across all connectors — the rest are in `if __name__ == "__main__"` test blocks.

## How Has This Been Tested?

- Pre-commit hooks (ruff, black, ty) pass
- No behavioral change — same message, proper logging channel

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced a bare print in the IMAP connector’s charset decoding fallback with logger.warning so warnings go through the logging system and comply with `ruff` G004. No behavior change.

<sup>Written for commit 8e0fc04912d9038330ab18b738aa44334db2cab0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

