### PR TITLE
fix(db): replace bare except clauses with except Exception

### DIFF
--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -406,7 +406,7 @@ def update_document_set(
             )
 
         db_session.commit()
-    except:
+    except Exception:
         db_session.rollback()
         raise
 
@@ -489,7 +489,7 @@ def mark_document_set_as_to_be_deleted(
         # are no more relationships to cc pairs
         document_set_row.is_up_to_date = False
         db_session.commit()
-    except:
+    except Exception:
         db_session.rollback()
         raise
 


### PR DESCRIPTION
## Description

Replaces two bare `except:` clauses with `except Exception:` in `document_set.py`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which should propagate normally rather than trigger a DB rollback.

Affected functions:
- `upsert_document_set` (line 409)
- `mark_document_set_as_to_be_deleted` (line 492)

## How Has This Been Tested?

- Pre-commit hooks (ruff, black, ty) pass
- `except Exception:` is semantically equivalent for all non-system exceptions

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace two bare `except:` clauses with `except Exception` in `document_set.py` so `KeyboardInterrupt` and `SystemExit` propagate instead of triggering unintended DB rollbacks.

<sup>Written for commit 60846671065a3a02a4827ecf0991b5a46e33db90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

