### PR TITLE
chore(agent): Refactor agent framework

### DIFF
--- a/backend/onyx/tools/fake_tools/agent_loop_utils.py
+++ b/backend/onyx/tools/fake_tools/agent_loop_utils.py
@@ -1,0 +1,167 @@
+"""Shared helpers for agentic-loop tools (research agent, coding agent, …).
+
+These extract patterns that both agents implement identically: detecting the
+think / finalize sentinel tool calls, appending the canned think-tool message
+pair, building an OpenAI parallel-tool-calls assistant message, the wall-clock
+force-finalize check, and the standard try/except shell that surfaces failures
+as a streaming-friendly PacketException.
+"""
+
+import time
+from collections.abc import Callable
+
+from pydantic import BaseModel
+
+from onyx.chat.emitter import Emitter
+from onyx.chat.models import ChatMessageSimple
+from onyx.chat.models import ToolCallSimple
+from onyx.configs.constants import MessageType
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_NAME
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_MESSAGE
+from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_TOKEN_COUNT
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.server.query_and_chat.streaming_models import PacketException
+from onyx.server.query_and_chat.streaming_models import StreamingType
+from onyx.tools.models import ToolCallKickoff
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class SpecialToolCalls(BaseModel):
+    """Sentinel tool calls every agentic loop watches for.
+
+    `finalize_tool_call` is the per-agent break-the-loop sentinel
+    (``generate_answer`` for coding, ``generate_report`` for research).
+    `think_tool_call` is the cross-agent reasoning sentinel.
+    """
+
+    think_tool_call: ToolCallKickoff | None = None
+    finalize_tool_call: ToolCallKickoff | None = None
+
+
+def find_special_tool_calls(
+    tool_calls: list[ToolCallKickoff],
+    finalize_tool_name: str,
+) -> SpecialToolCalls:
+    """Scan ``tool_calls`` for the think and finalize sentinels.
+
+    The think tool name is shared across agents; ``finalize_tool_name`` varies
+    (``GENERATE_ANSWER_TOOL_NAME`` / ``GENERATE_REPORT_TOOL_NAME`` / …).
+    """
+    think: ToolCallKickoff | None = None
+    finalize: ToolCallKickoff | None = None
+    for tc in tool_calls:
+        if tc.tool_name == THINK_TOOL_NAME:
+            think = tc
+        elif tc.tool_name == finalize_tool_name:
+            finalize = tc
+    return SpecialToolCalls(think_tool_call=think, finalize_tool_call=finalize)
+
+
+def append_think_tool_messages(
+    history: list[ChatMessageSimple],
+    think_tool_call: ToolCallKickoff,
+    token_counter: Callable[[str], int],
+) -> None:
+    """Append the standard assistant tool-call + canned tool-response pair.
+
+    Mutates ``history`` in place. The think tool's response is a fixed sentinel
+    string with a known token count; the assistant message carries only the
+    tool-call invocation.
+    """
+    msg_str = think_tool_call.to_msg_str()
+    tool_call_token_count = token_counter(msg_str)
+    history.append(
+        ChatMessageSimple(
+            message="",
+            token_count=tool_call_token_count,
+            message_type=MessageType.ASSISTANT,
+            tool_calls=[
+                ToolCallSimple(
+                    tool_call_id=think_tool_call.tool_call_id,
+                    tool_name=think_tool_call.tool_name,
+                    tool_arguments=think_tool_call.tool_args,
+                    token_count=tool_call_token_count,
+                )
+            ],
+            image_files=None,
+        )
+    )
+    history.append(
+        ChatMessageSimple(
+            message=THINK_TOOL_RESPONSE_MESSAGE,
+            token_count=THINK_TOOL_RESPONSE_TOKEN_COUNT,
+            message_type=MessageType.TOOL_CALL_RESPONSE,
+            tool_call_id=think_tool_call.tool_call_id,
+            image_files=None,
+        )
+    )
+
+
+def build_assistant_with_tool_calls(
+    tool_calls: list[ToolCallKickoff],
+    token_counter: Callable[[str], int],
+) -> ChatMessageSimple:
+    """Build a single ASSISTANT message bundling N tool calls.
+
+    Mirrors OpenAI's parallel-tool-calls form: one assistant turn carries every
+    tool call, then ``TOOL_CALL_RESPONSE`` messages follow one-per-call.
+    """
+    tool_calls_simple: list[ToolCallSimple] = []
+    for tc in tool_calls:
+        msg_str = tc.to_msg_str()
+        tool_calls_simple.append(
+            ToolCallSimple(
+                tool_call_id=tc.tool_call_id,
+                tool_name=tc.tool_name,
+                tool_arguments=tc.tool_args,
+                token_count=token_counter(msg_str),
+            )
+        )
+    return ChatMessageSimple(
+        message="",
+        token_count=sum(tcs.token_count for tcs in tool_calls_simple),
+        message_type=MessageType.ASSISTANT,
+        tool_calls=tool_calls_simple,
+        image_files=None,
+    )
+
+
+def should_force_finalize(
+    start_time: float,
+    timeout_seconds: float,
+    agent_name: str,
+) -> bool:
+    """Wall-clock guard: returns True once the loop has run too long.
+
+    Logs at INFO when the limit trips so operators can correlate forced
+    finalizations with elapsed time.
+    """
+    elapsed = time.monotonic() - start_time
+    if elapsed > timeout_seconds:
+        logger.info(
+            "%s exceeded %ss (elapsed: %.1fs); forcing final answer.",
+            agent_name,
+            timeout_seconds,
+            elapsed,
+        )
+        return True
+    return False
+
+
+def emit_agent_failure(
+    emitter: Emitter,
+    placement: Placement,
+    agent_name: str,
+    exc: Exception,
+) -> None:
+    """Log with stack trace and emit a streaming PacketException at ``placement``."""
+    logger.exception("Error running %s call: %s", agent_name, exc)
+    emitter.emit(
+        Packet(
+            placement=placement,
+            obj=PacketException(type=StreamingType.ERROR.value, exception=exc),
+        )
+    )

--- a/backend/onyx/tools/fake_tools/agent_loop_utils.py
+++ b/backend/onyx/tools/fake_tools/agent_loop_utils.py
@@ -1,12 +1,3 @@
-"""Shared helpers for agentic-loop tools (research agent, coding agent, …).
-
-These extract patterns that both agents implement identically: detecting the
-think / finalize sentinel tool calls, appending the canned think-tool message
-pair, building an OpenAI parallel-tool-calls assistant message, the wall-clock
-force-finalize check, and the standard try/except shell that surfaces failures
-as a streaming-friendly PacketException.
-"""
-
 import time
 from collections.abc import Callable
 
@@ -30,13 +21,6 @@ logger = setup_logger()
 
 
 class SpecialToolCalls(BaseModel):
-    """Sentinel tool calls every agentic loop watches for.
-
-    `finalize_tool_call` is the per-agent break-the-loop sentinel
-    (``generate_answer`` for coding, ``generate_report`` for research).
-    `think_tool_call` is the cross-agent reasoning sentinel.
-    """
-
     think_tool_call: ToolCallKickoff | None = None
     finalize_tool_call: ToolCallKickoff | None = None
 
@@ -45,11 +29,7 @@ def find_special_tool_calls(
     tool_calls: list[ToolCallKickoff],
     finalize_tool_name: str,
 ) -> SpecialToolCalls:
-    """Scan ``tool_calls`` for the think and finalize sentinels.
-
-    The think tool name is shared across agents; ``finalize_tool_name`` varies
-    (``GENERATE_ANSWER_TOOL_NAME`` / ``GENERATE_REPORT_TOOL_NAME`` / …).
-    """
+    """Scan ``tool_calls`` for the think and finalize sentinels."""
     think: ToolCallKickoff | None = None
     finalize: ToolCallKickoff | None = None
     for tc in tool_calls:
@@ -65,12 +45,7 @@ def append_think_tool_messages(
     think_tool_call: ToolCallKickoff,
     token_counter: Callable[[str], int],
 ) -> None:
-    """Append the standard assistant tool-call + canned tool-response pair.
-
-    Mutates ``history`` in place. The think tool's response is a fixed sentinel
-    string with a known token count; the assistant message carries only the
-    tool-call invocation.
-    """
+    """Append the assistant tool-call + canned tool-response pair to ``history``."""
     msg_str = think_tool_call.to_msg_str()
     tool_call_token_count = token_counter(msg_str)
     history.append(
@@ -104,11 +79,7 @@ def build_assistant_with_tool_calls(
     tool_calls: list[ToolCallKickoff],
     token_counter: Callable[[str], int],
 ) -> ChatMessageSimple:
-    """Build a single ASSISTANT message bundling N tool calls.
-
-    Mirrors OpenAI's parallel-tool-calls form: one assistant turn carries every
-    tool call, then ``TOOL_CALL_RESPONSE`` messages follow one-per-call.
-    """
+    """Build a single ASSISTANT message bundling N tool calls."""
     tool_calls_simple: list[ToolCallSimple] = []
     for tc in tool_calls:
         msg_str = tc.to_msg_str()
@@ -134,11 +105,7 @@ def should_force_finalize(
     timeout_seconds: float,
     agent_name: str,
 ) -> bool:
-    """Wall-clock guard: returns True once the loop has run too long.
-
-    Logs at INFO when the limit trips so operators can correlate forced
-    finalizations with elapsed time.
-    """
+    """Returns True once the loop has run past ``timeout_seconds``."""
     elapsed = time.monotonic() - start_time
     if elapsed > timeout_seconds:
         logger.info(

--- a/backend/onyx/tools/fake_tools/agentic_agent_base.py
+++ b/backend/onyx/tools/fake_tools/agentic_agent_base.py
@@ -1,13 +1,3 @@
-"""Generic agentic-loop driver shared by research / coding / future agents.
-
-Subclasses provide the per-agent bits (initial user message, system prompt
-template, tool definitions, real-tool dispatch, finalize step, …) by
-implementing the abstract methods. The base class owns the loop control flow:
-cycle counting, wall-clock force-finalize, the LLM step + packet drain,
-special-tool dispatch (think / finalize), tracing span, and the standard
-exception → ``PacketException`` shell.
-"""
-
 import time
 from abc import ABC
 from abc import abstractmethod
@@ -47,12 +37,7 @@ ResultT = TypeVar("ResultT")
 
 
 class AgenticAgentBase(ABC, Generic[ResultT]):
-    """Abstract base for agentic-loop tools.
-
-    Class attributes ``agent_name``, ``max_cycles``, ``force_finalize_seconds``,
-    ``finalize_tool_name``, and ``max_step_tokens`` are required. Subclasses
-    that target deep-research-style infra should set ``is_deep_research = True``.
-    """
+    """Abstract base for agentic-loop tools."""
 
     agent_name: ClassVar[str]
     max_cycles: ClassVar[int]
@@ -82,21 +67,17 @@ class AgenticAgentBase(ABC, Generic[ResultT]):
         self.msg_history: list[ChatMessageSimple] = []
         self.most_recent_reasoning: str | None = None
 
-    # ── Required overrides ────────────────────────────────────────────────
-
     @abstractmethod
     def initial_user_message(self) -> ChatMessageSimple:
         """Build the first USER message, seeded into ``msg_history``."""
 
     @abstractmethod
     def render_system_prompt(self, cycle: int) -> str:
-        """Render the system prompt for this cycle (template selection +
-        formatting)."""
+        """Render the system prompt for this cycle."""
 
     @abstractmethod
     def tool_definitions(self) -> list[dict[str, Any]]:
-        """Tool definitions passed to the LLM step (typically include the
-        think tool only for non-reasoning models)."""
+        """Tool definitions passed to the LLM step."""
 
     @abstractmethod
     def execute_tool_calls(
@@ -105,78 +86,46 @@ class AgenticAgentBase(ABC, Generic[ResultT]):
         step_result: LlmStepResult,
         step_placement: Placement,
     ) -> bool:
-        """Dispatch the non-special tool calls and append assistant +
-        ``TOOL_CALL_RESPONSE`` messages to ``self.msg_history``.
-
-        ``step_result`` exposes the LLM step's reasoning / tokens for
-        bookkeeping (e.g. attaching to ``ToolCallInfo``); ``step_placement``
-        is the same placement used for the LLM step (its ``sub_turn_index``
-        is the loop's per-cycle counter).
-
-        Returns ``True`` to continue the loop, ``False`` to break out and
-        finalize (e.g. when the model emits unexpected tool types).
-        """
+        """Dispatch non-special tool calls; returns False to break the loop."""
 
     @abstractmethod
     def finalize(self) -> ResultT:
-        """Generate the user-facing answer / report and emit any closing
-        packets. Called after the loop exits for any reason (finalize
-        sentinel, max cycles, force-finalize timeout, no-tool-calls)."""
-
-    # ── Optional overrides ────────────────────────────────────────────────
+        """Generate the user-facing answer and emit closing packets."""
 
     @contextmanager
     def setup(self) -> Iterator[None]:
-        """Pre-loop setup / post-loop teardown. Default: no-op.
-
-        Override to acquire per-run resources (sessions, clients, …). The
-        loop body runs inside this context.
-        """
+        """Pre-loop setup / post-loop teardown. Default: no-op."""
         yield
 
     def emit_start(self) -> None:
-        """Emit a start packet at the agent's root placement before the loop
-        begins. Default: no-op."""
+        """Emit a start packet before the loop begins. Default: no-op."""
         return None
 
     def transform_step_packet(
         self, packet: Packet, step_placement: Placement  # noqa: ARG002
     ) -> Packet | None:
-        """Transform a packet streaming out of ``run_llm_step_pkt_generator``
-        before emit. Return ``None`` to drop. Default: pass through."""
+        """Transform a step packet before emit; return None to drop."""
         return packet
 
     def reminder_message(self) -> ChatMessageSimple | None:
-        """Optional USER reminder message threaded into history each cycle.
-        Default: ``None``."""
+        """Optional USER reminder message threaded into history each cycle."""
         return None
 
     def filter_tool_calls(
         self, tool_calls: list[ToolCallKickoff]
     ) -> list[ToolCallKickoff]:
-        """Filter tool calls before special-tool detection. Default: identity.
-
-        Override to enforce per-agent constraints (e.g. research keeps only
-        the first tool type in a batch because its placement system can't
-        differentiate sub-tool calls of mixed types).
-        """
+        """Filter tool calls before special-tool detection."""
         return tool_calls
 
     def custom_token_processor(self) -> Callable[..., Any] | None:
-        """Token processor passed to the LLM step. Default: think-tool
-        processor for non-reasoning models, ``None`` for reasoning models."""
+        """Token processor passed to the LLM step."""
         return (
             create_think_tool_token_processor() if not self.is_reasoning_model else None
         )
 
-    # ── Helpers exposed to subclasses ─────────────────────────────────────
-
     @property
     def root_placement(self) -> Placement:
-        """Placement at the agent's top level (no ``sub_turn_index``)."""
         return Placement(turn_index=self.turn_index, tab_index=self.tab_index)
-
-    # ── Loop driver ───────────────────────────────────────────────────────
 
     def run(self) -> ResultT | None:
         with function_span(self.agent_name) as span:
@@ -260,13 +209,10 @@ class AgenticAgentBase(ABC, Generic[ResultT]):
                 )
                 return None
 
-    # ── Internal ──────────────────────────────────────────────────────────
-
     def _run_llm_step(
         self, step_placement: Placement, cycle: int
     ) -> tuple[LlmStepResult, bool]:
-        """Run one LLM step: render prompt, construct history, drain packets
-        through ``transform_step_packet``, return the (result, has_reasoned) tuple."""
+        """Run one LLM step and return ``(result, has_reasoned)``."""
         system_prompt_str = self.render_system_prompt(cycle)
         system_prompt = ChatMessageSimple(
             message=system_prompt_str,

--- a/backend/onyx/tools/fake_tools/agentic_agent_base.py
+++ b/backend/onyx/tools/fake_tools/agentic_agent_base.py
@@ -1,0 +1,307 @@
+"""Generic agentic-loop driver shared by research / coding / future agents.
+
+Subclasses provide the per-agent bits (initial user message, system prompt
+template, tool definitions, real-tool dispatch, finalize step, …) by
+implementing the abstract methods. The base class owns the loop control flow:
+cycle counting, wall-clock force-finalize, the LLM step + packet drain,
+special-tool dispatch (think / finalize), tracing span, and the standard
+exception → ``PacketException`` shell.
+"""
+
+import time
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Callable
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from typing import ClassVar
+from typing import Generic
+from typing import TypeVar
+
+from onyx.chat.emitter import Emitter
+from onyx.chat.llm_loop import construct_message_history
+from onyx.chat.llm_step import run_llm_step_pkt_generator
+from onyx.chat.models import ChatMessageSimple
+from onyx.chat.models import LlmStepResult
+from onyx.configs.constants import MessageType
+from onyx.deep_research.utils import create_think_tool_token_processor
+from onyx.llm.interfaces import LLM
+from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.models import ReasoningEffort
+from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.utils import model_is_reasoning_model
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.tools.fake_tools.agent_loop_utils import append_think_tool_messages
+from onyx.tools.fake_tools.agent_loop_utils import emit_agent_failure
+from onyx.tools.fake_tools.agent_loop_utils import find_special_tool_calls
+from onyx.tools.fake_tools.agent_loop_utils import should_force_finalize
+from onyx.tools.models import ToolCallKickoff
+from onyx.tracing.framework.create import function_span
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+ResultT = TypeVar("ResultT")
+
+
+class AgenticAgentBase(ABC, Generic[ResultT]):
+    """Abstract base for agentic-loop tools.
+
+    Class attributes ``agent_name``, ``max_cycles``, ``force_finalize_seconds``,
+    ``finalize_tool_name``, and ``max_step_tokens`` are required. Subclasses
+    that target deep-research-style infra should set ``is_deep_research = True``.
+    """
+
+    agent_name: ClassVar[str]
+    max_cycles: ClassVar[int]
+    force_finalize_seconds: ClassVar[float]
+    finalize_tool_name: ClassVar[str]
+    max_step_tokens: ClassVar[int]
+    is_deep_research: ClassVar[bool] = False
+
+    def __init__(
+        self,
+        kickoff: ToolCallKickoff,
+        emitter: Emitter,
+        llm: LLM,
+        token_counter: Callable[[str], int],
+        user_identity: LLMUserIdentity | None = None,
+    ):
+        self.kickoff = kickoff
+        self.emitter = emitter
+        self.llm = llm
+        self.token_counter = token_counter
+        self.user_identity = user_identity
+        self.is_reasoning_model = model_is_reasoning_model(
+            llm.config.model_name, llm.config.model_provider
+        )
+        self.turn_index = kickoff.placement.turn_index
+        self.tab_index = kickoff.placement.tab_index
+        self.msg_history: list[ChatMessageSimple] = []
+        self.most_recent_reasoning: str | None = None
+
+    # ── Required overrides ────────────────────────────────────────────────
+
+    @abstractmethod
+    def initial_user_message(self) -> ChatMessageSimple:
+        """Build the first USER message, seeded into ``msg_history``."""
+
+    @abstractmethod
+    def render_system_prompt(self, cycle: int) -> str:
+        """Render the system prompt for this cycle (template selection +
+        formatting)."""
+
+    @abstractmethod
+    def tool_definitions(self) -> list[dict[str, Any]]:
+        """Tool definitions passed to the LLM step (typically include the
+        think tool only for non-reasoning models)."""
+
+    @abstractmethod
+    def execute_tool_calls(
+        self,
+        tool_calls: list[ToolCallKickoff],
+        step_result: LlmStepResult,
+        step_placement: Placement,
+    ) -> bool:
+        """Dispatch the non-special tool calls and append assistant +
+        ``TOOL_CALL_RESPONSE`` messages to ``self.msg_history``.
+
+        ``step_result`` exposes the LLM step's reasoning / tokens for
+        bookkeeping (e.g. attaching to ``ToolCallInfo``); ``step_placement``
+        is the same placement used for the LLM step (its ``sub_turn_index``
+        is the loop's per-cycle counter).
+
+        Returns ``True`` to continue the loop, ``False`` to break out and
+        finalize (e.g. when the model emits unexpected tool types).
+        """
+
+    @abstractmethod
+    def finalize(self) -> ResultT:
+        """Generate the user-facing answer / report and emit any closing
+        packets. Called after the loop exits for any reason (finalize
+        sentinel, max cycles, force-finalize timeout, no-tool-calls)."""
+
+    # ── Optional overrides ────────────────────────────────────────────────
+
+    @contextmanager
+    def setup(self) -> Iterator[None]:
+        """Pre-loop setup / post-loop teardown. Default: no-op.
+
+        Override to acquire per-run resources (sessions, clients, …). The
+        loop body runs inside this context.
+        """
+        yield
+
+    def emit_start(self) -> None:
+        """Emit a start packet at the agent's root placement before the loop
+        begins. Default: no-op."""
+        return None
+
+    def transform_step_packet(
+        self, packet: Packet, step_placement: Placement  # noqa: ARG002
+    ) -> Packet | None:
+        """Transform a packet streaming out of ``run_llm_step_pkt_generator``
+        before emit. Return ``None`` to drop. Default: pass through."""
+        return packet
+
+    def reminder_message(self) -> ChatMessageSimple | None:
+        """Optional USER reminder message threaded into history each cycle.
+        Default: ``None``."""
+        return None
+
+    def filter_tool_calls(
+        self, tool_calls: list[ToolCallKickoff]
+    ) -> list[ToolCallKickoff]:
+        """Filter tool calls before special-tool detection. Default: identity.
+
+        Override to enforce per-agent constraints (e.g. research keeps only
+        the first tool type in a batch because its placement system can't
+        differentiate sub-tool calls of mixed types).
+        """
+        return tool_calls
+
+    def custom_token_processor(self) -> Callable[..., Any] | None:
+        """Token processor passed to the LLM step. Default: think-tool
+        processor for non-reasoning models, ``None`` for reasoning models."""
+        return (
+            create_think_tool_token_processor() if not self.is_reasoning_model else None
+        )
+
+    # ── Helpers exposed to subclasses ─────────────────────────────────────
+
+    @property
+    def root_placement(self) -> Placement:
+        """Placement at the agent's top level (no ``sub_turn_index``)."""
+        return Placement(turn_index=self.turn_index, tab_index=self.tab_index)
+
+    # ── Loop driver ───────────────────────────────────────────────────────
+
+    def run(self) -> ResultT | None:
+        with function_span(self.agent_name) as span:
+            span.span_data.input = str(self.kickoff.tool_args)
+            try:
+                with self.setup():
+                    self.emit_start()
+                    self.msg_history = [self.initial_user_message()]
+
+                    start_time = time.monotonic()
+                    cycle = 0
+                    llm_cycles = 0
+                    reasoning_cycles = 0
+
+                    while cycle < self.max_cycles:
+                        if should_force_finalize(
+                            start_time=start_time,
+                            timeout_seconds=self.force_finalize_seconds,
+                            agent_name=self.agent_name,
+                        ):
+                            break
+
+                        step_placement = Placement(
+                            turn_index=self.turn_index,
+                            tab_index=self.tab_index,
+                            sub_turn_index=llm_cycles + reasoning_cycles,
+                        )
+                        result, has_reasoned = self._run_llm_step(step_placement, cycle)
+                        if has_reasoned:
+                            reasoning_cycles += 1
+
+                        tool_calls = self.filter_tool_calls(result.tool_calls or [])
+                        if not tool_calls:
+                            logger.warning(
+                                "%s LLM produced no tool calls; forcing finalize",
+                                self.agent_name,
+                            )
+                            break
+
+                        special = find_special_tool_calls(
+                            tool_calls=tool_calls,
+                            finalize_tool_name=self.finalize_tool_name,
+                        )
+                        if special.finalize_tool_call:
+                            break
+                        if special.think_tool_call:
+                            with function_span("think_tool") as think_span:
+                                think_span.span_data.input = str(
+                                    special.think_tool_call.tool_args
+                                )
+                                append_think_tool_messages(
+                                    history=self.msg_history,
+                                    think_tool_call=special.think_tool_call,
+                                    token_counter=self.token_counter,
+                                )
+                                self.most_recent_reasoning = result.reasoning
+                            cycle += 1
+                            continue
+
+                        if not self.execute_tool_calls(
+                            tool_calls=tool_calls,
+                            step_result=result,
+                            step_placement=step_placement,
+                        ):
+                            break
+
+                        self.most_recent_reasoning = None
+                        cycle += 1
+                        llm_cycles += 1
+
+                    finalized = self.finalize()
+                    span.span_data.output = str(finalized)
+                    return finalized
+
+            except Exception as e:
+                emit_agent_failure(
+                    emitter=self.emitter,
+                    placement=self.root_placement,
+                    agent_name=self.agent_name,
+                    exc=e,
+                )
+                return None
+
+    # ── Internal ──────────────────────────────────────────────────────────
+
+    def _run_llm_step(
+        self, step_placement: Placement, cycle: int
+    ) -> tuple[LlmStepResult, bool]:
+        """Run one LLM step: render prompt, construct history, drain packets
+        through ``transform_step_packet``, return the (result, has_reasoned) tuple."""
+        system_prompt_str = self.render_system_prompt(cycle)
+        system_prompt = ChatMessageSimple(
+            message=system_prompt_str,
+            token_count=self.token_counter(system_prompt_str),
+            message_type=MessageType.SYSTEM,
+        )
+        constructed_history = construct_message_history(
+            system_prompt=system_prompt,
+            custom_agent_prompt=None,
+            simple_chat_history=self.msg_history,
+            reminder_message=self.reminder_message(),
+            context_files=None,
+            available_tokens=self.llm.config.max_input_tokens,
+        )
+        step_generator = run_llm_step_pkt_generator(
+            history=constructed_history,
+            tool_definitions=self.tool_definitions(),
+            tool_choice=ToolChoiceOptions.REQUIRED,
+            llm=self.llm,
+            placement=step_placement,
+            citation_processor=None,
+            state_container=None,
+            reasoning_effort=ReasoningEffort.LOW,
+            final_documents=None,
+            user_identity=self.user_identity,
+            custom_token_processor=self.custom_token_processor(),
+            use_existing_tab_index=True,
+            is_deep_research=self.is_deep_research,
+            max_tokens=self.max_step_tokens,
+        )
+        while True:
+            try:
+                packet = next(step_generator)
+                transformed = self.transform_step_packet(packet, step_placement)
+                if transformed is not None:
+                    self.emitter.emit(transformed)
+            except StopIteration as e:
+                return e.value

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -1,5 +1,4 @@
 import queue
-import time
 from collections.abc import Callable
 from typing import Any
 from typing import cast
@@ -13,23 +12,18 @@ from onyx.chat.citation_utils import collapse_citations
 from onyx.chat.citation_utils import update_citation_processor_from_tool_response
 from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import construct_message_history
-from onyx.chat.llm_step import run_llm_step
 from onyx.chat.llm_step import run_llm_step_pkt_generator
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import LlmStepResult
-from onyx.chat.models import ToolCallSimple
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
+from onyx.deep_research.dr_mock_tools import GENERATE_REPORT_TOOL_NAME
 from onyx.deep_research.dr_mock_tools import (
     get_research_agent_additional_tool_definitions,
 )
 from onyx.deep_research.dr_mock_tools import RESEARCH_AGENT_TASK_KEY
-from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_MESSAGE
-from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_TOKEN_COUNT
 from onyx.deep_research.models import CombinedResearchAgentCallResult
 from onyx.deep_research.models import ResearchAgentCallResult
-from onyx.deep_research.utils import check_special_tool_calls
-from onyx.deep_research.utils import create_think_tool_token_processor
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.models import ReasoningEffort
@@ -54,14 +48,13 @@ from onyx.server.query_and_chat.streaming_models import IntermediateReportCitedD
 from onyx.server.query_and_chat.streaming_models import IntermediateReportDelta
 from onyx.server.query_and_chat.streaming_models import IntermediateReportStart
 from onyx.server.query_and_chat.streaming_models import Packet
-from onyx.server.query_and_chat.streaming_models import PacketException
 from onyx.server.query_and_chat.streaming_models import ResearchAgentStart
 from onyx.server.query_and_chat.streaming_models import SectionEnd
-from onyx.server.query_and_chat.streaming_models import StreamingType
+from onyx.tools.fake_tools.agent_loop_utils import build_assistant_with_tool_calls
+from onyx.tools.fake_tools.agentic_agent_base import AgenticAgentBase
 from onyx.tools.interface import Tool
 from onyx.tools.models import ToolCallInfo
 from onyx.tools.models import ToolCallKickoff
-from onyx.tools.models import ToolResponse
 from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
@@ -203,6 +196,249 @@ def generate_intermediate_report(
         return final_report
 
 
+class ResearchAgent(AgenticAgentBase[ResearchAgentCallResult]):
+    agent_name = "research_agent"
+    max_cycles = MAX_RESEARCH_CYCLES
+    force_finalize_seconds = RESEARCH_AGENT_FORCE_REPORT_SECONDS
+    finalize_tool_name = GENERATE_REPORT_TOOL_NAME
+    # In case the model is tripped up by the long context and gets into an
+    # endless loop of e.g. null tokens, we cap output. None of the tool calls
+    # should be this long.
+    max_step_tokens = 1000
+    is_deep_research = True
+
+    def __init__(
+        self,
+        kickoff: ToolCallKickoff,
+        emitter: Emitter,
+        llm: LLM,
+        token_counter: Callable[[str], int],
+        user_identity: LLMUserIdentity | None,
+        *,
+        parent_tool_call_id: str,
+        tools: list[Tool],
+        state_container: ChatStateContainer,
+    ):
+        super().__init__(kickoff, emitter, llm, token_counter, user_identity)
+        self.parent_tool_call_id = parent_tool_call_id
+        self.tools = tools
+        self.state_container = state_container
+        self.tools_by_name: dict[str, Tool] = {t.name: t for t in tools}
+        # If this fails to parse, the loop can't run anyway — let it raise.
+        self.research_topic: str = kickoff.tool_args[RESEARCH_AGENT_TASK_KEY]
+        # KEEP_MARKERS preserves citation markers like [1], [2] in intermediate
+        # reports so collapse_citations() can renumber them in the final report.
+        self.citation_processor = DynamicCitationProcessor(
+            citation_mode=CitationMode.KEEP_MARKERS
+        )
+        self.citation_mapping: dict[int, str] = {}
+        self.just_ran_web_search = False
+
+    def emit_start(self) -> None:
+        self.emitter.emit(
+            Packet(
+                placement=self.root_placement,
+                obj=ResearchAgentStart(research_task=self.research_topic),
+            )
+        )
+
+    def initial_user_message(self) -> ChatMessageSimple:
+        return ChatMessageSimple(
+            message=self.research_topic,
+            token_count=self.token_counter(self.research_topic),
+            message_type=MessageType.USER,
+        )
+
+    def render_system_prompt(self, cycle: int) -> str:
+        tools_description = generate_tools_description(self.tools)
+        internal_search_tip = (
+            INTERNAL_SEARCH_GUIDANCE
+            if any(isinstance(t, SearchTool) for t in self.tools)
+            else ""
+        )
+        web_search_tip = (
+            WEB_SEARCH_TOOL_DESCRIPTION
+            if any(isinstance(t, WebSearchTool) for t in self.tools)
+            else ""
+        )
+        open_urls_tip = (
+            OPEN_URLS_TOOL_DESCRIPTION
+            if any(isinstance(t, OpenURLTool) for t in self.tools)
+            else ""
+        )
+        if self.is_reasoning_model and open_urls_tip:
+            open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION_REASONING
+
+        template = (
+            RESEARCH_AGENT_PROMPT_REASONING
+            if self.is_reasoning_model
+            else RESEARCH_AGENT_PROMPT
+        )
+        return template.format(
+            available_tools=tools_description,
+            current_datetime=get_current_llm_day_time(full_sentence=False),
+            current_cycle_count=cycle,
+            optional_internal_search_tool_description=internal_search_tip,
+            optional_web_search_tool_description=web_search_tip,
+            optional_open_url_tool_description=open_urls_tip,
+        )
+
+    def tool_definitions(self) -> list[dict[str, Any]]:
+        return [tool.tool_definition() for tool in self.tools] + (
+            get_research_agent_additional_tool_definitions(
+                include_think_tool=not self.is_reasoning_model
+            )
+        )
+
+    def reminder_message(self) -> ChatMessageSimple | None:
+        if not self.just_ran_web_search:
+            return None
+        # Consume the flag — the reminder applies once after a web search
+        # produced docs.
+        self.just_ran_web_search = False
+        return ChatMessageSimple(
+            message=OPEN_URL_REMINDER_RESEARCH_AGENT,
+            token_count=100,
+            message_type=MessageType.USER,
+        )
+
+    def filter_tool_calls(
+        self, tool_calls: list[ToolCallKickoff]
+    ) -> list[ToolCallKickoff]:
+        # TODO handle the restriction of only 1 tool call type per turn —
+        # the Placement system can't differentiate sub-tool calls of mixed
+        # types yet, so keep only the first type the model emitted.
+        if not tool_calls:
+            return tool_calls
+        first_type = tool_calls[0].tool_name
+        return [tc for tc in tool_calls if tc.tool_name == first_type]
+
+    def execute_tool_calls(
+        self,
+        tool_calls: list[ToolCallKickoff],
+        step_result: LlmStepResult,
+        step_placement: Placement,
+    ) -> bool:
+        parallel_results = run_tool_calls(
+            tool_calls=tool_calls,
+            tools=self.tools,
+            message_history=self.msg_history,
+            user_memory_context=None,
+            user_info=None,
+            citation_mapping=self.citation_mapping,
+            next_citation_num=self.citation_processor.get_next_citation_number(),
+            # Packets can't differentiate parallel calls at a nested level;
+            # deep research doesn't actually emit parallel anyway.
+            max_concurrent_tools=1,
+            skip_search_query_expansion=False,
+            url_snippet_map=extract_url_snippet_map(
+                [
+                    search_doc
+                    for tc in self.state_container.get_tool_calls()
+                    if tc.search_docs
+                    for search_doc in tc.search_docs
+                ]
+            ),
+        )
+        self.citation_mapping = parallel_results.updated_citation_mapping
+
+        if tool_calls and not parallel_results.tool_responses:
+            # Tool dispatch failed entirely; record failure messages and
+            # continue so we don't infinite-loop on the same prompt.
+            failure_messages = create_tool_call_failure_messages(
+                tool_calls, self.token_counter
+            )
+            self.msg_history.extend(failure_messages)
+            return True
+
+        valid_tool_responses = [
+            tr for tr in parallel_results.tool_responses if tr.tool_call is not None
+        ]
+        if not valid_tool_responses:
+            return True
+
+        # OpenAI parallel-tool-calls form: one assistant message bundling
+        # every call, then TOOL_CALL_RESPONSE messages one-per-call.
+        valid_tool_calls = [
+            tr.tool_call for tr in valid_tool_responses if tr.tool_call is not None
+        ]
+        self.msg_history.append(
+            build_assistant_with_tool_calls(
+                tool_calls=valid_tool_calls, token_counter=self.token_counter
+            )
+        )
+
+        for tool_response in valid_tool_responses:
+            tc = tool_response.tool_call
+            assert tc is not None  # filtered above
+            tool = self.tools_by_name.get(tc.tool_name)
+            if not tool:
+                raise ValueError(f"Tool '{tc.tool_name}' not found in tools list")
+
+            search_docs = None
+            displayed_docs = None
+            if isinstance(tool_response.rich_response, SearchDocsResponse):
+                search_docs = tool_response.rich_response.search_docs
+                displayed_docs = tool_response.rich_response.displayed_docs
+                if search_docs:
+                    self.state_container.add_search_docs(search_docs)
+                # Open-URL reminder fires only when web search yielded docs.
+                if search_docs and tc.tool_name == WebSearchTool.NAME:
+                    self.just_ran_web_search = True
+
+            update_citation_processor_from_tool_response(
+                tool_response=tool_response,
+                citation_processor=self.citation_processor,
+            )
+
+            # Research Agent is a top-level tool call; tools called by the
+            # research agent are sub-tool calls. At DB save time there's
+            # only a turn index — sub-turn is implied by the parent's turn
+            # and the depth of the tree traversal.
+            tool_call_info = ToolCallInfo(
+                parent_tool_call_id=self.parent_tool_call_id,
+                turn_index=step_placement.sub_turn_index or 0,
+                tab_index=tc.placement.tab_index,
+                tool_name=tc.tool_name,
+                tool_call_id=tc.tool_call_id,
+                tool_id=tool.id,
+                reasoning_tokens=step_result.reasoning or self.most_recent_reasoning,
+                tool_call_arguments=tc.tool_args,
+                tool_call_response=tool_response.llm_facing_response,
+                search_docs=displayed_docs or search_docs,
+                generated_images=None,
+            )
+            self.state_container.add_tool_call(tool_call_info)
+
+            self.msg_history.append(
+                ChatMessageSimple(
+                    message=tool_response.llm_facing_response,
+                    token_count=self.token_counter(tool_response.llm_facing_response),
+                    message_type=MessageType.TOOL_CALL_RESPONSE,
+                    tool_call_id=tc.tool_call_id,
+                    image_files=None,
+                )
+            )
+
+        return True
+
+    def finalize(self) -> ResearchAgentCallResult:
+        final_report = generate_intermediate_report(
+            research_topic=self.research_topic,
+            history=self.msg_history,
+            llm=self.llm,
+            token_counter=self.token_counter,
+            citation_processor=self.citation_processor,
+            user_identity=self.user_identity,
+            emitter=self.emitter,
+            placement=self.root_placement,
+        )
+        return ResearchAgentCallResult(
+            intermediate_report=final_report,
+            citation_mapping=self.citation_processor.get_seen_citations(),
+        )
+
+
 def run_research_agent_call(
     research_agent_call: ToolCallKickoff,
     parent_tool_call_id: str,
@@ -210,413 +446,20 @@ def run_research_agent_call(
     emitter: Emitter,
     state_container: ChatStateContainer,
     llm: LLM,
-    is_reasoning_model: bool,
+    is_reasoning_model: bool,  # noqa: ARG001 — derived from llm; kept for API stability
     token_counter: Callable[[str], int],
     user_identity: LLMUserIdentity | None,
 ) -> ResearchAgentCallResult | None:
-    turn_index = research_agent_call.placement.turn_index
-    tab_index = research_agent_call.placement.tab_index
-    with function_span("research_agent") as span:
-        span.span_data.input = str(research_agent_call.tool_args)
-        try:
-            # Track start time for timeout-based forced report generation
-            start_time = time.monotonic()
-
-            # Used to track citations while keeping original citation markers in intermediate reports.
-            # KEEP_MARKERS preserves citation markers like [1], [2] in the text unchanged
-            # while tracking which documents were cited via get_seen_citations().
-            # This allows collapse_citations() to later renumber them in the final report.
-            citation_processor = DynamicCitationProcessor(
-                citation_mode=CitationMode.KEEP_MARKERS
-            )
-
-            research_cycle_count = 0
-            llm_cycle_count = 0
-            current_tools = tools
-            reasoning_cycles = 0
-            just_ran_web_search = False
-
-            # If this fails to parse, we can't run the loop anyway, let this one fail in that case
-            research_topic = research_agent_call.tool_args[RESEARCH_AGENT_TASK_KEY]
-
-            emitter.emit(
-                Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
-                    obj=ResearchAgentStart(research_task=research_topic),
-                )
-            )
-
-            initial_user_message = ChatMessageSimple(
-                message=research_topic,
-                token_count=token_counter(research_topic),
-                message_type=MessageType.USER,
-            )
-            msg_history: list[ChatMessageSimple] = [initial_user_message]
-
-            citation_mapping: dict[int, str] = {}
-            most_recent_reasoning: str | None = None
-            while research_cycle_count <= MAX_RESEARCH_CYCLES:
-                # Check if we've exceeded the time limit - if so, skip LLM and generate report
-                elapsed_seconds = time.monotonic() - start_time
-                if elapsed_seconds > RESEARCH_AGENT_FORCE_REPORT_SECONDS:
-                    logger.info(
-                        "Research agent exceeded %ss (elapsed: %ss), forcing intermediate report generation",
-                        RESEARCH_AGENT_FORCE_REPORT_SECONDS,
-                        format(elapsed_seconds, ".1f"),
-                    )
-                    break
-
-                if research_cycle_count == MAX_RESEARCH_CYCLES:
-                    # Auto-generate report on last cycle
-                    logger.debug("Auto-generating intermediate report on last cycle.")
-                    break
-
-                tools_by_name = {tool.name: tool for tool in current_tools}
-
-                tools_description = generate_tools_description(current_tools)
-
-                internal_search_tip = (
-                    INTERNAL_SEARCH_GUIDANCE
-                    if any(isinstance(tool, SearchTool) for tool in current_tools)
-                    else ""
-                )
-                web_search_tip = (
-                    WEB_SEARCH_TOOL_DESCRIPTION
-                    if any(isinstance(tool, WebSearchTool) for tool in current_tools)
-                    else ""
-                )
-                open_urls_tip = (
-                    OPEN_URLS_TOOL_DESCRIPTION
-                    if any(isinstance(tool, OpenURLTool) for tool in current_tools)
-                    else ""
-                )
-                if is_reasoning_model and open_urls_tip:
-                    open_urls_tip = OPEN_URLS_TOOL_DESCRIPTION_REASONING
-
-                system_prompt_template = (
-                    RESEARCH_AGENT_PROMPT_REASONING
-                    if is_reasoning_model
-                    else RESEARCH_AGENT_PROMPT
-                )
-                system_prompt_str = system_prompt_template.format(
-                    available_tools=tools_description,
-                    current_datetime=get_current_llm_day_time(full_sentence=False),
-                    current_cycle_count=research_cycle_count,
-                    optional_internal_search_tool_description=internal_search_tip,
-                    optional_web_search_tool_description=web_search_tip,
-                    optional_open_url_tool_description=open_urls_tip,
-                )
-
-                system_prompt = ChatMessageSimple(
-                    message=system_prompt_str,
-                    token_count=token_counter(system_prompt_str),
-                    message_type=MessageType.SYSTEM,
-                )
-
-                if just_ran_web_search:
-                    reminder_message = ChatMessageSimple(
-                        message=OPEN_URL_REMINDER_RESEARCH_AGENT,
-                        token_count=100,
-                        message_type=MessageType.USER,
-                    )
-                else:
-                    reminder_message = None
-
-                constructed_history = construct_message_history(
-                    system_prompt=system_prompt,
-                    custom_agent_prompt=None,
-                    simple_chat_history=msg_history,
-                    reminder_message=reminder_message,
-                    context_files=None,
-                    available_tokens=llm.config.max_input_tokens,
-                )
-
-                research_agent_tools = get_research_agent_additional_tool_definitions(
-                    include_think_tool=not is_reasoning_model
-                )
-                # Use think tool processor for non-reasoning models to convert
-                # think_tool calls to reasoning content (same as dr_loop.py)
-                custom_processor = (
-                    create_think_tool_token_processor()
-                    if not is_reasoning_model
-                    else None
-                )
-
-                llm_step_result, has_reasoned = run_llm_step(
-                    emitter=emitter,
-                    history=constructed_history,
-                    tool_definitions=[tool.tool_definition() for tool in current_tools]
-                    + research_agent_tools,
-                    tool_choice=ToolChoiceOptions.REQUIRED,
-                    llm=llm,
-                    placement=Placement(
-                        turn_index=turn_index,
-                        tab_index=tab_index,
-                        sub_turn_index=llm_cycle_count + reasoning_cycles,
-                    ),
-                    citation_processor=None,
-                    state_container=None,
-                    reasoning_effort=ReasoningEffort.LOW,
-                    final_documents=None,
-                    user_identity=user_identity,
-                    custom_token_processor=custom_processor,
-                    use_existing_tab_index=True,
-                    is_deep_research=True,
-                    # In case the model is tripped up by the long context and gets into an endless loop of
-                    # things like null tokens, we set a max token limit here. The call will likely not be valid
-                    # in these situations but it at least allows a chance of recovery. None of the tool calls should
-                    # be this long.
-                    max_tokens=1000,
-                )
-                if has_reasoned:
-                    reasoning_cycles += 1
-
-                tool_responses: list[ToolResponse] = []
-                tool_calls = llm_step_result.tool_calls or []
-
-                # TODO handle the restriction of only 1 tool call type per turn
-                # This is a problem right now because of the Placement system not allowing for
-                # differentiating sub-tool calls.
-                # Filter tool calls to only include the first tool type used
-                # This prevents mixing different tool types in the same batch
-                if tool_calls:
-                    first_tool_type = tool_calls[0].tool_name
-                    tool_calls = [
-                        tc for tc in tool_calls if tc.tool_name == first_tool_type
-                    ]
-
-                just_ran_web_search = False
-
-                special_tool_calls = check_special_tool_calls(tool_calls=tool_calls)
-                if special_tool_calls.generate_report_tool_call:
-                    final_report = generate_intermediate_report(
-                        research_topic=research_topic,
-                        history=msg_history,
-                        llm=llm,
-                        token_counter=token_counter,
-                        citation_processor=citation_processor,
-                        user_identity=user_identity,
-                        emitter=emitter,
-                        placement=Placement(
-                            turn_index=turn_index,
-                            tab_index=tab_index,
-                        ),
-                    )
-                    span.span_data.output = final_report if final_report else None
-                    return ResearchAgentCallResult(
-                        intermediate_report=final_report,
-                        citation_mapping=citation_processor.get_seen_citations(),
-                    )
-                elif special_tool_calls.think_tool_call:
-                    think_tool_call = special_tool_calls.think_tool_call
-                    tool_call_message = think_tool_call.to_msg_str()
-                    tool_call_token_count = token_counter(tool_call_message)
-
-                    with function_span("think_tool") as think_span:
-                        think_span.span_data.input = str(think_tool_call.tool_args)
-
-                        # Create ASSISTANT message with tool_calls (OpenAI parallel format)
-                        think_tool_simple = ToolCallSimple(
-                            tool_call_id=think_tool_call.tool_call_id,
-                            tool_name=think_tool_call.tool_name,
-                            tool_arguments=think_tool_call.tool_args,
-                            token_count=tool_call_token_count,
-                        )
-                        think_assistant_msg = ChatMessageSimple(
-                            message="",
-                            token_count=tool_call_token_count,
-                            message_type=MessageType.ASSISTANT,
-                            tool_calls=[think_tool_simple],
-                            image_files=None,
-                        )
-                        msg_history.append(think_assistant_msg)
-
-                        think_tool_response_msg = ChatMessageSimple(
-                            message=THINK_TOOL_RESPONSE_MESSAGE,
-                            token_count=THINK_TOOL_RESPONSE_TOKEN_COUNT,
-                            message_type=MessageType.TOOL_CALL_RESPONSE,
-                            tool_call_id=think_tool_call.tool_call_id,
-                            image_files=None,
-                        )
-                        msg_history.append(think_tool_response_msg)
-                        think_span.span_data.output = THINK_TOOL_RESPONSE_MESSAGE
-                    reasoning_cycles += 1
-                    most_recent_reasoning = llm_step_result.reasoning
-                    continue
-                else:
-                    parallel_tool_call_results = run_tool_calls(
-                        tool_calls=tool_calls,
-                        tools=current_tools,
-                        message_history=msg_history,
-                        user_memory_context=None,
-                        user_info=None,
-                        citation_mapping=citation_mapping,
-                        next_citation_num=citation_processor.get_next_citation_number(),
-                        # Packets currently cannot differentiate between parallel calls in a nested level
-                        # so we just cannot show parallel calls in the UI. This should not happen for deep research anyhow.
-                        max_concurrent_tools=1,
-                        # May be better to not do this step, hard to say, needs to be tested
-                        skip_search_query_expansion=False,
-                        url_snippet_map=extract_url_snippet_map(
-                            [
-                                search_doc
-                                for tool_call in state_container.get_tool_calls()
-                                if tool_call.search_docs
-                                for search_doc in tool_call.search_docs
-                            ]
-                        ),
-                    )
-                    tool_responses = parallel_tool_call_results.tool_responses
-                    citation_mapping = (
-                        parallel_tool_call_results.updated_citation_mapping
-                    )
-
-                    if tool_calls and not tool_responses:
-                        failure_messages = create_tool_call_failure_messages(
-                            tool_calls, token_counter
-                        )
-                        msg_history.extend(failure_messages)
-
-                        # If there is a failure like this, we still increment to avoid potential infinite loops
-                        research_cycle_count += 1
-                        llm_cycle_count += 1
-                        continue
-
-                    # Filter to only responses with valid tool_call references
-                    valid_tool_responses = [
-                        tr for tr in tool_responses if tr.tool_call is not None
-                    ]
-
-                    # Build ONE ASSISTANT message with all tool calls (OpenAI parallel format)
-                    if valid_tool_responses:
-                        tool_calls_simple: list[ToolCallSimple] = []
-                        for tool_response in valid_tool_responses:
-                            tc = tool_response.tool_call
-                            assert tc is not None  # Already filtered above
-                            tool_call_message = tc.to_msg_str()
-                            tool_call_token_count = token_counter(tool_call_message)
-                            tool_calls_simple.append(
-                                ToolCallSimple(
-                                    tool_call_id=tc.tool_call_id,
-                                    tool_name=tc.tool_name,
-                                    tool_arguments=tc.tool_args,
-                                    token_count=tool_call_token_count,
-                                )
-                            )
-
-                        total_tool_call_tokens = sum(
-                            tc.token_count for tc in tool_calls_simple
-                        )
-                        assistant_with_tools = ChatMessageSimple(
-                            message="",
-                            token_count=total_tool_call_tokens,
-                            message_type=MessageType.ASSISTANT,
-                            tool_calls=tool_calls_simple,
-                            image_files=None,
-                        )
-                        msg_history.append(assistant_with_tools)
-
-                    # Now add tool call info and TOOL_CALL_RESPONSE messages for each
-                    for tool_response in valid_tool_responses:
-                        tc = tool_response.tool_call
-                        assert tc is not None  # Already filtered above
-                        tool_call_tab_index = tc.placement.tab_index
-
-                        tool = tools_by_name.get(tc.tool_name)
-                        if not tool:
-                            raise ValueError(
-                                f"Tool '{tc.tool_name}' not found in tools list"
-                            )
-
-                        search_docs = None
-                        displayed_docs = None
-                        if isinstance(tool_response.rich_response, SearchDocsResponse):
-                            search_docs = tool_response.rich_response.search_docs
-                            displayed_docs = tool_response.rich_response.displayed_docs
-
-                            # Add ALL search docs to state container for DB persistence
-                            if search_docs:
-                                state_container.add_search_docs(search_docs)
-
-                            # This is used for the Open URL reminder in the next cycle
-                            # only do this if the web search tool yielded results
-                            if search_docs and tc.tool_name == WebSearchTool.NAME:
-                                just_ran_web_search = True
-
-                        # Makes sure the citation processor is updated with all the possible docs
-                        # and citation numbers so that it's populated when passed in to report generation.
-                        update_citation_processor_from_tool_response(
-                            tool_response=tool_response,
-                            citation_processor=citation_processor,
-                        )
-
-                        # Research Agent is a top level tool call but the tools called by the research
-                        # agent are sub-tool calls.
-                        tool_call_info = ToolCallInfo(
-                            parent_tool_call_id=parent_tool_call_id,
-                            # At the DB save level, there is only a turn index, no sub-turn etc.
-                            # This is implied by the parent tool call's turn index and the depth
-                            # of the tree traversal.
-                            turn_index=llm_cycle_count + reasoning_cycles,
-                            tab_index=tool_call_tab_index,
-                            tool_name=tc.tool_name,
-                            tool_call_id=tc.tool_call_id,
-                            tool_id=tool.id,
-                            reasoning_tokens=llm_step_result.reasoning
-                            or most_recent_reasoning,
-                            tool_call_arguments=tc.tool_args,
-                            tool_call_response=tool_response.llm_facing_response,
-                            search_docs=displayed_docs or search_docs,
-                            generated_images=None,
-                        )
-                        state_container.add_tool_call(tool_call_info)
-
-                        tool_response_message = tool_response.llm_facing_response
-                        tool_response_token_count = token_counter(tool_response_message)
-
-                        tool_response_msg = ChatMessageSimple(
-                            message=tool_response_message,
-                            token_count=tool_response_token_count,
-                            message_type=MessageType.TOOL_CALL_RESPONSE,
-                            tool_call_id=tc.tool_call_id,
-                            image_files=None,
-                        )
-                        msg_history.append(tool_response_msg)
-
-                # If it reached this point, it did not call reasoning, so here we wipe it to not save it to multiple turns
-                most_recent_reasoning = None
-                llm_cycle_count += 1
-                research_cycle_count += 1
-
-            # If we've run out of cycles, just try to generate a report from everything so far
-            final_report = generate_intermediate_report(
-                research_topic=research_topic,
-                history=msg_history,
-                llm=llm,
-                token_counter=token_counter,
-                citation_processor=citation_processor,
-                user_identity=user_identity,
-                emitter=emitter,
-                placement=Placement(
-                    turn_index=turn_index,
-                    tab_index=tab_index,
-                ),
-            )
-            span.span_data.output = final_report if final_report else None
-            return ResearchAgentCallResult(
-                intermediate_report=final_report,
-                citation_mapping=citation_processor.get_seen_citations(),
-            )
-
-        except Exception as e:
-            logger.error("Error running research agent call: %s", e)
-            emitter.emit(
-                Packet(
-                    placement=Placement(turn_index=turn_index, tab_index=tab_index),
-                    obj=PacketException(type=StreamingType.ERROR.value, exception=e),
-                )
-            )
-            return None
+    return ResearchAgent(
+        kickoff=research_agent_call,
+        emitter=emitter,
+        llm=llm,
+        token_counter=token_counter,
+        user_identity=user_identity,
+        parent_tool_call_id=parent_tool_call_id,
+        tools=tools,
+        state_container=state_container,
+    ).run()
 
 
 def _on_research_agent_timeout(


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the agent framework with a shared loop base and utilities, and migrated the research agent to this base for cleaner control flow, consistent streaming, and easier future agents.

- **Refactors**
  - Added `agentic_agent_base.py` (`AgenticAgentBase`) to own cycles/timeouts, run LLM steps via `run_llm_step_pkt_generator`, handle think/finalize, add a packet transform hook, and standardize error emission; includes `custom_token_processor` for non-reasoning models, `is_deep_research` flag, and a max step token cap.
  - Added `agent_loop_utils.py` with `find_special_tool_calls`, `append_think_tool_messages`, `build_assistant_with_tool_calls`, `should_force_finalize`, and `emit_agent_failure`.
  - Rewrote `research_agent.py` as `ResearchAgent` subclass: emits start, keeps citations and report generation, adds Open-URL reminder only after web search yields docs, filters to one tool type per turn, bundles tool calls into a single ASSISTANT message, persists state/citations, and caps step tokens to 1000; `run_research_agent_call` now constructs and runs this class.

<sup>Written for commit c87045673843d94d71eb019b4c143c4a45e4dea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

