### PR TITLE
fix(types): replace any types with concrete types in AreaChart component

### DIFF
--- a/web/src/components/ui/areaChart.tsx
+++ b/web/src/components/ui/areaChart.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/card";
 
 interface AreaChartProps {
-  data?: any[];
+  data?: Array<Record<string, string | number>>;
   categories?: string[];
   index?: string;
   colors?: string[];
@@ -35,8 +35,8 @@ interface AreaChartProps {
   className?: string;
   title?: string;
   description?: string;
-  xAxisFormatter?: (value: any) => string;
-  yAxisFormatter?: (value: any) => string;
+  xAxisFormatter?: (value: string) => string;
+  yAxisFormatter?: (value: number) => string;
   stacked?: boolean;
 }
 


### PR DESCRIPTION
## Description

Replaces three `any` types in the `AreaChartProps` interface with concrete types based on how all callers actually use the component:

| Prop | Before | After |
|---|---|---|
| `data` | `any[]` | `Array<Record<string, string \| number>>` |
| `xAxisFormatter` param | `(value: any) => string` | `(value: string) => string` |
| `yAxisFormatter` param | `(value: any) => string` | `(value: number) => string` |

All callers pass objects with a string index key (e.g. `Day`) and numeric category values. The formatters consistently receive string (date) and number (metric) values respectively.

## How Has This Been Tested?

- TypeScript type check passes
- Prettier passes
- All existing callers are compatible with the new types

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened types in the `AreaChart` component by replacing three `any` usages with concrete types to improve type safety without changing behavior.

- **Refactors**
  - `data`: `any[]` → `Array<Record<string, string | number>>`
  - `xAxisFormatter`: `(value: any) => string` → `(value: string) => string`
  - `yAxisFormatter`: `(value: any) => string` → `(value: number) => string`

<sup>Written for commit 5e5be55a607e2ab6d22509c1e16bf3c4f5e24c59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

